### PR TITLE
Expose inputs and outputs for HBAR txs

### DIFF
--- a/modules/account-lib/src/coin/hbar/transaction.ts
+++ b/modules/account-lib/src/coin/hbar/transaction.ts
@@ -117,6 +117,7 @@ export class Transaction extends BaseTransaction {
     this._txBody = proto.TransactionBody.decode(tx.bodyBytes);
     this._hederaTx = tx;
     // this.loadPreviousSignatures();
+    this.loadInputsAndOutputs();
   }
 
   /**
@@ -141,6 +142,28 @@ export class Transaction extends BaseTransaction {
           this._signatures.push(toHex(signature));
         }
       });
+    }
+  }
+
+  /**
+   * Load the input and output data on this transaction using the transaction json
+   * if there are outputs. For transactions without outputs (e.g. wallet initializations),
+   * this function will not do anything
+   */
+  loadInputsAndOutputs(): void {
+    const txJson = this.toJson();
+    if (txJson.to && txJson.amount) {
+      this._outputs = [{
+        address: txJson.to,
+        value: txJson.amount,
+        coin: this._coinConfig.name,
+      }];
+
+      this._inputs = [{
+        address: txJson.from,
+        value: txJson.amount,
+        coin: this._coinConfig.name,
+      }];
     }
   }
 

--- a/modules/account-lib/test/unit/coin/hbar/transactionBuilder/transferBuilder.ts
+++ b/modules/account-lib/test/unit/coin/hbar/transactionBuilder/transferBuilder.ts
@@ -34,6 +34,13 @@ describe('HBAR Transfer Builder', () => {
         should.deepEqual(txJson.fee.toString(), testData.FEE);
         should.deepEqual(tx.toBroadcastFormat(), testData.SIGNED_TRANSFER_TRANSACTION);
         tx.type.should.equal(TransactionType.Send);
+
+        tx.outputs.length.should.equal(1);
+        tx.outputs[0].address.should.equal(testData.ACCOUNT_2.accountId);
+        tx.outputs[0].value.should.equal('10');
+        tx.inputs.length.should.equal(1);
+        tx.inputs[0].address.should.equal(testData.ACCOUNT_1.accountId);
+        tx.inputs[0].value.should.equal('10');
       });
 
       it('a transfer transaction signed multiple times', async () => {


### PR DESCRIPTION
This commit exposes inputs and outputs for HBAR transactions throgh the
baseTransaction inputs and outputs interface. These were previously left
empty - this commit fills them in whenever the transaction body is
initialized. This is useful for callers that need to quickly parse this
data from transactions using the common interface

CLOSES TICKET: BG-23927