### PR TITLE
Supply `recipients` in `accelerateTransaction()`

### DIFF
--- a/src/v2/wallet.ts
+++ b/src/v2/wallet.ts
@@ -1188,6 +1188,14 @@ Wallet.prototype.accelerateTransaction = function(params, callback) {
       }
     }
 
+    if (params.recipients !== undefined) {
+      if (!Array.isArray(params.recipients) || params.recipients.length !== 0) {
+        throw new Error(`invalid value for 'recipients': must be empty array when set`);
+      }
+    }
+
+    params.recipients = [];
+
     // We must pass the build params through to submit in case the CPFP tx ever has to be rebuilt.
     const submitParams = Object.assign(params, yield this.prebuildAndSignTransaction(params));
     return yield this.submitTransaction(submitParams);


### PR DESCRIPTION
The SDK docs don't mention that the platform API requires an empty
recipients parameter. The unit tests don't capture this because we are
not testing against the real backend.

This fix checks that `recipients` is either undefined or an empty
array (for backward compatibility), and sets it to an empty array.

Issue: BG-12074