### PR TITLE
Key generation enforcement and key curve into statics

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@bitgo/account-lib": "^1.3.0",
-    "@bitgo/statics": "^4.2.0",
+    "@bitgo/statics": "^4.3.0-rc.0",
     "@bitgo/unspents": "^0.6.0",
     "@types/bluebird": "^3.5.25",
     "@types/superagent": "^4.1.3",

--- a/modules/core/src/v2/coins/xtz.ts
+++ b/modules/core/src/v2/coins/xtz.ts
@@ -120,9 +120,14 @@ export class Xtz extends BaseCoin {
   generateKeyPair(seed?: Buffer): KeyPair {
     const keyPair = seed ? new bitgoAccountLib.Xtz.KeyPair({ seed }) : new bitgoAccountLib.Xtz.KeyPair();
     const keys = keyPair.getExtendedKeys();
+
+    if (!keys.xprv) {
+      throw new Error('Missing xprv in key generation.');
+    }
+
     return {
       pub: keys.xpub,
-      prv: keys.xprv!,
+      prv: keys.xprv,
     };
   }
 

--- a/modules/core/src/v2/coins/xtz.ts
+++ b/modules/core/src/v2/coins/xtz.ts
@@ -112,17 +112,17 @@ export class Xtz extends BaseCoin {
   }
 
   /**
-   * Generate Tezos key pair
+   * Generate Tezos key pair - BitGo xpub format
    *
    * @param seed
-   * @returns {Object} object with generated pub, prv
+   * @returns {Object} object with generated xpub, xprv
    */
   generateKeyPair(seed?: Buffer): KeyPair {
     const keyPair = seed ? new bitgoAccountLib.Xtz.KeyPair({ seed }) : new bitgoAccountLib.Xtz.KeyPair();
-    const keys = keyPair.getKeys();
+    const keys = keyPair.getExtendedKeys();
     return {
-      pub: keys.pub,
-      prv: keys.prv!,
+      pub: keys.xpub,
+      prv: keys.xprv!,
     };
   }
 

--- a/modules/core/test/v2/unit/coins/xtz.ts
+++ b/modules/core/test/v2/unit/coins/xtz.ts
@@ -130,8 +130,8 @@ describe('Tezos:', function() {
       const seedText = '80350b4208d381fbfe2276a326603049fe500731c46d3c9936b5ce036b51377f24bab7dd0c2af7f107416ef858ff79b0670c72406dad064e72bb17fc0a9038bb';
       const seed = Buffer.from(seedText, 'hex');
       const keyPair = basecoin.generateKeyPair(seed);
-      keyPair.pub.should.equal('sppk7bJUTTikwyNHT5n8ehzgSjgCou53Wmm1z81p6JvNTQ5oUuWEW8o');
-      keyPair.prv.should.equal('spsk1fKc5fEaM7ns4JkmozPU9QCkXUHHLj48Wyiap2PvewMo595e9X');
+      keyPair.pub.should.equal('xpub661MyMwAqRbcFAwqvSGbk35kJf7CQqdN1w4CMUBBTqH5e3ivjU6D8ugv9hRSgRbRenC4w3ahXdLVahwjgjXhSuQKMdNdn55Y9TNSagBktws');
+      keyPair.prv.should.equal('xprv9s21ZrQH143K2gsNpQjbNu91kdGi1NuWei8bZ5mZuVk6mFPnBvmxb7NSJQdbZW3FGpK3Ycn7jorAXcEzMvviGtbyBz5tBrjfnWyQp3g75FK');
     });
   });
 

--- a/modules/core/test/v2/unit/keychains.ts
+++ b/modules/core/test/v2/unit/keychains.ts
@@ -9,7 +9,7 @@ import * as common from '../../../src/common';
 import * as _ from 'lodash';
 import * as sinon from 'sinon';
 import {TestBitGo} from '../../lib/test_bitgo';
-import {CoinKind, coins, SupportedKeyCurve, CoinFamily, UnderlyingAsset} from '@bitgo/statics';
+import {CoinKind, coins, KeyCurve, CoinFamily, UnderlyingAsset} from '@bitgo/statics';
 
 const co = Promise.coroutine;
 
@@ -50,7 +50,7 @@ describe('V2 Keychains', function v2keychains() {
   describe('Key generation enforcement for SECP256K1', function() {
     // iterate over non-fiat crypto secp coins
     const coinFamilyValues = Object.keys(CoinFamily).map(n => n.toLowerCase());
-    const cryptoSecpCoins = coins.filter(n => n.primaryKeyCurve === SupportedKeyCurve.Secp256k1
+    const cryptoSecpCoins = coins.filter(n => n.primaryKeyCurve === KeyCurve.Secp256k1
       && n.kind === CoinKind.CRYPTO
       && n.asset !== UnderlyingAsset.USD
       && coinFamilyValues.includes(n.name));

--- a/modules/core/test/v2/unit/keychains.ts
+++ b/modules/core/test/v2/unit/keychains.ts
@@ -2,14 +2,16 @@
 // Test for Keychains
 //
 
-import 'should';
+import * as should from 'should';
 import * as Promise from 'bluebird';
-const co = Promise.coroutine;
 import * as nock from 'nock';
 import * as common from '../../../src/common';
 import * as _ from 'lodash';
 import * as sinon from 'sinon';
-import { TestBitGo } from '../../lib/test_bitgo';
+import {TestBitGo} from '../../lib/test_bitgo';
+import {CoinKind, coins, SupportedKeyCurve, CoinFamily, UnderlyingAsset} from '@bitgo/statics';
+
+const co = Promise.coroutine;
 
 describe('V2 Keychains', function v2keychains() {
   let bitgo;
@@ -38,6 +40,38 @@ describe('V2 Keychains', function v2keychains() {
       .reply(200, {});
       yield keychains.add({ pub: 'pub', derivedFromParentWithSeed: 'derivedFromParentWithSeed' });
     }));
+  });
+
+  /**
+   * This section's intention is to provide some key generation sanity checking. generateKeyPair is a general surface
+   * for key generation but the keys are treated the same by BitGo down the line. Any SECP256K1 based coins key-pairs can
+   * be re-used so need to be the same.
+   **/
+  describe('Key generation enforcement for SECP256K1', function() {
+    // iterate over non-fiat crypto secp coins
+    const coinFamilyValues = Object.keys(CoinFamily).map(n => n.toLowerCase());
+    const cryptoSecpCoins = coins.filter(n => n.primaryKeyCurve === SupportedKeyCurve.Secp256k1
+      && n.kind === CoinKind.CRYPTO
+      && n.asset !== UnderlyingAsset.USD
+      && coinFamilyValues.includes(n.name));
+
+    const expectedXpub = 'xpub661MyMwAqRbcGpZf8mxNWhSPdWaLGvQzzage6vq2oQFzq8toVzmkjygYZ3HcZw6eCzAfn9ZdyGjKoKkcpKwackdgznVbiunpq7rkxDu7quS';
+    const expectedXprv = 'xprv9s21ZrQH143K4LVC2kRN9ZVf5UjqsTh9dMm3JYRRF4j1xLZexTTWCBN4hmdZUHeT3vCJPL181ErVaY489ArBKSWaB7Du7vyVS6XC43WtK7A';
+
+    const seed = Buffer.from('this is some random seed we will use', 'utf-8');
+
+    it('should create the same key with the same seed', function() {
+      cryptoSecpCoins.forEach(function(coinName) {
+        const currentCoin = bitgo.coin(coinName.name);
+        const keyPair = currentCoin.generateKeyPair(seed);
+
+        should.exist(keyPair.pub);
+        should.exist(keyPair.prv);
+
+        keyPair.pub.should.equal(expectedXpub);
+        keyPair.prv.should.equal(expectedXprv);
+      });
+    });
   });
 
   describe('Update Password', function updatePassword() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -131,6 +131,9 @@
     protobufjs "^6.8.9"
     tronweb "^2.7.2"
 
+"@bitgo/statics@../statics":
+  version "0.0.0"
+
 "@bitgo/unspents@^0.6.0":
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/@bitgo/unspents/-/unspents-0.6.2.tgz#e89ff8d4e19d68253e1dc99fec2bb30192054390"

--- a/yarn.lock
+++ b/yarn.lock
@@ -131,6 +131,11 @@
     protobufjs "^6.8.9"
     tronweb "^2.7.2"
 
+"@bitgo/statics@^4.3.0-rc.0":
+  version "4.3.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@bitgo/statics/-/statics-4.3.0-rc.0.tgz#25d483f35478aa43a190d6cab82e7443671ef3a1"
+  integrity sha512-ist0joVFxLio3JKRsKTWViqZh+DR59nZFQUbaNo9BCn7jiHtDiR4Z3j08XljC6PDtZE9VoHVKey2WZHyGcqvYw==
+
 "@bitgo/unspents@^0.6.0":
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/@bitgo/unspents/-/unspents-0.6.2.tgz#e89ff8d4e19d68253e1dc99fec2bb30192054390"

--- a/yarn.lock
+++ b/yarn.lock
@@ -131,9 +131,6 @@
     protobufjs "^6.8.9"
     tronweb "^2.7.2"
 
-"@bitgo/statics@../statics":
-  version "0.0.0"
-
 "@bitgo/unspents@^0.6.0":
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/@bitgo/unspents/-/unspents-0.6.2.tgz#e89ff8d4e19d68253e1dc99fec2bb30192054390"


### PR DESCRIPTION
SECP key generation needs to be enforced uniformly for offline signing
and UI applications. This adds a Key curve feature to statics to help
with this aspect of testing.

Ticket: BG-22126