### PR TITLE
BG-9047 - Throw error on federation lookup csp error

### DIFF
--- a/src/v2/coins/xlm.js
+++ b/src/v2/coins/xlm.js
@@ -310,7 +310,11 @@ class Xlm extends BaseCoin {
           return yield stellar.FederationServer.resolve(address);
         }
       } catch (e) {
-        throw new Error('account not found');
+        if (e.message === 'Network Error') {
+          throw e;
+        } else {
+          throw new Error('account not found');
+        }
       }
     }).call(this);
   }


### PR DESCRIPTION
Summary: We need to be able to catch the csp error in the client.

Reviewers: bigly, luis

Subscribers: tyler

Differential Revision: https://phabricator.bitgo.com/D10765