### PR TITLE
TOKS-31 - Allow sending trustline txs from SDK

### DIFF
--- a/modules/core/src/v2/baseCoin.ts
+++ b/modules/core/src/v2/baseCoin.ts
@@ -58,6 +58,7 @@ export interface VerifyAddressOptions {
 export interface TransactionParams {
   recipients?: TransactionOutput[];
   walletPassphrase?: string;
+  type?: string;
 }
 
 export interface VerificationOptions {

--- a/modules/core/src/v2/coins/stellarToken.ts
+++ b/modules/core/src/v2/coins/stellarToken.ts
@@ -6,6 +6,7 @@ import { BitGo } from '../../bitgo';
 import { Xlm } from './xlm';
 import { CoinConstructor } from '../coinFactory';
 import { BitGoJsError } from '../../errors';
+import * as stellar from 'stellar-sdk';
 
 export interface StellarTokenConfig {
   name: string;
@@ -24,6 +25,8 @@ export class StellarToken extends Xlm {
   constructor(bitgo: BitGo, tokenConfig: StellarTokenConfig) {
     super(bitgo);
     this.tokenConfig = tokenConfig;
+    const network = this.tokenConfig.network === 'Testnet' ? stellar.Networks.TESTNET : stellar.Networks.PUBLIC;
+    stellar.Network.use(new stellar.Network(network));
 
     const [tokenCoin, token] = _.split(this.tokenConfig.type, Xlm.coinTokenPatternSeparator);
     if (tokenCoin !== tokenConfig.coin) {

--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -47,6 +47,11 @@ export interface MaximumSpendable {
   coin: string;
 }
 
+export interface Memo {
+  value: string;
+  type: string;
+}
+
 export interface PrebuildTransactionOptions {
   reqId?: RequestTracer;
   recipients?: {
@@ -71,10 +76,7 @@ export interface PrebuildTransactionOptions {
   validFromBlock?: number;
   validToBlock?: number;
   instant?: boolean;
-  memo?: {
-    value: string;
-    type: string;
-  }[];
+  memo?: Memo;
   addressType?: string;
   hop?: boolean;
   walletPassphrase?: string;
@@ -1239,7 +1241,7 @@ export class Wallet {
         'targetWalletUnspents', 'message', 'minValue', 'maxValue', 'sequenceId', 'lastLedgerSequence',
         'ledgerSequenceDelta', 'gasPrice', 'gasLimit', 'noSplitChange', 'unspents', 'changeAddress', 'instant', 'memo', 'addressType',
         'cpfpTxIds', 'cpfpFeeRate', 'maxFee', 'idfVersion', 'idfSignedTimestamp', 'idfUserId', 'strategy',
-        'validFromBlock', 'validToBlock',
+        'validFromBlock', 'validToBlock', 'type', 'trustlines',
       ]);
       debug('prebuilding transaction: %O', whitelistedParams);
 
@@ -1558,6 +1560,8 @@ export class Wallet {
    * @param {String} params.changeAddress - Specifies the destination of the change output
    * @param {Boolean} params.instant - Send this transaction using coin-specific instant sending method (if available)
    * @param {{value: String, type: String}} params.memo - Memo to use in transaction (supported by Stellar)
+   * @param {String} params.type - Type of the transaction (e.g. trustline)
+   * @param {{token: params, action: String, limit: String}[]} options.trustlines - Array of trustlines to manage (supported by Stellar)
    * @param callback
    * @returns {*}
    */
@@ -1588,7 +1592,7 @@ export class Wallet {
         'message', 'minValue', 'maxValue', 'sequenceId',
         'lastLedgerSequence', 'ledgerSequenceDelta', 'gasPrice',
         'noSplitChange', 'unspents', 'comment', 'otp', 'changeAddress',
-        'instant', 'memo'
+        'instant', 'memo', 'type', 'trustlines',
       ]);
       const finalTxParams = _.extend({}, halfSignedTransaction, selectParams);
       self.bitgo.setRequestTracer(reqId);


### PR DESCRIPTION
Hot wallets need the ability to send trustline txs to manage tokens they support.