### PR TITLE
BG-22526 Update bitcoin explorer

### DIFF
--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -109,13 +109,13 @@ class AlgorandTestnet extends Testnet implements AccountNetwork {
 
 class Bitcoin extends BitcoinLikeMainnet {
   family = CoinFamily.BTC;
-  explorerUrl = 'https://smartbit.com.au/tx/';
+  explorerUrl = 'https://blockstream.info/tx/';
   bech32 = 'bc';
 }
 
 class BitcoinTestnet extends BitcoinLikeTestnet {
   family = CoinFamily.BTC;
-  explorerUrl = 'https://testnet.smartbit.com.au/tx/';
+  explorerUrl = 'https://blockstream.info/testnet/tx/';
   bech32 = 'tb';
 }
 


### PR DESCRIPTION
Smartbit doesn't work for testnet anymore so I'm updating the testnet explorer. We should probably update the mainnet one too to match.

Thoughts?

TICKET: BG-22526