### PR TITLE
[BG-9024] verifyAddress change

### DIFF
--- a/src/v2/coins/abstractUtxoCoin.js
+++ b/src/v2/coins/abstractUtxoCoin.js
@@ -261,7 +261,7 @@ class AbstractUtxoCoin extends BaseCoin {
             // the address was found, but not on the wallet, which simply means it's external
             debug('Address %s presumed external', currentAddress);
             return _.extend({}, currentOutput, { external: true });
-          } else if (e.message.includes('address validation failure: invalid chain') && currentAddress === txParams.changeAddress) {
+          } else if (e instanceof errors.InvalidAddressDerivationProperty && currentAddress === txParams.changeAddress) {
             // expect to see this error when passing in a custom changeAddress with no chain or index
             return _.extend({}, currentOutput, { external: false });
           }
@@ -478,7 +478,7 @@ class AbstractUtxoCoin extends BaseCoin {
     }
 
     if ((_.isUndefined(chain) && _.isUndefined(index)) || (!(_.isFinite(chain) && _.isFinite(index)))) {
-      throw new errors.InvalidAddressVerificationObjectPropertyError(`address validation failure: invalid chain (${chain}) or index (${index})`);
+      throw new errors.InvalidAddressDerivationProperty(`address validation failure: invalid chain (${chain}) or index (${index})`);
     }
 
     if (!_.isObject(coinSpecific)) {

--- a/src/v2/coins/abstractUtxoCoin.js
+++ b/src/v2/coins/abstractUtxoCoin.js
@@ -262,7 +262,7 @@ class AbstractUtxoCoin extends BaseCoin {
             debug('Address %s presumed external', currentAddress);
             return _.extend({}, currentOutput, { external: true });
           } else if (e.message.includes('address validation failure: invalid chain') && currentAddress === txParams.changeAddress) {
-            // expect to see this error when passing in a changeAddress with no chain or index
+            // expect to see this error when passing in a custom changeAddress with no chain or index
             return _.extend({}, currentOutput, { external: false });
           }
 

--- a/src/v2/coins/abstractUtxoCoin.js
+++ b/src/v2/coins/abstractUtxoCoin.js
@@ -261,6 +261,9 @@ class AbstractUtxoCoin extends BaseCoin {
             // the address was found, but not on the wallet, which simply means it's external
             debug('Address %s presumed external', currentAddress);
             return _.extend({}, currentOutput, { external: true });
+          } else if (e.message.includes('address validation failure: invalid chain') && currentAddress === txParams.changeAddress) {
+            // expect to see this error when passing in a changeAddress with no chain or index
+            return _.extend({}, currentOutput, { external: false });
           }
 
           debug('Address %s verification failed', currentAddress);
@@ -474,11 +477,7 @@ class AbstractUtxoCoin extends BaseCoin {
       throw new errors.InvalidAddressError(`invalid address: ${address}`);
     }
 
-    if (_.isUndefined(chain) && _.isUndefined(index)) {
-      return; // if both chain and index are undefined, then the address is a custom address and need not be verified through chain and index
-    }
-
-    if (!(_.isFinite(chain) && _.isFinite(index))) {
+    if ((_.isUndefined(chain) && _.isUndefined(index)) || (!(_.isFinite(chain) && _.isFinite(index)))) {
       throw new errors.InvalidAddressVerificationObjectPropertyError(`address validation failure: invalid chain (${chain}) or index (${index})`);
     }
 

--- a/src/v2/coins/abstractUtxoCoin.js
+++ b/src/v2/coins/abstractUtxoCoin.js
@@ -474,6 +474,10 @@ class AbstractUtxoCoin extends BaseCoin {
       throw new errors.InvalidAddressError(`invalid address: ${address}`);
     }
 
+    if (_.isUndefined(chain) && _.isUndefined(index)) {
+      return; // if both chain and index are undefined, then the address is a custom address and need not be verified through chain and index
+    }
+
     if (!(_.isFinite(chain) && _.isFinite(index))) {
       throw new errors.InvalidAddressVerificationObjectPropertyError(`address validation failure: invalid chain (${chain}) or index (${index})`);
     }

--- a/src/v2/coins/abstractUtxoCoin.js
+++ b/src/v2/coins/abstractUtxoCoin.js
@@ -261,7 +261,7 @@ class AbstractUtxoCoin extends BaseCoin {
             // the address was found, but not on the wallet, which simply means it's external
             debug('Address %s presumed external', currentAddress);
             return _.extend({}, currentOutput, { external: true });
-          } else if (e instanceof errors.InvalidAddressDerivationProperty && currentAddress === txParams.changeAddress) {
+          } else if (e instanceof errors.InvalidAddressDerivationPropertyError && currentAddress === txParams.changeAddress) {
             // expect to see this error when passing in a custom changeAddress with no chain or index
             return _.extend({}, currentOutput, { external: false });
           }
@@ -478,7 +478,7 @@ class AbstractUtxoCoin extends BaseCoin {
     }
 
     if ((_.isUndefined(chain) && _.isUndefined(index)) || (!(_.isFinite(chain) && _.isFinite(index)))) {
-      throw new errors.InvalidAddressDerivationProperty(`address validation failure: invalid chain (${chain}) or index (${index})`);
+      throw new errors.InvalidAddressDerivationPropertyError(`address validation failure: invalid chain (${chain}) or index (${index})`);
     }
 
     if (!_.isObject(coinSpecific)) {

--- a/src/v2/errors.js
+++ b/src/v2/errors.js
@@ -28,7 +28,7 @@ class UnexpectedAddressError extends Error {
   }
 }
 
-class InvalidAddressDerivationProperty extends Error {
+class InvalidAddressDerivationPropertyError extends Error {
   constructor(message) {
     super(message || 'address chain and/or index are invalid');
   }
@@ -40,5 +40,5 @@ module.exports = {
   InvalidAddressError,
   InvalidAddressVerificationObjectPropertyError,
   UnexpectedAddressError,
-  InvalidAddressDerivationProperty
+  InvalidAddressDerivationPropertyError
 };

--- a/src/v2/errors.js
+++ b/src/v2/errors.js
@@ -28,10 +28,17 @@ class UnexpectedAddressError extends Error {
   }
 }
 
+class InvalidAddressDerivationProperty extends Error {
+  constructor(message) {
+    super(message || 'address chain and/or index are invalid');
+  }
+}
+
 module.exports = {
   P2wshUnsupportedError,
   UnsupportedAddressTypeError,
   InvalidAddressError,
   InvalidAddressVerificationObjectPropertyError,
-  UnexpectedAddressError
+  UnexpectedAddressError,
+  InvalidAddressDerivationProperty
 };

--- a/test/v2/unit/coins/abstractUtxoCoin.js
+++ b/test/v2/unit/coins/abstractUtxoCoin.js
@@ -88,5 +88,34 @@ describe('Abstract UTXO Coin:', () => {
       coin.explainTransaction.restore();
       coin.verifyAddress.restore();
     }));
+
+    it('should accept a custom change address', co(function *() {
+
+      const changeAddress = '33a9a4TTT47i2VSpNZA3YT7v3sKYaZFAYz';
+      const outputAmount = 10000;
+      const recipients = [];
+
+      sinon.stub(coin, 'explainTransaction')
+        .returns({
+          outputs: [],
+          changeOutputs: [{
+            address: changeAddress,
+            amount: outputAmount
+          }]
+        });
+
+      const parsedTransaction = yield coin.parseTransaction({ txParams: { changeAddress, recipients }, txPrebuild: {}, wallet, verification });
+
+      should.exist(parsedTransaction.outputs[0]);
+      parsedTransaction.outputs[0].should.deepEqual({
+        address: changeAddress,
+        amount: outputAmount,
+        external: false
+      });
+
+      coin.explainTransaction.restore();
+    }));
+
+
   });
 });


### PR DESCRIPTION
https://bitgoinc.atlassian.net/browse/BG-9024
[BG-9024] Currently verifyAddress throws if a custom address is provided with no chain and index. We should allow custom addresses. So if no chain and index are provided to the "verifyAddress," we return and allow the user to continue with their custom output address.

successfully tested with the script linked in the duplicate ticket here: https://bitgoinc.atlassian.net/browse/BG-8650