### PR TITLE
TRON-60: Make outputs field an array

### DIFF
--- a/modules/core/src/v2/coins/trx.ts
+++ b/modules/core/src/v2/coins/trx.ts
@@ -1,7 +1,6 @@
 /**
  * @prettier
  */
-import * as _ from 'lodash';
 import * as Bluebird from 'bluebird';
 import { CoinFamily } from '@bitgo/statics';
 const co = Bluebird.coroutine;
@@ -12,7 +11,6 @@ import { MethodNotImplementedError } from '../../errors';
 import {
   BaseCoin,
   KeyPair,
-  HalfSignedTransaction,
   ParsedTransaction,
   ParseTransactionOptions,
   SignedTransaction,
@@ -231,21 +229,37 @@ export class Trx extends BaseCoin {
       const txBuilder = new TransactionBuilder({ coinName });
       txBuilder.from(txHex);
       const tx = txBuilder.build();
-      const outputs = {
-        amount: tx.destinations[0].value.toString(),
-        address: tx.destinations[0].address, // Should turn it into a readable format, aka base58
-      };
-      return {
-        displayOrder: ['id', 'outputAmount', 'changeAmount', 'outputs', 'changeOutputs', 'fee', 'memo'],
+      const outputs = [
+        {
+          amount: tx.destinations[0].value.toString(),
+          address: tx.destinations[0].address, // Should turn it into a readable format, aka base58
+        },
+      ];
+
+      const displayOrder = [
+        'id',
+        'outputAmount',
+        'changeAmount',
+        'outputs',
+        'changeOutputs',
+        'fee',
+        'timestamp',
+        'expiration',
+      ];
+
+      const explanationResult: TronTransactionExplanation = {
+        displayOrder,
         id: tx.id,
         outputs,
-        outputAmount: outputs.amount,
+        outputAmount: outputs[0].amount,
         changeOutputs: [], // account based does not use change outputs
-        changeAmount: 0, // account base does not make change
-        fee: params.feeInfo.fee,
+        changeAmount: '0', // account base does not make change
+        fee: params.feeInfo,
         timestamp: tx.validFrom,
         expiration: tx.validTo,
       };
+
+      return explanationResult;
     })
       .call(this)
       .asCallback(callback);

--- a/modules/core/test/v2/unit/coins/trx.ts
+++ b/modules/core/test/v2/unit/coins/trx.ts
@@ -1,6 +1,5 @@
 import * as Promise from 'bluebird';
-import * as should from 'should';
-import { Trx } from '../../../../src/v2/coins/trx';
+import { Trx } from '../../../../src/v2/coins/';
 import * as bitgoAccountLib from '@bitgo/account-lib';
 import { signTxOptions, mockTx } from '../../fixtures/coins/trx';
 
@@ -32,14 +31,15 @@ describe('TRON:', function() {
     const explanation = yield basecoin.explainTransaction(explainParams);
     const toAddress = bitgoAccountLib.Trx.Utils.getBase58AddressFromHex(mockTx.raw_data.contract[0].parameter.value.to_address);
     explanation.id.should.equal(mockTx.txID);
-    explanation.outputs.amount.should.equal('10');
+    explanation.outputs.length.should.equal(1);
+    explanation.outputs[0].amount.should.equal('10');
+    explanation.outputs[0].address.should.equal(toAddress);
     explanation.outputAmount.should.equal('10');
-    explanation.changeAmount.should.equal(0);
+    explanation.changeAmount.should.equal('0');
     explanation.changeOutputs.length.should.equal(0);
-    explanation.fee.should.equal(1);
+    explanation.fee.fee.should.equal(1);
     explanation.expiration.should.equal(mockTx.raw_data.expiration);
     explanation.timestamp.should.equal((mockTx.raw_data.timestamp));
-    explanation.outputs.address.should.equal(toAddress);
   }));
 
   it('should throw if the params object is missing parameters', co(function *() {
@@ -61,14 +61,15 @@ describe('TRON:', function() {
     const explanation = yield basecoin.explainTransaction(explainParams);
     const toAddress = bitgoAccountLib.Trx.Utils.getBase58AddressFromHex(mockTx.raw_data.contract[0].parameter.value.to_address);
     explanation.id.should.equal(mockTx.txID);
-    explanation.outputs.amount.should.equal('10');
+    explanation.outputs.length.should.equal(1);
+    explanation.outputs[0].amount.should.equal('10');
+    explanation.outputs[0].address.should.equal(toAddress);
     explanation.outputAmount.should.equal('10');
-    explanation.changeAmount.should.equal(0);
+    explanation.changeAmount.should.equal('0');
     explanation.changeOutputs.length.should.equal(0);
-    explanation.fee.should.equal(1);
+    explanation.fee.fee.should.equal(1);
     explanation.expiration.should.equal(mockTx.raw_data.expiration);
     explanation.timestamp.should.equal((mockTx.raw_data.timestamp));
-    explanation.outputs.address.should.equal(toAddress);
   }));
 
   it('should sign a half signed tx', () => {


### PR DESCRIPTION
[TRON-60](https://bitgoinc.atlassian.net/browse/TRON-60) Fix some problems with the return types of explain transaction while testing the OVC:

- `outputs` field is an array (Tron transactions have only one output).
- `fee` is the `feeInfo`