### PR TITLE
BG-14844 Fix accelerateTx circular json bug

### DIFF
--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -1813,6 +1813,7 @@ export class Wallet {
 
       // We must pass the build params through to submit in case the CPFP tx ever has to be rebuilt.
       const submitParams = Object.assign(params, yield self.prebuildAndSignTransaction(params));
+      delete submitParams.wallet;
       return yield self.submitTransaction(submitParams);
     }).call(this).asCallback(callback);
   }


### PR DESCRIPTION
https://bitgoinc.atlassian.net/browse/BG-14844

For some reason a wallet object is getting added to the params before we do submitTransaction, and this is causing a failure as it shouldn't be there. This just deletes that wallet param and fixes the issue.

To test the issue and the fix, use the script linked in the comments below