### PR TITLE
CT-593 - Fix EOS isValidMemo params in SDK

### DIFF
--- a/modules/core/src/v2/coins/eos.ts
+++ b/modules/core/src/v2/coins/eos.ts
@@ -142,10 +142,10 @@ export class Eos extends BaseCoin {
   /**
    * Evaluates whether a memo is valid
    *
-   * @param memo - the memo to be checked
+   * @param value - the memo to be checked
    */
-  isValidMemo(memo: string): boolean {
-    return memo && memo.length <= 256;
+  isValidMemo({ value }: { value: string } ): boolean {
+    return value && value.length <= 256;
   }
 
   /**
@@ -154,7 +154,7 @@ export class Eos extends BaseCoin {
    * @param memoId - the memo id to be checked
    */
   isValidMemoId(memoId: string): boolean {
-    if (!this.isValidMemo(memoId)) {
+    if (!this.isValidMemo({ value: memoId })) {
       return false;
     }
 

--- a/modules/core/test/v2/unit/coins/eos.ts
+++ b/modules/core/test/v2/unit/coins/eos.ts
@@ -1,5 +1,4 @@
 import * as should from 'should';
-import * as crypto from 'crypto';
 import * as Promise from 'bluebird';
 const co = Promise.coroutine;
 import * as ecc from 'eosjs-ecc';
@@ -69,10 +68,10 @@ describe('EOS:', function() {
   });
 
   it('isValidMemoId should work', function() {
-    basecoin.isValidMemo('1').should.equal(true);
-    basecoin.isValidMemo('uno').should.equal(true);
+    basecoin.isValidMemo({ value: '1' }).should.equal(true);
+    basecoin.isValidMemo({ value: 'uno' }).should.equal(true);
     const string257CharsLong = '4WMNlu0fFU8N94AwukfpfPPQn2Myo80JdmLNF5rgeKAab9XLD93KUQipcT6US0LRwWWIGbUt89fjmdwpg3CBklNi8QIeBI2i8UDJCEuQKYobR5m4ismm1RooTXUnw5OPjmfLuuajYV4e5cS1jpC6hez5X43PZ5SsGaHNYX2YYXY03ir54cWWx5QW5VCPKPKUzfq2UYK5fjAG2Fe3xCUOzqgoR6KaAiuOOnDSyhZygLJyaoJpOXZM9olblNtAW75Ed';
-    basecoin.isValidMemo(string257CharsLong).should.equal(false);
+    basecoin.isValidMemo({ value: string257CharsLong }).should.equal(false);
   });
 
   it('should validate pub key', () => {
@@ -132,4 +131,3 @@ describe('EOS:', function() {
     });
   }));
 });
-


### PR DESCRIPTION
The isValidMemo SDK method is used by the client to validate memos for XLM and EOS. The format of the parameters must be the same for the call to work for both coins.

https://bitgoinc.atlassian.net/browse/CT-593