### PR TITLE
BLOCK-7 fix hmac error in non-bitgo eos recovery

### DIFF
--- a/modules/core/src/v2/coins/eos.ts
+++ b/modules/core/src/v2/coins/eos.ts
@@ -17,6 +17,7 @@ const co = Bluebird.coroutine;
 import { InvalidAddressError, UnexpectedAddressError } from '../../errors';
 import * as config from '../../config';
 import { Environments } from '../environments';
+import * as request from 'superagent';
 
 const EOS_ADDRESS_LENGTH = 12;
 
@@ -539,7 +540,7 @@ export class Eos extends BaseCoin {
       const nodeUrls = self.getPublicNodeUrls();
       for (const nodeUrl of nodeUrls) {
         try {
-          return yield this.bitgo.post(nodeUrl + endpoint).send(payload);
+          return yield request.post(nodeUrl + endpoint).send(payload);
         } catch (e) {
           // let's hope another call succeeds
         }


### PR DESCRIPTION
https://bitgoinc.atlassian.net/browse/BLOCK-7

When adding Non-BitGo EOS recoveries to the WRW, we ran into an hmac error because the EOS recovery function uses ```bitgo.post``` rather than ```request.post``` and therefore expects an hmac response, but doesn't get one.

Calls to third party blockchains should use ```request``` rather than ```bitgo```
