### PR TITLE
SERV-32 fix hop on pending approval

### DIFF
--- a/modules/core/src/v2/environments.ts
+++ b/modules/core/src/v2/environments.ts
@@ -97,13 +97,10 @@ const testnetBase: EnvironmentTemplate = {
   ],
 };
 
-const devBase: EnvironmentTemplate = Object.assign(
-  {
-    hsmXpub:
-      'xpub661MyMwAqRbcFWzoz8qnYRDYEFQpPLYwxVFoG6WLy3ck5ZupRGJTG4ju6yGb7Dj3ey6GsC4kstLRER2nKzgjLtmxyPgC4zHy7kVhUt6yfGn',
-  },
-  testnetBase
-);
+const devBase: EnvironmentTemplate = Object.assign({}, testnetBase, {
+  hsmXpub:
+    'xpub661MyMwAqRbcFWzoz8qnYRDYEFQpPLYwxVFoG6WLy3ck5ZupRGJTG4ju6yGb7Dj3ey6GsC4kstLRER2nKzgjLtmxyPgC4zHy7kVhUt6yfGn',
+});
 
 export const Environments: Environments = {
   prod: Object.assign(

--- a/modules/core/src/v2/pendingApproval.ts
+++ b/modules/core/src/v2/pendingApproval.ts
@@ -349,6 +349,11 @@ export class PendingApproval {
 
       const recipients = transactionRequest.recipients;
       const prebuildParams = _.extend({}, params, { recipients: recipients }, transactionRequest.buildParams);
+
+      if (!_.isUndefined(originalPrebuild.hopTransaction)) {
+        prebuildParams.hop = true;
+      }
+
       const signedTransaction = yield self.wallet.prebuildAndSignTransaction(prebuildParams);
       // compare PAYGo fees
       const originalParsedTransaction = yield self.baseCoin.parseTransaction({


### PR DESCRIPTION
https://bitgoinc.atlassian.net/browse/SERV-32
Hop TX's didn't work with pending approvals. 
There was a platform change that got us closer.
This should be the final change to enable hop tx's with pending approvals.
