### PR TITLE
Implement sign and explain for ETH-like coins

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -47,8 +47,8 @@
     "gen-docs": "typedoc"
   },
   "dependencies": {
-    "@bitgo/account-lib": "^1.3.0",
     "@bitgo/statics": "^4.3.0-rc.0",
+    "@bitgo/account-lib": "^1.5.0",
     "@bitgo/unspents": "^0.6.0",
     "@types/bluebird": "^3.5.25",
     "@types/superagent": "^4.1.3",


### PR DESCRIPTION
This commit adds an implementation of signTransaction and
explainTransaction for ETH-like coins relying heavily on logic in
bitgo-account-lib. The transaction explanation logic in
bitgo-account-lib is not fully finished yet, but that doesn't block an
initial implementation here -- when that is updated, we can simply add
a new change with the new verion of the library and extend our tests to
cover the newly explained fields.

This commit also bumps the version of dependency @bitgo/account-lib to
include new fixes required for signing transactions

Ticket: BG-22079