### PR TITLE
Add documentation about debug namespaces

### DIFF
--- a/modules/core/README.md
+++ b/modules/core/README.md
@@ -71,6 +71,39 @@ console.dir(result);
 ## More examples
 Further demos and examples in both Javascript and Typescript can be found in the [example](example) directory.
 
+# Enabling additional debugging output
+
+`bitgo` uses the `debug` package to emit extra information, which can be useful when debugging issues with BitGoJS or BitGo Express.
+
+When using the `bitgo` npm package, the easiest way to enable debug output is by setting the `DEBUG` environment variable to one or more of the debug namespaces in the table below. Multiple debug namespaces can be enabled by giving a comma-separated list or by using `*` as a wildcard. See the [debug package documentation](https://github.com/visionmedia/debug#readme) for more details.
+
+## Available Debug Namespaces
+| Namespace | Description |
+| --- | --- |
+| `bitgo:index` | Core BitGo object. Currently only constant fetch failures and HMAC response failures will emit debug information for this namespace. |
+| `bitgo:v1:txb` | Version 1 (legacy) transaction builder |
+| `bitgo:v2:pendingapprovals` | Pending approval operations. Currently only wallet fetch errors will emit debug information for this namespace. |
+| `bitgo:v2:wallet` | Wallet operations including transaction prebuild, sendMany calls and consolidation transactions |
+| `bitgo:v2:utxo` | Low level operations for UTXO coins, including transaction parsing, verification, signing and explanations |
+| `bitgo:v2:eth` | Ethereum specific output. Currently only failures to require the optional Ethereum libraries are reported |
+| `bitgo:v2:util` | SDK utilities specific output. Currently only failures to require the optional Ethereum libraries are reported |
+
+Another debug namespace which is not provided by BitGoJS but is helpful nonetheless is the `superagent` namespace, which will output all HTTP requests and responses (only the URL, not bodies).
+
+## Example
+
+To run an SDK script with debug output enabled, export the DEBUG environment variable before running.
+```shell script
+export DEBUG='bitgo:*' # enable all bitgo debug namespaces
+node myScript.js
+```
+
+To set debug namespaces in the browser, you should set `localStorage.debug` property instead of the `DEBUG` environment variable using your browser's development tools console.
+
+```js
+localStorage.debug = 'bitgo:*'; // enable all bitgo debug namespaces
+```
+
 # Using with Typescript
 
 `bitgo` is not yet compatible with the `noImplicitAny` compiler option. If you want to use this option in your project (and we recommend that you do), you must set the `skipLibCheck` option to supress errors about missing type definitions for dependencies of `bitgo`.

--- a/modules/express/README.md
+++ b/modules/express/README.md
@@ -174,7 +174,7 @@ BitGo Express is able to take configuration options from either command line arg
 | -e              | --env                  | `BITGO_ENV`                              | test          | BitGo environment to interact with.                                                                                     |
 | -t              | --timeout              | `BITGO_TIMEOUT`                          | 305000        | Number of milliseconds to wait before requests made by `bitgo-express` time out.
 | -d              | --debug                | N/A, use `BITGO_DEBUG_NAMESPACE` instead | N/A           | Enable debug output for bitgo-express. This is equivalent to passing `--debugnamespace bitgo:express`.                  |
-| -D              | --debugnamespace       | `BITGO_DEBUG_NAMESPACE`                  | N/A           | Enable debug output for a particular debug namespace. Multiple debug namespaces can be given as a comma separated list. |
+| -D              | --debugnamespace       | `BITGO_DEBUG_NAMESPACE`                  | N/A           | Enable debug output for a particular debug namespace. Multiple debug namespaces can be given as a comma separated list. See the [`bitgo` package README](https://github.com/BitGo/BitGoJS/blob/master/modules/core/README.md#available-debug-namespaces) for a complete list of recognized options, in addition to those listed in the table below. |
 | -k              | --keypath              | `BITGO_KEYPATH`                          | N/A           | Path to SSL .key file (required if running against production environment).                                             |
 | -c              | --crtpath              | `BITGO_CRTPATH`                          | N/A           | Path to SSL .crt file (required if running against production environment).                                             |
 | -u              | --customrooturi        | `BITGO_CUSTOM_ROOT_URI`                  | N/A           | Force a custom BitGo URI.                                                                                               |
@@ -193,6 +193,20 @@ BitGo Express is able to take configuration options from either command line arg
   * `DISABLE_PROXY`
 * Disable Environment Check
   * `DISABLE_ENV_CHECK`
+  
+## Enabling Additional Debug Output
+
+In addition to the debug namespaces defined in the [`bitgo` package README](https://github.com/BitGo/BitGoJS/blob/master/modules/core/README.md#available-debug-namespaces) there is a special BitGo Express specific debug namespaces which can be enabled:
+
+| Namespace | Description |
+| --- | --- |
+| `bitgo:express` | Additional debug information specific to BitGo Express operations. |
+
+### Example
+
+To enable the `bitgo:v2:utxo` and `bitgo:express` debug namespaces, start BitGo Express with `--debug-namespace bitgo:v2:utxo,bitgo:express`.
+
+Wildcards using `*` are also supported. For example, all bitgo debug namespaces can be enabled with `--debug-namespace bitgo:*`, but beware, this can be very noisy.
 
 # Release Notes
 


### PR DESCRIPTION
It was brought up that there was no comprehensive list of debug
namespaces supported by `core` and `express`, nor was there information
on how to use them to get extra debug information.

This commit adds this information to the `express` and `core` package
READMEs.

Ticket: BG-22900