### PR TITLE
CT-656 - Make explainTransaction methods return promise

### DIFF
--- a/modules/core/example/v2/send-wallet-transaction.js
+++ b/modules/core/example/v2/send-wallet-transaction.js
@@ -31,7 +31,7 @@ Promise.coroutine(function *() {
     ],
     walletPassphrase: walletPassphrase
   });
-  const explanation = basecoin.explainTransaction({ txHex: transaction.tx });
+  const explanation = yield basecoin.explainTransaction({ txHex: transaction.tx });
 
   console.log('Wallet ID:', walletInstance.id());
   console.log('Current Receive Address:', walletInstance.receiveAddress());

--- a/modules/core/src/v2/baseCoin.ts
+++ b/modules/core/src/v2/baseCoin.ts
@@ -15,6 +15,27 @@ const Keychains = require('./keychains');
 const PendingApprovals = require('./pendingApprovals');
 import { Enterprises } from './enterprises';
 
+export interface BaseCoinTransactionOutput {
+  address: string;
+  amount: string;
+}
+
+export interface BaseCoinTransactionFee {
+  fee: string;
+  feeRate?: number;
+  size?: number;
+}
+
+export interface BaseCoinTransactionExplanation {
+  displayOrder: string[];
+  id: string;
+  outputs: BaseCoinTransactionOutput[];
+  outputAmount: string;
+  changeOutputs: BaseCoinTransactionOutput[];
+  changeAmount: string;
+  fee: BaseCoinTransactionFee;
+}
+
 export abstract class BaseCoin {
 
   protected readonly bitgo;

--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -1,5 +1,6 @@
 import { hdPath } from '../../bitcoin';
 import { BaseCoin } from '../baseCoin';
+import { NodeCallback } from '../types';
 const config = require('../../config');
 const bitcoin = require('bitgo-utxo-lib');
 const bitcoinMessage = require('bitcoinjs-message');
@@ -12,6 +13,38 @@ const RecoveryTool = require('../recovery');
 const errors = require('../../errors');
 const debug = require('debug')('bitgo:v2:utxo');
 import { Codes, VirtualSizes } from '@bitgo/unspents';
+
+export interface Output {
+  address: string;
+  amount: string;
+}
+
+export interface TransactionFee {
+  fee: number;
+  feeRate?: number;
+  size: number
+}
+
+export interface AbstractUtxoCoinTransactionExplanation {
+  displayOrder: string[];
+  id: string;
+  outputs: Output[],
+  changeOutputs: Output[],
+  outputAmount: string;
+  changeAmount: number;
+  fee: TransactionFee;
+}
+
+export interface Unspent {
+  id: string,
+  value: string,
+}
+
+export interface AbstractUtxoCoinExplainTransactionOptions {
+  txHex: string;
+  txInfo: { changeAddresses: string[], unspents: Unspent[] };
+  feeInfo?: string;
+}
 
 export class AbstractUtxoCoin extends BaseCoin {
 
@@ -191,7 +224,7 @@ export class AbstractUtxoCoin extends BaseCoin {
       const keySignatures = _.get(wallet, '_wallet.keySignatures');
 
       // obtain all outputs
-      const explanation = this.explainTransaction({
+      const explanation = yield this.explainTransaction({
         txHex: txPrebuild.txHex,
         txInfo: txPrebuild.txInfo,
         keychains: keychains
@@ -1006,126 +1039,128 @@ export class AbstractUtxoCoin extends BaseCoin {
     return areAllSignaturesValid;
   }
 
-  explainTransaction(params = {} as any) {
-    const { txHex, txInfo } = params;
+  explainTransaction(params: AbstractUtxoCoinExplainTransactionOptions, callback?: NodeCallback<AbstractUtxoCoinTransactionExplanation>): Bluebird<AbstractUtxoCoinTransactionExplanation> {
+    return co(function *() {
+      const txHex = _.get(params, 'txHex');
+      if (!txHex || !_.isString(txHex) || !txHex.match(/^([a-f0-9]{2})+$/i)) {
+        throw new Error('invalid transaction hex, must be a valid hex string');
+      }
 
-    if (!txHex || !_.isString(txHex) || !txHex.match(/^([a-f0-9]{2})+$/i)) {
-      throw new Error('invalid transaction hex, must be a valid hex string');
-    }
+      let transaction;
+      try {
+        transaction = bitcoin.Transaction.fromHex(txHex, this.network);
+      } catch (e) {
+        throw new Error('failed to parse transaction hex');
+      }
 
-    let transaction;
-    try {
-      transaction = bitcoin.Transaction.fromHex(txHex, this.network);
-    } catch (e) {
-      throw new Error('failed to parse transaction hex');
-    }
+      const id = transaction.getId();
+      let changeAddresses = [];
+      let spendAmount = 0;
+      let changeAmount = 0;
+      const txInfo = _.get(params, 'txInfo');
+      if (txInfo && txInfo.changeAddresses) {
+        changeAddresses = txInfo.changeAddresses;
+      }
+      const explanation: any = {
+        displayOrder: ['id', 'outputAmount', 'changeAmount', 'outputs', 'changeOutputs'],
+        id: id,
+        outputs: [],
+        changeOutputs: []
+      };
 
-    const id = transaction.getId();
-    let changeAddresses = [];
-    let spendAmount = 0;
-    let changeAmount = 0;
-    if (txInfo && txInfo.changeAddresses) {
-      changeAddresses = txInfo.changeAddresses;
-    }
-    const explanation: any = {
-      displayOrder: ['id', 'outputAmount', 'changeAmount', 'outputs', 'changeOutputs'],
-      id: id,
-      outputs: [],
-      changeOutputs: []
-    };
+      transaction.outs.forEach((currentOutput) => {
+        const currentAddress = this.getCoinLibrary().address.fromOutputScript(currentOutput.script, this.network);
+        const currentAmount = currentOutput.value;
 
-    transaction.outs.forEach((currentOutput) => {
-      const currentAddress = this.getCoinLibrary().address.fromOutputScript(currentOutput.script, this.network);
-      const currentAmount = currentOutput.value;
+        if (changeAddresses.indexOf(currentAddress) !== -1) {
+          // this is change
+          changeAmount += currentAmount;
+          explanation.changeOutputs.push({
+            address: currentAddress,
+            amount: currentAmount
+          });
+          return;
+        }
 
-      if (changeAddresses.indexOf(currentAddress) !== -1) {
-        // this is change
-        changeAmount += currentAmount;
-        explanation.changeOutputs.push({
+        spendAmount += currentAmount;
+        explanation.outputs.push({
           address: currentAddress,
           amount: currentAmount
         });
-        return;
-      }
-
-      spendAmount += currentAmount;
-      explanation.outputs.push({
-        address: currentAddress,
-        amount: currentAmount
       });
-    });
-    explanation.outputAmount = spendAmount;
-    explanation.changeAmount = changeAmount;
+      explanation.outputAmount = spendAmount;
+      explanation.changeAmount = changeAmount;
 
-    // add fee info if available
-    if (params.feeInfo) {
-      explanation.displayOrder.push('fee');
-      explanation.fee = params.feeInfo;
-    }
-
-    if (_.isInteger(transaction.locktime) && transaction.locktime > 0) {
-      explanation.locktime = transaction.locktime;
-      explanation.displayOrder.push('locktime');
-    }
-
-    const unspentValues = {};
-
-    // get information on tx inputs
-    const inputSignatures = transaction.ins.map((input, idx) => {
-      const hasSigScript = !_.isEmpty(input.script);
-      const hasWitnessScript = !_.isEmpty(input.witness);
-
-      if (!hasSigScript && !hasWitnessScript) {
-        // no sig script or witness data for this input
-        debug('no signature script or witness script data for input %s', idx);
-        return 0;
+      // add fee info if available
+      if (params.feeInfo) {
+        explanation.displayOrder.push('fee');
+        explanation.fee = params.feeInfo;
       }
 
-      let parsedSigScript;
-      try {
-        parsedSigScript = this.parseSignatureScript(transaction, idx);
-      } catch (e) {
-        return false;
+      if (_.isInteger(transaction.locktime) && transaction.locktime > 0) {
+        explanation.locktime = transaction.locktime;
+        explanation.displayOrder.push('locktime');
       }
 
-      if (hasWitnessScript) {
-        if (!txInfo || !txInfo.unspents) {
-          // segwit txs require input values, cannot validate signatures
-          debug('unable to retrieve input amounts from unspents - cannot validate segwit input signatures');
+      const unspentValues = {};
+
+      // get information on tx inputs
+      const inputSignatures = transaction.ins.map((input, idx) => {
+        const hasSigScript = !_.isEmpty(input.script);
+        const hasWitnessScript = !_.isEmpty(input.witness);
+
+        if (!hasSigScript && !hasWitnessScript) {
+          // no sig script or witness data for this input
+          debug('no signature script or witness script data for input %s', idx);
           return 0;
         }
 
-        // lazily populate unspent values
-        if (_.isEmpty(unspentValues)) {
-          txInfo.unspents.forEach((unspent) => {
-            unspentValues[unspent.id] = unspent.value;
-          });
-        }
-      }
-
-      const nonEmptySignatures = parsedSigScript.signatures.filter((sig) => !_.isEmpty(sig));
-      const validSignatures = nonEmptySignatures.map((sig, sigIndex) => {
-        if (_.isEmpty(sig)) {
-          return false;
-        }
-
-        const parentTxId = (Buffer.from(input.hash).reverse() as Buffer).toString('hex');
-        const inputId = `${parentTxId}:${input.index}`;
-        const amount = unspentValues[inputId];
-
+        let parsedSigScript;
         try {
-          return this.verifySignature(transaction, idx, amount, { signatureIndex: sigIndex });
+          parsedSigScript = this.parseSignatureScript(transaction, idx);
         } catch (e) {
           return false;
         }
+
+        if (hasWitnessScript) {
+          if (!txInfo || !txInfo.unspents) {
+            // segwit txs require input values, cannot validate signatures
+            debug('unable to retrieve input amounts from unspents - cannot validate segwit input signatures');
+            return 0;
+          }
+
+          // lazily populate unspent values
+          if (_.isEmpty(unspentValues)) {
+            txInfo.unspents.forEach((unspent) => {
+              unspentValues[unspent.id] = unspent.value;
+            });
+          }
+        }
+
+        const nonEmptySignatures = parsedSigScript.signatures.filter((sig) => !_.isEmpty(sig));
+        const validSignatures = nonEmptySignatures.map((sig, sigIndex) => {
+          if (_.isEmpty(sig)) {
+            return false;
+          }
+
+          const parentTxId = (Buffer.from(input.hash).reverse() as Buffer).toString('hex');
+          const inputId = `${parentTxId}:${input.index}`;
+          const amount = unspentValues[inputId];
+
+          try {
+            return this.verifySignature(transaction, idx, amount, { signatureIndex: sigIndex });
+          } catch (e) {
+            return false;
+          }
+        });
+
+        return validSignatures.reduce((validCount, isValid) => isValid ? validCount + 1 : validCount, 0);
       });
 
-      return validSignatures.reduce((validCount, isValid) => isValid ? validCount + 1 : validCount, 0);
-    });
-
-    explanation.inputSignatures = inputSignatures;
-    explanation.signatures = _.max(inputSignatures);
-    return explanation;
+      explanation.inputSignatures = inputSignatures;
+      explanation.signatures = _.max(inputSignatures);
+      return explanation;
+    }).call(this).asCallback(callback);
   }
 
   createMultiSigAddress(addressType, signatureThreshold, keys) {

--- a/modules/core/src/v2/coins/xrp.ts
+++ b/modules/core/src/v2/coins/xrp.ts
@@ -1,5 +1,9 @@
-import { BaseCoin } from '../baseCoin';
-const BigNumber = require('bignumber.js');
+import {
+  BaseCoin,
+  BaseCoinTransactionExplanation,
+} from '../baseCoin';
+import { NodeCallback } from '../types';
+import { BigNumber } from 'bignumber.js';
 import * as crypto from 'crypto';
 const ripple = require('../../ripple');
 const rippleAddressCodec = require('ripple-address-codec');
@@ -37,27 +41,6 @@ interface SignTransactionOptions {
   prv: string;
 }
 
-interface Output {
-  address: string;
-  amount: string;
-}
-
-interface TransactionFee {
-  fee: number;
-  feeRate?: number;
-  size: number
-}
-
-interface TransactionExplanation {
-  displayOrder: string[];
-  id: string;
-  outputs: Output[],
-  changeOutputs: Output[],
-  outputAmount: string;
-  changeAmount: number;
-  fee: TransactionFee;
-}
-
 interface ExplainTransactionOptions {
   txHex: string;
 }
@@ -72,7 +55,7 @@ interface VerifyAddressOptions {
   rootAddress: string;
 }
 
-interface RecoveryInfo extends TransactionExplanation {
+interface RecoveryInfo extends BaseCoinTransactionExplanation {
   txHex: string;
   backupKey?: string;
   coin?: string;
@@ -373,43 +356,44 @@ export class Xrp extends BaseCoin {
   /**
    * Explain/parse transaction
    * @param params
-   * - txHex: hexadecimal representation of transaction
-   * @returns {{displayOrder: [string,string,string,string,string], id: *, outputs: Array, changeOutputs: Array}}
+   * @param callback
    */
-  public explainTransaction(params: ExplainTransactionOptions): TransactionExplanation {
-    let transaction;
-    let txHex;
-    try {
-      transaction = rippleBinaryCodec.decode(params.txHex);
-      txHex = params.txHex;
-    } catch (e) {
+  explainTransaction(params: ExplainTransactionOptions, callback?: NodeCallback<BaseCoinTransactionExplanation>): Bluebird<BaseCoinTransactionExplanation> {
+    return co(function *() {
+      let transaction;
+      let txHex;
       try {
-        transaction = JSON.parse(params.txHex);
-        txHex = rippleBinaryCodec.encode(transaction);
+        transaction = rippleBinaryCodec.decode(params.txHex);
+        txHex = params.txHex;
       } catch (e) {
-        throw new Error('txHex needs to be either hex or JSON string for XRP');
-      }
-    }
-    const id = rippleHashes.computeBinaryTransactionHash(txHex);
-    const address = transaction.Destination + ((transaction.DestinationTag >= 0) ? '?dt=' + transaction.DestinationTag : '');
-    return {
-      displayOrder: ['id', 'outputAmount', 'changeAmount', 'outputs', 'changeOutputs', 'fee'],
-      id: id,
-      changeOutputs: [],
-      outputAmount: transaction.Amount,
-      changeAmount: 0,
-      outputs: [
-        {
-          address,
-          amount: transaction.Amount
+        try {
+          transaction = JSON.parse(params.txHex);
+          txHex = rippleBinaryCodec.encode(transaction);
+        } catch (e) {
+          throw new Error('txHex needs to be either hex or JSON string for XRP');
         }
-      ],
-      fee: {
-        fee: transaction.Fee,
-        feeRate: null,
-        size: txHex.length / 2
       }
-    };
+      const id = rippleHashes.computeBinaryTransactionHash(txHex);
+      const address = transaction.Destination + ((transaction.DestinationTag >= 0) ? '?dt=' + transaction.DestinationTag : '');
+      return {
+        displayOrder: ['id', 'outputAmount', 'changeAmount', 'outputs', 'changeOutputs', 'fee'],
+        id: id,
+        changeOutputs: [],
+        outputAmount: transaction.Amount,
+        changeAmount: 0,
+        outputs: [
+          {
+            address,
+            amount: transaction.Amount
+          }
+        ],
+        fee: {
+          fee: transaction.Fee,
+          feeRate: null,
+          size: txHex.length / 2
+        }
+      };
+    }).call(this).asCallback(callback);
   }
 
   /**
@@ -422,7 +406,7 @@ export class Xrp extends BaseCoin {
    */
   public verifyTransaction({ txParams, txPrebuild }: VerifyTransactionOptions, callback): Bluebird<boolean> {
     return co(function *() {
-      const explanation = this.explainTransaction({
+      const explanation = yield this.explainTransaction({
         txHex: txPrebuild.txHex
       });
 
@@ -484,33 +468,33 @@ export class Xrp extends BaseCoin {
    * - recoveryDestination: target address to send recovered funds to
    * @param callback
    */
-  public recover(params: RecoveryOptions, callback): Bluebird<RecoveryInfo | string> {
-    const rippledUrl = this.getRippledUrl();
-    const self = this;
-    const isKrsRecovery = params.backupKey.startsWith('xpub') && !params.userKey.startsWith('xpub');
-    const isUnsignedSweep = params.backupKey.startsWith('xpub') && params.userKey.startsWith('xpub');
+  public recover(params: RecoveryOptions, callback?: NodeCallback<RecoveryInfo | string>): Bluebird<RecoveryInfo | string> {
+    return co(function *explainTransaction() {
+      const rippledUrl = this.getRippledUrl();
+      const isKrsRecovery = params.backupKey.startsWith('xpub') && !params.userKey.startsWith('xpub');
+      const isUnsignedSweep = params.backupKey.startsWith('xpub') && params.userKey.startsWith('xpub');
 
-    return this.initiateRecovery(params)
-    .then(function(keys) {
-      const addressDetailsPromise = self.bitgo.post(rippledUrl)
-      .send({
+      const accountInfoParams = {
         method: 'account_info',
         params: [{
           account: params.rootAddress,
           strict: true,
           ledger_index: 'current',
           queue: true,
-          signer_lists: true
-        }]
+          signer_lists: true,
+        }],
+      };
+
+      const { keys, addressDetails, feeDetails, serverDetails } = yield Bluebird.props({
+        keys: this.initiateRecovery(params),
+        addressDetails: this.bitgo.post(rippledUrl).send(accountInfoParams),
+        feeDetails: this.bitgo.post(rippledUrl).send({ method: 'fee' }),
+        serverDetails: this.bitgo.post(rippledUrl).send({ method: 'server_info' }),
       });
-      const feeDetailsPromise = self.bitgo.post(rippledUrl).send({ method: 'fee' });
-      const serverDetailsPromise = self.bitgo.post(rippledUrl).send({ method: 'server_info' });
-      return [addressDetailsPromise, feeDetailsPromise, serverDetailsPromise, keys];
-    })
-    .spread(function(addressDetails, feeDetails, serverDetails, keys) {
+
       const openLedgerFee = new BigNumber(feeDetails.body.result.drops.open_ledger_fee);
-      const baseReserve = new BigNumber(serverDetails.body.result.info.validated_ledger.reserve_base_xrp).times(self.getBaseFactor());
-      const reserveDelta = new BigNumber(serverDetails.body.result.info.validated_ledger.reserve_inc_xrp).times(self.getBaseFactor());
+      const baseReserve = new BigNumber(serverDetails.body.result.info.validated_ledger.reserve_base_xrp).times(this.getBaseFactor());
+      const reserveDelta = new BigNumber(serverDetails.body.result.info.validated_ledger.reserve_inc_xrp).times(this.getBaseFactor());
       const currentLedger = serverDetails.body.result.info.validated_ledger.seq;
       const sequenceId = addressDetails.body.result.account_data.Sequence;
       const balance = new BigNumber(addressDetails.body.result.account_data.Balance);
@@ -621,16 +605,15 @@ export class Xrp extends BaseCoin {
         signedTransaction = rippleLib.combine([userSignature.signedTransaction, backupSignature.signedTransaction]);
       }
 
-      const transactionExplanation = self.explainTransaction({ txHex: signedTransaction.signedTransaction }) as RecoveryInfo;
+      const transactionExplanation = yield this.explainTransaction({ txHex: signedTransaction.signedTransaction }) as RecoveryInfo;
       transactionExplanation.txHex = signedTransaction.signedTransaction;
 
       if (isKrsRecovery) {
         transactionExplanation.backupKey = params.backupKey;
-        transactionExplanation.coin = self.getChain();
+        transactionExplanation.coin = this.getChain();
       }
       return transactionExplanation;
-    })
-    .nodeify(callback);
+    }).call(this).asCallback(callback);
   }
 
   /**

--- a/modules/core/test/v2/integration/wallet.ts
+++ b/modules/core/test/v2/integration/wallet.ts
@@ -423,7 +423,7 @@ describe('V2 Wallet:', function() {
 
       };
       const prebuild = yield wallet.prebuildTransaction(params);
-      const explanation = basecoin.explainTransaction(prebuild);
+      const explanation = yield basecoin.explainTransaction(prebuild);
       explanation.displayOrder.length.should.equal(7);
       explanation.outputs.length.should.equal(1);
       // sometimes the change output is below the dust threshold and gets dumped to fees, so it may be missing

--- a/modules/core/test/v2/unit/coins/abstractUtxoCoin.ts
+++ b/modules/core/test/v2/unit/coins/abstractUtxoCoin.ts
@@ -38,8 +38,7 @@ describe('Abstract UTXO Coin:', () => {
     });
 
     it('should classify outputs which spend change back to a v1 wallet base address as internal', co(function *() {
-      sinon.stub(coin, 'explainTransaction')
-      .returns({
+      sinon.stub(coin, 'explainTransaction').resolves({
         outputs: [],
         changeOutputs: [{
           address: wallet._wallet.migratedFrom,
@@ -47,8 +46,7 @@ describe('Abstract UTXO Coin:', () => {
         }]
       });
 
-      sinon.stub(coin, 'verifyAddress')
-      .throws(new errors.UnexpectedAddressError('test error'));
+      sinon.stub(coin, 'verifyAddress').throws(new errors.UnexpectedAddressError('test error'));
 
 
       const parsedTransaction = yield coin.parseTransaction({ txParams: {}, txPrebuild: {}, wallet, verification });
@@ -66,8 +64,7 @@ describe('Abstract UTXO Coin:', () => {
 
     it('should classify outputs which spend to addresses not on the wallet as external', co(function *() {
       const externalAddress = 'external_address';
-      sinon.stub(coin, 'explainTransaction')
-      .returns({
+      sinon.stub(coin, 'explainTransaction').resolves({
         outputs: [{
           address: externalAddress,
           amount: outputAmount
@@ -75,8 +72,7 @@ describe('Abstract UTXO Coin:', () => {
         changeOutputs: []
       });
 
-      sinon.stub(coin, 'verifyAddress')
-      .throws(new errors.UnexpectedAddressError('test error'));
+      sinon.stub(coin, 'verifyAddress').throws(new errors.UnexpectedAddressError('test error'));
 
       const parsedTransaction = yield coin.parseTransaction({ txParams: {}, txPrebuild: {}, wallet, verification });
 
@@ -97,8 +93,7 @@ describe('Abstract UTXO Coin:', () => {
       const outputAmount = 10000;
       const recipients = [];
 
-      sinon.stub(coin, 'explainTransaction')
-      .returns({
+      sinon.stub(coin, 'explainTransaction').resolves({
         outputs: [],
         changeOutputs: [
           {

--- a/modules/core/test/v2/unit/coins/btc.ts
+++ b/modules/core/test/v2/unit/coins/btc.ts
@@ -413,36 +413,24 @@ describe('BTC:', function() {
       });
 
       describe('failure', () => {
-        it('should fail for invalid transaction hexes', () => {
-          (() => coin.explainTransaction())
-          .should.throw('invalid transaction hex, must be a valid hex string');
+        it('should fail for invalid transaction hexes', co(function *() {
+          yield coin.explainTransaction().should.be.rejectedWith('invalid transaction hex, must be a valid hex string');
 
-          (() => coin.explainTransaction({
-            txHex: ''
-          })).should.throw('invalid transaction hex, must be a valid hex string');
+          yield coin.explainTransaction({ txHex: '' }).should.be.rejectedWith('invalid transaction hex, must be a valid hex string');
 
-          (() => coin.explainTransaction({
-            txHex: 'nonsense'
-          })).should.throw('invalid transaction hex, must be a valid hex string');
+          yield coin.explainTransaction({ txHex: 'nonsense' }).should.be.rejectedWith('invalid transaction hex, must be a valid hex string');
 
-          (() => coin.explainTransaction({
-            txHex: 1234
-          })).should.throw('invalid transaction hex, must be a valid hex string');
+          yield coin.explainTransaction({ txHex: 1234 }).should.be.rejectedWith('invalid transaction hex, must be a valid hex string');
 
-          (() => coin.explainTransaction({
-            txHex: '1234a'
-          })).should.throw('invalid transaction hex, must be a valid hex string');
+          yield coin.explainTransaction({ txHex: '1234a' }).should.be.rejectedWith('invalid transaction hex, must be a valid hex string');
 
-          (() => coin.explainTransaction({
-            txHex: '1234ab'
-          })).should.throw('failed to parse transaction hex');
-        });
-
+          yield coin.explainTransaction({ txHex: '1234ab' }).should.be.rejectedWith('failed to parse transaction hex');
+        }));
       });
 
       describe('success', () => {
-        it('should handle undefined tx info for segwit transactions', () => {
-          const { signatures, inputSignatures } = coin.explainTransaction({
+        it('should handle undefined tx info for segwit transactions', co(function *() {
+          const { signatures, inputSignatures } = yield coin.explainTransaction({
             txHex: txs.p2shP2wsh.halfSigned
           });
 
@@ -452,10 +440,10 @@ describe('BTC:', function() {
           should.exist(inputSignatures);
           inputSignatures.should.have.length(2);
           inputSignatures.should.deepEqual([0, 0]);
-        });
+        }));
 
-        it('should count zero signatures on an unsigned transaction', () => {
-          const { signatures, inputSignatures } = coin.explainTransaction({
+        it('should count zero signatures on an unsigned transaction', co(function *() {
+          const { signatures, inputSignatures } = yield coin.explainTransaction({
             txHex: unsignedTx
           });
 
@@ -465,10 +453,10 @@ describe('BTC:', function() {
           should.exist(inputSignatures);
           inputSignatures.should.have.length(2);
           inputSignatures.should.deepEqual([0, 0]);
-        });
+        }));
 
-        it('should count one signature on a half-signed p2sh transaction', () => {
-          const { signatures, inputSignatures } = coin.explainTransaction({
+        it('should count one signature on a half-signed p2sh transaction', co(function *() {
+          const { signatures, inputSignatures } = yield coin.explainTransaction({
             txHex: txs.p2sh.halfSigned
           });
 
@@ -478,10 +466,10 @@ describe('BTC:', function() {
           should.exist(inputSignatures);
           inputSignatures.should.have.length(1);
           inputSignatures.should.deepEqual([1]);
-        });
+        }));
 
-        it('should count two signatures on a fully-signed p2sh transaction', () => {
-          const { signatures, inputSignatures } = coin.explainTransaction({
+        it('should count two signatures on a fully-signed p2sh transaction', co(function *() {
+          const { signatures, inputSignatures } = yield coin.explainTransaction({
             txHex: txs.p2sh.fullySigned
           });
 
@@ -491,10 +479,10 @@ describe('BTC:', function() {
           should.exist(inputSignatures);
           inputSignatures.should.have.length(1);
           inputSignatures.should.deepEqual([2]);
-        });
+        }));
 
-        it('should count one signature on a half-signed p2shP2wsh transaction', () => {
-          const { signatures, inputSignatures } = coin.explainTransaction({
+        it('should count one signature on a half-signed p2shP2wsh transaction', co(function *() {
+          const { signatures, inputSignatures } = yield coin.explainTransaction({
             txHex: txs.p2shP2wsh.halfSigned,
             txInfo: txs.p2shP2wsh.txInfo
           });
@@ -505,10 +493,10 @@ describe('BTC:', function() {
           should.exist(inputSignatures);
           inputSignatures.should.have.length(2);
           inputSignatures.should.deepEqual([1, 1]);
-        });
+        }));
 
-        it('should count two signatures on a fully-signed p2shP2wsh transaction', () => {
-          const { signatures, inputSignatures } = coin.explainTransaction({
+        it('should count two signatures on a fully-signed p2shP2wsh transaction', co(function *() {
+          const { signatures, inputSignatures } = yield coin.explainTransaction({
             txHex: txs.p2shP2wsh.fullySigned,
             txInfo: txs.p2shP2wsh.txInfo
           });
@@ -519,10 +507,10 @@ describe('BTC:', function() {
           should.exist(inputSignatures);
           inputSignatures.should.have.length(2);
           inputSignatures.should.deepEqual([2, 2]);
-        });
+        }));
 
-        it('should count one signature on a half-signed p2wsh transaction', () => {
-          const { signatures, inputSignatures } = coin.explainTransaction({
+        it('should count one signature on a half-signed p2wsh transaction', co(function *() {
+          const { signatures, inputSignatures } = yield coin.explainTransaction({
             txHex: txs.p2wsh.halfSigned,
             txInfo: txs.p2wsh.txInfo
           });
@@ -531,10 +519,10 @@ describe('BTC:', function() {
           signatures.should.equal(1);
 
           should.exist(inputSignatures);
-        });
+        }));
 
-        it('should count two signatures on a fully-signed p2wsh transaction', () => {
-          const { signatures, inputSignatures } = coin.explainTransaction({
+        it('should count two signatures on a fully-signed p2wsh transaction', co(function *() {
+          const { signatures, inputSignatures } = yield coin.explainTransaction({
             txHex: txs.p2wsh.fullySigned,
             txInfo: txs.p2wsh.txInfo
           });
@@ -543,7 +531,7 @@ describe('BTC:', function() {
           signatures.should.equal(2);
 
           should.exist(inputSignatures);
-        });
+        }));
       });
     });
   });

--- a/modules/core/test/v2/unit/coins/eos.ts
+++ b/modules/core/test/v2/unit/coins/eos.ts
@@ -133,21 +133,22 @@ describe('EOS:', function() {
     it('should be explain an EOS transaction', co(function *() {
       const explainTransactionParams = {
         headers: {
-          ref_block_prefix: 147898787,
-          ref_block_num: 41763,
-          expiration: '2019-07-10T00:34:48.500Z',
+          ref_block_prefix: 100,
+          ref_block_num: 995,
+          expiration: '2018-04-27T18:40:34.000Z',
         },
         tx: {
-          packed_trx: 'a832255d23a3a3c1d008000000000100a6823403ea3055000000572d3ccdcd01607bc2e8f219c9a500000000a8ed323221607bc2e8f219c9a56032c1a4af42d2f6102700000000000004454f53000000000000',
+          packed_trx: 'a26ee35ae30364000000000000000100a6823403ea3055000000572d3ccdcd019013e48c8ce5eed400000000a8ed3232229013e48c8ce5eed4b012362b61b31236640000000000000004454f5300000000013100',
         },
       };
 
-      const signedExplanation = yield basecoin.explainTransaction(explainTransactionParams);
-      signedExplanation.outputAmount.should.equal('10000');
-      signedExplanation.outputs.length.should.equal(1);
-      signedExplanation.outputs[0].amount.should.equal('10000');
-      signedExplanation.outputs[0].address.should.equal('yvd45fx4s4ta');
-      signedExplanation.id.should.equal('c00826caa09f7b340af773e7b9f68f5d7b16518658289461e9ddd35c9f04a99e');
+      const explainedTx = yield basecoin.explainTransaction(explainTransactionParams);
+      explainedTx.outputAmount.should.equal('100');
+      explainedTx.outputs.length.should.equal(1);
+      explainedTx.outputs[0].amount.should.equal('100');
+      explainedTx.outputs[0].address.should.equal('asdfasdfasdf');
+      explainedTx.id.should.equal('6132f3bf4a746e6ecad8a31df67d71b4741fc5b7c868ae36dde18309a91df8a6');
+      explainedTx.memo.should.equal('1');
     }));
   }));
 });

--- a/modules/core/test/v2/unit/coins/rmg.ts
+++ b/modules/core/test/v2/unit/coins/rmg.ts
@@ -1,4 +1,5 @@
 import * as should from 'should';
+import { coroutine as co } from 'bluebird';
 
 const TestV2BitGo = require('../../../lib/test_bitgo');
 const prova = require('prova-lib');
@@ -13,9 +14,9 @@ describe('RMG:', function() {
     basecoin = bitgo.coin('trmg');
   });
 
-  it('Should explain transaction', function() {
+  it('Should explain transaction', co(function *() {
     const txHex = '01000000018ff8476a60aaf5af8fb9fcf76430e07d53c8d3be512c78ebd42456711dddf9a6000000006a21025ceeba2ab4a635df2c0301a3d773da06ac5a18a7c3e0d09a795d7e57d233edf14730440220419c3c5f24da5709f946de50844bc3209f1bb0c6e916b9217795d0602b2cfe82022047e94c4ebe2fdc199c947ec577603ea8885f654f8c07b2aeb224ed0e075e7c1a01ffffffff0100f2052a010000001d521435dbbf04bca061e49dace08f858d8775c0a57c8e030000015153ba00000000';
-    const explanation = basecoin.explainTransaction({ txHex: txHex });
+    const explanation = yield basecoin.explainTransaction({ txHex: txHex });
     explanation.should.have.property('id');
     explanation.should.have.property('outputAmount');
     explanation.should.have.property('changeAmount');
@@ -26,7 +27,7 @@ describe('RMG:', function() {
     explanation.outputs.length.should.equal(1);
     explanation.outputs[0].address.should.equal('TCq7ZvyjTugZ3xDY8m1Mdgm95v4QmMpMfm3Fg8GCeE1uf');
     explanation.outputs[0].amount.should.equal(5000000000);
-  });
+  }));
 
   describe('Should test address generation', () => {
 

--- a/modules/core/test/v2/unit/coins/xlm.ts
+++ b/modules/core/test/v2/unit/coins/xlm.ts
@@ -80,22 +80,22 @@ describe('XLM:', function() {
     }).should.throw();
   });
 
-  it('Should be able to explain an XLM transaction', function() {
-    const signedExplanation = basecoin.explainTransaction({ txBase64: 'AAAAAMDHAbd3O7B2auR1e+EH/LRKe8IcQBOF+XP2lOxWi1PfAAAB9AAEvJEAAAABAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAB1RFU1RJTkcAAAAAAQAAAAAAAAABAAAAALgEl4p84728zfXtl/JdOsx3QbI97mcybqcXdfgdv54zAAAAAAAAAAEqBfIAAAAAAAAAAAFWi1PfAAAAQDoqo7juOBZawMlk8znIbYqSKemjgmINosp/P4+0SFGo/xJy1YgD6YEc65aWuyBxucFFBXCSlAxP2Z7nPMyjewM=' });
+  it('Should be able to explain an XLM transaction', co(function *() {
+    const signedExplanation = yield basecoin.explainTransaction({ txBase64: 'AAAAAMDHAbd3O7B2auR1e+EH/LRKe8IcQBOF+XP2lOxWi1PfAAAB9AAEvJEAAAABAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAB1RFU1RJTkcAAAAAAQAAAAAAAAABAAAAALgEl4p84728zfXtl/JdOsx3QbI97mcybqcXdfgdv54zAAAAAAAAAAEqBfIAAAAAAAAAAAFWi1PfAAAAQDoqo7juOBZawMlk8znIbYqSKemjgmINosp/P4+0SFGo/xJy1YgD6YEc65aWuyBxucFFBXCSlAxP2Z7nPMyjewM=' });
     signedExplanation.outputAmount.should.equal('5000000000');
     signedExplanation.fee.fee.should.equal('500');
     signedExplanation.memo.value.should.equal('TESTING');
     signedExplanation.memo.type.should.equal('text');
     signedExplanation.changeOutputs.length.should.equal(0);
     signedExplanation.changeAmount.should.equal('0');
-    const unsignedExplanation = basecoin.explainTransaction({ txBase64: 'AAAAAMDHAbd3O7B2auR1e+EH/LRKe8IcQBOF+XP2lOxWi1PfAAAAZAAEvJEAAAACAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAEAAAABAAAAAAAAAAEAAAAAuASXinzjvbzN9e2X8l06zHdBsj3uZzJupxd1+B2/njMAAAAAAAAAAlQL5AAAAAAAAAAAAA==' });
+    const unsignedExplanation = yield basecoin.explainTransaction({ txBase64: 'AAAAAMDHAbd3O7B2auR1e+EH/LRKe8IcQBOF+XP2lOxWi1PfAAAAZAAEvJEAAAACAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAEAAAABAAAAAAAAAAEAAAAAuASXinzjvbzN9e2X8l06zHdBsj3uZzJupxd1+B2/njMAAAAAAAAAAlQL5AAAAAAAAAAAAA==' });
     unsignedExplanation.outputAmount.should.equal('10000000000');
     unsignedExplanation.fee.fee.should.equal('100');
     unsignedExplanation.memo.value.should.equal('1');
     unsignedExplanation.memo.type.should.equal('id');
     unsignedExplanation.changeOutputs.length.should.equal(0);
     unsignedExplanation.changeAmount.should.equal('0');
-  });
+  }));
 
   it('isValidMemoId should work', function() {
     basecoin.isValidMemo({ value: '1', type: 'id' }).should.equal(true);

--- a/modules/core/test/v2/unit/coins/xrp.ts
+++ b/modules/core/test/v2/unit/coins/xrp.ts
@@ -81,14 +81,14 @@ describe('XRP:', function() {
     }
   });
 
-  it('Should be able to explain an XRP transaction', function() {
-    const signedExplanation = basecoin.explainTransaction({ txHex: '120000228000000024000000072E00000000201B0018D07161400000000003DE2968400000000000002D73008114726D0D8A26568D5D9680AC80577C912236717191831449EE221CCACC4DD2BF8862B22B0960A84FC771D9F3E010732103AFBB6845826367D738B0D42EA0756C94547E70B064E8FE1260CF21354C898B0B74473045022100CA3A98AA6FC8CCA251C3A2754992E474EA469884EB8D489D2B180EB644AC7695022037EB886DCF57928E5844DB73C2E86DE553FB59DCFC9408F3FD5D802ADB69DFCC8114F0DBA9D34C77B6769F6142AB7C9D0AF67D113EBCE1F1' });
-    const unsignedExplanation = basecoin.explainTransaction({ txHex: '{"TransactionType":"Payment","Account":"rBSpCz8PafXTJHppDcNnex7dYnbe3tSuFG","Destination":"rfjub8A4dpSD5nnszUFTsLprxu1W398jwc","DestinationTag":0,"Amount":"253481","Flags":2147483648,"LastLedgerSequence":1626225,"Fee":"45","Sequence":7}' });
+  it('Should be able to explain an XRP transaction', co(function *() {
+    const signedExplanation = yield basecoin.explainTransaction({ txHex: '120000228000000024000000072E00000000201B0018D07161400000000003DE2968400000000000002D73008114726D0D8A26568D5D9680AC80577C912236717191831449EE221CCACC4DD2BF8862B22B0960A84FC771D9F3E010732103AFBB6845826367D738B0D42EA0756C94547E70B064E8FE1260CF21354C898B0B74473045022100CA3A98AA6FC8CCA251C3A2754992E474EA469884EB8D489D2B180EB644AC7695022037EB886DCF57928E5844DB73C2E86DE553FB59DCFC9408F3FD5D802ADB69DFCC8114F0DBA9D34C77B6769F6142AB7C9D0AF67D113EBCE1F1' });
+    const unsignedExplanation = yield basecoin.explainTransaction({ txHex: '{"TransactionType":"Payment","Account":"rBSpCz8PafXTJHppDcNnex7dYnbe3tSuFG","Destination":"rfjub8A4dpSD5nnszUFTsLprxu1W398jwc","DestinationTag":0,"Amount":"253481","Flags":2147483648,"LastLedgerSequence":1626225,"Fee":"45","Sequence":7}' });
     unsignedExplanation.id.should.equal('CB36F366F1AC25FCDB38A19F17384ED3509D9B7F063520034597852FB10A1B45');
     signedExplanation.id.should.equal('D52681436CC5B94E9D00BC8172047B1A6F3C028D2D0A5CDFB81680039C48ADFD');
     unsignedExplanation.outputAmount.should.equal('253481');
     signedExplanation.outputAmount.should.equal('253481');
-  });
+  }));
 
   it('should be able to cosign XRP transaction in any form', function() {
     const unsignedTxHex = '120000228000000024000000072E00000000201B0018D07161400000000003DE2968400000000000002D8114726D0D8A26568D5D9680AC80577C912236717191831449EE221CCACC4DD2BF8862B22B0960A84FC771D9';
@@ -109,14 +109,14 @@ describe('XRP:', function() {
     coSignedHexTransaction.id.should.equal(coSignedJsonTransaction.id);
   });
 
-  it('Should be unable to explain bogus XRP transaction', function() {
+  it('Should be unable to explain bogus XRP transaction', co(function *() {
     try {
-      basecoin.explainTransaction({ txHex: 'abcdefgH' });
+      yield basecoin.explainTransaction({ txHex: 'abcdefgH' });
       throw new Error('this is the wrong error!');
     } catch (e) {
       e.message.should.equal('txHex needs to be either hex or JSON string for XRP');
     }
-  });
+  }));
 
 
   describe('Fee Management', () => {


### PR DESCRIPTION
The explainTransaction method for EOS makes an asynchronous call and returns a promise. In order to be consistent, other coins should return a promise as well.

References:
https://bitgoinc.atlassian.net/browse/CT-656
https://bitgoinc.atlassian.net/browse/CT-637