### PR TITLE
Fix incorrect type check on string literal

### DIFF
--- a/modules/core/src/bitgo.ts
+++ b/modules/core/src/bitgo.ts
@@ -1275,14 +1275,15 @@ export class BitGo {
   }
 
   /**
-   *
+   * Process the username, password and otp into an object containing the username and hashed password, ready to
+   * send to bitgo for authentication.
    */
   preprocessAuthenticationParams({ username, password, otp, forceSMS, extensible, trust }: AuthenticateOptions): ProcessedAuthenticationOptions {
-    if (!_.isString('username')) {
+    if (!_.isString(username)) {
       throw new Error('expected string username');
     }
 
-    if (!_.isString('password')) {
+    if (!_.isString(password)) {
       throw new Error('expected string password');
     }
 

--- a/modules/core/test/unit/bitgo.ts
+++ b/modules/core/test/unit/bitgo.ts
@@ -257,7 +257,6 @@ describe('BitGo Prototype Methods', function() {
       const sharingKey2 = bitgo.getECDHSecret({ eckey: eckey2, otherPubKeyHex: eckey1.getPublicKeyBuffer().toString('hex') });
       sharingKey1.should.equal(sharingKey2);
     });
-
   });
 
   describe('change password', function() {
@@ -496,5 +495,13 @@ describe('BitGo Prototype Methods', function() {
     after(function() {
       nock.pendingMocks().should.be.empty();
     });
+  });
+
+  describe('preprocessAuthenticationParams', () => {
+    const bitgo = new TestBitGo({ env: 'mock' });
+    it('should fail if passed non-string username or password', co(function *() {
+      (() => bitgo.preprocessAuthenticationParams({ username: 123 })).should.throw(/expected string username/);
+      (() => bitgo.preprocessAuthenticationParams({ username: 'abc', password: {} })).should.throw(/expected string password/);
+    }));
   });
 });


### PR DESCRIPTION
Before our typescript refactor last year, these properties were checked
with the deprecated `common.validateParams`, which takes an array string
literals of the properties to check for on the given object. When we
refactored however, we continued using the string literal instead of the
variable of the same name.

This is the only location in the code where the string `isString('`
appears, so I don't think we have made this mistake anywhere else.

Ticket: BG-18946