### PR TITLE
CT-942/BG-12581: Fix `isValidAddress` and improve `canonicalAddress` …

### DIFF
--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -296,7 +296,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
     // otherwise, try decoding as bech32
     try {
       const { version, prefix } = this.getCoinLibrary().address.fromBech32(address);
-      if (prefix === this.network.bech32) {
+      if (_.isString(this.network.bech32) && prefix === this.network.bech32) {
         return version;
       }
     } catch (e) {
@@ -334,7 +334,15 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
     const addressVersion = this.getAddressVersion(address);
 
     // the address version needs to be among the valid ones
-    return validVersions.includes(addressVersion) || this.network.bech32 === this.getAddressPrefix(address);
+    const addressVersionValid = _.isNumber(addressVersion) && validVersions.includes(addressVersion);
+    const addressPrefix = this.getAddressPrefix(address);
+
+    if (!this.supportsP2wsh() || _.isUndefined(addressPrefix)) {
+      return addressVersionValid;
+    }
+
+    // address has a potential bech32 prefix, validate that
+    return _.isString(this.network.bech32) && this.network.bech32 === addressPrefix;
   }
 
   /**

--- a/modules/core/test/v2/unit/coins/ltc.ts
+++ b/modules/core/test/v2/unit/coins/ltc.ts
@@ -21,62 +21,93 @@ describe('LTC:', function() {
   });
 
   describe('Canonicalize address', function() {
+
     it('base58 mainnet address', function() {
-      const oldAddress = '3GBygsGPvTdfKMbq4AKZZRu1sPMWPEsBfd';
-      const newAddress = ltc.canonicalAddress(oldAddress, 2);
-      newAddress.should.equal('MNQ7zkgMsaV67rsjA3JuP59RC5wxRXpwgE');
-      const sameAddress = ltc.canonicalAddress(oldAddress, 1);
-      oldAddress.should.equal(sameAddress);
-      const newOldAddress = ltc.canonicalAddress(newAddress, 1);
-      oldAddress.should.equal(newOldAddress);
+      const standardBase58Address = '3GBygsGPvTdfKMbq4AKZZRu1sPMWPEsBfd';
+      const litecoinBase58Address = 'MNQ7zkgMsaV67rsjA3JuP59RC5wxRXpwgE';
+
+      // convert from new format to old
+      const downgradedAddress = ltc.canonicalAddress(litecoinBase58Address, 1);
+      downgradedAddress.should.equal(standardBase58Address);
+
+      // convert from new format to new (no-op)
+      const unmodifiedAddress = ltc.canonicalAddress(litecoinBase58Address, 2);
+      unmodifiedAddress.should.equal(litecoinBase58Address);
+
+      // convert from old format to new
+      const upgradedAddress = ltc.canonicalAddress(standardBase58Address, 2);
+      upgradedAddress.should.equal(litecoinBase58Address);
     });
 
     it('base58 testnet address', function() {
-      const newAddress = 'QLc2RwpX2rFtZzoZrexLibcAgV6Nsg74Jn';
-      const oldAddress = tltc.canonicalAddress(newAddress, 1);
-      oldAddress.should.equal('2MsFGJvxH1kCoRp3XEYvKduAjY6eYz9PJHz');
-      const sameAddress = tltc.canonicalAddress(newAddress, 2);
-      newAddress.should.equal(sameAddress);
-      const newNewAddress = tltc.canonicalAddress(oldAddress, 2);
-      newAddress.should.equal(newNewAddress);
+      const standardBase58Address = '2MsFGJvxH1kCoRp3XEYvKduAjY6eYz9PJHz';
+      const litecoinBase58Address = 'QLc2RwpX2rFtZzoZrexLibcAgV6Nsg74Jn';
+
+      // convert from new format to old
+      const downgradedAddress = tltc.canonicalAddress(litecoinBase58Address, 1);
+      downgradedAddress.should.equal(standardBase58Address);
+
+      // convert from new format to new (no-op)
+      const unmodifiedAddress = tltc.canonicalAddress(litecoinBase58Address, 2);
+      unmodifiedAddress.should.equal(litecoinBase58Address);
+
+      // convert from old format to new
+      const upgradedAddress = tltc.canonicalAddress(standardBase58Address, 2);
+      upgradedAddress.should.equal(litecoinBase58Address);
     });
 
     it('bech32 mainnet address', function() {
-      // canonicalAddress is a no-op for bech32 addresses - they are already in canonical format,
-      // and the script hash version is not relevant
+      // canonicalAddress will only lower case bech32 addresses - they are already
+      // in canonical format, and the script hash version is not relevant
       const bech32Address = 'ltc1qgrl8zpndsklaa9swgd5vevyxmx5x63vcrl7dk4';
-      const newAddress = ltc.canonicalAddress(bech32Address, 2);
-      newAddress.should.equal(bech32Address);
+      const version1Address = ltc.canonicalAddress(bech32Address, 1);
+      version1Address.should.equal(bech32Address);
+      const version2Address = ltc.canonicalAddress(bech32Address, 2);
+      version2Address.should.equal(bech32Address);
     });
 
     it('upper case bech32 mainnet address', function() {
-      // casing is not relevant for bech32 addresses, but canonical bech32 addresses should be lowercase
+      // bech32 addresses which are all upper case or all lower case are potentially valid,
+      // but mixed case is always invalid. Canonical bech32 addresses should be all lower case however
       const bech32Address = 'LTC1QGRL8ZPNDSKLAA9SWGD5VEVYXMX5X63VCRL7DK4';
       const newAddress = ltc.canonicalAddress(bech32Address);
       newAddress.should.equal(bech32Address.toLowerCase());
     });
 
     it('bech32 testnet address', function() {
-      const newAddress = 'tltc1qu78xur5xnq6fjy83amy0qcjfau8m367defyhms';
-      const oldAddress = tltc.canonicalAddress(newAddress, 1);
-      oldAddress.should.equal(newAddress);
-      const sameAddress = tltc.canonicalAddress(newAddress, 2);
-      newAddress.should.equal(sameAddress);
-      const newNewAddress = tltc.canonicalAddress(oldAddress, 2);
-      newAddress.should.equal(newNewAddress);
+      const bech32Address = 'tltc1qu78xur5xnq6fjy83amy0qcjfau8m367defyhms';
+      const version1Address = tltc.canonicalAddress(bech32Address, 1);
+      version1Address.should.equal(bech32Address);
+      const version2Address = tltc.canonicalAddress(bech32Address, 2);
+      version2Address.should.equal(bech32Address);
     });
   });
 
   describe('should validate addresses', () => {
     it('should validate base58 addresses', () => {
+      // known valid main and testnet base58 address are valid
       ltc.isValidAddress('MH6J1PzpsAfapZek7QGHv2mheUxnP8Kdek').should.be.true();
       tltc.isValidAddress('QWC1miKKHFikbwg2iyt8KZBGsTSEBKr21i').should.be.true();
+
+      // malformed base58 addresses are invalid
       ltc.isValidAddress('MH6J1PzpsAfapZek7QGHv2mheUxnP8Kder').should.be.false();
       tltc.isValidAddress('QWC1miKKHFikbwg2iyt8KZBGsTSEBKr21l').should.be.false();
     });
+
     it('should validate bech32 addresses', () => {
+      // all lower case is valid
       ltc.isValidAddress('ltc1qq7fzt3ek5ege3v92wh0q6wzcjr39pqswlpe36mu28f6yufark3wspfryg7').should.be.true();
       tltc.isValidAddress('tltc1qq7fzt3ek5ege3v92wh0q6wzcjr39pqswlpe36mu28f6yufark3ws2x86ht').should.be.true();
+
+      // all upper case is also valid
+      ltc.isValidAddress('LTC1QQ7FZT3EK5EGE3V92WH0Q6WZCJR39PQSWLPE36MU28F6YUFARK3WSPFRYG7').should.be.true();
+      tltc.isValidAddress('TLTC1QQ7FZT3EK5EGE3V92WH0Q6WZCJR39PQSWLPE36MU28F6YUFARK3WS2X86HT').should.be.true();
+
+      // mixed case is invalid
+      ltc.isValidAddress('LTC1QQ7FZT3EK5EGE3V92WH0Q6WZCJR39PQSWLPE36MU28F6YUFARK3WSPFRYg7').should.be.false();
+      tltc.isValidAddress('TLTC1QQ7FZT3EK5EGE3V92WH0Q6WZCJR39PQSWLPE36MU28F6YUFARK3WS2X86Ht').should.be.false();
+
+      // malformed addresses are invalid
       ltc.isValidAddress('ltc1qq7fzt3ek5ege3v92wh0q6wzcjr39pqswlpe36mu28f6yufark3wspfryg9').should.be.false();
       tltc.isValidAddress('tltc1qq7fzt3ek5ege3v92wh0q6wzcjr39pqswlpe36mu28f6yufark3ws2x86hl').should.be.false();
     });


### PR DESCRIPTION
…for bech32 addresses

* Fix an issue in `isValidAddress` where it would incorrectly return
true for coins which did not support bech32. Note that addresses are
also validated server side, so there is no risk of accidentally sending
funds to an invalid address.
* Improve `canonicalAddress` to handle Litecoin bech32 addresses