### PR TITLE
Update @bitgo/account-lib to 1.7.0

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@bitgo/statics": "^4.3.0-rc.0",
-    "@bitgo/account-lib": "^1.6.0",
+    "@bitgo/account-lib": "^1.7.0",
     "@bitgo/unspents": "^0.6.0",
     "@types/bluebird": "^3.5.25",
     "@types/superagent": "^4.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -108,12 +108,12 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@bitgo/account-lib@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@bitgo/account-lib/-/account-lib-1.3.0.tgz#fc2f2bbdc97ecfa1cb8e73e23fc8b0261d22595b"
-  integrity sha512-sYEjJLOD0K0VQMbBY57l0fD+7bc9SghPdturYKAgAZD1WNpHHYImpbzqyJ0zF7NGBZyVd/dbPHaU/WjFAfwe1w==
+"@bitgo/account-lib@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@bitgo/account-lib/-/account-lib-1.7.0.tgz#7378add541464bcd4398003a1f3a5199e692d3df"
+  integrity sha512-GoW1NfcJGNZLj5LP65p2afJ61TkeuXjyIvEGjbItV5YvlnUrnDmXUmW3cI+D6IU7GDYGKdMG7uvooPyAVxs1XQ==
   dependencies:
-    "@bitgo/statics" "^4.1.0-rc.2"
+    "@bitgo/statics" "^4.3.0-rc.2"
     "@celo/contractkit" "0.3.1"
     "@taquito/local-forging" "^6.0.3-beta.0"
     "@taquito/signer" "^6.0.3-beta.0"
@@ -135,6 +135,11 @@
   version "4.3.0-rc.0"
   resolved "https://registry.yarnpkg.com/@bitgo/statics/-/statics-4.3.0-rc.0.tgz#25d483f35478aa43a190d6cab82e7443671ef3a1"
   integrity sha512-ist0joVFxLio3JKRsKTWViqZh+DR59nZFQUbaNo9BCn7jiHtDiR4Z3j08XljC6PDtZE9VoHVKey2WZHyGcqvYw==
+
+"@bitgo/statics@^4.3.0-rc.2":
+  version "4.3.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@bitgo/statics/-/statics-4.3.0-rc.5.tgz#81a58495055d0d5b24bdac5d62c6311897b27f38"
+  integrity sha512-CSci4mfHQoTeDXJVzdNd2uB7bDIreA20zJR+qMzOWvYTdkyyRDoFMe37F3G1EBdhgdewfJhs5xEbKyii3bh9eQ==
 
 "@bitgo/unspents@^0.6.0":
   version "0.6.2"
@@ -2405,7 +2410,6 @@ bl@^1.0.0:
 
 "blake2b@https://github.com/BitGo/blake2b#6268e6dd678661e0acc4359e9171b97eb1ebf8ac":
   version "2.1.3"
-  uid "6268e6dd678661e0acc4359e9171b97eb1ebf8ac"
   resolved "https://github.com/BitGo/blake2b#6268e6dd678661e0acc4359e9171b97eb1ebf8ac"
   dependencies:
     blake2b-wasm "https://github.com/BitGo/blake2b-wasm#193cdb71656c1a6c7f89b05d0327bb9b758d071b"


### PR DESCRIPTION
This commit updates @bitgo/account-lib to 1.7.0 to pull in an important
security fix for CELO, ETC and RSK

Ticket: BG-22449