### PR TITLE
Add connection timeout

### DIFF
--- a/src/bitgo.js
+++ b/src/bitgo.js
@@ -206,6 +206,7 @@ var BitGo = function(params) {
         // browser (browserify sets process.browser).
         req.set('User-Agent', self._userAgent);
       }
+      req.timeout(process.env.BITGO_TIMEOUT || 60000);
       return req;
     };
   };


### PR DESCRIPTION
BitGo doesn't set a superagent request timeout. In case of a network failure the BitGo SDK just hangs indefinitely because of that.

This PR adds a default timeout of 60 seconds and makes it configurable through the environment variable `BITGO_TIMEOUT`