### PR TITLE
BG-10687: Allow fetching and usage of ledger segwit unspents

### DIFF
--- a/src/transactionBuilder.js
+++ b/src/transactionBuilder.js
@@ -29,6 +29,7 @@ const debug = require('debug')('bitgo:v1:txb');
 //   minUnspentSize: The minimum size in satoshis of unspent to use (to prevent spending unspents worth less than fee added). Defaults to 0.
 //   feeSingleKeySourceAddress: Use this single key address to pay fees
 //   feeSingleKeyWIF: Use the address based on this private key to pay fees
+//   unspentsFetchParams: Extra parameters to use for fetching unspents for this transaction
 exports.createTransaction = function(params) {
   const minConfirms = params.minConfirms || 0;
   const validate = params.validate === undefined ? true : params.validate;
@@ -55,7 +56,8 @@ exports.createTransaction = function(params) {
   (params.unspents && (!Array.isArray(params.unspents) || params.unspents.length < 1)) ||
   (params.feeTxConfirmTarget && !_.isInteger(params.feeTxConfirmTarget)) ||
   (params.instant && !_.isBoolean(params.instant)) ||
-  (params.bitgoFee && !_.isObject(params.bitgoFee))
+  (params.bitgoFee && !_.isObject(params.bitgoFee)) ||
+  (params.unspentsFetchParams && !_.isObject(params.unspentsFetchParams))
   ) {
     throw new Error('invalid argument');
   }
@@ -276,12 +278,12 @@ exports.createTransaction = function(params) {
     }
 
     // Get enough unspents for the requested amount
-    const options = {
+    const options = _.merge({}, params.unspentsFetchParams || {}, {
       target: totalAmount,
       minSize: params.minUnspentSize || 0,
       instant: params.instant, // insist on instant unspents only
       targetWalletUnspents: params.targetWalletUnspents
-    };
+    });
     if (params.instant) {
       options.instant = params.instant; // insist on instant unspents only
     }

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -635,6 +635,7 @@ Wallet.prototype.unspents = function(params, callback) {
  * @param params.targetWalletUnspents desired number of unspents to have in the wallet after the tx goes through (requires target)
  * @param params.minSize minimum unspent size in satoshis
  * @param params.segwit request segwit unspents (defaults to true if undefined)
+ * @param params.allowLedgerSegwit allow segwit unspents for ledger devices (defaults to false if undefined)
  * @param callback
  * @returns {*}
  */
@@ -672,6 +673,9 @@ Wallet.prototype.unspentsPaged = function(params, callback) {
   if (!_.isUndefined(params.targetWalletUnspents) && _.isUndefined(params.target)) {
     throw new Error('targetWalletUnspents can only be specified in conjunction with a target');
   }
+  if (!_.isUndefined(params.allowLedgerSegwit) && !_.isBoolean(params.allowLedgerSegwit)) {
+    throw new Error('invalid argument: allowLedgerSegwit must be a boolean');
+  }
 
   const queryObject = _.cloneDeep(params);
 
@@ -684,6 +688,10 @@ Wallet.prototype.unspentsPaged = function(params, callback) {
   queryObject.segwit = true;
   if (!_.isUndefined(params.segwit)) {
     queryObject.segwit = params.segwit;
+  }
+
+  if (!_.isUndefined(params.allowLedgerSegwit)) {
+    queryObject.allowLedgerSegwit = params.allowLedgerSegwit;
   }
 
   return this.bitgo.get(this.url('/unspents'))


### PR DESCRIPTION
This change allows you to request segwit ledger unspents from `wallet.unspents()`, as well as allowing you to pass in custom unspent fetch params to `TransactionBuilder.createTransaction()`. The custom unspent fetch params will be passed to `wallet.unspents()` inside `createTransaction()`.

This change also adds a test to ensure that custom unspent fetch params are correctly passed from `createTransaction()` through to `wallet.unspents()`