### PR TITLE
Insert external HBAR signatures

### DIFF
--- a/modules/account-lib/src/coin/hbar/ifaces.ts
+++ b/modules/account-lib/src/coin/hbar/ifaces.ts
@@ -1,3 +1,5 @@
+import { KeyPair } from '.';
+
 export interface TxData {
   id: string;
   hash?: string;
@@ -5,4 +7,9 @@ export interface TxData {
   data: string;
   fee: number;
   startTime: string;
+}
+
+export interface SignatureData {
+  signature: string;
+  keyPair: KeyPair;
 }

--- a/modules/account-lib/src/coin/hbar/transaction.ts
+++ b/modules/account-lib/src/coin/hbar/transaction.ts
@@ -31,14 +31,24 @@ export class Transaction extends BaseTransaction {
     }
     const secretKey = toUint8Array(keys.prv + keys.pub);
     const signature = nacl.sign.detached(this._hederaTx.bodyBytes, secretKey);
+    this.addSignature(toHex(signature), keyPair);
+  }
+
+  /**
+   * Add a signature to this transaction
+   * @param signature The signature to add, in string hex format
+   * @param key The key of the key that created the signature
+   */
+  addSignature(signature: string, key: KeyPair): void {
     const sigPair = new proto.SignaturePair();
-    sigPair.pubKeyPrefix = toUint8Array(keys.pub);
-    sigPair.ed25519 = signature;
+    sigPair.pubKeyPrefix = toUint8Array(key.getKeys(true).pub);
+    sigPair.ed25519 = toUint8Array(signature);
 
     const sigMap = this._hederaTx.sigMap || new proto.SignatureMap();
     sigMap.sigPair!.push(sigPair);
     this._hederaTx.sigMap = sigMap;
   }
+
 
   /** @inheritdoc */
   toBroadcastFormat(): string {

--- a/modules/account-lib/src/coin/hbar/transactionBuilder.ts
+++ b/modules/account-lib/src/coin/hbar/transactionBuilder.ts
@@ -110,6 +110,15 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
    * @returns This transaction builder
    */
   signature(signature: string, keyPair: KeyPair): this {
+    // if we already have a signature for this key pair, just update it
+    for (const oldSignature of this._signatures) {
+      if (oldSignature.keyPair.getKeys().pub === keyPair.getKeys().pub) {
+        oldSignature.signature = signature;
+        return this;
+      }
+    }
+
+    // otherwise add the new signature
     this._signatures.push({ signature, keyPair });
     return this;
   }

--- a/modules/account-lib/src/coin/hbar/transactionBuilder.ts
+++ b/modules/account-lib/src/coin/hbar/transactionBuilder.ts
@@ -12,6 +12,7 @@ import { proto } from '../../../resources/hbar/protobuf/hedera';
 import { Transaction } from './transaction';
 import { getCurrentTime, isValidAddress, isValidTimeString, toUint8Array } from './utils';
 import { KeyPair } from './keyPair';
+import { SignatureData } from './ifaces';
 
 export abstract class TransactionBuilder extends BaseTransactionBuilder {
   protected _fee: BaseFee;
@@ -19,11 +20,13 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
   protected _source: BaseAddress;
   protected _startTime: proto.ITimestamp;
   protected _multiSignerKeyPairs: KeyPair[];
+  protected _signatures: SignatureData[];
 
   constructor(_coinConfig: Readonly<CoinConfig>) {
     super(_coinConfig);
     this._transaction = new Transaction(_coinConfig);
     this._multiSignerKeyPairs = [];
+    this._signatures = [];
   }
 
   // region Base Builder
@@ -96,6 +99,18 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
   source(address: BaseAddress): this {
     this.validateAddress(address);
     this._source = address;
+    return this;
+  }
+
+  /**
+   * Set an external transaction signature
+   *
+   * @param signature Hex encoded signature string
+   * @param keyPair The public key keypair that was used to create the signature
+   * @returns This transaction builder
+   */
+  signature(signature: string, keyPair: KeyPair): this {
+    this._signatures.push({ signature, keyPair });
     return this;
   }
 

--- a/modules/account-lib/src/coin/hbar/walletInitializationBuilder.ts
+++ b/modules/account-lib/src/coin/hbar/walletInitializationBuilder.ts
@@ -40,6 +40,10 @@ export class WalletInitializationBuilder extends TransactionBuilder {
     for (const kp of this._multiSignerKeyPairs) {
       await transaction.sign(kp);
     }
+
+    for (const { signature, keyPair } of this._signatures) {
+      await transaction.addSignature(signature, keyPair);
+    }
     return transaction;
   }
 

--- a/modules/account-lib/test/unit/coin/hbar/walletInitialization.ts
+++ b/modules/account-lib/test/unit/coin/hbar/walletInitialization.ts
@@ -51,6 +51,23 @@ describe('Wallet initialization', () => {
       const txJson = tx.toJson();
       should.equal(txJson.from, testData.ACCOUNT1);
     });
+
+    it('an init transaction with external signature included twice', async () => {
+      const txBuilder = factory.getWalletInitializationBuilder();
+      txBuilder.fee({ fee: '1000000000' });
+      txBuilder.owner(testData.OWNER1);
+      txBuilder.owner(testData.OWNER2);
+      txBuilder.owner(testData.OWNER3);
+      txBuilder.source({ address: testData.OPERATOR.accountId });
+      txBuilder.signature('20bc01a6da677b99974b17204de5ff6f34f8e5904f58d6df1ceb39b473e7295dccf60fcedaf4f' +
+        'dc3f6bef93edcfbe2a7ec33cc94c893906a063383c27b014f09', new KeyPair({ pub: testData.ACCOUNT_1.publicKey }));
+      txBuilder.signature('20bc01a6da677b99974b17204de5ff6f34f8e5904f58d6df1ceb39b473e7295dccf60fcedaf4f' +
+        'dc3f6bef93edcfbe2a7ec33cc94c893906a063383c27b014f09', new KeyPair({ pub: testData.ACCOUNT_1.publicKey }));
+
+      const tx = await txBuilder.build();
+      const txJson = tx.toJson();
+      should.equal(txJson.from, testData.ACCOUNT1);
+    });
   });
 
   describe('should fail to build', () => {

--- a/modules/account-lib/test/unit/coin/hbar/walletInitialization.ts
+++ b/modules/account-lib/test/unit/coin/hbar/walletInitialization.ts
@@ -1,6 +1,6 @@
 import should from 'should';
 import { register } from '../../../../src/index';
-import { TransactionBuilderFactory } from '../../../../src/coin/hbar';
+import { KeyPair, TransactionBuilderFactory } from '../../../../src/coin/hbar';
 import * as testData from '../../../resources/hbar/hbar';
 
 describe('Wallet initialization', () => {
@@ -34,6 +34,21 @@ describe('Wallet initialization', () => {
       const tx = await txBuilder.build();
       const txJson = tx.toJson();
       txJson.fee.should.equal(1000000000);
+      should.equal(txJson.from, testData.ACCOUNT1);
+    });
+
+    it('an init transaction with external signature', async () => {
+      const txBuilder = factory.getWalletInitializationBuilder();
+      txBuilder.fee({ fee: '1000000000' });
+      txBuilder.owner(testData.OWNER1);
+      txBuilder.owner(testData.OWNER2);
+      txBuilder.owner(testData.OWNER3);
+      txBuilder.source({ address: testData.OPERATOR.accountId });
+      txBuilder.signature('20bc01a6da677b99974b17204de5ff6f34f8e5904f58d6df1ceb39b473e7295dccf60fcedaf4f' +
+        'dc3f6bef93edcfbe2a7ec33cc94c893906a063383c27b014f09', new KeyPair({ pub: testData.ACCOUNT_1.publicKey }));
+
+      const tx = await txBuilder.build();
+      const txJson = tx.toJson();
       should.equal(txJson.from, testData.ACCOUNT1);
     });
   });


### PR DESCRIPTION
Sometimes we need to be able to generate signatures outside of the
account-lib library. In this case we need to be able to insert these
signatures into a transaction and re-serialize it accordingly. This
commit adds this functionality to the hedera transaction builder

Ticket: BG-23598