### PR TITLE
BG-11836: Fix typo in v1 wallets test

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -20,7 +20,7 @@ local Install(version, limit_branches=false) = {
   name: "install",
   image: "node:" + version,
   commands: [
-    "npm install",
+    "npm install --unsafe-perm",
   ],
   [if limit_branches then "when"]: branches(),
 };

--- a/.drone.yml
+++ b/.drone.yml
@@ -16,7 +16,7 @@ steps:
 - name: install
   image: node:lts
   commands:
-  - npm install
+  - npm install --unsafe-perm
 
 - name: audit
   image: node:lts
@@ -41,7 +41,7 @@ steps:
 - name: install
   image: node:lts
   commands:
-  - npm install
+  - npm install --unsafe-perm
 
 - name: lint
   image: node:lts
@@ -67,7 +67,7 @@ steps:
 - name: install
   image: node:6
   commands:
-  - npm install
+  - npm install --unsafe-perm
 
 - name: unit tests
   image: node:6
@@ -110,7 +110,7 @@ steps:
 - name: install
   image: node:8
   commands:
-  - npm install
+  - npm install --unsafe-perm
 
 - name: unit tests
   image: node:8
@@ -153,7 +153,7 @@ steps:
 - name: install
   image: node:9
   commands:
-  - npm install
+  - npm install --unsafe-perm
 
 - name: unit tests
   image: node:9
@@ -196,7 +196,7 @@ steps:
 - name: install
   image: node:10
   commands:
-  - npm install
+  - npm install --unsafe-perm
 
 - name: unit tests
   image: node:10
@@ -239,7 +239,7 @@ steps:
 - name: install
   image: node:11
   commands:
-  - npm install
+  - npm install --unsafe-perm
 
 - name: unit tests
   image: node:11
@@ -287,7 +287,7 @@ steps:
 - name: install
   image: node:10
   commands:
-  - npm install
+  - npm install --unsafe-perm
   when:
     branch:
     - master

--- a/test/integration/wallet.ts
+++ b/test/integration/wallet.ts
@@ -5,7 +5,7 @@
 //
 
 import { strict as assert } from 'assert';
-import { VirtualSizes } from '@bitgo/unpents';
+import { VirtualSizes } from '@bitgo/unspents';
 import * as should from 'should';
 const Q = require('q');
 

--- a/test/v2/integration/wallets.ts
+++ b/test/v2/integration/wallets.ts
@@ -326,7 +326,6 @@ describe('V2 Wallets:', function() {
           m: 2,
           n: 3,
           keys: [userKeychainId, backupKeychainId, bitgoKeychainId],
-          enterprise: '',
           isCold: true
         };
         return wallets.add(params);


### PR DESCRIPTION
* CI: update drone config to install with `--unsafe-perm`. This is
necessary because otherwise the prepublish script will not be run,
which will cause drone to not compile the typescript source. This is not
optimal, but will catch type errors in drone.