### PR TITLE
Set nLockTime to next block

### DIFF
--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -380,7 +380,9 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       if (_.isUndefined(prebuild.blockHeight)) {
         prebuild.blockHeight = (yield self.getLatestBlockHeight()) as number;
       }
-      transaction.locktime = prebuild.blockHeight + 1;
+      // Lock transaction to the next block to discourage fee sniping
+      // See: https://github.com/bitcoin/bitcoin/blob/fb0ac482eee761ec17ed2c11df11e054347a026d/src/wallet/wallet.cpp#L2133
+      transaction.locktime = prebuild.blockHeight;
       return _.extend({}, prebuild, { txHex: transaction.toHex() });
     }).call(this).asCallback(callback);
   }

--- a/modules/core/test/v2/integration/wallet.ts
+++ b/modules/core/test/v2/integration/wallet.ts
@@ -414,7 +414,7 @@ describe('V2 Wallet:', function() {
       explanation.outputAmount.should.equal(0.01 * 1e8);
       explanation.outputs[0].amount.should.equal(0.01 * 1e8);
       const chainhead = yield bitgo.get(basecoin.url('/public/block/latest')).result();
-      explanation.locktime.should.be.greaterThan(chainhead.height);
+      explanation.locktime.should.equal(chainhead.height);
       explanation.should.have.property('fee');
       const transaction = yield wallet.sendMany({
         prebuildTx: prebuild,


### PR DESCRIPTION
The locktime denominates the height at which a transaction gets valid
and may be relayed. Only a block with a height greater than the locktime
may include the locktimed transaction.

Consequently, the `nLockTime` should be set to the _current_ height to
allow relaying immediately and to make the transaction eligible to be
included in the next block. For the locktime to be respected, the
`nSequence` on at least one input must be set to `UINT_MAX - 1`. If
`nSequence` on all inputs is set to the maximum value of `0xffffffff`
this signals that a transaction is final and the locktime will be
disregarded. Setting it lower signals BIP-125 replaceability, which we
don't want either at this time.

References:
* https://btcinformation.org/en/developer-guide#locktime-and-sequence-number
* https://bitcoin.stackexchange.com/a/92416/5406
* https://github.com/achow101/btcinformation.org/pull/32

Issue: BLOCK-262