### PR TITLE
Add support for verifying transactions which spend to custom change wallets

### DIFF
--- a/modules/core/src/v2/baseCoin.ts
+++ b/modules/core/src/v2/baseCoin.ts
@@ -64,12 +64,20 @@ export interface TransactionParams {
   type?: string;
 }
 
+export interface AddressVerificationData {
+  coinSpecific?: AddressCoinSpecific;
+  chain?: number;
+  index?: number;
+}
+
 export interface VerificationOptions {
   disableNetworking?: boolean;
   keychains?: {
     user?: Keychain;
     backup?: Keychain;
+    bitgo?: Keychain;
   };
+  addresses?: { [address: string]: AddressVerificationData };
 }
 
 export interface VerifyTransactionOptions {

--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -1,32 +1,41 @@
+import { Codes, VirtualSizes } from '@bitgo/unspents';
+import { UnspentType } from '@bitgo/unspents/dist/codes';
 import * as bitcoin from '@bitgo/utxo-lib';
 import * as bitcoinMessage from 'bitcoinjs-message';
 import * as Bluebird from 'bluebird';
 import { randomBytes } from 'crypto';
-import * as request from 'superagent';
-import * as _ from 'lodash';
 import * as debugLib from 'debug';
-import { Codes, VirtualSizes } from '@bitgo/unspents';
-import { UnspentType } from '@bitgo/unspents/dist/codes';
+import * as _ from 'lodash';
+import * as request from 'superagent';
 
 import { hdPath } from '../../bitcoin';
 import { BitGo } from '../../bitgo';
+import * as config from '../../config';
+import * as errors from '../../errors';
+
 import {
-  BaseCoin, AddressCoinSpecific,
-  ExtraPrebuildParamsOptions, KeychainsTriplet,
-  PrecreateBitGoOptions, PresignTransactionOptions, SupplementGenerateWalletOptions,
+  AddressCoinSpecific,
+  BaseCoin,
+  ExtraPrebuildParamsOptions,
+  KeychainsTriplet,
+  PrecreateBitGoOptions,
+  PresignTransactionOptions,
+  SignedTransaction,
+  SupplementGenerateWalletOptions,
+  TransactionParams as BaseTransactionParams,
+  TransactionPrebuild as BaseTransactionPrebuild,
+  TransactionRecipient,
+  VerificationOptions,
   VerifyAddressOptions as BaseVerifyAddressOptions,
   VerifyRecoveryTransactionOptions,
   VerifyTransactionOptions,
-  TransactionParams as BaseTransactionParams,
-  TransactionPrebuild as BaseTransactionPrebuild, VerificationOptions, TransactionRecipient, SignedTransaction,
 } from '../baseCoin';
 import { CustomChangeOptions, parseOutput } from '../internal/parseOutput';
-import { Keychain, KeyIndices } from '../keychains';
-import { NodeCallback } from '../types';
-import * as config from '../../config';
-import { CrossChainRecoveryTool } from '../recovery';
-import * as errors from '../../errors';
 import { RequestTracer } from '../internal/util';
+import { Keychain, KeyIndices } from '../keychains';
+import { promiseProps } from '../promise-utils';
+import { CrossChainRecoveryTool } from '../recovery';
+import { NodeCallback } from '../types';
 import { Wallet } from '../wallet';
 import { RecoveryAccountData, RecoveryUnspent } from '../recovery/types';
 
@@ -108,11 +117,14 @@ export interface ParseTransactionOptions {
 
 export interface ParsedTransaction {
   keychains: {
-    user?: Keychain,
-    backup?: Keychain,
-    bitgo?: Keychain,
+    user?: Keychain;
+    backup?: Keychain;
+    bitgo?: Keychain;
   };
-  keySignatures: any[];
+  keySignatures: {
+    backupPub: string;
+    bitgoPub: string;
+  };
   outputs: Output[];
   missingOutputs: Output[];
   explicitExternalOutputs: Output[];
@@ -121,6 +133,7 @@ export interface ParsedTransaction {
   explicitExternalSpendAmount: number;
   implicitExternalSpendAmount: number;
   needsCustomChangeKeySignatureVerification: boolean;
+  customChange?: CustomChangeOptions;
 }
 
 export interface GenerateAddressOptions {
@@ -222,21 +235,15 @@ export interface RecoverParams {
 }
 
 export interface VerifyKeySignaturesOptions {
-  userKeychain: Keychain;
-  keychainToVerify: Keychain;
-  keySignature: string;
+  userKeychain?: Keychain;
+  keychainToVerify?: Keychain;
+  keySignature?: string;
 }
 
 export interface VerifyUserPublicKeyOptions {
-  userKeychain: Keychain;
+  userKeychain?: Keychain;
   disableNetworking: boolean;
   txParams: TransactionParams;
-}
-
-interface Keychains {
-  user?: Keychain,
-  backup?: Keychain,
-  bitgo?: Keychain,
 }
 
 export abstract class AbstractUtxoCoin extends BaseCoin {
@@ -471,8 +478,8 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       }
       const disableNetworking = verification.disableNetworking;
 
-      async function fetchKeychains(wallet: Wallet): Promise<Keychains> {
-        return Bluebird.props({
+      async function fetchKeychains(wallet: Wallet): Promise<VerificationOptions['keychains']> {
+        return promiseProps({
           user: self.keychains().get({ id: wallet.keyIds()[KeyIndices.USER], reqId }),
           backup: self.keychains().get({ id: wallet.keyIds()[KeyIndices.BACKUP], reqId }),
           bitgo: self.keychains().get({ id: wallet.keyIds()[KeyIndices.BITGO], reqId }),
@@ -480,7 +487,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       }
 
       // obtain the keychains and key signatures
-      let keychains: Keychains | undefined = verification.keychains;
+      let keychains: VerificationOptions['keychains'] | undefined = verification.keychains;
       if (!keychains) {
         if (disableNetworking) {
           throw new Error('cannot fetch keychains without networking');
@@ -514,13 +521,16 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       // get the keychains from the custom change wallet if needed
       let customChange: CustomChangeOptions | undefined;
       const { customChangeWalletId = undefined } = wallet.coinSpecific() || {};
-      debugger;
       if (customChangeWalletId) {
         // fetch keychains from custom change wallet for deriving addresses.
         // These keychains should be signed and this should be verified in verifyTransaction
-        const customChangeKeySignatures = _.get(wallet, '_wallet.customChangeKeySignatures');
-        const customChangeWallet = yield self.wallets().get({ id: customChangeWalletId });
+        const customChangeKeySignatures = _.get(wallet, '_wallet.customChangeKeySignatures', {});
+        const customChangeWallet: Wallet = yield self.wallets().get({ id: customChangeWalletId });
         const customChangeKeys = yield fetchKeychains(customChangeWallet);
+
+        if (!customChangeKeys) {
+          throw new Error('failed to fetch keychains for custom change wallet');
+        }
         const customChangeKeychains: [Keychain, Keychain, Keychain] = [customChangeKeys.user, customChangeKeys.backup, customChangeKeys.bitgo];
 
         if (customChangeKeychains && customChangeWallet) {
@@ -589,6 +599,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
         explicitExternalSpendAmount,
         implicitExternalSpendAmount,
         needsCustomChangeKeySignatureVerification,
+        customChange,
       };
       return result;
     }).call(this).asCallback(callback);
@@ -602,6 +613,10 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
    */
   protected verifyUserPublicKey(params: VerifyUserPublicKeyOptions): boolean {
     const { userKeychain, txParams, disableNetworking } = params;
+    if (!userKeychain) {
+      throw new Error('user keychain is required');
+    }
+
     const userPub = userKeychain.pub;
 
     // decrypt the user private key so we can verify that the claimed public key is a match
@@ -652,12 +667,59 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       throw new Error('user keychain is required');
     }
 
+    if (!keychainToVerify) {
+      throw new Error('keychain to verify is required');
+    }
+
+    if (!keySignature) {
+      throw new Error('key signature is required');
+    }
+
     // verify the signature against the user public key
     const signingAddress = bitcoin.HDNode.fromBase58(userKeychain.pub).keyPair.getAddress();
 
     // BG-5703: use BTC mainnet prefix for all key signature operations
     // (this means do not pass a prefix parameter, and let it use the default prefix instead)
-    return bitcoinMessage.verify(keychainToVerify.pub, signingAddress, Buffer.from(keySignature, 'hex'));
+    try {
+      return bitcoinMessage.verify(keychainToVerify.pub, signingAddress, Buffer.from(keySignature, 'hex'));
+    } catch (e) {
+      debug('error thrown from bitcoinmessage while verifying key signature', e);
+      return false;
+    }
+  }
+
+  /**
+   * Verify signatures against the user private key over the change wallet extended keys
+   * @param {ParsedTransaction} tx
+   * @param {Keychain} userKeychain
+   * @return {boolean}
+   * @protected
+   */
+  protected verifyCustomChangeKeySignatures(tx: ParsedTransaction, userKeychain: Keychain): boolean {
+    if (!tx.customChange) {
+      throw new Error('parsed transaction is missing required custom change verification data');
+    }
+
+    if (!Array.isArray(tx.customChange.keys) || !Array.isArray(tx.customChange.signatures)) {
+      throw new Error('customChange property is missing keys or signatures');
+    }
+
+    for (const keyIndex of [KeyIndices.USER, KeyIndices.BACKUP, KeyIndices.BITGO]) {
+      const keychainToVerify = tx.customChange.keys[keyIndex];
+      const keySignature = tx.customChange.signatures[keyIndex];
+      if (!keychainToVerify) {
+        throw new Error(`missing required custom change ${KeyIndices[keyIndex].toLowerCase()} keychain public key`);
+      }
+      if (!keySignature) {
+        throw new Error(`missing required custom change ${KeyIndices[keyIndex].toLowerCase()} keychain signature`);
+      }
+      if (!this.verifyKeySignature({ userKeychain, keychainToVerify, keySignature })) {
+        debug('failed to verify custom change %s key signature!', KeyIndices[keyIndex].toLowerCase());
+        return false;
+      }
+    }
+
+    return true;
   }
 
   /**
@@ -680,25 +742,44 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
     return co<boolean>(function *() {
       const { txParams, txPrebuild, wallet, verification = {}, reqId } = params;
       const disableNetworking = !!verification.disableNetworking;
-      const parsedTransaction = yield self.parseTransaction({ txParams, txPrebuild, wallet, verification, reqId });
+      const parsedTransaction: ParsedTransaction = yield self.parseTransaction({ txParams, txPrebuild, wallet, verification, reqId });
 
       const keychains = parsedTransaction.keychains;
+
+      // verify that the claimed user public key corresponds to the wallet's user private key
+      let userPublicKeyVerified = false;
+      try {
+        // verify the user public key matches the private key - this will throw if there is no match
+        userPublicKeyVerified = self.verifyUserPublicKey({ userKeychain: keychains.user, disableNetworking, txParams });
+      } catch (e) {
+        debug('failed to verify user public key!', e);
+      }
 
       // let's verify these keychains
       const keySignatures = parsedTransaction.keySignatures;
       if (!_.isEmpty(keySignatures)) {
-        // verify the user public key matches the private key - this will throw if there is no match
-        self.verifyUserPublicKey({ userKeychain: keychains.user, disableNetworking, txParams });
-
-        const isBackupKeySignatureValid = self.verifyKeySignature({ userKeychain: keychains.user, keychainToVerify: keychains.backup, keySignature: keySignatures.backupPub });
-        const isBitgoKeySignatureValid = self.verifyKeySignature({ userKeychain: keychains.user, keychainToVerify: keychains.bitgo, keySignature: keySignatures.bitgoPub });
+        const verify = (key, pub) => self.verifyKeySignature({ userKeychain: keychains.user, keychainToVerify: key, keySignature: pub });
+        const isBackupKeySignatureValid = verify(keychains.backup, keySignatures.backupPub);
+        const isBitgoKeySignatureValid = verify(keychains.bitgo, keySignatures.bitgoPub);
         if (!isBackupKeySignatureValid || !isBitgoKeySignatureValid) {
           throw new Error('secondary public key signatures invalid');
         }
+        debug('successfully verified backup and bitgo key signatures');
       } else if (!disableNetworking) {
         // these keys were obtained online and their signatures were not verified
         // this could be dangerous
         console.log('unsigned keys obtained online are being used for address verification');
+      }
+
+      if (parsedTransaction.needsCustomChangeKeySignatureVerification) {
+        if (!keychains.user || !userPublicKeyVerified) {
+          throw new Error('transaction requires verification of user public key, but it was unable to be verified');
+        }
+        const customChangeKeySignaturesVerified = self.verifyCustomChangeKeySignatures(parsedTransaction, keychains.user);
+        if (!customChangeKeySignaturesVerified) {
+          throw new Error('transaction requires verification of custom change key signatures, but they were unable to be verified');
+        }
+        debug('successfully verified user public key and custom change key signatures');
       }
 
       const missingOutputs = parsedTransaction.missingOutputs;

--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -20,6 +20,7 @@ import {
   TransactionParams as BaseTransactionParams,
   TransactionPrebuild as BaseTransactionPrebuild, VerificationOptions, TransactionRecipient, SignedTransaction,
 } from '../baseCoin';
+import { parseOutput } from '../internal/parseOutput';
 import { Keychain, KeyIndices } from '../keychains';
 import { NodeCallback } from '../types';
 import * as config from '../../config';
@@ -216,6 +217,12 @@ export interface RecoverParams {
   bitgoKey: string;
   walletPassphrase?: string;
   apiKey?: string;
+}
+
+interface Keychains {
+  user?: Keychain,
+  backup?: Keychain,
+  bitgo?: Keychain,
 }
 
 export abstract class AbstractUtxoCoin extends BaseCoin {
@@ -450,27 +457,28 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       }
       const disableNetworking = verification.disableNetworking;
 
-      // obtain the keychains and key signatures
-      let keychains: {
-        user?: Keychain,
-        backup?: Keychain,
-        bitgo?: Keychain,
-      } | undefined = verification.keychains;
-      if (!keychains && disableNetworking) {
-        throw new Error('cannot fetch keychains without networking');
-      } else if (!keychains) {
-        keychains = yield Bluebird.props({
+      async function fetchKeychains(wallet: Wallet): Promise<Keychains> {
+        return Bluebird.props({
           user: self.keychains().get({ id: wallet.keyIds()[KeyIndices.USER], reqId }),
           backup: self.keychains().get({ id: wallet.keyIds()[KeyIndices.BACKUP], reqId }),
           bitgo: self.keychains().get({ id: wallet.keyIds()[KeyIndices.BITGO], reqId }),
         });
       }
 
+      // obtain the keychains and key signatures
+      let keychains: Keychains | undefined = verification.keychains;
       if (!keychains) {
+        if (disableNetworking) {
+          throw new Error('cannot fetch keychains without networking');
+        }
+        keychains = yield fetchKeychains(wallet);
+      }
+
+      if (!keychains || !keychains.user || !keychains.backup || !keychains.bitgo) {
         throw new Error('keychains are required, but could not be fetched');
       }
 
-      const keychainArray = [keychains.user, keychains.backup, keychains.bitgo];
+      const keychainArray: [Keychain, Keychain, Keychain] = [keychains.user, keychains.backup, keychains.bitgo];
 
       const keySignatures = _.get(wallet, '_wallet.keySignatures');
 
@@ -493,98 +501,9 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
        * Loop through all the outputs and classify each of them as either internal spends
        * or external spends by setting the "external" property to true or false on the output object.
        */
-      const allOutputDetails: Output[] = yield Bluebird.map(allOutputs, co(function *(currentOutput) {
-        const currentAddress = currentOutput.address;
-
-        // attempt to grab the address details from either the prebuilt tx, or the verification params.
-        // If both of these are empty, then we will try to get the address details from bitgo instead
-        const addressDetailsPrebuild = _.get(txPrebuild, `txInfo.walletAddressDetails.${currentAddress}`, {});
-        const addressDetailsVerification = _.get(verification, `addresses.${currentAddress}`, {});
-        debug('Parsing address details for %s', currentAddress);
-        try {
-          /**
-           * The only way to determine whether an address is known on the wallet is to initiate a network request and
-           * fetch it. Should the request fail and return a 404, it will throw and therefore has to be caught. For that
-           * reason, address wallet ownership detection is wrapped in a try/catch. Additionally, once the address
-           * details are fetched on the wallet, a local address validation is run, whose errors however are generated
-           * client-side and can therefore be analyzed with more granularity and type checking.
-           */
-          let addressDetails = _.extend({}, addressDetailsPrebuild, addressDetailsVerification);
-          debug('Locally available address %s details: %O', currentAddress, addressDetails);
-          if (_.isEmpty(addressDetails) && !disableNetworking) {
-            addressDetails = yield wallet.getAddress({ address: currentAddress, reqId });
-            debug('Downloaded address %s details: %O', currentAddress, addressDetails);
-          }
-          // verify that the address is on the wallet. verifyAddress throws if
-          // it fails to correctly rederive the address, meaning it's external
-          const addressType = AbstractUtxoCoin.inferAddressType(addressDetails);
-          self.verifyAddress(_.extend({ addressType }, addressDetails, {
-            keychains: keychainArray,
-            address: currentAddress,
-          }));
-          debug('Address %s verification passed', currentAddress);
-
-          // verify address succeeded without throwing, so the address was
-          // correctly rederived from the wallet keychains, making it not external
-          return _.extend({}, currentOutput, addressDetails, { external: false });
-        } catch (e) {
-          // verify address threw an exception
-          debug('Address %s verification threw an error:', currentAddress, e);
-          // Todo: name server-side errors to avoid message-based checking [BG-5124]
-          const walletAddressNotFound = e.message.includes('wallet address not found');
-          const unexpectedAddress = (e instanceof errors.UnexpectedAddressError);
-          if (walletAddressNotFound || unexpectedAddress) {
-            if (unexpectedAddress && !walletAddressNotFound) {
-              /**
-               * this could be a migrated SafeHD BCH wallet, and the transaction we are currently
-               * parsing is trying to spend change back to the v1 wallet base address.
-               * It does this since we don't allow new address creation for these wallets,
-               * and instead return the base address from the v1 wallet when a new address is requested.
-               * If this new address is requested for the purposes of spending change back to the wallet,
-               * the change will go to the v1 wallet base address. This address *is* on the wallet,
-               * but it will still cause an error to be thrown by verifyAddress, since the derivation path
-               * used for this address is non-standard. (I have seen these addresses derived using paths m/0/0 and m/101,
-               * whereas the v2 addresses are derived using path  m/0/0/${chain}/${index}).
-               *
-               * This means we need to check for this case explicitly in this catch block, and classify
-               * these types of outputs as internal instead of external. Failing to do so would cause the
-               * transaction's implicit external outputs (ie, outputs which go to addresses not specified in
-               * the recipients array) to add up to more than the 150 basis point limit which we enforce on
-               * pay-as-you-go outputs (which should be the only implicit external outputs on our transactions).
-               *
-               * The 150 basis point limit for implicit external sends is enforced in verifyTransaction,
-               * which calls this function to get information on the total external/internal spend amounts
-               * for a transaction. The idea here is to protect from the transaction being maliciously modified
-               * to add more implicit external spends (eg, to an attacker-controlled wallet).
-               *
-               * See verifyTransaction for more information on how transaction prebuilds are verified before signing.
-               */
-
-              if (_.isString(wallet.migratedFrom()) && wallet.migratedFrom() === currentAddress) {
-                debug('found address %s which was migrated from v1 wallet, address is not external', currentAddress);
-                return _.extend({}, currentOutput, { external: false });
-              }
-
-              debug('Address %s was found on wallet but could not be reconstructed', currentAddress);
-            }
-
-            // the address was found, but not on the wallet, which simply means it's external
-            debug('Address %s presumed external', currentAddress);
-            return _.extend({}, currentOutput, { external: true });
-          } else if (e instanceof errors.InvalidAddressDerivationPropertyError && currentAddress === txParams.changeAddress) {
-            // expect to see this error when passing in a custom changeAddress with no chain or index
-            return _.extend({}, currentOutput, { external: false });
-          }
-
-          debug('Address %s verification failed', currentAddress);
-          /**
-           * It might be a completely invalid address or a bad validation attempt or something else completely, in
-           * which case we do not proceed and rather rethrow the error, which is safer than assuming that the address
-           * validation failed simply because it's external to the wallet.
-           */
-          throw e;
-        }
-      }).bind(this));
+      const allOutputDetails: Output[] = yield Bluebird.map(allOutputs, (currentOutput) => {
+        return parseOutput(currentOutput, self, txPrebuild, verification, keychainArray, wallet, txParams, reqId);
+      });
 
       const changeOutputs = _.filter(allOutputDetails, { external: false });
 

--- a/modules/core/src/v2/internal/parseOutput.ts
+++ b/modules/core/src/v2/internal/parseOutput.ts
@@ -1,0 +1,119 @@
+/**
+ * @prettier
+ */
+
+import * as debugLib from 'debug';
+import * as _ from 'lodash';
+import * as errors from '../../errors';
+import { TransactionPrebuild, VerificationOptions } from '../baseCoin';
+import { AbstractUtxoCoin, Output, TransactionParams } from '../coins/abstractUtxoCoin';
+import { Keychain } from '../keychains';
+import { Wallet } from '../wallet';
+import { RequestTracer } from './util';
+
+const debug = debugLib('bitgo:v2:parseoutput');
+
+export async function parseOutput(
+  currentOutput: Output,
+  coin: AbstractUtxoCoin,
+  txPrebuild: TransactionPrebuild,
+  verification: VerificationOptions,
+  keychainArray: [Keychain, Keychain, Keychain],
+  wallet: Wallet,
+  txParams: TransactionParams,
+  reqId?: RequestTracer
+): Promise<Output> {
+  const disableNetworking = !!verification.disableNetworking;
+  const currentAddress = currentOutput.address;
+
+  // attempt to grab the address details from either the prebuilt tx, or the verification params.
+  // If both of these are empty, then we will try to get the address details from bitgo instead
+  const addressDetailsPrebuild = _.get(txPrebuild, `txInfo.walletAddressDetails.${currentAddress}`, {});
+  const addressDetailsVerification = _.get(verification, `addresses.${currentAddress}`, {});
+  debug('Parsing address details for %s', currentAddress);
+  try {
+    /**
+     * The only way to determine whether an address is known on the wallet is to initiate a network request and
+     * fetch it. Should the request fail and return a 404, it will throw and therefore has to be caught. For that
+     * reason, address wallet ownership detection is wrapped in a try/catch. Additionally, once the address
+     * details are fetched on the wallet, a local address validation is run, whose errors however are generated
+     * client-side and can therefore be analyzed with more granularity and type checking.
+     */
+    let addressDetails = _.extend({}, addressDetailsPrebuild, addressDetailsVerification);
+    debug('Locally available address %s details: %O', currentAddress, addressDetails);
+    if (_.isEmpty(addressDetails) && !disableNetworking) {
+      addressDetails = await wallet.getAddress({ address: currentAddress, reqId });
+      debug('Downloaded address %s details: %O', currentAddress, addressDetails);
+    }
+    // verify that the address is on the wallet. verifyAddress throws if
+    // it fails to correctly rederive the address, meaning it's external
+    const addressType = AbstractUtxoCoin.inferAddressType(addressDetails);
+    coin.verifyAddress(
+      _.extend({ addressType }, addressDetails, {
+        keychains: keychainArray,
+        address: currentAddress,
+      })
+    );
+    debug('Address %s verification passed', currentAddress);
+
+    // verify address succeeded without throwing, so the address was
+    // correctly rederived from the wallet keychains, making it not external
+    return _.extend({}, currentOutput, addressDetails, { external: false });
+  } catch (e) {
+    // verify address threw an exception
+    debug('Address %s verification threw an error:', currentAddress, e);
+    // Todo: name server-side errors to avoid message-based checking [BG-5124]
+    const walletAddressNotFound = e.message.includes('wallet address not found');
+    const unexpectedAddress = e instanceof errors.UnexpectedAddressError;
+    if (walletAddressNotFound || unexpectedAddress) {
+      if (unexpectedAddress && !walletAddressNotFound) {
+        /**
+         * this could be a migrated SafeHD BCH wallet, and the transaction we are currently
+         * parsing is trying to spend change back to the v1 wallet base address.
+         * It does this since we don't allow new address creation for these wallets,
+         * and instead return the base address from the v1 wallet when a new address is requested.
+         * If this new address is requested for the purposes of spending change back to the wallet,
+         * the change will go to the v1 wallet base address. This address *is* on the wallet,
+         * but it will still cause an error to be thrown by verifyAddress, since the derivation path
+         * used for this address is non-standard. (I have seen these addresses derived using paths m/0/0 and m/101,
+         * whereas the v2 addresses are derived using path  m/0/0/${chain}/${index}).
+         *
+         * This means we need to check for this case explicitly in this catch block, and classify
+         * these types of outputs as internal instead of external. Failing to do so would cause the
+         * transaction's implicit external outputs (ie, outputs which go to addresses not specified in
+         * the recipients array) to add up to more than the 150 basis point limit which we enforce on
+         * pay-as-you-go outputs (which should be the only implicit external outputs on our transactions).
+         *
+         * The 150 basis point limit for implicit external sends is enforced in verifyTransaction,
+         * which calls this function to get information on the total external/internal spend amounts
+         * for a transaction. The idea here is to protect from the transaction being maliciously modified
+         * to add more implicit external spends (eg, to an attacker-controlled wallet).
+         *
+         * See verifyTransaction for more information on how transaction prebuilds are verified before signing.
+         */
+
+        if (_.isString(wallet.migratedFrom()) && wallet.migratedFrom() === currentAddress) {
+          debug('found address %s which was migrated from v1 wallet, address is not external', currentAddress);
+          return _.extend({}, currentOutput, { external: false });
+        }
+
+        debug('Address %s was found on wallet but could not be reconstructed', currentAddress);
+      }
+
+      // the address was found, but not on the wallet, which simply means it's external
+      debug('Address %s presumed external', currentAddress);
+      return _.extend({}, currentOutput, { external: true });
+    } else if (e instanceof errors.InvalidAddressDerivationPropertyError && currentAddress === txParams.changeAddress) {
+      // expect to see this error when passing in a custom changeAddress with no chain or index
+      return _.extend({}, currentOutput, { external: false });
+    }
+
+    debug('Address %s verification failed', currentAddress);
+    /**
+     * It might be a completely invalid address or a bad validation attempt or something else completely, in
+     * which case we do not proceed and rather rethrow the error, which is safer than assuming that the address
+     * validation failed simply because it's external to the wallet.
+     */
+    throw e;
+  }
+}

--- a/modules/core/src/v2/internal/parseOutput.ts
+++ b/modules/core/src/v2/internal/parseOutput.ts
@@ -13,16 +13,191 @@ import { RequestTracer } from './util';
 
 const debug = debugLib('bitgo:v2:parseoutput');
 
-export async function parseOutput(
-  currentOutput: Output,
-  coin: AbstractUtxoCoin,
-  txPrebuild: TransactionPrebuild,
-  verification: VerificationOptions,
-  keychainArray: [Keychain, Keychain, Keychain],
-  wallet: Wallet,
-  txParams: TransactionParams,
-  reqId?: RequestTracer
-): Promise<Output> {
+/**
+ * Check an address which failed initial validation to see if it's the base address of a migrated v1 bch wallet.
+ *
+ * The wallet in question could be a migrated SafeHD BCH wallet, and the transaction we
+ * are currently parsing is trying to spend change back to the v1 wallet base address.
+ *
+ * It does this since we don't allow new address creation for these wallets,
+ * and instead return the base address from the v1 wallet when a new address is requested.
+ * If this new address is requested for the purposes of spending change back to the wallet,
+ * the change will go to the v1 wallet base address. This address *is* on the wallet,
+ * but it will still cause an error to be thrown by verifyAddress, since the derivation path
+ * used for this address is non-standard. (I have seen these addresses derived using paths m/0/0 and m/101,
+ * whereas the v2 addresses are derived using path  m/0/0/${chain}/${index}).
+ *
+ * This means we need to check for this case explicitly in this catch block, and classify
+ * these types of outputs as internal instead of external. Failing to do so would cause the
+ * transaction's implicit external outputs (ie, outputs which go to addresses not specified in
+ * the recipients array) to add up to more than the 150 basis point limit which we enforce on
+ * pay-as-you-go outputs (which should be the only implicit external outputs on our transactions).
+ *
+ * The 150 basis point limit for implicit external sends is enforced in verifyTransaction,
+ * which calls this function to get information on the total external/internal spend amounts
+ * for a transaction. The idea here is to protect from the transaction being maliciously modified
+ * to add more implicit external spends (eg, to an attacker-controlled wallet).
+ *
+ * See verifyTransaction for more information on how transaction prebuilds are verified before signing.
+ *
+ * @param wallet {Wallet} wallet which is making the transaction
+ * @param currentAddress {string} address to check for externality relative to v1 wallet base address
+ */
+function isMigratedAddress(wallet: Wallet, currentAddress: string): boolean {
+  if (_.isString(wallet.migratedFrom()) && wallet.migratedFrom() === currentAddress) {
+    debug('found address %s which was migrated from v1 wallet, address is not external', currentAddress);
+    return true;
+  }
+
+  return false;
+}
+
+interface VerifyCustomChangeAddressOptions {
+  coin: AbstractUtxoCoin;
+  customChangeKeys: HandleVerifyAddressErrorOptions['customChangeKeys'];
+  addressType: HandleVerifyAddressErrorOptions['addressType'];
+  addressDetails: HandleVerifyAddressErrorOptions['addressDetails'];
+  currentAddress: HandleVerifyAddressErrorOptions['currentAddress'];
+}
+
+/**
+ * Check to see if an address is derived from the given custom change keys
+ * @param {VerifyCustomChangeAddressOptions} params
+ * @return {boolean}
+ */
+function verifyCustomChangeAddress(params: VerifyCustomChangeAddressOptions): boolean {
+  const { coin, customChangeKeys, addressType, addressDetails, currentAddress } = params;
+  try {
+    return coin.verifyAddress(
+      _.extend({ addressType }, addressDetails, {
+        keychains: customChangeKeys,
+        address: currentAddress,
+      })
+    );
+  } catch (e) {
+    debug('failed to verify custom change address %s', currentAddress);
+    return false;
+  }
+}
+
+interface HandleVerifyAddressErrorOptions {
+  e: Error;
+  currentAddress: string;
+  wallet: Wallet;
+  txParams: TransactionParams;
+  customChangeKeys?: CustomChangeOptions['keys'];
+  coin: AbstractUtxoCoin;
+  addressDetails?: any;
+  addressType?: string;
+}
+
+function handleVerifyAddressError({
+  e,
+  currentAddress,
+  wallet,
+  txParams,
+  customChangeKeys,
+  coin,
+  addressDetails,
+  addressType,
+}: HandleVerifyAddressErrorOptions): { external: boolean; needsCustomChangeKeySignatureVerification?: boolean } {
+  // Todo: name server-side errors to avoid message-based checking [BG-5124]
+  const walletAddressNotFound = e.message.includes('wallet address not found');
+  const unexpectedAddress = e instanceof errors.UnexpectedAddressError;
+  if (walletAddressNotFound || unexpectedAddress) {
+    if (unexpectedAddress && !walletAddressNotFound) {
+      // check to see if this is a migrated v1 bch address - it could be internal
+      const isMigrated = isMigratedAddress(wallet, currentAddress);
+      if (isMigrated) {
+        return { external: false };
+      }
+
+      debug('Address %s was found on wallet but could not be reconstructed', currentAddress);
+      debugger;
+
+      // attempt to verify address using custom change address keys if the wallet has that feature enabled
+      if (
+        customChangeKeys &&
+        verifyCustomChangeAddress({ coin, addressDetails, addressType, currentAddress, customChangeKeys })
+      ) {
+        // address is valid against the custom change keys. Mark address as not external
+        // and request signature verification for the custom change keys
+        debug('Address %s verified as derived from the custom change keys', currentAddress);
+        return { external: false, needsCustomChangeKeySignatureVerification: true };
+      }
+    }
+
+    // the address was found, but not on the wallet, which simply means it's external
+    debug('Address %s presumed external', currentAddress);
+    return { external: true };
+  } else if (e instanceof errors.InvalidAddressDerivationPropertyError && currentAddress === txParams.changeAddress) {
+    // expect to see this error when passing in a custom changeAddress with no chain or index
+    return { external: false };
+  }
+
+  debug('Address %s verification failed', currentAddress);
+  /**
+   * It might be a completely invalid address or a bad validation attempt or something else completely, in
+   * which case we do not proceed and rather rethrow the error, which is safer than assuming that the address
+   * validation failed simply because it's external to the wallet.
+   */
+  throw e;
+}
+
+interface FetchAddressDetailsOptions {
+  reqId?: RequestTracer;
+  disableNetworking: boolean;
+  addressDetailsPrebuild: any;
+  addressDetailsVerification: any;
+  currentAddress: string;
+  wallet: Wallet;
+}
+
+async function fetchAddressDetails({
+  reqId,
+  disableNetworking,
+  addressDetailsPrebuild,
+  addressDetailsVerification,
+  currentAddress,
+  wallet,
+}: FetchAddressDetailsOptions) {
+  let addressDetails = _.extend({}, addressDetailsPrebuild, addressDetailsVerification);
+  debug('Locally available address %s details: %O', currentAddress, addressDetails);
+  if (_.isEmpty(addressDetails) && !disableNetworking) {
+    addressDetails = await wallet.getAddress({ address: currentAddress, reqId });
+    debug('Downloaded address %s details: %O', currentAddress, addressDetails);
+  }
+  return addressDetails;
+}
+
+export interface CustomChangeOptions {
+  keys: [Keychain, Keychain, Keychain];
+  signatures: [string, string, string];
+}
+
+export interface ParseOutputOptions {
+  currentOutput: Output;
+  coin: AbstractUtxoCoin;
+  txPrebuild: TransactionPrebuild;
+  verification: VerificationOptions;
+  keychainArray: [Keychain, Keychain, Keychain];
+  wallet: Wallet;
+  txParams: TransactionParams;
+  customChange?: CustomChangeOptions;
+  reqId?: RequestTracer;
+}
+
+export async function parseOutput({
+  currentOutput,
+  coin,
+  txPrebuild,
+  verification,
+  keychainArray,
+  wallet,
+  txParams,
+  customChange,
+  reqId,
+}: ParseOutputOptions): Promise<Output> {
   const disableNetworking = !!verification.disableNetworking;
   const currentAddress = currentOutput.address;
 
@@ -31,6 +206,8 @@ export async function parseOutput(
   const addressDetailsPrebuild = _.get(txPrebuild, `txInfo.walletAddressDetails.${currentAddress}`, {});
   const addressDetailsVerification = _.get(verification, `addresses.${currentAddress}`, {});
   debug('Parsing address details for %s', currentAddress);
+  let currentAddressDetails = undefined;
+  let currentAddressType: string | undefined = undefined;
   try {
     /**
      * The only way to determine whether an address is known on the wallet is to initiate a network request and
@@ -39,17 +216,20 @@ export async function parseOutput(
      * details are fetched on the wallet, a local address validation is run, whose errors however are generated
      * client-side and can therefore be analyzed with more granularity and type checking.
      */
-    let addressDetails = _.extend({}, addressDetailsPrebuild, addressDetailsVerification);
-    debug('Locally available address %s details: %O', currentAddress, addressDetails);
-    if (_.isEmpty(addressDetails) && !disableNetworking) {
-      addressDetails = await wallet.getAddress({ address: currentAddress, reqId });
-      debug('Downloaded address %s details: %O', currentAddress, addressDetails);
-    }
+    const addressDetails = await fetchAddressDetails({
+      reqId,
+      addressDetailsVerification,
+      addressDetailsPrebuild,
+      currentAddress,
+      disableNetworking,
+      wallet,
+    });
     // verify that the address is on the wallet. verifyAddress throws if
     // it fails to correctly rederive the address, meaning it's external
-    const addressType = AbstractUtxoCoin.inferAddressType(addressDetails);
+    currentAddressType = AbstractUtxoCoin.inferAddressType(addressDetails) || undefined;
+    currentAddressDetails = addressDetails;
     coin.verifyAddress(
-      _.extend({ addressType }, addressDetails, {
+      _.extend({ addressType: currentAddressType }, addressDetails, {
         keychains: keychainArray,
         address: currentAddress,
       })
@@ -60,60 +240,20 @@ export async function parseOutput(
     // correctly rederived from the wallet keychains, making it not external
     return _.extend({}, currentOutput, addressDetails, { external: false });
   } catch (e) {
-    // verify address threw an exception
     debug('Address %s verification threw an error:', currentAddress, e);
-    // Todo: name server-side errors to avoid message-based checking [BG-5124]
-    const walletAddressNotFound = e.message.includes('wallet address not found');
-    const unexpectedAddress = e instanceof errors.UnexpectedAddressError;
-    if (walletAddressNotFound || unexpectedAddress) {
-      if (unexpectedAddress && !walletAddressNotFound) {
-        /**
-         * this could be a migrated SafeHD BCH wallet, and the transaction we are currently
-         * parsing is trying to spend change back to the v1 wallet base address.
-         * It does this since we don't allow new address creation for these wallets,
-         * and instead return the base address from the v1 wallet when a new address is requested.
-         * If this new address is requested for the purposes of spending change back to the wallet,
-         * the change will go to the v1 wallet base address. This address *is* on the wallet,
-         * but it will still cause an error to be thrown by verifyAddress, since the derivation path
-         * used for this address is non-standard. (I have seen these addresses derived using paths m/0/0 and m/101,
-         * whereas the v2 addresses are derived using path  m/0/0/${chain}/${index}).
-         *
-         * This means we need to check for this case explicitly in this catch block, and classify
-         * these types of outputs as internal instead of external. Failing to do so would cause the
-         * transaction's implicit external outputs (ie, outputs which go to addresses not specified in
-         * the recipients array) to add up to more than the 150 basis point limit which we enforce on
-         * pay-as-you-go outputs (which should be the only implicit external outputs on our transactions).
-         *
-         * The 150 basis point limit for implicit external sends is enforced in verifyTransaction,
-         * which calls this function to get information on the total external/internal spend amounts
-         * for a transaction. The idea here is to protect from the transaction being maliciously modified
-         * to add more implicit external spends (eg, to an attacker-controlled wallet).
-         *
-         * See verifyTransaction for more information on how transaction prebuilds are verified before signing.
-         */
-
-        if (_.isString(wallet.migratedFrom()) && wallet.migratedFrom() === currentAddress) {
-          debug('found address %s which was migrated from v1 wallet, address is not external', currentAddress);
-          return _.extend({}, currentOutput, { external: false });
-        }
-
-        debug('Address %s was found on wallet but could not be reconstructed', currentAddress);
-      }
-
-      // the address was found, but not on the wallet, which simply means it's external
-      debug('Address %s presumed external', currentAddress);
-      return _.extend({}, currentOutput, { external: true });
-    } else if (e instanceof errors.InvalidAddressDerivationPropertyError && currentAddress === txParams.changeAddress) {
-      // expect to see this error when passing in a custom changeAddress with no chain or index
-      return _.extend({}, currentOutput, { external: false });
-    }
-
-    debug('Address %s verification failed', currentAddress);
-    /**
-     * It might be a completely invalid address or a bad validation attempt or something else completely, in
-     * which case we do not proceed and rather rethrow the error, which is safer than assuming that the address
-     * validation failed simply because it's external to the wallet.
-     */
-    throw e;
+    return _.extend(
+      {},
+      currentOutput,
+      handleVerifyAddressError({
+        e,
+        coin,
+        currentAddress,
+        wallet,
+        txParams,
+        customChangeKeys: customChange && customChange.keys,
+        addressDetails: currentAddressDetails,
+        addressType: currentAddressType,
+      })
+    );
   }
 }

--- a/modules/core/src/v2/internal/parseOutput.ts
+++ b/modules/core/src/v2/internal/parseOutput.ts
@@ -5,7 +5,7 @@
 import * as debugLib from 'debug';
 import * as _ from 'lodash';
 import * as errors from '../../errors';
-import { TransactionPrebuild, VerificationOptions } from '../baseCoin';
+import { AddressVerificationData, TransactionPrebuild, VerificationOptions } from '../baseCoin';
 import { AbstractUtxoCoin, Output, TransactionParams } from '../coins/abstractUtxoCoin';
 import { Keychain } from '../keychains';
 import { Wallet } from '../wallet';
@@ -113,7 +113,6 @@ function handleVerifyAddressError({
       }
 
       debug('Address %s was found on wallet but could not be reconstructed', currentAddress);
-      debugger;
 
       // attempt to verify address using custom change address keys if the wallet has that feature enabled
       if (
@@ -204,7 +203,7 @@ export async function parseOutput({
   // attempt to grab the address details from either the prebuilt tx, or the verification params.
   // If both of these are empty, then we will try to get the address details from bitgo instead
   const addressDetailsPrebuild = _.get(txPrebuild, `txInfo.walletAddressDetails.${currentAddress}`, {});
-  const addressDetailsVerification = _.get(verification, `addresses.${currentAddress}`, {});
+  const addressDetailsVerification: AddressVerificationData = _.get(verification, `addresses.${currentAddress}`, {});
   debug('Parsing address details for %s', currentAddress);
   let currentAddressDetails = undefined;
   let currentAddressType: string | undefined = undefined;

--- a/modules/core/src/v2/keychains.ts
+++ b/modules/core/src/v2/keychains.ts
@@ -346,4 +346,3 @@ export class Keychains {
     }).call(this).asCallback(callback);
   }
 }
-

--- a/modules/core/src/v2/promise-utils.ts
+++ b/modules/core/src/v2/promise-utils.ts
@@ -1,0 +1,9 @@
+export type PromiseProps<T> = { [K in keyof T]?: Promise<T[K] | undefined> };
+export async function promiseProps<T>(obj: PromiseProps<T>): Promise<T> {
+  const promKeys = Object.keys(obj);
+  return (await Promise.all(Object.values(obj)))
+    .reduce((acc: T, cur, idx) => {
+      acc[promKeys[idx]] = cur;
+      return acc;
+    }, {});
+}

--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -133,6 +133,7 @@ export interface WalletCoinSpecific {
   addressVersion?: number;
   baseAddress?: string;
   rootAddress?: string;
+  customChangeWalletId: string;
 }
 
 export interface PaginationOptions {
@@ -383,6 +384,11 @@ interface WalletData {
   coinSpecific: WalletCoinSpecific;
   pendingApprovals: PendingApprovalData[];
   enterprise: string;
+  customChangeKeySignatures?: {
+    user?: string;
+    backup?: string;
+    bitgo?: string;
+  };
 }
 
 export interface RecoverTokenOptions {

--- a/modules/core/src/v2/wallets.ts
+++ b/modules/core/src/v2/wallets.ts
@@ -5,12 +5,11 @@ import * as bitcoin from '@bitgo/utxo-lib';
 import { BitGo } from '../bitgo';
 import * as common from '../common';
 import { BaseCoin, KeychainsTriplet, SupplementGenerateWalletOptions } from './baseCoin';
-import { NodeCallback } from './types';
+import { NodeCallback, RequestTracer as IRequestTracer } from './types';
 import { PaginationOptions, Wallet } from './wallet';
 import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
 import { hdPath } from '../bitcoin';
-import { RequestTracer as IRequestTracer } from './types';
 import { RequestTracer } from './internal/util';
 
 const co = Bluebird.coroutine;

--- a/modules/core/test/v2/unit/coins/abstractUtxoCoin.ts
+++ b/modules/core/test/v2/unit/coins/abstractUtxoCoin.ts
@@ -21,7 +21,11 @@ describe('Abstract UTXO Coin:', () => {
      */
     const verification = {
       disableNetworking: true,
-      keychains: {}
+      keychains: {
+        user: {},
+        backup: {},
+        bitgo: {},
+      },
     };
 
     const wallet = sinon.createStubInstance(Wallet, {

--- a/modules/core/test/v2/unit/coins/abstractUtxoCoin.ts
+++ b/modules/core/test/v2/unit/coins/abstractUtxoCoin.ts
@@ -1,7 +1,10 @@
 import * as should from 'should';
-import { coroutine as co } from 'bluebird';
+import * as Bluebird from 'bluebird';
+const co = Bluebird.coroutine;
 import * as sinon from 'sinon';
-import { Wallet } from '../../../../src/v2/wallet';
+import { BitGo, VerificationOptions } from '../../../../src';
+import { Wallet } from '../../../../src/v2';
+import { AbstractUtxoCoin } from '../../../../src/v2/coins';
 const recoveryNocks = require('../../lib/recovery-nocks');
 const fixtures = require('../../fixtures/coins/recovery');
 import { TestBitGo } from '../../../lib/test_bitgo';
@@ -11,87 +14,90 @@ import * as errors from '../../../../src/errors';
 
 describe('Abstract UTXO Coin:', () => {
   describe('Parse Transaction:', () => {
-    let coin;
-    let bitgo;
+    const bitgo: BitGo = new TestBitGo({ env: 'mock' });
+    const coin = bitgo.coin('tbtc') as AbstractUtxoCoin;
 
     /*
      * mock objects which get passed into parse transaction.
      * These objects are structured to force parse transaction into a
      * particular execution path for these tests.
      */
-    const verification = {
+    const verification: VerificationOptions = {
       disableNetworking: true,
       keychains: {
-        user: {},
-        backup: {},
-        bitgo: {},
+        user: { id: '0', pub: 'aaa' },
+        backup: { id: '1', pub: 'bbb' },
+        bitgo: { id: '2', pub: 'ccc' },
       },
     };
 
     const wallet = sinon.createStubInstance(Wallet, {
-      migratedFrom: 'v1_wallet_base_address'
+      migratedFrom: 'v1_wallet_base_address',
     });
 
     const outputAmount = 0.01 * 1e8;
 
-    before(() => {
-      bitgo = new TestBitGo({ env: 'mock' });
-      coin = bitgo.coin('btc');
-    });
-
-    it('should classify outputs which spend change back to a v1 wallet base address as internal', co(function *() {
+    it('should classify outputs which spend change back to a v1 wallet base address as internal', co(function* () {
       sinon.stub(coin, 'explainTransaction').resolves({
         outputs: [],
         changeOutputs: [{
           address: wallet.migratedFrom(),
-          amount: outputAmount
-        }]
-      });
+          amount: outputAmount,
+        }],
+      } as any);
 
       sinon.stub(coin, 'verifyAddress').throws(new errors.UnexpectedAddressError('test error'));
 
-
-      const parsedTransaction = yield coin.parseTransaction({ txParams: {}, txPrebuild: { txHex: '' }, wallet, verification });
+      const parsedTransaction = yield coin.parseTransaction({
+        txParams: {},
+        txPrebuild: { txHex: '' },
+        wallet: wallet as any,
+        verification: verification as any
+      });
 
       should.exist(parsedTransaction.outputs[0]);
       parsedTransaction.outputs[0].should.deepEqual({
         address: wallet.migratedFrom(),
         amount: outputAmount,
-        external: false
+        external: false,
       });
 
-      coin.explainTransaction.restore();
-      coin.verifyAddress.restore();
+      (coin.explainTransaction as any).restore();
+      (coin.verifyAddress as any).restore();
     }));
 
-    it('should classify outputs which spend to addresses not on the wallet as external', co(function *() {
+    it('should classify outputs which spend to addresses not on the wallet as external', co(function* () {
       const externalAddress = 'external_address';
       sinon.stub(coin, 'explainTransaction').resolves({
         outputs: [{
           address: externalAddress,
-          amount: outputAmount
+          amount: outputAmount,
         }],
-        changeOutputs: []
-      });
+        changeOutputs: [],
+      } as any);
 
       sinon.stub(coin, 'verifyAddress').throws(new errors.UnexpectedAddressError('test error'));
 
-      const parsedTransaction = yield coin.parseTransaction({ txParams: {}, txPrebuild: { txHex: '' }, wallet, verification });
+      const parsedTransaction = yield coin.parseTransaction({
+        txParams: {},
+        txPrebuild: { txHex: '' },
+        wallet: wallet as any,
+        verification: verification as any
+      });
 
       should.exist(parsedTransaction.outputs[0]);
       parsedTransaction.outputs[0].should.deepEqual({
         address: externalAddress,
         amount: outputAmount,
-        external: true
+        external: true,
       });
 
-      coin.explainTransaction.restore();
-      coin.verifyAddress.restore();
+      (coin.explainTransaction as any).restore();
+      (coin.verifyAddress as any).restore();
     }));
 
-    it('should accept a custom change address', co(function *() {
-
-      const changeAddress = '33a9a4TTT47i2VSpNZA3YT7v3sKYaZFAYz';
+    it('should accept a custom change address', co(function* () {
+      const changeAddress = '2NAuziD75WnPPHJVwnd4ckgY4SuJaDVVbMD';
       const outputAmount = 10000;
       const recipients = [];
 
@@ -103,19 +109,290 @@ describe('Abstract UTXO Coin:', () => {
             amount: outputAmount,
           },
         ],
-      });
+      } as any);
 
-      const parsedTransaction = yield coin.parseTransaction({ txParams: { changeAddress, recipients }, txPrebuild: { txHex: '' }, wallet, verification });
+      const parsedTransaction = yield coin.parseTransaction({
+        txParams: { changeAddress, recipients },
+        txPrebuild: { txHex: '' },
+        wallet: wallet as any,
+        verification: verification as any
+      });
 
       should.exist(parsedTransaction.outputs[0]);
       parsedTransaction.outputs[0].should.deepEqual({
         address: changeAddress,
         amount: outputAmount,
-        external: false
+        external: false,
       });
 
-      coin.explainTransaction.restore();
+      (coin.explainTransaction as any).restore();
     }));
+  });
+
+  describe('Custom Change Wallets', () => {
+    const bitgo: BitGo = new TestBitGo({ env: 'mock' });
+    const coin = bitgo.coin('tbtc') as AbstractUtxoCoin;
+
+    const keys = {
+      send: {
+        user: { id: '0', key: coin.keychains().create() },
+        backup: { id: '1', key: coin.keychains().create() },
+        bitgo: { id: '2', key: coin.keychains().create() },
+      },
+      change: {
+        user: { id: '3', key: coin.keychains().create() },
+        backup: { id: '4', key: coin.keychains().create() },
+        bitgo: { id: '5', key: coin.keychains().create() },
+      },
+    };
+
+    const customChangeKeySignatures = {
+      user: '',
+      backup: '',
+      bitgo: '',
+    };
+
+    const addressData = {
+      chain: 11,
+      index: 1,
+      addressType: 'p2shP2wsh',
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      keychains: [{ pub: keys.change.user.key.pub! }, { pub: keys.change.backup.key.pub! }, { pub: keys.change.bitgo.key.pub! }],
+      threshold: 2,
+    };
+
+    const { address: changeAddress, coinSpecific } = coin.generateAddress(addressData);
+
+    const changeWalletId = 'changeWalletId';
+    const stubData = {
+      signedSendingWallet: {
+        keyIds: sinon.stub().returns([keys.send.user.id, keys.send.backup.id, keys.send.bitgo.id]),
+        coinSpecific: sinon.stub().returns({ customChangeWalletId: changeWalletId }),
+      },
+      changeWallet: {
+        keyIds: sinon.stub().returns([keys.change.user.id, keys.change.backup.id, keys.change.bitgo.id]),
+        createAddress: sinon.stub().resolves(changeAddress),
+      },
+    };
+
+    before(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const sign = async ({ key }) => (await coin.signMessage({ prv: keys.send.user.key.prv }, key.pub!)).toString('hex');
+      customChangeKeySignatures.user = await sign(keys.change.user);
+      customChangeKeySignatures.backup = await sign(keys.change.backup);
+      customChangeKeySignatures.bitgo = await sign(keys.change.bitgo);
+    });
+
+    it('should consider addresses derived from the custom change keys as internal spends', async () => {
+      const signedSendingWallet = sinon.createStubInstance(Wallet, stubData.signedSendingWallet as any);
+      const changeWallet = sinon.createStubInstance(Wallet, stubData.changeWallet as any);
+
+      sinon.stub(coin, 'keychains').returns({
+        get: sinon.stub().callsFake(({ id }) => {
+          switch (id) {
+            case keys.send.user.id:
+              return Promise.resolve({ id, ...keys.send.user.key });
+            case keys.send.backup.id:
+              return Promise.resolve({ id, ...keys.send.backup.key });
+            case keys.send.bitgo.id:
+              return Promise.resolve({ id, ...keys.send.bitgo.key });
+            case keys.change.user.id:
+              return Promise.resolve({ id, ...keys.change.user.key });
+            case keys.change.backup.id:
+              return Promise.resolve({ id, ...keys.change.backup.key });
+            case keys.change.bitgo.id:
+              return Promise.resolve({ id, ...keys.change.bitgo.key });
+          }
+        }),
+      } as any);
+
+      sinon.stub(coin, 'wallets').returns({
+        get: sinon.stub().callsFake(() => Promise.resolve(changeWallet)),
+      } as any);
+
+      const outputAmount = 10000;
+      const recipients = [];
+
+      sinon.stub(coin, 'explainTransaction').resolves({
+        outputs: [],
+        changeOutputs: [
+          {
+            address: changeAddress,
+            amount: outputAmount,
+          },
+        ],
+      } as any);
+
+      const parsedTransaction = await coin.parseTransaction({
+        txParams: { changeAddress, recipients },
+        txPrebuild: { txHex: '' },
+        wallet: signedSendingWallet as any,
+        verification: {
+          addresses: {
+            [changeAddress]: {
+              coinSpecific,
+              chain: addressData.chain,
+              index: addressData.index,
+            },
+          },
+        },
+      });
+
+      should.exist(parsedTransaction.outputs[0]);
+      parsedTransaction.outputs[0].should.deepEqual({
+        address: changeAddress,
+        amount: outputAmount,
+        external: false,
+        needsCustomChangeKeySignatureVerification: true,
+      });
+
+      (coin.explainTransaction as any).restore();
+      (coin.wallets as any).restore();
+      (coin.keychains as any).restore();
+    });
+  });
+
+  describe('Verify Transaction', () => {
+    const bitgo: BitGo = new TestBitGo({ env: 'mock' });
+    const coin = bitgo.coin('tbtc') as AbstractUtxoCoin;
+
+    const userKeychain = coin.keychains().create();
+    const otherKeychain = coin.keychains().create();
+
+    const changeKeys = {
+      user: coin.keychains().create(),
+      backup: coin.keychains().create(),
+      bitgo: coin.keychains().create(),
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const sign = async (key, keychain) => (await coin.signMessage(keychain, key.pub!)).toString('hex');
+    const signUser = (key) => sign(key, userKeychain);
+    const signOther = (key) => sign(key, otherKeychain);
+    const passphrase = 'test_passphrase';
+
+    const stubData = {
+      unsignedSendingWallet: {
+        keyIds: sinon.stub().returns(['0', '1', '2']),
+      },
+      parseTransactionData: {
+        badKey: {
+          keychains: {
+            // user public key swapped out
+            user: { pub: otherKeychain.pub, encryptedPrv: bitgo.encrypt({ input: userKeychain.prv, password: passphrase }) },
+          },
+          needsCustomChangeKeySignatureVerification: true,
+        },
+        noCustomChange: {
+          keychains: { user: userKeychain },
+          needsCustomChangeKeySignatureVerification: true,
+        },
+        emptyCustomChange: {
+          keychains: { user: userKeychain },
+          needsCustomChangeKeySignatureVerification: true,
+          customChange: {},
+        },
+        // needs to be async function to create signatures
+        badSigs: async () => ({
+          keychains: { user: userKeychain },
+          needsCustomChangeKeySignatureVerification: true,
+          customChange: {
+            keys: [changeKeys.user, changeKeys.backup, changeKeys.bitgo],
+            signatures: [await signOther(changeKeys.user), await signOther(changeKeys.backup), await signOther(changeKeys.bitgo)],
+          },
+        }),
+        goodSigs: async () => ({
+          keychains: { user: userKeychain },
+          needsCustomChangeKeySignatureVerification: true,
+          customChange: {
+            keys: [changeKeys.user, changeKeys.backup, changeKeys.bitgo],
+            signatures: [await signUser(changeKeys.user), await signUser(changeKeys.backup), await signUser(changeKeys.bitgo)],
+          },
+          missingOutputs: 1,
+        }),
+      },
+    };
+
+    const unsignedSendingWallet = sinon.createStubInstance(Wallet, stubData.unsignedSendingWallet as any);
+
+    it('should fail if the user private key cannot be verified to match the user public key', async () => {
+      sinon.stub(coin, 'parseTransaction').resolves(stubData.parseTransactionData.badKey as any);
+      const verifyWallet = sinon.createStubInstance(Wallet, {});
+
+      await coin.verifyTransaction({
+        txParams: {
+          walletPassphrase: passphrase,
+        },
+        txPrebuild: {},
+        wallet: verifyWallet as any,
+        verification: {},
+      }).should.be.rejectedWith(/transaction requires verification of user public key, but it was unable to be verified/);
+
+      (coin.parseTransaction as any).restore();
+    });
+
+    it('should fail if the custom change verification data is required but missing', async () => {
+      sinon.stub(coin, 'parseTransaction').resolves(stubData.parseTransactionData.noCustomChange as any);
+
+      await coin.verifyTransaction({
+        txParams: {
+          walletPassphrase: passphrase,
+        },
+        txPrebuild: {},
+        wallet: unsignedSendingWallet as any,
+        verification: {},
+      }).should.be.rejectedWith(/parsed transaction is missing required custom change verification data/);
+
+      (coin.parseTransaction as any).restore();
+    });
+
+    it('should fail if the custom change keys or key signatures are missing', async () => {
+      sinon.stub(coin, 'parseTransaction').resolves(stubData.parseTransactionData.emptyCustomChange as any);
+
+      await coin.verifyTransaction({
+        txParams: {
+          walletPassphrase: passphrase,
+        },
+        txPrebuild: {},
+        wallet: unsignedSendingWallet as any,
+        verification: {},
+      }).should.be.rejectedWith(/customChange property is missing keys or signatures/);
+
+      (coin.parseTransaction as any).restore();
+    });
+
+    it('should fail if the custom change key signatures cannot be verified', async () => {
+      sinon.stub(coin, 'parseTransaction').resolves(await stubData.parseTransactionData.badSigs() as any);
+
+      await coin.verifyTransaction({
+        txParams: {
+          walletPassphrase: passphrase,
+        },
+        txPrebuild: {},
+        wallet: unsignedSendingWallet as any,
+        verification: {},
+      }).should.be.rejectedWith(/transaction requires verification of custom change key signatures, but they were unable to be verified/);
+
+      (coin.parseTransaction as any).restore();
+    });
+
+    it('should successfully verify a custom change transaction when change keys and signatures are valid', async () => {
+      sinon.stub(coin, 'parseTransaction').resolves(await stubData.parseTransactionData.goodSigs() as any);
+
+      // if verify transaction gets rejected with the outputs missing error message,
+      // then we know that the verification of the custom change key signatures was successful
+      await coin.verifyTransaction({
+        txParams: {
+          walletPassphrase: passphrase,
+        },
+        txPrebuild: {},
+        wallet: unsignedSendingWallet as any,
+        verification: {},
+      }).should.be.rejectedWith(/expected outputs missing in transaction prebuild/);
+
+      (coin.parseTransaction as any).restore();
+
+    });
   });
 
   // TODO: BG-23161 - replace smartbit block explorer which is now permanently down


### PR DESCRIPTION
This PR adds the following features to `AbstractUtxoCoin` transaction parsing and verification.

1) When parsing transactions, try deriving addresses from the custom change wallet keys before assuming the address to be external
2) If an output address was found to be derived from the custom change wallet keys, mark the transaction as needing verification of the custom change wallet key signatures
3) If this flag is found to be set on the parsed transaction, transaction verification requires valid signatures from the spending wallet's user key over the custom change wallet user, backup and bitgo public keys. If the signatures or keys are missing or otherwise found to be invalid, the transaction validation fails

Ticket: BG-23613