### PR TITLE
fix(test): remove illegal use of `bufferutils`

### DIFF
--- a/modules/core/test/integration/wallet.ts
+++ b/modules/core/test/integration/wallet.ts
@@ -1812,7 +1812,7 @@ describe('Wallet API', function() {
           // parse tx to make sure the single key address was used to pay the fee
           const transaction = bitcoin.Transaction.fromHex(result.transactionHex);
           const singleKeyInput = transaction.ins[transaction.ins.length - 1];
-          const inputTxHash = bitcoin.bufferutils.reverse(singleKeyInput.hash).toString('hex');
+          const inputTxHash = Buffer.from(singleKeyInput.hash).reverse().toString('hex');
 
           // get the input tx to find the amount taken from the single key fee address
           return bitgo.get(bitgo.url('/tx/' + inputTxHash))


### PR DESCRIPTION
The method `bufferutils.reverse` was removed a long time ago:
https://github.com/BitGo/bitgo-utxo-lib/commit/29a865788d30b8b776cc1a1a2fd042d70085ec5f#diff-73e64645f9c04dc17e67b782cb9342fd

It is unclear why this did not cause an error

Issue: BG-16466