### PR TITLE
Convert messages to hex before signing

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -47,7 +47,7 @@
     "gen-docs": "typedoc"
   },
   "dependencies": {
-    "@bitgo/account-lib": "^1.0.2",
+    "@bitgo/account-lib": "^1.0.3",
     "@bitgo/statics": "^3.4.4",
     "@bitgo/unspents": "^0.6.0",
     "@types/bluebird": "^3.5.25",

--- a/modules/core/src/v2/coins/xtz.ts
+++ b/modules/core/src/v2/coins/xtz.ts
@@ -187,7 +187,8 @@ export class Xtz extends BaseCoin {
   signMessage(key: KeyPair, message: string | Buffer, callback?: NodeCallback<Buffer>): Bluebird<Buffer> {
     return co<Buffer>(function* cosignMessage() {
       const keyPair = new bitgoAccountLib.Xtz.KeyPair({ prv: key.prv });
-      const signatureData = yield bitgoAccountLib.Xtz.Utils.sign(keyPair, message as string);
+      const messageHex = message instanceof Buffer ? message.toString('hex') : new Buffer(message).toString('hex');
+      const signatureData = yield bitgoAccountLib.Xtz.Utils.sign(keyPair, messageHex);
       return signatureData.sig;
     })
       .call(this)

--- a/modules/core/test/v2/unit/coins/xtz.ts
+++ b/modules/core/test/v2/unit/coins/xtz.ts
@@ -1,5 +1,6 @@
 import * as Promise from 'bluebird';
 import { Xtz } from '../../../../src/v2/coins/';
+import * as bitgoAccountLib from '@bitgo/account-lib';
 
 const co = Promise.coroutine;
 import { TestBitGo } from '../../../lib/test_bitgo';
@@ -132,5 +133,30 @@ describe('Tezos:', function() {
       keyPair.pub.should.equal('sppk7bJUTTikwyNHT5n8ehzgSjgCou53Wmm1z81p6JvNTQ5oUuWEW8o');
       keyPair.prv.should.equal('spsk1fKc5fEaM7ns4JkmozPU9QCkXUHHLj48Wyiap2PvewMo595e9X');
     });
+  });
+
+  describe('Sign message:', () => {
+    it('should sign and validate a string message', co(function *() {
+      const keyPair = basecoin.generateKeyPair();
+      const message = 'hello world';
+      const signature = yield basecoin.signMessage(keyPair, message);
+
+      const messageHex = new Buffer(message).toString('hex');
+      const publicKey = new bitgoAccountLib.Xtz.KeyPair({ pub: keyPair.pub });
+      const isValid = yield bitgoAccountLib.Xtz.Utils.verifySignature(messageHex, publicKey.getKeys().pub, signature);
+      isValid.should.equal(true);
+    }));
+
+    it('should fail to validate a string message with wrong public key', co(function *() {
+      const keyPair = basecoin.generateKeyPair();
+      const message = 'hello world';
+      const signature = yield basecoin.signMessage(keyPair, message);
+
+      const messageHex = new Buffer(message).toString('hex');
+
+      const publicKey = new bitgoAccountLib.Xtz.KeyPair();
+      const isValid = yield bitgoAccountLib.Xtz.Utils.verifySignature(messageHex, publicKey.getKeys().pub, signature);
+      isValid.should.equal(false);
+    }));
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -103,10 +103,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@bitgo/account-lib@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@bitgo/account-lib/-/account-lib-1.0.2.tgz#b0422219a294f8f6fc632423050dc8920ea97af3"
-  integrity sha512-zvPUEsoypzNrXxrDNIjUOkjIBmdaQK8OoVxew0fHiNkGSjPSlr3Be144HOuWxBxyVuLmgXqaW/5Fyaizt1O3TA==
+"@bitgo/account-lib@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@bitgo/account-lib/-/account-lib-1.0.3.tgz#dd4bfbcf3265b982253ac861acb89a69096b2d1e"
+  integrity sha512-nPOyIk7vTkAHuE+OBpld5lHuio0T23vbPwkJHkUaIKV3YkIdM7sKr+gQjjr37J4Dv4MgzjW/AX3WLRMBwusq5g==
   dependencies:
     "@bitgo/statics" "^3.4.2"
     "@taquito/local-forging" "^6.0.3-beta.0"
@@ -115,6 +115,7 @@
     bitgo-utxo-lib "^1.6.0"
     blake2b "git+https://github.com/BitGo/blake2b.git#6268e6dd678661e0acc4359e9171b97eb1ebf8ac"
     bs58check "^2.1.2"
+    elliptic "^6.5.2"
     libsodium-wrappers "^0.7.6"
     protobufjs "^6.8.9"
     tronweb "^2.7.2"
@@ -3907,7 +3908,7 @@ elliptic@^6.0.0, elliptic@^6.2.3, elliptic@^6.4.0, elliptic@^6.4.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
-elliptic@^6.5.1:
+elliptic@^6.5.1, elliptic@^6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.2.tgz#05c5678d7173c049d8ca433552224a495d0e3762"
   integrity sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==


### PR DESCRIPTION
In tezos, we need to pass the message in hex format before creating a signature.

TICKET: BG-19590