### PR TITLE
Add internal publish step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -84,6 +84,44 @@ trigger:
 
 ---
 kind: pipeline
+name: internal publish (node:10)
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: build information
+  image: node:10
+  commands:
+  - node --version
+  - npm --version
+  - yarn --version
+  - git --version
+
+- name: install
+  image: node:10
+  commands:
+  - git fetch origin +refs/heads/$DRONE_REPO_BRANCH:$DRONE_REPO_BRANCH || true
+  - yarn install
+
+- name: lerna publish
+  image: node:10
+  commands:
+  - npm config set unsafe-perm true
+  - yarn run internal-publish
+  environment:
+    NPM_CONFIG_TOKEN:
+      from_secret: npm_config_token
+
+trigger:
+  branch:
+  - master
+  event:
+  - push
+
+---
+kind: pipeline
 name: unit tests (node:8)
 
 platform:

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "upload-docs": "lerna run upload-docs --stream --parallel",
     "gen-docs": "lerna run gen-docs --stream --parallel",
     "check-fmt-changed": "lerna run check-fmt --since ${DRONE_REPO_BRANCH:-master}^..${DRONE_COMMIT:-HEAD} --stream --parallel",
-    "check-fmt": "lerna run check-fmt --stream --parallel"
+    "check-fmt": "lerna run check-fmt --stream --parallel",
+    "internal-publish": "lerna publish --canary -y --registry https://npm.bitgo.com"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This commit adds a step to publish a canary to a npm proxy repository
upon merging in order to get quick access to integrate with new versions
of packages in this repository

Ticket: BG-22965