### PR TITLE
BG-9584: Require node production config when running express against prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ We recommend using `nvm`, the [Node Version Manager](https://github.com/creation
 
 # Full Documentation
 
-View our [Javascript SDK Documentation](https://www.bitgo.com/api/?javascript#authentication).
+View our [Javascript SDK Documentation](https://www.bitgo.com/api/v2).
 
 # Example Usage
 
@@ -79,7 +79,7 @@ wallet.sendCoins({
 ```
 
 ## More examples
-Further demos and examples can be found in the [example](example/) directory and [documented here](https://www.bitgo.com/api/?javascript#examples).
+Further demos and examples can be found in the [example](example/) directory and [documented here](https://www.bitgo.com/api/v2/?javascript#examples).
 
 # BitGo Express Local Signing Server (REST API)
 
@@ -89,6 +89,8 @@ BitGo Express runs as a service in your own datacenter, and handles the client-s
 This ensures your keys never leave your network, and are not seen by BitGo. BitGo Express can also proxy the standard BitGo REST APIs, providing a unified interface to BitGo through a single REST API.
 
 `bin/bitgo-express [-h] [-v] [-p PORT] [-b BIND] [-e ENV] [-d] [-l LOGFILEPATH] [-k KEYPATH] [-c CRTPATH]`
+
+**Note:** When running against the BitGo production environment, you must run node in a production configuration as well. You can do that by running `export NODE_ENV=production` prior to starting bitgo-express.
 
 For a full tutorial of how to install, authenticate, and use Bitgo Express, see the [Bitgo Express Quickstart](https://platform.bitgo.com/bitgo-express/)
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -15,7 +15,14 @@ class TlsConfigurationError extends BitGoJsError {
   }
 }
 
+class NodeEnvironmentError extends BitGoJsError {
+  constructor(message) {
+    super(message || 'NODE_ENV is invalid for the current bitgo environment');
+  }
+}
+
 module.exports = {
   BitGoJsError,
-  TlsConfigurationError
+  TlsConfigurationError,
+  NodeEnvironmentError
 };

--- a/src/expressApp.js
+++ b/src/expressApp.js
@@ -37,8 +37,12 @@ function validateArgs(args) {
     throw new TlsConfigurationError('Must provide both keypath and crtpath when running in TLS mode!');
   }
 
-  if (env === 'prod' && process.env.NODE_ENV !== 'production' && !disableenvcheck) {
-    throw new NodeEnvironmentError('NODE_ENV should be set to production when running against prod environment. Use --disableenvcheck if you really want to run in a non-production node configuration.');
+  if (env === 'prod' && process.env.NODE_ENV !== 'production') {
+    if (!disableenvcheck) {
+      throw new NodeEnvironmentError('NODE_ENV should be set to production when running against prod environment. Use --disableenvcheck if you really want to run in a non-production node configuration.');
+    } else {
+      console.warn(`warning: unsafe NODE_ENV '${process.env.NODE_ENV}'. NODE_ENV must be set to 'production' when running against BitGo production environment.`);
+    }
   }
 
   return args;
@@ -226,6 +230,7 @@ module.exports.parseArgs = function() {
 
   parser.addArgument(['--disableenvcheck'], {
     action: 'storeTrue',
+    defaultValue: true, // BG-9584: temporarily disable env check while we give users time to react to change in runtime behavior
     help: 'disable checking for proper NODE_ENV when running in prod environment'
   });
 


### PR DESCRIPTION
When node is running in development mode, it can output some debugging information which reveals sensitive data about the system running bitgo-express. It is currently possible to run express against the BitGo production environment, while the node environment is development (which is the default), thus potentially exposing customer system information.

By requiring that NODE_ENV is production when running against prod, express will not output this debugging information.

Note that this behavior is overridable by passing the `--disableenvcheck` flag when starting bitgo express, in case some customer wants to keep using the current behavior.

Signed-off-by: Tyler Levine <tyler@bitgo.com>