### PR TITLE
BG-14020 / Update microservices auth route

### DIFF
--- a/modules/core/src/bitgo.ts
+++ b/modules/core/src/bitgo.ts
@@ -1323,7 +1323,7 @@ export class BitGo {
       }
 
       const authUrl = self._microservicesUrl ?
-        self.microservicesUrl('/api/v1/auth/session') :
+        self.microservicesUrl('/api/auth/v1/session') :
         self.url('/user/login');
       const request = self.post(authUrl);
 
@@ -1596,7 +1596,7 @@ export class BitGo {
       }
 
       const authUrl = self._microservicesUrl ?
-        self.microservicesUrl('/api/v1/auth/accesstoken') :
+        self.microservicesUrl('/api/auth/v1/accesstoken') :
         self.url('/user/accesstoken');
       const request = self.post(authUrl);
 

--- a/modules/core/test/unit/bitgo.ts
+++ b/modules/core/test/unit/bitgo.ts
@@ -92,7 +92,7 @@ describe('BitGo Prototype Methods', function() {
     it('goes to microservices', co(function *() {
       bitgo = new TestBitGo({ env: 'custom', microservicesUri });
       const scope = nock(microservicesUri)
-        .post('/api/v1/auth/session')
+        .post('/api/auth/v1/session')
         .reply(200, { user: 'test@bitgo.com', access_token: 'token12356' });
 
       yield bitgo.authenticate(authenticateRequest);


### PR DESCRIPTION
We've updated all authentication routes in microservices to
/api/auth/v1 instead of /api/v1/auth.