### PR TITLE
Fix for bitgo-utxo-lib types

### DIFF
--- a/types/bitgo-utxo-lib/index.d.ts
+++ b/types/bitgo-utxo-lib/index.d.ts
@@ -28,7 +28,7 @@ declare module 'bitgo-utxo-lib' {
   }
 
   export class ECPair {
-    static makeRandom({ network: Network }): ECPair;
+    static makeRandom({ network }: { network: Network }): ECPair;
     static fromWIF(wif: string, network: Network): ECPair;
     static fromPublicKeyBuffer(buffer: Buffer): ECPair;
     constructor(d: any, Q: any, options: any): ECPair;

--- a/types/bitgo-utxo-lib/index.d.ts
+++ b/types/bitgo-utxo-lib/index.d.ts
@@ -122,7 +122,6 @@ declare module 'bitgo-utxo-lib' {
     static types: {
       P2PKH: string;
       P2SH: string;
-      P2PKH: string;
       P2WSH: string;
     };
     static classifyWitness(script: string, something: boolean): InputClassification;


### PR DESCRIPTION
* Fix unintended param renaming instead of type specification
* Remove duplicate P2PKH identifier