### PR TITLE
BG-10188 bump bitgo-utxo-lib version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1505,9 +1505,9 @@
       }
     },
     "bitgo-utxo-lib": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/bitgo-utxo-lib/-/bitgo-utxo-lib-1.3.0.tgz",
-      "integrity": "sha512-jry6Y97g2jr1XlY1Ou5WkWUg1rQbyioLYp9AgyK4OwZ7t2ETRyTB1rcJV9kYOlTnTjC6k+Sef+IKcZLM/u9zjA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/bitgo-utxo-lib/-/bitgo-utxo-lib-1.3.1.tgz",
+      "integrity": "sha512-kWdv12SdNVCd6xbp2vLxxN12+TgcrZAxp8hWgNC5czzvYZq3uXJDT6iAkc5amFR2DT5OCO/faP9B/NWtMnKApg==",
       "requires": {
         "bech32": "0.0.3",
         "bigi": "^1.4.0",
@@ -1545,22 +1545,6 @@
             "bs58": "^4.0.0",
             "create-hash": "^1.1.0",
             "safe-buffer": "^5.1.2"
-          }
-        },
-        "secp256k1": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.6.2.tgz",
-          "integrity": "sha512-90nYt7yb0LmI4A2jJs1grglkTAXrBwxYAjP9bpeKjvJKOjG2fOeH/YI/lchDMIvjrOasd5QXwvV2jwN168xNng==",
-          "optional": true,
-          "requires": {
-            "bindings": "^1.2.1",
-            "bip66": "^1.1.3",
-            "bn.js": "^4.11.3",
-            "create-hash": "^1.1.2",
-            "drbg.js": "^1.0.1",
-            "elliptic": "^6.2.3",
-            "nan": "^2.2.1",
-            "safe-buffer": "^5.1.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "bigi": "1.4.0",
     "bignumber.js": "8.0.1",
     "bitcoinjs-message": "2.0.0",
-    "bitgo-utxo-lib": "1.3.0",
+    "bitgo-utxo-lib": "1.3.1",
     "bluebird": "3.5.3",
     "body-parser": "1.18.3",
     "bs58": "2.0.1",


### PR DESCRIPTION
In order to build an electron app on macOS we need to fall back to `ripemd160` if `rmd160` is not supported. Updated `bitgo-utxo-lib` and released v1.3.1 to npm. 