### PR TITLE
Add support for retrieving offline verification data

### DIFF
--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -98,6 +98,7 @@ export interface PrebuildTransactionOptions {
       expireTime?: string;
       pendingApprovalId?: string;
     };
+    offlineVerification?: boolean;
 }
 
 export interface PrebuildAndSignTransactionOptions extends PrebuildTransactionOptions {
@@ -1629,7 +1630,12 @@ export class Wallet {
       }
       const extraParams = yield self.baseCoin.getExtraPrebuildParams(Object.assign(params, { wallet: self }));
       Object.assign(whitelistedParams, extraParams);
+      const queryParams = {
+        offlineVerification: params.offlineVerification ? true : undefined,
+      };
+
       const buildQuery = self.bitgo.post(self.baseCoin.url('/wallet/' + self.id() + '/tx/build'))
+        .query(queryParams)
         .send(whitelistedParams)
         .result();
       const utxoCoin = self.baseCoin as AbstractUtxoCoin;

--- a/modules/core/test/v2/integration/wallet.ts
+++ b/modules/core/test/v2/integration/wallet.ts
@@ -303,6 +303,31 @@ describe('V2 Wallet:', function() {
     }));
   });
 
+  describe('Prebuild Transactions', () => {
+    it('should retrieve offline verification data for transaction prebuilds, if requested', co(function *() {
+      const recipientAddress = yield wallet.createAddress();
+      const params = {
+        recipients: [
+          {
+            amount: 0.01 * 1e8, // 0.01 tBTC
+            address: recipientAddress.address,
+          },
+        ],
+        offlineVerification: true,
+      };
+      const prebuild = yield wallet.prebuildTransaction(params);
+
+      prebuild.should.have.property('txInfo');
+      prebuild.txInfo.should.have.property('unspents');
+      prebuild.txInfo.should.have.property('txHexes');
+
+      const txIds = Object.keys(prebuild.txInfo.txHexes);
+      for (const unspent of prebuild.txInfo.unspents) {
+        txIds.some((txId) => unspent.id.split(':')[0] === txId).should.be.true();
+      }
+    }));
+  });
+
   describe('Send Transactions', function() {
     // some of the tests will return the error "Error: transaction attempted to double spend",
     // that occurs when the same unspent is selected different transactions, this is unlikely when


### PR DESCRIPTION
Platform has had support for adding extra metadata to a transaction
prebuild which would assist in offline verification of the transaction
inputs. However, SDK did not support passing the parameter which would
tell platform to append this extra data.

This commit adds support for passing the `offlineVerification` flag when
calling `prebuildTransaction`, closing this feature gap.

Ticket: BG-18802