### PR TITLE
BG-22155 Add API Key as a parameter

### DIFF
--- a/modules/core/src/bitgo.ts
+++ b/modules/core/src/bitgo.ts
@@ -156,6 +156,7 @@ export interface BitGoOptions {
   refreshToken?: string;
   validate?: boolean;
   proxy?: string;
+  etherscanApiToken?: string;
 }
 
 export interface User {
@@ -493,6 +494,10 @@ export class BitGo {
       this._baseUrl = common.Environments[env].uri;
     }
     this._env = this.env = env;
+
+    if (params.etherscanApiToken) {
+      common.Environments[env].etherscanApiToken = params.etherscanApiToken;
+    }
 
     common.setNetwork(common.Environments[env].network);
     common.setRmgNetwork(common.Environments[env].rmgNetwork);

--- a/modules/core/src/v2/coins/eth.ts
+++ b/modules/core/src/v2/coins/eth.ts
@@ -1105,6 +1105,9 @@ export class Eth extends BaseCoin {
   recoveryBlockchainExplorerQuery(query: any, callback?: NodeCallback<any>): Bluebird<any> {
     const self = this;
     return co(function*() {
+      if (common.Environments[self.bitgo.getEnv()].etherscanApiToken) {
+        query.apikey = common.Environments[self.bitgo.getEnv()].etherscanApiToken;
+      }
       const response = yield request
         .get(common.Environments[self.bitgo.getEnv()].etherscanBaseUrl + '/api')
         .query(query);

--- a/modules/core/src/v2/environments.ts
+++ b/modules/core/src/v2/environments.ts
@@ -20,6 +20,7 @@ interface EnvironmentTemplate {
   bsvExplorerBaseUrl?: string;
   btgExplorerBaseUrl?: string;
   etherscanBaseUrl: string;
+  etherscanApiToken?: string;
   ltcExplorerBaseUrl: string;
   zecExplorerBaseUrl: string;
   dashExplorerBaseUrl: string;
@@ -94,6 +95,7 @@ const mainnetBase: EnvironmentTemplate = {
   bchExplorerBaseUrl: 'https://blockdozer.com/insight-api',
   btgExplorerBaseUrl: 'https://btgexplorer.com/api',
   etherscanBaseUrl: 'https://api.etherscan.io',
+  etherscanApiToken: process.env.ETHERSCAN_API_TOKEN,
   ltcExplorerBaseUrl: 'https://insight.litecore.io/api',
   zecExplorerBaseUrl: 'https://zcashnetwork.info/api',
   dashExplorerBaseUrl: 'https://insight.dash.org/insight-api',
@@ -116,6 +118,7 @@ const testnetBase: EnvironmentTemplate = {
   smartBitApiBaseUrl: 'https://testnet-api.smartbit.com.au/v1',
   bchExplorerBaseUrl: 'https://test-bch-insight.bitpay.com/api',
   etherscanBaseUrl: 'https://kovan.etherscan.io',
+  etherscanApiToken: process.env.ETHERSCAN_API_TOKEN,
   ltcExplorerBaseUrl: 'http://explorer.litecointools.com/api',
   zecExplorerBaseUrl: 'https://explorer.testnet.z.cash/api',
   dashExplorerBaseUrl: 'https://testnet-insight.dashevo.org/insight-api',
@@ -169,6 +172,7 @@ export const Environments: Environments = {
     bchExplorerBaseUrl: 'https://test-bch-insight.bitpay.fakeurl/api',
     stellarFederationServerUrl: 'https://bitgo.fakeurl/api/v2/txlm/federation',
     etherscanBaseUrl: 'https://kovan.etherscan.fakeurl',
+    etherscanApiToken: process.env.ETHERSCAN_API_TOKEN,
     ltcExplorerBaseUrl: 'http://explorer.litecointools.fakeurl/api',
     zecExplorerBaseUrl: 'https://explorer.testnet.z.fakeurl/api',
     dashExplorerBaseUrl: 'https://testnet-insight.dashevo.fakeurl/insight-api',

--- a/modules/core/test/lib/test_bitgo.ts
+++ b/modules/core/test/lib/test_bitgo.ts
@@ -15,6 +15,7 @@ import 'should';
 import 'should-http';
 
 import * as nock from 'nock';
+import * as common from '../../src/common';
 nock.enableNetConnect();
 
 try {
@@ -430,16 +431,21 @@ BitGo.prototype.nockEthWallet = function() {
     encryptedPrv: '{"iv":"15FsbDVI1zG9OggD8YX+Hg==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"hHbNH3Sz/aU=","ct":"WoNVKz7afiRxXI2w/YkzMdMyoQg/B15u1Q8aQgi96jJZ9wk6TIaSEc6bXFH3AHzD9MdJCWJQUpRhoQc/rgytcn69scPTjKeeyVMElGCxZdFVS/psQcNE+lue3//2Zlxj+6t1NkvYO+8yAezSMRBK5OdftXEjNQI="}'
   });
 
-  // Nock tokens stuck on the wallet
-  nock('https://kovan.etherscan.io')
-  .get('/api')
-  .query({
+  const params: any = {
     module: 'account',
     action: 'tokenbalance',
     contractaddress: BitGo.V2.TEST_ERC20_TOKEN_ADDRESS,
     address: BitGo.V2.TEST_ETH_WALLET_FIRST_ADDRESS,
-    tag: 'latest'
-  })
+    tag: 'latest',
+  };
+  if (common.Environments[this.getEnv()].etherscanApiToken) {
+    params.apikey = common.Environments[this.getEnv()].etherscanApiToken;
+  }
+
+  // Nock tokens stuck on the wallet
+  nock('https://kovan.etherscan.io')
+  .get('/api')
+  .query(params)
   .reply(200, { status: '1', message: 'OK', result: '2400' });
 
   return wallet;

--- a/modules/core/test/v2/lib/recovery-nocks.ts
+++ b/modules/core/test/v2/lib/recovery-nocks.ts
@@ -1769,109 +1769,134 @@ module.exports.nockWrongChainRecoveries = function(bitgo) {
     ]);
 };
 
-module.exports.nockEthRecovery = function() {
-  nock('https://kovan.etherscan.io')
-    .get('/api')
-    .query({
-      module: 'account',
-      action: 'txlist',
-      address: '0x74c2137d54b0fc9f907e13f14e0dd18485fee924',
-    })
-    .reply(200, {
-      status: '0',
-      message: 'No transactions found',
-      result: [],
-    })
-    .get('/api')
-    .query({
-      module: 'account',
-      action: 'balance',
-      address: '0x74c2137d54b0fc9f907e13f14e0dd18485fee924',
-    })
-    .reply(200, {
-      status: '1',
-      message: 'OK',
-      result: '100000000000000000',
-    })
-    .get('/api')
-    .query({
-      module: 'account',
-      action: 'balance',
-      address: '0x5df5a96b478bb1808140d87072143e60262e8670',
-    })
-    .reply(200, {
-      status: '1',
-      message: 'OK',
-      result: '2200000000000000000',
-    })
-    .get('/api')
-    .query({
-      module: 'account',
-      action: 'txlist',
-      address: '0xba6d9d82cf2920c544b834b72f4c6d11a3ef3de6',
-    })
-    .reply(200, {
-      status: '0',
-      message: 'No transactions found',
-      result: [],
-    })
-    .get('/api')
-    .query({
-      module: 'account',
-      action: 'balance',
-      address: '0xba6d9d82cf2920c544b834b72f4c6d11a3ef3de6',
-    })
-    .reply(200, {
-      status: '1',
-      message: 'OK',
-      result: '0',
-    })
-    .get('/api')
-    .query({
-      module: 'account',
-      action: 'txlist',
-      address: '0x74c2137d54b0fc9f907e13f14e0dd18485fee924',
-    })
-    .reply(200, {
-      status: '0',
-      message: 'No transactions found',
-      result: [],
-    })
-    .get('/api')
-    .query({
-      module: 'account',
-      action: 'balance',
-      address: '0x74c2137d54b0fc9f907e13f14e0dd18485fee924',
-    })
-    .reply(200, {
-      status: '1',
-      message: 'OK',
-      result: '100000000000000000',
-    })
-    .get('/api')
-    .query({
-      module: 'account',
-      action: 'balance',
-      address: '0x5df5a96b478bb1808140d87072143e60262e8670',
-    })
-    .reply(200, {
-      status: '1',
-      message: 'OK',
-      result: '2200000000000000000',
-    })
-    .get('/api')
-    .query({
-      module: 'proxy',
-      action: 'eth_call',
-      to: '0x5df5a96b478bb1808140d87072143e60262e8670',
-      data: 'a0b7967b',
-      tag: 'latest',
-    })
-    .reply(200, {
-      jsonrpc: '2.0',
-      result: '0x0000000000000000000000000000000000000000000000000000000000000001',
-      id: 1,
-    });
+module.exports.nockEthRecovery = function(bitgo) {
+  const nockData: any[] = [
+    {
+      params: {
+        module: 'account',
+        action: 'txlist',
+        address: '0x74c2137d54b0fc9f907e13f14e0dd18485fee924',
+      },
+      response: {
+        status: '0',
+        message: 'No transactions found',
+        result: [],
+      },
+    },
+    {
+      params: {
+        module: 'account',
+        action: 'balance',
+        address: '0x74c2137d54b0fc9f907e13f14e0dd18485fee924',
+      },
+      response: {
+        status: '1',
+        message: 'OK',
+        result: '100000000000000000',
+      },
+    },
+    {
+      params: {
+        module: 'account',
+        action: 'balance',
+        address: '0x5df5a96b478bb1808140d87072143e60262e8670',
+      },
+      response: {
+        status: '1',
+        message: 'OK',
+        result: '2200000000000000000',
+      },
+    },
+    {
+      params: {
+        module: 'account',
+        action: 'txlist',
+        address: '0xba6d9d82cf2920c544b834b72f4c6d11a3ef3de6',
+      },
+      response: {
+        status: '0',
+        message: 'No transactions found',
+        result: [],
+      },
+    },
+    {
+      params: {
+        module: 'account',
+        action: 'balance',
+        address: '0xba6d9d82cf2920c544b834b72f4c6d11a3ef3de6',
+      },
+      response: {
+        status: '1',
+        message: 'OK',
+        result: '0',
+      },
+    },
+    {
+      params: {
+        module: 'account',
+        action: 'txlist',
+        address: '0x74c2137d54b0fc9f907e13f14e0dd18485fee924',
+      },
+      response: {
+        status: '0',
+        message: 'No transactions found',
+        result: [],
+      },
+    },
+    {
+      params: {
+        module: 'account',
+        action: 'balance',
+        address: '0x74c2137d54b0fc9f907e13f14e0dd18485fee924',
+      },
+      response: {
+        status: '1',
+        message: 'OK',
+        result: '100000000000000000',
+      },
+    },
+    {
+      params: {
+        module: 'account',
+        action: 'balance',
+        address: '0x5df5a96b478bb1808140d87072143e60262e8670',
+      },
+      response: {
+        status: '1',
+        message: 'OK',
+        result: '2200000000000000000',
+      },
+    },
+    {
+      params: {
+        module: 'proxy',
+        action: 'eth_call',
+        to: '0x5df5a96b478bb1808140d87072143e60262e8670',
+        data: 'a0b7967b',
+        tag: 'latest',
+      },
+      response: {
+        jsonrpc: '2.0',
+        result: '0x0000000000000000000000000000000000000000000000000000000000000001',
+        id: 1,
+      },
+    },
+  ];
+
+  let apiKey;
+  if (Environments[bitgo.getEnv()].etherscanApiToken) {
+    apiKey = Environments[bitgo.getEnv()].etherscanApiToken;
+  }
+
+  nockData.forEach(data => {
+    if (apiKey) {
+      data.params.apiKey = apiKey;
+    }
+    nock('https://kovan.etherscan.io')
+      .get('/api')
+      .query(data.params)
+      .reply(200, data.response);
+  });
 };
 
 module.exports.nockLtcRecovery = function(isKrsRecovery) {

--- a/modules/core/test/v2/unit/recovery.ts
+++ b/modules/core/test/v2/unit/recovery.ts
@@ -831,7 +831,7 @@ describe('Recovery:', function() {
 
   describe('Recover Ethereum', function() {
     it('should construct a recovery transaction without BitGo', co(function *() {
-      recoveryNocks.nockEthRecovery();
+      recoveryNocks.nockEthRecovery(bitgo);
 
       const basecoin = bitgo.coin('teth');
       const recovery = yield basecoin.recover({
@@ -855,7 +855,7 @@ describe('Recovery:', function() {
     }));
 
     it('should construct a recovery transaction without BitGo and with KRS', co(function *() {
-      recoveryNocks.nockEthRecovery();
+      recoveryNocks.nockEthRecovery(bitgo);
 
       const basecoin = bitgo.coin('teth');
       const recovery = yield basecoin.recover({
@@ -877,7 +877,7 @@ describe('Recovery:', function() {
     }));
 
     it('should error when the backup key is unfunded (cannot pay gas)', co(function *() {
-      recoveryNocks.nockEthRecovery();
+      recoveryNocks.nockEthRecovery(bitgo);
 
       const basecoin = bitgo.coin('teth');
       const error = yield bitgo.getAsyncError(basecoin.recover({


### PR DESCRIPTION
It is easier for a user to pass the API key as a method paramter than exposing it as an env variable.
Having it as an ENV variable it's still useful in test environments, so it doesn't hurt to leave it.

TICKET: BG-22155