### PR TITLE
AGS-18 / Add by referral code and specify trading partner type

### DIFF
--- a/modules/core/src/v2/trading/tradingPartner.ts
+++ b/modules/core/src/v2/trading/tradingPartner.ts
@@ -15,6 +15,15 @@ const co = Bluebird.coroutine;
 
 export enum TradingPartnerStatus {
   ACCEPTED = 'accepted',
+  REJECTED = 'rejected',
+  CANCELED = 'canceled',
+  PENDING = 'pending',
+}
+
+// Type of partnership used for settlements
+export enum TradingPartnerType {
+  DIRECT = 'direct', // direct settlement between requester and counterparty
+  AGENCY = 'agency', // agent settlement between two counterparties of the agent
 }
 
 export class TradingPartner {
@@ -22,14 +31,24 @@ export class TradingPartner {
   private enterpriseId: string;
   private currentAccount: TradingAccount; // account of the user using the SDK, needed to construct balance check URL
 
-  public name: string;
-  public accountId: string;
+  public id: string;
+  public primaryEnterpriseName: string;
+  public primaryAccountId: string;
+  public secondaryEnterpriseName: string;
+  public secondaryAccountId: string;
+  public requesterAccountId: string;
   public status: TradingPartnerStatus;
+  public type: TradingPartnerType;
 
   constructor(tradingPartnerData, bitgo: BitGo, enterpriseId: string, currentAccount: TradingAccount) {
-    this.name = tradingPartnerData.name;
-    this.accountId = tradingPartnerData.accountId;
+    this.id = tradingPartnerData.id;
+    this.primaryEnterpriseName = tradingPartnerData.primaryEnterpriseName;
+    this.primaryAccountId = tradingPartnerData.primaryAccountId;
+    this.secondaryEnterpriseName = tradingPartnerData.secondaryEnterpriseName;
+    this.secondaryAccountId = tradingPartnerData.secondaryAccountId;
+    this.requesterAccountId = tradingPartnerData.requesterAccountId;
     this.status = tradingPartnerData.status;
+    this.type = tradingPartnerData.type;
 
     this.bitgo = bitgo;
     this.enterpriseId = enterpriseId;
@@ -44,9 +63,11 @@ export class TradingPartner {
    */
   checkBalance(currency: string, amount: string, callback?: NodeCallback<boolean>): Bluebird<boolean> {
     const self = this;
+    const partnerAccountId =
+      self.primaryAccountId === self.currentAccount.id ? self.secondaryAccountId : self.primaryAccountId;
     return co<boolean>(function* checkBalance() {
       const url = self.bitgo.microservicesUrl(
-        `/api/trade/v1/enterprise/${self.enterpriseId}/account/${self.currentAccount.id}/tradingpartners/${self.accountId}/balance`
+        `/api/trade/v1/enterprise/${self.enterpriseId}/account/${self.currentAccount.id}/tradingpartners/${partnerAccountId}/balance`
       );
 
       const response = yield self.bitgo

--- a/modules/core/test/v2/fixtures/trading/tradingPartner.ts
+++ b/modules/core/test/v2/fixtures/trading/tradingPartner.ts
@@ -1,14 +1,34 @@
 export default {
   listTradingPartners: {
     tradingPartners: [{
-      name: 'ja65mcgekmm5111mem6z9g9kwdp58pbw',
-      accountId: '5cfa13da09357e3a00320cecaa119b26',
-      status: 'accepted'
+      id: '6e30a6e7-c073-46fb-a03f-ca8578688d1d',
+      primaryEnterpriseName: 'Test Enterprise',
+      primaryAccountId: '5cf940969449412d00f53b4c55fc2139',
+      secondaryEnterpriseName: 'ja65mcgekmm5111mem6z9g9kwdp58pbw',
+      secondaryAccountId: '5cfa13da09357e3a00320cecaa119b26',
+      requesterAccountId: '5cf940969449412d00f53b4c55fc2139',
+      type: 'direct',
+      status: 'accepted',
     }, {
-      name: 'cugl1je9iem91gogv8h1fbqd1gau3fhk',
-      accountId: '5cfa13db09357e3a00320d0b75900419',
-      status: 'accepted'
+      id: '07d06a32-d33f-458a-b5de-3dfb2df0efba',
+      primaryEnterpriseName: 'cugl1je9iem91gogv8h1fbqd1gau3fhk',
+      primaryAccountId: '5cfa13db09357e3a00320d0b75900419',
+      secondaryEnterpriseName: 'Test Enterprise',
+      secondaryAccountId: '5cf940969449412d00f53b4c55fc2139',
+      requesterAccountId: '5cf940969449412d00f53b4c55fc2139',
+      type: 'agency',
+      status: 'accepted',
     }]
+  },
+  addByCodeResponse: {
+    id: '01889e6c-d12a-423a-af8d-649b63e2f7a5',
+    primaryEnterpriseName: 'Test Enterprise',
+    primaryAccountId: '5cf940969449412d00f53b4c55fc2139',
+    secondaryEnterpriseName: 'ja65mcgekmm5111mem6z9g9kwdp58pbw',
+    secondaryAccountId: '5cfa13da09357e3a00320cecaa119b26',
+    requesterAccountId: '5cf940969449412d00f53b4c55fc2139',
+    type: 'agency',
+    status: 'pending',
   },
   balanceCheckTrueRequest: {
     amount: '24128',

--- a/modules/core/test/v2/unit/trading/tradingPartner.ts
+++ b/modules/core/test/v2/unit/trading/tradingPartner.ts
@@ -3,7 +3,8 @@ import * as nock from 'nock';
 import * as should from 'should';
 
 import fixtures from '../../fixtures/trading/tradingPartner';
-import { TradingPartnerStatus } from '../../../../src/v2/trading/tradingPartner';
+import { TradingPartnerStatus, TradingPartnerType } from '../../../../src/v2/trading/tradingPartner';
+import { TradingReferralRequesterSide } from '../../../../src/v2/trading/tradingPartners';
 
 import { Enterprise } from '../../../../src/v2/enterprise';
 import { Wallet } from '../../../../src/v2/wallet';
@@ -37,6 +38,25 @@ describe('Trading Partners', function() {
     tradingAccount = wallet.toTradingAccount();
   }));
 
+  it('should refer check trading partner by code', co(function *() {
+    const scope = nock(microservicesUri)
+      .post(`/api/trade/v1/enterprise/${enterprise.id}/account/${tradingAccount.id}/tradingpartners`)
+      .reply(200, fixtures.addByCodeResponse);
+
+    const addByCodeResponse = yield tradingAccount.partners().addByCode({referralCode: 'TEST', type: TradingPartnerType.AGENCY, requesterSide: TradingReferralRequesterSide.PRIMARY});
+
+    addByCodeResponse.should.have.property('id');
+    addByCodeResponse.should.have.property('primaryAccountId');
+    addByCodeResponse.should.have.property('primaryEnterpriseName');
+    addByCodeResponse.should.have.property('secondaryAccountId');
+    addByCodeResponse.should.have.property('secondaryEnterpriseName');
+    addByCodeResponse.should.have.property('requesterAccountId', tradingAccount.id);
+    addByCodeResponse.status.should.eql(TradingPartnerStatus.PENDING);
+    addByCodeResponse.type.should.eql(TradingPartnerType.AGENCY);
+
+    scope.isDone().should.be.true();
+  }));
+
   it('should list all trading partners', co(function *() {
     const scope = nock(microservicesUri)
       .get(`/api/trade/v1/enterprise/${enterprise.id}/account/${tradingAccount.id}/tradingpartners`)
@@ -48,7 +68,14 @@ describe('Trading Partners', function() {
     partners.should.have.length(2);
 
     for (const partner of partners) {
+      partner.should.have.property('id');
+      partner.should.have.property('primaryAccountId');
+      partner.should.have.property('primaryEnterpriseName');
+      partner.should.have.property('secondaryAccountId');
+      partner.should.have.property('secondaryEnterpriseName');
+      partner.should.have.property('requesterAccountId');
       partner.status.should.eql(TradingPartnerStatus.ACCEPTED);
+      [TradingPartnerType.DIRECT,TradingPartnerType.AGENCY].includes(partner.type);
     }
 
     scope.isDone().should.be.true();
@@ -58,7 +85,7 @@ describe('Trading Partners', function() {
     const scope = nock(microservicesUri)
       .get(`/api/trade/v1/enterprise/${enterprise.id}/account/${tradingAccount.id}/tradingpartners`)
       .reply(200, fixtures.listTradingPartners)
-      .get(`/api/trade/v1/enterprise/${enterprise.id}/account/${tradingAccount.id}/tradingpartners/${fixtures.listTradingPartners.tradingPartners[0].accountId}/balance`)
+      .get(`/api/trade/v1/enterprise/${enterprise.id}/account/${tradingAccount.id}/tradingpartners/${fixtures.listTradingPartners.tradingPartners[0].secondaryAccountId}/balance`)
       .query(fixtures.balanceCheckTrueRequest)
       .reply(200, { check: true });
 


### PR DESCRIPTION
add trading partner by referral code added to SDK
update trading partner responses to new trading partner response object
add trading partner type ('direct' or 'agency') to response
add requester side ('primary' or 'secondary') and type ('direct', 'agency') to request parameters for referral form and referral code