### PR TITLE
Install latest npm in container before express

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM node:10 AS builder
 MAINTAINER Tyler Levine <tyler@bitgo.com>
 COPY --chown=node:node . /tmp/bitgo/
 WORKDIR /tmp/bitgo/modules/express
+RUN npm install npm@latest -g
 USER node
 RUN npm ci && npm prune --production
 FROM node:10-alpine


### PR DESCRIPTION
The default version of npm in the docker base image fails during npm
prune with `npm ERR! invalid bin entry for package msgpack-lite`.

This is a known and fixed bug in npm: https://github.com/npm/cli/issues/613

Ticket: BG-19035