### PR TITLE
[CT-27] Make payment ID a string rather than a number

### DIFF
--- a/src/v2/coins/eth.ts
+++ b/src/v2/coins/eth.ts
@@ -845,7 +845,7 @@ class Eth extends BaseCoin {
       const gasPrice = Math.round((feeEstimate.feeEstimate) / gasLimit);
       const gasPriceMax = gasPrice * 5;
       // Payment id a random number so its different for every tx
-      const paymentId = Math.floor(Math.random() * 10000000000);
+      const paymentId = Math.floor(Math.random() * 10000000000).toString();
       const hopDigest: Buffer = Eth.getHopDigest([recipientAddress, recipientAmount, gasPriceMax, gasLimit, paymentId]);
 
       const userReqSig = optionalDeps.ethUtil.addHexPrefix(secp256k1.sign(hopDigest, userPrvBuffer).signature.toString('hex'));


### PR DESCRIPTION
# Overview

Payment id is meant to be a string, when changing it from the current ISODate to a random number, we broke this and the platform rejects it as a valid payment id