### PR TITLE
fix slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ The SDK is fully integrated with the BitGo co-signing service for managing all o
 
 Included in the SDK are examples for how to use the API to manage your multi-signature wallets.
 
-Please join us on our [Slack channel](https://slack.bitgo.com) if you have questions or comments about this API.
+Please join us on our [Slack channel](https://bitgodevs.slack.com) if you have questions or comments about this API.
 
-[![Known Vulnerabilities](https://snyk.io/test/npm/bitgo/badge.svg)](https://snyk.io/test/npm/bitgo) [![Build Status](https://travis-ci.org/BitGo/BitGoJS.png?branch=master)](https://travis-ci.org/BitGo/BitGoJS) [![BitGo Slack](https://slack.bitgo.com/badge.svg)](https://slack.bitgo.com)
+[![Known Vulnerabilities](https://snyk.io/test/npm/bitgo/badge.svg)](https://snyk.io/test/npm/bitgo) [![Build Status](https://travis-ci.org/BitGo/BitGoJS.png?branch=master)](https://travis-ci.org/BitGo/BitGoJS)
 
 # Installation
 


### PR DESCRIPTION
The SlackIn badge we used to use no longer works because our custom subdomain was removed. Change it back to use the slack domain.