### PR TITLE
BG-14806 reject hop param for erc-20 token build

### DIFF
--- a/modules/core/src/v2/coins/eth.ts
+++ b/modules/core/src/v2/coins/eth.ts
@@ -22,6 +22,7 @@ import {
   TransactionPrebuild as BaseTransactionPrebuild,
   HalfSignedTransaction as BaseHalfSignedTransaction,
 } from '../baseCoin';
+import { Erc20Token } from './erc20Token';
 import { BitGo } from '../../bitgo';
 import { NodeCallback } from '../types';
 import { Wallet } from '../wallet';
@@ -1268,6 +1269,11 @@ export class Eth extends BaseCoin {
         !_.isUndefined(buildParams.recipients) &&
         !_.isUndefined(buildParams.walletPassphrase)
       ) {
+        if (this instanceof Erc20Token) {
+          throw new Error(
+            `Hop transactions are not enabled for ERC-20 tokens, nor are they necessary. Please remove the 'hop' parameter and try again.`
+          );
+        }
         return yield self.createHopTransactionParams({
           wallet: buildParams.wallet,
           recipients: buildParams.recipients,

--- a/modules/core/test/v2/unit/ethWallet.ts
+++ b/modules/core/test/v2/unit/ethWallet.ts
@@ -324,4 +324,21 @@ describe('prebuildTransaction', function() {
     scope.isDone().should.equal(true);
     prebuild.success.should.equal(true);
   }));
+
+  it('should reject hop param for an erc20 token build', co(function *() {
+    const token = bitgo.coin('terc');
+    const tokenWallet = token.newWalletObject(bitgo, token, {});
+    recipients = [{
+      address: '0xe59dfe5c67114b39a5662cc856be536c614124c0',
+      amount: '100',
+    }];
+    let error;
+    try {
+      yield tokenWallet.prebuildTransaction({ recipients, hop: true, walletPassphrase: 'hi' });
+    } catch (err) {
+      error = err;
+    }
+    should.exist(error);
+    error.message.should.equal(`Hop transactions are not enabled for ERC-20 tokens, nor are they necessary. Please remove the 'hop' parameter and try again.`);
+  }));
 });


### PR DESCRIPTION
https://bitgoinc.atlassian.net/browse/BG-14806

Customer was getting a weird error when they tried this and was confused. We should have this error more explicit because we don't support hops for ERC-20 tokens and there is no reason to.