### PR TITLE
BG-11728: Rename OFC tokens

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -231,6 +231,13 @@ export const tokens = {
         { type: 'hydro', coin: 'eth', network: 'Mainnet', name: 'Hydro', tokenContractAddress: '0xebbdf302c940c6bfd49c6b165f457fdb324649bc', decimalPlaces: 18 },
 
       ]
+    },
+    ofc: {
+      tokens: [
+        { type: 'ofcusd', coin: 'ofc', decimalPlaces: 2, name: 'Offchain USD', backingCoin: 'susd', isFiat: true },
+        { type: 'ofcbtc', coin: 'ofc', decimalPlaces: 8, name: 'Offchain Bitcoin Mainnet', backingCoin: 'btc' },
+        { type: 'ofceth', coin: 'ofc', decimalPlaces: 18, name: 'Offchain Ether Mainnet', backingCoin: 'eth' }
+      ]
     }
   },
   // network name for test environments (testnet tokens must be added here)
@@ -247,7 +254,9 @@ export const tokens = {
     },
     ofc: {
       tokens: [
-        { type: 'otestusd', coin: 'ofc', decimalPlaces: 2, name: 'Offchain Test USD', backingCoin: 'tsusd', isFiat: true }
+        { type: 'ofctusd', coin: 'ofc', decimalPlaces: 2, name: 'Offchain Test USD', backingCoin: 'tsusd', isFiat: true },
+        { type: 'ofctbtc', coin: 'ofc', decimalPlaces: 8, name: 'Offchain Bitcoin Test', backingCoin: 'tbtc' },
+        { type: 'ofcteth', coin: 'ofc', decimalPlaces: 18, name: 'Offchain Ether Testnet', backingCoin: 'teth' }
       ]
     }
   }

--- a/test/v2/unit/coins/ofcToken.ts
+++ b/test/v2/unit/coins/ofcToken.ts
@@ -9,14 +9,26 @@ describe('OFC:', function() {
   before(function() {
     bitgo = new TestV2BitGo({ env: 'test' });
     bitgo.initializeTestVars();
-    otestusdCoin = bitgo.coin('otestusd');
+    otestusdCoin = bitgo.coin('ofctusd');
   });
 
   it('functions that return constants', function() {
-    otestusdCoin.getChain().should.equal('otestusd');
+    otestusdCoin.getChain().should.equal('ofctusd');
     otestusdCoin.getFullName().should.equal('Offchain Test USD');
     otestusdCoin.getBaseFactor().should.equal('100');
   });
+
+  it('test crypto coins', function() {
+    const tbtc = bitgo.coin('ofctbtc');
+    tbtc.getChain().should.equal('ofctbtc');
+    tbtc.getFullName().should.equal('Offchain Bitcoin Test');
+    tbtc.getBaseFactor().should.equal('100000000');
+
+    const teth = bitgo.coin('ofcteth');
+    teth.getChain().should.equal('ofcteth');
+    teth.getFullName().should.equal('Offchain Ether Testnet');
+    teth.getBaseFactor().should.equal('1000000000000000000');
+  })
 
   it('can sign payloads', function() {
     const inputParams = {


### PR DESCRIPTION
We recently updated the ofc tokens in client constants. This updates the cache inside the SDK. The frontend likely works without this since it will get the live client constants quickly, but this makes scripting easier.