### PR TITLE
Remove webhook in wallet integration test

### DIFF
--- a/modules/core/test/v2/integration/wallets.ts
+++ b/modules/core/test/v2/integration/wallets.ts
@@ -328,6 +328,13 @@ describe('V2 Wallets:', function() {
   });
 
   describe('Get Wallet', function() {
+    const webhookUrl = 'https://mockbin.org/bin/dbd0a0cd-060a-4a64-8cd8-f3113b36cb7d';
+
+    before(async function () {
+      const currentWallet = await wallets.getWallet({ id: TestBitGo.V2.TEST_WALLET1_ID });
+      await currentWallet.removeWebhook({ url: webhookUrl, type: 'transfer' });
+    });
+
     it('should get wallet', function() {
       return wallets.getWallet({ id: TestBitGo.V2.TEST_WALLET1_ID })
       .then(function(wallet) {
@@ -379,7 +386,7 @@ describe('V2 Wallets:', function() {
         webhooks.should.have.property('webhooks');
         count = webhooks.webhooks.length;
         return wallet.addWebhook({
-          url: 'https://mockbin.org/bin/dbd0a0cd-060a-4a64-8cd8-f3113b36cb7d',
+          url: webhookUrl,
           type: 'transfer'
         });
       })
@@ -402,12 +409,12 @@ describe('V2 Wallets:', function() {
       }).then(function(simulation) {
         simulation.should.have.property('webhookNotifications');
         const notification = simulation.webhookNotifications[0];
-        notification.url.should.equal('https://mockbin.org/bin/dbd0a0cd-060a-4a64-8cd8-f3113b36cb7d');
+        notification.url.should.equal(webhookUrl);
         notification.hash.should.equal('96b2376fb0ccfdbcc9472489ca3ec75df1487b08a0ea8d9d82c55da19d8cceea');
         notification.type.should.equal('transfer');
         notification.coin.should.equal('tbtc');
         return wallet.removeWebhook({
-          url: 'https://mockbin.org/bin/dbd0a0cd-060a-4a64-8cd8-f3113b36cb7d',
+          url: webhookUrl,
           type: 'transfer'
         });
       })


### PR DESCRIPTION
There is a wallet integration test that creates a new webhook and checks
that it works. However, it is stateful and if anything happens in the
middle of a test, for example it gets canceled - it's possible that the
webhook will be left in existence and all future tests will fail due to
this. To avoid this issue, this commit adds a before hook which removes
the webhook, hopefully making it self-healing

Ticket: BG-22987