### PR TITLE
BG-9575 - Add root private key for wallet add

### DIFF
--- a/src/v2/wallets.js
+++ b/src/v2/wallets.js
@@ -131,6 +131,13 @@ Wallets.prototype.add = function(params, callback) {
     walletParams.rootPub = params.rootPub;
   }
 
+  // In XLM this private key is used only for wallet creation purposes, once the wallet is initialized then we
+  // update its weight to 0 making it an invalid key.
+  // https://www.stellar.org/developers/guides/concepts/multi-sig.html#additional-signing-keys
+  if (params.rootPrivateKey) {
+    walletParams.rootPrivateKey = params.rootPrivateKey;
+  }
+
   if (params.initializationTxs) {
     walletParams.initializationTxs = params.initializationTxs;
   }


### PR DESCRIPTION
Jira Ticket: [BG-9575](https://bitgoinc.atlassian.net/browse/BG-9575)

We need to pass the root private when we create the wallet so that the keycard matches with the wallet root address.

API already supports this, we just need to update sdk to pass the parameter along.

## Test:

- Create an stellar wallet using: https://github.com/BitGo/bitgo-client-private/pull/1076
- After the wallet is created the keycard box C must be the wallet address