### PR TITLE
BG-7960: v2 wallet share succeeds without encryptedPrv

### DIFF
--- a/src/v2/wallet.ts
+++ b/src/v2/wallet.ts
@@ -979,6 +979,11 @@ Wallet.prototype.shareWallet = function(params, callback) {
             path: sharing.path
           };
         }
+      }).catch(function(e) {
+        if (e.message === 'No encrypted keychains on this wallet.') {
+          return; // ignore this error because this looks like a cold wallet
+        }
+        throw e;
       });
     }
   })

--- a/test/v2/unit/wallet.ts
+++ b/test/v2/unit/wallet.ts
@@ -758,4 +758,30 @@ describe('V2 Wallet:', function() {
       response.isDone().should.be.true();
     }));
   });
+
+  describe('Wallet Sharing', function () {
+    it('should share to cold wallet without passing skipKeychain', co(function *() {
+      const userId = '123';
+      const email = 'shareto@sdktest.com';
+      const permissions = 'view,spend';
+
+      const getSharingKeyNock = nock(bgUrl)
+      .post('/api/v1/user/sharingkey', { email })
+      .reply(200, { userId });
+
+      const getKeyNock = nock(bgUrl)
+      .get(`/api/v2/tbtc/key/${wallet._wallet.keys[0]}`)
+      .reply(200, {});
+
+      const createShareNock = nock(bgUrl)
+      .post(`/api/v2/tbtc/wallet/${wallet._wallet.id}/share`, { user: userId, permissions })
+      .reply(200, {});
+
+      yield wallet.shareWallet({ email, permissions });
+
+      getSharingKeyNock.isDone().should.be.True();
+      getKeyNock.isDone().should.be.True();
+      createShareNock.isDone().should.be.True();
+    }));
+  });
 });


### PR DESCRIPTION
We are currently throwing an error when a share is initiated without the `skipKeychains` flag for a cold wallet (no encryptedPrv on any of the wallet keys). This is a problem because there are some wallets that are not marked as cold, i.e. the customer created them via the API by creating their own keys (e.g. having their user key in a customer HSM). This change modifies the wallet share function to ignore this error and to continue with the share.