### PR TITLE
SERV-46: Fix importing ethereumjs-util in browsers

### DIFF
--- a/modules/core/src/v2/internal/util.ts
+++ b/modules/core/src/v2/internal/util.ts
@@ -19,7 +19,7 @@ let ethUtil;
 let isEthAvailable = false;
 
 const ethImport = 'ethereumjs-util';
-import(ethImport)
+import('ethereumjs-util')
   .then(eth => {
     ethUtil = eth;
     isEthAvailable = true;


### PR DESCRIPTION
To verify fix follow these steps:

1) In bitgojs, run these commands:
* `cd modules/core`
* `yarn clean`
* `yarn`
* `yarn compile`
* `yarn pack`
* `cp bitgo-v8.1.2.tgz ~/path/to/client-private`

2) In the client, run these commands:
* Edit package.json to set bitgo version to `./bitgo-v8.1.2.tgz`
* `npm run full-build`

3) Start platform with this version of client, try to send a teth transaction. It should be successful and there should be no errors about ethereumjs-util.

I'm not sure why this PR fixes the issue exactly.  My WAG is that there is some optimization that tsc or webpack can do when it sees `import('static-string')` that it can't do when it sees `import(dynamicVariable)`. If anyone knows anything about this, please share.
