### PR TITLE
BG-11717: Fix build, update @bitgo/unspents to 0.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -154,21 +154,26 @@
       }
     },
     "@bitgo/unspents": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/unspents/-/unspents-0.5.0.tgz",
-      "integrity": "sha512-nwDYAPNwAMRObPEP2hW+7hBNd0qzp4tb7Em5T8Dg7BGGps5AbvSflb93GjUJaxSrBBkxaCrHE7E1rlWZpGMwsA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@bitgo/unspents/-/unspents-0.5.1.tgz",
+      "integrity": "sha512-jY4+/i/1bW1ROEPD4+E1zUuo2iegTp1fVykGQzg0pApHtWrNnKvw0EPcJ9MDpRZwpXCSYcbsSKYYUDWhLoh8ow==",
       "requires": {
-        "@types/lodash": "^4.14.120",
-        "@types/node": "^10.12.18",
-        "lodash": "^4.17.11",
-        "tcomb": "^3.2.27",
-        "typescript": "^3.2.4"
+        "@types/lodash": "4.14.123",
+        "@types/node": "10.14.4",
+        "lodash": "4.17.11",
+        "tcomb": "3.2.29",
+        "typescript": "3.3.4000"
       },
       "dependencies": {
+        "@types/lodash": {
+          "version": "4.14.123",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.123.tgz",
+          "integrity": "sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q=="
+        },
         "@types/node": {
-          "version": "10.14.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.3.tgz",
-          "integrity": "sha512-2lhc7S28vo8FwR3Jv3Ifyd77AxEsx+Nl9ajWiac6/eWuvZ84zPK4RE05pfqcn3acIzlZDpQj5F1rIKQZX3ptLQ=="
+          "version": "10.14.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.4.tgz",
+          "integrity": "sha512-DT25xX/YgyPKiHFOpNuANIQIVvYEwCWXgK2jYYwqgaMrYE6+tq+DtmMwlD3drl6DJbUwtlIDnn0d7tIn/EbXBg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "postinstall": "./node_modules/.bin/tsc && node scripts/copySjcl.js"
   },
   "dependencies": {
-    "@bitgo/unspents": "0.5.0",
+    "@bitgo/unspents": "^0.5.1",
     "@types/bluebird": "3.5.25",
     "@types/lodash": "4.14.121",
     "@types/mocha": "5.2.6",


### PR DESCRIPTION
Use caret dependency to avoid having to do this kind of change in the
future.

Issue: BG-11717