### PR TITLE
CT-684: Handle keyreg txes in algo explainTransaction

### DIFF
--- a/modules/core/src/v2/coins/algo.ts
+++ b/modules/core/src/v2/coins/algo.ts
@@ -219,14 +219,14 @@ export class Algo extends BaseCoin {
     const id = tx.txID();
     const fee = { fee: tx.fee };
 
-    const outputs = [
-      {
-        amount: tx.amount,
+    const outputAmount = tx.amount || 0;
+    var outputs = [];
+    if (tx.to) {
+      outputs.push({
+        amount: outputAmount,
         address: Address.encode(new Uint8Array(tx.to.publicKey)),
-      },
-    ];
-
-    const outputAmount = tx.amount;
+      });
+    }
 
     // TODO(CT-480): add recieving address display here
     const memo = tx.note;


### PR DESCRIPTION
JIRA: CT-684

This commit checks if the `to` field exists on a tx before
attempting to derive the address from its public key. Prior to this
commit there was no check and `explainTransaction` would blindly
try to derive an address froma transaction's `to` field, which does
not exist on keyreg txes.