### PR TITLE
CT-180: Fix bitgo-express startup command for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Suitable for developers working in a language without an official BitGo SDK.
 BitGo Express runs as a service in your own datacenter, and handles the client-side operations involving your own keys, such as partially signing transactions before submitting to BitGo.
 This ensures your keys never leave your network, and are not seen by BitGo. BitGo Express can also proxy the standard BitGo REST APIs, providing a unified interface to BitGo through a single REST API.
 
-`npm explore bitgo -- bin/bitgo-express [-h] [-v] [-p PORT] [-b BIND] [-e ENV] [-d] [-l LOGFILEPATH] [-k KEYPATH] [-c CRTPATH]`
+`npm explore bitgo -- node bin/bitgo-express [-h] [-v] [-p PORT] [-b BIND] [-e ENV] [-d] [-l LOGFILEPATH] [-k KEYPATH] [-c CRTPATH]`
 
 **Note:** When running against the BitGo production environment, you must run node in a production configuration as well. You can do that by running `export NODE_ENV=production` prior to starting bitgo-express.
 


### PR DESCRIPTION
The default windows terminal does not respect the shebang line which
starts the bin/bitgo-express startup script. Instead, we should invoke
node directly, and pass it the startup script as an argument. This
should be portable across all supported platforms.