### PR TITLE
update documentation url to point to v2 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We recommend using `nvm`, the [Node Version Manager](https://github.com/creation
 
 # Full Documentation
 
-View our [Javascript SDK Documentation](https://www.bitgo.com/api/?javascript#authentication).
+View our [Javascript SDK Documentation](https://www.bitgo.com/api/v2/).
 
 # Example Usage
 


### PR DESCRIPTION
I spent hours trying to find a way to interact with my xrp wallet, only to find out that I was using the wrong api version 