### PR TITLE
[CT-27] Add Hop transactions building and sending

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1580,7 +1580,6 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.4.tgz",
       "integrity": "sha1-CGxHuMgjFsnUcCLCYYWVRXbdjiY=",
-      "optional": true,
       "requires": {
         "js-sha3": "^0.6.1",
         "safe-buffer": "^5.1.1"
@@ -3329,6 +3328,20 @@
             "rlp": "^2.0.0",
             "safe-buffer": "^5.1.1",
             "secp256k1": "^3.0.1"
+          },
+          "dependencies": {
+            "keccak": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+              "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+              "optional": true,
+              "requires": {
+                "bindings": "^1.2.1",
+                "inherits": "^2.0.3",
+                "nan": "^2.2.1",
+                "safe-buffer": "^5.1.0"
+              }
+            }
           }
         }
       }
@@ -5722,8 +5735,7 @@
     "js-sha3": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.6.1.tgz",
-      "integrity": "sha1-W4n3enR3Z5h39YxKB1JAk0sflcA=",
-      "optional": true
+      "integrity": "sha1-W4n3enR3Z5h39YxKB1JAk0sflcA="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -5864,10 +5876,9 @@
       "dev": true
     },
     "keccak": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-      "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-      "optional": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.0.0.tgz",
+      "integrity": "sha512-rKe/lRr0KGhjoz97cwg+oeT1Rj/Y4cjae6glArioUC8JBF9ROGZctwIaaruM7d7naovME4Q8WcQSO908A8qcyQ==",
       "requires": {
         "bindings": "^1.2.1",
         "inherits": "^2.0.3",
@@ -5879,7 +5890,6 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.3.tgz",
       "integrity": "sha512-BjLkNDcfaZ6l8HBG9tH0tpmDv3sS2mA7FNQxFHpCdzP3Gb2MVruXBSuoM66SnVxKJpAr5dKGdkHD+bDokt8fTg==",
-      "optional": true,
       "requires": {
         "browserify-sha3": "^0.0.4",
         "sha3": "^1.2.2"
@@ -7135,7 +7145,7 @@
         },
         "convert-source-map": {
           "version": "1.6.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
           "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
           "dev": true,
           "requires": {
@@ -8767,20 +8777,11 @@
       }
     },
     "sha3": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.2.tgz",
-      "integrity": "sha1-pmxQmN5MJbyIM27ItIF9AFvKe6k=",
-      "optional": true,
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.3.tgz",
+      "integrity": "sha512-sOWDZi8cDBRkLfWOw18wvJyNblXDHzwMGnRWut8zNNeIeLnmMRO17bjpLc7OzMuj1ASUgx2IyohzUCAl+Kx5vA==",
       "requires": {
-        "nan": "2.10.0"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-          "optional": true
-        }
+        "nan": "2.13.2"
       }
     },
     "shasum": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "eol": "0.5.0",
     "express": "4.16.4",
     "http-proxy": "1.11.1",
+    "keccak": "1.4.0",
     "lodash": "4.17.11",
     "minimist": "0.2.0",
     "moment": "2.20.1",

--- a/src/v2/baseCoin.ts
+++ b/src/v2/baseCoin.ts
@@ -354,11 +354,29 @@ class BaseCoin {
   }
 
   /**
+   * Get extra parameters for prebuilding a tx. Add things like hop transaction params
+   */
+  getExtraPrebuildParams(buildParams, callback) {
+    return Promise.method(function() {
+      return { };
+    }).call(this).asCallback(callback);
+  }
+
+  /**
    * Modify prebuild after receiving it from the server. Add things like nlocktime
    */
   postProcessPrebuild(prebuildResponse, callback) {
     return Promise.method(function() {
       return prebuildResponse;
+    }).call(this).asCallback(callback);
+  }
+
+  /**
+   * Coin-specific things done before signing a transaction, i.e. verification
+   */
+  presignTransaction(params, callback) {
+    return Promise.method(function() {
+      return params;
     }).call(this).asCallback(callback);
   }
 

--- a/test/v2/unit/ethWallet.ts
+++ b/test/v2/unit/ethWallet.ts
@@ -1,10 +1,15 @@
 
 import * as Promise from 'bluebird';
 const co = Promise.coroutine;
+const should = require('should');
+const secp256k1 = require('secp256k1');
+const nock = require('nock');
+const bitGoUtxoLib = require('bitgo-utxo-lib');
 import 'should';
 const TestV2BitGo = require('../../lib/test_bitgo');
 const sinon = require('sinon');
 const Util = require('../../../src/util');
+const common = require('../../../src/common');
 const fixtures = require('../fixtures/eth.ts');
 const EthTx = require('ethereumjs-tx');
 
@@ -44,6 +49,225 @@ describe('Sign ETH Transaction', co(function *() {
     yield ethWallet.signTransaction({ txPrebuild: { recipients: 'not-array' }, prv: 'my_user_prv' }).should.be.rejectedWith('recipients missing or not array');
   }));
 
+}));
+
+describe('Ethereum Hop Transactions', co(function *() {
+  let bitgo;
+  let ethWallet;
+  let tx;
+  let txid;
+  let bitgoSignature;
+  let bitgoKeyXprv;
+  let bgUrl;
+
+  const userKeypair = {
+    xprv: 'xprv9s21ZrQH143K2fJ91S4BRsupcYrE6mmY96fcX5HkhoTrrwmwjd16Cn87cWinJjByrfpojjx7ezsJLx7TAKLT8m8hM5Kax9YcoxnBeJZ3t2k',
+    xpub: 'xpub661MyMwAqRbcF9Nc7TbBo1rZAagiWEVPWKbDKThNG8zqjk76HAKLkaSbTn6dK2dQPfuD7xjicxCZVWvj67fP5nQ9W7QURmoMVAX8m6jZsGp',
+    rawPub: '02c103ac74481874b5ef0f385d12725e4f14aedc9e00bc814ce96f47f62ce7adf2',
+    rawPrv: '936c5af3f8af81f75cdad1b08f29e7d9c01e598e2db2d7be18b9e5a8646e87c6',
+    path: 'm',
+    walletSubPath: '/0/0'
+  };
+  const bitgoKey = {
+    pub: 'xpub661MyMwAqRbcGNtyHK3eQ9p5MZCuobtmnmEHXH9wWjb9L3jWVUANF5hKPhdPFPmfXqep5X7vd9roR2gvkC5RxwAzBBVsRWcuZaSuSuweMv8',
+    path: 'm',
+    walletSubPath: '/0/0'
+  };
+
+  before(co(function *() {
+    tx = '0xf86c82015285012a05f200825208945208d8e80c6d1aef9be37b4bd19a9cf75ed93dc886b5e620f480008026a00e13f9e0e11337b2b0227e3412211d3625e43f1083fda399cc361dd4bf89083ba06c801a761e0aa3bc8db0ac2568d575b0fb306a1f04f4d5ba82ba3cc0ea0a83bd';
+    txid = '0x0ac669c5fef8294443c75a31e32c44b97bbc9e43a18ea8beabcc2a3b45eb6ffa';
+    bitgoKeyXprv = 'xprv9s21ZrQH143K3tpWBHWe31sLoXNRQ9AvRYJgitkKxQ4ATFQMwvr7hHNqYRUnS7PsjzB7aK1VxqHLuNQjj1sckJ2Jwo2qxmsvejwECSpFMfC';
+    const bitgoPrvBuffer = bitGoUtxoLib.HDNode.fromBase58(bitgoKeyXprv).getKey().getPrivateKeyBuffer();
+    bitgoSignature = '0xaa' + secp256k1.sign(Buffer.from(txid.slice(2), 'hex'), bitgoPrvBuffer).signature.toString('hex');
+
+    bitgo = new TestV2BitGo({ env: 'test' });
+    bitgo.initializeTestVars();
+    bgUrl = common.Environments[bitgo.getEnv()].uri;
+    const coin = bitgo.coin('teth');
+    ethWallet = coin.newWalletObject({ keys: ['user', 'backup', 'bitgo'] });
+  }));
+
+  const nockBitGoKey = function(key = bitgoKey) {
+    nock(bgUrl)
+      .get('/api/v2/teth/key/bitgo')
+      .reply(200, key);
+  };
+
+  describe('Verify HSM Hop prebuild', co(function *() {
+    let prebuild;
+    let buildParams;
+    let finalRecipient;
+    let sendAmount;
+
+    before(co(function *() {
+      finalRecipient = '0x5208d8e80c6d1aef9be37b4bd19a9cf75ed93dc8';
+      sendAmount = '200000000000000';
+      prebuild = {
+        tx,
+        id: txid,
+        signature: bitgoSignature,
+      };
+      buildParams = {
+        recipients: [{
+          address: finalRecipient,
+          amount: sendAmount
+        }]
+      };
+    }));
+
+    it('should accept a valid hop prebuild', co(function *() {
+      let error = undefined;
+      nockBitGoKey();
+      try {
+        yield ethWallet.baseCoin.validateHopPrebuild(ethWallet, prebuild, buildParams);
+      } catch (e) {
+        error = e.message;
+      }
+      should.not.exist(error);
+    }));
+
+    it('should fail if the HSM prebuild recipient is wrong', co(function *() {
+      let error = undefined;
+      const badBuildParams = JSON.parse(JSON.stringify(buildParams));
+      badBuildParams.recipients[0].address = '0x54bf1609aeed804aa231f08c53dbb18f7d374615';
+
+      nockBitGoKey();
+      try {
+        yield ethWallet.baseCoin.validateHopPrebuild(ethWallet, prebuild, badBuildParams);
+      } catch (e) {
+        error = e.message;
+      }
+      should.exist(error);
+      error.should.containEql("does not equal original recipient");
+    }));
+
+    it('should fail if the HSM prebuild tx amount is wrong', co(function *() {
+      let error = undefined;
+      const badBuildParams = JSON.parse(JSON.stringify(buildParams));
+      badBuildParams.recipients[0].amount = '50000000';
+
+      nockBitGoKey();
+      try {
+        yield ethWallet.baseCoin.validateHopPrebuild(ethWallet, prebuild, badBuildParams);
+      } catch (e) {
+        error = e.message;
+      }
+      should.exist(error);
+      error.should.containEql("does not equal original amount");
+    }));
+
+    it('should fail if the HSM signature is invalid', co(function *() {
+      let error = undefined;
+      const differentBitGoKey = JSON.parse(JSON.stringify(bitgoKey));
+      // Mocking a different BitGo key means the signing key should be wrong (it maps to a different address than this xpub)
+      differentBitGoKey.pub = 'xpub661MyMwAqRbcErFqVXGiUFv9YeoPbhN72UiNCUdj9nj3T6M8h7iKNmbCYpMVWVZP7LA2ma3HWcPngz1gRTm4FPdtm9mHfrNvU93MCoszsGL';
+
+      nockBitGoKey(differentBitGoKey);
+      try {
+        yield ethWallet.baseCoin.validateHopPrebuild(ethWallet, prebuild, buildParams);
+      } catch (e) {
+        error = e.message;
+      }
+      should.exist(error);
+      error.should.containEql("Hop txid signature invalid");
+    }));
+
+    it('should fail if the HSM signature signed the wrong HSM commitment digest', co(function *() {
+      let error = undefined;
+      const badTxid = '0xb4b3827a529c9166786e796528017889ac5027255b65b3fa2a3d3ad91244a12b';
+      const badTxidBuffer = Buffer.from(badTxid.slice(2), 'hex');
+      const xprvNode = bitGoUtxoLib.HDNode.fromBase58(bitgoKeyXprv);
+
+      const badSignature = '0xaa' + secp256k1.sign(badTxidBuffer, xprvNode.getKey().getPrivateKeyBuffer()).signature.toString('hex');
+      const badPrebuild = JSON.parse(JSON.stringify(prebuild));
+      badPrebuild.signature = badSignature;
+
+      nockBitGoKey();
+      try {
+        yield ethWallet.baseCoin.validateHopPrebuild(ethWallet, badPrebuild, buildParams);
+      } catch (e) {
+        error = e.message;
+      }
+      should.exist(error);
+      error.should.containEql("Hop txid signature invalid");
+    }));
+  }));
+
+  describe('Prebuild hop transaction', co(function *() {
+    let prebuild;
+    let buildParams;
+    let finalRecipient;
+    let sendAmount;
+    let gasLimitEstimate;
+    let gasPrice;
+
+    const nockUserKey = function() {
+      nock(bgUrl)
+        .get(`/api/v2/teth/key/user`)
+        .reply(200, {
+          encryptedPrv: bitgo.encrypt({ input: userKeypair.xprv, password: TestV2BitGo.TEST_WALLET1_PASSCODE }),
+          path: userKeypair.path + userKeypair.walletSubPath
+        });
+    };
+    const nockFees = function() {
+      nock(bgUrl)
+        .get('/api/v2/teth/tx/fee')
+        .query(true)
+        .reply(200, {
+          gasLimitEstimate: gasLimitEstimate,
+          feeEstimate: gasLimitEstimate * gasPrice,
+        });
+    };
+
+    const nockBuild = function(walletId) {
+      nock(bgUrl)
+        .post('/api/v2/teth/wallet/' + walletId + '/tx/build')
+        .reply(200, { hopTransaction: prebuild, buildParams});
+    };
+
+    before(co(function* () {
+      gasLimitEstimate = 100000;
+      gasPrice = 50000000;
+      finalRecipient = '0x5208d8e80c6d1aef9be37b4bd19a9cf75ed93dc8';
+      sendAmount = '200000000000000';
+      prebuild = {
+        tx,
+        id: txid,
+        signature: bitgoSignature,
+      };
+      buildParams = {
+        recipients: [{
+          address: finalRecipient,
+          amount: sendAmount
+        }],
+        hop: true,
+        walletPassphrase: TestV2BitGo.TEST_WALLET1_PASSCODE,
+      };
+    }));
+
+   it('should prebuild a hop transaction if given the correct args', co(function *() {
+     let error = undefined;
+
+     nockUserKey();
+     nockBitGoKey();
+     nockFees();
+     nockBuild(ethWallet.id());
+     try {
+       const res = yield ethWallet.prebuildTransaction(buildParams);
+       should.exist(res.hopTransaction);
+       should.exist(res.hopTransaction.tx);
+       should.exist(res.hopTransaction.tx);
+       should.exist(res.hopTransaction.id);
+       should.exist(res.hopTransaction.signature);
+       should.not.exist(res.wallet);
+       should.not.exist(res.buildParams);
+     } catch (e) {
+       error = e.message;
+     }
+     should.not.exist(error);
+   }));
+  }));
 }));
 
 describe('Add final signature to ETH tx from offline vault', function() {

--- a/test/v2/unit/wallet.ts
+++ b/test/v2/unit/wallet.ts
@@ -693,7 +693,11 @@ describe('V2 Wallet:', function() {
       const postProcessStub = sinon.stub(basecoin, 'postProcessPrebuild').resolves({});
       yield wallet.prebuildTransaction(params);
       blockHeightStub.should.have.been.calledOnce();
-      postProcessStub.should.have.been.calledOnceWith({ blockHeight });
+      postProcessStub.should.have.been.calledOnceWith({
+        blockHeight: 100,
+        wallet: wallet,
+        buildParams: { },
+      });
     }));
 
     it('prebuild should call build but not getLatestBlockHeight for account coins', co(function *() {
@@ -714,7 +718,10 @@ describe('V2 Wallet:', function() {
         .reply(200, {});
         const postProcessStub = sinon.stub(accountcoin, 'postProcessPrebuild').resolves({});
         yield accountWallet.prebuildTransaction(params);
-        postProcessStub.should.have.been.calledOnceWith({ });
+        postProcessStub.should.have.been.calledOnceWith({
+          wallet: accountWallet,
+          buildParams: { },
+        });
       }));
     }));
   });


### PR DESCRIPTION
# Overview
Build a hop transaction with flag `hop`
Send a hop transaction with flag `hop`
Verify hop transaction and signature from the HSM
Send a commitment signature to the HSM, so it can verify that the tx was actually intended from the user


