### PR TITLE
Add key 'bitgoExpress' to error messages

### DIFF
--- a/src/clientRoutes.js
+++ b/src/clientRoutes.js
@@ -497,7 +497,7 @@ const promiseWrapper = function(promiseRequestHandler, args) {
       const message = err.message || 'local error';
       // use attached result, or make one
       let result = err.result || { error: message };
-      result = _.extend({}, result);
+      result = _.extend({ bitgoExpress: BITGOEXPRESS_USER_AGENT }, result);
       result.message = err.message;
       const status = err.status || 500;
       if (!(status >= 200 && status < 300)) {

--- a/test/integration/bitgoExpress.js
+++ b/test/integration/bitgoExpress.js
@@ -52,6 +52,7 @@ describe('Bitgo Express', function() {
       return disabledProxyAgent.get('/api/v1/market/latest')
       .send()
       .then(function(res) {
+        res.body.should.match({ bitgoExpress: /^BitGoExpress.*/ });
         res.should.have.status(404);
       });
     });


### PR DESCRIPTION
Summary:
I have noticed that it can be unclear where an error originates from.
This key should make the error origin more apparent.

Issue: BG-8863

Reviewers: bigly, tyler, alex

Subscribers: tyler

Differential Revision: https://phabricator.bitgo.com/D10374