### PR TITLE
CT-24 Lowercase hop destination before checking

### DIFF
--- a/modules/core/src/v2/coins/eth.ts
+++ b/modules/core/src/v2/coins/eth.ts
@@ -906,7 +906,7 @@ class Eth extends BaseCoin {
         if (!hopAmount.eq(originalAmount)) {
           throw new Error(`Hop amount: ${hopAmount} does not equal original amount: ${originalAmount}`);
         }
-        if (hopDestination !== originalDestination) {
+        if (hopDestination.toLowerCase() !== originalDestination.toLowerCase()) {
           throw new Error(`Hop destination: ${hopDestination} does not equal original recipient: ${hopDestination}`);
         }
       }


### PR DESCRIPTION
This was causing issues if the user tried sending a tx with non-lowercased address, the comparison failed. 