### PR TITLE
Add Transaction Type for HBAR transactions

### DIFF
--- a/modules/account-lib/src/coin/hbar/transaction.ts
+++ b/modules/account-lib/src/coin/hbar/transaction.ts
@@ -5,7 +5,7 @@ import { Writer } from 'protobufjs';
 import * as nacl from 'tweetnacl';
 import Long from 'long';
 import { proto } from '../../../resources/hbar/protobuf/hedera';
-import { BaseTransaction } from '../baseCoin';
+import { BaseTransaction, TransactionType } from '../baseCoin';
 import { BaseKey } from '../baseCoin/iface';
 import { SigningError } from '../baseCoin/errors';
 import { TxData } from './ifaces';
@@ -15,6 +15,7 @@ import { KeyPair } from './';
 export class Transaction extends BaseTransaction {
   private _hederaTx: proto.Transaction;
   private _txBody: proto.TransactionBody;
+  protected _type: TransactionType;
 
   constructor(_coinConfig: Readonly<CoinConfig>) {
     super(_coinConfig);
@@ -116,6 +117,15 @@ export class Transaction extends BaseTransaction {
     this._txBody = proto.TransactionBody.decode(tx.bodyBytes);
     this._hederaTx = tx;
     // this.loadPreviousSignatures();
+  }
+
+  /**
+   * Set the transaction type
+   *
+   * @param {TransactionType} transactionType The transaction type to be set
+   */
+  setTransactionType(transactionType: TransactionType): void {
+    this._type = transactionType;
   }
 
   /**

--- a/modules/account-lib/src/coin/hbar/transferBuilder.ts
+++ b/modules/account-lib/src/coin/hbar/transferBuilder.ts
@@ -7,6 +7,7 @@ import { BaseKey } from '../baseCoin/iface';
 import { TransactionBuilder, DEFAULT_M } from './transactionBuilder';
 import { Transaction } from './transaction';
 import { isValidAddress, isValidAmount, stringifyAccountId } from './utils';
+import { TransactionType } from '../baseCoin';
 
 export class TransferBuilder extends TransactionBuilder {
   private _txBodyData: proto.CryptoTransferTransactionBody;
@@ -22,8 +23,8 @@ export class TransferBuilder extends TransactionBuilder {
   /** @inheritdoc */
   protected async buildImplementation(): Promise<Transaction> {
     this._txBodyData.transfers = this.buildTransferData();
-    this.transaction = await super.buildImplementation();
-    return this.transaction;
+    this.transaction.setTransactionType(TransactionType.Send);
+    return await super.buildImplementation();
   }
 
   private buildTransferData(): proto.ITransferList {
@@ -47,6 +48,7 @@ export class TransferBuilder extends TransactionBuilder {
   /** @inheritdoc */
   initBuilder(tx: Transaction): void {
     super.initBuilder(tx);
+    this.transaction.setTransactionType(TransactionType.Send);
     const transferData = tx.txBody.cryptoTransfer;
     if (transferData && transferData.transfers && transferData.transfers.accountAmounts) {
       this.initTransfers(transferData.transfers.accountAmounts);

--- a/modules/account-lib/src/coin/hbar/walletInitializationBuilder.ts
+++ b/modules/account-lib/src/coin/hbar/walletInitializationBuilder.ts
@@ -5,6 +5,7 @@ import { TransactionBuilder, DEFAULT_M } from './transactionBuilder';
 import { Transaction } from './transaction';
 import { isValidPublicKey, toUint8Array, toHex } from './utils';
 import { KeyPair } from './';
+import { TransactionType } from '../baseCoin';
 
 export class WalletInitializationBuilder extends TransactionBuilder {
   private _owners: string[] = [];
@@ -22,7 +23,8 @@ export class WalletInitializationBuilder extends TransactionBuilder {
   protected async buildImplementation(): Promise<Transaction> {
     this._txBodyData.key = { thresholdKey: this.buildOwnersKeys() };
     this._txBodyData.initialBalance = 0;
-    return super.buildImplementation();
+    this.transaction.setTransactionType(TransactionType.WalletInitialization);
+    return await super.buildImplementation();
   }
 
   /**
@@ -44,6 +46,7 @@ export class WalletInitializationBuilder extends TransactionBuilder {
   /** @inheritdoc */
   initBuilder(tx: Transaction): void {
     super.initBuilder(tx);
+    this.transaction.setTransactionType(TransactionType.WalletInitialization);
     const createAcc = tx.txBody.cryptoCreateAccount;
     if (createAcc && createAcc.key && createAcc.key.thresholdKey) {
       this.initOwners(createAcc.key.thresholdKey as proto.ThresholdKey);

--- a/modules/account-lib/test/unit/coin/hbar/transactionBuilder/transferBuilder.ts
+++ b/modules/account-lib/test/unit/coin/hbar/transactionBuilder/transferBuilder.ts
@@ -3,6 +3,7 @@ import { register } from '../../../../../src/index';
 import { TransactionBuilderFactory } from '../../../../../src/coin/hbar';
 import * as testData from '../../../../resources/hbar/hbar';
 import { Transaction } from '../../../../../src/coin/hbar/transaction';
+import { TransactionType } from '../../../../../src/coin/baseCoin';
 
 describe('HBAR Transfer Builder', () => {
   const factory = register('thbar', TransactionBuilderFactory);
@@ -32,6 +33,7 @@ describe('HBAR Transfer Builder', () => {
         should.deepEqual(txJson.from, testData.ACCOUNT_1.accountId);
         should.deepEqual(txJson.fee.toString(), testData.FEE);
         should.deepEqual(tx.toBroadcastFormat(), testData.SIGNED_TRANSFER_TRANSACTION);
+        tx.type.should.equal(TransactionType.Send);
       });
 
       it('a transfer transaction signed multiple times', async () => {
@@ -101,12 +103,14 @@ describe('HBAR Transfer Builder', () => {
         builder.sign({ key: testData.ACCOUNT_1.prvKeyWithPrefix });
         const tx2 = await builder.build();
         should.deepEqual(tx2.toBroadcastFormat(), testData.SIGNED_TRANSFER_TRANSACTION);
+        tx2.type.should.equal(TransactionType.Send);
       });
 
       it('a signed transfer transaction from serilaized', async () => {
         const txBuilder = factory.from(testData.SIGNED_TRANSFER_TRANSACTION);
         const tx = await txBuilder.build();
         should.deepEqual(tx.toBroadcastFormat(), testData.SIGNED_TRANSFER_TRANSACTION);
+        tx.type.should.equal(TransactionType.Send);
       });
 
       it('an offline multisig transfer transaction', async () => {

--- a/modules/account-lib/test/unit/coin/hbar/transactionBuilder/walletInitialization.ts
+++ b/modules/account-lib/test/unit/coin/hbar/transactionBuilder/walletInitialization.ts
@@ -3,6 +3,7 @@ import { register } from '../../../../../src/index';
 import { KeyPair, TransactionBuilderFactory } from '../../../../../src/coin/hbar';
 import * as testData from '../../../../resources/hbar/hbar';
 import { WalletInitializationBuilder } from '../../../../../src/coin/hbar/walletInitializationBuilder';
+import { TransactionType } from '../../../../../src/coin/baseCoin';
 
 describe('HBAR Wallet initialization', () => {
   const factory = register('thbar', TransactionBuilderFactory);
@@ -28,6 +29,8 @@ describe('HBAR Wallet initialization', () => {
       should.deepEqual(tx.signature.length, 1);
       should.deepEqual(tx.toJson(), tx2.toJson());
       should.deepEqual(raw, tx2.toBroadcastFormat());
+      tx.type.should.equal(TransactionType.WalletInitialization);
+      tx2.type.should.equal(TransactionType.WalletInitialization);
     });
 
     it('an init transaction', async () => {
@@ -37,6 +40,7 @@ describe('HBAR Wallet initialization', () => {
       txJson.fee.should.equal(1000000000);
       should.deepEqual(tx.signature.length, 1);
       should.equal(txJson.from, testData.OPERATOR.accountId);
+      tx.type.should.equal(TransactionType.WalletInitialization);
     });
 
     it('offline signing init transaction', async () => {


### PR DESCRIPTION
This commit fills in the transaction type field for HBAR transactions so
that users of the library can know what type of transactions they be
dealin with

CLOSES TICKET: BG-23897