### PR TITLE
Update UnsupportedCoinError to to include tip

### DIFF
--- a/modules/core/src/errors.ts
+++ b/modules/core/src/errors.ts
@@ -30,7 +30,7 @@ export class NodeEnvironmentError extends BitGoJsError {
 
 export class UnsupportedCoinError extends BitGoJsError {
   public constructor(coin: string) {
-    super(`Coin or token type ${coin} not supported or not compiled`);
+    super(`Coin or token type ${coin} not supported or not compiled. Please be sure that you are using the latest version of BitGoJS.`);
     Object.setPrototypeOf(this, UnsupportedCoinError.prototype);
   }
 }

--- a/modules/core/test/v2/unit/coins/token.ts
+++ b/modules/core/test/v2/unit/coins/token.ts
@@ -13,7 +13,7 @@ describe('Virtual Token:', function() {
   });
 
   it('should not instantiate coin interface before loading client constants', function() {
-    (() => bitgo.coin('mycrappytoken')).should.throw('Coin or token type mycrappytoken not supported or not compiled');
+    (() => bitgo.coin('mycrappytoken')).should.throw('Coin or token type mycrappytoken not supported or not compiled. Please be sure that you are using the latest version of BitGoJS.');
   });
 
   it('should wait for client constants before instantiating coin', Bluebird.coroutine(function *() {


### PR DESCRIPTION
BitGoJS throws an error whenever a user tries to use a coin that is not
supported in the current version of BitGoJS. Oftentimes the fix is to
simply update BitGoJS to a version that includes the desired coin or
token. This commit adds an extra sentence to that error message to
hopefully lead users to the solution more quickly.

Ticket: BG-21130