### PR TITLE
Allow trx to sign with an xprv

### DIFF
--- a/modules/core/test/v2/unit/coins/trx.ts
+++ b/modules/core/test/v2/unit/coins/trx.ts
@@ -84,6 +84,24 @@ describe('TRON:', function() {
     signedTxJson.signature[0].should.equal('0a9944316924ec7fba4895f1ea1e7cc95f9e2b828ae268a48a8dbeddef40c6f5e127170a95aed9f3f5425b13058d0cb6ef1f5c2213190e482e87043691f22e6800');
     });
 
+  it('should sign with an Xprv a half signed tx', () => {
+    const p = {
+      prv: "xprv9s21ZrQH143K2sg2Cukk5XqLQdrYnMCDah3y1FFVy6Hz9bQfqMSfmUiHPVHKhcUyft3N1emE5FudJVxgFm5N12MAg5o7DTPsDATTkwNgr73",
+      txPrebuild: {
+        txHex: signTxOptions.txPrebuild.txHex
+      }
+    };
+    const tx = basecoin.signTransaction(p);
+    const unsignedTxJson = JSON.parse(signTxOptions.txPrebuild.txHex);
+    const signedTxJson = JSON.parse(tx.halfSigned.txHex);
+
+    signedTxJson.txID.should.equal(unsignedTxJson.txID);
+    signedTxJson.raw_data_hex.should.equal(unsignedTxJson.raw_data_hex);
+    JSON.stringify(signedTxJson.raw_data).should.eql(JSON.stringify(unsignedTxJson.raw_data));
+    signedTxJson.signature.length.should.equal(1);
+    signedTxJson.signature[0].should.equal('65e56f53a458c6f82d1ef39b2cf5be685a906ad22bb02699f907fcb72ef26f1e91cfc2b6a43bf5432faa0b63bdc5aebf1dc2f49a675d28d23fd7e038b3358b0600');
+  });
+
   describe('Keypairs:', () => {
     it('should generate a keypair from random seed', function() {
       const keyPair = basecoin.generateKeyPair();


### PR DESCRIPTION
If an xprv is used to sign a Tron transaction, convert it to the uncompressed version, and then sign.