### PR TITLE
BG-10483: Adding SUSD coin to SDK

### DIFF
--- a/src/v2/baseCoin.js
+++ b/src/v2/baseCoin.js
@@ -205,6 +205,11 @@ class BaseCoin {
       BaseCoin.setupOffchainTokens(coins, bitgo);
     }
 
+    if (process.env.BITGO_EXCLUDE_SUSD !== 'exclude') {
+      coins.susd = require('./coins/susd');
+      coins.tsusd = require('./coins/tsusd');
+    }
+
     return coins;
   }
 

--- a/src/v2/coins/susd.js
+++ b/src/v2/coins/susd.js
@@ -1,0 +1,33 @@
+const BaseCoin = require('../baseCoin');
+
+class Susd extends BaseCoin {
+
+  /**
+   * Returns the factor between the base unit and its smallest subdivison
+   * @return {number}
+   */
+  getBaseFactor() {
+    return 1e2;
+  }
+
+  getChain() {
+    return 'susd';
+  }
+
+  getFamily() {
+    return 'susd';
+  }
+
+  getFullName() {
+    return 'Silvergate USD';
+  }
+
+  /**
+   * Return whether the given m of n wallet signers/ key amounts are valid for the coin
+   */
+  isValidMofNSetup({ m, n }) {
+    return m === 0 && n === 0;
+  }
+}
+
+module.exports = Susd;

--- a/src/v2/coins/tsusd.js
+++ b/src/v2/coins/tsusd.js
@@ -1,0 +1,18 @@
+const Susd = require('./susd');
+
+class Tsusd extends Susd {
+
+  constructor() {
+    super();
+  }
+
+  getChain() {
+    return 'tsusd';
+  }
+
+  getFullName() {
+    return 'Test Silvergate USD';
+  }
+}
+
+module.exports = Tsusd;

--- a/test/v2/unit/coins/ofcToken.js
+++ b/test/v2/unit/coins/ofcToken.js
@@ -30,7 +30,7 @@ describe('OFC:', function() {
         payload: '{\"token\":\"otestusd\"}',
         signature: '2049b94a22c69650ad9529767da993a23c078347fdf7d887409793dce8d07190e108a846869edf387d294cd75c6c770a12847615b2553b22a61de29be5d91770dd',
       }
-    }
+    };
 
     const signedResult = otestusdCoin.signTransaction(inputParams);
     signedResult.should.deepEqual(expectedResult);

--- a/test/v2/unit/coins/susd.js
+++ b/test/v2/unit/coins/susd.js
@@ -1,0 +1,27 @@
+require('should');
+
+const TestV2BitGo = require('../../../lib/test_bitgo');
+
+describe('SUSD:', function() {
+  let bitgo;
+  let susdCoin;
+
+  before(function() {
+    bitgo = new TestV2BitGo({ env: 'test' });
+    bitgo.initializeTestVars();
+    susdCoin = bitgo.coin('susd');
+  });
+
+  it('functions that return constants', function() {
+    susdCoin.getChain().should.equal('susd');
+    susdCoin.getFullName().should.equal('Silvergate USD');
+    susdCoin.getFamily().should.equal('susd');
+    susdCoin.getBaseFactor().should.equal(100);
+  });
+
+  it('isValidMofNSetup', function() {
+    susdCoin.isValidMofNSetup({ m: 2, n: 3 }).should.be.false();
+    susdCoin.isValidMofNSetup({ m: 1, n: 3 }).should.be.false();
+    susdCoin.isValidMofNSetup({ m: 0, n: 0 }).should.be.true();
+  });
+});


### PR DESCRIPTION
I did the bare minimum so that the coin itself can be used when requesting resources from the server. The following should work:
```
const Promise = require('Bluebird');
const co = Promise.coroutine;
const BitGoJS = require('../src/index.js');

const env = 'localNonSecure';
const accessToken = 'v2x1234';

const bitgo = new BitGoJS.BitGo({ env });

co(function *() {
  bitgo.authenticateWithAccessToken({ accessToken });

  const res = yield bitgo.coin('tsusd').pendingApprovals().list({ walletId: '5c0edba1a1d79908e1409f8b4612f5da' }); // you have to be a user on the wallet
  console.log(res.pendingApprovals[0]);
})();
```