### PR TITLE
Add Regtest ERC20 Token

### DIFF
--- a/modules/core/test/unit/bitgo.ts
+++ b/modules/core/test/unit/bitgo.ts
@@ -461,9 +461,9 @@ describe('BitGo Prototype Methods', function() {
       bitgo.initializeTestVars();
       const tokens = bitgo.getConstants().eth.tokens;
 
-      // currently four tokens are defined for non-production environments
+      // currently seven tokens are defined for non-production environments
       should.exist(tokens);
-      tokens.length.should.equal(6);
+      tokens.length.should.equal(7);
     }));
 
     after(function tokenDefinitionsAfter() {

--- a/modules/core/test/v2/integration/bitgo.ts
+++ b/modules/core/test/v2/integration/bitgo.ts
@@ -292,7 +292,10 @@ describe('BitGo', function() {
         })
         .then(function(wallet3) {
           return wallet3.setLabel({ label: 'testLabel3', address: TestBitGo.TEST_WALLET3_ADDRESS2 });
-        });
+        })
+          .then(function(Res) {
+            console.log(Res);
+          });
       });
 
       it('success', function(done) {

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -363,6 +363,7 @@ export const enum UnderlyingAsset {
   TCAD = 'tcad',
   TEN = 'ten',
   TENX = 'tenx',
+  TERC20 = 'terc20',
   TGBP = 'tgbp',
   THKD = 'thkd',
   TIOX = 'tiox',

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -393,6 +393,7 @@ export const coins = CoinMap.fromCoins([
   terc20('schz', 'SchnauzerCoin', 18, '0x050e25a2630b2aee94546589fd39785254de112c', UnderlyingAsset.SCHZ),
   terc20('tcat', 'Test CAT-20 Token', 18, '0x63137319f3a14a985eb31547370e0e3bd39b03b8', UnderlyingAsset.CAT),
   terc20('tfmf', 'Test Formosa Financial Token', 18, '0xd8463d2f8c5b3be9de95c63b73a0ae4c79423452', UnderlyingAsset.FMF),
+  terc20('terc20', 'Test ERC20 Token', 18, '0x731a10897d267e19b34503ad902d0a29173ba4b1', UnderlyingAsset.TERC20),
   tstellarToken(
     'txlm:BST-GBQTIOS3XGHB7LVYGBKQVJGCZ3R4JL5E4CBSWJ5ALIJUHBKS6263644L',
     'BitGo Shield Token',


### PR DESCRIPTION
In order to run e2e tests on ERC20 tokens, we needed to add one to our
regtest deployments. We added a token which  will be initialized
with the first transaction from the hard-coded
rich address on the regtest chain. This means the token will always
have the same address: 0x731a10897d267e19b34503ad902d0a29173ba4b1.

Ticket: BG-19512