### PR TITLE
TRON-109 - valid address need to be over base58 and hex addresses

### DIFF
--- a/modules/core/src/v2/coins/trx.ts
+++ b/modules/core/src/v2/coins/trx.ts
@@ -100,7 +100,7 @@ export class Trx extends BaseCoin {
 
   /**
    * Checks if this is a valid base58 or hex address
-   * @param address 
+   * @param address
    */
   isValidAddress(address: string): boolean {
     if (!address) {

--- a/modules/core/src/v2/coins/trx.ts
+++ b/modules/core/src/v2/coins/trx.ts
@@ -98,8 +98,22 @@ export class Trx extends BaseCoin {
     return true;
   }
 
-  /** Check whether the address is a tron address in hex format */
+  /**
+   * Checks if this is a valid base58 or hex address
+   * @param address 
+   */
   isValidAddress(address: string): boolean {
+    if (!address) {
+      return false;
+    }
+    return this.isValidHexAddress(address) || bitgoAccountLib.Trx.Utils.isBase58Address(address);
+  }
+
+  /**
+   * Checks if this is a valid hex address
+   * @param address hex address
+   */
+  isValidHexAddress(address: string): boolean {
     return address.length === 42 && /^(0x)?([0-9a-f]{2})+$/i.test(address);
   }
 

--- a/modules/core/test/v2/unit/coins/trx.ts
+++ b/modules/core/test/v2/unit/coins/trx.ts
@@ -42,6 +42,14 @@ describe('TRON:', function() {
     explanation.timestamp.should.equal((mockTx.raw_data.timestamp));
   }));
 
+  it('should check valid addresses', co(function *() {
+    const badAddresses = [ '', null, 'xxxx', 'YZ09fd-', '412C2BA4A9FF6C53207DC5B686BFECF75EA7B805772', '412C2BA4A9FF6C53207DC5B686BFECF75EA7B80', 'TBChwKYNaTo4a4N68Me1qEiiKsRDspXqLLZ' ];
+    const goodAddresses = [ 'TBChwKYNaTo4a4N68Me1qEiiKsRDspXqLp', 'TPcf5jtYUhCN1X14tN577zF4NepbDZbxT7', '41E0C0F581D7D02D40826C1C6CBEE71F625D6344D0', '412C2BA4A9FF6C53207DC5B686BFECF75EA7B80577' ];
+    
+    badAddresses.map(addr => { basecoin.isValidAddress(addr).should.equal(false); })
+    goodAddresses.map(addr => { basecoin.isValidAddress(addr).should.equal(true); })
+  }));
+
   it('should throw if the params object is missing parameters', co(function *() {
     const explainParams = {
       feeInfo: { fee: 1 },


### PR DESCRIPTION
Valid addresses need to encompass both hex and base58 variations. (Both are legit in Tron)