### PR TITLE
BG-9640 decrease error noise for offline usage

### DIFF
--- a/src/bitgo.js
+++ b/src/bitgo.js
@@ -437,7 +437,7 @@ const BitGo = function(params) {
     if (err) {
       // make sure an error does not terminate the entire script
       console.error('failed to fetch initial client constants from BitGo');
-      console.trace(e.stack);
+      debug('Error stack:', e.stack);
     }
   });
 };


### PR DESCRIPTION
Let's change this error stack log to a "debug" to allow offline usage of the SDK without scary error messages.