### PR TITLE
Fix CGLD sending with xprv

### DIFF
--- a/modules/core/src/v2/coins/abstractEthLikeCoin.ts
+++ b/modules/core/src/v2/coins/abstractEthLikeCoin.ts
@@ -139,7 +139,7 @@ export abstract class AbstractEthLikeCoin extends BaseCoin {
   ): Bluebird<SignedTransaction> {
     const txBuilder = this.getTransactionBuilder();
     txBuilder.from(params.txPrebuild.txHex);
-    txBuilder.transfer().key(params.prv);
+    txBuilder.transfer().key(new Eth.KeyPair({ prv: params.prv }).getKeys().prv!);
     const transaction = await txBuilder.build();
 
     return {


### PR DESCRIPTION
This commit fixes CGLD sending with xprvs by mapping all keys to
compressed format before signing transactions with them. After this
commit, signTransaction will work with both xprv and compressed prv
passed as the prv parameter

Ticket: BG-22282