### PR TITLE
Fix typo and add explanation of minUnspentSize

### DIFF
--- a/src/transactionBuilder.js
+++ b/src/transactionBuilder.js
@@ -33,7 +33,7 @@ const TX_OVERHEAD_SIZE = 10;
 //   noSplitChange: set to true to disable automatic change splitting for purposes of unspent management
 //   targetWalletUnspents: specify a number of target unspents to maintain in the wallet (currently defaulted to 8 by the server)
 //   validate: extra verification of the change addresses, which is always done server-side and is redundant client-side (defaults true)
-//   minUnspentSize: The minimum use of unspent to use (don't spend dust transactions). Defaults to 0.
+//   minUnspentSize: The minimum size in satoshis of unspent to use (to prevent spending unspents worth less than fee added). Defaults to 0.
 //   feeSingleKeySourceAddress: Use this single key address to pay fees
 //   feeSingleKeyWIF: Use the address based on this private key to pay fees
 exports.createTransaction = function(params) {


### PR DESCRIPTION
Some engineers might be confused with "dust" in this context...

dust in the context of outputs is the limit that defines a standard transaction by the value of its outputs being over `((34+148)÷1000)×(3×minRelayTxFee)` which with current default of 0.00001 BTC will give 0.00000546 BTC

dust in the context of spending a utxo (adding an input) is "if you must spend more than x% of the value of the unspent to pay the extra fees from the added unspent, you should consider not including it at all"

There is currently no best practice for what x is, and fee estimation algorithm variance can greatly affect the meaning of dust in this context...

but at the very least we should address this fact so novice developers say "oh, well I never got a 546 satoshi or less utxo before so I'm good." when a 2-of-3 non-segwit input is 297 bytes... so if we say x is 30% and fees are 1 satoshi/byte, then dust for unspent would be ceil(297/0.3) or 990 satoshis would be dust.

Obviously if we say "shouldn't spend more than %10" that will be higher, also as sat/byte fees rise that will be higher.

Personally, this kind of logic should be `maxUnspentFeePercent` where the user tells you x% and you use the sat/byte rate you calculate to decide what the minUnspentSize should be...

Any thoughts...? Maybe this should be a separate issue?