### PR TITLE
BG-11931: Add slow-deps CI pipeline to measure install size and timing

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -80,6 +80,22 @@ local IntegrationTest(version, limit_branches=true) = {
   ],
 };
 
+local MeasureSizeAndTiming(version, limit_branches=false) = {
+  kind: "pipeline",
+  name: "size and timing (node:" + version + ")",
+  steps: [
+    {
+      name: "slow-deps",
+      image: "node:" + version,
+      commands: [
+        "npm install -g slow-deps",
+        "slow-deps"
+      ],
+      [if limit_branches then "when"]: branches(),
+    },
+  ],
+};
+
 [
   {
     kind: "pipeline",
@@ -118,5 +134,6 @@ local IntegrationTest(version, limit_branches=true) = {
   UnitTest("10"),
   UnitTest("11"),
   IntegrationTest("10"),
+  MeasureSizeAndTiming("lts"),
 ]
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -322,4 +322,19 @@ steps:
     - "rel/*"
     - prod/production
 
+---
+kind: pipeline
+name: size and timing (node:lts)
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: slow-deps
+  image: node:lts
+  commands:
+  - npm install -g slow-deps
+  - slow-deps
+
 ...


### PR DESCRIPTION
We should really have a small script instead which does this measurement, but this will get us the metrics we need to move forward on reducing the installed package size.