### PR TITLE
[BG-6524] must delete feeRate

### DIFF
--- a/src/pendingapproval.js
+++ b/src/pendingapproval.js
@@ -294,6 +294,7 @@ PendingApproval.prototype.approve = function(params, callback) {
       .then(function() {
         const recreationParams = _.extend({}, params, { txHex: self.info().transactionRequest.transaction }, self.info().transactionRequest.buildParams);
         delete recreationParams.unspents; // we delete the previous unspents, because we want to recreate a tx with new ones
+        delete recreationParams.feeRate;
         return self.recreateAndSignTransaction(recreationParams);
       });
     }

--- a/test/integration/markets.js
+++ b/test/integration/markets.js
@@ -37,7 +37,6 @@ describe('Market', function() {
       marketData.latest.currencies.USD.should.have.property('ask');
       marketData.latest.currencies.USD.should.have.property('last');
       marketData.latest.currencies.USD.should.have.property('total_vol');
-      marketData.latest.currencies.USD.should.have.property('prevDayHigh');
       marketData.latest.currencies.USD.should.have.property('prevDayLow');
       marketData.latest.currencies.USD.should.have.property('24h_avg');
       marketData.latest.currencies.USD.should.have.property('total_vol');
@@ -46,7 +45,6 @@ describe('Market', function() {
       marketData.latest.currencies.USD.should.have.property('monthlyLow');
       marketData.latest.currencies.USD.should.have.property('monthlyHigh');
       marketData.latest.currencies.USD.should.have.property('prevDayLow');
-      marketData.latest.currencies.USD.should.have.property('prevDayHigh');
       marketData.latest.currencies.USD.should.have.property('lastHourLow');
       marketData.latest.currencies.USD.should.have.property('lastHourHigh');
       done();

--- a/test/v2/integration/markets.js
+++ b/test/v2/integration/markets.js
@@ -49,7 +49,6 @@ describe('Market', function() {
         marketData.latest.currencies.USD.should.have.property('24h_avg');
 
         if (isMainnet(coin)) {
-          marketData.latest.currencies.USD.should.have.property('prevDayHigh');
           marketData.latest.currencies.USD.should.have.property('prevDayLow');
           marketData.latest.currencies.USD.should.have.property('total_vol');
           marketData.latest.currencies.USD.should.have.property('timestamp');
@@ -57,7 +56,6 @@ describe('Market', function() {
           marketData.latest.currencies.USD.should.have.property('monthlyLow');
           marketData.latest.currencies.USD.should.have.property('monthlyHigh');
           marketData.latest.currencies.USD.should.have.property('prevDayLow');
-          marketData.latest.currencies.USD.should.have.property('prevDayHigh');
           marketData.latest.currencies.USD.should.have.property('lastHourLow');
           marketData.latest.currencies.USD.should.have.property('lastHourHigh');
         }


### PR DESCRIPTION
We need to delete feeRate before recreating the transaction, because a pendingapproval stores "feeRate" and another field "fee". Then the SDK throws the error: 'cannot specify more than one of fee, feeRate and feeTxConfirmTarget'