### PR TITLE
TOKS-13 - Change explainTransaction method to work with Stellar trustline and token txs

### DIFF
--- a/modules/core/src/v2/baseCoin.ts
+++ b/modules/core/src/v2/baseCoin.ts
@@ -161,6 +161,7 @@ export abstract class BaseCoin {
   protected readonly _webhooks: Webhooks;
   protected readonly _pendingApprovals: PendingApprovals;
   protected readonly _markets: Markets;
+  protected static readonly _coinTokenPatternSeparator = ':';
 
   protected constructor(bitgo: BitGo) {
     this.bitgo = bitgo;
@@ -199,6 +200,10 @@ export abstract class BaseCoin {
 
   public markets(): Markets {
     return this._markets;
+  }
+
+  public static get coinTokenPatternSeparator(): string {
+    return this._coinTokenPatternSeparator;
   }
 
   public get type(): string {

--- a/modules/core/src/v2/coinFactory.ts
+++ b/modules/core/src/v2/coinFactory.ts
@@ -43,7 +43,6 @@ import { Zec } from './coins/zec';
 import * as errors from '../errors';
 
 export type CoinConstructor = (bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) => BaseCoin;
-export const coinTokenPatternSeparator = ':';
 
 export class CoinFactory {
   private coinConstructors = new Map<string, CoinConstructor>();

--- a/modules/core/src/v2/coins/stellarToken.ts
+++ b/modules/core/src/v2/coins/stellarToken.ts
@@ -4,7 +4,7 @@
 import * as _ from 'lodash';
 import { BitGo } from '../../bitgo';
 import { Xlm } from './xlm';
-import { CoinConstructor, coinTokenPatternSeparator } from '../coinFactory';
+import { CoinConstructor } from '../coinFactory';
 import { BitGoJsError } from '../../errors';
 
 export interface StellarTokenConfig {
@@ -25,7 +25,7 @@ export class StellarToken extends Xlm {
     super(bitgo);
     this.tokenConfig = tokenConfig;
 
-    const [tokenCoin, token] = _.split(this.tokenConfig.type, coinTokenPatternSeparator);
+    const [tokenCoin, token] = _.split(this.tokenConfig.type, Xlm.coinTokenPatternSeparator);
     if (tokenCoin !== tokenConfig.coin) {
       throw new BitGoJsError(`invalid coin found in token: ${this.tokenConfig.type}`);
     }

--- a/modules/core/test/v2/unit/coins/xlm.ts
+++ b/modules/core/test/v2/unit/coins/xlm.ts
@@ -112,9 +112,14 @@ describe('XLM:', function() {
     basecoin.isValidStellarUsername('Foo@bar.baz').should.equal(false); // only lowercase letters are allowed
   });
 
-  it('Should be able to explain an XLM transaction', co(function *() {
+  it('Should explain an XLM transaction', co(function *() {
     const signedExplanation = yield basecoin.explainTransaction({ txBase64: 'AAAAAMDHAbd3O7B2auR1e+EH/LRKe8IcQBOF+XP2lOxWi1PfAAAB9AAEvJEAAAABAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAB1RFU1RJTkcAAAAAAQAAAAAAAAABAAAAALgEl4p84728zfXtl/JdOsx3QbI97mcybqcXdfgdv54zAAAAAAAAAAEqBfIAAAAAAAAAAAFWi1PfAAAAQDoqo7juOBZawMlk8znIbYqSKemjgmINosp/P4+0SFGo/xJy1YgD6YEc65aWuyBxucFFBXCSlAxP2Z7nPMyjewM=' });
     signedExplanation.outputAmount.should.equal('5000000000');
+    signedExplanation.outputAmounts.should.have.property('txlm', '5000000000');
+    signedExplanation.outputs.length.should.equal(1);
+    signedExplanation.outputs[0].address.should.equal('GC4AJF4KPTR33PGN6XWZP4S5HLGHOQNSHXXGOMTOU4LXL6A5X6PDH445');
+    signedExplanation.outputs[0].amount.should.equal('5000000000');
+    signedExplanation.outputs[0].coin.should.equal('txlm');
     signedExplanation.fee.fee.should.equal('500');
     signedExplanation.memo.value.should.equal('TESTING');
     signedExplanation.memo.type.should.equal('text');
@@ -122,11 +127,42 @@ describe('XLM:', function() {
     signedExplanation.changeAmount.should.equal('0');
     const unsignedExplanation = yield basecoin.explainTransaction({ txBase64: 'AAAAAMDHAbd3O7B2auR1e+EH/LRKe8IcQBOF+XP2lOxWi1PfAAAAZAAEvJEAAAACAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAEAAAABAAAAAAAAAAEAAAAAuASXinzjvbzN9e2X8l06zHdBsj3uZzJupxd1+B2/njMAAAAAAAAAAlQL5AAAAAAAAAAAAA==' });
     unsignedExplanation.outputAmount.should.equal('10000000000');
+    unsignedExplanation.outputAmounts.should.have.property('txlm', '10000000000');
+    unsignedExplanation.outputs.length.should.equal(1);
+    unsignedExplanation.outputs[0].address.should.equal('GC4AJF4KPTR33PGN6XWZP4S5HLGHOQNSHXXGOMTOU4LXL6A5X6PDH445');
+    unsignedExplanation.outputs[0].amount.should.equal('10000000000');
+    unsignedExplanation.outputs[0].coin.should.equal('txlm');
     unsignedExplanation.fee.fee.should.equal('100');
     unsignedExplanation.memo.value.should.equal('1');
     unsignedExplanation.memo.type.should.equal('id');
     unsignedExplanation.changeOutputs.length.should.equal(0);
     unsignedExplanation.changeAmount.should.equal('0');
+  }));
+
+  it('Should explain a trustline transaction', co(function *() {
+    const explanation = yield basecoin.explainTransaction({ txBase64: 'AAAAAIKWO6R0/V4oJDk2LZsdiEInIzgJ6L0GxmSU2Ffs8Y7ZAAABLAAIj4EAAAACAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABQlNUAAAAAABhNDpbuY4frrgwVQqkws7jxK+k4IMrJ6BaE0OFUva9vwAAAOjUpRAAAAAAAAAAAAA=' });
+    explanation.outputAmount.should.equal('0');
+    explanation.fee.fee.should.equal('300');
+    explanation.memo.should.be.empty();
+    explanation.changeOutputs.length.should.equal(0);
+    explanation.changeAmount.should.equal('0');
+    explanation.operations.length.should.equal(1);
+    explanation.operations[0].limit.should.equal('100000');
+    explanation.operations[0].coin.should.equal('txlm:BST-GBQTIOS3XGHB7LVYGBKQVJGCZ3R4JL5E4CBSWJ5ALIJUHBKS6263644L');
+    explanation.operations[0].type.should.equal('changeTrust');
+    explanation.operations[0].should.have.property('asset');
+    explanation.operations[0].asset.code.should.equal('BST');
+    explanation.operations[0].asset.issuer.should.equal('GBQTIOS3XGHB7LVYGBKQVJGCZ3R4JL5E4CBSWJ5ALIJUHBKS6263644L');
+  }));
+
+  it('Should explain a token transaction', co(function *() {
+    const explanation = yield basecoin.explainTransaction({ txBase64: 'AAAAAIXpiGPR/Yc+gSN614hAf1N1hecXFL7Lac99olpq38K/AAAAZAAC9TAAAAAEAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAgpY7pHT9XigkOTYtmx2IQicjOAnovQbGZJTYV+zxjtkAAAABQlNUAAAAAABhNDpbuY4frrgwVQqkws7jxK+k4IMrJ6BaE0OFUva9vwAAAAAdzWUAAAAAAAAAAAFq38K/AAAAQPJTLIGGY06BuVDw0ISasYwHZpR6V38CaOfGhSooclY+4IBE9JKdKuMyGNXXCcFxM/NxrX64jhBXk+lWvjjo4wY=' });
+    explanation.outputAmount.should.equal('0');
+    explanation.fee.fee.should.equal('100');
+    explanation.memo.should.be.empty();
+    explanation.changeOutputs.length.should.equal(0);
+    explanation.changeAmount.should.equal('0');
+    explanation.outputAmounts.should.have.property('txlm:BST-GBQTIOS3XGHB7LVYGBKQVJGCZ3R4JL5E4CBSWJ5ALIJUHBKS6263644L', '500000000');
   }));
 
   it('isValidMemoId should work', function() {


### PR DESCRIPTION
Adds trustline data to the `operations` property, so trustline txs can be displayed correctly.
Adds the `outputAmounts` property to track balance changes for different coins. `outputAmount` continues to track the output amount for XLM-only txs for compatibility.

https://bitgoinc.atlassian.net/browse/TOKS-13

Depends on: https://github.com/BitGo/statics/pull/57