### PR TITLE
Added supportsBlockTarget function in v2 coins

### DIFF
--- a/src/v2/baseCoin.js
+++ b/src/v2/baseCoin.js
@@ -150,6 +150,14 @@ BaseCoin.prototype.verifyAddress = function() {
 };
 
 /**
+ * Check whether a coin supports blockTarget for transactions to be included in
+ * @returns {boolean}
+ */
+BaseCoin.prototype.supportsBlockTarget = function() {
+  return false;
+};
+
+/**
  * If a coin needs to add additional parameters to the wallet generation, it does it in this method
  * @param walletParams
  * @return {*}

--- a/src/v2/coins/btc.js
+++ b/src/v2/coins/btc.js
@@ -28,6 +28,7 @@ Btc.prototype.getBaseFactor = function() {
 Btc.prototype.getChain = function() {
   return 'btc';
 };
+
 Btc.prototype.getFamily = function() {
   return 'btc';
 };
@@ -193,6 +194,10 @@ Btc.prototype.verifyAddress = function({ address, keychains, coinSpecific, chain
   if (expectedAddress.address !== address) {
     throw new Error(`address validation failure: expected ${expectedAddress.address} but got ${address}`);
   }
+};
+
+Btc.prototype.supportsBlockTarget = function() {
+  return true;
 };
 
 /**

--- a/test/v2/baseCoin.js
+++ b/test/v2/baseCoin.js
@@ -30,4 +30,10 @@ describe('V2 Base Coin:', function() {
       basecoin.baseUnitsToBigUnits('1000000010000000000').should.equal('1.00000001');
     });
   });
+
+  describe('supportsBlockTarget', function() {
+    it('should return false', function() {
+      basecoin.supportsBlockTarget().should.equal(false);
+    });
+  });
 });


### PR DESCRIPTION
Summary:
As of now we can only set the transaction fee based on when we would
like the transaction be confirmed for Bitcoin transactions. The
supportsBlockTarget function tells whether the given coin supports
this feature or not.

Reviewers: bigly, arik

Subscribers: ben

Differential Revision: https://phabricator.bitgo.com/D7740