### PR TITLE
BLOCK-147: Call API route for Federation lookups

### DIFF
--- a/modules/core/src/errors.ts
+++ b/modules/core/src/errors.ts
@@ -120,7 +120,7 @@ export class KeyRecoveryServiceError extends BitGoJsError {
 export class AddressGenerationError extends BitGoJsError {
   public constructor(message?: string) {
     super(message || 'address generation failed');
-    Object.setPrototypeOf(this, KeyRecoveryServiceError.prototype);
+    Object.setPrototypeOf(this, AddressGenerationError.prototype);
   }
 }
 
@@ -128,5 +128,12 @@ export class EthereumLibraryUnavailableError extends BitGoJsError {
   public constructor(packageName: string) {
     super(`Ethereum library required for operation is not available. Please install "${(packageName)}".`);
     Object.setPrototypeOf(this, EthereumLibraryUnavailableError.prototype);
+  }
+}
+
+export class StellarFederationUserNotFoundError extends BitGoJsError {
+  public constructor(message?: string) {
+    super(message || 'account not found');
+    Object.setPrototypeOf(this, StellarFederationUserNotFoundError.prototype);
   }
 }


### PR DESCRIPTION
The change in https://github.com/BitGo/platform/pull/1508 adds ability to perform Federation lookups through the `v2.federation` platform API
The SDK can now pass the params to look up the account through the BitGo Federation server instead of making the request directly to the external federation server

BLOCK-147