### PR TITLE
BG-14104 return status=pendingApproval on pending approval

### DIFF
--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -1947,9 +1947,13 @@ export class Wallet {
       ]);
       const finalTxParams = _.extend({}, halfSignedTransaction, selectParams);
       self.bitgo.setRequestTracer(reqId);
-      return self.bitgo.post(self.url('/tx/send'))
+      const result = yield self.bitgo.post(self.url('/tx/send'))
         .send(finalTxParams)
         .result();
+      if (result.pendingApproval) {
+        result.status = 'pendingApproval';
+      }
+      return result;
     }).call(this).asCallback(callback);
   }
 


### PR DESCRIPTION
https://bitgoinc.atlassian.net/browse/BG-14104

We have a bug regarding comms between Express and Core:
When you do a ```sendcoins``` or ```sendmany``` through Express that triggers a pending approval, the platform responds with ```202```, but Express responds with ```200``` to the user. This is because Express expects that ```result.status``` will equal ```pendingApproval``` but this is not the case. See screenshot for the Express code where this happens.

My proposed solution is to add ```result.status = "pendingApproval"``` before returning the ```sendMany``` function in Core.

This will cause Express to correctly throw a 202 on pending approvals.

CAUTION: this will be a breaking change. Even thought it is technically in line with our API docs, we are changing broken behavior to non-broken behavior. We should think about this and notify customers accordingly.

Below is the code from Express (that we are *not* changing). See the last few lines where we check if ```status === 'pendingApproval'```
<img width="604" alt="Screen Shot 2019-10-24 at 11 54 13 AM" src="https://user-images.githubusercontent.com/43550949/67516337-575ee280-f655-11e9-8e26-d9a0d6618579.png">
