### PR TITLE
fix(express): Deprecate older forms of environment variable config

### DIFF
--- a/modules/express/README.md
+++ b/modules/express/README.md
@@ -167,21 +167,32 @@ BitGo Express currently supports the following proxy protocols:
 
 BitGo Express is able to take configuration options from either command line arguments, or via environment variables.
 
-| Flag Short Name | Flag Long Name | Environment Variable | Default Value | Description |
-| --- | --- | --- | --- | --- |
-| -p | --port | `BITGO_PORT` | 3080 | Port which bitgo express should listen on. |
-| -b | --bind | `BITGO_BIND` | localhost | Interface which bitgo express should listen on. To listen on all interfaces, this should be set to `0.0.0.0`. |
-| -e | --env | `BITGO_ENV` | test | BitGo environment to interact with. |
-| -d | --debug | N/A, use `BITGO_DEBUG_NAMESPACE` instead | N/A | Enable debug output for bitgo-express. This is equivalent to passing `--debugnamespace bitgo:express`. |
-| -D | --debugnamespace | `BITGO_DEBUG_NAMESPACE` | N/A | Enable debug output for a particular debug namespace. Multiple debug namespaces can be given as a comma separated list. |
-| -k | --keypath | `BITGO_KEYPATH` | N/A | Path to SSL .key file (required if running against production environment). |
-| -c | --crtpath | `BITGO_CRTPATH` | N/A | Path to SSL .crt file (required if running against production environment). |
-| -u | --customrooturi | `BITGO_CUSTOM_ROOT_URI` | N/A | Force a custom BitGo URI. |
-| -n | --custombitcoinnetwork | `BITGO_CUSTOM_BITCOIN_NETWORK` | N/A | Force a custom BitGo network |
-| -l | --logfile | `BITGO_LOGFILE` | N/A | Filepath to write access logs. |
-| N/A | --disablessl | `BITGO_DISABLESSL` | N/A | Disable requiring SSL when accessing bitgo production environment. **USE AT YOUR OWN RISK, NOT RECOMMENDED**. |
-| N/A | --disableproxy | `BITGO_DISABLE_PROXY` | N/A | Disable proxying of routes not explicitly handled by bitgo-express |
-| N/A | --disableenvcheck | `BITGO_DISABLE_ENV_CHECK` | N/A | Disable checking for correct `NODE_ENV` environment variable when running against BitGo production environment. |
+| Flag Short Name | Flag Long Name         | Environment Variable                     | Default Value | Description                                                                                                             |
+| --------------- | ---------------------- | ---------------------------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| -p              | --port                 | `BITGO_PORT`                             | 3080          | Port which bitgo express should listen on.                                                                              |
+| -b              | --bind                 | `BITGO_BIND`                             | localhost     | Interface which bitgo express should listen on. To listen on all interfaces, this should be set to `0.0.0.0`.           |
+| -e              | --env                  | `BITGO_ENV`                              | test          | BitGo environment to interact with.                                                                                     |
+| -t              | --timeout              | `BITGO_TIMEOUT`                          | 305000        | Number of milliseconds to wait before requests made by `bitgo-express` time out.
+| -d              | --debug                | N/A, use `BITGO_DEBUG_NAMESPACE` instead | N/A           | Enable debug output for bitgo-express. This is equivalent to passing `--debugnamespace bitgo:express`.                  |
+| -D              | --debugnamespace       | `BITGO_DEBUG_NAMESPACE`                  | N/A           | Enable debug output for a particular debug namespace. Multiple debug namespaces can be given as a comma separated list. |
+| -k              | --keypath              | `BITGO_KEYPATH`                          | N/A           | Path to SSL .key file (required if running against production environment).                                             |
+| -c              | --crtpath              | `BITGO_CRTPATH`                          | N/A           | Path to SSL .crt file (required if running against production environment).                                             |
+| -u              | --customrooturi        | `BITGO_CUSTOM_ROOT_URI`                  | N/A           | Force a custom BitGo URI.                                                                                               |
+| -n              | --custombitcoinnetwork | `BITGO_CUSTOM_BITCOIN_NETWORK`           | N/A           | Force a custom BitGo network                                                                                            |
+| -l              | --logfile              | `BITGO_LOGFILE`                          | N/A           | Filepath to write access logs.                                                                                          |
+| N/A             | --disablessl           | `BITGO_DISABLE_SSL` <sup>0</sup>         | N/A           | Disable requiring SSL when accessing bitgo production environment. **USE AT YOUR OWN RISK, NOT RECOMMENDED**.           |
+| N/A             | --disableproxy         | `BITGO_DISABLE_PROXY` <sup>0</sup>       | N/A           | Disable proxying of routes not explicitly handled by bitgo-express                                                      |
+| N/A             | --disableenvcheck      | `BITGO_DISABLE_ENV_CHECK` <sup>0</sup>   | N/A           | Disable checking for correct `NODE_ENV` environment variable when running against BitGo production environment.         |
+
+\[0]: BitGo will also check the additional environment variables for some options for backwards compatibility, but these environment variables should be considered deprecated:
+* Disable SSL
+  * `DISABLESSL`
+  * `DISABLE_SSL`
+  * `BITGO_DISABLESSL`
+* Disable Proxy
+  * `DISABLE_PROXY`
+* Disable Environment Check
+  * `DISABLE_ENV_CHECK`
 
 # Release Notes
 

--- a/modules/express/src/config.ts
+++ b/modules/express/src/config.ts
@@ -3,6 +3,19 @@ import { isNil, isNumber } from 'lodash';
 
 import { args } from './args';
 
+function readEnvVar(name, ...deprecatedAliases): string | undefined {
+  if (process.env[name] !== undefined) {
+    return process.env[name];
+  }
+
+  for (const deprecatedAlias of deprecatedAliases) {
+    if (process.env[deprecatedAlias] !== undefined) {
+      console.warn(`warning: using deprecated environment variable '${deprecatedAlias}'. Please use the '${name}' environment variable instead.`);
+      return process.env[deprecatedAlias];
+    }
+  }
+}
+
 export interface Config {
   port: number;
   bind: string;
@@ -36,20 +49,20 @@ export const ArgConfig = (args): Partial<Config> => ({
 });
 
 export const EnvConfig = (): Partial<Config> => ({
-  port: Number(process.env.BITGO_PORT),
-  bind: process.env.BITGO_BIND || DefaultConfig.bind,
-  env: (process.env.BITGO_ENV as EnvironmentName) || DefaultConfig.env,
-  debugNamespace: (process.env.BITGO_DEBUG_NAMESPACE || '').split(','),
-  keyPath: process.env.BITGO_KEYPATH,
-  crtPath: process.env.BITGO_CRTPATH,
-  logFile: process.env.BITGO_LOGFILE,
-  disableSSL: (process.env.DISABLESSL || process.env.DISABLE_SSL) ?
-    Boolean((process.env.DISABLESSL || process.env.DISABLE_SSL)) : undefined,
-  disableProxy: process.env.DISABLE_PROXY ? Boolean(process.env.DISABLE_PROXY) : undefined,
-  disableEnvCheck: process.env.DISABLE_ENV_CHECK ? Boolean(process.env.DISABLE_ENV_CHECK) : undefined,
-  timeout: Number(process.env.BITGO_TIMEOUT),
-  customRootUri: process.env.BITGO_CUSTOM_ROOT_URI,
-  customBitcoinNetwork: (process.env.BITGO_CUSTOM_BITCOIN_NETWORK as V1Network),
+  port: Number(readEnvVar('BITGO_PORT')),
+  bind: readEnvVar('BITGO_BIND') || DefaultConfig.bind,
+  env: (readEnvVar('BITGO_ENV') as EnvironmentName) || DefaultConfig.env,
+  debugNamespace: (readEnvVar('BITGO_DEBUG_NAMESPACE') || '').split(','),
+  keyPath: readEnvVar('BITGO_KEYPATH'),
+  crtPath: readEnvVar('BITGO_CRTPATH'),
+  logFile: readEnvVar('BITGO_LOGFILE'),
+  disableSSL: readEnvVar('BITGO_DISABLE_SSL', 'BITGO_DISABLESSL', 'DISABLESSL', 'DISABLE_SSL') ?
+    true : undefined,
+  disableProxy: readEnvVar('BITGO_DISABLE_PROXY', 'DISABLE_PROXY') ? true : undefined,
+  disableEnvCheck: readEnvVar('BITGO_DISABLE_ENV_CHECK', 'DISABLE_ENV_CHECK') ? true : undefined,
+  timeout: Number(readEnvVar('BITGO_TIMEOUT')),
+  customRootUri: readEnvVar('BITGO_CUSTOM_ROOT_URI'),
+  customBitcoinNetwork: (readEnvVar('BITGO_CUSTOM_BITCOIN_NETWORK') as V1Network),
 });
 
 export const DefaultConfig: Config = {

--- a/modules/express/test/unit/config.ts
+++ b/modules/express/test/unit/config.ts
@@ -39,25 +39,65 @@ describe('Config:', () => {
 
   it('should correctly handle boolean config precedence', () => {
     const argStub = sinon.stub(args, 'args').returns({ disablessl: true });
-    const envStub = sinon.stub(process, 'env').value({ DISABLE_SSL: undefined });
+    const envStub = sinon.stub(process, 'env').value({ BITGO_DISABLE_SSL: undefined });
     config().disableSSL.should.equal(true);
     argStub.restore();
     envStub.restore();
   });
 
-  it('should allow DISABLE_SSL option', () => {
-    const argStub = sinon.stub(args, 'args').returns({});
-    const envStub = sinon.stub(process, 'env').value({ DISABLE_SSL: true });
-    config().disableSSL.should.equal(true);
-    argStub.restore();
-    envStub.restore();
+  it('should allow all DISABLE_SSL option forms, including deprecated', () => {
+    const optionForms = [
+      { deprecated: true, DISABLESSL: true },
+      { deprecated: true, DISABLE_SSL: true },
+      { BITGO_DISABLE_SSL: true },
+      { deprecated: true, BITGO_DISABLESSL: true },
+    ];
+
+    for (const { deprecated, ...form } of optionForms) {
+      const argStub = sinon.stub(args, 'args').returns({});
+      const envStub = sinon.stub(process, 'env').value(form);
+      const consoleStub = sinon.stub(console, 'warn').returns(undefined);
+      config().disableSSL.should.equal(true);
+      argStub.restore();
+      envStub.restore();
+      consoleStub.restore();
+      if (deprecated) {
+        consoleStub.calledOnceWithExactly(sinon.match(/deprecated environment variable/)).should.be.true();
+      }
+    }
   });
 
-  it('should also allow DISABLESSL option', () => {
-    const argStub = sinon.stub(args, 'args').returns({});
-    const envStub = sinon.stub(process, 'env').value({ DISABLESSL: true });
-    config().disableSSL.should.equal(true);
-    argStub.restore();
-    envStub.restore();
+  it('should allow all DISABLE_PROXY option forms, including deprecated', () => {
+    const optionForms = [{ deprecated: true, DISABLE_PROXY: true }, { BITGO_DISABLE_PROXY: true }];
+
+    for (const { deprecated = false, ...form } of optionForms) {
+      const argStub = sinon.stub(args, 'args').returns({});
+      const envStub = sinon.stub(process, 'env').value(form);
+      const consoleStub = sinon.stub(console, 'warn').returns(undefined);
+      config().disableProxy.should.equal(true);
+      argStub.restore();
+      envStub.restore();
+      consoleStub.restore();
+      if (deprecated) {
+        consoleStub.calledOnceWithExactly(sinon.match(/deprecated environment variable/)).should.be.true();
+      }
+    }
+  });
+
+  it('should allow all DISABLE_ENV_CHECK option forms, including deprecated', () => {
+    const optionForms = [{ BITGO_DISABLE_ENV_CHECK: true }, { deprecated: true, DISABLE_ENV_CHECK: true }];
+
+    for (const { deprecated = false, ...form } of optionForms) {
+      const argStub = sinon.stub(args, 'args').returns({});
+      const envStub = sinon.stub(process, 'env').value(form);
+      const consoleStub = sinon.stub(console, 'warn').returns(undefined);
+      config().disableEnvCheck.should.equal(true);
+      argStub.restore();
+      envStub.restore();
+      consoleStub.restore();
+      if (deprecated) {
+        consoleStub.calledOnceWithExactly(sinon.match(/deprecated environment variable/)).should.be.true();
+      }
+    }
   });
 });


### PR DESCRIPTION
* Emit warning upon usage of a deprecated environment variable
* Update README to clearly explain the preferred environment
variables, and which ones are deprecated but still usable for backwards
compatibility reasons

JIRA: BG-17569