### PR TITLE
Add Celo USD ERC20 token

### DIFF
--- a/modules/statics/src/account.ts
+++ b/modules/statics/src/account.ts
@@ -93,6 +93,26 @@ export class Erc20Coin extends AccountCoinToken {
 }
 
 /**
+ * The CELO blockchain supports tokens of the ERC20 standard similar to ETH ERC20 tokens.
+ */
+export class CeloCoin extends AccountCoinToken {
+  public contractAddress: ContractAddress;
+
+  constructor(options: Erc20ConstructorOptions) {
+    super({
+      ...options,
+    });
+
+    // valid ERC 20 contract addresses are "0x" followed by 40 lowercase hex characters
+    if (!options.contractAddress.match(/^0x[a-f0-9]{40}$/)) {
+      throw new InvalidContractAddressError(options.name, options.contractAddress);
+    }
+
+    this.contractAddress = (options.contractAddress as unknown) as ContractAddress;
+  }
+}
+
+/**
  * The Stellar network supports tokens (non-native assets)
  * XLM is also known as the native asset.
  * Stellar tokens work similar to XLM, but the token name is determined by the chain,
@@ -219,6 +239,73 @@ export function terc20(
   network: AccountNetwork = Networks.test.kovan
 ) {
   return erc20(name, fullName, decimalPlaces, contractAddress, asset, features, prefix, suffix, network);
+}
+
+/**
+ * Factory function for celo token instances.
+ *
+ * @param name unique identifier of the token
+ * @param fullName Complete human-readable name of the token
+ * @param decimalPlaces Number of decimal places this token supports (divisibility exponent)
+ * @param contractAddress Contract address of this token
+ * @param asset Asset which this coin represents. This is the same for both mainnet and testnet variants of a coin.
+ * @param prefix? Optional token prefix. Defaults to empty string
+ * @param suffix? Optional token suffix. Defaults to token name.
+ * @param network? Optional token network. Defaults to CELO main network.
+ * @param features? Features of this coin. Defaults to the DEFAULT_FEATURES defined in `AccountCoin`
+ */
+export function celoToken(
+  name: string,
+  fullName: string,
+  decimalPlaces: number,
+  contractAddress: string,
+  asset: UnderlyingAsset,
+  features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
+  prefix: string = '',
+  suffix: string = name.toUpperCase(),
+  network: AccountNetwork = Networks.main.celo
+) {
+  return Object.freeze(
+    new CeloCoin({
+      name,
+      fullName,
+      network,
+      contractAddress,
+      prefix,
+      suffix,
+      features,
+      decimalPlaces,
+      asset,
+      isToken: true,
+    })
+  );
+}
+
+/**
+ * Factory function for testnet celo token instances.
+ *
+ * @param name unique identifier of the token
+ * @param fullName Complete human-readable name of the token
+ * @param decimalPlaces Number of decimal places this token supports (divisibility exponent)
+ * @param contractAddress Contract address of this token
+ * @param asset Asset which this coin represents. This is the same for both mainnet and testnet variants of a coin.
+ * @param prefix? Optional token prefix. Defaults to empty string
+ * @param suffix? Optional token suffix. Defaults to token name.
+ * @param network? Optional token network. Defaults to the testnet CELO network.
+ * @param features? Features of this coin. Defaults to the DEFAULT_FEATURES defined in `AccountCoin`
+ */
+export function tceloToken(
+  name: string,
+  fullName: string,
+  decimalPlaces: number,
+  contractAddress: string,
+  asset: UnderlyingAsset,
+  features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
+  prefix: string = '',
+  suffix: string = name.toUpperCase(),
+  network: AccountNetwork = Networks.test.celo
+) {
+  return celoToken(name, fullName, decimalPlaces, contractAddress, asset, features, prefix, suffix, network);
 }
 
 /**

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -214,6 +214,7 @@ export const enum UnderlyingAsset {
   CRPT = 'crpt',
   CSLV = 'cslv',
   CSP = 'csp',
+  CUSD = 'cusd',
   CUSDC = 'cusdc',
   CWBTC = 'cwbtc',
   CVC = 'cvc',

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -1,4 +1,4 @@
-import { account, AccountCoin, erc20, terc20, stellarToken, tstellarToken } from './account';
+import { account, AccountCoin, celoToken, tceloToken, erc20, terc20, stellarToken, tstellarToken } from './account';
 import { CoinFeature, CoinKind, UnderlyingAsset } from './base';
 import { CoinMap } from './map';
 import { Networks } from './networks';
@@ -351,6 +351,7 @@ export const coins = CoinMap.fromCoins([
   erc20('zmt', 'Zipmex Token', 18, '0xaa602de53347579f86b996d2add74bb6f79462b2', UnderlyingAsset.ZMT),
   erc20('zoom', 'CoinZoom', 18, '0x69cf3091c91eb72db05e45c76e58225177dea742', UnderlyingAsset.ZOOM),
   erc20('zrx', '0x Token', 18, '0xe41d2489571d322189246dafa5ebde1f4699f498', UnderlyingAsset.ZRX),
+  celoToken('cusd', 'Celo USD', 18, '0x765de816845861e75a25fca122bb6898b8b1282a', UnderlyingAsset.CUSD),
   stellarToken(
     'xlm:BST-GADDFE4R72YUP2AOEL67OHZN3GJQYPC3VE734N2XFMEGRR2L32CZ3XYZ',
     'BitGo Shield Token',
@@ -418,6 +419,7 @@ export const coins = CoinMap.fromCoins([
   terc20('tcat', 'Test CAT-20 Token', 18, '0x63137319f3a14a985eb31547370e0e3bd39b03b8', UnderlyingAsset.CAT),
   terc20('tfmf', 'Test Formosa Financial Token', 18, '0xd8463d2f8c5b3be9de95c63b73a0ae4c79423452', UnderlyingAsset.FMF),
   terc20('terc20', 'Test ERC20 Token', 18, '0x731a10897d267e19b34503ad902d0a29173ba4b1', UnderlyingAsset.TERC20),
+  tceloToken('tcusd', 'Test Celo USD Token', 18, '0xa561131a1c8ac25925fb848bca45a74af61e5a38', UnderlyingAsset.CUSD),
   tstellarToken(
     'txlm:BST-GBQTIOS3XGHB7LVYGBKQVJGCZ3R4JL5E4CBSWJ5ALIJUHBKS6263644L',
     'BitGo Shield Token',


### PR DESCRIPTION
The CELO blockchain supports the ERC20 standard and thus has various
ERC20 tokens just like Ethereum. This commit adds a new factory builder
for those tokens, and adds our first one -- the celoUSD token, which
comes by pre-compiled with the blockchain.

Ticket: BG-21618