### PR TITLE
BG-9640 suppress offline error message

### DIFF
--- a/src/bitgo.js
+++ b/src/bitgo.js
@@ -437,7 +437,7 @@ const BitGo = function(params) {
     if (err) {
       // make sure an error does not terminate the entire script
       console.error('failed to fetch initial client constants from BitGo');
-      console.trace(e.stack);
+      debug(e.stack);
     }
   });
 };


### PR DESCRIPTION
Let's not print a big scary error message if users want to use bitgo offline. Instead leave the one-line warning log, but move the big stack trace message to "debug".