### PR TITLE
SDKT-17: Automatic documentation generation and upload

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -36,6 +36,31 @@ steps:
   commands:
   - yarn run check-fmt
 
+- name: generate docs
+  image: bitgosdk/upload-tools:latest
+  commands:
+  - yarn run gen-docs
+  when:
+    event:
+    - tag
+    status:
+    - success
+
+- name: upload docs
+  image: bitgosdk/upload-tools:latest
+  commands:
+  - yarn run upload-docs
+  environment:
+    reports_s3_akid:
+      from_secret: reports_s3_akid
+    reports_s3_sak:
+      from_secret: reports_s3_sak
+  when:
+    event:
+    - tag
+    status:
+    - success
+
 ---
 kind: pipeline
 name: size and timing (node:lts)
@@ -88,10 +113,9 @@ steps:
     BITGOJS_TEST_PASSWORD:
       from_secret: password
 
-- name: upload reports
-  image: node:6
+- name: upload artifacts
+  image: bitgosdk/upload-tools:latest
   commands:
-  - yarn add -s -W --ignore-engines --no-lockfile --ignore-scripts codecov aws-sdk
   - yarn run artifacts
   - yarn run gen-coverage-changed
   - yarn run coverage -F unit
@@ -145,10 +169,9 @@ steps:
     BITGOJS_TEST_PASSWORD:
       from_secret: password
 
-- name: upload reports
-  image: node:8
+- name: upload artifacts
+  image: bitgosdk/upload-tools:latest
   commands:
-  - yarn add -s -W --ignore-engines --no-lockfile --ignore-scripts codecov aws-sdk
   - yarn run artifacts
   - yarn run gen-coverage-changed
   - yarn run coverage -F unit
@@ -202,10 +225,9 @@ steps:
     BITGOJS_TEST_PASSWORD:
       from_secret: password
 
-- name: upload reports
-  image: node:10
+- name: upload artifacts
+  image: bitgosdk/upload-tools:latest
   commands:
-  - yarn add -s -W --ignore-engines --no-lockfile --ignore-scripts codecov aws-sdk
   - yarn run artifacts
   - yarn run gen-coverage-changed
   - yarn run coverage -F unit
@@ -259,10 +281,9 @@ steps:
     BITGOJS_TEST_PASSWORD:
       from_secret: password
 
-- name: upload reports
-  image: node:11
+- name: upload artifacts
+  image: bitgosdk/upload-tools:latest
   commands:
-  - yarn add -s -W --ignore-engines --no-lockfile --ignore-scripts codecov aws-sdk
   - yarn run artifacts
   - yarn run gen-coverage-changed
   - yarn run coverage -F unit
@@ -316,10 +337,9 @@ steps:
     BITGOJS_TEST_PASSWORD:
       from_secret: password
 
-- name: upload reports
-  image: node:lts
+- name: upload artifacts
+  image: bitgosdk/upload-tools:latest
   commands:
-  - yarn add -s -W --ignore-engines --no-lockfile --ignore-scripts codecov aws-sdk
   - yarn run artifacts
   - yarn run gen-coverage
   - yarn run coverage -F integration

--- a/modules/core/.gitignore
+++ b/modules/core/.gitignore
@@ -19,3 +19,5 @@ example/eth/test.js
 .nyc_output/
 coverage.lcov
 dist/
+docs/
+bitgo-*.tgz

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -42,7 +42,9 @@
     "check-fmt": "prettier --check '{src,test}/**/*.{ts,js,json}'",
     "precommit": "lint-staged",
     "unprettied": "grep -R -L --include '*.ts' --include '*.js' --include '*.json' '@prettier' src test",
-    "fmt": "prettier --write '{src,test}/**/*.{ts,js,json}'"
+    "fmt": "prettier --write '{src,test}/**/*.{ts,js,json}'",
+    "upload-docs": "node scripts/upload-docs.js",
+    "gen-docs": "typedoc"
   },
   "dependencies": {
     "@bitgo/statics": "^2.1.0",
@@ -115,7 +117,7 @@
     "terser": "^3.16.1",
     "terser-webpack-plugin": "^1.2.3",
     "ts-node": "^8.3.0",
-    "typescript": "~3.3.4000",
+    "typescript": "~3.5.3",
     "utf-8-validate": "^4.0.2",
     "webpack": "^4.29.6",
     "webpack-cli": "^3.2.3"

--- a/modules/core/scripts/upload-docs.js
+++ b/modules/core/scripts/upload-docs.js
@@ -1,0 +1,98 @@
+const path = require('path');
+const fs = require('fs');
+const S3 = require('aws-sdk/clients/s3');
+const { version } = require('../package.json');
+const { promisify } = require('util');
+
+const {
+  reports_s3_akid,
+  reports_s3_sak,
+  DRONE,
+  DRONE_TAG,
+  DRONE_STAGE_STATUS,
+} = process.env;
+
+if (!DRONE) {
+  console.log('Not running in drone, exiting...');
+  process.exit(0);
+}
+
+if (!DRONE_TAG) {
+  console.log('Not a tag build, exiting...');
+  process.exit(0);
+}
+
+if (DRONE_STAGE_STATUS !== 'success') {
+  console.log('Drone pipeline is failed, exiting...');
+  process.exit(0);
+}
+
+const s3 = new S3({
+  accessKeyId: reports_s3_akid,
+  secretAccessKey: reports_s3_sak,
+  signatureVersion: 'v4',
+});
+
+const readdir = promisify(fs.readdir);
+const readFile = promisify(fs.readFile);
+const stat = promisify(fs.stat);
+const putObject = promisify(s3.putObject);
+
+const ROOTDIR = path.dirname(path.dirname(require.main.filename));
+const MODULE = path.basename(ROOTDIR);
+const OBJECT_ROOT = `${MODULE}/${version}`;
+const DOCS_ROOT = `${ROOTDIR}/docs/`;
+
+async function walk(currentDirPath, seen = []) {
+  const files = await readdir(currentDirPath);
+  for (const file of files) {
+    const filePath = path.join(currentDirPath, file);
+    const fileStat = await stat(filePath);
+    if (fileStat.isFile()) {
+      seen.push({ filePath, stat: fileStat });
+    } else if (fileStat.isDirectory()) {
+      await walk(filePath, seen);
+    }
+  }
+  return seen;
+}
+
+async function upload(uploadParams) {
+  try {
+    await putObject(uploadParams);
+  } catch (e) {
+    console.error(`S3 error: ${e}\n${e.stack}`);
+    throw e;
+  }
+}
+
+async function uploadDocs(root, key) {
+  const uploadPromises = [];
+  const now = Date.now();
+  const files = await walk(root);
+  console.log(`Uploading ${files.length} documentation source files to S3`);
+  for (const { filePath } of files) {
+    const bucketPath = `${key}/${filePath.replace(DOCS_ROOT, '')}`;
+    const uploadParams = {
+      Body: await readFile(filePath),
+      Bucket: 'bitgo-sdk-docs',
+      Key: bucketPath,
+      ACL: 'public-read',
+      ContentType: 'text/html',
+    };
+
+    uploadPromises.push(upload(uploadParams));
+  }
+
+  await Promise.all(uploadPromises);
+  console.log();
+  console.log(`=== DOCS UPLOADED SUCCESSFULLY (${Date.now() - now} ms) ===`);
+  console.log(`https://bitgo-sdk-docs.s3.amazonaws.com/${key}/index.html`);
+  console.log();
+}
+
+if (!fs.existsSync(DOCS_ROOT) || !fs.statSync(DOCS_ROOT).isDirectory()) {
+  console.warn(`Docs directory '${DOCS_ROOT}' not found. Skipping docs upload...`);
+} else {
+  uploadDocs(DOCS_ROOT, OBJECT_ROOT);
+}

--- a/modules/core/scripts/upload-tools/Dockerfile
+++ b/modules/core/scripts/upload-tools/Dockerfile
@@ -1,0 +1,2 @@
+FROM node:10
+RUN yarn global add codecov typedoc && yarn add aws-sdk

--- a/modules/core/scripts/upload-tools/README.md
+++ b/modules/core/scripts/upload-tools/README.md
@@ -1,0 +1,10 @@
+# BitGo SDK Upload Tools
+
+`bitgosdk/upload-tools` is a `node:10`-derived docker image which has a few npm packages pre-installed to reduce install times during builds.
+
+Currently, the following binaries are installed via `yarn global add`:
+* `codecov`
+* `typedoc`
+
+The following libraries are installed via `yarn add`:
+* `aws-sdk`

--- a/modules/core/src/bitcoin.ts
+++ b/modules/core/src/bitcoin.ts
@@ -1,3 +1,9 @@
+/**
+ * @hidden
+ */
+
+/**
+ */
 import * as common from './common';
 import * as bitcoin from 'bitgo-utxo-lib';
 import { V1Network } from './v2/types';
@@ -99,11 +105,10 @@ function deriveFast(hdnode: bitcoin.HDNode, index: number): bitcoin.HDNode {
 }
 
 /**
- *  Derive a BIP32 path, given a root key
- *  We cache keys at each level of hierarchy we derive, to avoid re-deriving (approx 25ms per derivation)
+ * Derive a BIP32 path, given a root key
+ * We cache keys at each level of hierarchy we derive, to avoid re-deriving (approx 25ms per derivation)
  * @param rootKey key to derive off
- * @param path the path, e.g. 'm/0/0/0/1'
- * @returns {*} the derived hd key
+ * @returns {*} function which can be used to derive a new HDNode from the root HDNode on a given path
  */
 export function hdPath(rootKey): { derive: (path: string) => bitcoin.HDNode; deriveKey: (path: string) => bitcoin.ECPair; } {
   const cache = {};

--- a/modules/core/src/bitgo.ts
+++ b/modules/core/src/bitgo.ts
@@ -18,7 +18,7 @@ import bs58 = require('bs58');
 import * as common from './common';
 import { EnvironmentName } from './v2/environments';
 import { NodeCallback, V1Network } from './v2/types';
-import { RequestTracer, Util } from './v2/util';
+import { RequestTracer, Util } from './v2/internal/util';
 import * as Bluebird from 'bluebird';
 import co = Bluebird.coroutine;
 import pjson = require('../package.json');
@@ -29,7 +29,7 @@ import * as querystring from 'querystring';
 import * as config from './config';
 import * as crypto from 'crypto';
 import * as debugLib from 'debug';
-import { bytesToWord } from './v2/internal';
+import { bytesToWord } from './v2/internal/internal';
 
 const TransactionBuilder = require('./transactionBuilder');
 const Blockchain = require('./blockchain');

--- a/modules/core/src/blockchain.ts
+++ b/modules/core/src/blockchain.ts
@@ -1,3 +1,9 @@
+/**
+ * @hidden
+ */
+
+/**
+ */
 //
 // Blockchain Object
 // BitGo accessor to a any Bitcoin address.

--- a/modules/core/src/keychains.ts
+++ b/modules/core/src/keychains.ts
@@ -1,3 +1,9 @@
+/**
+ * @hidden
+ */
+
+/**
+ */
 //
 // Keychains Object
 // BitGo accessor to a user's keychain.
@@ -7,7 +13,7 @@
 
 import * as crypto from 'crypto';
 import * as common from './common';
-import { Util } from './v2/util';
+import { Util } from './v2/internal/util';
 import * as bitcoin from 'bitgo-utxo-lib';
 import { hdPath } from './bitcoin';
 const _ = require('lodash');

--- a/modules/core/src/markets.ts
+++ b/modules/core/src/markets.ts
@@ -1,3 +1,9 @@
+/**
+ * @hidden
+ */
+
+/**
+ */
 //
 // Markets Object
 // BitGo accessor to Bitcoin market data.

--- a/modules/core/src/pendingapproval.ts
+++ b/modules/core/src/pendingapproval.ts
@@ -1,4 +1,9 @@
-//
+/**
+ * @hidden
+ */
+
+/**
+ */
 // Pending Approval Object
 // Handles approving, rejecting and getting information on pending approvals
 //

--- a/modules/core/src/pendingapprovals.ts
+++ b/modules/core/src/pendingapprovals.ts
@@ -1,3 +1,9 @@
+/**
+ * @hidden
+ */
+
+/**
+ */
 //
 // Pending approvals listing object
 // Lists pending approvals and get pending approval objects

--- a/modules/core/src/prova.ts
+++ b/modules/core/src/prova.ts
@@ -1,3 +1,9 @@
+/**
+ * @hidden
+ */
+
+/**
+ */
 import common = require('./common');
 const prova = require('prova-lib');
 

--- a/modules/core/src/ripple.ts
+++ b/modules/core/src/ripple.ts
@@ -1,3 +1,9 @@
+/**
+ * @hidden
+ */
+
+/**
+ */
 const rippleKeypairs = require('ripple-keypairs');
 const ripple = require('ripple-lib');
 const prova = require('./prova');

--- a/modules/core/src/transactionBuilder.ts
+++ b/modules/core/src/transactionBuilder.ts
@@ -1,3 +1,9 @@
+/**
+ * @hidden
+ */
+
+/**
+ */
 //
 // TransactionBuilder
 // A utility for building and signing transactions

--- a/modules/core/src/travelRule.ts
+++ b/modules/core/src/travelRule.ts
@@ -1,3 +1,9 @@
+/**
+ * @hidden
+ */
+
+/**
+ */
 //
 // TravelRule Object
 // BitGo accessor for a specific enterprise

--- a/modules/core/src/v2/baseCoin.ts
+++ b/modules/core/src/v2/baseCoin.ts
@@ -9,7 +9,7 @@ import * as Bluebird from 'bluebird';
 import { BitGo } from '../bitgo';
 import * as errors from '../errors';
 import { NodeCallback } from './types';
-import { RequestTracer } from './util';
+import { RequestTracer } from './internal/util';
 const co = Bluebird.coroutine;
 
 import { Wallet } from './wallet';

--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -25,7 +25,7 @@ import { NodeCallback } from '../types';
 import * as config from '../../config';
 import { CrossChainRecoveryTool } from '../recovery';
 import * as errors from '../../errors';
-import { RequestTracer } from '../util';
+import { RequestTracer } from '../internal/util';
 import { Wallet } from '../wallet';
 
 const debug = debugLib('bitgo:v2:utxo');

--- a/modules/core/src/v2/coins/erc20Token.ts
+++ b/modules/core/src/v2/coins/erc20Token.ts
@@ -9,7 +9,7 @@ import { NodeCallback } from '../types';
 
 import { Eth, RecoverOptions, RecoveryInfo, optionalDeps } from './eth';
 import { CoinConstructor } from '../coinFactory';
-import { Util } from '../util';
+import { Util } from '../internal/util';
 import * as config from '../../config';
 
 const co = Bluebird.coroutine;

--- a/modules/core/src/v2/coins/eth.ts
+++ b/modules/core/src/v2/coins/eth.ts
@@ -34,7 +34,7 @@ import { NodeCallback, Recipient } from '../types';
 import { Wallet } from '../wallet';
 import * as common from '../../common';
 import * as config from '../../config';
-import { Util } from '../util';
+import { Util } from '../internal/util';
 
 const co = Bluebird.coroutine;
 const debug = debugLib('bitgo:v2:eth');

--- a/modules/core/src/v2/coins/xlm.ts
+++ b/modules/core/src/v2/coins/xlm.ts
@@ -785,7 +785,7 @@ export class Xlm extends BaseCoin {
       // value() and arm() that provide memo value and type, respectively.
       const memo: TransactionMemo = _.result(tx, '_memo.value') && _.result(tx, '_memo.arm') ?
         {
-          value: _.result(tx, '_memo.value').toString(),
+          value: (_.result(tx, '_memo.value') as any).toString(),
           type: _.result(tx, '_memo.arm'),
         } : {};
 

--- a/modules/core/src/v2/coins/xlm.ts
+++ b/modules/core/src/v2/coins/xlm.ts
@@ -9,7 +9,7 @@ import { BigNumber } from 'bignumber.js';
 import { BitGo } from '../../bitgo';
 import { KeyIndices } from '../keychains';
 
-import { Ed25519KeyDeriver } from '../keyDeriver';
+import { Ed25519KeyDeriver } from '../internal/keyDeriver';
 import * as config from '../../config';
 import * as common from '../../common';
 import {

--- a/modules/core/src/v2/enterprise.ts
+++ b/modules/core/src/v2/enterprise.ts
@@ -7,7 +7,7 @@ import { BitGo } from '../bitgo';
 import { BaseCoin } from './baseCoin';
 import { NodeCallback } from './types';
 import { Wallet } from './wallet';
-import { getFirstPendingTransaction } from './internal';
+import { getFirstPendingTransaction } from './internal/internal';
 
 import { Settlements } from './trading/settlements';
 import { Affirmations } from './trading/affirmations';

--- a/modules/core/src/v2/internal/internal.ts
+++ b/modules/core/src/v2/internal/internal.ts
@@ -1,9 +1,13 @@
 /**
  * @prettier
+ * @hidden
+ */
+
+/**
  */
 import * as Bluebird from 'bluebird';
-import { BitGo } from '../bitgo';
-import { BaseCoin } from './baseCoin';
+import { BitGo } from '../../bitgo';
+import { BaseCoin } from '../baseCoin';
 import { isUndefined } from 'lodash';
 
 const co = Bluebird.coroutine;

--- a/modules/core/src/v2/internal/keyDeriver.ts
+++ b/modules/core/src/v2/internal/keyDeriver.ts
@@ -1,5 +1,9 @@
 /**
  * @prettier
+ * @hidden
+ */
+
+/**
  */
 import * as createHmac from 'create-hmac';
 

--- a/modules/core/src/v2/internal/keycard.ts
+++ b/modules/core/src/v2/internal/keycard.ts
@@ -1,3 +1,9 @@
+/**
+ * @hidden
+ */
+
+/**
+ */
 import { isUndefined } from 'lodash';
 /**
  * Return the list of questions that will appear on the second page of the keycard

--- a/modules/core/src/v2/internal/util.ts
+++ b/modules/core/src/v2/internal/util.ts
@@ -1,12 +1,17 @@
 /**
  * @prettier
+ * @hidden
+ */
+
+/**
  */
 import * as bitcoin from 'bitgo-utxo-lib';
 import * as Big from 'big.js';
 import * as _ from 'lodash';
 import * as crypto from 'crypto';
 import * as debugLib from 'debug';
-import { EthereumLibraryUnavailableError } from '../errors';
+import { EthereumLibraryUnavailableError } from '../../errors';
+import { RequestTracer as IRequestTracer } from '../types';
 
 const debug = debugLib('bitgo:v2:util');
 
@@ -28,7 +33,7 @@ import(ethImport)
 /**
  * Create a request tracer for tracing workflows which involve multiple round trips to the server
  */
-export class RequestTracer {
+export class RequestTracer implements IRequestTracer {
   private _seq = 0;
   private readonly _seed: Buffer;
   constructor() {

--- a/modules/core/src/v2/keychains.ts
+++ b/modules/core/src/v2/keychains.ts
@@ -5,7 +5,7 @@ import { BitGo } from '../bitgo';
 import { BaseCoin, KeyPair } from './baseCoin';
 import { NodeCallback } from './types';
 import { Wallet } from './wallet';
-import { RequestTracer } from './util';
+import { RequestTracer } from './internal/util';
 import { validateParams } from '../common';
 
 const co = Bluebird.coroutine;

--- a/modules/core/src/v2/trading/affirmation.ts
+++ b/modules/core/src/v2/trading/affirmation.ts
@@ -1,5 +1,9 @@
 /**
  * @prettier
+ * @hidden
+ */
+
+/**
  */
 import * as Bluebird from 'bluebird';
 import { BitGo } from '../../bitgo';

--- a/modules/core/src/v2/trading/affirmations.ts
+++ b/modules/core/src/v2/trading/affirmations.ts
@@ -1,5 +1,9 @@
 /**
  * @prettier
+ * @hidden
+ */
+
+/**
  */
 import * as Bluebird from 'bluebird';
 import { BitGo } from '../../bitgo';

--- a/modules/core/src/v2/trading/lock.ts
+++ b/modules/core/src/v2/trading/lock.ts
@@ -1,5 +1,9 @@
 /**
  * @prettier
+ * @hidden
+ */
+
+/**
  */
 export interface Lock {
   id: string;

--- a/modules/core/src/v2/trading/payload.ts
+++ b/modules/core/src/v2/trading/payload.ts
@@ -1,7 +1,10 @@
 /**
  * @prettier
+ * @hidden
  */
 
+/**
+ */
 type CURRENT_PAYLOAD_VERSION = '1.1.1';
 
 export interface Payload {

--- a/modules/core/src/v2/trading/settlement.ts
+++ b/modules/core/src/v2/trading/settlement.ts
@@ -1,5 +1,9 @@
 /**
  * @prettier
+ * @hidden
+ */
+
+/**
  */
 import { BitGo } from '../../bitgo';
 import { Trade } from './trade';

--- a/modules/core/src/v2/trading/settlements.ts
+++ b/modules/core/src/v2/trading/settlements.ts
@@ -1,5 +1,9 @@
 /**
  * @prettier
+ * @hidden
+ */
+
+/**
  */
 import * as Bluebird from 'bluebird';
 import { BitGo } from '../../bitgo';

--- a/modules/core/src/v2/trading/trade.ts
+++ b/modules/core/src/v2/trading/trade.ts
@@ -1,5 +1,6 @@
 /**
  * @prettier
+ * @hidden
  */
 /**
  * Represents a single trade to be settled as part of a settlement. Only off-chain (OFC) currencies are supported, and

--- a/modules/core/src/v2/trading/tradingAccount.ts
+++ b/modules/core/src/v2/trading/tradingAccount.ts
@@ -1,5 +1,9 @@
 /**
  * @prettier
+ * @hidden
+ */
+
+/**
  */
 import { BigNumber } from 'bignumber.js';
 import * as Bluebird from 'bluebird';

--- a/modules/core/src/v2/trading/tradingPartner.ts
+++ b/modules/core/src/v2/trading/tradingPartner.ts
@@ -1,5 +1,9 @@
 /**
  * @prettier
+ * @hidden
+ */
+
+/**
  */
 import * as Bluebird from 'bluebird';
 import { BitGo } from '../../bitgo';

--- a/modules/core/src/v2/trading/tradingPartners.ts
+++ b/modules/core/src/v2/trading/tradingPartners.ts
@@ -1,5 +1,9 @@
 /**
  * @prettier
+ * @hidden
+ */
+
+/**
  */
 import * as Bluebird from 'bluebird';
 import { BitGo } from '../../bitgo';

--- a/modules/core/src/v2/types.ts
+++ b/modules/core/src/v2/types.ts
@@ -9,3 +9,8 @@ export interface Recipient {
   address: string;
   amount: string;
 }
+
+export interface RequestTracer {
+  inc(): void;
+  toString(): string;
+}

--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -17,13 +17,13 @@ import {
 } from './baseCoin';
 import { AbstractUtxoCoin } from './coins/abstractUtxoCoin';
 import { Eth } from './coins';
-import * as internal from './internal';
-import { drawKeycard } from './keycard';
+import * as internal from './internal/internal';
+import { drawKeycard } from './internal/keycard';
 import { Keychain } from './keychains';
 import { TradingAccount } from './trading/tradingAccount';
 import { NodeCallback } from './types';
 import { PendingApproval } from './pendingApproval';
-import { RequestTracer } from './util';
+import { RequestTracer } from './internal/util';
 
 const debug = debugLib('bitgo:v2:wallet');
 const co = Bluebird.coroutine;

--- a/modules/core/src/v2/wallets.ts
+++ b/modules/core/src/v2/wallets.ts
@@ -10,7 +10,7 @@ import { Wallet } from './wallet';
 import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
 import { hdPath } from '../bitcoin';
-import { RequestTracer } from './util';
+import { RequestTracer } from './internal/util';
 
 const co = Bluebird.coroutine;
 

--- a/modules/core/src/wallet.ts
+++ b/modules/core/src/wallet.ts
@@ -1,3 +1,9 @@
+/**
+ * @hidden
+ */
+
+/**
+ */
 //
 // Wallet Object
 // BitGo accessor for a specific wallet

--- a/modules/core/src/wallets.ts
+++ b/modules/core/src/wallets.ts
@@ -1,3 +1,9 @@
+/**
+ * @hidden
+ */
+
+/**
+ */
 //
 // Wallets Object
 // BitGo accessor to a user's wallets.

--- a/modules/core/test/v2/unit/ethWallet.ts
+++ b/modules/core/test/v2/unit/ethWallet.ts
@@ -4,7 +4,7 @@ import * as secp256k1 from 'secp256k1';
 import * as nock from 'nock';
 import * as bitGoUtxoLib from 'bitgo-utxo-lib';
 import * as sinon from 'sinon';
-import { Util } from '../../../src/v2/util';
+import { Util } from '../../../src/v2/internal/util';
 import * as common from '../../../src/common';
 
 import { TestBitGo } from '../../lib/test_bitgo';

--- a/modules/core/test/v2/unit/internal.ts
+++ b/modules/core/test/v2/unit/internal.ts
@@ -1,7 +1,7 @@
 import 'should';
 
 import { randomBytes } from 'crypto';
-import { bytesToWord } from '../../../src/v2/internal';
+import { bytesToWord } from '../../../src/v2/internal/internal';
 
 describe('Internal:', () => {
   describe('bytesToWord', () => {

--- a/modules/core/test/v2/unit/keyDeriver.ts
+++ b/modules/core/test/v2/unit/keyDeriver.ts
@@ -1,5 +1,5 @@
 import 'should';
-import { Ed25519KeyDeriver } from '../../../src/v2/keyDeriver';
+import { Ed25519KeyDeriver } from '../../../src/v2/internal/keyDeriver';
 import { keys } from '../fixtures/keyDeriver';
 
 describe('Key Derivation:', () => {

--- a/modules/core/tsconfig.json
+++ b/modules/core/tsconfig.json
@@ -18,7 +18,6 @@
     "mode": "modules",
     "out": "docs",
     "title": "BitGo SDK Documentation",
-    "theme": "minimal",
     "excludeNotExported": true,
     "excludePrivate": true,
     "excludeProtected": true,

--- a/modules/core/tsconfig.json
+++ b/modules/core/tsconfig.json
@@ -13,5 +13,15 @@
   "include": [
     "src/**/*",
     "package.json"
-  ]
+  ],
+  "typedocOptions": {
+    "mode": "modules",
+    "out": "docs",
+    "title": "BitGo SDK Documentation",
+    "theme": "minimal",
+    "excludeNotExported": true,
+    "excludePrivate": true,
+    "excludeProtected": true,
+    "ignoreCompilerErrors": true
+  }
 }

--- a/modules/express/package.json
+++ b/modules/express/package.json
@@ -79,7 +79,7 @@
     "supertest": "^4.0.2",
     "supertest-as-promised": "https://github.com/BitGo/supertest-as-promised/archive/a7f4b612b9fa090ae33a9616c41862aec2b25c7e.tar.gz",
     "ts-node": "^8.1.0",
-    "typescript": "~3.3.4000"
+    "typescript": "~3.5.3"
   },
   "nyc": {
     "extension": [

--- a/modules/express/src/config.ts
+++ b/modules/express/src/config.ts
@@ -75,10 +75,9 @@ function mergeConfigs(...configs: Config[]): Config {
   // helper to get the first defined value for a given config key
   // from the config sources in a type safe manner
   function get<T extends keyof Config>(k: T): Config[T] {
-    return configs.reduce((item: Config[T], c) => {
-      const current = c[k];
-      return isNilOrNaN(item) && !isNilOrNaN(current) ? current : item;
-    }, undefined);
+    return configs
+      .reverse()
+      .reduce((entry: Config[T], config) => !isNilOrNaN(config[k]) ? config[k] : entry, DefaultConfig[k]);
   }
 
   return {
@@ -101,5 +100,5 @@ function mergeConfigs(...configs: Config[]): Config {
 export const config = () => {
   const arg = ArgConfig(args());
   const env = EnvConfig();
-  return mergeConfigs(arg, env, DefaultConfig);
+  return mergeConfigs(arg, env);
 };

--- a/modules/express/test/unit/config.ts
+++ b/modules/express/test/unit/config.ts
@@ -28,4 +28,12 @@ describe('Config:', () => {
     config().port.should.equal(DefaultConfig.port);
     argStub.restore();
   });
+
+  it('should correctly handle config precedence', () => {
+    const argStub = sinon.stub(args, 'args').returns({ port: 23456 });
+    const envStub = sinon.stub(process, 'env').value({ BITGO_PORT: '12345' });
+    config().port.should.equal(23456);
+    argStub.restore();
+    envStub.restore();
+  });
 });

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "gen-coverage": "lerna run gen-coverage --stream --parallel",
     "coverage": "lerna run upload-coverage --stream --parallel --",
     "artifacts": "lerna run upload-artifacts --stream --parallel",
+    "upload-docs": "lerna run upload-docs --stream --parallel",
+    "gen-docs": "lerna run gen-docs --stream --parallel",
     "check-fmt-changed": "lerna run check-fmt --since ${DRONE_REPO_BRANCH:-master}^..${DRONE_COMMIT:-HEAD} --stream --parallel",
     "check-fmt": "lerna run check-fmt --stream --parallel"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10186,10 +10186,10 @@ typeforce@~1.10.6:
   dependencies:
     inherits "^2.0.1"
 
-typescript@~3.3.4000:
-  version "3.3.4000"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.4000.tgz#76b0f89cfdbf97827e1112d64f283f1151d6adf0"
-  integrity sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==
+typescript@~3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
 uglify-js@3.4.x:
   version "3.4.10"


### PR DESCRIPTION
* Set up typedoc + required config
* Upgrade `core` and `express` modules to typescript@3.5.3 to match typedoc version
* Add `scripts/upload-docs.js` for uploading documentation files
* Add drone step to generate docs for tag builds
* Add drone step to call `scripts/upload-docs.js`
* Introduce `bitgosdk/upload-tools` container to build pipeline to reduce install times

Example docs build: https://bitgo-sdk-docs.s3.amazonaws.com/core/docs-test-rel-tag/index.html

Note that docs will only get built for tag builds (that is, builds which are the result of pushing a tag). It is expected that this is mostly releases. Each docs run generates ~80 MB of HTML which gets uploaded to S3, so we should only generate docs as needed and not for each build.