### PR TITLE
fix(SERV-597): Ensure `Error.captureStackTrace` is defined before call

### DIFF
--- a/modules/core/src/errors.ts
+++ b/modules/core/src/errors.ts
@@ -7,7 +7,9 @@
 export class BitGoJsError extends Error {
   public constructor(message?: string) {
     super(message);
-    Error.captureStackTrace(this, this.constructor);
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, this.constructor);
+    }
     Object.setPrototypeOf(this, BitGoJsError.prototype);
   }
 }

--- a/modules/core/test/v2/unit/errors.ts
+++ b/modules/core/test/v2/unit/errors.ts
@@ -1,0 +1,20 @@
+import 'should';
+import * as sinon from 'sinon';
+import { BitGoJsError } from '../../../src/errors';
+
+describe('Error handling', () => {
+
+  it('should construct custom errors if Error.captureStackTrace is missing', () => {
+    const captureStub = sinon.stub(Error, 'captureStackTrace').value(undefined);
+    new BitGoJsError();
+    captureStub.callCount.should.equal(0);
+    captureStub.restore();
+  });
+
+  it('should construct custom errors with Error.captureStackTrace if present', () => {
+    const captureStub = sinon.stub(Error, 'captureStackTrace').returns();
+    new BitGoJsError();
+    captureStub.callCount.should.equal(1);
+    captureStub.restore();
+  });
+});


### PR DESCRIPTION
The `Error.captureStackTrace` function is only available in V8, so error
construction fails in other JS runtimes. This makes it difficult to
determine the root cause of errors. Instead, we should only call this if
it is defined.