### PR TITLE
BG-13831 / Refactor Settlement APIs

### DIFF
--- a/modules/core/src/v2/enterprise.ts
+++ b/modules/core/src/v2/enterprise.ts
@@ -131,13 +131,13 @@ export class Enterprise {
    * Manage settlements for an enterprise
    */
   settlements(): Settlements {
-    return new Settlements(this.bitgo, this);
+    return new Settlements(this.bitgo, this.id);
   }
 
   /**
    * Manage affirmations for an enterprise
    */
   affirmations(): Affirmations {
-    return new Affirmations(this.bitgo, this);
+    return new Affirmations(this.bitgo, this.id);
   }
 }

--- a/modules/core/src/v2/trading/settlement.ts
+++ b/modules/core/src/v2/trading/settlement.ts
@@ -4,8 +4,17 @@
 import { Trade } from './trade';
 import { Affirmation } from './affirmation';
 
+export enum SettlementStatus {
+  CANCELED = 'canceled',
+  PENDING = 'pending',
+  REJECTED = 'rejected',
+  SETTLED = 'settled',
+  FAILED = 'failed',
+}
+
 export class Settlement {
   private bitgo: any;
+  private enterpriseId: string;
 
   public id: string;
   public requesterAccountId: string;
@@ -16,24 +25,19 @@ export class Settlement {
   public settledAt: Date;
   public trades: Trade[];
 
-  constructor(settlementData, bitgo) {
+  constructor(settlementData, bitgo, enterpriseId: string) {
     this.bitgo = bitgo;
+    this.enterpriseId = enterpriseId;
 
     this.id = settlementData.id;
     this.requesterAccountId = settlementData.requesterAccountId;
     this.status = settlementData.status;
-    this.affirmations = settlementData.affirmations.map(affirmation => new Affirmation(affirmation, this.bitgo));
+    this.affirmations = settlementData.affirmations.map(
+      affirmation => new Affirmation(affirmation, this.bitgo, this.enterpriseId)
+    );
     this.createdAt = new Date(settlementData.createdAt);
     this.expireAt = new Date(settlementData.expireAt);
     this.settledAt = new Date(settlementData.settledAt);
     this.trades = settlementData.trades as Trade[];
   }
-}
-
-export enum SettlementStatus {
-  CANCELED = 'canceled',
-  PENDING = 'pending',
-  REJECTED = 'rejected',
-  SETTLED = 'settled',
-  FAILED = 'failed',
 }

--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -1648,7 +1648,7 @@ export class Wallet {
       throw new Error('Can only convert an Offchain (OFC) wallet to a trading account');
     }
 
-    return new TradingAccount(this, this.bitgo);
+    return new TradingAccount(this._wallet.enterprise, this, this.bitgo);
   }
 
   /**

--- a/modules/core/test/v2/fixtures/trading/affirmation.ts
+++ b/modules/core/test/v2/fixtures/trading/affirmation.ts
@@ -5,36 +5,36 @@ export default {
     affirmations: [
       {
         id: '8c25d5e9-ec3e-41d4-9c5e-b517f9e6c2a9',
-        partyAccountId: '5cf997706280263a00fe912d66361bb9',
+        partyAccountId: '5cf940969449412d00f53b4c55fc2139',
         status: 'affirmed',
         settlement: 'e19f3371-46dd-4e0a-9817-253060c1f610',
         lock: {
           id: '07eb3e5c-453f-4d4b-bff0-7defb1a7fa25',
-          accountId: '5cf997706280263a00fe912d66361bb9',
+          accountId: '5cf940969449412d00f53b4c55fc2139',
           status: 'settled',
           amount: '43144',
           currency: 'ofctbtc',
           createdAt: '2019-06-06T22:45:09.988Z'
         },
-        payload: '{"walletId":"5cf997706280263a00fe912d66361bb9","currency":"ofctbtc","amount":"43144","nonceHold":"AVGynQTfZb8V4WlK7RRqaQ==","nonceSettle":"QlOA+ob2U5JFsV27pNVYDg==","otherParties":["5cf9976f6280263a00fe911648fc2d6d"]}',
+        payload: '{"walletId":"5cf940969449412d00f53b4c55fc2139","currency":"ofctbtc","amount":"43144","nonceHold":"AVGynQTfZb8V4WlK7RRqaQ==","nonceSettle":"QlOA+ob2U5JFsV27pNVYDg==","otherParties":["5cf9976f6280263a00fe911648fc2d6d"]}',
         signature: '203075f08e6295853cf2c40974f0d813b19abd1eff65a4c77950dea50f2dbaf5904baacd1e97b42f4f4d4621cc1034198a34ee903e4e00c6ae5899a51f3a1f7a33',
         createdAt: '2019-06-06T22:45:10.114Z',
         expireAt: '2019-06-07T22:45:10.105Z'
       },
       {
         id: 'c22bfbed-9a16-4319-b26c-f15caaf80cc2',
-        partyAccountId: '5cf997706280263a00fe912d66361bb9',
+        partyAccountId: '5cf940969449412d00f53b4c55fc2139',
         status: 'rejected',
         settlement: '6804c586-d65a-40b9-a2b3-66352ec4b964',
         lock: {
           id: '68c1d408-87cf-4c30-91cb-a9271c9526d7',
-          accountId: '5cf997706280263a00fe912d66361bb9',
+          accountId: '5cf940969449412d00f53b4c55fc2139',
           status: 'released',
           amount: '62369',
           currency: 'ofctbtc',
           createdAt: '2019-06-06T22:45:20.352Z'
         },
-        payload: '{"walletId":"5cf997706280263a00fe912d66361bb9","currency":"ofctbtc","amount":"62369","nonceHold":"7D5LPdn2/dW6hVXCtQKjiw==","nonceSettle":"DZX72/xWxjloNmGjies4tw==","otherParties":["5cf9976f6280263a00fe911648fc2d6d"]}',
+        payload: '{"walletId":"5cf940969449412d00f53b4c55fc2139","currency":"ofctbtc","amount":"62369","nonceHold":"7D5LPdn2/dW6hVXCtQKjiw==","nonceSettle":"DZX72/xWxjloNmGjies4tw==","otherParties":["5cf9976f6280263a00fe911648fc2d6d"]}',
         createdAt: '2019-06-06T22:45:20.433Z',
         expireAt: '2019-06-07T22:45:20.426Z'
       },
@@ -51,7 +51,7 @@ export default {
           currency: 'ofctusd',
           createdAt: '2019-06-06T22:45:28.794Z'
         },
-        payload: '{"walletId":"5cf9976f6280263a00fe911648fc2d6d","currency":"ofctusd","amount":"94386","nonceHold":"Y/MzgFBTR5jw3qIKj9kpHw==","nonceSettle":"L6U3HmJQhvdHeyheramwiw==","otherParties":["5cf997706280263a00fe912d66361bb9"]}',
+        payload: '{"walletId":"5cf9976f6280263a00fe911648fc2d6d","currency":"ofctusd","amount":"94386","nonceHold":"Y/MzgFBTR5jw3qIKj9kpHw==","nonceSettle":"L6U3HmJQhvdHeyheramwiw==","otherParties":["5cf940969449412d00f53b4c55fc2139"]}',
         signature: '1f6489c0443bf28094b960f20ab44cfcd8b30df3211c9b958cd0a6c9ddd9eb2e9d7b32d3c12f13a9ea51f277db9f9fd5d719fd219e09c5de34fc4d5de098948ae9',
         createdAt: '2019-06-06T22:45:28.864Z',
         expireAt: '2019-06-07T22:45:28.860Z'
@@ -62,18 +62,18 @@ export default {
     affirmations: [
       {
         id: 'c22bfbed-9a16-4319-b26c-f15caaf80cc2',
-        partyAccountId: '5cf997706280263a00fe912d66361bb9',
+        partyAccountId: '5cf940969449412d00f53b4c55fc2139',
         status: 'overdue',
         settlement: '6804c586-d65a-40b9-a2b3-66352ec4b964',
         lock: {
           id: '68c1d408-87cf-4c30-91cb-a9271c9526d7',
-          accountId: '5cf997706280263a00fe912d66361bb9',
+          accountId: '5cf940969449412d00f53b4c55fc2139',
           status: 'released',
           amount: '62369',
           currency: 'ofctbtc',
           createdAt: '2019-06-06T22:45:20.352Z'
         },
-        payload: '{"walletId":"5cf997706280263a00fe912d66361bb9","currency":"ofctbtc","amount":"62369","nonceHold":"7D5LPdn2/dW6hVXCtQKjiw==","nonceSettle":"DZX72/xWxjloNmGjies4tw==","otherParties":["5cf9976f6280263a00fe911648fc2d6d"]}',
+        payload: '{"walletId":"5cf940969449412d00f53b4c55fc2139","currency":"ofctbtc","amount":"62369","nonceHold":"7D5LPdn2/dW6hVXCtQKjiw==","nonceSettle":"DZX72/xWxjloNmGjies4tw==","otherParties":["5cf9976f6280263a00fe911648fc2d6d"]}',
         createdAt: '2019-06-06T22:45:20.433Z',
         expireAt: '2019-06-07T22:45:20.426Z'
       }
@@ -81,25 +81,24 @@ export default {
   },
   singleAffirmation: {
     id: '8c25d5e9-ec3e-41d4-9c5e-b517f9e6c2a9',
-    partyAccountId: '5cf997706280263a00fe912d66361bb9',
+    partyAccountId: '5cf940969449412d00f53b4c55fc2139',
     status: 'affirmed',
     settlement: 'e19f3371-46dd-4e0a-9817-253060c1f610',
     lock: {
       id: '07eb3e5c-453f-4d4b-bff0-7defb1a7fa25',
-      accountId: '5cf997706280263a00fe912d66361bb9',
+      accountId: '5cf940969449412d00f53b4c55fc2139',
       status: 'settled',
       amount: '43144',
       currency: 'ofctbtc',
       createdAt: '2019-06-06T22:45:09.988Z'
     },
-    payload: '{"walletId":"5cf997706280263a00fe912d66361bb9","currency":"ofctbtc","amount":"43144","nonceHold":"AVGynQTfZb8V4WlK7RRqaQ==","nonceSettle":"QlOA+ob2U5JFsV27pNVYDg==","otherParties":["5cf9976f6280263a00fe911648fc2d6d"]}',
+    payload: '{"walletId":"5cf940969449412d00f53b4c55fc2139","currency":"ofctbtc","amount":"43144","nonceHold":"AVGynQTfZb8V4WlK7RRqaQ==","nonceSettle":"QlOA+ob2U5JFsV27pNVYDg==","otherParties":["5cf9976f6280263a00fe911648fc2d6d"]}',
     signature: '203075f08e6295853cf2c40974f0d813b19abd1eff65a4c77950dea50f2dbaf5904baacd1e97b42f4f4d4621cc1034198a34ee903e4e00c6ae5899a51f3a1f7a33',
     createdAt: '2019-06-06T22:45:10.114Z',
     expireAt: '2019-06-07T22:45:10.105Z'
   },
   affirmAffirmationPayloadRequest: {
     version: '1.1.1',
-    accountId: '5cf940969449412d00f53b4c55fc2139',
     currency: 'ofctusd',
     amount: '555',
     otherParties: [

--- a/modules/core/test/v2/fixtures/trading/settlement.ts
+++ b/modules/core/test/v2/fixtures/trading/settlement.ts
@@ -114,7 +114,6 @@ export default {
   },
   createSettlementPayloadRequest: {
     version: '1.1.1',
-    accountId: '5cf940969449412d00f53b4c55fc2139',
     currency: 'ofctusd',
     amount: '555',
     otherParties: [

--- a/modules/core/test/v2/fixtures/trading/tradingPartner.ts
+++ b/modules/core/test/v2/fixtures/trading/tradingPartner.ts
@@ -10,7 +10,7 @@ export default {
       status: 'accepted'
     }]
   },
-  balanceCheckTrue: {
+  balanceCheckTrueRequest: {
     amount: '24128',
     currency: 'ofctbtc'
   }

--- a/modules/core/test/v2/unit/trading/affirmation.ts
+++ b/modules/core/test/v2/unit/trading/affirmation.ts
@@ -31,7 +31,7 @@ describe('Affirmations', function() {
     const walletData = {
       id: '5cf940969449412d00f53b4c55fc2139',
       coin: 'tofc',
-      enterprise: enterprise,
+      enterprise: enterprise.id,
       keys: [
         'keyid'
       ]
@@ -71,10 +71,10 @@ describe('Affirmations', function() {
 
   it('should get a single affirmation', co(function *() {
     const scope = nock(microservicesUri)
-      .get(`/api/trade/v1/enterprise/${enterprise.id}/affirmations/8c25d5e9-ec3e-41d4-9c5e-b517f9e6c2a9`)
+      .get(`/api/trade/v1/enterprise/${enterprise.id}/account/${tradingAccount.id}/affirmations/8c25d5e9-ec3e-41d4-9c5e-b517f9e6c2a9`)
       .reply(200, fixtures.singleAffirmation);
 
-    affirmation = yield enterprise.affirmations().get({ id: '8c25d5e9-ec3e-41d4-9c5e-b517f9e6c2a9' });
+    affirmation = yield tradingAccount.affirmations().get({ id: '8c25d5e9-ec3e-41d4-9c5e-b517f9e6c2a9' });
     should.exist(affirmation);
 
     scope.isDone().should.be.true();
@@ -82,9 +82,9 @@ describe('Affirmations', function() {
 
   it('should affirm an affirmation', co(function *() {
     const scope = nock(microservicesUri)
-      .post('/api/trade/v1/payload', fixtures.affirmAffirmationPayloadRequest)
+      .post(`/api/trade/v1/enterprise/${enterprise.id}/account/${tradingAccount.id}/payload`, fixtures.affirmAffirmationPayloadRequest)
       .reply(200, fixtures.affirmAffirmationPayloadResponse)
-      .put(`/api/trade/v1/affirmations/${affirmation.id}`, (body) => body.status === AffirmationStatus.AFFIRMED)
+      .put(`/api/trade/v1/enterprise/${enterprise.id}/account/${tradingAccount.id}/affirmations/${affirmation.id}`, (body) => body.status === AffirmationStatus.AFFIRMED)
       .reply(200, fixtures.updateAffirmation('affirmed'));
 
     const xprv = 'xprv9s21ZrQH143K2MUz7uPUBVzdmvJQE6fPEQCkR3mypPbZgijPqfmGH7pjijdjeJx3oCoxPWVbjC4VYHzgN6wqEfYnnbNjK7jm2CkrvWrvkbR';
@@ -112,7 +112,7 @@ describe('Affirmations', function() {
 
   it('should reject an affirmation', co(function *() {
     const scope = nock(microservicesUri)
-      .put(`/api/trade/v1/affirmations/${affirmation.id}`, (body) => body.status === AffirmationStatus.REJECTED)
+      .put(`/api/trade/v1/enterprise/${enterprise.id}/account/${tradingAccount.id}/affirmations/${affirmation.id}`, (body) => body.status === AffirmationStatus.REJECTED)
       .reply(200, fixtures.updateAffirmation('rejected'));
 
     yield affirmation.reject();
@@ -122,7 +122,7 @@ describe('Affirmations', function() {
 
   it('should cancel an affirmation', co(function *() {
     const scope = nock(microservicesUri)
-      .put(`/api/trade/v1/affirmations/${affirmation.id}`, (body) => body.status === AffirmationStatus.CANCELED)
+      .put(`/api/trade/v1/enterprise/${enterprise.id}/account/${tradingAccount.id}/affirmations/${affirmation.id}`, (body) => body.status === AffirmationStatus.CANCELED)
       .reply(200, fixtures.updateAffirmation('canceled'));
 
     yield affirmation.cancel();

--- a/modules/core/test/v2/unit/trading/settlement.ts
+++ b/modules/core/test/v2/unit/trading/settlement.ts
@@ -31,7 +31,7 @@ describe('Settlements', function() {
     const walletData = {
       id: '5cf940969449412d00f53b4c55fc2139',
       coin: 'tofc',
-      enterprise: enterprise,
+      enterprise: enterprise.id,
       keys: [
         'keyid'
       ]
@@ -65,10 +65,10 @@ describe('Settlements', function() {
 
   it('should get a single settlement', co(function *() {
     const scope = nock(microservicesUri)
-      .get(`/api/trade/v1/enterprise/${enterprise.id}/settlements/${fixtures.singleSettlementId}`)
+      .get(`/api/trade/v1/enterprise/${enterprise.id}/account/${tradingAccount.id}/settlements/${fixtures.singleSettlementId}`)
       .reply(200, fixtures.getSingleSettlement);
 
-    const settlement = yield enterprise.settlements().get({ id: fixtures.singleSettlementId });
+    const settlement = yield tradingAccount.settlements().get({ id: fixtures.singleSettlementId });
 
     should.exist(settlement);
     settlement.requesterAccountId.should.eql(tradingAccount.id);
@@ -85,9 +85,9 @@ describe('Settlements', function() {
 
   it('should create a new settlement', co(function *() {
     const msScope = nock(microservicesUri)
-      .post('/api/trade/v1/payload', fixtures.createSettlementPayloadRequest)
+      .post(`/api/trade/v1/enterprise/${enterprise.id}/account/${tradingAccount.id}/payload`, fixtures.createSettlementPayloadRequest)
       .reply(200, fixtures.createSettlementPayloadResponse)
-      .post('/api/trade/v1/settlement', fixtures.createSettlementRequest)
+      .post(`/api/trade/v1/enterprise/${enterprise.id}/account/${tradingAccount.id}/settlements`, fixtures.createSettlementRequest)
       .reply(200, fixtures.createSettlementResponse);
 
     const xprv = 'xprv9s21ZrQH143K2MUz7uPUBVzdmvJQE6fPEQCkR3mypPbZgijPqfmGH7pjijdjeJx3oCoxPWVbjC4VYHzgN6wqEfYnnbNjK7jm2CkrvWrvkbR';
@@ -107,7 +107,7 @@ describe('Settlements', function() {
 
     const signature = yield tradingAccount.signPayload({ payload, walletPassphrase: TestV2BitGo.OFC_TEST_PASSWORD });
 
-    const settlement = yield enterprise.settlements().create({
+    const settlement = yield tradingAccount.settlements().create({
       requesterAccountId: tradingAccount.id,
       payload: payload,
       signature: signature,

--- a/modules/core/test/v2/unit/trading/tradingPartner.ts
+++ b/modules/core/test/v2/unit/trading/tradingPartner.ts
@@ -5,6 +5,7 @@ import * as should from 'should';
 import fixtures from '../../fixtures/trading/tradingPartner';
 import { TradingPartnerStatus } from '../../../../src/v2/trading/tradingPartner';
 
+import { Enterprise } from '../../../../src/v2/enterprise';
 import { Wallet } from '../../../../src/v2/wallet';
 const TestV2BitGo = require('../../../lib/test_bitgo');
 
@@ -12,6 +13,7 @@ describe('Trading Partners', function() {
   const microservicesUri = 'https://bitgo-microservices.example';
   let bitgo;
   let basecoin;
+  let enterprise;
   let tradingAccount;
 
   before(co(function *() {
@@ -20,9 +22,12 @@ describe('Trading Partners', function() {
     basecoin = bitgo.coin('ofc');
     basecoin.keychains();
 
+    enterprise = new Enterprise(bitgo, basecoin, { id: '5cf940949449412d00f53b3d92dbcaa3', name: 'Test Enterprise' });
+
     const walletData = {
       id: '5cf940969449412d00f53b4c55fc2139',
       coin: 'tofc',
+      enterprise: enterprise.id,
       keys: [
         'keyid'
       ]
@@ -34,7 +39,7 @@ describe('Trading Partners', function() {
 
   it('should list all trading partners', co(function *() {
     const scope = nock(microservicesUri)
-      .get(`/api/trade/v1/account/${tradingAccount.id}/tradingPartners`)
+      .get(`/api/trade/v1/enterprise/${enterprise.id}/account/${tradingAccount.id}/tradingpartners`)
       .reply(200, fixtures.listTradingPartners);
 
     const partners = yield tradingAccount.partners().list();
@@ -51,11 +56,11 @@ describe('Trading Partners', function() {
 
   it('should balance check trading partners', co(function *() {
     const scope = nock(microservicesUri)
-      .get(`/api/trade/v1/account/${tradingAccount.id}/tradingPartners`)
+      .get(`/api/trade/v1/enterprise/${enterprise.id}/account/${tradingAccount.id}/tradingpartners`)
       .reply(200, fixtures.listTradingPartners)
-      .get(`/api/trade/v1/account/${tradingAccount.id}/tradingPartners/${fixtures.listTradingPartners.tradingPartners[0].accountId}/balance`)
-      .query(fixtures.balanceCheckTrue)
-      .reply(200, true);
+      .get(`/api/trade/v1/enterprise/${enterprise.id}/account/${tradingAccount.id}/tradingpartners/${fixtures.listTradingPartners.tradingPartners[0].accountId}/balance`)
+      .query(fixtures.balanceCheckTrueRequest)
+      .reply(200, { check: true });
 
     const partners = yield tradingAccount.partners().list();
     should.exist(partners);


### PR DESCRIPTION
We refactored the settlement APIs to be much more consistent, this PR updates the SDK to call the new routes.

You can now call `.settlements()` and `.affirmations()` on an enterprise to list objects across the entire enterprise. But creating and updating settlements/affirmations requires a Settlements/Affirmations controller attached to a specific trading account, not an enterprise.