### PR TITLE
BGA-240 Improve Key Pair abstraction

### DIFF
--- a/modules/account-lib/src/coin/baseCoin/ed25519KeyPair.ts
+++ b/modules/account-lib/src/coin/baseCoin/ed25519KeyPair.ts
@@ -1,9 +1,9 @@
 import * as nacl from 'tweetnacl';
 import { toHex, toUint8Array } from '../hbar/utils';
+import { isValidEd25519PublicKey, isValidEd25519SecretKey, isValidEd25519Seed } from '../../utils/crypto';
 import { BaseKeyPair } from './baseKeyPair';
 import { AddressFormat } from './enum';
 import { isPrivateKey, isPublicKey, isSeed, DefaultKeys, KeyPairOptions } from './iface';
-import { NotImplementedError } from './errors';
 
 const DEFAULT_SEED_SIZE_BYTES = 32;
 
@@ -41,17 +41,37 @@ export abstract class Ed25519KeyPair implements BaseKeyPair {
     };
   }
 
+  /** @inheritdoc */
   recordKeysFromPrivateKey(prv: string): void {
-    const decodedPrv = toUint8Array(prv);
-    const naclKeyPair = nacl.sign.keyPair.fromSeed(decodedPrv);
-    this.setKeyPair(naclKeyPair);
+    if (isValidEd25519Seed(prv)) {
+      const decodedPrv = toUint8Array(prv);
+      const naclKeyPair = nacl.sign.keyPair.fromSeed(decodedPrv);
+      this.setKeyPair(naclKeyPair);
+    } else if (isValidEd25519SecretKey(prv)) {
+      const decodedPrv = toUint8Array(prv);
+      const naclKeyPair = nacl.sign.keyPair.fromSecretKey(decodedPrv);
+      this.setKeyPair(naclKeyPair);
+    } else {
+      this.keyPair = this.recordKeysFromPrivateKeyInProtocolFormat(prv);
+    }
   }
 
+  /** @inheritdoc */
   recordKeysFromPublicKey(pub: string): void {
-    throw new NotImplementedError("recordKeysFromPublicKey not implemented since it's protocol dependent");
+    if (isValidEd25519PublicKey(pub)) {
+      this.keyPair = { pub };
+    } else {
+      this.keyPair = this.recordKeysFromPublicKeyInProtocolFormat(pub);
+    }
   }
 
+  abstract recordKeysFromPrivateKeyInProtocolFormat(prv: string): DefaultKeys;
+
+  abstract recordKeysFromPublicKeyInProtocolFormat(prv: string): DefaultKeys;
+
+  /** @inheritdoc */
   abstract getAddress(format?: AddressFormat): string;
 
+  /** @inheritdoc */
   abstract getKeys(): any;
 }

--- a/modules/account-lib/src/coin/baseCoin/errors.ts
+++ b/modules/account-lib/src/coin/baseCoin/errors.ts
@@ -79,3 +79,12 @@ export class NotSupported extends ExtendableError {
     super(message);
   }
 }
+
+/**
+ * Error for invalid seed, public, or private keys
+ */
+export class InvalidKey extends ExtendableError {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/modules/account-lib/src/coin/hbar/utils.ts
+++ b/modules/account-lib/src/coin/hbar/utils.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash';
 import { AccountId } from '@hashgraph/sdk/lib/account/AccountId';
 import { Ed25519PublicKey, TransactionId } from '@hashgraph/sdk';
+import * as hex from '@stablelib/hex';
 
 /**
  * Returns whether or not the string is a valid Hedera account.
@@ -51,7 +52,7 @@ export function isValidPublicKey(key: string): boolean {
     return false;
   }
   try {
-    const pubKey = Ed25519PublicKey.fromString(key);
+    const pubKey = Ed25519PublicKey.fromString(key.toLowerCase());
     return !_.isNaN(pubKey.toString());
   } catch (e) {
     return false;
@@ -65,17 +66,17 @@ export function isValidPublicKey(key: string): boolean {
  * @returns {string} - the hex value
  */
 export function toHex(buffer: Buffer | Uint8Array): string {
-  return Buffer.from(buffer).toString('hex');
+  return hex.encode(buffer, true);
 }
 
 /**
  * Returns a Uint8Array of the given hex string
  *
- * @param {string} hex - the hex string to be converted
+ * @param {string} str - the hex string to be converted
  * @returns {string} - the Uint8Array value
  */
-export function toUint8Array(hex: string): Uint8Array {
-  return Uint8Array.from(Buffer.from(hex, 'hex'));
+export function toUint8Array(str: string): Uint8Array {
+  return hex.decode(str);
 }
 
 /**

--- a/modules/account-lib/src/utils/crypto.ts
+++ b/modules/account-lib/src/utils/crypto.ts
@@ -1,5 +1,7 @@
 import { HDNode, ECPair, networks } from '@bitgo/utxo-lib';
+import * as nacl from 'tweetnacl';
 import { ExtendedKeys } from '../coin/baseCoin/iface';
+import { toUint8Array } from '../coin/hbar/utils';
 
 /**
  * @param {string} xpub - a base-58 encoded extended public key (BIP32)
@@ -102,4 +104,49 @@ export function isValidPrv(prv: string): boolean {
     return false;
   }
   return true;
+}
+
+/**
+ * Whether the input is a valid ed25519 private key
+ *
+ * @param {string} prv A hexadecimal private key to validate
+ * @returns {boolean} Whether the input is a valid public key or not
+ */
+export function isValidEd25519Seed(prv: string): boolean {
+  try {
+    const decodedPrv = toUint8Array(prv);
+    return decodedPrv.length === nacl.sign.seedLength;
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
+ * Whether the input is a valid ed25519 private key
+ *
+ * @param {string} prv A hexadecimal private key to validate
+ * @returns {boolean} Whether the input is a valid public key or not
+ */
+export function isValidEd25519SecretKey(prv: string): boolean {
+  try {
+    const decodedPrv = toUint8Array(prv);
+    return decodedPrv.length === nacl.sign.secretKeyLength;
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
+ * Whether the input is a valid ed25519 public key
+ *
+ * @param {string} pub A hexadecimal public key to validate
+ * @returns {boolean} Whether the input is a valid public key or not
+ */
+export function isValidEd25519PublicKey(pub: string): boolean {
+  try {
+    const decodedPub = toUint8Array(pub);
+    return decodedPub.length === nacl.sign.publicKeyLength;
+  } catch (e) {
+    return false;
+  }
 }

--- a/modules/account-lib/test/resources/hbar/hbar.ts
+++ b/modules/account-lib/test/resources/hbar/hbar.ts
@@ -35,7 +35,8 @@ export const TXDATA = 'not defined';
 export const UNSIGNED_TX = 'not defined';
 
 export const ENCODED_TRANSACTION = 'not defined';
-export const errorMessageFailedToParse = 'Failed to parse correct key';
+export const errorMessageInvalidPrivateKey = 'Invalid private key';
+export const errorMessageInvalidPublicKey = 'Invalid public key:';
 export const errorMessageNotPossibleToDeriveAddress = 'Address derivation is not supported in Hedera';
 
 export const privateKeyBytes = Uint8Array.of(

--- a/modules/account-lib/test/unit/coin/hbar/keyPair.ts
+++ b/modules/account-lib/test/unit/coin/hbar/keyPair.ts
@@ -3,8 +3,8 @@ import * as nacl from 'tweetnacl';
 import { KeyPair } from '../../../../src/coin/hbar';
 import * as testData from '../../../resources/hbar/hbar';
 
-const pub = testData.ACCOUNT_1.publicKey.slice(24);
-const prv = testData.ACCOUNT_1.privateKey.slice(32);
+const pub = testData.ACCOUNT_1.publicKey;
+const prv = testData.ACCOUNT_1.privateKey;
 
 describe('Hedera Key Pair', () => {
   describe('should create a valid KeyPair', () => {
@@ -26,12 +26,6 @@ describe('Hedera Key Pair', () => {
 
     it('from a private key with prefix', () => {
       const keyPair = new KeyPair({ prv: testData.ACCOUNT_1.privateKey });
-      should.equal(keyPair.getKeys().prv!, prv);
-      should.equal(keyPair.getKeys().pub, pub);
-    });
-
-    it('from a private key + public key', () => {
-      const keyPair = new KeyPair({ prv: prv + pub });
       should.equal(keyPair.getKeys().prv!, prv);
       should.equal(keyPair.getKeys().pub, pub);
     });
@@ -65,7 +59,7 @@ describe('Hedera Key Pair', () => {
       const source = { pub: '01D63D' };
       should.throws(
         () => new KeyPair(source),
-        e => e.message === testData.errorMessageFailedToParse,
+        e => e.message.includes(testData.errorMessageInvalidPublicKey),
       );
     });
 
@@ -75,15 +69,19 @@ describe('Hedera Key Pair', () => {
       const prvWithPrefix = { prv: testData.ed25519PrivKeyPrefix + prv + '1' };
       should.throws(
         () => new KeyPair(shorterPrv),
-        e => e.message === testData.errorMessageFailedToParse,
+        e => e.message === testData.errorMessageInvalidPrivateKey,
       );
       should.throws(
         () => new KeyPair(longerPrv),
-        e => e.message === testData.errorMessageFailedToParse,
+        e => e.message === testData.errorMessageInvalidPrivateKey,
       );
       should.throws(
         () => new KeyPair(prvWithPrefix),
-        e => e.message === testData.errorMessageFailedToParse,
+        e => e.message === testData.errorMessageInvalidPrivateKey,
+      );
+      should.throws(
+        () => new KeyPair({ prv: prv + pub }),
+        e => e.message === testData.errorMessageInvalidPrivateKey,
       );
     });
   });

--- a/modules/account-lib/test/unit/coin/xtz/transactionBuilder.ts
+++ b/modules/account-lib/test/unit/coin/xtz/transactionBuilder.ts
@@ -400,7 +400,6 @@ describe('Tezos Transaction builder', function() {
       tx.owners.length.should.equal(0);
       const indexesByTransactionType = tx.getIndexesByTransactionType();
       Object.keys(indexesByTransactionType).length.should.equal(1);
-      console.log(indexesByTransactionType);
       indexesByTransactionType.transaction.length.should.equal(2);
       indexesByTransactionType.transaction[0].should.equal(0);
       indexesByTransactionType.transaction[1].should.equal(1);

--- a/modules/core/src/v2/coins/trx.ts
+++ b/modules/core/src/v2/coins/trx.ts
@@ -27,6 +27,7 @@ import {
 
 import { BitGo } from '../../bitgo';
 import { NodeCallback } from '../types';
+import { BaseTransactionBuilder } from '@bitgo/account-lib/dist/src/coin/baseCoin';
 
 export const MINIMUM_TRON_MSIG_TRANSACTION_FEE = 1e6;
 
@@ -219,6 +220,10 @@ export class Trx extends BaseCoin {
     const self = this;
     return co<SignedTransaction>(function*() {
       const txBuilder = bitgoAccountLib.getBuilder(self.getChain());
+      // Newer coins can return BaseTransactionBuilderFactory instead of BaseTransactionBuilder
+      if (!(txBuilder instanceof BaseTransactionBuilder)) {
+        throw new Error('getBuilder() did not return an BaseTransactionBuilder object. Has it been updated?');
+      }
       txBuilder.from(params.txPrebuild.txHex);
       txBuilder.sign({ key: params.prv });
       const transaction = yield txBuilder.build();
@@ -487,6 +492,10 @@ export class Trx extends BaseCoin {
 
       // construct our tx
       const txBuilder = bitgoAccountLib.getBuilder(self.getChain());
+      // Newer coins can return BaseTransactionBuilderFactory instead of BaseTransactionBuilder
+      if (!(txBuilder instanceof BaseTransactionBuilder)) {
+        throw new Error('getBuilder() did not return an BaseTransactionBuilder object. Has it been updated?');
+      }
       txBuilder.from(buildTx);
 
       // this tx should be enough to drop into a node
@@ -534,6 +543,10 @@ export class Trx extends BaseCoin {
         throw new Error('missing explain tx parameters');
       }
       const txBuilder = bitgoAccountLib.getBuilder(self.getChain());
+      // Newer coins can return BaseTransactionBuilderFactory instead of BaseTransactionBuilder
+      if (!(txBuilder instanceof BaseTransactionBuilder)) {
+        throw new Error('getBuilder() did not return an BaseTransactionBuilder object. Has it been updated?');
+      }
       txBuilder.from(txHex);
       const tx = yield txBuilder.build();
       const outputs = [

--- a/modules/core/src/v2/coins/xtz.ts
+++ b/modules/core/src/v2/coins/xtz.ts
@@ -25,6 +25,7 @@ import { BitGo } from '../../bitgo';
 import { NodeCallback } from '../types';
 import BigNumber from 'bignumber.js';
 import { MethodNotImplementedError } from '../../errors';
+import { BaseTransactionBuilder } from '@bitgo/account-lib/dist/src/coin/baseCoin';
 
 export interface XtzSignTransactionOptions extends SignTransactionOptions {
   txPrebuild: TransactionPrebuild;
@@ -229,6 +230,10 @@ export class Xtz extends BaseCoin {
         throw new Error('missing explain tx parameters');
       }
       const txBuilder = bitgoAccountLib.getBuilder(self.getChain());
+      // Newer coins can return BaseTransactionBuilderFactory instead of BaseTransactionBuilder
+      if (!(txBuilder instanceof BaseTransactionBuilder)) {
+        throw new Error('getBuilder() did not return an BaseTransactionBuilder object. Has it been updated?');
+      }
       txBuilder.from(txHex);
       const tx: any = yield txBuilder.build();
 

--- a/modules/core/test/v2/unit/coins/hbar.ts
+++ b/modules/core/test/v2/unit/coins/hbar.ts
@@ -42,8 +42,8 @@ describe('Hedera Hashgraph:', function() {
       const seed = Buffer.from(seedText, 'hex');
       const keyPair = basecoin.generateKeyPair(seed);
 
-      keyPair.pub.should.equal('9cc402b5c75214269c2826e3c6119377cab6c367601338661c87a4e07c6e0333');
       keyPair.prv.should.equal('80350b4208d381fbfe2276a326603049fe500731c46d3c9936b5ce036b51377f');
+      keyPair.pub.should.equal('9cc402b5c75214269c2826e3c6119377cab6c367601338661c87a4e07c6e0333');
     });
   });
 });


### PR DESCRIPTION
I'm making some adjustments to the abstraction model to better accommodate for core logic sharing and new specialized coins Key pairs:
![Key Pairs UML class diagram](https://user-images.githubusercontent.com/12958852/88467308-a955c280-ce8a-11ea-9df8-83716a8938f1.png)

I'm introducing `@stablelib/hex` dependency again because I noticed hex encoding/decoding with Buffer and Uint8array is not idempotent. An example of a buggy conversion is:

`302e020100300506032b657004220420302e020100300506032b65700422042062b0b669de0ab5e91b4328e1431859a5ca47e7426e701019272f5c2d52825b011` 

This key converted back and forth from hex string to Uint8array did not result in the same string, which is extremely dangerous.