### PR TITLE
Add try-catch to recoveries

### DIFF
--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -1745,8 +1745,13 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       let recoveryAmount = totalInputAmount - approximateFee;
       let krsFee;
       if (isKrsRecovery) {
-        krsFee = yield self.calculateFeeAmount({ provider: params.krsProvider, amount: recoveryAmount });
-        recoveryAmount -= krsFee;
+        try {
+          krsFee = yield self.calculateFeeAmount({ provider: params.krsProvider, amount: recoveryAmount });
+          recoveryAmount -= krsFee;
+        } catch (err) {
+          // Don't let this error block the recovery - 
+          console.dir(err);
+        }
       }
 
       if (recoveryAmount < 0) {


### PR DESCRIPTION
The "calculateFeeAmount" function of UTXO recoveries
can fail for two reasons:
- krsProvider's fee structure not configured
- 3rd party market data site is down
We don't want either of these to block the recovery
from happening, so lets encapsulate this call in
a try-catch and just log the error if there is one

Ticket: BG-18417