### PR TITLE
BG-11902 / Build and sign a trade payload

### DIFF
--- a/src/v2/trading.ts
+++ b/src/v2/trading.ts
@@ -1,0 +1,81 @@
+import * as Bluebird from 'bluebird';
+const co = Bluebird.coroutine;
+
+export class Trading {
+  private bitgo;
+  private basecoin;
+  private wallet;
+
+  constructor(bitgo, basecoin, wallet) {
+    this.bitgo = bitgo;
+    this.basecoin = basecoin;
+    this.wallet = wallet;
+  }
+
+  /**
+   * Builds a payload authorizing a trade from this trading account. The currency and amount must be specified, as well as a list
+   * of trade counterparties.
+   * @param params
+   * @param params.currency the currency this wallet will be sending as part of the trade
+   * @param params.amount the amount of currency (in base units, such as cents, satoshis, or wei) authorized to be spent as part of the trade
+   * @param params.otherParties array of trading account IDs authorized to receive funds as part of the trade
+   * @param callback
+   * @returns unsigned trade payload for the given parameters
+   */
+  public buildTradePayload(params: BuildPayloadParameters, callback?): Bluebird<string> {
+    return co(function *buildTradePayload() {
+      const url = this.bitgo.microservicesUrl('/api/trade/v1/payload');
+
+      const body = {
+        accountId: this.wallet.id(),
+        currency: params.currency,
+        amount: params.amount,
+        otherParties: params.otherParties
+      };
+
+      const response = yield this.bitgo.post(url).send(body).result();
+
+      return response.payload;
+    }).call(this).asCallback(callback);
+  }
+
+  /**
+   * Builds and signs a payload authorizing a trade from this trading account. The currency and amount must be specified, as well
+   * as a list of trade counterparties. Requires the wallet keychain or raw private key to sign the transaction. Both
+   * the payload and signature are returned.
+   * @param params
+   * @param params.currency the currency this wallet will be sending as part of the trade
+   * @param params.amount the amount of currency (in base units, such as cents, satoshis, or wei) authorized to be spent as part of the trade
+   * @param params.otherParties array of trading account IDs authorized to receive funds as part of the trade
+   * @param params.walletPassphrase the wallet password, for decrypting the private key for signing
+   * @param callback
+   * @returns {{payload: string, signature: string}}
+   */
+  public signTradePayload(params: SignPayloadParameters, callback?): Bluebird<SignedPayload> {
+    return co(function *signTradePayload() {
+      const payload = yield this.buildTradePayload(params);
+
+      const key = yield this.basecoin.keychains().get({ id: this.wallet.keyIds()[0] });
+      const prv = this.bitgo.decrypt({ input: key.encryptedPrv, password: params.walletPassphrase });
+
+      const signature = this.basecoin.signMessage({ prv }, payload).toString('hex');
+
+      return { payload, signature };
+    }).call(this).asCallback(callback);
+  }
+}
+
+export interface BuildPayloadParameters {
+  currency: string;
+  amount: string;
+  otherParties: string[]
+}
+
+export interface SignPayloadParameters extends BuildPayloadParameters {
+  walletPassphrase?: string;
+}
+
+export interface SignedPayload {
+  payload: string;
+  signature: string;
+}

--- a/src/v2/wallet.ts
+++ b/src/v2/wallet.ts
@@ -5,6 +5,7 @@ const PendingApproval = require('./pendingApproval');
 import * as Promise from 'bluebird';
 const co = Promise.coroutine;
 import * as _ from 'lodash';
+import { Trading } from './trading';
 const debug = require('debug')('bitgo:v2:wallet');
 const internal = require('./internal');
 const util = require('../util');
@@ -1514,6 +1515,9 @@ Wallet.prototype.remove = function(params, callback) {
   }).call(this).asCallback(callback);
 };
 
+Wallet.prototype.trading = function() {
+  return new Trading(this.bitgo, this.baseCoin, this);
+};
 
 /**
  * Creates and downloads PDF keycard for wallet (requires response from wallets.generateWallet)

--- a/test/lib/test_bitgo.ts
+++ b/test/lib/test_bitgo.ts
@@ -49,6 +49,9 @@ BitGo.TEST_KNOWN_BALANCE = 9999586400;
 BitGo.TEST_ENTERPRISE_CREATION_USER = 'enterprisecreator@bitgo.com';
 BitGo.TEST_ENTERPRISE_CREATION_PASSWORD = BitGo.TEST_PASSWORD;
 
+BitGo.OFC_TEST_USER = 'tester+employee@bitgo.com';
+BitGo.OFC_TEST_PASSWORD = BitGo.TEST_PASSWORD;
+
 BitGo.TEST_CLIENTID = 'test';
 BitGo.TEST_CLIENTSECRET = 'testclientsecret';
 
@@ -93,6 +96,7 @@ BitGo.prototype.initializeTestVars = function() {
     BitGo.V2.TEST_WALLET1_PASSCODE = 'iVWeATjqLS1jJShrPpETti0b';
     BitGo.V2.TEST_WALLET1_XPUB = 'xpub661MyMwAqRbcGicVM5K5UnocWoFt3Yh1RZKzSEHPPARhyMf9w7DVqM3PgBgiVW5NHRp8UteqhMoQb17rCQsLbmGXuPx43MKskyB31R97p3G';
     BitGo.V2.TEST_WALLET1_ID = '585cc5335573b0a8416aadb1fce63ce3';
+    BitGo.V2.OFC_TEST_WALLET_ID = '5cbe3223311315fc7c96ce087f32dbdd';
 
   } else {
     BitGo.TEST_USERID = '543c11ed356d00cb7600000b98794503';
@@ -173,6 +177,8 @@ BitGo.prototype.initializeTestVars = function() {
 
     // webhooks
     BitGo.V2.TEST_WEBHOOK_TRANSFER_SIMULATION_ID = '59b7041619dd52cd0737a4cbf39dbd44';
+
+    BitGo.V2.OFC_TEST_WALLET_ID = '5cbe3563afc275b40369e096073b8a16';
   }
 
   BitGo.TEST_FEE_SINGLE_KEY_WIF = 'cRVQ6cbUyGHVvByPKF9GnEhaB4HUBFgLQ2jVX1kbQARHaTaD7WJ2';
@@ -249,6 +255,14 @@ BitGo.prototype.authenticateChangePWTestUser = function(otp, callback) {
     response.should.have.property('user');
 
     return { password: params.password, alternatePassword };
+  }).call(this).asCallback(callback);
+};
+
+BitGo.prototype.authenticateOfcTestUser = function(otp, callback) {
+  return co(function *() {
+    const response = yield this.authenticate({ username: BitGo.OFC_TEST_USER, password: BitGo.OFC_TEST_PASSWORD, otp: otp });
+    response.should.have.property('access_token');
+    response.should.have.property('user');
   }).call(this).asCallback(callback);
 };
 

--- a/test/v2/unit/trading.ts
+++ b/test/v2/unit/trading.ts
@@ -1,0 +1,83 @@
+import { coroutine as co } from 'bluebird';
+import * as should from 'should';
+import * as nock from 'nock';
+import * as bitcoinMessage from 'bitcoinjs-message';
+import { HDNode } from 'bitgo-utxo-lib';
+
+const Wallet = require('../../../src/v2/wallet');
+const TestV2BitGo = require('../../lib/test_bitgo');
+const common = require('../../../src/common');
+
+describe('V2 Trading', function() {
+  const microservicesUri = 'https://bitgo-microservices.example';
+  let bitgo;
+  let basecoin;
+  let wallet;
+  let trading;
+  let bgUrl;
+
+  before(co(function *() {
+    bitgo = new TestV2BitGo({ env: 'mock', microservicesUri });
+    bitgo.initializeTestVars();
+    basecoin = bitgo.coin('ofc');
+    basecoin.keychains();
+
+    const walletData = {
+      id: 'walletId',
+      coin: 'tbtc',
+      keys: [
+        'keyid'
+      ]
+    };
+
+    wallet = new Wallet(bitgo, basecoin, walletData);
+    trading = wallet.trading();
+    bgUrl = common.Environments[bitgo.getEnv()].uri;
+  }));
+
+  it('should create and sign a trade payload', co(function *() {
+    const xprv = 'xprv9s21ZrQH143K2MUz7uPUBVzdmvJQE6fPEQCkR3mypPbZgijPqfmGH7pjijdjeJx3oCoxPWVbjC4VYHzgN6wqEfYnnbNjK7jm2CkrvWrvkbR';
+    const xpub = 'xpub661MyMwAqRbcEqZTDvvUYdwNKx8tdZPEbd8MDSBbNj8YZX4YPD5Wpv9Da2YzLC8ZNRhundXP7mVhhu9WdJChzZJFGLQD7tyY1KGfmjuBvcX';
+
+    const msScope = nock(microservicesUri)
+    .post('/api/trade/v1/payload')
+    .reply(200, {
+      payload: JSON.stringify({
+        walletId: 'walletId',
+        currency: 'tbtc',
+        amount: '100000000',
+        otherParties: ['test_counter_party_1'],
+        nonce: Date.now()
+      })
+    });
+    const platformScope = nock(bgUrl)
+    .get('/api/v2/ofc/key/keyid')
+    .reply(200, {
+      pub: xpub,
+      encryptedPrv: bitgo.encrypt({ input: xprv, password: TestV2BitGo.OFC_TEST_PASSWORD })
+    });
+
+    const { payload, signature } = yield trading.signTradePayload({
+      currency: 'tbtc',
+      amount: '100000000',
+      otherParties: ['test_counterparty_1'],
+      walletPassphrase: TestV2BitGo.OFC_TEST_PASSWORD
+    });
+
+    should.exist(payload);
+    // The payload should be a valid JSON object
+    // NOTE: we shouldn't do any more validation than this, as the schema is subject to change often
+    (() => { JSON.parse(payload); }).should.not.throw();
+
+    should.exist(signature);
+    // signature should be a hex string
+    signature.should.match(/^[0-9a-f]+$/);
+
+    const address = HDNode.fromBase58(xpub).getAddress();
+
+    bitcoinMessage.verify(payload, address, Buffer.from(signature, 'hex')).should.be.True();
+
+    msScope.isDone().should.be.True();
+    platformScope.isDone().should.be.True();
+  }));
+});


### PR DESCRIPTION
Started the new trading module with a couple of methods to build and sign a DAX payload authorizing a trade. 

buildTradePayload calls the microservices stack to request a DAX payload
signTradePayload first builds the payload then signs it with the user key on the OFC wallet

Added an integration test to validate everything, but it's pretty loose on the validation as the DAX schema is subject to change somewhat often