### PR TITLE
Skip verify in BTG Recovery

### DIFF
--- a/modules/core/src/v2/coins/btg.ts
+++ b/modules/core/src/v2/coins/btg.ts
@@ -1,10 +1,11 @@
 import { BitGo } from '../../bitgo';
-import { BaseCoin } from '../baseCoin';
+import {BaseCoin, VerifyRecoveryTransactionOptions} from '../baseCoin';
 import { Btc } from './btc';
 import * as bitcoin from 'bitgo-utxo-lib';
 import * as Bluebird from 'bluebird';
 const co = Bluebird.coroutine;
 import * as common from '../../common';
+import * as errors from "../../errors";
 const request = require('superagent');
 
 export class Btg extends Btc {
@@ -106,5 +107,9 @@ export class Btg extends Btc {
 
       return unspents;
     }).call(this);
+  }
+
+  verifyRecoveryTransaction(txInfo: VerifyRecoveryTransactionOptions): Bluebird<any> {
+    return Bluebird.reject(new errors.MethodNotImplementedError());
   }
 }


### PR DESCRIPTION
BTG incorrectly inherits BTC's verify
function during the recovery process,
which causes an error because the BTG
block explorer does not support the
/decodetx endpoint. This commit throws
the proper error for BTG in this situation
so that the recovery does not get blocked

Ticket: BG-18467

You can see why this error is necessary to throw by looking [here](https://github.com/BitGo/BitGoJS/blob/master/modules/core/src/v2/coins/abstractUtxoCoin.ts#L1778)