### PR TITLE
BG-10632 / SDK to Microservices connection

### DIFF
--- a/src/bitgo.js
+++ b/src/bitgo.js
@@ -219,6 +219,7 @@ const BitGo = function(params) {
     this._baseUrl = common.Environments[env].uri;
   }
 
+  this._microservicesUrl = params.microservicesUri;
   this._baseApiUrl = this._baseUrl + '/api/v1';
   this._baseApiUrlV2 = this._baseUrl + '/api/v2';
   this._user = null;
@@ -1089,7 +1090,9 @@ BitGo.prototype.authenticate = function(params, callback) {
     return this.reject('already logged in', callback);
   }
 
-  const request = this.post(this.url('/user/login'));
+  const authUrl = this._microservicesUrl ? this.microservicesUrl('/api/v1/auth/session') : this.url('/user/login');
+  const request = this.post(authUrl);
+
   if (forceV1Auth) {
     request.forceV1Auth = true;
     // tell the server that the client was forced to downgrade the authentication protocol
@@ -1704,6 +1707,10 @@ BitGo.prototype.newWalletObject = function(walletParams) {
 BitGo.prototype.url = function(path, version = 1) {
   const baseUrl = version === 2 ? this._baseApiUrlV2 : this._baseApiUrl;
   return baseUrl + path;
+};
+
+BitGo.prototype.microservicesUrl = function(path) {
+  return this._microservicesUrl + path;
 };
 
 //

--- a/test/unit/bitgo.js
+++ b/test/unit/bitgo.js
@@ -75,6 +75,40 @@ describe('BitGo Prototype Methods', function() {
     });
   });
 
+  describe('Authenticate in Microservices', () => {
+    let bitgo;
+    const microservicesUri = 'https://microservices.uri';
+    const uri = 'https://test.bitgo.com';
+    const authenticateRequest = {
+      username: 'test@bitgo.com',
+      password: 'password',
+      otp: '000000',
+      extensible: false,
+      extensionAddress: "address",
+      forceSMS: false
+    }
+
+    it('goes to microservices', () => {
+      bitgo = new TestBitGo({env: 'custom', microservicesUri });
+      const scope = nock(microservicesUri)
+        .post('/api/v1/auth/session')
+        .reply(200, {user: 'test@bitgo.com', access_token: 'token12356'});
+
+      const response = bitgo.authenticate(authenticateRequest);
+      scope.isDone().should.be.true();
+    });
+
+    it('goes to normal uri', () => {
+      bitgo = new TestBitGo();
+      const scope = nock(uri)
+        .post('/api/v1/user/login')
+        .reply(200, {user: 'test@bitgo.com', access_token: 'token12356'});
+
+      const response = bitgo.authenticate(authenticateRequest);
+      scope.isDone().should.be.true();
+    });
+  });
+
   describe('Verify Address', () => {
     let bitgo;
     before(() => {


### PR DESCRIPTION
We need to add a connection to the microservices api
the client microservices will use the sdk to make the requests to the backend microservices.
this allows client microservices to use the authenticate method of the sdk to call teh auth-service login method instead of platform login method
client microservices can also make sdk calls using the microservicesUrl that is passed in.