### PR TITLE
Retrieve prices from CoinGecko API

### DIFF
--- a/modules/core/src/config.ts
+++ b/modules/core/src/config.ts
@@ -170,7 +170,7 @@ export const krsProviders = {
   }
 };
 
-export const bitcoinAverageBaseUrl = 'https://apiv2.bitcoinaverage.com/indices/local/ticker/';
+export const coinGeckoBaseUrl = 'https://api.coingecko.com/api/v3/';
 
 // TODO: once server starts returning eth address keychains, remove bitgoEthAddress
 /**

--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -1518,14 +1518,33 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
   getRecoveryMarketPrice(): Bluebird<string> {
     const self = this;
     return co<string>(function *getRecoveryMarketPrice() {
-      const bitcoinAverageUrl = config.bitcoinAverageBaseUrl + self.getFamily().toUpperCase() + 'USD';
-      const response = yield request.get(bitcoinAverageUrl).retry(2).result();
+      const familyNamesToCoinGeckoIds = new Map()
+        .set('BTC', 'bitcoin')
+        .set('LTC', 'litecoin')
+        .set('BCH', 'bitcoin-cash')
+        .set('ZEC', 'zcash')
+        .set('DASH', 'dash');
+      const coinGeckoId = familyNamesToCoinGeckoIds.get(self.getFamily().toUpperCase());
+      if (!coinGeckoId) {
+        throw new Error(`There is no CoinGecko id for family name ${self.getFamily().toUpperCase()}.`);
+      }
+      const coinGeckoUrl = config.coinGeckoBaseUrl + `simple/price?ids=${coinGeckoId}&vs_currencies=USD`;
+      const response = yield request.get(coinGeckoUrl).retry(2).result();
 
-      if (response === null || typeof response.last !== 'number') {
-        throw new Error('unable to reach BitcoinAverage for price data');
+      // An example of response
+      // {
+      //   "ethereum": {
+      //     "usd": 220.64
+      //   }
+      // }
+      if (!response) {
+        throw new Error('Unable to reach Coin Gecko API for price data');
+      }
+      if (!response[coinGeckoId]['usd'] || typeof response[coinGeckoId]['usd'] !== 'number') {
+        throw new Error('Unexpected response from Coin Gecko API for price data');
       }
 
-      return response.last;
+      return response[coinGeckoId]['usd'];
     }).call(this);
   }
 
@@ -1749,7 +1768,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
           krsFee = yield self.calculateFeeAmount({ provider: params.krsProvider, amount: recoveryAmount });
           recoveryAmount -= krsFee;
         } catch (err) {
-          // Don't let this error block the recovery - 
+          // Don't let this error block the recovery -
           console.dir(err);
         }
       }

--- a/modules/core/test/v2/lib/recovery-nocks.ts
+++ b/modules/core/test/v2/lib/recovery-nocks.ts
@@ -876,10 +876,12 @@ export function nockBtcRecovery(bitgo, isKrsRecovery) {
 
   if (isKrsRecovery) {
     // unnecessary market data removed
-    nock('https://apiv2.bitcoinaverage.com')
-      .get('/indices/local/ticker/BTCUSD')
+    nock('https://api.coingecko.com')
+      .get('/api/v3/simple/price?ids=bitcoin&vs_currencies=USD')
       .reply(200, {
-        last: 10000,
+        bitcoin: {
+          usd: 10000,
+        },
       });
   }
 }
@@ -1089,10 +1091,12 @@ module.exports.nockBchRecovery = function nockBchRecovery(bitgo, isKrsRecovery) 
 
   if (isKrsRecovery) {
     // unnecessary market data removed
-    nock('https://apiv2.bitcoinaverage.com')
-      .get('/indices/local/ticker/BCHUSD')
+    nock('https://api.coingecko.com')
+      .get('/api/v3/simple/price?ids=bitcoin-cash&vs_currencies=USD')
       .reply(200, {
-        last: 1000,
+        'bitcoin-cash': {
+          usd: 1000,
+        },
       });
   }
 };
@@ -2053,10 +2057,12 @@ module.exports.nockLtcRecovery = function(isKrsRecovery) {
 
   if (isKrsRecovery) {
     // unnecessary market data removed
-    nock('https://apiv2.bitcoinaverage.com')
-      .get('/indices/local/ticker/LTCUSD')
+    nock('https://api.coingecko.com')
+      .get('/api/v3/simple/price?ids=litecoin&vs_currencies=USD')
       .reply(200, {
-        last: 1000,
+        litecoin: {
+          usd: 1000,
+        },
       });
   }
 };
@@ -2245,10 +2251,12 @@ module.exports.nockZecRecovery = function(bitgo, isKrsRecovery) {
 
   if (isKrsRecovery) {
     // unnecessary market data removed
-    nock('https://apiv2.bitcoinaverage.com')
-      .get('/indices/local/ticker/ZECUSD')
+    nock('https://api.coingecko.com')
+      .get('/api/v3/simple/price?ids=zcash&vs_currencies=USD')
       .reply(200, {
-        last: 1000,
+        zcash: {
+          usd: 1000,
+        },
       });
   }
 };
@@ -2377,10 +2385,12 @@ module.exports.nockDashRecovery = function(bitgo, isKrsRecovery) {
 
   if (isKrsRecovery) {
     // unnecessary market data removed
-    nock('https://apiv2.bitcoinaverage.com')
-      .get('/indices/local/ticker/DASHUSD')
+    nock('https://api.coingecko.com')
+      .get('/api/v3/simple/price?ids=dash&vs_currencies=USD')
       .reply(200, {
-        last: 1000,
+        dash: {
+          usd: 1000,
+        },
       });
   }
 };


### PR DESCRIPTION
Bitcoin Average recently deprecated their free endpoint, so we can no
longer use them to get transaction data for recoveries.

This change swaps out bitcoin average for coingecko for recovery cases.

Ticket: BG-18654