### PR TITLE
BG-12022: Don't ignore integration test failures

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -299,7 +299,6 @@ steps:
   image: node:10
   commands:
   - "npx nyc -- node_modules/.bin/mocha -r ts-node/register --timeout 20000 --reporter list --exit 'test/v2/integration/**/*.ts'"
-  failure: ignore
   environment:
     BITGOJS_TEST_PASSWORD:
       from_secret: password


### PR DESCRIPTION
* Re-enables integration tests failures causing CI failures
* Integration test failures were disabled as part of PR #314