### PR TITLE
Fix docker build "invalid bin entry for package"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM node:10 AS builder
 MAINTAINER Tyler Levine <tyler@bitgo.com>
 COPY --chown=node:node . /tmp/bitgo/
 WORKDIR /tmp/bitgo/modules/express
+RUN npm install npm@latest -g
 USER node
 RUN npm ci && npm prune --production
 FROM node:10-alpine


### PR DESCRIPTION
The following error was causing the `docker build -t bitgo-express .` command to fail
`npm ERR! invalid bin entry for package msgpack-lite`

@sabodash proposed the fix related to the npm package upstream issue:
https://github.com/npm/cli/issues/613

Fixes: #667