### PR TITLE
Update bitgo-utxo-lib to v1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1192,9 +1192,9 @@
       }
     },
     "bitgo-utxo-lib": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/bitgo-utxo-lib/-/bitgo-utxo-lib-1.3.1.tgz",
-      "integrity": "sha512-kWdv12SdNVCd6xbp2vLxxN12+TgcrZAxp8hWgNC5czzvYZq3uXJDT6iAkc5amFR2DT5OCO/faP9B/NWtMnKApg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bitgo-utxo-lib/-/bitgo-utxo-lib-1.5.0.tgz",
+      "integrity": "sha512-J7KAdUPPY4DkVJM605IR3ElSY9WHpbFM6SOlNlhflfq+PepzLIpk3EIvd4Erg/2uBjNkpAO6YGpIuRagTTk5Uw==",
       "requires": {
         "bech32": "0.0.3",
         "bigi": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "bigi": "1.4.0",
     "bignumber.js": "8.0.1",
     "bitcoinjs-message": "2.0.0",
-    "bitgo-utxo-lib": "1.3.1",
+    "bitgo-utxo-lib": "^1.5.0",
     "bluebird": "3.5.3",
     "body-parser": "1.18.3",
     "bs58": "2.0.1",


### PR DESCRIPTION
JIRA: CT-230

Adds support for Dash special transactions.