### PR TITLE
BG-9093: Prevent proxying of non-api routes through bitgo-express

### DIFF
--- a/src/expressApp.js
+++ b/src/expressApp.js
@@ -109,8 +109,14 @@ function configureProxy(app, { env }) {
   });
 
   app.use(function(req, res) {
-    req.isProxy = true;
-    proxy.web(req, res, { target: common.Environments[env].uri, changeOrigin: true });
+    if (req.url && /^\/api\/v[12]\/.*$/.test(req.url)) {
+      req.isProxy = true;
+      proxy.web(req, res, { target: common.Environments[env].uri, changeOrigin: true });
+      return;
+    }
+
+    // user tried to access a url which is not an api route, do not proxy
+    res.status(404).send('bitgo-express can only proxy BitGo API requests');
   });
 }
 

--- a/test/v2/integration/bitgoExpress.js
+++ b/test/v2/integration/bitgoExpress.js
@@ -163,4 +163,11 @@ describe('Bitgo Express', function() {
       res.should.have.status(413);
     }));
   });
+
+  describe('Only API routes are proxied', () => {
+    it('should not proxy a non-api route', co(function *() {
+      const res = yield agent.get('/info/solutions').send();
+      res.should.have.status(404);
+    }));
+  });
 });


### PR DESCRIPTION
Signed-off-by: Tyler Levine <tyler@bitgo.com>