### PR TITLE
BLOCK-16 prebuild should accept gasLimit

### DIFF
--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -1133,6 +1133,7 @@ export class Wallet {
    * @param {Number} params.lastLedgerSequence - Absolute max ledger the transaction should be accepted in, whereafter it will be rejected.
    * @param {String} params.ledgerSequenceDelta - Relative ledger height (in relation to the current ledger) that the transaction should be accepted in, whereafter it will be rejected.
    * @param {Number} params.gasPrice - Custom gas price to be used for sending the transaction
+   * @param {Number} params.gasLimit - Custom gas limit to be used for sending the transaction
    * @param {Boolean} params.noSplitChange - Set to true to disable automatic change splitting for purposes of unspent management
    * @param {Array} params.unspents - The unspents to use in the transaction. Each unspent should be in the form prevTxId:nOutput
    * @param {String} params.changeAddress - Specifies the destination of the change output
@@ -1153,7 +1154,7 @@ export class Wallet {
       const whitelistedParams = _.pick(params, [
         'recipients', 'numBlocks', 'feeRate', 'maxFeeRate', 'minConfirms', 'enforceMinConfirmsForChange',
         'targetWalletUnspents', 'message', 'minValue', 'maxValue', 'sequenceId', 'lastLedgerSequence',
-        'ledgerSequenceDelta', 'gasPrice', 'noSplitChange', 'unspents', 'changeAddress', 'instant', 'memo', 'addressType',
+        'ledgerSequenceDelta', 'gasPrice', 'gasLimit', 'noSplitChange', 'unspents', 'changeAddress', 'instant', 'memo', 'addressType',
         'cpfpTxIds', 'cpfpFeeRate', 'maxFee', 'idfVersion', 'idfSignedTimestamp', 'idfUserId', 'strategy',
         'validFromBlock', 'validToBlock',
       ]);

--- a/modules/core/test/v2/unit/ethWallet.ts
+++ b/modules/core/test/v2/unit/ethWallet.ts
@@ -292,3 +292,36 @@ describe('Add final signature to ETH tx from offline vault', function() {
     response.txHex.should.equal(expectedResult.txHex);
   });
 });
+
+describe('prebuildTransaction', function() {
+  let bitgo;
+  let ethWallet;
+  let recipients;
+  let bgUrl;
+  let gasLimit;
+
+  before(function() {
+    bitgo = new TestBitGo({ env: 'test' });
+    bitgo.initializeTestVars();
+    const coin = bitgo.coin('teth');
+    ethWallet = coin.newWalletObject(bitgo, coin, {});
+    gasLimit = 2100000;
+    recipients = [{
+      address: '0xe59dfe5c67114b39a5662cc856be536c614124c0',
+      amount: '100000'
+    }];
+    bgUrl = common.Environments[bitgo.getEnv()].uri;
+  });
+
+  it('should successfully accept gasLimit as a param', co(function *() {
+    const scope = nock(bgUrl)
+      .post('/api/v2/teth/wallet/' + ethWallet.id() + '/tx/build', {
+        recipients,
+        gasLimit,
+      })
+      .reply(200, { success: true });
+    const prebuild = yield ethWallet.prebuildTransaction({ recipients, gasLimit });
+    scope.isDone().should.equal(true);
+    prebuild.success.should.equal(true);
+  }));
+});


### PR DESCRIPTION
https://bitgoinc.atlassian.net/browse/BLOCK-16

A customer has identified a bug - when inputting a custom gasLimit in the UI, the value does not get recognized by the SDK, and does not get included in the transaction.

This PR fixes the SDK so that ```prebuildTransaction``` correctly handles gasLimit as a parameter