### PR TITLE
Default to native segwit change addresses for testnet

### DIFF
--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -846,11 +846,11 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
   }
 
   /**
-   * Indicates whether a coin defaults to native segwit change outputs
-   * @returns {boolean}
+   * Set a default address format for change addresses, which overrides the default address format for that coin
+   * @returns {string}
    */
-  defaultsToP2wshChange() {
-    return false;
+  defaultChangeAddressType(): string {
+    return this.supportsP2shP2wsh() ? `p2shP2wsh` : `p2sh`;
   }
 
   /**

--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -846,6 +846,14 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
   }
 
   /**
+   * Indicates whether a coin defaults to native segwit change outputs
+   * @returns {boolean}
+   */
+  defaultsToP2wshChange() {
+    return false;
+  }
+
+  /**
    * TODO(BG-11487): Remove addressType, segwit, and bech32 params in SDKv6
    * Generate an address for a wallet based on a set of configurations
    * @param params.addressType {string}   Deprecated

--- a/modules/core/src/v2/coins/btc.ts
+++ b/modules/core/src/v2/coins/btc.ts
@@ -1,7 +1,6 @@
 import { BitGo } from '../../bitgo';
 import { BaseCoin } from '../baseCoin';
 import { AbstractUtxoCoin, UtxoNetwork } from './abstractUtxoCoin';
-import * as common from '../../common';
 import * as bitcoin from '@bitgo/utxo-lib';
 import * as request from 'superagent';
 import * as _ from 'lodash';

--- a/modules/core/src/v2/coins/tbtc.ts
+++ b/modules/core/src/v2/coins/tbtc.ts
@@ -23,7 +23,7 @@ export class Tbtc extends Btc {
     return 'Testnet Bitcoin';
   }
 
-  defaultsToP2wshChange(): boolean {
-    return this.supportsP2wsh();
+  defaultChangeAddressType() {
+    return this.supportsP2wsh() ? `p2wsh` : this.supportsP2shP2wsh() ? `p2shP2wsh` : `p2sh`;
   }
 }

--- a/modules/core/src/v2/coins/tbtc.ts
+++ b/modules/core/src/v2/coins/tbtc.ts
@@ -22,4 +22,8 @@ export class Tbtc extends Btc {
   getFullName() {
     return 'Testnet Bitcoin';
   }
+
+  defaultsToP2wshChange(): boolean {
+    return this.supportsP2wsh();
+  }
 }

--- a/modules/core/src/v2/coins/tltc.ts
+++ b/modules/core/src/v2/coins/tltc.ts
@@ -41,4 +41,8 @@ export class Tltc extends Ltc {
   getFullName() {
     return 'Testnet Litecoin';
   }
+
+  defaultsToP2wshChange(): boolean {
+    return this.supportsP2wsh();
+  }
 }

--- a/modules/core/src/v2/coins/tltc.ts
+++ b/modules/core/src/v2/coins/tltc.ts
@@ -42,7 +42,7 @@ export class Tltc extends Ltc {
     return 'Testnet Litecoin';
   }
 
-  defaultsToP2wshChange(): boolean {
-    return this.supportsP2wsh();
+  defaultChangeAddressType() {
+    return this.supportsP2wsh() ? `p2wsh` : this.supportsP2shP2wsh() ? `p2shP2wsh` : `p2sh`;
   }
 }

--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -1634,10 +1634,13 @@ export class Wallet {
       debug('prebuilding transaction: %O', whitelistedParams);
 
       const utxoCoin = self.baseCoin as AbstractUtxoCoin;
-      const supportsP2wsh = _.isFunction(utxoCoin.defaultsToP2wshChange) ? utxoCoin.defaultsToP2wshChange() : false;
-      if (supportsP2wsh) {
-        // Default to native segwit change addresses
-        whitelistedParams = Object.assign({ addressType: `p2wsh` }, whitelistedParams);
+      if (_.isFunction(utxoCoin.defaultChangeAddressType) && utxoCoin.defaultChangeAddressType() === `p2wsh`) {
+        /**
+         * During native segwit rollout phase, only send `addressType` on coins that default to native segwit change
+         * addresses. Can be removed after native segwit rollout is complete and default address is generally set to
+         * native segwit. For non-segwit coins, leave change address format up to wallet platform.
+         */
+        whitelistedParams = Object.assign({ addressType: utxoCoin.defaultChangeAddressType() }, whitelistedParams);
       }
 
       if (params.reqId) {


### PR DESCRIPTION
    Default to p2wsh change addresses on tbtc/tltc

    If the `addressType` is not specified explicitly by the user, we will
    default to native segwit (p2wsh) addresses for change outputs on tbtc
    and tltc. After a period of testing, we will enable the same for btc and
    ltc.

Ticket: BG-23508