### PR TITLE
BG-11845 - Require superagent without es6 import

### DIFF
--- a/src/bitgo.ts
+++ b/src/bitgo.ts
@@ -4,7 +4,7 @@
 // Copyright 2014, BitGo, Inc.  All Rights Reserved.
 //
 
-import superagent = require('superagent');
+const superagent = require('superagent');
 import bitcoin = require('./bitcoin');
 import bitcoinMessage = require('bitcoinjs-message');
 import sanitizeHtml = require('sanitize-html');


### PR DESCRIPTION
If @types/superagent is installed when we build the sdk it will do a type checking for the superagent library. We want to disable that checking by not doing an es6 import and doing a _const_ require instead