### PR TITLE
Remove source for ETH-like transaction building

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@bitgo/statics": "^4.3.0-rc.0",
-    "@bitgo/account-lib": "^1.5.0",
+    "@bitgo/account-lib": "^1.6.0",
     "@bitgo/unspents": "^0.6.0",
     "@types/bluebird": "^3.5.25",
     "@types/superagent": "^4.1.3",

--- a/modules/core/src/v2/coins/abstractEthLikeCoin.ts
+++ b/modules/core/src/v2/coins/abstractEthLikeCoin.ts
@@ -60,8 +60,6 @@ export interface ExplainTransactionOptions {
   feeInfo: TransactionFee;
 }
 
-const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
-
 export abstract class AbstractEthLikeCoin extends BaseCoin {
   protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
 
@@ -223,13 +221,6 @@ export abstract class AbstractEthLikeCoin extends BaseCoin {
    * @return a new transaction builder
    */
   private getTransactionBuilder(): Eth.TransactionBuilder {
-    const txBuilder: Eth.TransactionBuilder = getBuilder(this.getChain()) as Eth.TransactionBuilder;
-
-    // @bitgo/account-lib requires something to be set here,
-    // though it doesn't do anything except when signing the external transaction
-    // TODO: Remove when bug in account lib requiring this field is fixed
-    txBuilder.source(NULL_ADDRESS);
-
-    return txBuilder;
+    return getBuilder(this.getChain()) as Eth.TransactionBuilder;
   }
 }

--- a/modules/core/test/v2/unit/coins/abstractEthCoin.ts
+++ b/modules/core/test/v2/unit/coins/abstractEthCoin.ts
@@ -39,7 +39,6 @@ describe('ETH-like coins', () => {
       /**
        * Build an unsigned account-lib multi-signature send transactino
        * @param destination The destination address of the transaction
-       * @param source The sending address of the transactino
        * @param contractAddress The address of the smart contract processing the transaction
        * @param contractSequenceId The sequence id of the contract
        * @param nonce The nonce of the sending address
@@ -50,7 +49,6 @@ describe('ETH-like coins', () => {
        */
       const buildUnsignedTransaction = async function({
         destination,
-        source,
         contractAddress,
         contractSequenceId = 1,
         nonce = 0,
@@ -61,12 +59,10 @@ describe('ETH-like coins', () => {
       }) {
         const txBuilder: Eth.TransactionBuilder = getBuilder(coinName) as Eth.TransactionBuilder;
         txBuilder.type(BaseCoin.TransactionType.Send);
-        txBuilder.chainId(1);
         txBuilder.fee({
           fee: gasPrice,
           gasLimit: gasLimit,
         });
-        txBuilder.source(source);
         txBuilder.counter(nonce);
         txBuilder.contract(contractAddress);
         txBuilder
@@ -182,7 +178,6 @@ describe('ETH-like coins', () => {
             amount,
             expireTime: inputExpireTime,
             contractSequenceId: inputSequenceId,
-            source: key.getAddress(),
           });
 
           const tx = await basecoin.signTransaction({
@@ -232,7 +227,6 @@ describe('ETH-like coins', () => {
             amount,
             expireTime: inputExpireTime,
             contractSequenceId: inputSequenceId,
-            source: key.getAddress(),
           });
 
           const tx = await basecoin.signTransaction({
@@ -301,7 +295,6 @@ describe('ETH-like coins', () => {
           const unsignedTransaction = await buildUnsignedTransaction({
             destination,
             contractAddress,
-            source: key.getAddress(),
           });
 
           const explainParams = {
@@ -323,7 +316,6 @@ describe('ETH-like coins', () => {
           const unsignedTransaction = await buildUnsignedTransaction({
             destination,
             contractAddress,
-            source: key.getAddress(),
           });
 
           const signedTx = await basecoin.signTransaction({


### PR DESCRIPTION
This commit updates to the latest version of Bitgo-account-lib and
removes an unnecessary field that we had to set for every transaction
built for ETHlike coins

Ticket: BG-22391