### PR TITLE
BRE-515 Upgraded SDK version for sprint Austin release ra20190530.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bitgo",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5876,9 +5876,9 @@
       "dev": true
     },
     "keccak": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.0.0.tgz",
-      "integrity": "sha512-rKe/lRr0KGhjoz97cwg+oeT1Rj/Y4cjae6glArioUC8JBF9ROGZctwIaaruM7d7naovME4Q8WcQSO908A8qcyQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+      "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
       "requires": {
         "bindings": "^1.2.1",
         "inherits": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitgo",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "BitGo Javascript SDK",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",


### PR DESCRIPTION
# JIRA Ticket
[BRE-515](https://bitgoinc.atlassian.net/browse/BRE-515)

# Description
Upgrading SDK version for sprint Austin release ra20190530.

Per discussion with @marktoda, there was a mixture of keccak versions 1.4.0 and 2.0.0, so when I ran "npm install --package-lock-only", it reverted keccak from 2.0.0 to 1.4.0.

```
Jamess-MacBook-Pro:BitGoJS jamesmn$ git show 6c9276610a97616d489997e3d28129a59a5e815c
commit 6c9276610a97616d489997e3d28129a59a5e815c (origin/CT-27-hop-transactions)
Author: Mark Toda <mtoda@bitgo.com>
Date:   Fri May 17 17:41:22 2019 -0700

    [CT-27] Add Hop transactions building and sending
    
    Build a hop transaction with flag hop
    Send a hop transaction with flag hop
    Sign and verify hop parameters

diff --git a/package-lock.json b/package-lock.json
index 7e86d99..65b8fe2 100644
--- a/package-lock.json
+++ b/package-lock.json
@@ -1580,7 +1580,6 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.4.tgz",
       "integrity": "sha1-CGxHuMgjFsnUcCLCYYWVRXbdjiY=",
-      "optional": true,
       "requires": {
         "js-sha3": "^0.6.1",
         "safe-buffer": "^5.1.1"
@@ -3329,6 +3328,20 @@
             "rlp": "^2.0.0",
             "safe-buffer": "^5.1.1",
             "secp256k1": "^3.0.1"
+          },
+          "dependencies": {
+            "keccak": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+              "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+              "optional": true,
+              "requires": {
+                "bindings": "^1.2.1",
+                "inherits": "^2.0.3",
+                "nan": "^2.2.1",
+                "safe-buffer": "^5.1.0"
+              }
+            }
           }
         }
       }
@@ -5722,8 +5735,7 @@
     "js-sha3": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.6.1.tgz",
-      "integrity": "sha1-W4n3enR3Z5h39YxKB1JAk0sflcA=",
-      "optional": true
+      "integrity": "sha1-W4n3enR3Z5h39YxKB1JAk0sflcA="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -5864,10 +5876,9 @@
       "dev": true
     },
     "keccak": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-      "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-      "optional": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.0.0.tgz",
+      "integrity": "sha512-rKe/lRr0KGhjoz97cwg+oeT1Rj/Y4cjae6glArioUC8JBF9ROGZctwIaaruM7d7naovME4Q8WcQSO908A8qcyQ==",
       "requires": {
         "bindings": "^1.2.1",
         "inherits": "^2.0.3",
@@ -5879,7 +5890,6 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.3.tgz",
       "integrity": "sha512-BjLkNDcfaZ6l8HBG9tH0tpmDv3sS2mA7FNQxFHpCdzP3Gb2MVruXBSuoM66SnVxKJpAr5dKGdkHD+bDokt8fTg==",
-      "optional": true,
       "requires": {
         "browserify-sha3": "^0.0.4",
         "sha3": "^1.2.2"
@@ -7135,7 +7145,7 @@
         },
```