### PR TITLE
BG-11323: Deprecate conflicting params in generateAddress

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -193,6 +193,25 @@
         }
       }
     },
+    "@bitgo/unspents": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@bitgo/unspents/-/unspents-0.5.0.tgz",
+      "integrity": "sha512-nwDYAPNwAMRObPEP2hW+7hBNd0qzp4tb7Em5T8Dg7BGGps5AbvSflb93GjUJaxSrBBkxaCrHE7E1rlWZpGMwsA==",
+      "requires": {
+        "@types/lodash": "^4.14.120",
+        "@types/node": "^10.12.18",
+        "lodash": "^4.17.11",
+        "tcomb": "^3.2.27",
+        "typescript": "^3.2.4"
+      },
+      "dependencies": {
+        "@types/lodash": {
+          "version": "4.14.123",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.123.tgz",
+          "integrity": "sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q=="
+        }
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
@@ -4243,7 +4262,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4264,12 +4284,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4284,17 +4306,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4411,7 +4436,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4423,6 +4449,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4437,6 +4464,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4444,12 +4472,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4468,6 +4498,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4548,7 +4579,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4560,6 +4592,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4645,7 +4678,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4681,6 +4715,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4700,6 +4735,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4743,12 +4779,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -10691,6 +10729,11 @@
         }
       }
     },
+    "tcomb": {
+      "version": "3.2.29",
+      "resolved": "https://registry.npmjs.org/tcomb/-/tcomb-3.2.29.tgz",
+      "integrity": "sha512-di2Hd1DB2Zfw6StGv861JoAF5h/uQVu/QJp2g8KVbtfKnoHdBQl5M32YWq6mnSYBQ1vFFrns5B1haWJL7rKaOQ=="
+    },
     "text-encoding": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
@@ -10914,6 +10957,11 @@
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
       "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
+    },
+    "typescript": {
+      "version": "3.3.4000",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.4000.tgz",
+      "integrity": "sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA=="
     },
     "uglify-js": {
       "version": "3.0.15",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "generate_drone": "drone jsonnet --stream"
   },
   "dependencies": {
+    "@bitgo/unspents": "0.5.0",
     "argparse": "1.0.10",
     "assert": "0.4.9",
     "big.js": "3.1.3",

--- a/src/errors.js
+++ b/src/errors.js
@@ -27,6 +27,18 @@ class UnsupportedCoinError extends BitGoJsError {
   }
 }
 
+class AddressTypeChainMismatchError extends BitGoJsError {
+  constructor(addressType, chain) {
+    super(`address type ${addressType} does not correspond to chain ${chain}`);
+  }
+}
+
+class P2shP2wshUnsupportedError extends BitGoJsError {
+  constructor(message) {
+    super(message || 'p2shP2wsh not supported by this coin');
+  }
+}
+
 class P2wshUnsupportedError extends BitGoJsError {
   constructor(message) {
     super(message || 'p2wsh not supported by this coin');
@@ -81,6 +93,8 @@ module.exports = {
   TlsConfigurationError,
   NodeEnvironmentError,
   WalletRecoveryUnsupported,
+  AddressTypeChainMismatchError,
+  P2shP2wshUnsupportedError,
   P2wshUnsupportedError,
   UnsupportedAddressTypeError,
   InvalidAddressError,

--- a/src/v2/coins/btc.js
+++ b/src/v2/coins/btc.js
@@ -27,6 +27,10 @@ class Btc extends AbstractUtxoCoin {
     return true;
   }
 
+  supportsP2shP2wsh() {
+    return true;
+  }
+
   supportsP2wsh() {
     return true;
   }

--- a/src/v2/coins/btg.js
+++ b/src/v2/coins/btg.js
@@ -26,6 +26,14 @@ class Btg extends Btc {
     return false;
   }
 
+  supportsP2shP2wsh() {
+    return true;
+  }
+
+  supportsP2wsh() {
+    return true;
+  }
+
   /**
    *
    * @param txBuilder

--- a/src/v2/coins/ltc.js
+++ b/src/v2/coins/ltc.js
@@ -45,6 +45,10 @@ class Ltc extends AbstractUtxoCoin {
     return false;
   }
 
+  supportsP2shP2wsh() {
+    return true;
+  }
+
   supportsP2wsh() {
     return true;
   }

--- a/test/v2/unit/coins/btc.js
+++ b/test/v2/unit/coins/btc.js
@@ -1,10 +1,10 @@
 const should = require('should');
 const Promise = require('bluebird');
 const co = Promise.coroutine;
+const { Codes } = require('@bitgo/unspents');
 
 const TestV2BitGo = require('../../../lib/test_bitgo');
 const Wallet = require('../../../../src/v2/wallet');
-const AbstractUtxoCoin = require('../../../../src/v2/coins/abstractUtxoCoin');
 
 describe('BTC:', function() {
   let bitgo;
@@ -81,19 +81,21 @@ describe('BTC:', function() {
     });
 
     it('should generate p2sh-wrapped segwit address', function() {
-      const generatedAddress = coin.generateAddress({ keychains, addressType: AbstractUtxoCoin.AddressTypes.P2SH_P2WSH });
-      const generatedTestAddress = testCoin.generateAddress({ keychains, addressType: AbstractUtxoCoin.AddressTypes.P2SH_P2WSH });
+      const addressType = Codes.UnspentTypeTcomb('p2shP2wsh');
+      const chain = Codes.forType(addressType)[Codes.PurposeTcomb('external')];
+      const generatedAddress = coin.generateAddress({ keychains, addressType, chain });
+      const generatedTestAddress = testCoin.generateAddress({ keychains, addressType, chain });
 
       [generatedAddress, generatedTestAddress].forEach((currentAddress) => {
-        currentAddress.chain.should.equal(0);
+        currentAddress.chain.should.equal(chain);
         currentAddress.index.should.equal(0);
-        currentAddress.coinSpecific.outputScript.should.equal('a91426e34781478f08fff903cb70ae67311c3f9bc6a987');
-        currentAddress.coinSpecific.redeemScript.should.equal('00209a10eb58331e95333f4a6eafd5f03e442e17e0986c824e392642e872f431b7ef');
-        currentAddress.coinSpecific.witnessScript.should.equal('5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae');
+        currentAddress.coinSpecific.outputScript.should.equal('a9147ff13f3faeba4d439ef40604f7c127951e77eb6a87');
+        currentAddress.coinSpecific.redeemScript.should.equal('00207aad7d57b238a09b5daa10ff47c54483b7f2ad47f3f0c0aa230958b9df334260');
+        currentAddress.coinSpecific.witnessScript.should.equal('52210304fcea3fb05f6e8a8fe91db2087bdd13b18102a0b10a77c1fdbb326b0ce7cec421028242a3ea9e20d4e6b78e3f0dde21aff86a623d48322681b203b6827e22d04a9d2102ceec88b222a55ec67d1414b523bcfc0f53eb6ac012ba91744a4ed8eb448d55f753ae');
       });
 
-      generatedAddress.address.should.equal('35EdsUd5eRsbcGySufrWQ8PXxFq668U5vA');
-      generatedTestAddress.address.should.equal('2MvnqwDZ7FtNwp4bzaoUP25NoAc3FmvGE1H');
+      generatedAddress.address.should.equal('3DMWk3dd5aJmwA2UVxjKcu9KdgA7k8Homg');
+      generatedTestAddress.address.should.equal('2N4uionZeh2p88wf2B6MCEr8ar2NHWEnQeQ');
 
       coin.isValidAddress(generatedAddress.address).should.equal(true);
       testCoin.isValidAddress(generatedTestAddress.address).should.equal(true);
@@ -102,19 +104,20 @@ describe('BTC:', function() {
     });
 
     it('should generate p2wsh bech32 address', function() {
-      const generatedAddress = coin.generateAddress({ keychains, addressType: AbstractUtxoCoin.AddressTypes.P2WSH });
-      const generatedTestAddress = testCoin.generateAddress({ keychains, addressType: AbstractUtxoCoin.AddressTypes.P2WSH });
-
+      const addressType = Codes.UnspentTypeTcomb('p2wsh');
+      const chain = Codes.forType(addressType)[Codes.PurposeTcomb('external')];
+      const generatedAddress = coin.generateAddress({ keychains, addressType, chain });
+      const generatedTestAddress = testCoin.generateAddress({ keychains, addressType, chain });
       [generatedAddress, generatedTestAddress].forEach((currentAddress) => {
-        currentAddress.chain.should.equal(0);
+        currentAddress.chain.should.equal(chain);
         currentAddress.index.should.equal(0);
-        currentAddress.coinSpecific.outputScript.should.equal('00209a10eb58331e95333f4a6eafd5f03e442e17e0986c824e392642e872f431b7ef');
+        currentAddress.coinSpecific.outputScript.should.equal('002090448b5ba5fde14fc4b0bfc756c4b55fe4e3854c8d21f39ee75364c0063bc73e');
         currentAddress.coinSpecific.should.not.have.property('redeemScript');
-        currentAddress.coinSpecific.witnessScript.should.equal('5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae');
+        currentAddress.coinSpecific.witnessScript.should.equal('522103cf858f42c759d590d80f3715ce59be999089e6b1f381d0f4338276546fd3a04e2102dca1ab8670d45f5213c7c9d66b2f89b50a4cbd33fd72db89ba18d3e82d3dd5ee210294b6dab0dc112831a0dc1e219769bd81d13eb38a8bdb938103f919d8dd7e004353ae');
       });
 
-      generatedAddress.address.should.equal('bc1qnggwkkpnr62nx062d6hatup7gshp0cycdjpyuwfxgt589ap3klhslqfmuc');
-      generatedTestAddress.address.should.equal('tb1qnggwkkpnr62nx062d6hatup7gshp0cycdjpyuwfxgt589ap3klhsggl5xh');
+      generatedAddress.address.should.equal('bc1qjpzgkka9lhs5l39shlr4d394tljw8p2v35sl88h82djvqp3mculqa08n0a');
+      generatedTestAddress.address.should.equal('tb1qjpzgkka9lhs5l39shlr4d394tljw8p2v35sl88h82djvqp3mculq283u4j');
 
       coin.isValidAddress(generatedAddress.address).should.equal(true);
       testCoin.isValidAddress(generatedTestAddress.address).should.equal(true);
@@ -143,26 +146,28 @@ describe('BTC:', function() {
       testCoin.isValidAddress(generatedAddress.address).should.equal(false);
     });
 
-    it('should generate 3/3 custom chain p2shP2sh address', function() {
-      const generatedAddress = coin.generateAddress({ keychains, threshold: 3, addressType: AbstractUtxoCoin.AddressTypes.P2SH_P2WSH, chain: 20, index: 756 });
+    it('should generate 3/3 custom chain p2shP2wsh address', function() {
+      const addressType = Codes.UnspentTypeTcomb('p2shP2wsh');
+      const chain = Codes.forType(addressType)[Codes.PurposeTcomb('external')];
+      const generatedAddress = coin.generateAddress({ keychains, threshold: 3, addressType, chain, index: 756 });
       const generatedTestAddress = testCoin.generateAddress({
         keychains,
         threshold: 3,
-        addressType: AbstractUtxoCoin.AddressTypes.P2SH_P2WSH,
-        chain: 20,
+        addressType: Codes.UnspentTypeTcomb('p2shP2wsh'),
+        chain,
         index: 756
       });
 
       [generatedAddress, generatedTestAddress].forEach((currentAddress) => {
-        currentAddress.chain.should.equal(20);
+        currentAddress.chain.should.equal(chain);
         currentAddress.index.should.equal(756);
-        currentAddress.coinSpecific.outputScript.should.equal('a91424ba55e2753970236fae8593ca2b49654bf9f4c487');
-        currentAddress.coinSpecific.redeemScript.should.equal('0020c8fc4f071770e15f21a13ba48c6f32421daed431a74e00e13d0187990964bbce');
-        currentAddress.coinSpecific.witnessScript.should.equal('532103db7ec7ef3c549705582d6bb5ee258b3bc14d147ec3b069dfd4fd80adb4e9373e210387b1f7cacb6e0c78b79062e94ed0aee691bdfa34a0d1b522103c434205587ad52102044a9f965fd9b54d82e5afe9d4338d0f59027a4e11cff3a39b90fbf5978ae7e753ae');
+        currentAddress.coinSpecific.outputScript.should.equal('a914ad395d176042ce737e4f5b65c0eb5de703a4e80087');
+        currentAddress.coinSpecific.redeemScript.should.equal('0020d15d8d124adb4c213905ebb2cec8517faf38ae0ec4f7b4f1cfa358e6cc06a93d');
+        currentAddress.coinSpecific.witnessScript.should.equal('532102bb8096d5c12e8b0ee50dd2b14f63dd09c8494b5a0a730794a0e392a6f2a3b2a8210366dbf2135105dc65eed5173c1acf1a902fc2e9dd366b9a6fa0e682c0fb4c21a32102bf998121d4d09d4305b025b5d2de8a7e954fe96179a1dfc076ad11ad4751c99e53ae');
       });
 
-      generatedAddress.address.should.equal('353DUGPtAEGj551Vf3esXMdaaY96ytsub2');
-      generatedTestAddress.address.should.equal('2MvbRY1Kumgn5Gre3LBGk9JcqntMGk22Y72');
+      generatedAddress.address.should.equal('3HUwYRepxeeHMedeU9tTkMRF3Udi6ZibEj');
+      generatedTestAddress.address.should.equal('2N939cAara79dZSGC9HWLNJQWFpqsutd5dW');
 
       coin.isValidAddress(generatedAddress.address).should.equal(true);
       testCoin.isValidAddress(generatedTestAddress.address).should.equal(true);
@@ -174,14 +179,14 @@ describe('BTC:', function() {
       const generatedAddress = coin.generateAddress({
         keychains,
         threshold: 3,
-        addressType: AbstractUtxoCoin.AddressTypes.P2WSH,
+        addressType: Codes.UnspentTypeTcomb('p2wsh'),
         chain: 20,
         index: 756
       });
       const generatedTestAddress = testCoin.generateAddress({
         keychains,
         threshold: 3,
-        addressType: AbstractUtxoCoin.AddressTypes.P2WSH,
+        addressType: Codes.UnspentTypeTcomb('p2wsh'),
         chain: 20,
         index: 756
       });
@@ -287,7 +292,7 @@ describe('BTC:', function() {
           coinSpecific: {
             witnessScript: '522103d4788cda52f91c1f6c82eb91491ca76108c9c5f0839bc4f02eccc55fedb3311c210391bcef9dcc89570a79ba3c7514e65cd48e766a8868eca2769fa9242fdcc796662102ef3c5ebac4b54df70dea1bb2655126368be10ca0462382fcb730e55cddd2dd6a53ae'
           },
-          addressType: AbstractUtxoCoin.AddressTypes.P2WSH
+          addressType: Codes.UnspentTypeTcomb('p2wsh')
         },
         pendingApprovals: []
       };
@@ -309,7 +314,7 @@ describe('BTC:', function() {
               witnessScript: '522103d4788cda52f91c1f6c82eb91491ca76108c9c5f0839bc4f02eccc55fedb3311c210391bcef9dcc89570a79ba3c7514e65cd48e766a8868eca2769fa9242fdcc796662102ef3c5ebac4b54df70dea1bb2655126368be10ca0462382fcb730e55cddd2dd6a53ae',
               id: '0296ef0ac1c035e52e6e3f415ab20649730646dfda5a67122087dd96d9828fd5:0',
               address: 'tb1qtxxqmkkdx4n4lcp0nt2cct89uh3h3dlcu940kw9fcqyyq36peh0st94hfp',
-              addressType: AbstractUtxoCoin.AddressTypes.P2WSH,
+              addressType: Codes.UnspentTypeTcomb('p2wsh'),
               value: 10000000
             }
           ],
@@ -360,7 +365,7 @@ describe('BTC:', function() {
   describe('Explain transaction:', () => {
 
     describe('Signature count:', () => {
-      // p2sh, p2wsh, p2sh-p2wsh does not matter for unsigned inputs, so we will only test one
+      // p2sh, p2wsh, p2shP2wsh does not matter for unsigned inputs, so we will only test one
       const unsignedTx = '0100000002ece0eb669e085aeb13527e3f20873caa2845a9196c5dc23bd3d366da46996c9e0100000000ffffffff471f27cdf9f75a0e610281cb8d7b5caa44cd3a5d7048fabf9acbededdb709a590100000000ffffffff0240420f000000000017a914a364c319fddbc93dafdaa9d006d728961958a03f87eee80a000000000017a914e006ca6b2a68ce7ee9d9e3cbf62af153b8ae3420876e011600';
 
       const p2shP2wshUnspents = [
@@ -379,7 +384,7 @@ describe('BTC:', function() {
           halfSigned: '0100000001accf0cd2599ea4d6d8b032405f9396fe218c247b661e58cf3e9e4bb3c095426828000000b700483045022100cd5a6a660f56da89f7b27e566406e90282f4120bffef1918518f744a6bb3209f022055774755ee323dae0b555a2f5b8f548c20b905b6a7fe954d1d93e415c71e77060100004c6952210272ed48816a9600b7262388e3ae9d9faf1a14ff773350835c784dde916ce7bfff2103c388215ac5a6400db9ec2a3d69e965f3c30ad6935d729c9cef083124646ae5482102bc24b831b847b501dbcbb383fbc64138043573ad766968e0ee66744e00bf08a353aeffffffff01ce15fa020000000017a9147676db43fea61814cf0e2317b5e9b336054f8a2e87ad600800',
           fullySigned: '0100000001accf0cd2599ea4d6d8b032405f9396fe218c247b661e58cf3e9e4bb3c095426828000000fdfd0000483045022100cd5a6a660f56da89f7b27e566406e90282f4120bffef1918518f744a6bb3209f022055774755ee323dae0b555a2f5b8f548c20b905b6a7fe954d1d93e415c71e77060147304402200476814f5ec0b4ded9b57414395ac7deda570339fb5d71377b9fc896c1d6e78b0220249237943e11062592c32f4f68d8ef03372bf16a83e8846d6effdba0a6ada020014c6952210272ed48816a9600b7262388e3ae9d9faf1a14ff773350835c784dde916ce7bfff2103c388215ac5a6400db9ec2a3d69e965f3c30ad6935d729c9cef083124646ae5482102bc24b831b847b501dbcbb383fbc64138043573ad766968e0ee66744e00bf08a353aeffffffff01ce15fa020000000017a9147676db43fea61814cf0e2317b5e9b336054f8a2e87ad600800'
         },
-        ['p2sh-p2wsh']: {
+        p2shP2wsh: {
           halfSigned: '0100000000010283c93cf99e7b8dc0de81dedd9f0903e8dfae93509c9c1e63459a24ceeb5a67c10100000023220020dced90433eee50a13a9a5e3a01d4f011eda3832cfe7078202f435125908a8023ffffffffd7228a6a98b73a02bec7f3a8709966a19e6985efd7cd26eb396eacb105b6d61c0000000023220020d3943e78dc44bbaddb8c5ff3f24956efb3175a019d01b5690841910c219b5f01ffffffff02c9370f000000000017a9142f2ddab3f793ceab164ed186afa4dfec9eb9c9e58740420f000000000017a9145bac3641fa38b9dad47a2a027d3a39e38b476124870500483045022100ec86cfba7d76fa7b9fb39ff56a3b708eee06d1cfefe9266455f16db5b37654c80220219158789c81dac85d04bbb584255c4cd0fdc2dbc3690cc18b29f04a2ffa193201000069522102d31024f6184956b730294a1275383c6d57c8fcfdfebb4870fd91882b1c08a8a821028f4b8d4508169c746a2381155bf7cbfa56eeff237937040597e7be632ff74719210315f8700de6902daa99e4c511b008e5018d8f3b586143183f80ab97db8fde770a53ae0500483045022100e37c1cf55b9f23b4ef0bfb018fb54eaae8a5541635269f06176b4f715151a9d102202b057455a3353ba1e2e32526d55e267e957ba00fe416ac59458bf9c1b5044e690100006952210311322726192eb6cbbec6445514d148722a936d5805360be2faf2f8adc8b5aec42102d2e6cf4c6dcdc8e3e1633e7e64b2e41f5be4a583934adbf1f2372240f41b59ae21023799f2560c321587ae734da2d1faafa7c4931145b4b785a3263fa5aa193a208753ae7f011600',
           fullySigned: '0100000000010283c93cf99e7b8dc0de81dedd9f0903e8dfae93509c9c1e63459a24ceeb5a67c10100000023220020dced90433eee50a13a9a5e3a01d4f011eda3832cfe7078202f435125908a8023ffffffffd7228a6a98b73a02bec7f3a8709966a19e6985efd7cd26eb396eacb105b6d61c0000000023220020d3943e78dc44bbaddb8c5ff3f24956efb3175a019d01b5690841910c219b5f01ffffffff02c9370f000000000017a9142f2ddab3f793ceab164ed186afa4dfec9eb9c9e58740420f000000000017a9145bac3641fa38b9dad47a2a027d3a39e38b476124870400483045022100ec86cfba7d76fa7b9fb39ff56a3b708eee06d1cfefe9266455f16db5b37654c80220219158789c81dac85d04bbb584255c4cd0fdc2dbc3690cc18b29f04a2ffa19320147304402206c6c7760d7acbd595e8649e80e64a67aee8a7b1d16ca9e6b090d31235252fb2902200e2655df8a4f3c230df6e4a1ca881a7b4781963b786479f4ebc02aaa9b6031e90169522102d31024f6184956b730294a1275383c6d57c8fcfdfebb4870fd91882b1c08a8a821028f4b8d4508169c746a2381155bf7cbfa56eeff237937040597e7be632ff74719210315f8700de6902daa99e4c511b008e5018d8f3b586143183f80ab97db8fde770a53ae0400483045022100e37c1cf55b9f23b4ef0bfb018fb54eaae8a5541635269f06176b4f715151a9d102202b057455a3353ba1e2e32526d55e267e957ba00fe416ac59458bf9c1b5044e690148304502210097cab2c37d2335328f169fb0c8420e9abd4dd81dff988ea657707a43512b5df1022075aeeb099e75565e205743419b3b756e34a6f0d68a4e7d0e6f2a482ab70e276e016952210311322726192eb6cbbec6445514d148722a936d5805360be2faf2f8adc8b5aec42102d2e6cf4c6dcdc8e3e1633e7e64b2e41f5be4a583934adbf1f2372240f41b59ae21023799f2560c321587ae734da2d1faafa7c4931145b4b785a3263fa5aa193a208753ae7f011600',
           txInfo: {
@@ -432,7 +437,7 @@ describe('BTC:', function() {
       describe('success', () => {
         it('should handle undefined tx info for segwit transactions', () => {
           const { signatures, inputSignatures } = coin.explainTransaction({
-            txHex: txs['p2sh-p2wsh'].halfSigned
+            txHex: txs.p2shP2wsh.halfSigned
           });
 
           should.exist(signatures);
@@ -482,10 +487,10 @@ describe('BTC:', function() {
           inputSignatures.should.deepEqual([2]);
         });
 
-        it('should count one signature on a half-signed p2sh-p2wsh transaction', () => {
+        it('should count one signature on a half-signed p2shP2wsh transaction', () => {
           const { signatures, inputSignatures } = coin.explainTransaction({
-            txHex: txs['p2sh-p2wsh'].halfSigned,
-            txInfo: txs['p2sh-p2wsh'].txInfo
+            txHex: txs.p2shP2wsh.halfSigned,
+            txInfo: txs.p2shP2wsh.txInfo
           });
 
           should.exist(signatures);
@@ -496,10 +501,10 @@ describe('BTC:', function() {
           inputSignatures.should.deepEqual([1, 1]);
         });
 
-        it('should count two signatures on a fully-signed p2sh-p2wsh transaction', () => {
+        it('should count two signatures on a fully-signed p2shP2wsh transaction', () => {
           const { signatures, inputSignatures } = coin.explainTransaction({
-            txHex: txs['p2sh-p2wsh'].fullySigned,
-            txInfo: txs['p2sh-p2wsh'].txInfo
+            txHex: txs.p2shP2wsh.fullySigned,
+            txInfo: txs.p2shP2wsh.txInfo
           });
 
           should.exist(signatures);

--- a/test/v2/unit/coins/btg.js
+++ b/test/v2/unit/coins/btg.js
@@ -1,7 +1,8 @@
 require('should');
 
+const { Codes } = require('@bitgo/unspents');
+
 const TestV2BitGo = require('../../../lib/test_bitgo');
-const AbstractUtxoCoin = require('../../../../src/v2/coins/abstractUtxoCoin');
 
 describe('BTG:', function() {
   let bitgo;
@@ -237,13 +238,15 @@ describe('BTG:', function() {
     });
 
     it('should generate standard segwit address', () => {
-      const generatedAddress = coin.generateAddress({ keychains, addressType: AbstractUtxoCoin.AddressTypes.P2SH_P2WSH });
-      generatedAddress.chain.should.equal(0);
+      const addressType = Codes.UnspentTypeTcomb('p2shP2wsh');
+      const chain = Codes.forType(addressType)[Codes.PurposeTcomb('external')];
+      const generatedAddress = coin.generateAddress({ keychains, addressType, chain });
+      generatedAddress.chain.should.equal(chain);
       generatedAddress.index.should.equal(0);
-      generatedAddress.coinSpecific.outputScript.should.equal('a91426e34781478f08fff903cb70ae67311c3f9bc6a987');
-      generatedAddress.coinSpecific.redeemScript.should.equal('00209a10eb58331e95333f4a6eafd5f03e442e17e0986c824e392642e872f431b7ef');
-      generatedAddress.coinSpecific.witnessScript.should.equal('5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae');
-      generatedAddress.address.should.equal('AKKVbRzGRgDNL5V1MDrF8PHhHLU4n9Vwuq');
+      generatedAddress.coinSpecific.outputScript.should.equal('a9147ff13f3faeba4d439ef40604f7c127951e77eb6a87');
+      generatedAddress.coinSpecific.redeemScript.should.equal('00207aad7d57b238a09b5daa10ff47c54483b7f2ad47f3f0c0aa230958b9df334260');
+      generatedAddress.coinSpecific.witnessScript.should.equal('52210304fcea3fb05f6e8a8fe91db2087bdd13b18102a0b10a77c1fdbb326b0ce7cec421028242a3ea9e20d4e6b78e3f0dde21aff86a623d48322681b203b6827e22d04a9d2102ceec88b222a55ec67d1414b523bcfc0f53eb6ac012ba91744a4ed8eb448d55f753ae');
+      generatedAddress.address.should.equal('ATSNTzzorpeYexY2wWj4MA3Uxko6YqsQmh');
     });
 
     it('should generate 3/3 non-segwit address', () => {
@@ -256,13 +259,15 @@ describe('BTG:', function() {
     });
 
     it('should generate 3/3 custom chain segwit address', () => {
-      const generatedAddress = coin.generateAddress({ keychains, threshold: 3, addressType: AbstractUtxoCoin.AddressTypes.P2SH_P2WSH, chain: 20, index: 756 });
-      generatedAddress.chain.should.equal(20);
+      const addressType = Codes.UnspentTypeTcomb('p2shP2wsh');
+      const chain = Codes.forType(addressType)[Codes.PurposeTcomb('external')];
+      const generatedAddress = coin.generateAddress({ keychains, threshold: 3, addressType, chain, index: 756 });
+      generatedAddress.chain.should.equal(chain);
       generatedAddress.index.should.equal(756);
-      generatedAddress.coinSpecific.outputScript.should.equal('a91424ba55e2753970236fae8593ca2b49654bf9f4c487');
-      generatedAddress.coinSpecific.redeemScript.should.equal('0020c8fc4f071770e15f21a13ba48c6f32421daed431a74e00e13d0187990964bbce');
-      generatedAddress.coinSpecific.witnessScript.should.equal('532103db7ec7ef3c549705582d6bb5ee258b3bc14d147ec3b069dfd4fd80adb4e9373e210387b1f7cacb6e0c78b79062e94ed0aee691bdfa34a0d1b522103c434205587ad52102044a9f965fd9b54d82e5afe9d4338d0f59027a4e11cff3a39b90fbf5978ae7e753ae');
-      generatedAddress.address.should.equal('AK85CDm4wUcVnsX46becFcXjucn5ptct7F');
+      generatedAddress.coinSpecific.outputScript.should.equal('a914ad395d176042ce737e4f5b65c0eb5de703a4e80087');
+      generatedAddress.coinSpecific.redeemScript.should.equal('0020d15d8d124adb4c213905ebb2cec8517faf38ae0ec4f7b4f1cfa358e6cc06a93d');
+      generatedAddress.coinSpecific.witnessScript.should.equal('532102bb8096d5c12e8b0ee50dd2b14f63dd09c8494b5a0a730794a0e392a6f2a3b2a8210366dbf2135105dc65eed5173c1acf1a902fc2e9dd366b9a6fa0e682c0fb4c21a32102bf998121d4d09d4305b025b5d2de8a7e954fe96179a1dfc076ad11ad4751c99e53ae');
+      generatedAddress.address.should.equal('AXZoGP21jtz45T9CuhtCUcKQNZGgvwqfdS');
     });
 
     it('should validate pub key', () => {

--- a/test/v2/unit/coins/ltc.js
+++ b/test/v2/unit/coins/ltc.js
@@ -5,9 +5,9 @@ const co = Promise.coroutine;
 const _ = require('lodash');
 const bitcoin = require('bitgo-utxo-lib');
 const prova = require('prova-lib');
+const { Codes } = require('@bitgo/unspents');
 const TestV2BitGo = require('../../../lib/test_bitgo');
 const Wallet = require('../../../../src/v2/wallet');
-const AbstractUtxoCoin = require('../../../../src/v2/coins/abstractUtxoCoin');
 
 describe('LTC:', function() {
   let bitgo;
@@ -101,9 +101,8 @@ describe('LTC:', function() {
     });
 
     it('should generate custom chain p2wsh bech32 address', () => {
-      const generatedAddress = coin.generateAddress({ keychains, chain: 21, index: 113, addressType: AbstractUtxoCoin.AddressTypes.P2WSH });
-      const generatedTestAddress = testCoin.generateAddress({ keychains, chain: 21, index: 113, addressType: AbstractUtxoCoin.AddressTypes.P2WSH });
-
+      const generatedAddress = coin.generateAddress({ keychains, chain: 21, index: 113, addressType: Codes.UnspentTypeTcomb('p2wsh') });
+      const generatedTestAddress = testCoin.generateAddress({ keychains, chain: 21, index: 113, addressType: Codes.UnspentTypeTcomb('p2wsh') });
       [generatedAddress, generatedTestAddress].forEach((currentAddress) => {
         currentAddress.chain.should.equal(21);
         currentAddress.index.should.equal(113);
@@ -120,19 +119,21 @@ describe('LTC:', function() {
     });
 
     it('should generate p2sh-wrapped segwit address', () => {
-      const generatedAddress = coin.generateAddress({ keychains, addressType: AbstractUtxoCoin.AddressTypes.P2SH_P2WSH });
-      const generatedTestAddress = testCoin.generateAddress({ keychains, addressType: AbstractUtxoCoin.AddressTypes.P2SH_P2WSH });
+      const addressType = Codes.UnspentTypeTcomb('p2shP2wsh');
+      const chain = Codes.forType(addressType)[Codes.PurposeTcomb('external')];
+      const generatedAddress = coin.generateAddress({ keychains, addressType, chain });
+      const generatedTestAddress = testCoin.generateAddress({ keychains, addressType, chain });
 
       [generatedAddress, generatedTestAddress].forEach((currentAddress) => {
-        currentAddress.chain.should.equal(0);
+        currentAddress.chain.should.equal(chain);
         currentAddress.index.should.equal(0);
-        currentAddress.coinSpecific.outputScript.should.equal('a91426e34781478f08fff903cb70ae67311c3f9bc6a987');
-        currentAddress.coinSpecific.redeemScript.should.equal('00209a10eb58331e95333f4a6eafd5f03e442e17e0986c824e392642e872f431b7ef');
-        currentAddress.coinSpecific.witnessScript.should.equal('5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae');
+        currentAddress.coinSpecific.outputScript.should.equal('a9147ff13f3faeba4d439ef40604f7c127951e77eb6a87');
+        currentAddress.coinSpecific.redeemScript.should.equal('00207aad7d57b238a09b5daa10ff47c54483b7f2ad47f3f0c0aa230958b9df334260');
+        currentAddress.coinSpecific.witnessScript.should.equal('52210304fcea3fb05f6e8a8fe91db2087bdd13b18102a0b10a77c1fdbb326b0ce7cec421028242a3ea9e20d4e6b78e3f0dde21aff86a623d48322681b203b6827e22d04a9d2102ceec88b222a55ec67d1414b523bcfc0f53eb6ac012ba91744a4ed8eb448d55f753ae');
       });
 
-      generatedAddress.address.should.equal('MBSnBN33bYj2QnFM1YqrDmdwGxRY5Q5acM');
-      generatedTestAddress.address.should.equal('QQ9c4ERMGzS2xFN3CuWQ6mpEJzV5iE7iao');
+      generatedAddress.address.should.equal('MKZf3w3b2hACjfJNbqifSYPixNkZjxBTg9');
+      generatedTestAddress.address.should.equal('QYGUvoRti8sDH8R4oCPDKYa1zQp7UWCfAA');
 
       coin.verifyAddress(_.extend({}, generatedAddress, { keychains }));
       testCoin.verifyAddress(_.extend({}, generatedTestAddress, { keychains }));
@@ -154,25 +155,27 @@ describe('LTC:', function() {
     });
 
     it('should generate 3/3 custom chain p2sh-wrapped segwit address', () => {
-      const generatedAddress = coin.generateAddress({ keychains, threshold: 3, addressType: AbstractUtxoCoin.AddressTypes.P2SH_P2WSH, chain: 20, index: 756 });
+      const addressType = Codes.UnspentTypeTcomb('p2shP2wsh');
+      const chain = Codes.forType(addressType)[Codes.PurposeTcomb('external')];
+      const generatedAddress = coin.generateAddress({ keychains, threshold: 3, addressType, chain, index: 756 });
       const generatedTestAddress = testCoin.generateAddress({
         keychains,
         threshold: 3,
-        addressType: AbstractUtxoCoin.AddressTypes.P2SH_P2WSH,
-        chain: 20,
+        addressType,
+        chain,
         index: 756
       });
 
       [generatedAddress, generatedTestAddress].forEach((currentAddress) => {
-        currentAddress.chain.should.equal(20);
+        currentAddress.chain.should.equal(chain);
         currentAddress.index.should.equal(756);
-        currentAddress.coinSpecific.outputScript.should.equal('a91424ba55e2753970236fae8593ca2b49654bf9f4c487');
-        currentAddress.coinSpecific.redeemScript.should.equal('0020c8fc4f071770e15f21a13ba48c6f32421daed431a74e00e13d0187990964bbce');
-        currentAddress.coinSpecific.witnessScript.should.equal('532103db7ec7ef3c549705582d6bb5ee258b3bc14d147ec3b069dfd4fd80adb4e9373e210387b1f7cacb6e0c78b79062e94ed0aee691bdfa34a0d1b522103c434205587ad52102044a9f965fd9b54d82e5afe9d4338d0f59027a4e11cff3a39b90fbf5978ae7e753ae');
+        currentAddress.coinSpecific.outputScript.should.equal('a914ad395d176042ce737e4f5b65c0eb5de703a4e80087');
+        currentAddress.coinSpecific.redeemScript.should.equal('0020d15d8d124adb4c213905ebb2cec8517faf38ae0ec4f7b4f1cfa358e6cc06a93d');
+        currentAddress.coinSpecific.witnessScript.should.equal('532102bb8096d5c12e8b0ee50dd2b14f63dd09c8494b5a0a730794a0e392a6f2a3b2a8210366dbf2135105dc65eed5173c1acf1a902fc2e9dd366b9a6fa0e682c0fb4c21a32102bf998121d4d09d4305b025b5d2de8a7e954fe96179a1dfc076ad11ad4751c99e53ae');
       });
 
-      generatedAddress.address.should.equal('MBFMn9or7M89saHPkveDLzsyuEjZ22ftmo');
-      generatedTestAddress.address.should.equal('QPxBf2C9nnqAR3Q5xHJmE14GwGo6fwNtii');
+      generatedAddress.address.should.equal('MPh5rK4numViA9uYa2soZzfeNBEA6rFUPj');
+      generatedTestAddress.address.should.equal('QcPujBT6bDCihd2EmPYMSzqwQDHhpjb96x');
     });
 
     it('should validate pub key', () => {

--- a/test/v2/unit/recovery.js
+++ b/test/v2/unit/recovery.js
@@ -47,7 +47,7 @@ describe('Recovery:', function() {
         walletPassphrase: TestV2BitGo.V2.TEST_WALLET1_PASSCODE,
         recoveryDestination: '2NB5Ynem6iNvA6GBLZwRxwid3Kui33729Nw',
         scan: 5,
-        ignoreAddressTypes: ['p2wsh', 'p2sh-p2wsh']
+        ignoreAddressTypes: ['p2wsh', 'p2shP2wsh']
       });
 
       recovery.transactionHex.should.equal('010000000174eda73749d65473a8197bac5c26660c66d60cc77a751298ef74931a478382e100000000fb0046304302202f51d7ad8d2feea3194ab0238297fae860e87fe02b789858ce92fb374629faf0021f48011d587171984e95524c3ecdfe9bae8ebe4c8a282881b416da8f713751e9014730440220673b1a059e2d851059dd7f1b0501af4bf6d205c81249f49828e7ae987f4a90c5022047f73ff3d4e17ce6ebfe9565351796851d2a4472223acecd7ee00e2729824f38014c69522102f5ca5d074093abf996278d1e82b64497333254c786e9a69d34909a785aa9af32210239125d1a21ba8ae375cd37a92e48700cbb3bc1b1268d3c3f7e1d95f42155e1a821031ab00568ea1522a55f277699110649f3b8d08022494af2cc475c09e8a43b3a3a53aeffffffff0178757b000000000017a914c39dcc27823a8bd42cd3318a1dac8c25789b7ac78700000000');
@@ -78,7 +78,7 @@ describe('Recovery:', function() {
         bitgoKey: 'xpub661MyMwAqRbcGsSbYgWmr9G1dFgPE8HEb1ASRShbw9S1Mmu1dTQ7QStNwpaYFESq3MeKivGidN8twMeJzqh1veuSP1t2XLENL3mwpatfTst',
         recoveryDestination: '2NB5Ynem6iNvA6GBLZwRxwid3Kui33729Nw',
         scan: 5,
-        ignoreAddressTypes: ['p2wsh', 'p2sh-p2wsh']
+        ignoreAddressTypes: ['p2wsh', 'p2shP2wsh']
       });
 
       recovery.transactionHex.should.equal('010000000174eda73749d65473a8197bac5c26660c66d60cc77a751298ef74931a478382e100000000fb0046304302202f51d7ad8d2feea3194ab0238297fae860e87fe02b789858ce92fb374629faf0021f48011d587171984e95524c3ecdfe9bae8ebe4c8a282881b416da8f713751e9014730440220673b1a059e2d851059dd7f1b0501af4bf6d205c81249f49828e7ae987f4a90c5022047f73ff3d4e17ce6ebfe9565351796851d2a4472223acecd7ee00e2729824f38014c69522102f5ca5d074093abf996278d1e82b64497333254c786e9a69d34909a785aa9af32210239125d1a21ba8ae375cd37a92e48700cbb3bc1b1268d3c3f7e1d95f42155e1a821031ab00568ea1522a55f277699110649f3b8d08022494af2cc475c09e8a43b3a3a53aeffffffff0178757b000000000017a914c39dcc27823a8bd42cd3318a1dac8c25789b7ac78700000000');
@@ -111,7 +111,7 @@ describe('Recovery:', function() {
         recoveryDestination: '2NB5Ynem6iNvA6GBLZwRxwid3Kui33729Nw',
         krsProvider: 'keyternal',
         scan: 5,
-        ignoreAddressTypes: ['p2wsh', 'p2sh-p2wsh']
+        ignoreAddressTypes: ['p2wsh', 'p2shP2wsh']
       });
 
       recovery.transactionHex.should.equal('010000000174eda73749d65473a8197bac5c26660c66d60cc77a751298ef74931a478382e100000000b40047304402201e998e77860b1dc62fac80f60b1db62d14abd7bdbff29767718c024413b908380220200cdf49e76a8d41e60d8ef646e88c26352717fe759083322de5516865d50b65014c69522102f5ca5d074093abf996278d1e82b64497333254c786e9a69d34909a785aa9af32210239125d1a21ba8ae375cd37a92e48700cbb3bc1b1268d3c3f7e1d95f42155e1a821031ab00568ea1522a55f277699110649f3b8d08022494af2cc475c09e8a43b3a3a53aeffffffff02004d6c000000000017a914c39dcc27823a8bd42cd3318a1dac8c25789b7ac787301b0f000000000017a9141b60c33def13c3eda4cf4835e11a633e4b3302ec8700000000');
@@ -155,7 +155,7 @@ describe('Recovery:', function() {
         recoveryDestination: '2NB5Ynem6iNvA6GBLZwRxwid3Kui33729Nw',
         krsProvider: 'keyternal',
         scan: 5,
-        ignoreAddressTypes: ['p2wsh', 'p2sh-p2wsh']
+        ignoreAddressTypes: ['p2wsh', 'p2shP2wsh']
       }));
 
       should.exist(error);
@@ -179,7 +179,7 @@ describe('Recovery:', function() {
         recoveryDestination: '2NB5Ynem6iNvA6GBLZwRxwid3Kui33729Nw',
         krsProvider: 'keyternal',
         scan: 5,
-        ignoreAddressTypes: ['p2wsh', 'p2sh-p2wsh']
+        ignoreAddressTypes: ['p2wsh', 'p2shP2wsh']
       }));
 
       should.exist(error);
@@ -205,7 +205,7 @@ describe('Recovery:', function() {
         walletPassphrase: TestV2BitGo.V2.TEST_RECOVERY_PASSCODE,
         recoveryDestination: '2MztSo6jqjLWcvH4g6QoMChbrWkJ3HHzQua',
         scan: 5,
-        ignoreAddressTypes: ['p2wsh', 'p2sh-p2wsh']
+        ignoreAddressTypes: ['p2wsh', 'p2shP2wsh']
       });
 
       should.exist(recovery);
@@ -230,7 +230,7 @@ describe('Recovery:', function() {
         krsProvider: 'keyternal',
         recoveryDestination: '2MztSo6jqjLWcvH4g6QoMChbrWkJ3HHzQua',
         scan: 5,
-        ignoreAddressTypes: ['p2wsh', 'p2sh-p2wsh']
+        ignoreAddressTypes: ['p2wsh', 'p2shP2wsh']
       });
 
       should.exist(recovery);
@@ -331,7 +331,7 @@ describe('Recovery:', function() {
         walletPassphrase: TestV2BitGo.V2.TEST_RECOVERY_PASSCODE,
         recoveryDestination: 'Qhe8AWhZr1wBNV3iry2uVxnthbawRLhNcF',
         scan: 5,
-        ignoreAddressTypes: ['p2wsh', 'p2sh-p2wsh']
+        ignoreAddressTypes: ['p2wsh', 'p2shP2wsh']
       });
 
       recovery.transactionHex.should.equal('0100000001ffe4ac6dd97fbe9d4526a122c039d9c93ac5d595b1b8d1e0cf23df1b3caecfbc00000000fc0047304402207c87fa565629d0d5bdf1cd4a34c54c90b3ff3a5c50c481ce41cad7709cc9d8d20220774791a635c79d344ccae60b448463ab10e88704405bae47f8c6ffe0eba6ffe80147304402205ebfc4377598dea11a3b50fe7b9e2b3bdb54869407cf651f8f119115738e4e7902201bf86eae5eb417d8355bdc5a5e3f3f306e569475660707e1380395366751600c014c6952210353bcad5447cbed8af7a7e4b010412b1fcc748e7efd225047729bfc452735c10c2103e6f65db8d3718b8a851f0ea64c9bf776cbc9e089f03b12210c7360cadb980031210246cdc4f2c735ccbf5952eded3734a2179104f136a5ed9ec8a1bea50fcaa45d4e53aeffffffff01b03ec9010000000017a914e6c2329cb2f901f30b9606cf839ee09cfce8414e8700000000');
@@ -355,7 +355,7 @@ describe('Recovery:', function() {
         recoveryDestination: 'Qhe8AWhZr1wBNV3iry2uVxnthbawRLhNcF',
         krsProvider: 'keyternal',
         scan: 5,
-        ignoreAddressTypes: ['p2wsh', 'p2sh-p2wsh']
+        ignoreAddressTypes: ['p2wsh', 'p2shP2wsh']
       });
 
       recovery.transactionHex.should.equal('0100000001ffe4ac6dd97fbe9d4526a122c039d9c93ac5d595b1b8d1e0cf23df1b3caecfbc00000000b4004730440220735cb8b3597cdfecf0292007f4861986a86ee5baf8ab6682f563425b1011f4d302205c8544f9c60ed9d7872dc45f9a94afa3b3e567280284cae73a1338ee4e7bd8db014c6952210353bcad5447cbed8af7a7e4b010412b1fcc748e7efd225047729bfc452735c10c2103e6f65db8d3718b8a851f0ea64c9bf776cbc9e089f03b12210c7360cadb980031210246cdc4f2c735ccbf5952eded3734a2179104f136a5ed9ec8a1bea50fcaa45d4e53aeffffffff02882132010000000017a914e6c2329cb2f901f30b9606cf839ee09cfce8414e87e00f97000000000017a914d115b837da7f1563069a3925daf4b243bdd3cb238700000000');
@@ -380,7 +380,7 @@ describe('Recovery:', function() {
         walletPassphrase: TestV2BitGo.V2.TEST_RECOVERY_PASSCODE,
         recoveryDestination: 't2GnC5sFN5Km2UuYaYjHNBQRJBDAXVQqSfJ',
         scan: 5,
-        ignoreAddressTypes: ['p2wsh', 'p2sh-p2wsh']
+        ignoreAddressTypes: ['p2wsh', 'p2shP2wsh']
       });
 
       recovery.transactionHex.should.equal('0400008085202f89010f89e651a4d827d82dbe164cae6c09c21435b950a395e35afae813a1f775497500000000fc00473044022051814041484343dc52fa435be57a892a9084be2672801ae319328149ad96618e022029d36c49865b9df3b4c5820aec7ed44ba5ad787bca997d42313197c62b43473e01473044022027c7c2f527c2f5e3794e2e51611611e5f4b341e1736b0fde660cb4425ba9220702202f4e5ae7047bb2615680fa92ff29397d51a3da8acc3dc2f930899c613c8d33fe014c6952210222dba86781026f53d30be3bd2d07678c61926cb52c0de52b6ecef3d5c96e32fa2102b8a369ca2ef0d202b342fe3742585468813bebf821856fa4c2e90337bcee1d5e2102dcb29b842c2bb5e1efcab6483db61ab06bc08cb8c2667399bb1b5fb826a841a153aeffffffff01b03ec9010000000017a91470391ef30163f580806ee8a5f0aacc724e7f68558700000000000000000000000000000000000000');
@@ -404,7 +404,7 @@ describe('Recovery:', function() {
         recoveryDestination: 't2GnC5sFN5Km2UuYaYjHNBQRJBDAXVQqSfJ',
         krsProvider: 'keyternal',
         scan: 5,
-        ignoreAddressTypes: ['p2wsh', 'p2sh-p2wsh']
+        ignoreAddressTypes: ['p2wsh', 'p2shP2wsh']
       });
 
       recovery.transactionHex.should.equal('0400008085202f89010f89e651a4d827d82dbe164cae6c09c21435b950a395e35afae813a1f775497500000000b500483045022100e4d64617ed56e178384ca219d7839882cff305803fc934845e832345777bda3802205983abea1d0da7ead06e178010fce086ea77f1fbb81d7a0842fc7ef2163d009b014c6952210222dba86781026f53d30be3bd2d07678c61926cb52c0de52b6ecef3d5c96e32fa2102b8a369ca2ef0d202b342fe3742585468813bebf821856fa4c2e90337bcee1d5e2102dcb29b842c2bb5e1efcab6483db61ab06bc08cb8c2667399bb1b5fb826a841a153aeffffffff02882132010000000017a91470391ef30163f580806ee8a5f0aacc724e7f685587e00f97000000000017a9142ad735dfc86e2835100b9dc6476facddad6c87ec8700000000000000000000000000000000000000');
@@ -429,7 +429,7 @@ describe('Recovery:', function() {
         walletPassphrase: TestV2BitGo.V2.TEST_RECOVERY_PASSCODE,
         recoveryDestination: '8hh6nS2vpKCnebjoWcKJF7ebyEt4yNnEzW',
         scan: 3,
-        ignoreAddressTypes: ['p2wsh', 'p2sh-p2wsh']
+        ignoreAddressTypes: ['p2wsh', 'p2shP2wsh']
       });
 
       recovery.transactionHex.should.equal('0100000001edda677a92037140f01cacc1ac0e22391adb9bf4dbce1c4c218822128ac6fd5301000000fc0047304402204a6e7373fa43494d78f3013ea4a0ea0f73a002d48cc29bfe8816b696280c2b08022056a5ad97886b5add39bca9135d445f36c99928b3c83bb0fc613c2a4a00feb93401473044022048de910b7a969ed2729fd9b628377cfdd1d2aa93036694a21bc39271b2f5e30a0220460b9a53ad4166738403bf60628ee4336f7ac984ac2ae1dce1398b30e30226a3014c69522103944ef399da9b45f26407dc3d7abd3544ef6fe6c32236bd6fe39f0db339f267a1210281941b32001f6fd10140e7a8f9a8df881f28d96f172528143e275d96c951a0422103a8ad848ac08c1fc598a91cb0786d6b663084ed3e399072de7c15c397629f2c6f53aeffffffff01b01198000000000017a91423dd90d164d5dfd07ba41814142a5bff0ad5446f8700000000');
@@ -453,7 +453,7 @@ describe('Recovery:', function() {
         krsProvider: 'keyternal',
         recoveryDestination: '8hh6nS2vpKCnebjoWcKJF7ebyEt4yNnEzW',
         scan: 3,
-        ignoreAddressTypes: ['p2wsh', 'p2sh-p2wsh']
+        ignoreAddressTypes: ['p2wsh', 'p2shP2wsh']
       });
 
       recovery.transactionHex.should.equal('0100000001edda677a92037140f01cacc1ac0e22391adb9bf4dbce1c4c218822128ac6fd5301000000b500483045022100c70ade07a526cdfdf29e0c16bd02ef38005695e2b140b937dbe2578253bee90402206611a571593272630a05406d653d5dc6950152665f24a0ac19fb006c2db33f8c014c69522103944ef399da9b45f26407dc3d7abd3544ef6fe6c32236bd6fe39f0db339f267a1210281941b32001f6fd10140e7a8f9a8df881f28d96f172528143e275d96c951a0422103a8ad848ac08c1fc598a91cb0786d6b663084ed3e399072de7c15c397629f2c6f53aeffffffff0288f400000000000017a91423dd90d164d5dfd07ba41814142a5bff0ad5446f87e00f97000000000017a91405437769516c39063ef0c4ed50cd323495cc913d8700000000');


### PR DESCRIPTION
Currently there are 4(!) params in generateAddress that conflict in
specifying what kind of address to create. Chain is the ultimate
source of truth in determining what kind of unspent (and thus what
kind of address) is created by our platform. This commit deprecates
the addressType, segwit, and bech32 params from the generateAddress
function. However, since they are already in the SDK API they are
not removed in this commit, nor is their functionality changed.
There are only two functionality changes to the function. The
first is a check that the addressType derived from addressType,
segwit, and bech32 matches the chain passed. Otherwise an error is
thrown. The second is to check that wrapped segwit is supported
when creating an address for a wrapped segwit unspent. This check
already existed for native segwit and also should have been in
place for wrapped segwit.

We bring in the new @bitgo/unspents library in this commit as well
as it is used to do type checking in generateAddress.
AbstractUtxoCoin.AddressTypes and
AbstractUtxoCoin.AddressTypeChains are elided for canonical enums
defined in this library that will be used across SDK and other
internal bitgo infrastructure.
