### PR TITLE
SERV-582 Add issue tracker template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug Report
+about: Report any bugs you find to help us improve the library.
+labels: 'bug'
+
+---
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Environment Details
+* **OS:** <!--- What is your operating system -->
+* **Node Version:** <!--- What version of node are you running  -->
+* **Yarn Version:** <!--- What version of yarn are you running -->
+* **BitGoJS Version:** <!--- What version of this library are you running  -->
+* **BitGo Environment:** <!--- Are you running against testnet or mainnet  -->
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+## Current Behavior
+<!--- Tell us what happens instead of the expected behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+
+## Steps to Reproduce
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -15,5 +15,3 @@ labels: 'feature'
 
 ## Context
 <!--- Not obligatory; but provide any other context that would be helpful in terms of prioritization. -->
-
-## Steps to Reproduce

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature Request
+about: Suggest an idea for this project.
+labels: 'feature'
+
+---
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Feature Description
+<!-- A concise description of the feature you would like. -->
+
+## Motivation
+<!-- Why should this feature be added. -->
+
+## Context
+<!--- Not obligatory; but provide any other context that would be helpful in terms of prioritization. -->
+
+## Steps to Reproduce


### PR DESCRIPTION
# Overview
Add two GitHub issues templates to this project (https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository):

1. Bugs: Add a standardized template for contributors to report bugs to
the project maintainers.
2. Feature Requests: Add a template that allows contributors to request
features.


# Motivation
There is no standardized way for people to report their issues to this project. When bugs are reported, they tend to omit critical details such as node version, os, etc. which are extremely helpful in diagnosing the issue.

Addresses: https://bitgoinc.atlassian.net/browse/SERV-582