### PR TITLE
Added redeemScript and witnessScript to SignTransactionOptions

### DIFF
--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -150,6 +150,8 @@ export interface SignTransactionOptions {
         index?: number;
         value?: number;
         address?: string;
+        redeemScript?: string;
+        witnessScript?: string;
       }[];
     }
   };


### PR DESCRIPTION
## Issue

`redeemScript` and `witnessScript` are not documented as being part of the `signTransaction` params, but signing will fail if these are needed for signing the tx.

## Changes

- [X] Added `redeemScript` and `witnessScript` to `SignTransactionOptions`.