### PR TITLE
Add hbar to coinbuildermap

### DIFF
--- a/modules/account-lib/src/index.ts
+++ b/modules/account-lib/src/index.ts
@@ -41,6 +41,8 @@ const coinBuilderMap = {
   trbtc: Rbtc.TransactionBuilder,
   celo: Celo.TransactionBuilder,
   tcelo: Celo.TransactionBuilder,
+  hbar: Hbar.TransactionBuilderFactory,
+  thbar: Hbar.TransactionBuilderFactory,
 };
 
 /**


### PR DESCRIPTION
Need to be able to instantiate an hbar builder with the getBuilder
helper utility - this commit adds it to the map that allows us to do so

Ticket: BG-23580