### PR TITLE
Fix HBAR Sign Transaction

### DIFF
--- a/modules/core/test/v2/unit/coins/hbar.ts
+++ b/modules/core/test/v2/unit/coins/hbar.ts
@@ -1,7 +1,6 @@
-import * as Promise from 'bluebird';
 import { Hbar } from '../../../../src/v2/coins/';
+import * as accountLib from '@bitgo/account-lib';
 
-const co = Promise.coroutine;
 import { TestBitGo } from '../../../lib/test_bitgo';
 
 describe('Hedera Hashgraph:', function() {
@@ -19,13 +18,13 @@ describe('Hedera Hashgraph:', function() {
     basecoin.should.be.an.instanceof(Hbar);
   });
 
-  it('should check valid addresses', co(function *() {
+  it('should check valid addresses', async function () {
     const badAddresses = ['', '0.0', 'YZ09fd-', '0.0.0.a', 'sadasdfggg', '0.2.a.b'];
     const goodAddresses = ['0', '0.0.0', '0.0.41098'];
 
     badAddresses.map(addr => { basecoin.isValidAddress(addr).should.equal(false); });
     goodAddresses.map(addr => { basecoin.isValidAddress(addr).should.equal(true); });
-  }));
+  });
 
   describe('Keypairs:', () => {
     it('should generate a keypair from random seed', function() {
@@ -44,6 +43,61 @@ describe('Hedera Hashgraph:', function() {
 
       keyPair.prv.should.equal('302e020100300506032b65700422042080350b4208d381fbfe2276a326603049fe500731c46d3c9936b5ce036b51377f');
       keyPair.pub.should.equal('302a300506032b65700321009cc402b5c75214269c2826e3c6119377cab6c367601338661c87a4e07c6e0333');
+    });
+  });
+
+  describe('Sign transaction:', () => {
+    /**
+     * Build an unsigned account-lib multi-signature send transaction
+     * @param destination The destination address of the transaction
+     * @param source The account sending thist ransaction
+     * @param amount The amount to send to the recipient
+     */
+    const buildUnsignedTransaction = async function({
+                                                      destination,
+                                                      source,
+                                                      amount = '100000',
+                                                    }) {
+
+      const factory = accountLib.register('thbar', accountLib.Hbar.TransactionBuilderFactory);
+      const txBuilder = factory.getTransferBuilder();
+      txBuilder.fee({
+        fee: '100000',
+      });
+      txBuilder.source({ address: source });
+      txBuilder.to(destination);
+      txBuilder.amount(amount);
+
+      return await txBuilder.build();
+    };
+
+    it('should sign transaction', async function() {
+      const key = new accountLib.Hbar.KeyPair();
+      const destination = '0.0.129369';
+      const source = '0.0.1234';
+      const amount = '100000';
+
+      const unsignedTransaction = await buildUnsignedTransaction({
+        destination,
+        source,
+        amount,
+      });
+
+      const tx = await basecoin.signTransaction({
+        prv: key.getKeys().prv,
+        txPrebuild: {
+          txHex: unsignedTransaction.toBroadcastFormat(),
+        },
+      });
+
+      const factory = accountLib.register('thbar', accountLib.Hbar.TransactionBuilderFactory);
+      const txBuilder = factory.from(tx.halfSigned.txHex);
+      const signedTx = await txBuilder.build();
+      const txJson = signedTx.toJson();
+      txJson.to.should.equal(destination);
+      txJson.from.should.equal(source);
+      txJson.amount.should.equal(amount);
+      signedTx.signature.length.should.equal(1);
     });
   });
 });


### PR DESCRIPTION
This commit fixes the sign transaction logic for HBAR and adds a test to
ensure that it continues to work in the future as more changes are made.
It also implements signMessage function, which unfortunately had to use
the algosdk library as @bitgo/account-lib does not implement signMessage
functionality

CLOSES TICKET: BG-24080