### PR TITLE
BG-13379 - Overwrite stellar federation url in custom config

### DIFF
--- a/modules/core/src/bitgo.ts
+++ b/modules/core/src/bitgo.ts
@@ -152,7 +152,7 @@ const createResponseErrorString = function(res) {
 let testNetWarningMessage = false;
 const BitGo = function(params) {
   params = params || {};
-  if (!common.validateParams(params, [], ['clientId', 'clientSecret', 'refreshToken', 'accessToken', 'userAgent', 'customRootURI', 'customBitcoinNetwork', 'serverXpub']) ||
+  if (!common.validateParams(params, [], ['clientId', 'clientSecret', 'refreshToken', 'accessToken', 'userAgent', 'customRootURI', 'customBitcoinNetwork', 'serverXpub', 'stellarFederationServerUrl']) ||
     (params.useProduction && !_.isBoolean(params.useProduction))) {
     throw new Error('invalid argument');
   }
@@ -188,6 +188,9 @@ const BitGo = function(params) {
     }
     if (params.serverXpub) {
       common.Environments['custom'].serverXpub = params.serverXpub;
+    }
+    if (params.stellarFederationServerUrl) {
+      common.Environments['custom'].stellarFederationServerUrl = params.stellarFederationServerUrl;
     }
   } else {
     env = params.env || process.env.BITGO_ENV;


### PR DESCRIPTION
Jira Ticket: [BG-](https://bitgoinc.atlassian.net/browse/BG-13379)

Since the custom config for is initialized with `process.env.BITGO_CUSTOM_ROOT_URI` it is setting up the URL as `https://undefined/api/v2/txlm/federation`
We need to be able to set that from the client.

## Changes 
Ability to overwrite the stellarFederationServerUrl config.

