### PR TITLE
Add `allowPartialSweep` option to sweep

### DIFF
--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -199,6 +199,7 @@ export interface SweepOptions {
   feeRate?: number;
   maxFeeRate?: number;
   feeTxConfirmTarget?: number;
+  allowPartialSweep?: boolean;
 }
 
 export interface FreezeOptions {
@@ -966,6 +967,7 @@ export class Wallet {
    * @param {Number} params.feeTxConfirmTarget - Estimate the fees to aim for first confirmation within this number of blocks
    * @param {Number} params.feeRate - The desired fee rate for the transaction in satoshis/kB
    * @param {Number} [params.maxFeeRate] - upper limit for feeRate in satoshis/kB
+   * @param {Boolean} [params.allowPartialSweep] - allows sweeping 200 unspents when the wallet has more than that
    * @param [callback]
    * @returns txHex {String} the txHex of the signed transaction
    */
@@ -994,12 +996,12 @@ export class Wallet {
       // the following flow works for all UTXO coins
 
       const reqId = new RequestTracer();
-      const filteredParams = _.pick(params, ['address', 'feeRate', 'maxFeeRate', 'feeTxConfirmTarget']);
+      const filteredParams = _.pick(params, ['address', 'feeRate', 'maxFeeRate', 'feeTxConfirmTarget', 'allowPartialSweep']);
       self.bitgo.setRequestTracer(reqId);
       const response = yield self.bitgo.post(self.url('/sweepWallet'))
         .send(filteredParams)
         .result();
-      // TODO: add txHex validation to protect man in the middle attacks replacing the txHex, BG-3588
+      // TODO(BG-3588): add txHex validation to protect man in the middle attacks replacing the txHex
 
       const keychain = yield self.baseCoin.keychains().get({ id: self._wallet.keys[0], reqId });
       const transactionParams = _.extend({}, params, { txPrebuild: response, keychain: keychain, prv: params.xprv });

--- a/modules/core/test/v2/unit/wallet.ts
+++ b/modules/core/test/v2/unit/wallet.ts
@@ -681,6 +681,39 @@ describe('V2 Wallet:', function() {
     }));
   });
 
+  describe('allowPartialSweep verification', function() {
+    const address = '5b34252f1bf349930e34020a';
+    const allowPartialSweep = true;
+    let basecoin;
+    let wallet;
+
+    before(co(function *() {
+      basecoin = bitgo.coin('tbtc');
+      const walletData = {
+        id: '5b34252f1bf349930e34020a',
+        coin: 'tbtc',
+        keys: ['5b3424f91bf349930e340175'],
+      };
+      wallet = new Wallet(bitgo, basecoin, walletData);
+    }));
+
+    it('should pass allowPartialSweep parameter when calling sweep wallets', co(function *() {
+      const path = `/api/v2/${wallet.coin()}/wallet/${wallet.id()}/sweepWallet`;
+      const response = nock(bgUrl)
+          .post(path, _.matches({ address, allowPartialSweep })) // use _.matches to do a partial match on request body object instead of strict matching
+          .reply(200);
+
+      try {
+        yield wallet.sweep({ address, allowPartialSweep });
+      } catch (e) {
+        // the sweep method will probably throw an exception for not having all of the correct nocks
+        // we only care about /sweepWallet and whether allowPartialSweep is an allowed parameter
+      }
+
+      response.isDone().should.be.true();
+    }));
+  });
+
   describe('Transaction prebuilds', function() {
     it('prebuild should call build and getLatestBlockHeight for utxo coins', co(function *() {
       const params = {};


### PR DESCRIPTION
Express filters body parameters before calling platform, so we have to
whitelist the `allowPartialSweep` parameter for it to be available.

Ticket: BG-17594