### PR TITLE
opreturn example, fix incorrect bitcoinjs-lib reference

### DIFF
--- a/example/transactionOPReturn.js
+++ b/example/transactionOPReturn.js
@@ -54,7 +54,7 @@ var sendBitcoin = function() {
       keychain.xprv = bitgo.decrypt({ password: walletPassphrase, input: keychain.encryptedXprv });
 
       var data = new Buffer(message);
-      var outputScript = BitcoinJSLib.scripts.nullDataOutput(data);
+      var outputScript = BitcoinJSLib.script.nullDataOutput(data);
 
       // Set recipients
       var recipients = [];


### PR DESCRIPTION
`bitcoinjslib.scripts` should be`bitcoinjslib.script`

See https://github.com/bitcoinjs/bitcoinjs-lib/blob/master/test/integration/advanced.js#L36