### PR TITLE
feat: add node 12 support to the bitgo core package

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -15,7 +15,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=8 <12.0.0",
+    "node": ">=8 <13.0.0",
     "npm": ">=3.10.10"
   },
   "scripts": {


### PR DESCRIPTION
The 2 current version of node lts are now 10 and 12.
See https://nodejs.org/en/about/releases/.

I didn't remove node 8 to not create a breaking change. Let me know if you want me to remove it :)

I was also not able to add node 12 to the drone configuration, when I run the command `drone jsonnet` I get the following error:
```
2020/01/30 17:58:32 yaml: unmarshal errors:
  line 1: cannot unmarshal !!seq into yaml.RawResource
```

Let me know what you think about this and if I need to change something, thanks!