### PR TITLE
Expose CeloCoin from @bitgo/statics

### DIFF
--- a/modules/statics/src/index.ts
+++ b/modules/statics/src/index.ts
@@ -4,5 +4,5 @@ export * from './networks';
 export * from './errors';
 export { OfcCoin } from './ofc';
 export { UtxoCoin } from './utxo';
-export { AccountCoin, Erc20Coin, StellarCoin } from './account';
+export { AccountCoin, CeloCoin, Erc20Coin, StellarCoin } from './account';
 export { CoinMap } from './map';


### PR DESCRIPTION
Other libraries need to be able to compare statics `Coin` objects with
the type of coin that they are an instance of. This commit exposes
`CeloCoin` so that this functionality is available

Ticket: BG-21696