### PR TITLE
fix(core): Recreate XLM integration test wallets

### DIFF
--- a/modules/core/test/v2/integration/coins/xlm.ts
+++ b/modules/core/test/v2/integration/coins/xlm.ts
@@ -11,8 +11,8 @@ import * as nock from 'nock';
 describe('XLM:', function() {
   let bitgo: typeof TestBitGo;
   let basecoin: BaseCoin;
-  const uninitializedWallet = '5db9e854e6895ae1050ef414f9b8e0e9'; // wallet which has not been initialized on-chain
-  const initializedWallet = '5db9e8a736378852063fc715b5722751'; // wallet which has been correctly initialized on chain
+  const uninitializedWallet = '5e3a0ca5507bb231046168b40da06149'; // wallet which has not been initialized on-chain
+  const initializedWallet = '5e3a0d15489ba3030479c174b27f50ee'; // wallet which has been correctly initialized on chain
 
   before(co(function*() {
     nock.restore();


### PR DESCRIPTION
Quarterly XLM testnet reset was done on 1/31, and we need to recreate
the wallets.

Ticket: BG-17683