### PR TITLE
Stop generating XRP initialization txs for new wallets

### DIFF
--- a/modules/core/src/v2/coins/xrp.ts
+++ b/modules/core/src/v2/coins/xrp.ts
@@ -83,6 +83,10 @@ interface HalfSignedTransaction {
   }
 }
 
+interface SupplementGenerateWalletOptions {
+  rootPrivateKey?: string;
+}
+
 export class Xrp extends BaseCoin {
   protected constructor(bitgo: BitGo) {
     super(bitgo);
@@ -259,8 +263,8 @@ export class Xrp extends BaseCoin {
    * @param walletParams
    * - rootPrivateKey: optional hex-encoded Ripple private key
    */
-  supplementGenerateWallet(walletParams): Bluebird<any> {
-    return co(function *() {
+  supplementGenerateWallet(walletParams: SupplementGenerateWalletOptions): Bluebird<SupplementGenerateWalletOptions> {
+    return co<SupplementGenerateWalletOptions>(function *() {
       if (walletParams.rootPrivateKey) {
         if (walletParams.rootPrivateKey.length !== 64) {
           throw new Error('rootPrivateKey needs to be a hexadecimal private key string');

--- a/modules/core/test/v2/integration/coins/xrp.ts
+++ b/modules/core/test/v2/integration/coins/xrp.ts
@@ -28,7 +28,7 @@ describe('XRP:', function() {
     nock.cleanAll();
   });
 
-  // TODO enable when initialization txs are built in platform
+  // TODO (BG-20879) - enable when initialization txs are built in platform
   xit('Should generate wallet with custom root address', function() {
     const hdNode = HDNode.fromSeedBuffer(crypto.randomBytes(32));
     const params = {

--- a/modules/core/test/v2/integration/coins/xrp.ts
+++ b/modules/core/test/v2/integration/coins/xrp.ts
@@ -28,7 +28,8 @@ describe('XRP:', function() {
     nock.cleanAll();
   });
 
-  it('Should generate wallet with custom root address', function() {
+  // TODO enable when initialization txs are built in platform
+  xit('Should generate wallet with custom root address', function() {
     const hdNode = HDNode.fromSeedBuffer(crypto.randomBytes(32));
     const params = {
       passphrase: TestBitGo.V2.TEST_WALLET1_PASSCODE,

--- a/modules/core/test/v2/integration/wallets.ts
+++ b/modules/core/test/v2/integration/wallets.ts
@@ -61,7 +61,8 @@ describe('V2 Wallets:', function() {
       yield testWalletGeneration('tbch');
     }));
 
-    it(`should generate a txrp wallet`, co(function *() {
+    // TODO (BG-20879) - enable when initialization txs are built in platform
+    xit(`should generate a txrp wallet`, co(function *() {
       yield testWalletGeneration('txrp');
     }));
 

--- a/modules/core/test/v2/unit/coins/xrp.ts
+++ b/modules/core/test/v2/unit/coins/xrp.ts
@@ -140,7 +140,7 @@ describe('XRP:', function() {
       }
     };
 
-    it('Should supplement wallet generation with fees', co(function *() {
+    it('Should supplement wallet generation', co(function *() {
       const details = yield nockBasecoin.supplementGenerateWallet({});
       details.should.have.property('rootPrivateKey');
     }));

--- a/modules/core/test/v2/unit/coins/xrp.ts
+++ b/modules/core/test/v2/unit/coins/xrp.ts
@@ -141,35 +141,8 @@ describe('XRP:', function() {
     };
 
     it('Should supplement wallet generation with fees', co(function *() {
-      const fees = [{
-        open: '10',
-        median: '6000',
-        expected: '9000'
-      }, {
-        open: '7000',
-        median: '4000',
-        expected: '10500'
-      }];
-
-      for (const currentFees of fees) {
-        nock('https://test.bitgo.com/api/v2/txrp/public')
-        .get('/feeinfo')
-        .reply(200, {
-          date: '2017-10-18T18:28:13.083Z',
-          height: 3353255,
-          xrpBaseReserve: '20000000',
-          xrpIncReserve: '5000000',
-          xrpOpenLedgerFee: currentFees.open,
-          xrpMedianFee: currentFees.median
-        });
-        const details = yield nockBasecoin.supplementGenerateWallet({}, keychains);
-        const disableMasterKey = rippleBinaryCodec.decode(details.initializationTxs.disableMasterKey);
-        const forceDestinationTag = rippleBinaryCodec.decode(details.initializationTxs.forceDestinationTag);
-        const setMultisig = rippleBinaryCodec.decode(details.initializationTxs.setMultisig);
-        disableMasterKey.Fee.should.equal(currentFees.expected);
-        forceDestinationTag.Fee.should.equal(currentFees.expected);
-        setMultisig.Fee.should.equal(currentFees.expected);
-      }
+      const details = yield nockBasecoin.supplementGenerateWallet({});
+      details.should.have.property('rootPrivateKey');
     }));
 
     it('should validate pub key', () => {


### PR DESCRIPTION
With the DeletableAccounts amendment enabled, platform can't rely on SDK to
build and sign initialization txs because their sequence id has to be obtained
from the network once the account has been funded

Ticket: BG-20878