### PR TITLE
Fix CELO receive address generation

### DIFF
--- a/modules/core/src/v2/baseCoin.ts
+++ b/modules/core/src/v2/baseCoin.ts
@@ -54,6 +54,7 @@ export interface VerifyAddressOptions {
   keychains?: {
     pub: string;
   }[];
+  error?: string;
   coinSpecific?: AddressCoinSpecific;
 }
 
@@ -159,6 +160,7 @@ export interface AddressCoinSpecific {
   redeemScript?: string;
   witnessScript?: string;
   baseAddress?: string;
+  pendingChainInitialization?: boolean;
 }
 
 export interface FullySignedTransaction {

--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -10,7 +10,7 @@ import { AddressGenerationError } from '../errors';
 import {
   BaseCoin,
   SignedTransaction, TransactionPrebuild,
-  VerificationOptions,
+  VerificationOptions, VerifyAddressOptions,
 } from './baseCoin';
 import { AbstractUtxoCoin } from './coins/abstractUtxoCoin';
 import { Eth } from './coins';
@@ -1262,13 +1262,16 @@ export class Wallet {
         }
 
         newAddress.keychains = keychains;
-        const verificationData = _.merge({}, newAddress, { rootAddress });
+        const verificationData: VerifyAddressOptions = _.merge({}, newAddress, { rootAddress });
 
         if (verificationData.error) {
           throw new AddressGenerationError(verificationData.error);
         }
 
-        self.baseCoin.verifyAddress(verificationData);
+        if (verificationData.coinSpecific && !verificationData.coinSpecific.pendingChainInitialization) {
+          // can't verify addresses which are pending chain initialization, as the address is hidden
+          self.baseCoin.verifyAddress(verificationData);
+        }
 
         return newAddress;
       }).bind(this));

--- a/modules/core/test/v2/unit/coins/abstractEthCoin.ts
+++ b/modules/core/test/v2/unit/coins/abstractEthCoin.ts
@@ -147,6 +147,20 @@ describe('ETH-like coins', () => {
           basecoin.isValidAddress('not an address').should.equal(false);
           basecoin.isValidAddress('3KgL6DTUb6gEoqSwMMJzyf96ekH8oZtWtZ').should.equal(false);
         });
+
+        it('Should not throw when verifying valid addresses', () => {
+          basecoin.verifyAddress({ address: '0x2af9152fc4afd89a8124731bdfb8710c8751f3ed' }).should.equal(true);
+          basecoin.verifyAddress({ address: '0x2af9152FC4afd89A8124731BdFb8710c8751f3eD' }).should.equal(true);
+        });
+
+        it('Should throw when verifying invalid addresses', () => {
+          should.throws(() => basecoin.verifyAddress({ address: '0x2af9152fc4afd89a8124731bdfb8710c8751f3edd' }));
+          should.throws(() => basecoin.verifyAddress({ address: '0x2af9152fc4afd89a8124731bdfb8710c8751f3e' }));
+          should.throws(() => basecoin.verifyAddress({ address: '2af9152fc4afd89a8124731bdfb8710c8751f3ed' }));
+          should.throws(() => basecoin.verifyAddress({ address: 'notanaddress' }));
+          should.throws(() => basecoin.verifyAddress({ address: 'not an address' }));
+          should.throws(() => basecoin.verifyAddress({ address: '3KgL6DTUb6gEoqSwMMJzyf96ekH8oZtWtZ' }));
+        });
       });
 
       describe('Is valid pub', () => {


### PR DESCRIPTION
When CELO addresses are generated, it throws a validation error but
still actually generates the address. This is because it tries to
"verify" the address, but since it is pending chain initialization the
address is not there yet. This commit changes the verifyAddress function
to only verify addresses that are not pending chain initialization.

Ticket: BG-22647

https://bitgoinc.atlassian.net/browse/BG-22647