### PR TITLE
Properly deserialize EOS staking transactions

### DIFF
--- a/modules/core/src/v2/baseCoin.ts
+++ b/modules/core/src/v2/baseCoin.ts
@@ -39,6 +39,8 @@ export interface TransactionExplanation {
   changeOutputs: TransactionRecipient[];
   changeAmount: string;
   fee: TransactionFee;
+  proxy?: string;
+  producers?: string[];
 }
 
 export interface KeyPair {

--- a/modules/core/src/v2/coins/eos.ts
+++ b/modules/core/src/v2/coins/eos.ts
@@ -97,6 +97,19 @@ interface DeserializedEosTransaction extends EosTransactionHeaders {
   amount: string;
   transaction_id: string;
   memo?: string;
+  proxy?: string;
+  producers?: string[];
+}
+
+interface DeserializedStakeAction {
+  address: string;
+  amount: string;
+}
+
+interface DeserializedVoteAction {
+  address: string;
+  proxy: string;
+  producers: string[];
 }
 
 interface ExplainTransactionOptions {
@@ -399,6 +412,40 @@ export class Eos extends BaseCoin {
     return { halfSigned: txParams };
   }
 
+  private deserializeStakeAction(eosClient: EosJs, serializedStakeAction: string): DeserializedStakeAction {
+    const eosStakeActionStruct = eosClient.fc.abiCache.abi('eosio').structs.delegatebw;
+    const serializedStakeActionBuffer = Buffer.from(serializedStakeAction, 'hex');
+    const stakeAction = EosJs.modules.Fcbuffer.fromBuffer(eosStakeActionStruct, serializedStakeActionBuffer);
+
+    if (stakeAction.from !== stakeAction.receiver) {
+      throw new Error(`staker (${stakeAction.from}) and receiver (${stakeAction.receiver}) must be the same`);
+    }
+
+    if (stakeAction.transfer !== 0) {
+      throw new Error('cannot transfer funds as part of delegatebw action');
+    }
+
+    // stake_cpu_quantity is used as the amount because the BitGo platform only stakes cpu for voting transactions
+    return {
+      address: stakeAction.from,
+      amount: this.bigUnitsToBaseUnits(stakeAction.stake_cpu_quantity.split(' ')[0]),
+    };
+  }
+
+  private static deserializeVoteAction(eosClient: EosJs, serializedVoteAction: string): DeserializedVoteAction {
+    const eosVoteActionStruct = eosClient.fc.abiCache.abi('eosio').structs.voteproducer;
+    const serializedVoteActionBuffer = Buffer.from(serializedVoteAction, 'hex');
+    const voteAction = EosJs.modules.Fcbuffer.fromBuffer(eosVoteActionStruct, serializedVoteActionBuffer);
+
+    const proxyIsEmpty = _.isEmpty(voteAction.proxy);
+    const producersIsEmpty = _.isEmpty(voteAction.producers);
+    if ((proxyIsEmpty && producersIsEmpty) || (!proxyIsEmpty && !producersIsEmpty)) {
+      throw new Error('voting transactions must specify either producers or proxy to vote for');
+    }
+
+    return { address: voteAction.voter, proxy: voteAction.proxy, producers: voteAction.producers };
+  }
+
   /**
    * Deserialize a transaction
    * @param transaction
@@ -421,25 +468,80 @@ export class Eos extends BaseCoin {
       const serializedTxBuffer = Buffer.from(transaction.packed_trx, 'hex');
       const tx = EosJs.modules.Fcbuffer.fromBuffer(eosTxStruct, serializedTxBuffer);
 
-      // Get transfer action values
-      // Only support transactions with one action: transfer
-      if (tx.actions.length !== 1) {
+      // Only support transactions with one (transfer | voteproducer) or two (delegatebw & voteproducer) actions
+      if (tx.actions.length !== 1 && tx.actions.length !== 2) {
         throw new Error(`invalid number of actions: ${tx.actions.length}`);
       }
+
       const txAction = tx.actions[0];
       if (!txAction) {
         throw new Error('missing transaction action');
       }
-      if (txAction.name !== 'transfer') {
+
+      if (txAction.name === 'transfer') {
+        // Transfers should only have 1 action
+        if (tx.actions.length !== 1) {
+          throw new Error(`transfers should only have 1 action: ${tx.actions.length} given`);
+        }
+
+        const transferStruct = eosClient.fc.abiCache.abi('eosio.token').structs.transfer;
+        const serializedTransferDataBuffer = Buffer.from(txAction.data, 'hex');
+        const transferActionData = EosJs.modules.Fcbuffer.fromBuffer(transferStruct, serializedTransferDataBuffer);
+        tx.address = transferActionData.to;
+        tx.amount = this.bigUnitsToBaseUnits(transferActionData.quantity.split(' ')[0]);
+        tx.memo = transferActionData.memo;
+      } else if (txAction.name === 'delegatebw') {
+        // The delegatebw action should only be part of voting transactions
+        if (tx.actions.length !== 2) {
+          throw new Error(
+            `staking transactions that include the delegatebw action should have 2 actions: ${tx.actions.length} given`
+          );
+        }
+
+        const txAction2 = tx.actions[1];
+        if (txAction2.name !== 'voteproducer') {
+          throw new Error(`invalid staking transaction action: ${txAction2.name}, expecting: voteproducer`);
+        }
+
+        const deserializedStakeAction = self.deserializeStakeAction(eosClient, txAction.data);
+        const deserializedVoteAction = Eos.deserializeVoteAction(eosClient, txAction2.data);
+        if (deserializedStakeAction.address !== deserializedVoteAction.address) {
+          throw new Error(
+            `staker (${deserializedStakeAction.address}) and voter (${deserializedVoteAction.address}) must be the same`
+          );
+        }
+
+        tx.amount = deserializedStakeAction.amount;
+        tx.proxy = deserializedVoteAction.proxy;
+        tx.producers = deserializedVoteAction.producers;
+      } else if (txAction.name === 'voteproducer') {
+        if (tx.actions.length > 2) {
+          throw new Error('voting transactions should not have more than 2 actions');
+        }
+
+        let deserializedStakeAction;
+        if (tx.actions.length === 2) {
+          const txAction2 = tx.actions[1];
+          if (txAction2.name !== 'delegatebw') {
+            throw new Error(`invalid staking transaction action: ${txAction2.name}, expecting: delegatebw`);
+          }
+
+          deserializedStakeAction = self.deserializeStakeAction(eosClient, txAction2.data);
+        }
+
+        const deserializedVoteAction = Eos.deserializeVoteAction(eosClient, txAction.data);
+        if (!!deserializedStakeAction && deserializedStakeAction.address !== deserializedVoteAction.address) {
+          throw new Error(
+            `staker (${deserializedStakeAction.address}) and voter (${deserializedVoteAction.address}) must be the same`
+          );
+        }
+
+        tx.amount = !!deserializedStakeAction ? deserializedStakeAction.amount : '0';
+        tx.proxy = deserializedVoteAction.proxy;
+        tx.producers = deserializedVoteAction.producers;
+      } else {
         throw new Error(`invalid action: ${txAction.name}`);
       }
-      const transferStruct = eosClient.fc.abiCache.abi('eosio.token').structs.transfer;
-      const serializedTransferDataBuffer = Buffer.from(txAction.data, 'hex');
-      const transferActionData = EosJs.modules.Fcbuffer.fromBuffer(transferStruct, serializedTransferDataBuffer);
-      tx.address = transferActionData.to;
-      tx.amount = this.bigUnitsToBaseUnits(transferActionData.quantity.split(' ')[0]);
-      tx.memo = transferActionData.memo;
-
       // Get the tx id if tx headers were provided
       if (headers) {
         const rebuiltTransaction = yield eosClient.transaction(
@@ -471,19 +573,26 @@ export class Eos extends BaseCoin {
         throw new Error('invalid EOS transaction or headers');
       }
       return {
-        displayOrder: ['id', 'outputAmount', 'changeAmount', 'outputs', 'changeOutputs', 'fee', 'memo'],
+        displayOrder: [
+          'id',
+          'outputAmount',
+          'changeAmount',
+          'outputs',
+          'changeOutputs',
+          'fee',
+          'memo',
+          'proxy',
+          'producers',
+        ],
         id: transaction.transaction_id,
         changeOutputs: [],
         outputAmount: transaction.amount,
         changeAmount: 0,
-        outputs: [
-          {
-            address: transaction.address,
-            amount: transaction.amount,
-          },
-        ],
+        outputs: !!transaction.address ? [{ address: transaction.address, amount: transaction.amount }] : [],
         fee: {},
         memo: transaction.memo,
+        proxy: transaction.proxy,
+        producers: transaction.producers,
       };
     })
       .call(this)


### PR DESCRIPTION
JIRA: ETSTK-11

This commit adds functionality to deserialize EOS staking
transactions. EOS staking transactions consist of two actions,
delegatebw and voteproducer. The delegatebw action specifies the
amount of EOS to be staked and the account to stake it for. In our
case the staker and the receiver of the stake will always be the
same. The voteproducer action specifies the proxy or producers that
the staked funds will vote for.