### PR TITLE
BG-7960: pass empty keychain for wallet share for cold wallet

### DIFF
--- a/src/v2/wallet.ts
+++ b/src/v2/wallet.ts
@@ -981,6 +981,7 @@ Wallet.prototype.shareWallet = function(params, callback) {
         }
       }).catch(function(e) {
         if (e.message === 'No encrypted keychains on this wallet.') {
+          sharedKeychain = {};
           return; // ignore this error because this looks like a cold wallet
         }
         throw e;

--- a/test/v2/unit/wallet.ts
+++ b/test/v2/unit/wallet.ts
@@ -774,7 +774,7 @@ describe('V2 Wallet:', function() {
       .reply(200, {});
 
       const createShareNock = nock(bgUrl)
-      .post(`/api/v2/tbtc/wallet/${wallet._wallet.id}/share`, { user: userId, permissions })
+      .post(`/api/v2/tbtc/wallet/${wallet._wallet.id}/share`, { user: userId, permissions, keychain: {} })
       .reply(200, {});
 
       yield wallet.shareWallet({ email, permissions });


### PR DESCRIPTION
The original fix didn't fully solve the problem because platform expects a keychain param to be passed when doing the share. When the skipKeychain param is passed into the SDK `shareWallet` function, we already set the keychain to an empty object, we have to do the same for any cold wallets even if the skipKeychain param wasn't passed.