### PR TITLE
BG-11426: Treat errors thrown from verifySignature as invalid signatures

### DIFF
--- a/src/v2/coins/abstractUtxoCoin.js
+++ b/src/v2/coins/abstractUtxoCoin.js
@@ -1029,11 +1029,19 @@ class AbstractUtxoCoin extends BaseCoin {
             const inputId = `${parentTxId}:${input.index}`;
             const amount = unspentValues[inputId];
 
-            return this.verifySignature(transaction, idx, amount, verificationParams);
+            try {
+              return this.verifySignature(transaction, idx, amount, verificationParams);
+            } catch (e) {
+              return false;
+            }
           }
 
           // p2sh
-          return this.verifySignature(transaction, idx, undefined, verificationParams);
+          try {
+            return this.verifySignature(transaction, idx, undefined, verificationParams);
+          } catch (e) {
+            return false;
+          }
         });
 
         return validSignatures.reduce((validCount, isValid) => isValid ? validCount + 1 : validCount, 0);


### PR DESCRIPTION
Signed-off-by: Tyler Levine <tyler@bitgo.com>