### PR TITLE
[BG-10112] must include amount for altcoins

### DIFF
--- a/src/v2/coins/abstractUtxoCoin.js
+++ b/src/v2/coins/abstractUtxoCoin.js
@@ -1207,7 +1207,7 @@ class AbstractUtxoCoin extends BaseCoin {
           chainPath: address.chainPath,
           redeemScript: address.redeemScript.toString('hex'),
           witnessScript: address.witnessScript && address.witnessScript.toString('hex'),
-          value: unspent.value_int
+          value: unspent.amount
         };
       });
 


### PR DESCRIPTION
The recovery route was not including the amount for some altcoins, because it had a different name ("value_int" vs "amount") when getting it from the public block explorer