### PR TITLE
BLOCK-226 Update bitgo-utxo-lib to use new Zcash params.

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -57,7 +57,7 @@
     "bigi": "^1.4.0",
     "bignumber.js": "^8.0.1",
     "bitcoinjs-message": "^2.0.0",
-    "bitgo-utxo-lib": "^1.6.0",
+    "bitgo-utxo-lib": "^1.7.0-rc",
     "bluebird": "^3.5.3",
     "bs58": "^2.0.1",
     "bs58check": "^1.0.4",


### PR DESCRIPTION
JIRA Ticket: [BLOCK-226](https://bitgoinc.atlassian.net/browse/BLOCK-226)
Updated bitgo-utxo-lib version to 1.7.0-rc (then 1.7.0 later) which supports new Blossom network params.
