### PR TITLE
BG-11239: Handle undefined txInfo for p2sh-p2wsh txs in `explainTransaction()`

### DIFF
--- a/src/v2/coins/abstractUtxoCoin.js
+++ b/src/v2/coins/abstractUtxoCoin.js
@@ -996,7 +996,7 @@ class AbstractUtxoCoin extends BaseCoin {
       const sigScript = this.parseSignatureScript(transaction, idx);
 
       if (hasWitnessScript) {
-        if (!txInfo.unspents) {
+        if (!txInfo || !txInfo.unspents) {
           // segwit txs require input values, cannot validate signatures
           debug('unable to retrieve input amounts from unspents - cannot validate segwit input signatures');
           return 0;

--- a/test/v2/unit/coins/btc.js
+++ b/test/v2/unit/coins/btc.js
@@ -430,6 +430,19 @@ describe('BTC:', function() {
       });
 
       describe('success', () => {
+        it('should handle undefined tx info for segwit transactions', () => {
+          const { signatures, inputSignatures } = coin.explainTransaction({
+            txHex: txs['p2sh-p2wsh'].halfSigned
+          });
+
+          should.exist(signatures);
+          signatures.should.equal(0);
+
+          should.exist(inputSignatures);
+          inputSignatures.should.have.length(2);
+          inputSignatures.should.deepEqual([0, 0]);
+        });
+
         it('should count zero signatures on an unsigned transaction', () => {
           const { signatures, inputSignatures } = coin.explainTransaction({
             txHex: unsignedTx


### PR DESCRIPTION
Signed-off-by: Tyler Levine <tyler@bitgo.com>