### PR TITLE
BG-13597 / Update payload verification for settlement fees

### DIFF
--- a/modules/core/src/v2/trading/payload.ts
+++ b/modules/core/src/v2/trading/payload.ts
@@ -8,6 +8,11 @@ export interface Payload {
   version: CURRENT_PAYLOAD_VERSION;
   accountId: string;
   currency: string;
+  subtotal: string;
+  fees?: {
+    feeType: string;
+    feeAmount: string;
+  }[];
   amount: string;
   nonceHold: string;
   nonceSettle: string;

--- a/modules/core/test/v2/fixtures/trading/affirmation.ts
+++ b/modules/core/test/v2/fixtures/trading/affirmation.ts
@@ -111,7 +111,7 @@ export default {
     ]
   },
   affirmAffirmationPayloadResponse: {
-    payload: '{"version":"1.1.1","accountId":"5cf940969449412d00f53b4c55fc2139","currency":"ofctusd","amount":"555","nonceHold":"djTPc0eRtQixTviodw1iJQ==","nonceSettle":"Wemw9X+iFcwsRFV3nJebxA==","otherParties":[{"accountId":"5cf940a49449412d00f53b8f7392f7c0","currency":"ofctbtc","amount":"500"}]}'
+    payload: '{"version":"1.1.1","accountId":"5cf940969449412d00f53b4c55fc2139","currency":"ofctusd","subtotal":"555","amount":"555","nonceHold":"djTPc0eRtQixTviodw1iJQ==","nonceSettle":"Wemw9X+iFcwsRFV3nJebxA==","otherParties":[{"accountId":"5cf940a49449412d00f53b8f7392f7c0","currency":"ofctbtc","amount":"500"}]}'
   },
   updateAffirmation: function(status) {
     const affirmation = { status, ...this.singleAffirmation };

--- a/modules/core/test/v2/fixtures/trading/payload.ts
+++ b/modules/core/test/v2/fixtures/trading/payload.ts
@@ -4,7 +4,14 @@ export default {
       version: '1.1.1',
       accountId: 'walletId',
       currency: 'ofctbtc',
-      amount: '100000000',
+      subtotal: '100000000',
+      fees: [
+        {
+          feeType: 'BITGO_SETTLEMENT_FEE',
+          feeAmount: '1000'
+        }
+      ],
+      amount: '100001000',
       nonceHold: 'bfrE8itPwYZB+ofDhblE6g==',
       nonceSettle: 'EymF2LXnRzn8acbcCFwgUA==',
       otherParties: [
@@ -26,7 +33,14 @@ export default {
       version: '1.1.1',
       accountId: 'walletId',
       currency: 'ofctbtc',
-      amount: '10000000000',
+      subtotal: '10000000000',
+      fees: [
+        {
+          feeType: 'BITGO_SETTLEMENT_FEE',
+          feeAmount: '1000'
+        }
+      ],
+      amount: '10000001000',
       nonceHold: 'bfrE8itPwYZB+ofDhblE6g==',
       nonceSettle: 'EymF2LXnRzn8acbcCFwgUA==',
       otherParties: [

--- a/modules/core/test/v2/fixtures/trading/settlement.ts
+++ b/modules/core/test/v2/fixtures/trading/settlement.ts
@@ -126,7 +126,7 @@ export default {
     ]
   },
   createSettlementPayloadResponse: {
-    payload: '{"version":"1.1.1","accountId":"5cf940969449412d00f53b4c55fc2139","currency":"ofctusd","amount":"555","nonceHold":"djTPc0eRtQixTviodw1iJQ==","nonceSettle":"Wemw9X+iFcwsRFV3nJebxA==","otherParties":[{"accountId":"5cf940a49449412d00f53b8f7392f7c0","currency":"ofctbtc","amount":"500"}]}'
+    payload: '{"version":"1.1.1","accountId":"5cf940969449412d00f53b4c55fc2139","currency":"ofctusd","subtotal":"555","amount":"555","nonceHold":"djTPc0eRtQixTviodw1iJQ==","nonceSettle":"Wemw9X+iFcwsRFV3nJebxA==","otherParties":[{"accountId":"5cf940a49449412d00f53b8f7392f7c0","currency":"ofctbtc","amount":"500"}]}'
   },
   createSettlementRequest: {
     requesterAccountId: '5cf940969449412d00f53b4c55fc2139',

--- a/modules/core/test/v2/unit/trading/payload.ts
+++ b/modules/core/test/v2/unit/trading/payload.ts
@@ -72,7 +72,7 @@ describe('Trade Payloads', function() {
     payload.should.have.property('version', '1.1.1');
     payload.should.have.property('accountId', 'walletId');
     payload.should.have.property('currency', 'ofctbtc');
-    payload.should.have.property('amount', '100000000');
+    payload.should.have.property('subtotal', '100000000');
     payload.should.have.property('nonceHold');
     payload.should.have.property('nonceSettle');
     payload.should.have.property('otherParties').with.length(2);


### PR DESCRIPTION
Fees are now specified in the trade payload returned from the backend. Update verification logic to match the requested amount against the `subtotal` field, and also verify that the total is calculated correctly