### PR TITLE
SDKT-32: Improve usability for typescript dependents

### DIFF
--- a/modules/core/README.md
+++ b/modules/core/README.md
@@ -71,6 +71,10 @@ console.dir(result);
 ## More examples
 Further demos and examples in both Javascript and Typescript can be found in the [example](example) directory.
 
+# Using with Typescript
+
+`bitgo` is not yet compatible with the `noImplicitAny` compiler option. If you want to use this option in your project (and we recommend that you do), you must set the `skipLibCheck` option to supress errors about missing type definitions for dependencies of `bitgo`.
+
 # Usage in Browser
 
 Since version 6, `bitgo` includes a minified, browser-compatible bundle by default at `dist/browser/BitGoJS.min.js`. It can be copied from there directly into your project.

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -3,7 +3,7 @@
   "version": "8.2.2",
   "description": "BitGo Javascript SDK",
   "main": "./dist/src/index.js",
-  "types": "./dist/src/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "keywords": [
     "bitgo",
     "bitcoin",
@@ -49,6 +49,8 @@
   "dependencies": {
     "@bitgo/statics": "^2.1.0",
     "@bitgo/unspents": "^0.6.0",
+    "@types/bluebird": "^3.5.25",
+    "@types/superagent": "^4.1.3",
     "algosdk": "git+https://github.com/BitGo/algosdk-bitgo.git",
     "assert": "^0.4.9",
     "big.js": "^3.1.3",
@@ -78,7 +80,6 @@
     "tronweb": "^2.7.0"
   },
   "devDependencies": {
-    "@types/bluebird": "^3.5.25",
     "@types/create-hmac": "^1.1.0",
     "@types/debug": "^4.1.4",
     "@types/lodash": "^4.14.121",
@@ -87,7 +88,6 @@
     "@types/node": "^11.11.4",
     "@types/sinon": "^7.0.6",
     "@types/stellar-sdk": "^0.11.1",
-    "@types/superagent": "^4.1.3",
     "@typescript-eslint/eslint-plugin": "^1.4.2",
     "@typescript-eslint/parser": "^1.4.2",
     "awesome-typescript-loader": "^5.2.1",

--- a/modules/core/src/bitgo.ts
+++ b/modules/core/src/bitgo.ts
@@ -158,112 +158,115 @@ export interface BitGoOptions {
   proxy?: string;
 }
 
-interface User {
+export interface User {
   username: string;
 }
 
-interface BitGoJson {
+export interface BitGoJson {
   user?: User;
   token?: string;
   extensionKey?: string;
 }
 
-interface VerifyAddressOptions {
+/**
+ * @deprecated
+ */
+export interface DeprecatedVerifyAddressOptions {
   address?: string;
 }
 
-interface VerifyPasswordOptions {
+export interface VerifyPasswordOptions {
   password?: string;
 }
 
-interface EncryptOptions {
+export interface EncryptOptions {
   input?: string;
   password?: string;
 }
 
-interface DecryptOptions {
+export interface DecryptOptions {
   input?: string;
   password?: string;
 }
 
-interface SplitSecretOptions {
+export interface SplitSecretOptions {
   seed: string;
   passwords: string[];
   m: number;
 }
 
-interface SplitSecret {
+export interface SplitSecret {
   xpub: string;
   m: number;
   n: number;
   seedShares: any;
 }
 
-interface ReconstituteSecretOptions {
+export interface ReconstituteSecretOptions {
   shards: string[];
   passwords: string[];
 }
 
-interface ReconstitutedSecret {
+export interface ReconstitutedSecret {
   xpub: string;
   xprv: string;
   seed: string;
 }
 
-interface VerifyShardsOptions {
+export interface VerifyShardsOptions {
   shards: string[];
   passwords: string[];
   m: number;
   xpub: string;
 }
 
-interface GetEcdhSecretOptions {
+export interface GetEcdhSecretOptions {
   otherPubKeyHex: string;
   eckey: bitcoin.ECPair;
 }
 
-interface AccessTokenOptions {
+export interface AccessTokenOptions {
   accessToken: string;
 }
 
-interface TokenIssuanceResponse {
+export interface TokenIssuanceResponse {
   derivationPath: string;
   encryptedToken: string;
   encryptedECDHXprv?: string;
 }
 
-interface TokenIssuance {
+export interface TokenIssuance {
   token: string;
   ecdhXprv?: string;
 }
 
-interface CalculateHmacSubjectOptions {
+export interface CalculateHmacSubjectOptions {
   urlPath: string;
   text: string;
   timestamp: number;
   statusCode?: number;
 }
 
-interface CalculateRequestHmacOptions {
+export interface CalculateRequestHmacOptions {
   url: string;
   text: string;
   timestamp: number;
   token: string;
 }
 
-interface CalculateRequestHeadersOptions {
+export interface CalculateRequestHeadersOptions {
   url: string;
   text: string;
   token: string;
 }
 
-interface RequestHeaders {
+export interface RequestHeaders {
   hmac: string;
   timestamp: number;
   tokenHash: string;
 }
 
-interface VerifyResponseOptions extends CalculateRequestHeadersOptions {
+export interface VerifyResponseOptions extends CalculateRequestHeadersOptions {
   hmac: string;
   url: string;
   text: string;
@@ -271,7 +274,7 @@ interface VerifyResponseOptions extends CalculateRequestHeadersOptions {
   statusCode?: number;
 }
 
-interface AuthenticateOptions {
+export interface AuthenticateOptions {
   username: string;
   password: string;
   otp?: string;
@@ -281,7 +284,7 @@ interface AuthenticateOptions {
   forceV1Auth?: boolean;
 }
 
-interface ProcessedAuthenticationOptions {
+export interface ProcessedAuthenticationOptions {
   email: string;
   password: string;
   forceSMS: boolean;
@@ -292,7 +295,7 @@ interface ProcessedAuthenticationOptions {
   forceV1Auth?: boolean;
 }
 
-interface AddAccessTokenOptions {
+export interface AddAccessTokenOptions {
   label: string;
   otp?: string;
   duration?: number;
@@ -301,38 +304,41 @@ interface AddAccessTokenOptions {
   scope: string[];
 }
 
-interface RemoveAccessTokenOptions {
+export interface RemoveAccessTokenOptions {
   id?: string;
   label?: string;
 }
 
-interface GetUserOptions {
+export interface GetUserOptions {
   id: string;
 }
 
-interface ChangePasswordOptions {
+export interface ChangePasswordOptions {
   oldPassword: string;
   newPassword: string;
 }
 
-interface UnlockOptions {
+export interface UnlockOptions {
   otp?: string;
   duration?: number
 }
 
-interface ExtendTokenOptions {
+export interface ExtendTokenOptions {
   duration?: string;
 }
 
-interface GetSharingKeyOptions {
+export interface GetSharingKeyOptions {
   email: string;
 }
 
-interface PingOptions {
+export interface PingOptions {
   reqId?: RequestTracer;
 }
 
-interface EstimateFeeOptions {
+/**
+ * @deprecated
+ */
+export interface EstimateFeeOptions {
   numBlocks?: number;
   maxFee?: number;
   inputs?: string[];
@@ -340,35 +346,46 @@ interface EstimateFeeOptions {
   cpfpAware?: boolean;
 }
 
-interface WebhookOptions {
+/**
+ * @deprecated
+ */
+export interface WebhookOptions {
   url: string;
   type: string;
 }
 
-interface ListWebhookiNotificationsOptions {
+export interface ListWebhookNotificationsOptions {
   prevId?: string;
   limit?: number;
 }
 
-interface SimulateWebhookOptions {
+export interface SimulateWebhookOptions {
   webhookId: string;
   blockId: string;
 }
 
-interface AuthenticateWithAuthCodeOptions {
+export interface AuthenticateWithAuthCodeOptions {
   authCode: string;
 }
 
-interface VerifyPushTokenOptions {
+/**
+ * @deprecated
+ */
+export interface VerifyPushTokenOptions {
   pushVerificationToken: string;
 }
 
+export interface BitGoRequest extends superagent.Request {
+  result: (optionalField?: string) => Bluebird<any>;
+  end: (callback?: NodeCallback<superagent.Response>) => Bluebird<superagent.Response>;
+}
+
 export interface BitGo {
-  get(url: string, callback?: NodeCallback<superagent.Response>): superagent.Request;
-  post(url: string, callback?: NodeCallback<superagent.Response>): superagent.Request;
-  put(url: string, callback?: NodeCallback<superagent.Response>): superagent.Request;
-  del(url: string, callback?: NodeCallback<superagent.Response>): superagent.Request;
-  patch(url: string, callback?: NodeCallback<superagent.Response>): superagent.Request;
+  get(url: string, callback?: NodeCallback<superagent.Response>): BitGoRequest;
+  post(url: string, callback?: NodeCallback<superagent.Response>): BitGoRequest;
+  put(url: string, callback?: NodeCallback<superagent.Response>): BitGoRequest;
+  del(url: string, callback?: NodeCallback<superagent.Response>): BitGoRequest;
+  patch(url: string, callback?: NodeCallback<superagent.Response>): BitGoRequest;
 }
 
 export class BitGo {
@@ -828,7 +845,7 @@ export class BitGo {
    * Verify a Bitcoin address is a valid base58 address
    * @deprecated
    */
-  verifyAddress(params: VerifyAddressOptions = {}): boolean {
+  verifyAddress(params: DeprecatedVerifyAddressOptions = {}): boolean {
     common.validateParams(params, ['address'], []);
 
     if (!_.isString(params.address)) {
@@ -2141,7 +2158,7 @@ export class BitGo {
    * @param callback
    * @returns {*}
    */
-  listWebhookNotifications(params: ListWebhookiNotificationsOptions = {}, callback?: NodeCallback<any>): Bluebird<any> {
+  listWebhookNotifications(params: ListWebhookNotificationsOptions = {}, callback?: NodeCallback<any>): Bluebird<any> {
     const query: any = {};
     if (params.prevId) {
       if (!_.isString(params.prevId)) {

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -8,7 +8,7 @@
 //
 import * as common from './common';
 
-export { BitGo } from './bitgo';
+export * from './bitgo';
 
 // Expose bitcoin and sjcl
 import * as utxoLib from 'bitgo-utxo-lib';

--- a/modules/core/tsconfig.json
+++ b/modules/core/tsconfig.json
@@ -8,7 +8,8 @@
       "../../types",
       "./node_modules/@types",
       "../../node_modules/@types"
-    ]
+    ],
+    "declarationDir": "./dist/types"
   },
   "include": [
     "src/**/*",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,11 +6,13 @@
       "dom",
       "es2016"
     ],
-    "sourceMap": true,
     "declaration": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strictNullChecks": true,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "declarationMap": true,
     "typeRoots": [
       "./node_modules/@types",
       "./types"

--- a/types/superagent/index.d.ts
+++ b/types/superagent/index.d.ts
@@ -5,8 +5,6 @@ declare module 'superagent' {
   interface Request {
     result: (optionalField?: string) => bluebird<any>;
     proxy: (proxyUrl: string) => this;
-    // can't redefine return type of end() ...  makes sense
-    // end: (callback?: NodeCallback<superagent.Response>) => Bluebird<superagent.Response>;
     verifyResponse: (response: superagent.Response) => superagent.Response;
     forceV1Auth: boolean;
     authenticationToken?: string;


### PR DESCRIPTION
* Add @types/bluebird and @types/superagent to the deps list from dev deps,
  since these types are exported by the BitGoJS public API
* Export BitGo object interfaces
* Return custom `BitGoRequest` instead of raw superagent Request.
  Methods patched onto the superagent Request object will be declared on
  this interface instead of augmenting superagent.Request.
* Separate source files from type declarations in dist/

This commit covers the following tickets:
* SDKT-32
* SDKT-33
* SDKT-31