### PR TITLE
CT-374: Update release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,28 @@
-# BitGo SDK
+# BitGo Javascript SDK
+
+The BitGo Platform and SDK makes it easy to build multi-signature crypto-currency applications today with support for Bitcoin, Ethereum and many other coins.
+The SDK is fully integrated with the BitGo co-signing service for managing all of your BitGo wallets.
+
+Included in the SDK are examples for how to use the API to manage your multi-signature wallets.
+
+Please email us at support@bitgo.com if you have questions or comments about this API.
 
 ## Module Overview
 
+The BitGo SDK repository is a monorepo composed of separate modules, each of which implement some subset of the features of the SDK.
+
 | Package Name | Module | Description | |
 | --- | --- | --- | --- |
-| bitgo | `core` | Authentication, wallet management, user authentication, cryptographic primitives, abstract coin interfaces | [Link](https://github.com/bitgo/bitgojs/) |
-| @bitgo/express | `express` | Local BitGo transaction signing server and proxy | [Link](https://github.com/bitgo/bitgojs/) |
+| bitgo | `core` | Authentication, wallet management, user authentication, cryptographic primitives, abstract coin interfaces, coin implementations | [Link](https://github.com/BitGo/BitGoJS/tree/master/modules/core) |
+| @bitgo/express | `express` | Local BitGo transaction signing server and proxy | [Link](https://github.com/BitGo/BitGoJS/tree/master/modules/express) |
+
+# Release Notes
+
+Each module provides release notes in `modules/*/RELEASE_NOTES.md`.
+
+The release notes for the `core` module are [here](https://github.com/BitGo/BitGoJS/blob/master/modules/core/RELEASE_NOTES.md).
 
 # Notes for Developers
 
-See DEVELOPERS.md
+See [DEVELOPERS.md](https://github.com/BitGo/BitGoJS/blob/master/DEVELOPERS.md)
 

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,6 @@
   "useWorkspaces": true,
   "command": {
     "version": {
-      "allowBranch": "rel/*",
       "message": "chore(release): publish modules"
     }
   }

--- a/modules/core/README.md
+++ b/modules/core/README.md
@@ -1,6 +1,4 @@
-# BitGoJS
-
-BitGo JavaScript SDK
+# BitGo Javascript SDK
 
 The BitGo Platform and SDK makes it easy to build multi-signature crypto-currency applications today with support for Bitcoin, Ethereum and many other coins.
 The SDK is fully integrated with the BitGo co-signing service for managing all of your BitGo wallets.
@@ -16,7 +14,7 @@ Please email us at support@bitgo.com if you have questions or comments about thi
 Please make sure you are running at least Node version 8 (the latest LTS release is recommended) and NPM version 6.
 We recommend using `nvm`, the [Node Version Manager](https://github.com/creationix/nvm/blob/master/README.markdown#installation), for setting your Node version.
 
-`npm install bitgo`
+`npm install --save bitgo`
 
 # Full Documentation
 
@@ -24,7 +22,7 @@ View our [API Documentation](https://www.bitgo.com/api/v2).
 
 # Release Notes
 
-You can find the complete release notes (since version 4.44.0) [here](https://github.com/BitGo/BitGoJS/blob/master/RELEASE_NOTES.md).
+You can find the complete release notes (since version 4.44.0) [here](https://github.com/BitGo/BitGoJS/blob/master/modules/core/RELEASE_NOTES.md).
 
 # Example Usage
 
@@ -78,29 +76,16 @@ wallet.sendCoins({
 ```
 
 ## More examples
-Further demos and examples can be found in the [example](example/) directory and [documented here](https://www.bitgo.com/api/v2/?javascript#examples).
-
-# BitGo Express Local Signing Server (REST API)
-
-Suitable for developers working in a language without an official BitGo SDK.
-
-BitGo Express runs as a service in your own datacenter, and handles the client-side operations involving your own keys, such as partially signing transactions before submitting to BitGo.
-This ensures your keys never leave your network, and are not seen by BitGo. BitGo Express can also proxy the standard BitGo REST APIs, providing a unified interface to BitGo through a single REST API.
-
-`npm explore bitgo -- node bin/bitgo-express [-h] [-v] [-p PORT] [-b BIND] [-e ENV] [-d] [-l LOGFILEPATH] [-k KEYPATH] [-c CRTPATH]`
-
-**Note:** When running against the BitGo production environment, you must run node in a production configuration as well. You can do that by running `export NODE_ENV=production` prior to starting bitgo-express.
-
-For a full tutorial of how to install, authenticate, and use Bitgo Express, see the [Bitgo Express Quickstart](https://platform.bitgo.com/bitgo-express/)
+Further demos and examples can be found in the [example](example/v2) directory and [documented here](https://www.bitgo.com/api/v2/?javascript#examples).
 
 # Usage in Browser
 
-For use inside a browser, BitGoJS can be bundled with any module bundler. There is a Webpack configuration file already included, which can be triggered with package scripts.
+Since version 6, `bitgo` includes a minified, browser-compatible bundle by default at `dist/browser/BitGoJS.min.js`. It can be copied from there directly into your project.
+
+BitGoJS can also be bundled with any module bundler. There is a Webpack configuration file already included, which can be triggered with package scripts.
 
 For a production build: `npm run-script compile`
 
 For a development (non-minified) build: `npm run-script compile-dbg`
 
 To build the test suite into a single test file: `npm run-script compile-test`
-
-To build for specific coins: `npm run compile -- --env.coins="eth, btc, ..."`

--- a/modules/core/RELEASE_NOTES.md
+++ b/modules/core/RELEASE_NOTES.md
@@ -1,22 +1,94 @@
 # BitGoJS Release Notes
 
+## 6.0.0
+The BitGoJS SDK is being modularized! The code base has been split into two modules: `core` and `express`.
+
+`core` contains the Javascript library that you get when you `require('bitgo')`.
+
+`express` contains the source for the BitGo Express local signing server, and it uses the `core` module to provide access to BitGoJS functionality over a REST interface.
+
+The long term plan is to modularize based on each underlying coin library, so users of `bitgo` won't need to bring in many large dependencies for coins they aren't using. This may require additional major versions if breaking changes are required, but we will do as much as possible to maintain the current API of the BitGoJS SDK.
+
+### Breaking Changes
+* Users who pin a git hash of BitGoJS in their package.json will need to update their build steps, since the structure of the git repository has changed. If the desire is to simply use bitgo as a Javascript library outside a browser context, we recommend using a semantic version string instead of a git hash to specify which version should be installed. For development in a browser setting, a browser compatible bundle is now distrubuted in the package at `node_modules/bitgo/dist/browser/BitGoJS.min.js`. As an alternative to downloading the package from npm, a tarball of BitGoJS could also bundled in your application and used during install.
+* `bitgo-express` is no longer bundled with the `bitgo` npm package. The recommended install instructions are now to install via the official Docker image `bitgo/express:latest`. If you aren't able to run bitgo-express via Docker, you can also install and run `bitgo-express` from the source code. See the [`bitgo-express` README](https://github.com/BitGo/BitGoJS/tree/master/modules/express#running-bitgo-express) for more information on how to install and run BitGo Express.
+* For version 1 wallets, the bitcoin network by the BitGo object is no longer global, and is now determined by the bitgo object's environment when it was initialized.
+
+As an example, before the behavior was as follows:
+```typescript
+const BitGoJS = require('bitgo');
+// create a new bitgo object using the default (test) environment
+const bitgo = new BitGoJS.BitGo();
+
+// BAD: Global network is checked by all bitgo objects, but this
+// leads to race conditions when multiple bitgo objects are setting the
+// global bitcoin network unpredictably
+BitGoJS.setNetwork('bitcoin');
+// verify a main net address using bitgo object using test environment
+bitgo.verifyAddress({ address: '1Bu3bhwRmevHLAy1JrRB6AfcxfgDG2vXRd' }).should.be.true();
+```
+
+After version 6, the behavior will change to this:
+```typescript
+const BitGoJS = require('bitgo');
+
+// create a new bitgo object using the default (test) environment
+const bitgo = new BitGoJS.BitGo();
+
+// BREAKING CHANGE: returns false since this bitgo object is using
+// the test environment and cannot verify a main net address
+bitgo.verifyAddress({ address: '1Bu3bhwRmevHLAy1JrRB6AfcxfgDG2vXRd' }).should.be.true();
+
+// create a new bitgo object using the production environment
+const prodBitgo = new BitGoJS.BitGo({ env: 'prod' });
+
+// OK: Able to verify main net address with bitgo using production environment
+prodBitgo.verifyAddress({ address: '1Bu3bhwRmevHLAy1JrRB6AfcxfgDG2vXRd' }).should.be.true();
+```
+
+To switch to another bitcoin network, a new bitgo object should be constructed in the correct environment.
+
+### Other Changes
+* Overhaul how coins are loaded, in anticipation of a pluggable coin system in a future version of `bitgo`.
+* Rework CI system to reduce test runtimes by running tests for each module in parallel
+* Create and upload mochawesome report after each test run. [Here's an example](https://bitgo-sdk-test-reports.s3.amazonaws.com/1166/core/integration%20tests%20\(node:lts\).html).
+* Remove coin instantiation logic from BaseCoin and move methods to prototype instead of attaching to coin object instances.
+
+## 5.4.0
+
+### New Features
+* Add support for verifying and signing Ethereum hop transactions
+* Add support for new ERC 20 tokens (TIOX, SPO)
+
+### Bug Fixes
+* Remove duplicate ERC 20 token definition (AION)
+
+## 5.3.0
+
+### New Features
+* Add support for new ERC 20 tokens (USX, EUX, PLX, CQX, KZE)
+
+### Other Changes
+* Improve test performance by making more requests in parallel when checking wallet funding
+* Fix bitgo-express startup command on Windows where the shebang line is ignored
+
 ## 5.2.0
 
 ### New Features
 * Add support for new ERC 20 tokens (WHT, AMN, BTU, TAUD)
 * Add support for trade payload signing
 
-## Bug Fixes
+### Bug Fixes
 * Allow sharing "pseudo-cold" wallets where the encrypted user key is not held by BitGo.
 * Correctly update matching wallet passphrases when the user login password is updated.
 * Add missing filter parameters in `wallet.transfers`.
 
-## Other Changes
+### Other Changes
 * Update README to clarify package description and improve example snippets
 
 ## 5.1.1
 
-## Bug Fixes
+### Bug Fixes
 * Separate input signing and signature verification steps in `AbstractUtxoCoin.signTransaction`. This fixes an issue where Native Segwit inputs which were not the last input in the transaction were not being properly constructed.
 
 ## 5.1.0

--- a/modules/express/RELEASE_NOTES.md
+++ b/modules/express/RELEASE_NOTES.md
@@ -1,0 +1,9 @@
+# BitGo Express Release Notes
+
+## 6.0.0
+
+BitGo Express has been separated from the core `bitgo` Javascript library, and is now its own module in the BitGoJS monorepo. It's been split from the core Javascript library because it's an application which should be distributed differently than a library. By packaging and distributing separately, we have much better control over the tree of dependencies which BitGo Express needs to operate.
+
+The recommended install instructions are now to install via the official bitgo-express Docker image `bitgo/express:latest`. If you aren't able to run bitgo-express via Docker, you can also install and run `bitgo-express` from the source code.
+
+See the [`bitgo-express` README](https://github.com/BitGo/BitGoJS/tree/master/modules/express#running-bitgo-express) for more information on how to install and run BitGo Express.


### PR DESCRIPTION
* Update release notes versions for 5.3.0, 5.4.0, core@6.0.0, and express@6.0.0
* Don't restrict lerna versioning to rel/* branches
* Improve READMEs and fix links