### PR TITLE
BGA-240 Change HBAR Keys format

### DIFF
--- a/modules/account-lib/src/coin/hbar/keyPair.ts
+++ b/modules/account-lib/src/coin/hbar/keyPair.ts
@@ -1,6 +1,6 @@
 import { Ed25519PrivateKey, Ed25519PublicKey } from '@hashgraph/sdk';
 import { Ed25519KeyPair } from '../baseCoin/ed25519KeyPair';
-import { KeyPairOptions, ByteKeys } from '../baseCoin/iface';
+import { KeyPairOptions, DefaultKeys } from '../baseCoin/iface';
 import { NotSupported } from '../baseCoin/errors';
 import { toHex } from './utils';
 
@@ -17,17 +17,16 @@ export class KeyPair extends Ed25519KeyPair {
   /**
    * Hedera default keys format is a pair of Uint8Array keys
    *
-   * @returns { ByteKeys } The keys in the protocol default key format
+   * @returns { DefaultKeys } The keys in the protocol default format
    */
-  getKeys(): ByteKeys {
-    const result: ByteKeys = {
-      pub: Uint8Array.from(Buffer.from(this.keyPair.pub, 'hex')),
+  getKeys(): DefaultKeys {
+    const result: DefaultKeys = {
+      pub: this.keyPair.pub,
     };
 
     if (this.keyPair.prv) {
-      result.prv = Uint8Array.from(Buffer.from(this.keyPair.prv, 'hex'));
+      result.prv = this.keyPair.prv;
     }
-
     return result;
   }
 

--- a/modules/account-lib/src/coin/hbar/walletInitializationBuilder.ts
+++ b/modules/account-lib/src/coin/hbar/walletInitializationBuilder.ts
@@ -5,7 +5,7 @@ import { proto } from '../../../resources/hbar/protobuf/hedera';
 import { BuildTransactionError } from '../baseCoin/errors';
 import { TransactionBuilder } from './transactionBuilder';
 import { Transaction } from './transaction';
-import { isValidPublicKey } from './utils';
+import { isValidPublicKey, toUint8Array } from './utils';
 import { KeyPair } from './';
 
 const DEFAULT_M = 3;
@@ -44,7 +44,7 @@ export class WalletInitializationBuilder extends TransactionBuilder {
     return this._owners.reduce((tKeys, key) => {
       if (tKeys.keys && tKeys.keys.keys) {
         tKeys.keys.keys.push({
-          ed25519: new KeyPair({ pub: key }).getKeys().pub,
+          ed25519: toUint8Array(new KeyPair({ pub: key }).getKeys().pub),
         });
       }
       return tKeys;

--- a/modules/account-lib/test/unit/coin/hbar/keyPair.ts
+++ b/modules/account-lib/test/unit/coin/hbar/keyPair.ts
@@ -10,30 +10,30 @@ describe('Hedera Key Pair', () => {
   describe('should create a valid KeyPair', () => {
     it('from a public key', () => {
       const keyPair = new KeyPair({ pub: pub });
-      should.equal(Buffer.from(keyPair.getKeys().pub).toString('hex'), pub);
+      should.equal(keyPair.getKeys().pub, pub);
     });
 
     it('from a public key with pefix', () => {
       const keyPair = new KeyPair({ pub: testData.ACCOUNT_1.publicKey });
-      should.equal(Buffer.from(keyPair.getKeys().pub).toString('hex'), pub);
+      should.equal(keyPair.getKeys().pub, pub);
     });
 
     it('from a private key', () => {
       const keyPair = new KeyPair({ prv: prv });
-      should.equal(Buffer.from(keyPair.getKeys().prv!).toString('hex'), prv);
-      should.equal(Buffer.from(keyPair.getKeys().pub).toString('hex'), pub);
+      should.equal(keyPair.getKeys().prv!, prv);
+      should.equal(keyPair.getKeys().pub, pub);
     });
 
     it('from a private key with prefix', () => {
       const keyPair = new KeyPair({ prv: testData.ACCOUNT_1.privateKey });
-      should.equal(Buffer.from(keyPair.getKeys().prv!).toString('hex'), prv);
-      should.equal(Buffer.from(keyPair.getKeys().pub).toString('hex'), pub);
+      should.equal(keyPair.getKeys().prv!, prv);
+      should.equal(keyPair.getKeys().pub, pub);
     });
 
     it('from a private key + public key', () => {
       const keyPair = new KeyPair({ prv: prv + pub });
-      should.equal(Buffer.from(keyPair.getKeys().prv!).toString('hex'), prv);
-      should.equal(Buffer.from(keyPair.getKeys().pub).toString('hex'), pub);
+      should.equal(keyPair.getKeys().prv!, prv);
+      should.equal(keyPair.getKeys().pub, pub);
     });
 
     it('from seed', () => {
@@ -51,12 +51,12 @@ describe('Hedera Key Pair', () => {
 
     it('from a byte array private key', () => {
       const keyPair = new KeyPair({ prv: Buffer.from(testData.privateKeyBytes).toString('hex') });
-      should.equal(Buffer.from(keyPair.getKeys().prv!).toString('hex'), prv);
+      should.equal(keyPair.getKeys().prv!, prv);
     });
 
     it('from a byte array public key', () => {
       const keyPair = new KeyPair({ pub: Buffer.from(testData.publicKeyBytes).toString('hex') });
-      should.equal(Buffer.from(keyPair.getKeys().pub).toString('hex'), pub);
+      should.equal(keyPair.getKeys().pub, pub);
     });
   });
 


### PR DESCRIPTION
We need keeys as string instead of Uint8Array.

TICKET: BGA-240