### PR TITLE
BG-11566: Add type information for XRP

### DIFF
--- a/src/bitcoin.ts
+++ b/src/bitcoin.ts
@@ -14,7 +14,7 @@ try {
   console.log('running without secp256k1 acceleration');
 }
 
-bitcoin.getNetwork = function(network) {
+bitcoin.getNetwork = function(network?: any) {
   network = network || common.getNetwork();
   return bitcoin.networks[network];
 };
@@ -23,7 +23,7 @@ bitcoin.makeRandomKey = function() {
   return bitcoin.ECPair.makeRandom({ network: bitcoin.getNetwork() });
 };
 
-HDNode.prototype.getKey = function(network) {
+HDNode.prototype.getKey = function(network?: any) {
   network = network || bitcoin.getNetwork();
   const k = this.keyPair;
   const result = new bitcoin.ECPair(k.d, k.d ? null : k.Q, { network: network, compressed: k.compressed });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -36,12 +36,14 @@ export class UnsupportedCoinError extends BitGoJsError {
 export class AddressTypeChainMismatchError extends BitGoJsError {
   constructor(addressType, chain) {
     super(`address type ${addressType} does not correspond to chain ${chain}`);
+    Object.setPrototypeOf(this, AddressTypeChainMismatchError.prototype);
   }
 }
 
 export class P2shP2wshUnsupportedError extends BitGoJsError {
   constructor(message) {
     super(message || 'p2shP2wsh not supported by this coin');
+    Object.setPrototypeOf(this, P2shP2wshUnsupportedError.prototype);
   }
 }
 

--- a/src/v2/coins/txrp.ts
+++ b/src/v2/coins/txrp.ts
@@ -1,19 +1,31 @@
+/**
+ * Testnet XRP
+ *
+ * @format
+ */
 const Xrp = require('./xrp');
 
 class Txrp extends Xrp {
-
-  getChain() {
+  /**
+   * Identifier for the blockchain which supports this coin
+   */
+  public getChain(): string {
     return 'txrp';
   }
 
-  getRippledUrl() {
+  /**
+   * URL of a well-known, public facing (non-bitgo) rippled instance which can be used for recovery
+   */
+  public getRippledUrl(): string {
     return 'https://s.altnet.rippletest.net:51234';
   }
 
-  getFullName() {
+  /**
+   * Complete human-readable name of this coin
+   */
+  public getFullName(): string {
     return 'Testnet Ripple';
   }
-
 }
 
-module.exports = Txrp;
+export = Txrp;


### PR DESCRIPTION
Additionally, this pull request runs prettier on txrp.ts and xrp.ts, and updates the eslint rules so that prettier output satisfies eslint.

Will squash before merging. The first commit adds type information, the second and third are the result of running prettier on the first commit.