### PR TITLE
Send XTZ signatures as buffer

### DIFF
--- a/modules/core/src/v2/coins/xtz.ts
+++ b/modules/core/src/v2/coins/xtz.ts
@@ -189,7 +189,7 @@ export class Xtz extends BaseCoin {
       const keyPair = new bitgoAccountLib.Xtz.KeyPair({ prv: key.prv });
       const messageHex = message instanceof Buffer ? message.toString('hex') : new Buffer(message).toString('hex');
       const signatureData = yield bitgoAccountLib.Xtz.Utils.sign(keyPair, messageHex);
-      return signatureData.sig;
+      return Buffer.from(signatureData.sig).toString('hex');
     })
       .call(this)
       .asCallback(callback);

--- a/modules/core/test/v2/unit/coins/xtz.ts
+++ b/modules/core/test/v2/unit/coins/xtz.ts
@@ -142,8 +142,9 @@ describe('Tezos:', function() {
       const signature = yield basecoin.signMessage(keyPair, message);
 
       const messageHex = new Buffer(message).toString('hex');
+      const sig = Buffer.from(signature, 'hex').toString();
       const publicKey = new bitgoAccountLib.Xtz.KeyPair({ pub: keyPair.pub });
-      const isValid = yield bitgoAccountLib.Xtz.Utils.verifySignature(messageHex, publicKey.getKeys().pub, signature);
+      const isValid = yield bitgoAccountLib.Xtz.Utils.verifySignature(messageHex, publicKey.getKeys().pub, sig);
       isValid.should.equal(true);
     }));
 
@@ -154,8 +155,9 @@ describe('Tezos:', function() {
 
       const messageHex = new Buffer(message).toString('hex');
 
+      const sig = Buffer.from(signature, 'hex').toString();
       const publicKey = new bitgoAccountLib.Xtz.KeyPair();
-      const isValid = yield bitgoAccountLib.Xtz.Utils.verifySignature(messageHex, publicKey.getKeys().pub, signature);
+      const isValid = yield bitgoAccountLib.Xtz.Utils.verifySignature(messageHex, publicKey.getKeys().pub, sig);
       isValid.should.equal(false);
     }));
   });


### PR DESCRIPTION
Signature verification was failing in the platform because the signature was not a buffer.

TICKET: BG-19801