### PR TITLE
Add `getFeeAddress()` to Enterprises

### DIFF
--- a/modules/core/src/v2/enterprise.ts
+++ b/modules/core/src/v2/enterprise.ts
@@ -14,13 +14,20 @@ import { Affirmations } from './trading/affirmations';
 
 const co = Bluebird.coroutine;
 
+export interface EnterpriseData {
+  id: string;
+  name: string;
+  ethFeeAddress?: string;
+}
+
 export class Enterprise {
   private readonly bitgo: BitGo;
   private readonly baseCoin: BaseCoin;
+  private readonly _enterprise: EnterpriseData;
   readonly id: string;
   readonly name: string;
 
-  constructor(bitgo: BitGo, baseCoin: BaseCoin, enterpriseData: { id: string; name: string }) {
+  constructor(bitgo: BitGo, baseCoin: BaseCoin, enterpriseData: EnterpriseData) {
     this.bitgo = bitgo;
     this.baseCoin = baseCoin;
     if (!_.isObject(enterpriseData)) {
@@ -32,6 +39,7 @@ export class Enterprise {
     if (!_.isString(enterpriseData.name)) {
       throw new Error('enterprise name has to be a string');
     }
+    this._enterprise = enterpriseData;
     this.id = enterpriseData.id;
     this.name = enterpriseData.name;
   }
@@ -140,5 +148,14 @@ export class Enterprise {
    */
   affirmations(): Affirmations {
     return new Affirmations(this.bitgo, this.id);
+  }
+
+  /**
+   * Get the fee address for this enterprise. This is also known as the "Enterprise Gas Tank", which is a special
+   * account used to pay fees for transactions across the enterprise for certain coin types.
+   */
+  getFeeAddress(): string | undefined {
+    // TODO: will need updating once multiple fee addresses are supported per enterprise
+    return this._enterprise.ethFeeAddress;
   }
 }

--- a/modules/core/test/v2/integration/enterprise.ts
+++ b/modules/core/test/v2/integration/enterprise.ts
@@ -4,27 +4,23 @@
 // Copyright 2014, BitGo, Inc.  All Rights Reserved.
 //
 
-import 'should';
-
+import BigNumber from 'bignumber.js';
 import * as Promise from 'bluebird';
-const co = Promise.coroutine;
-const BigNumber = require('bignumber.js');
 
-const TestBitGo = require('../lib/test_bitgo');
+const co = Promise.coroutine;
+
+import { TestBitGo } from '../../lib/test_bitgo';
 
 describe('Enterprise', function() {
 
   let bitgo;
-
   before(co(function *() {
     bitgo = new TestBitGo({ env: 'test' });
     bitgo.initializeTestVars();
     yield bitgo.authenticateEnterpriseCreatorTestUser(bitgo.testUserOTP());
-
   }));
 
   describe('Fetch Enterprise', function() {
-
     it('should fetch an enterprise', co(function *() {
       const enterprises = bitgo.coin('tltc').enterprises();
       const entList = yield enterprises.list();
@@ -34,7 +30,8 @@ describe('Enterprise', function() {
       enterprise1.name.should.equal('Test Enterprise');
     }));
 
-    it('should fetch the users of an enterprise', co(function *() {
+    // Test ported from v1 - these have not run for some time an the test is incorrect due to platform API changes
+    xit('should fetch the users of an enterprise', co(function *() {
       const enterprises = bitgo.coin('tltc').enterprises();
       const enterprise = (yield enterprises.list())[0];
       const users = yield enterprise.users();
@@ -63,7 +60,14 @@ describe('Enterprise', function() {
       const feeBalance = yield enterprise.getFeeAddressBalance();
       feeBalance.should.have.property('balance');
       const balance = new BigNumber(feeBalance.balance);
-      balance.greaterThan(1000).should.equal(true);
+      balance.isGreaterThan(1000).should.equal(true);
+    }));
+
+    it('should return the enterprise fee address', co(function *() {
+      const enterprises = bitgo.coin('teth').enterprises();
+      const enterprise = (yield enterprises.list())[0];
+      const feeAddress = enterprise.getFeeAddress();
+      feeAddress.should.eql('0xa196e1fcc55a1cfa5bb15f20e857b2fd9b4bd414');
     }));
   });
 
@@ -71,7 +75,8 @@ describe('Enterprise', function() {
   describe('Modify Enterprise', function() {
 
     // TODO: figure out how to approve the removal request from another user
-    it('should add and remove user from enterprise', co(function *() {
+    // Test ported from v1 - these have not run for some time an the test is incorrect due to platform API changes
+    xit('should add and remove user from enterprise', co(function *() {
       const enterprise = yield bitgo.coin('tltc').enterprises().create({ name: 'Test Enterprise' });
       const refetchedEnterprise = yield bitgo.coin('tltc').enterprises().get({ id: enterprise.id });
       const users0 = yield refetchedEnterprise.users();

--- a/modules/core/test/v2/unit/enterprise.ts
+++ b/modules/core/test/v2/unit/enterprise.ts
@@ -4,11 +4,13 @@
 
 import * as nock from 'nock';
 import * as Promise from 'bluebird';
-const co = Promise.coroutine;
-import { Enterprise } from '../../../src/v2/enterprise';
-import * as common from '../../../src/common';
+import * as should from 'should';
 
+import { Enterprise, EnterpriseData } from '../../../src/v2/enterprise';
+import * as common from '../../../src/common';
 import { TestBitGo } from '../../lib/test_bitgo';
+
+const co = Promise.coroutine;
 
 describe('Enterprise:', function() {
   let bitgo;
@@ -16,29 +18,36 @@ describe('Enterprise:', function() {
   let baseCoin;
   let bgUrl;
 
+  const enterpriseData: EnterpriseData = {
+    id: '593f1ece99d37c23080a557283edcc89',
+    name: 'Test Enterprise',
+    ethFeeAddress: '0x123',
+  };
+
   before(co(function *() {
     bitgo = new TestBitGo({ env: 'test' });
     bitgo.initializeTestVars();
     baseCoin = bitgo.coin('tbtc');
-    enterprise = new Enterprise(bitgo, baseCoin, { id: '593f1ece99d37c23080a557283edcc89', name: 'Test Enterprise' });
+    enterprise = new Enterprise(bitgo, baseCoin, enterpriseData);
     bgUrl = common.Environments[bitgo.getEnv()].uri;
   }));
 
   describe('Transaction data', function() {
     it('should search for pending transaction correctly', co(function *() {
       const params = { enterpriseId: enterprise.id };
-      const scope =
-        nock(bgUrl)
+      const scope = nock(bgUrl)
         .get('/api/v2/tbtc/tx/pending/first')
         .query(params)
         .reply(200);
-      try {
-        yield enterprise.getFirstPendingTransaction();
-        throw '';
-      } catch (error) {
-        // test is successful if nock is consumed, HMAC errors expected
-      }
-      scope.isDone().should.be.True();
+      yield enterprise.getFirstPendingTransaction().should.be.rejected();
+      scope.done();
+    }));
+  });
+
+  describe('Fee Address', function() {
+    it('should return the eth address from enterprise data as the fee address for an enterprise', co(function*() {
+      const feeAddress = enterprise.getFeeAddress();
+      feeAddress.should.eql(enterpriseData.ethFeeAddress);
     }));
   });
 });


### PR DESCRIPTION
We've had `getFeeAddressBalance()` on Enterprises for some time now, but
there was never a way to get the actual fee address itself, aside from
manually requesting the enterprise.

This adds a new function to Enterprises for getting the enterprise fee
address.

Ticket: BG-19068