### PR TITLE
chore: update node version in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:boron
+FROM node:lts
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY package.json /usr/src/app/


### PR DESCRIPTION
With node:boron the docker container would return an exit code of -1 on build.

This commit updates node version in the Dockerfile to allow for container to be built successfully.

