### PR TITLE
CT-745 - Resolve responses in explainTransaction coin methods in SDK

### DIFF
--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -1405,7 +1405,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
 
       explanation.inputSignatures = inputSignatures;
       explanation.signatures = _.max(inputSignatures);
-      return explanation;
+      return Bluebird.resolve(explanation);
     }).call(this).asCallback(callback);
   }
 

--- a/modules/core/src/v2/coins/algo.ts
+++ b/modules/core/src/v2/coins/algo.ts
@@ -214,7 +214,7 @@ export class Algo extends BaseCoin {
       // TODO(CT-480): add recieving address display here
       const memo = tx.note;
 
-      return {
+      const explanation = {
         displayOrder: ['id', 'outputAmount', 'changeAmount', 'outputs', 'changeOutputs', 'fee', 'memo'],
         id,
         outputs,
@@ -224,6 +224,7 @@ export class Algo extends BaseCoin {
         changeOutputs: [],
         memo,
       };
+      return Bluebird.resolve(explanation);
     })
       .call(this)
       .asCallback(callback);

--- a/modules/core/src/v2/coins/rmg.ts
+++ b/modules/core/src/v2/coins/rmg.ts
@@ -328,7 +328,7 @@ export class Rmg extends AbstractUtxoCoin {
         explanation.displayOrder.push('fee');
         explanation.fee = params.feeInfo;
       }
-      return explanation;
+      return Bluebird.resolve(explanation);
     }).call(this).asCallback(callback);
   }
 

--- a/modules/core/src/v2/coins/xlm.ts
+++ b/modules/core/src/v2/coins/xlm.ts
@@ -793,7 +793,7 @@ export class Xlm extends BaseCoin {
         size: null,
       };
 
-      return {
+      const explanation = {
         displayOrder: ['id', 'outputAmount', 'changeAmount', 'outputs', 'changeOutputs', 'fee', 'memo'],
         id,
         outputs,
@@ -803,6 +803,7 @@ export class Xlm extends BaseCoin {
         memo,
         fee,
       };
+      return Bluebird.resolve(explanation);
     }).call(this).asCallback(callback);
   }
 

--- a/modules/core/src/v2/coins/xrp.ts
+++ b/modules/core/src/v2/coins/xrp.ts
@@ -601,14 +601,14 @@ export class Xrp extends BaseCoin {
         signedTransaction = rippleLib.combine([userSignature.signedTransaction, backupSignature.signedTransaction]);
       }
 
-      const transactionExplanation = yield this.explainTransaction({ txHex: signedTransaction.signedTransaction }) as RecoveryInfo;
-      transactionExplanation.txHex = signedTransaction.signedTransaction;
+      const explanation = yield this.explainTransaction({ txHex: signedTransaction.signedTransaction }) as RecoveryInfo;
+      explanation.txHex = signedTransaction.signedTransaction;
 
       if (isKrsRecovery) {
-        transactionExplanation.backupKey = params.backupKey;
-        transactionExplanation.coin = this.getChain();
+        explanation.backupKey = params.backupKey;
+        explanation.coin = this.getChain();
       }
-      return transactionExplanation;
+      return Bluebird.resolve(explanation);
     }).call(this).asCallback(callback);
   }
 


### PR DESCRIPTION
Use Bluebird's resolve in responses from explainTransaction functions that don't explicitly return a promise so that they can be used in calls using `then()`.

https://bitgoinc.atlassian.net/browse/CT-745