### PR TITLE
Add ETH features to CELO

### DIFF
--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -60,7 +60,8 @@ export const coins = CoinMap.fromCoins([
     Networks.main.celo,
     18,
     '0x471ece3750da237f93b8e339c536989b8978a438',
-    UnderlyingAsset.CELO
+    UnderlyingAsset.CELO,
+    ETH_FEATURES
   ),
   erc20CompatibleAccountCoin(
     'tcelo',
@@ -68,7 +69,8 @@ export const coins = CoinMap.fromCoins([
     Networks.test.celo,
     18,
     '0xf194afdf50b03e69bd7d057c1aa9e10c9954e4c9',
-    UnderlyingAsset.CELO
+    UnderlyingAsset.CELO,
+    ETH_FEATURES
   ),
   hederaCoin(
     'hbar',


### PR DESCRIPTION
The CELO  statics object did not have the correct features set - this
commit sets the ETH features for the CELO coin objects

Ticket: BG-22984