### PR TITLE
CT-823 - Add support for Stellar tokens

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -46,7 +46,7 @@
     "fmt": "prettier --write '{src,test}/**/*.{ts,js,json}'"
   },
   "dependencies": {
-    "@bitgo/statics": "^2.0.0-rc.0",
+    "@bitgo/statics": "^2.1.0",
     "@bitgo/unspents": "^0.6.0",
     "algosdk": "git+https://github.com/BitGo/algosdk-bitgo.git",
     "assert": "^0.4.9",

--- a/modules/core/src/v2/coinFactory.ts
+++ b/modules/core/src/v2/coinFactory.ts
@@ -34,7 +34,8 @@ import { Txrp } from './coins/txrp';
 import { Tzec } from './coins/tzec';
 import { Xlm } from './coins/xlm';
 import { Xrp } from './coins/xrp';
-import { Token } from './coins/token';
+import { Erc20Token } from './coins/erc20Token';
+import { StellarToken } from './coins/stellarToken';
 import { OfcToken } from './coins/ofcToken';
 import { tokens } from '../config';
 import { Zec } from './coins/zec';
@@ -42,6 +43,7 @@ import { Zec } from './coins/zec';
 import * as errors from '../errors';
 
 export type CoinConstructor = (bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) => BaseCoin;
+export const coinTokenPatternSeparator = ':';
 
 export class CoinFactory {
   private coinConstructors = new Map<string, CoinConstructor>();
@@ -72,7 +74,7 @@ export class CoinFactory {
     if (ethConstructor) {
       const ethCoin = ethConstructor(bitgo, staticsCoin);
       if (ethCoin.isValidAddress(name)) {
-        const unknownTokenConstructor = Token.createTokenConstructor({
+        const unknownTokenConstructor = Erc20Token.createTokenConstructor({
           type: 'unknown',
           coin: 'eth',
           network: 'Mainnet',
@@ -130,9 +132,14 @@ GlobalCoinFactory.registerCoinConstructor('susd', Susd.createInstance);
 GlobalCoinFactory.registerCoinConstructor('tsusd', Tsusd.createInstance);
 
 for (const token of [...tokens.bitcoin.eth.tokens, ...tokens.testnet.eth.tokens]) {
-  const tokenConstructor = Token.createTokenConstructor(token);
+  const tokenConstructor = Erc20Token.createTokenConstructor(token);
   GlobalCoinFactory.registerCoinConstructor(token.type, tokenConstructor);
   GlobalCoinFactory.registerCoinConstructor(token.tokenContractAddress, tokenConstructor);
+}
+
+for (const token of [...tokens.bitcoin.xlm.tokens, ...tokens.testnet.xlm.tokens]) {
+  const tokenConstructor = StellarToken.createTokenConstructor(token);
+  GlobalCoinFactory.registerCoinConstructor(token.type, tokenConstructor);
 }
 
 for (const ofcToken of [...tokens.bitcoin.ofc.tokens, ...tokens.testnet.ofc.tokens]) {

--- a/modules/core/src/v2/coins/erc20Token.ts
+++ b/modules/core/src/v2/coins/erc20Token.ts
@@ -14,7 +14,7 @@ import * as config from '../../config';
 
 const co = Bluebird.coroutine;
 
-export interface TokenConfig {
+export interface Erc20TokenConfig {
   name: string;
   type: string;
   coin: string;
@@ -23,16 +23,16 @@ export interface TokenConfig {
   decimalPlaces: number;
 }
 
-export class Token extends Eth {
-  public readonly tokenConfig: TokenConfig;
+export class Erc20Token extends Eth {
+  public readonly tokenConfig: Erc20TokenConfig;
 
-  constructor(bitgo: BitGo, tokenConfig: TokenConfig) {
+  constructor(bitgo: BitGo, tokenConfig: Erc20TokenConfig) {
     super(bitgo);
     this.tokenConfig = tokenConfig;
   }
 
-  static createTokenConstructor(config: TokenConfig): CoinConstructor {
-    return (bitgo: BitGo) => new Token(bitgo, config);
+  static createTokenConstructor(config: Erc20TokenConfig): CoinConstructor {
+    return (bitgo: BitGo) => new Erc20Token(bitgo, config);
   }
 
   get type() {

--- a/modules/core/src/v2/coins/stellarToken.ts
+++ b/modules/core/src/v2/coins/stellarToken.ts
@@ -1,0 +1,85 @@
+/**
+ * @prettier
+ */
+import * as _ from 'lodash';
+import { BitGo } from '../../bitgo';
+import { Xlm } from './xlm';
+import { CoinConstructor, coinTokenPatternSeparator } from '../coinFactory';
+import { BitGoJsError } from '../../errors';
+
+export interface StellarTokenConfig {
+  name: string;
+  type: string;
+  coin: string;
+  network: string;
+  decimalPlaces: number;
+}
+
+export class StellarToken extends Xlm {
+  static readonly tokenPattern: RegExp = /[A-Z]{1,12}-G[A-Z0-9]{55}/;
+  public readonly tokenConfig: StellarTokenConfig;
+  private readonly _code: string;
+  private readonly _issuer: string;
+
+  constructor(bitgo: BitGo, tokenConfig: StellarTokenConfig) {
+    super(bitgo);
+    this.tokenConfig = tokenConfig;
+
+    const [tokenCoin, token] = _.split(this.tokenConfig.type, coinTokenPatternSeparator);
+    if (tokenCoin !== tokenConfig.coin) {
+      throw new BitGoJsError(`invalid coin found in token: ${this.tokenConfig.type}`);
+    }
+    if (!token || !token.match(StellarToken.tokenPattern)) {
+      throw new BitGoJsError(`invalid token: ${this.tokenConfig.type}`);
+    }
+    [this._code, this._issuer] = _.split(token, '-');
+  }
+
+  static createTokenConstructor(config: StellarTokenConfig): CoinConstructor {
+    return (bitgo: BitGo) => new StellarToken(bitgo, config);
+  }
+
+  get type() {
+    return this.tokenConfig.type;
+  }
+
+  get name() {
+    return this.tokenConfig.name;
+  }
+
+  get coin() {
+    return this.tokenConfig.coin;
+  }
+
+  get network() {
+    return this.tokenConfig.network;
+  }
+
+  get code() {
+    return this._code;
+  }
+
+  get issuer() {
+    return this._issuer;
+  }
+
+  get decimalPlaces() {
+    return this.tokenConfig.decimalPlaces;
+  }
+
+  getChain() {
+    return this.tokenConfig.coin;
+  }
+
+  getFullName() {
+    return 'Stellar Token';
+  }
+
+  /**
+   * Flag for sending value of 0
+   * @returns {boolean} True if okay to send 0 value, false otherwise
+   */
+  valuelessTransferAllowed() {
+    return true;
+  }
+}

--- a/modules/core/test/v2/unit/baseCoin.ts
+++ b/modules/core/test/v2/unit/baseCoin.ts
@@ -6,7 +6,8 @@ import 'should';
 import * as nock from 'nock';
 
 import { TestBitGo } from '../../lib/test_bitgo';
-import { Token } from '../../../src/v2/coins/token';
+import { Erc20Token } from '../../../src/v2/coins/erc20Token';
+import { StellarToken } from '../../../src/v2/coins/stellarToken';
 
 nock.disableNetConnect();
 
@@ -14,17 +15,21 @@ describe('V2 Base Coin:', function() {
   let bitgo;
   let basecoinEth;
   let basecoinBtc;
-  let basecoinTokenWithName;
-  let basecoinTokenWithContractHash;
+  let basecoinXlm;
+  let basecoinErc20TokenWithName;
+  let basecoinErc20TokenWithContractHash;
+  let baseCoinStellarToken;
 
   before(function() {
     bitgo = new TestBitGo({ env: 'test' });
     bitgo.initializeTestVars();
     basecoinEth = bitgo.coin('teth');
     basecoinBtc = bitgo.coin('tbtc');
+    basecoinXlm = bitgo.coin('txlm');
     basecoinEth.keychains();
-    basecoinTokenWithName = bitgo.coin('terc');
-    basecoinTokenWithContractHash = bitgo.coin('0x945ac907cf021a6bcd07852bb3b8c087051706a9');
+    basecoinErc20TokenWithName = bitgo.coin('terc');
+    basecoinErc20TokenWithContractHash = bitgo.coin('0x945ac907cf021a6bcd07852bb3b8c087051706a9');
+    baseCoinStellarToken = bitgo.coin('txlm:BST-GBQTIOS3XGHB7LVYGBKQVJGCZ3R4JL5E4CBSWJ5ALIJUHBKS6263644L');
   });
 
   describe('Currency conversion', function() {
@@ -51,6 +56,17 @@ describe('V2 Base Coin:', function() {
       // others
       basecoinBtc.baseUnitsToBigUnits(200000397901).should.equal('2000.00397901');
     });
+
+    it('should convert stroop amounts to XLM', function() {
+      // 1 stroop
+      basecoinXlm.baseUnitsToBigUnits('1').should.equal('0.0000001');
+      // 100 stroops
+      basecoinXlm.baseUnitsToBigUnits('100').should.equal('0.00001');
+      // 1 XLM
+      basecoinXlm.baseUnitsToBigUnits('10000000').should.equal('1');
+      // others
+      basecoinXlm.baseUnitsToBigUnits('10000001').should.equal('1.0000001');
+    });
   });
 
   describe('supportsBlockTarget', function() {
@@ -60,21 +76,26 @@ describe('V2 Base Coin:', function() {
   });
 
   describe('Token initialization', function() {
-    it('Tokens initialized with name and contract should be instances of Token', function() {
-      (basecoinTokenWithName instanceof Token).should.equal(true);
-      (basecoinTokenWithContractHash instanceof Token).should.equal(true);
+    it('ERC20 Tokens initialized with name and contract should be instances of Erc20Token', function() {
+      basecoinErc20TokenWithName.should.be.instanceof(Erc20Token);
+      basecoinErc20TokenWithContractHash.should.be.instanceof(Erc20Token);
     });
 
-    it('Tokens initialized with name and contract should be instances of each others constructor', function() {
-      (basecoinTokenWithName instanceof basecoinTokenWithContractHash.constructor).should.equal(true);
-      (basecoinTokenWithContractHash instanceof basecoinTokenWithName.constructor).should.equal(true);
+    it('ERC20 Tokens initialized with name and contract should be instances of each others constructor', function() {
+      basecoinErc20TokenWithName.should.be.instanceof(basecoinErc20TokenWithContractHash.constructor);
+      basecoinErc20TokenWithContractHash.should.be.instanceof(basecoinErc20TokenWithContractHash.constructor);
     });
 
-    it('Token comparison', function() {
-      basecoinTokenWithName.getBaseFactor().should.equal(basecoinTokenWithContractHash.getBaseFactor());
-      basecoinTokenWithName.getChain().should.equal(basecoinTokenWithContractHash.getChain());
-      basecoinTokenWithName.getFamily().should.equal(basecoinTokenWithContractHash.getFamily());
-      basecoinTokenWithName.getFullName().should.equal(basecoinTokenWithContractHash.getFullName());
+    it('ERC20 Token comparison', function() {
+      basecoinErc20TokenWithName.getBaseFactor().should.equal(basecoinErc20TokenWithContractHash.getBaseFactor());
+      basecoinErc20TokenWithName.getChain().should.equal(basecoinErc20TokenWithContractHash.getChain());
+      basecoinErc20TokenWithName.getFamily().should.equal(basecoinErc20TokenWithContractHash.getFamily());
+      basecoinErc20TokenWithName.getFullName().should.equal(basecoinErc20TokenWithContractHash.getFullName());
+    });
+
+    it('Stellar Tokens should be instances of StellarToken', function() {
+      (baseCoinStellarToken instanceof StellarToken).should.equal(true);
+      (baseCoinStellarToken instanceof StellarToken).should.equal(true);
     });
   });
 

--- a/modules/core/test/v2/unit/coins/stellarToken.ts
+++ b/modules/core/test/v2/unit/coins/stellarToken.ts
@@ -1,0 +1,28 @@
+import 'should';
+
+import { TestBitGo } from '../../../lib/test_bitgo';
+
+describe('Stellar Token:', function() {
+  let bitgo;
+  let stellarTokenCoin;
+  const tokenName = 'txlm:BST-GBQTIOS3XGHB7LVYGBKQVJGCZ3R4JL5E4CBSWJ5ALIJUHBKS6263644L';
+
+  before(function() {
+    bitgo = new TestBitGo({ env: 'test' });
+    bitgo.initializeTestVars();
+    stellarTokenCoin = bitgo.coin(tokenName);
+  });
+
+  it('should return constants', function() {
+    stellarTokenCoin.getChain().should.equal('txlm');
+    stellarTokenCoin.getFullName().should.equal('Stellar Token');
+    stellarTokenCoin.getBaseFactor().should.equal(1e7);
+    stellarTokenCoin.type.should.equal(tokenName);
+    stellarTokenCoin.name.should.equal('Test BST Token');
+    stellarTokenCoin.coin.should.equal('txlm');
+    stellarTokenCoin.network.should.equal('Testnet');
+    stellarTokenCoin.code.should.equal('BST');
+    stellarTokenCoin.issuer.should.equal('GBQTIOS3XGHB7LVYGBKQVJGCZ3R4JL5E4CBSWJ5ALIJUHBKS6263644L');
+    stellarTokenCoin.decimalPlaces.should.equal(7);
+  });
+});


### PR DESCRIPTION
This change allows instantiating a Stellar token defined in the statics library as:
`bitgo.coin('txlm:BST-GBQTIOS3XGHB7LVYGBKQVJGCZ3R4JL5E4CBSWJ5ALIJUHBKS6263644L');`

The token name is composed of `<coin>:<token code>-<token issuer>`

Depends on: https://github.com/BitGo/statics/pull/57