### PR TITLE
TOKS-27 - Fix getChain method of stellarCoin

### DIFF
--- a/modules/core/src/v2/coins/stellarToken.ts
+++ b/modules/core/src/v2/coins/stellarToken.ts
@@ -68,7 +68,7 @@ export class StellarToken extends Xlm {
   }
 
   getChain() {
-    return this.tokenConfig.coin;
+    return this.tokenConfig.type;
   }
 
   getFullName() {

--- a/modules/core/test/v2/unit/coins/stellarToken.ts
+++ b/modules/core/test/v2/unit/coins/stellarToken.ts
@@ -14,7 +14,7 @@ describe('Stellar Token:', function() {
   });
 
   it('should return constants', function() {
-    stellarTokenCoin.getChain().should.equal('txlm');
+    stellarTokenCoin.getChain().should.equal('txlm:BST-GBQTIOS3XGHB7LVYGBKQVJGCZ3R4JL5E4CBSWJ5ALIJUHBKS6263644L');
     stellarTokenCoin.getFullName().should.equal('Stellar Token');
     stellarTokenCoin.getBaseFactor().should.equal(1e7);
     stellarTokenCoin.type.should.equal(tokenName);


### PR DESCRIPTION
The `getChain` method in the SDK is used by the `url` method to get the token name, not its actual chain.

https://bitgoinc.atlassian.net/browse/TOKS-27