### PR TITLE
Changed naming of the following env vars to reflect actual code

### DIFF
--- a/modules/express/README.md
+++ b/modules/express/README.md
@@ -167,21 +167,21 @@ BitGo Express currently supports the following proxy protocols:
 
 BitGo Express is able to take configuration options from either command line arguments, or via environment variables.
 
-| Flag Short Name | Flag Long Name | Environment Variable | Default Value | Description |
-| --- | --- | --- | --- | --- |
-| -p | --port | `BITGO_PORT` | 3080 | Port which bitgo express should listen on. |
-| -b | --bind | `BITGO_BIND` | localhost | Interface which bitgo express should listen on. To listen on all interfaces, this should be set to `0.0.0.0`. |
-| -e | --env | `BITGO_ENV` | test | BitGo environment to interact with. |
-| -d | --debug | N/A, use `BITGO_DEBUG_NAMESPACE` instead | N/A | Enable debug output for bitgo-express. This is equivalent to passing `--debugnamespace bitgo:express`. |
-| -D | --debugnamespace | `BITGO_DEBUG_NAMESPACE` | N/A | Enable debug output for a particular debug namespace. Multiple debug namespaces can be given as a comma separated list. |
-| -k | --keypath | `BITGO_KEYPATH` | N/A | Path to SSL .key file (required if running against production environment). |
-| -c | --crtpath | `BITGO_CRTPATH` | N/A | Path to SSL .crt file (required if running against production environment). |
-| -u | --customrooturi | `BITGO_CUSTOM_ROOT_URI` | N/A | Force a custom BitGo URI. |
-| -n | --custombitcoinnetwork | `BITGO_CUSTOM_BITCOIN_NETWORK` | N/A | Force a custom BitGo network |
-| -l | --logfile | `BITGO_LOGFILE` | N/A | Filepath to write access logs. |
-| N/A | --disablessl | `BITGO_DISABLESSL` | N/A | Disable requiring SSL when accessing bitgo production environment. **USE AT YOUR OWN RISK, NOT RECOMMENDED**. |
-| N/A | --disableproxy | `BITGO_DISABLE_PROXY` | N/A | Disable proxying of routes not explicitly handled by bitgo-express |
-| N/A | --disableenvcheck | `BITGO_DISABLE_ENV_CHECK` | N/A | Disable checking for correct `NODE_ENV` environment variable when running against BitGo production environment. |
+| Flag Short Name | Flag Long Name         | Environment Variable                     | Default Value | Description                                                                                                             |
+| --------------- | ---------------------- | ---------------------------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| -p              | --port                 | `BITGO_PORT`                             | 3080          | Port which bitgo express should listen on.                                                                              |
+| -b              | --bind                 | `BITGO_BIND`                             | localhost     | Interface which bitgo express should listen on. To listen on all interfaces, this should be set to `0.0.0.0`.           |
+| -e              | --env                  | `BITGO_ENV`                              | test          | BitGo environment to interact with.                                                                                     |
+| -d              | --debug                | N/A, use `BITGO_DEBUG_NAMESPACE` instead | N/A           | Enable debug output for bitgo-express. This is equivalent to passing `--debugnamespace bitgo:express`.                  |
+| -D              | --debugnamespace       | `BITGO_DEBUG_NAMESPACE`                  | N/A           | Enable debug output for a particular debug namespace. Multiple debug namespaces can be given as a comma separated list. |
+| -k              | --keypath              | `BITGO_KEYPATH`                          | N/A           | Path to SSL .key file (required if running against production environment).                                             |
+| -c              | --crtpath              | `BITGO_CRTPATH`                          | N/A           | Path to SSL .crt file (required if running against production environment).                                             |
+| -u              | --customrooturi        | `BITGO_CUSTOM_ROOT_URI`                  | N/A           | Force a custom BitGo URI.                                                                                               |
+| -n              | --custombitcoinnetwork | `BITGO_CUSTOM_BITCOIN_NETWORK`           | N/A           | Force a custom BitGo network                                                                                            |
+| -l              | --logfile              | `BITGO_LOGFILE`                          | N/A           | Filepath to write access logs.                                                                                          |
+| N/A             | --disablessl           | `DISABLE_SSL`                            | N/A           | Disable requiring SSL when accessing bitgo production environment. **USE AT YOUR OWN RISK, NOT RECOMMENDED**.           |
+| N/A             | --disableproxy         | `DISABLE_PROXY`                          | N/A           | Disable proxying of routes not explicitly handled by bitgo-express                                                      |
+| N/A             | --disableenvcheck      | `DISABLE_ENV_CHECK`                      | N/A           | Disable checking for correct `NODE_ENV` environment variable when running against BitGo production environment.         |
 
 # Release Notes
 


### PR DESCRIPTION
Fixes #635  

Changes to `README.md`:
- `BITGO_DISABLESSL`->`DISABLE_SSL`, 
- `BITGO_DISABLE_PROXY`->`DISABLE_PROXY`, and 
- `BITGO_DISABLE_ENV_CHECK`->`DISABLE_ENV_CHECK`