### PR TITLE
CT-779 - Fix EOS deserializeTransaction param names

### DIFF
--- a/modules/core/test/v2/unit/coins/eos.ts
+++ b/modules/core/test/v2/unit/coins/eos.ts
@@ -131,14 +131,14 @@ describe('EOS:', function() {
       ecc.verify(signature, Buffer.from(signatureData, 'hex'), eosPubkey).should.eql(true);
     });
 
-    it('should be explain an EOS transaction', co(function *() {
+    it('should explain an EOS transaction', co(function *() {
       const explainTransactionParams = {
         headers: {
           ref_block_prefix: 100,
           ref_block_num: 995,
           expiration: '2018-04-27T18:40:34.000Z',
         },
-        tx: {
+        transaction: {
           packed_trx: 'a26ee35ae30364000000000000000100a6823403ea3055000000572d3ccdcd019013e48c8ce5eed400000000a8ed3232229013e48c8ce5eed4b012362b61b31236640000000000000004454f5300000000013100',
         },
       };

--- a/modules/core/test/v2/unit/recovery.ts
+++ b/modules/core/test/v2/unit/recovery.ts
@@ -572,10 +572,10 @@ describe('Recovery:', function() {
         recoveryDestination: 'jzjkpn1bjnti',
       });
 
-      recoveryTx.should.have.property('tx');
-      recoveryTx.tx.compression.should.equal('none');
-      recoveryTx.tx.packed_trx.should.equal('01c0305d5e91d408e1b3000000000100a6823403ea3055000000572d3ccdcd0150f3ea2e4cf4bc8300000000a8ed32322150f3ea2e4cf4bc83e0f27c27cc0adf7f640000000000000000454f53000000000000');
-      recoveryTx.tx.signatures.length.should.equal(2);
+      recoveryTx.should.have.property('transaction');
+      recoveryTx.transaction.compression.should.equal('none');
+      recoveryTx.transaction.packed_trx.should.equal('01c0305d5e91d408e1b3000000000100a6823403ea3055000000572d3ccdcd0150f3ea2e4cf4bc8300000000a8ed32322150f3ea2e4cf4bc83e0f27c27cc0adf7f640000000000000000454f53000000000000');
+      recoveryTx.transaction.signatures.length.should.equal(2);
       recoveryTx.txid.should.equal('48185c63f724831382ab860171d5bdf4b433471707b8c59fa2f4ea8e151ab093');
     }));
 
@@ -587,10 +587,10 @@ describe('Recovery:', function() {
         recoveryDestination: 'jzjkpn1bjnti',
       });
 
-      recoveryTx.should.have.property('tx');
-      recoveryTx.tx.compression.should.equal('none');
-      recoveryTx.tx.packed_trx.should.equal('01c0305d5e91d408e1b3000000000100a6823403ea3055000000572d3ccdcd0150f3ea2e4cf4bc8300000000a8ed32322150f3ea2e4cf4bc83e0f27c27cc0adf7f640000000000000000454f53000000000000');
-      recoveryTx.tx.signatures.length.should.equal(2);
+      recoveryTx.should.have.property('transaction');
+      recoveryTx.transaction.compression.should.equal('none');
+      recoveryTx.transaction.packed_trx.should.equal('01c0305d5e91d408e1b3000000000100a6823403ea3055000000572d3ccdcd0150f3ea2e4cf4bc8300000000a8ed32322150f3ea2e4cf4bc83e0f27c27cc0adf7f640000000000000000454f53000000000000');
+      recoveryTx.transaction.signatures.length.should.equal(2);
       console.log('WITH unencrypted keys');
       recoveryTx.txid.should.equal('48185c63f724831382ab860171d5bdf4b433471707b8c59fa2f4ea8e151ab093');
     }));
@@ -604,10 +604,10 @@ describe('Recovery:', function() {
         recoveryDestination: 'jzjkpn1bjnti',
       });
 
-      recoveryTx.should.have.property('tx');
-      recoveryTx.tx.compression.should.equal('none');
-      recoveryTx.tx.packed_trx.should.equal('01c0305d5e91d408e1b3000000000100a6823403ea3055000000572d3ccdcd0150f3ea2e4cf4bc8300000000a8ed32322150f3ea2e4cf4bc83e0f27c27cc0adf7f640000000000000000454f53000000000000');
-      recoveryTx.tx.signatures.length.should.equal(0);
+      recoveryTx.should.have.property('transaction');
+      recoveryTx.transaction.compression.should.equal('none');
+      recoveryTx.transaction.packed_trx.should.equal('01c0305d5e91d408e1b3000000000100a6823403ea3055000000572d3ccdcd0150f3ea2e4cf4bc8300000000a8ed32322150f3ea2e4cf4bc83e0f27c27cc0adf7f640000000000000000454f53000000000000');
+      recoveryTx.transaction.signatures.length.should.equal(0);
       recoveryTx.txid.should.equal('48185c63f724831382ab860171d5bdf4b433471707b8c59fa2f4ea8e151ab093');
     }));
   });


### PR DESCRIPTION
As a result of https://github.com/BitGo/BitGoJS/pull/454 and https://github.com/BitGo/platform/pull/1009, the tx param used by the explainTransaction and deserializeTransaction methods should be renamed transaction.