### PR TITLE
Add ENTERPRISE_PAYS_FEES and accountExplorerUrl

### DIFF
--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -112,6 +112,10 @@ export const enum CoinFeature {
    * For example, Ethereum's ERC 20 token standard means that it supports tokens, so it shall have this feature.
    */
   SUPPORTS_TOKENS = 'supports-tokens',
+  /*
+   * Are fees for transactions of this coin paid for by the Enterprise (eg, Enterprise gas tank)?
+   */
+  ENTERPRISE_PAYS_FEES = 'enterprise-pays-fees',
 }
 
 /**

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -5,8 +5,9 @@ import { Networks } from './networks';
 import { ofc, tofc, ofcerc20, tofcerc20 } from './ofc';
 import { utxo } from './utxo';
 
-const ETH_FEATURES = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.SUPPORTS_TOKENS];
+const ETH_FEATURES = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.SUPPORTS_TOKENS, CoinFeature.ENTERPRISE_PAYS_FEES];
 const XLM_FEATURES = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.SUPPORTS_TOKENS];
+const XTZ_FEATURES = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.ENTERPRISE_PAYS_FEES];
 
 export const coins = CoinMap.fromCoins([
   utxo('bch', 'Bitcoin Cash', Networks.main.bitcoinCash, UnderlyingAsset.BCH),
@@ -34,8 +35,8 @@ export const coins = CoinMap.fromCoins([
   account('txrp', 'Testnet Ripple', Networks.test.xrp, 6, UnderlyingAsset.XRP),
   account('xlm', 'Stellar', Networks.main.stellar, 7, UnderlyingAsset.XLM, XLM_FEATURES),
   account('txlm', 'Testnet Stellar', Networks.test.stellar, 7, UnderlyingAsset.XLM, XLM_FEATURES),
-  account('xtz', 'Tezos', Networks.main.xtz, 6, UnderlyingAsset.XTZ),
-  account('txtz', 'Testnet Tezos Babylonnet', Networks.test.xtz, 6, UnderlyingAsset.XTZ),
+  account('xtz', 'Tezos', Networks.main.xtz, 6, UnderlyingAsset.XTZ, XTZ_FEATURES),
+  account('txtz', 'Testnet Tezos Babylonnet', Networks.test.xtz, 6, UnderlyingAsset.XTZ, XTZ_FEATURES),
   account('susd', 'Silvergate USD', Networks.main.susd, 2, UnderlyingAsset.USD),
   account('tsusd', 'Testnet Silvergate USD', Networks.test.susd, 2, UnderlyingAsset.USD),
   ofc('ofcusd', 'USD', 2, UnderlyingAsset.USD, CoinKind.FIAT),

--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -36,8 +36,13 @@ export interface UtxoNetwork extends BaseNetwork {
   wif: number;
 }
 
-export interface AccountNetwork extends BaseNetwork {}
+export interface AccountNetwork extends BaseNetwork {
+  // some chains pay fees via an enterprise gas task. The account explorer url
+  // is a url that can be used to look up the account for the gas tank on-chain.
+  readonly accountExplorerUrl?: string;
+}
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface OfcNetwork extends BaseNetwork {}
 
 abstract class Mainnet extends BaseNetwork {
@@ -171,11 +176,13 @@ class DashTestnet extends BitcoinLikeTestnet {
 class Ethereum extends Mainnet implements AccountNetwork {
   family = CoinFamily.ETH;
   explorerUrl = 'https://etherscan.io/tx/';
+  accountExplorerUrl = 'https://etherscan.io/address/';
 }
 
 class Kovan extends Testnet implements AccountNetwork {
   family = CoinFamily.ETH;
   explorerUrl = 'https://kovan.etherscan.io/tx/';
+  accountExplorerUrl = 'https://kovan.etherscan.io/address/';
 }
 
 class Eos extends Mainnet implements AccountNetwork {
@@ -261,11 +268,13 @@ class XrpTestnet extends Testnet implements AccountNetwork {
 class Xtz extends Mainnet implements AccountNetwork {
   family = CoinFamily.XTZ;
   explorerUrl = 'https://tezblock.io/transaction/';
+  accountExplorerUrl = 'https://tezblock.io/account/';
 }
 
 class XtzTestnet extends Testnet implements AccountNetwork {
   family = CoinFamily.XTZ;
   explorerUrl = 'https://babylonnet.tezblock.io/transaction/';
+  accountExplorerUrl = 'https://babylonnet.tezblock.io/account/';
 }
 
 // https://github.com/zcash/zcash/blob/master/src/validation.cpp


### PR DESCRIPTION
A common use case in the front end is building a URL to a block explorer
for a specific transaction, so a user can see the status of their
  transaction on chain.

For some account coins, fees are paid from the Enterprise, instead of
from the wallet itself. For those coins, we'd like to be able to:
1) Know that this is one of those coins where the enterprise pays fees
2) How to build an explorer URL so a user can look at the on chain
balance of their Enterprise fee address

This commit adds the ENTEPRISE_PAYS_FEES coin feature, and adds this
feature to XTZ and ETH (the only two coins which currently pay fees from
the Enterprise gas tank). This solves for case #1.

This commit also adds a new optional field to `AccountNetwork` called
`accountExplorerUrl`. This can be used for building urls just like the
`explorerUrl`, and therefore solves case #2 above.

Ticket: BG-19107