### PR TITLE
Make CELO not a "token"

### DIFF
--- a/modules/statics/src/account.ts
+++ b/modules/statics/src/account.ts
@@ -66,7 +66,6 @@ export class AccountCoinToken extends AccountCoin {
   constructor(options: AccountConstructorOptions) {
     super({
       ...options,
-      isToken: true,
     });
   }
 }
@@ -101,7 +100,15 @@ export class Erc20Coin extends ContractAddressDefinedToken {}
 /**
  * Some blockchains have native coins which also support the ERC20 interface such as CGLD.
  */
-export class Erc20CompatibleAccountCoin extends ContractAddressDefinedToken {}
+export class Erc20CompatibleAccountCoin extends ContractAddressDefinedToken {
+  constructor(options: Erc20ConstructorOptions) {
+    super({
+      ...options,
+      // These coins should not be classified as tokens as they are not children of other coins
+      isToken: false,
+    });
+  }
+}
 
 /**
  * The CELO blockchain supports tokens of the ERC20 standard similar to ETH ERC20 tokens.
@@ -280,7 +287,7 @@ export function erc20CompatibleAccountCoin(
       features,
       decimalPlaces,
       asset,
-      isToken: true,
+      isToken: false,
       primaryKeyCurve,
     })
   );


### PR DESCRIPTION
CELO is a weird edge case in that it is both the native coin on its
chain and follows the ERC20 token interface. Thus we had to make a new
class for it to illustrate that. However, the coin should not be
specified as a "token" as that causes some components to fail, as they
assume that all "token"s as children of another coin and thus should not
be displayed as first class citizens. This commit changes CELO to not be
considered a token in this way

Ticket: BG-22435