### PR TITLE
BG-6956: Fix access of undefined property in createAddress

### DIFF
--- a/src/v2/wallet.js
+++ b/src/v2/wallet.js
@@ -682,6 +682,7 @@ Wallet.prototype.createAddress = function({ chain, gasPrice, count = 1, label, b
 
     // get keychains for address verification
     const keychains = yield Promise.map(this._wallet.keys, k => this.baseCoin.keychains().get({ id: k, reqId }));
+    const rootAddress = _.get(this._wallet, 'receiveAddress.address');
 
     const newAddresses = _.times(count, co(function *createAndVerifyAddress() {
       this.bitgo._reqId = reqId;
@@ -695,7 +696,7 @@ Wallet.prototype.createAddress = function({ chain, gasPrice, count = 1, label, b
       }
 
       newAddress.keychains = keychains;
-      const verificationData = _.merge({}, newAddress, { rootAddress: this._wallet.receiveAddress.address });
+      const verificationData = _.merge({}, newAddress, { rootAddress });
       this.baseCoin.verifyAddress(verificationData);
 
       return newAddress;

--- a/test/v2/integration/wallet.js
+++ b/test/v2/integration/wallet.js
@@ -53,6 +53,15 @@ describe('V2 Wallet:', function() {
       });
     });
 
+    it('should create a new address from a listed wallet', co(function *() {
+      const { wallets: walletsListing } = yield wallets.list();
+
+      // there is one known bad wallet with missing keychains. This will break this test, so filter it out
+      const wallet = _(walletsListing).filter(w => w.id() !== '585cc6eb16efb0a50675fe4e3054662b').sample();
+      const { address } = yield wallet.createAddress('listed wallet address');
+      basecoin.isValidAddress(address).should.be.True();
+    }));
+
     it('should create new addresses in bulk', co(function *() {
       const result = yield wallet.createAddress({ count: 3 });
       result.should.have.property('addresses');


### PR DESCRIPTION
Only wallets returned from wallet.get() will have the receiveAddress property,
and specifically, wallets returned from wallets.list() will not have this property.

This causes an access of an undefined property when we try to create a
new address on these wallets.

Signed-off-by: Tyler Levine <tyler@bitgo.com>