### PR TITLE
Extend EOS recovery expiration from 1 to 8 hours

### DIFF
--- a/modules/core/src/v2/coins/eos.ts
+++ b/modules/core/src/v2/coins/eos.ts
@@ -759,7 +759,7 @@ export class Eos extends BaseCoin {
     return co(function*() {
       const chainInfo = yield self.getChainInfoFromNode();
       const headBlockInfoResult = yield self.getBlockFromNode({ blockNumOrId: chainInfo.head_block_num });
-      const expireSeconds = 3600; // maximum tx expire time of 1h
+      const expireSeconds = 28800; // maximum tx expire time of 8h
       const chainDate = new Date(chainInfo.head_block_time + 'Z');
       const expirationDate = new Date(chainDate.getTime() + expireSeconds * 1000);
 

--- a/modules/express/test/mocha.opts
+++ b/modules/express/test/mocha.opts
@@ -1,5 +1,5 @@
 --require ts-node/register
---timeout 30000
+--timeout 60000
 --reporter mochawesome
 --reporter-option cdn=true,json=false,consoleReporter=spec
 --exit

--- a/modules/express/test/mocha.opts
+++ b/modules/express/test/mocha.opts
@@ -1,5 +1,5 @@
 --require ts-node/register
---timeout 20000
+--timeout 30000
 --reporter mochawesome
 --reporter-option cdn=true,json=false,consoleReporter=spec
 --exit


### PR DESCRIPTION
Resolves https://github.com/BitGo/BitGoJS/issues/677 by extending EOS recovery expiration from 1 to 8 hours.

Adds a unit test to demonstrate that the correct expiration date is encoded, by comparing it to the head block time (which is mocked [here](https://github.com/BitGo/BitGoJS/blob/ade4e9ab1459055bf6805e8ca551e98fb44d9a45/modules/core/test/v2/lib/recovery-nocks.ts#L2594)). Also updates the expected packed transaction used across EOS recovery unit tests. (Note: only the first seven bytes are different from the prior packed transaction, which presumably is where the expiration date is encoded.)