### PR TITLE
BG-9228: Add support for ofc tokens and signing transactions.

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -219,6 +219,11 @@ exports.tokens = {
         { type: 'schz', coin: 'teth', network: 'Kovan', tokenContractAddress: '0x050e25a2630b2aee94546589fd39785254de112c', decimalPlaces: 18, name: 'SchnauzerCoin' },
         { type: 'tcat', coin: 'teth', network: 'Kovan', tokenContractAddress: '0x63137319f3a14a985eb31547370e0e3bd39b03b8', decimalPlaces: 18, name: 'Test CAT-20 Token' }
       ]
+    },
+    ofc: {
+      tokens: [
+        { type: 'otestusd', coin: 'ofc', decimalPlaces:2, name: 'Offchain Test USD', backingCoin: 'tsusd', isFiat:true }
+      ]
     }
   }
 };

--- a/src/v2/coins/ofc.js
+++ b/src/v2/coins/ofc.js
@@ -1,6 +1,6 @@
 const BaseCoin = require('../baseCoin');
 const crypto = require('crypto');
-const prova = require('prova-lib');
+const bitGoUtxoLib = require('bitgo-utxo-lib');
 
 class Ofc extends BaseCoin {
 
@@ -21,12 +21,16 @@ class Ofc extends BaseCoin {
       // maximum entropy and gives us maximum security against cracking.
       seed = crypto.randomBytes(512 / 8);
     }
-    const extendedKey = prova.HDNode.fromSeedBuffer(seed);
+    const extendedKey = bitGoUtxoLib.HDNode.fromSeedBuffer(seed);
     const xpub = extendedKey.neutered().toBase58();
     return {
       pub: xpub,
       prv: extendedKey.toBase58()
     };
+  }
+
+  getFamily() {
+    return 'ofc';
   }
 
   getFullName() {
@@ -38,6 +42,21 @@ class Ofc extends BaseCoin {
    */
   isValidMofNSetup({ m, n }) {
     return m === 1 && n === 1;
+  }
+
+  /**
+   * Return boolean indicating whether input is valid public key for the coin.
+   *
+   * @param {String} pub the pub to be checked
+   * @returns {Boolean} is it valid?
+   */
+  isValidPub(pub) {
+    try {
+      bitGoUtxoLib.HDNode.fromBase58(pub);
+      return true;
+    } catch (e) {
+      return false;
+    }
   }
 }
 

--- a/src/v2/coins/ofcToken.js
+++ b/src/v2/coins/ofcToken.js
@@ -1,0 +1,67 @@
+const Ofc = require('./ofc');
+const _ = require('lodash');
+const Promise = require('bluebird');
+const co = Promise.coroutine;
+
+class OFCToken extends Ofc {
+
+  static get tokenConfig() {
+    return {};
+  }
+
+  constructor() {
+    super();
+    Object.assign(this, this.constructor.tokenConfig);
+  }
+
+  getChain() {
+    return this.type;
+  }
+
+  getFullName() {
+    return this.name;
+  }
+
+  getBaseFactor() {
+    return String(Math.pow(10, this.decimalPlaces));
+  }
+
+  /**
+   * Flag for sending value of 0
+   * @returns {boolean} True if okay to send 0 value, false otherwise
+   */
+  valuelessTransferAllowed() {
+    return false;
+  }
+
+  static generateToken(config) {
+    // dynamically generate a new class
+    class CurrentToken extends OFCToken {
+      static get tokenConfig() {
+        return config;
+      }
+    }
+
+    return CurrentToken;
+  }
+
+  /**
+   * Assemble keychain and half-sign prebuilt transaction
+   * @param params
+   * - txPrebuild
+   * - prv
+   * @returns {{txHex}}
+   */
+  signTransaction(params) {
+    const txPrebuild = params.txPrebuild;
+    const userPrv = params.prv;
+
+    const payload = txPrebuild.payload;
+    const signatureBuffer = this.signMessage(params, payload);
+    const signature = signatureBuffer.toString('hex');
+    return { halfSigned: { payload, signature } };
+  }
+
+}
+
+module.exports = OFCToken;

--- a/test/v2/unit/coins/ofc.js
+++ b/test/v2/unit/coins/ofc.js
@@ -22,4 +22,9 @@ describe('OFC:', function() {
     ofcCoin.isValidMofNSetup({ m: 1, n: 3 }).should.be.false();
     ofcCoin.isValidMofNSetup({ m: 1, n: 1 }).should.be.true();
   });
+
+  it('should validate pub key', () => {
+    const { pub } = ofcCoin.keychains().create();
+    ofcCoin.isValidPub(pub).should.equal(true);
+  });
 });

--- a/test/v2/unit/coins/ofcToken.js
+++ b/test/v2/unit/coins/ofcToken.js
@@ -1,0 +1,38 @@
+require('should');
+
+const TestV2BitGo = require('../../../lib/test_bitgo');
+
+describe('OFC:', function() {
+  let bitgo;
+  let otestusdCoin;
+
+  before(function() {
+    bitgo = new TestV2BitGo({ env: 'test' });
+    bitgo.initializeTestVars();
+    otestusdCoin = bitgo.coin('otestusd');
+  });
+
+  it('functions that return constants', function() {
+    otestusdCoin.getChain().should.equal('otestusd');
+    otestusdCoin.getFullName().should.equal('Offchain Test USD');
+    otestusdCoin.getBaseFactor().should.equal('100');
+  });
+
+  it('can sign payloads', function() {
+    const inputParams = {
+      txPrebuild: {
+        payload: '{"token":"otestusd"}'
+      },
+      prv: 'xprv9s21ZrQH143K3WG4of3nSYUC55XNFCgZTyghae9cMSFDkcKU7YJgTahJMpdTY9CjCcjgSo2TJ635uUVx176BufUMBFpieKYVJD9J3VvrGRm'
+    };
+    const expectedResult = {
+      halfSigned: {
+        payload: '{\"token\":\"otestusd\"}',
+        signature: '2049b94a22c69650ad9529767da993a23c078347fdf7d887409793dce8d07190e108a846869edf387d294cd75c6c770a12847615b2553b22a61de29be5d91770dd',
+      }
+    }
+
+    const signedResult = otestusdCoin.signTransaction(inputParams);
+    signedResult.should.deepEqual(expectedResult);
+  });
+});


### PR DESCRIPTION
I've attached some example code using this. 

[ofc_spend.txt](https://github.com/BitGo/BitGoJS/files/2763140/ofc_spend.txt)
