### PR TITLE
Add integration test for accelerateTx

### DIFF
--- a/test/v2/integration/accelerateTx.js
+++ b/test/v2/integration/accelerateTx.js
@@ -1,5 +1,6 @@
 require('should');
-const co = require('bluebird').coroutine;
+const Promise = require('bluebird');
+const co = Promise.coroutine;
 
 const BitGoJS = require('../../../src');
 
@@ -40,6 +41,8 @@ describe('accelerateTransaction', function() {
   let unconfirmedTx;
 
   before(co(function *() {
+    const MILLISECONDS_WAIT_IMS = 2000;
+
     this.timeout(0);
     console.log('unlocking account...');
     yield bitgo.unlock({ otp: '0000000' });
@@ -51,11 +54,13 @@ describe('accelerateTransaction', function() {
     unconfirmedTx = yield getUnconfirmedTx(wallet);
     console.log('created tx', unconfirmedTx);
     (unconfirmedTx === undefined).should.eql(false);
+
+    console.log(`waiting ${MILLISECONDS_WAIT_IMS / 1000}s for IMS to see tx...`);
+    yield Promise.delay(MILLISECONDS_WAIT_IMS);
   }));
 
   it('can accelerate an unconfirmed tx', co(function *() {
-    console.log('acclerateTx...');
-    // FIXME: the tx is not found in the db when we go to access it
+    // FIXME: Error `cannot build transaction without available unspents`
     const result = yield wallet.accelerateTransaction({
       cpfpTxIds: [unconfirmedTx],
       cpfpFeeRate,

--- a/test/v2/integration/accelerateTx.js
+++ b/test/v2/integration/accelerateTx.js
@@ -1,0 +1,61 @@
+require('should');
+const co = require('bluebird').coroutine;
+
+const BitGoJS = require('../../../src');
+
+describe('AccelerateTx', function() {
+  // latest.bitgo.com / otto-latest@bitgo.com
+  const accessToken = 'v2x0f5a14ab6aa4c3d4a420444ed6494157b7259de634ad3836ba748335812c6252';
+  // wallet "cpfptest2"
+  const walletId = '5c346da55cb4b705795c5176eb7c70cd';
+  const walletPassphrase = 'cpfptest2';
+  const coinName = 'tbtc';
+  const bitgo = new BitGoJS.BitGo({ env: 'latest', accessToken });
+
+  let wallet;
+
+  // wallet was funded with 10_000_000 sats,
+  // so this should be sufficient for 1000 txs with satAmount
+  const satAmount = 10000;
+
+  const baseFeeRate = 1;
+  const cpfpFeeRate = 10;
+
+  const getUnconfirmedTx = co(function *(wallet) {
+    const { address } = yield wallet.createAddress();
+    const { transfer } = yield wallet.send({
+      amount: satAmount,
+      address,
+      feeRate: baseFeeRate,
+      walletPassphrase
+    });
+    return transfer.txid;
+  }.bind(this));
+
+  let unconfirmedTx;
+
+  before(co(function *() {
+    this.timeout(0);
+    console.log('unlocking account...');
+    yield bitgo.unlock({ otp: '0000000' });
+    console.log('getting wallet...');
+    wallet = yield bitgo.coin(coinName).wallets().get({ id: walletId });
+    (wallet === undefined).should.eql(false);
+
+    console.log('creating unconfirmed tx...');
+    unconfirmedTx = yield getUnconfirmedTx(wallet);
+    console.log('created tx', unconfirmedTx);
+    (unconfirmedTx === undefined).should.eql(false);
+  }));
+
+  it('can accelerate unconfirmed tx', co(function *() {
+    console.log('acclerateTx..');
+    const result = yield wallet.accelerateTransaction({
+      cpfpTxIds: [unconfirmedTx],
+      cpfpFeeRate,
+      maxFee: 1000000
+    });
+    console.log('result', result);
+  }));
+});
+


### PR DESCRIPTION
Currently uses latest.bitgo.com

Fails with `Error: route not found` due to outdated IMS version that
does not support the `/select-cpfp` route.

Issue: BG-9646