### PR TITLE
Add RSK to the OVC

### DIFF
--- a/modules/core/src/v2/coins/abstractEthLikeCoin.ts
+++ b/modules/core/src/v2/coins/abstractEthLikeCoin.ts
@@ -164,13 +164,14 @@ export abstract class AbstractEthLikeCoin extends BaseCoin {
       };
     }
 
-    const outputEntry = transaction.outputs[0];
-    const recipients = [
-      {
-        address: outputEntry.address,
-        amount: outputEntry.value,
-      },
-    ];
+    const recipients: Recipient[] = [];
+    let output;
+    for (output of transaction.outputs) {
+      recipients.push({
+        address: output.address,
+        amount: output.value,
+      });
+    }
 
     const signatures = transaction.signature;
 

--- a/modules/core/src/v2/coins/eth.ts
+++ b/modules/core/src/v2/coins/eth.ts
@@ -493,7 +493,6 @@ export class Eth extends BaseCoin {
    */
   signFinal(params: SignFinalOptions): FullySignedTransaction {
     const txPrebuild = params.txPrebuild;
-
     if (!_.isNumber(params.signingKeyNonce)) {
       throw new Error('must have signingKeyNonce as a parameter, and it must be a number');
     }

--- a/modules/core/src/v2/coins/eth.ts
+++ b/modules/core/src/v2/coins/eth.ts
@@ -152,6 +152,7 @@ interface OfflineVaultTxInfo {
   gasLimit: number;
   recipients: Recipient[];
   walletContractAddress: string;
+  walletBaseAddress?: string;
   amount: string;
   backupKeyNonce: number;
 }

--- a/modules/core/src/v2/coins/eth.ts
+++ b/modules/core/src/v2/coins/eth.ts
@@ -152,7 +152,6 @@ interface OfflineVaultTxInfo {
   gasLimit: number;
   recipients: Recipient[];
   walletContractAddress: string;
-  walletBaseAddress?: string;
   amount: string;
   backupKeyNonce: number;
 }
@@ -494,6 +493,7 @@ export class Eth extends BaseCoin {
    */
   signFinal(params: SignFinalOptions): FullySignedTransaction {
     const txPrebuild = params.txPrebuild;
+
     if (!_.isNumber(params.signingKeyNonce)) {
       throw new Error('must have signingKeyNonce as a parameter, and it must be a number');
     }

--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -99,7 +99,7 @@ export interface PrebuildTransactionOptions {
       pendingApprovalId?: string;
     };
     offlineVerification?: boolean;
-    walletBaseAddress?: string;
+    walletContractAddress?: string;
 }
 
 export interface PrebuildAndSignTransactionOptions extends PrebuildTransactionOptions {
@@ -484,7 +484,7 @@ export class Wallet {
       'feeRate', 'gasLimit', 'gasPrice', 'idfSignedTimestamp', 'idfUserId', 'idfVersion', 'instant',
       'lastLedgerSequence', 'ledgerSequenceDelta', 'maxFee', 'maxFeeRate', 'maxValue', 'memo', 'message', 'minConfirms',
       'minValue', 'noSplitChange', 'numBlocks', 'recipients', 'reservation', 'sequenceId', 'strategy',
-      'targetWalletUnspents', 'trustlines', 'type', 'unspents', 'validFromBlock', 'validToBlock', 'walletBaseAddress',
+      'targetWalletUnspents', 'trustlines', 'type', 'unspents', 'validFromBlock', 'validToBlock',
     ];
   }
 
@@ -1624,6 +1624,7 @@ export class Wallet {
    * @param {Boolean} params.hop - Build this as an Ethereum hop transaction
    * @param {Object} params.reservation - Object to reserve the unspents that this tx build uses. Format is reservation = { expireTime: ISODateString, pendingApprovalId: String }
    * @param {String} params.walletPassphrase The passphrase to the wallet user key, to sign commitment data for Ethereum hop transactions
+   * @param {String} params.walletContractAddress - The contract address used as the "to" field of a transaction
    * @param callback
    * @returns {*}
    */
@@ -1663,8 +1664,8 @@ export class Wallet {
       delete prebuild.wallet;
       delete prebuild.buildParams;
       prebuild = _.extend({}, prebuild, { walletId: self.id() });
-      if (self._wallet && self._wallet.coinSpecific) {
-        prebuild = _.extend({}, prebuild, { walletBaseAddress: self._wallet.coinSpecific.baseAddress });
+      if (self._wallet && self._wallet.coinSpecific && !params.walletContractAddress) {
+        prebuild = _.extend({}, prebuild, { walletContractAddress: self._wallet.coinSpecific.baseAddress });
       }
       debug('final transaction prebuild: %O', prebuild);
       return prebuild as PrebuildTransactionResult;

--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -99,6 +99,7 @@ export interface PrebuildTransactionOptions {
       pendingApprovalId?: string;
     };
     offlineVerification?: boolean;
+    walletBaseAddress?: string;
 }
 
 export interface PrebuildAndSignTransactionOptions extends PrebuildTransactionOptions {
@@ -479,11 +480,11 @@ export class Wallet {
 
   prebuildWhitelistedParams(): string[] {
     return [
-      'addressType', 'changeAddress', 'cpfpFeeRate', 'cpfpTxIds', 'enforceMinConfirmsForChange', 'feeRate', 'gasLimit',
-      'gasPrice', 'idfSignedTimestamp', 'idfUserId', 'idfVersion', 'instant', 'lastLedgerSequence',
-      'ledgerSequenceDelta', 'maxFee', 'maxFeeRate', 'maxValue', 'memo', 'message', 'minConfirms', 'minValue',
-      'noSplitChange', 'numBlocks', 'recipients', 'reservation', 'sequenceId', 'strategy', 'targetWalletUnspents',
-      'trustlines', 'type', 'unspents', 'validFromBlock', 'validToBlock',
+      'addressType', 'changeAddress', 'consolidateAddresses', 'cpfpFeeRate', 'cpfpTxIds', 'enforceMinConfirmsForChange',
+      'feeRate', 'gasLimit', 'gasPrice', 'idfSignedTimestamp', 'idfUserId', 'idfVersion', 'instant',
+      'lastLedgerSequence', 'ledgerSequenceDelta', 'maxFee', 'maxFeeRate', 'maxValue', 'memo', 'message', 'minConfirms',
+      'minValue', 'noSplitChange', 'numBlocks', 'recipients', 'reservation', 'sequenceId', 'strategy',
+      'targetWalletUnspents', 'trustlines', 'type', 'unspents', 'validFromBlock', 'validToBlock', 'walletBaseAddress',
     ];
   }
 
@@ -492,7 +493,7 @@ export class Wallet {
    */
   prebuildConsolidateTransactionParams(): string[] {
     return [
-      'feeRate', 'maxFeeRate', 'memo', 'validFromBlock', 'validToBlock',
+      'consolidateAddresses', 'feeRate', 'maxFeeRate', 'memo', 'validFromBlock', 'validToBlock',
     ];
   }
 
@@ -1662,6 +1663,9 @@ export class Wallet {
       delete prebuild.wallet;
       delete prebuild.buildParams;
       prebuild = _.extend({}, prebuild, { walletId: self.id() });
+      if (self._wallet && self._wallet.coinSpecific) {
+        prebuild = _.extend({}, prebuild, { walletBaseAddress: self._wallet.coinSpecific.baseAddress });
+      }
       debug('final transaction prebuild: %O', prebuild);
       return prebuild as PrebuildTransactionResult;
     }).call(this).asCallback(callback);


### PR DESCRIPTION
Adds required fields for explaining/signing OVC transactions. Specifically, needs expiryTime, signature, and recipients in halfsignedTx.
Ticket: https://bitgoinc.atlassian.net/browse/BG-23403