### PR TITLE
[BG-6524] delete feeRate before recreating transaction

### DIFF
--- a/src/pendingapproval.js
+++ b/src/pendingapproval.js
@@ -294,6 +294,7 @@ PendingApproval.prototype.approve = function(params, callback) {
       .then(function() {
         const recreationParams = _.extend({}, params, { txHex: self.info().transactionRequest.transaction }, self.info().transactionRequest.buildParams);
         delete recreationParams.unspents; // we delete the previous unspents, because we want to recreate a tx with new ones
+        delete recreationParams.feeRate;
         return self.recreateAndSignTransaction(recreationParams);
       });
     }


### PR DESCRIPTION
We must delete the feeRate before recreating the transaction, otherwise we get an error, as we cannot pass a "fee" and "feeRate"