### PR TITLE
Update AbstractETHLikeCoin to actually be abstract

### DIFF
--- a/modules/core/src/v2/coins/abstractEthLikeCoin.ts
+++ b/modules/core/src/v2/coins/abstractEthLikeCoin.ts
@@ -55,10 +55,10 @@ export interface ExplainTransactionOptions {
   feeInfo: TransactionFee;
 }
 
-export class AbstractEthLikeCoin extends BaseCoin {
+export abstract class AbstractEthLikeCoin extends BaseCoin {
   protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
 
-  constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  protected constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo);
 
     if (!staticsCoin) {


### PR DESCRIPTION
The class should never be instantiated by itself -- it's meant to be the
base for coins with ETH-like behavior. This commit adds the abstract
flag to make it more clear that it shouldn't be instantiated

Ticket: BG-17980