### PR TITLE
BG-8732: Clean up usage of bech32 as a var name

### DIFF
--- a/src/v2/coins/abstractUtxoCoin.js
+++ b/src/v2/coins/abstractUtxoCoin.js
@@ -676,8 +676,8 @@ class AbstractUtxoCoin extends BaseCoin {
           txb.sign(index, privKey, prevOutScript, sigHashType, currentUnspent.value, witnessScript);
         } else {
           const subscript = new Buffer(currentUnspent.redeemScript, 'hex');
-          const isp2shP2wsh = !!currentUnspent.witnessScript;
-          if (isp2shP2wsh) {
+          const isP2shP2wsh = !!currentUnspent.witnessScript;
+          if (isP2shP2wsh) {
             debug('Signing p2shP2wsh input');
             const witnessScript = Buffer.from(currentUnspent.witnessScript, 'hex');
             txb.sign(index, privKey, subscript, sigHashType, currentUnspent.value, witnessScript);
@@ -700,7 +700,7 @@ class AbstractUtxoCoin extends BaseCoin {
         transaction = txb.buildIncomplete();
       }
 
-      // after signature validation, prepare native segwit setup
+      // after signature validation, prepare p2wsh setup
       if (isP2wsh) {
         transaction.setInputScript(index, Buffer.alloc(0));
         p2wshIndices.push(index);

--- a/src/v2/coins/bch.js
+++ b/src/v2/coins/bch.js
@@ -9,6 +9,7 @@ const _ = require('lodash');
 
 const VALID_ADDRESS_VERSIONS = {
   base58: 'base58',
+  // TODO(BG-11325): remove bech32 in future major version release
   bech32: 'bech32',
   cashaddr: 'cashaddr'
 };
@@ -47,7 +48,7 @@ class Bch extends AbstractUtxoCoin {
    * Canonicalize a Bitcoin Cash address for a specific version
    *
    * Starting on January 14th, 2018 Bitcoin Cash's bitcoin-abc node switched over to using cashaddr
-   * encoding for all of their addresses in order to distinguish them from Bitcoin Core's
+   * encoding for all of their addresses in order to distinguish them from Bitcoin Core's.
    * https://www.bitcoinabc.org/cashaddr. We're sticking with the old base58 format because
    * migrating over to the new format will be laborious, and we want to see how the space evolves
    *

--- a/test/v2/unit/coins/bch.js
+++ b/test/v2/unit/coins/bch.js
@@ -21,28 +21,28 @@ describe('BCH:', function() {
 
     // we use mainnet bch so we can reuse the mainnet address examples
     it('should correctly convert addresses', function() {
-      // P2PKH bech32 -> bech32
-      bch.canonicalAddress('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a', 'bech32').should.equal('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a');
+      // P2PKH cashaddr -> cashaddr
+      bch.canonicalAddress('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a', 'cashaddr').should.equal('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a');
 
-      // P2PKH base58 -> bech32
-      bch.canonicalAddress('1BpEi6DfDAUFd7GtittLSdBeYJvcoaVggu', 'bech32').should.equal('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a');
+      // P2PKH base58 -> cashaddr
+      bch.canonicalAddress('1BpEi6DfDAUFd7GtittLSdBeYJvcoaVggu', 'cashaddr').should.equal('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a');
 
-      // P2SH bech32 -> bech32
-      bch.canonicalAddress('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq', 'bech32').should.equal('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq');
+      // P2SH cashaddr -> cashaddr
+      bch.canonicalAddress('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq', 'cashaddr').should.equal('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq');
 
-      // P2SH base58 -> bech32
-      bch.canonicalAddress('3CWFddi6m4ndiGyKqzYvsFYagqDLPVMTzC', 'bech32').should.equal('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq');
+      // P2SH base58 -> cashaddr
+      bch.canonicalAddress('3CWFddi6m4ndiGyKqzYvsFYagqDLPVMTzC', 'cashaddr').should.equal('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq');
 
       // no 'bitcoincash:' prefix
-      bch.canonicalAddress('ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq', 'bech32').should.equal('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq');
+      bch.canonicalAddress('ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq', 'cashaddr').should.equal('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq');
 
-      // P2PKH bech32 -> base58
+      // P2PKH cashaddr -> base58
       bch.canonicalAddress('bitcoincash:qqq3728yw0y47sqn6l2na30mcw6zm78dzqre909m2r', 'base58').should.equal('16w1D5WRVKJuZUsSRzdLp9w3YGcgoxDXb');
 
-      // P2PKH bech32 -> base58
+      // P2PKH cashaddr -> base58
       bch.canonicalAddress('16w1D5WRVKJuZUsSRzdLp9w3YGcgoxDXb', 'base58').should.equal('16w1D5WRVKJuZUsSRzdLp9w3YGcgoxDXb');
 
-      // P2SH bech32 -> base58
+      // P2SH cashaddr -> base58
       bch.canonicalAddress('bitcoincash:pr95sy3j9xwd2ap32xkykttr4cvcu7as4yc93ky28e', 'base58').should.equal('3LDsS579y7sruadqu11beEJoTjdFiFCdX4');
 
       // P2SH base58 -> base58
@@ -55,12 +55,12 @@ describe('BCH:', function() {
       bch.canonicalAddress('bitcoincash:QQQ3728YW0Y47SQN6L2NA30MCW6ZM78DZQRE909M2R', 'base58').should.equal('16w1D5WRVKJuZUsSRzdLp9w3YGcgoxDXb');
 
       // testnet addresses
-      tbch.canonicalAddress('2NCEDmmKNNnqKvnWw7pE3RLzuFe5aHHVy1X', 'bech32').should.equal('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f');
-      tbch.canonicalAddress('n3jYBjCzgGNydQwf83Hz6GBzGBhMkKfgL1', 'bech32').should.equal('bchtest:qremgr9dr9x5swv82k69qdjzrvdxgkaaesftdp5xla');
-      tbch.canonicalAddress('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'bech32').should.equal('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f');
+      tbch.canonicalAddress('2NCEDmmKNNnqKvnWw7pE3RLzuFe5aHHVy1X', 'cashaddr').should.equal('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f');
+      tbch.canonicalAddress('n3jYBjCzgGNydQwf83Hz6GBzGBhMkKfgL1', 'cashaddr').should.equal('bchtest:qremgr9dr9x5swv82k69qdjzrvdxgkaaesftdp5xla');
+      tbch.canonicalAddress('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'cashaddr').should.equal('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f');
       tbch.canonicalAddress('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'base58').should.equal('2NCEDmmKNNnqKvnWw7pE3RLzuFe5aHHVy1X');
       tbch.canonicalAddress('prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'base58').should.equal('2NCEDmmKNNnqKvnWw7pE3RLzuFe5aHHVy1X');
-      tbch.canonicalAddress('prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'bech32').should.equal('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f');
+      tbch.canonicalAddress('prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'cashaddr').should.equal('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f');
     });
 
     it('should reject invalid addresses', function() {
@@ -69,7 +69,7 @@ describe('BCH:', function() {
         bch.canonicalAddress('bitcoincash:sy3j9xwd2ap32xkykttr4cvcu7as4yc93ky28e', 'base58');
       });
 
-      // mismatched data segment (bech32)
+      // mismatched data segment (cashaddr)
       assert.throws(function() {
         bch.canonicalAddress('bitcoincash:yr95sy3j9xwd2ap32xkykttr4cvcu7as4yc93ky28e', 'base58');
       });
@@ -94,7 +94,7 @@ describe('BCH:', function() {
 
       // mismatched capitalization
       assert.throws(function() {
-        bch.canonicalAddress('bitcoincash:QPM2Qsznhks23z7629mms6s4cwef74vcwvy22gdx6a', 'bech32');
+        bch.canonicalAddress('bitcoincash:QPM2Qsznhks23z7629mms6s4cwef74vcwvy22gdx6a', 'cashaddr');
       });
 
       // improper version

--- a/test/v2/unit/coins/bch.js
+++ b/test/v2/unit/coins/bch.js
@@ -23,23 +23,33 @@ describe('BCH:', function() {
     it('should correctly convert addresses', function() {
       // P2PKH cashaddr -> cashaddr
       bch.canonicalAddress('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a', 'cashaddr').should.equal('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a');
+      // TODO(BG-11325): remove bech32 in future major version release
+      bch.canonicalAddress('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a', 'bech32').should.equal('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a');
 
       // P2PKH base58 -> cashaddr
       bch.canonicalAddress('1BpEi6DfDAUFd7GtittLSdBeYJvcoaVggu', 'cashaddr').should.equal('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a');
+      // TODO(BG-11325): remove bech32 in future major version release
+      bch.canonicalAddress('1BpEi6DfDAUFd7GtittLSdBeYJvcoaVggu', 'bech32').should.equal('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a');
 
       // P2SH cashaddr -> cashaddr
       bch.canonicalAddress('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq', 'cashaddr').should.equal('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq');
+      // TODO(BG-11325): remove bech32 in future major version release
+      bch.canonicalAddress('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq', 'bech32').should.equal('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq');
 
       // P2SH base58 -> cashaddr
       bch.canonicalAddress('3CWFddi6m4ndiGyKqzYvsFYagqDLPVMTzC', 'cashaddr').should.equal('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq');
+      // TODO(BG-11325): remove bech32 in future major version release
+      bch.canonicalAddress('3CWFddi6m4ndiGyKqzYvsFYagqDLPVMTzC', 'bech32').should.equal('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq');
 
       // no 'bitcoincash:' prefix
       bch.canonicalAddress('ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq', 'cashaddr').should.equal('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq');
+      // TODO(BG-11325): remove bech32 in future major version release
+      bch.canonicalAddress('ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq', 'bech32').should.equal('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq');
 
       // P2PKH cashaddr -> base58
       bch.canonicalAddress('bitcoincash:qqq3728yw0y47sqn6l2na30mcw6zm78dzqre909m2r', 'base58').should.equal('16w1D5WRVKJuZUsSRzdLp9w3YGcgoxDXb');
 
-      // P2PKH cashaddr -> base58
+      // P2PKH base58 -> base58
       bch.canonicalAddress('16w1D5WRVKJuZUsSRzdLp9w3YGcgoxDXb', 'base58').should.equal('16w1D5WRVKJuZUsSRzdLp9w3YGcgoxDXb');
 
       // P2SH cashaddr -> base58
@@ -56,11 +66,19 @@ describe('BCH:', function() {
 
       // testnet addresses
       tbch.canonicalAddress('2NCEDmmKNNnqKvnWw7pE3RLzuFe5aHHVy1X', 'cashaddr').should.equal('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f');
+      // TODO(BG-11325): remove bech32 in future major version release
+      tbch.canonicalAddress('2NCEDmmKNNnqKvnWw7pE3RLzuFe5aHHVy1X', 'bech32').should.equal('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f');
       tbch.canonicalAddress('n3jYBjCzgGNydQwf83Hz6GBzGBhMkKfgL1', 'cashaddr').should.equal('bchtest:qremgr9dr9x5swv82k69qdjzrvdxgkaaesftdp5xla');
+      // TODO(BG-11325): remove bech32 in future major version release
+      tbch.canonicalAddress('n3jYBjCzgGNydQwf83Hz6GBzGBhMkKfgL1', 'bech32').should.equal('bchtest:qremgr9dr9x5swv82k69qdjzrvdxgkaaesftdp5xla');
       tbch.canonicalAddress('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'cashaddr').should.equal('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f');
+      // TODO(BG-11325): remove bech32 in future major version release
+      tbch.canonicalAddress('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'bech32').should.equal('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f');
       tbch.canonicalAddress('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'base58').should.equal('2NCEDmmKNNnqKvnWw7pE3RLzuFe5aHHVy1X');
       tbch.canonicalAddress('prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'base58').should.equal('2NCEDmmKNNnqKvnWw7pE3RLzuFe5aHHVy1X');
       tbch.canonicalAddress('prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'cashaddr').should.equal('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f');
+      // TODO(BG-11325): remove bech32 in future major version release
+      tbch.canonicalAddress('prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'bech32').should.equal('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f');
     });
 
     it('should reject invalid addresses', function() {
@@ -95,6 +113,11 @@ describe('BCH:', function() {
       // mismatched capitalization
       assert.throws(function() {
         bch.canonicalAddress('bitcoincash:QPM2Qsznhks23z7629mms6s4cwef74vcwvy22gdx6a', 'cashaddr');
+      });
+
+      // TODO(BG-11325): remove bech32 in future major version release
+      assert.throws(function() {
+        bch.canonicalAddress('bitcoincash:QPM2Qsznhks23z7629mms6s4cwef74vcwvy22gdx6a', 'bech32');
       });
 
       // improper version

--- a/test/v2/unit/coins/btc.js
+++ b/test/v2/unit/coins/btc.js
@@ -101,7 +101,7 @@ describe('BTC:', function() {
       testCoin.isValidAddress(generatedAddress.address).should.equal(false);
     });
 
-    it('should generate native bech32 address', function() {
+    it('should generate native segwit bech32 address', function() {
       const generatedAddress = coin.generateAddress({ keychains, addressType: AbstractUtxoCoin.AddressTypes.P2WSH });
       const generatedTestAddress = testCoin.generateAddress({ keychains, addressType: AbstractUtxoCoin.AddressTypes.P2WSH });
 
@@ -170,7 +170,7 @@ describe('BTC:', function() {
       testCoin.isValidAddress(generatedAddress.address).should.equal(false);
     });
 
-    it('should generate 3/3 custom chain native bech32 address', function() {
+    it('should generate 3/3 custom chain native segwit bech32 address', function() {
       const generatedAddress = coin.generateAddress({
         keychains,
         threshold: 3,
@@ -209,7 +209,7 @@ describe('BTC:', function() {
     });
   });
 
-  describe('Bech32 transaction signing:', function() {
+  describe('Native segwit transaction signing:', function() {
 
     let basecoin;
     let wallet;

--- a/test/v2/unit/coins/btc.js
+++ b/test/v2/unit/coins/btc.js
@@ -101,7 +101,7 @@ describe('BTC:', function() {
       testCoin.isValidAddress(generatedAddress.address).should.equal(false);
     });
 
-    it('should generate native segwit bech32 address', function() {
+    it('should generate p2wsh bech32 address', function() {
       const generatedAddress = coin.generateAddress({ keychains, addressType: AbstractUtxoCoin.AddressTypes.P2WSH });
       const generatedTestAddress = testCoin.generateAddress({ keychains, addressType: AbstractUtxoCoin.AddressTypes.P2WSH });
 
@@ -143,7 +143,7 @@ describe('BTC:', function() {
       testCoin.isValidAddress(generatedAddress.address).should.equal(false);
     });
 
-    it('should generate 3/3 custom chain p2sh-wrapped segwit address', function() {
+    it('should generate 3/3 custom chain p2shP2sh address', function() {
       const generatedAddress = coin.generateAddress({ keychains, threshold: 3, addressType: AbstractUtxoCoin.AddressTypes.P2SH_P2WSH, chain: 20, index: 756 });
       const generatedTestAddress = testCoin.generateAddress({
         keychains,
@@ -170,7 +170,7 @@ describe('BTC:', function() {
       testCoin.isValidAddress(generatedAddress.address).should.equal(false);
     });
 
-    it('should generate 3/3 custom chain native segwit bech32 address', function() {
+    it('should generate 3/3 custom chain p2wsh bech32 address', function() {
       const generatedAddress = coin.generateAddress({
         keychains,
         threshold: 3,
@@ -209,7 +209,7 @@ describe('BTC:', function() {
     });
   });
 
-  describe('Native segwit transaction signing:', function() {
+  describe('p2wsh transaction signing:', function() {
 
     let basecoin;
     let wallet;

--- a/test/v2/unit/coins/ltc.js
+++ b/test/v2/unit/coins/ltc.js
@@ -100,7 +100,7 @@ describe('LTC:', function() {
       testCoin.verifyAddress(_.extend({}, generatedTestAddress, { keychains }));
     });
 
-    it('should generate custom chain bech32 p2wsh address', () => {
+    it('should generate custom chain p2wsh bech32 address', () => {
       const generatedAddress = coin.generateAddress({ keychains, chain: 21, index: 113, addressType: AbstractUtxoCoin.AddressTypes.P2WSH });
       const generatedTestAddress = testCoin.generateAddress({ keychains, chain: 21, index: 113, addressType: AbstractUtxoCoin.AddressTypes.P2WSH });
 


### PR DESCRIPTION
- BCH cashaddr addresses were incorrectly being called bech32
  addresses. Cashaddr is similar to bech32 but not the same so this
  was cleaned up to avoid confusion between the two.
- Bech32 was being used in abstractUtxoCoin to describe inputs.
  Bech32 is an address format; native segwit is the input type.
  This was cleaned up as well.