### PR TITLE
Improve failing test for testnet tokens

### DIFF
--- a/modules/core/test/unit/bitgo.ts
+++ b/modules/core/test/unit/bitgo.ts
@@ -459,11 +459,8 @@ describe('BitGo Prototype Methods', function() {
     it('Should return a non-empty list of tokens before the server responds', co(function *coTokenDefinitionsIt() {
       const bitgo = new TestBitGo({ env: 'mock' });
       bitgo.initializeTestVars();
-      const tokens = bitgo.getConstants().eth.tokens;
-
-      // currently seven tokens are defined for non-production environments
-      should.exist(tokens);
-      tokens.length.should.equal(7);
+      const constants = bitgo.getConstants();
+      constants.should.have.propertyByPath('eth', 'tokens', 'length').greaterThan(0);
     }));
 
     after(function tokenDefinitionsAfter() {


### PR DESCRIPTION
We added a new testnet token to statics, and this is causing a unit test
to fail in modules/core. Instead of asserting the exact number of
testnet tokens, let's just make sure the property exists and has a
length greater than zero.

Ticket: BG-22644