### PR TITLE
BG-24067 modify recovery function to take blockchair API key

### DIFF
--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -215,6 +215,7 @@ export interface RecoverParams {
   ignoreAddressTypes: string[];
   bitgoKey: string;
   walletPassphrase?: string;
+  apiKey?: string;
 }
 
 export abstract class AbstractUtxoCoin extends BaseCoin {
@@ -1581,8 +1582,8 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
     return response;
   }
 
-  protected abstract getAddressInfoFromExplorer(address: string): Bluebird<AddressInfo>;
-  protected abstract getUnspentInfoFromExplorer(address: string): Bluebird<UnspentInfo[]>;
+  protected abstract getAddressInfoFromExplorer(address: string, apiKey?: string): Bluebird<AddressInfo>;
+  protected abstract getUnspentInfoFromExplorer(address: string, apiKey?: string): Bluebird<UnspentInfo[]>;
 
   /**
    * Builds a funds recovery transaction without BitGo
@@ -1619,7 +1620,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
             const keys = derivedKeys.map(k => k.getPublicKeyBuffer());
             const address: any = self.createMultiSigAddress(Codes.typeForCode(chain), 2, keys);
 
-            const addrInfo: AddressInfo = yield self.getAddressInfoFromExplorer(address.address);
+            const addrInfo: AddressInfo = yield self.getAddressInfoFromExplorer(address.address, params.apiKey);
 
             if (addrInfo.txCount === 0) {
               numSequentialAddressesWithoutTxs++;
@@ -1634,7 +1635,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
                 addressesById[address.address] = address;
 
                 // Try to find unspents on it.
-                const addressUnspents: UnspentInfo[] = yield self.getUnspentInfoFromExplorer(address.address);
+                const addressUnspents: UnspentInfo[] = yield self.getUnspentInfoFromExplorer(address.address, params.apiKey);
 
                 addressUnspents.forEach(function addAddressToUnspent(unspent) {
                   unspent.address = address.address;

--- a/modules/core/src/v2/coins/btc.ts
+++ b/modules/core/src/v2/coins/btc.ts
@@ -71,33 +71,16 @@ export class Btc extends AbstractUtxoCoin {
     return common.Environments[this.bitgo.getEnv()].blockchairBaseUrl + url;
   }
 
-  /**
-   * Sanitize api key, decorate it so it is ready to be appended to an URL of an explorer
-   * @param {string} apiKey
-   * @returns {string}
-   */
-  transformExplorersApiKey(apiKey?: string): string { // TODO: make this works with multiple explorers
-    if (!apiKey) {
-      return '';
-    }
-    if (!_.isString(apiKey)) {
-      throw new Error('api key must be a valid string')
-    }
-
-    const key = `?key=${apiKey}`;
-    return key;
-  }
-
   getAddressInfoFromExplorer(addressBase58: string, apiKey?: string): Bluebird<any> {
     const self = this;
     return co(function *getAddressInfoFromExplorer() {
       // we are using blockchair api: https://blockchair.com/api/docs#link_300
       // https://api.blockchair.com/{:btc_chain}/dashboards/address/{:address}₀
-      const key = self.transformExplorersApiKey(apiKey);
-      const addrInfo = yield request.get(self.recoveryBlockchainExplorerUrl(`/dashboards/address/${addressBase58}`) + key).result();
+      const addrInfo = yield request.get(self.recoveryBlockchainExplorerUrl(`/dashboards/address/${addressBase58}`))
+       .query({ key: apiKey })
+       .result();
       addrInfo.txCount = addrInfo.data[addressBase58].address.transaction_count;
       addrInfo.totalBalance = addrInfo.data[addressBase58].address.balance;
-
       return addrInfo;
     }).call(this);
   }
@@ -109,8 +92,9 @@ export class Btc extends AbstractUtxoCoin {
       // https://api.blockchair.com/{:btc_chain}/dashboards/address/{:address}₀
       // example utxo from response:
       // {"block_id":-1,"transaction_hash":"cf5bcd42c688cb7c55b5811645e7f0d2a000a85564ca3d6b9fc20f57e14b30bb","index":1,"value":558},
-      const key = self.transformExplorersApiKey(apiKey);
-      const unspentInfo = yield request.get(self.recoveryBlockchainExplorerUrl(`/dashboards/address/${addressBase58}`) + key).result();
+      const unspentInfo = yield request.get(self.recoveryBlockchainExplorerUrl(`/dashboards/address/${addressBase58}`))
+        .query({ key: apiKey })
+        .result();
 
       const unspents = unspentInfo.data[addressBase58].utxo;
 

--- a/modules/core/src/v2/coins/btc.ts
+++ b/modules/core/src/v2/coins/btc.ts
@@ -71,12 +71,30 @@ export class Btc extends AbstractUtxoCoin {
     return common.Environments[this.bitgo.getEnv()].blockchairBaseUrl + url;
   }
 
-  getAddressInfoFromExplorer(addressBase58: string): Bluebird<any> {
+  /**
+   * Sanitize api key, decorate it so it is ready to be appended to an URL of an explorer
+   * @param {string} apiKey
+   * @returns {string}
+   */
+  transformExplorersApiKey(apiKey?: string): string { // TODO: make this works with multiple explorers
+    if (!apiKey) {
+      return '';
+    }
+    if (!_.isString(apiKey)) {
+      throw new Error('api key must be a valid string')
+    }
+
+    const key = `?key=${apiKey}`;
+    return key;
+  }
+
+  getAddressInfoFromExplorer(addressBase58: string, apiKey?: string): Bluebird<any> {
     const self = this;
     return co(function *getAddressInfoFromExplorer() {
       // we are using blockchair api: https://blockchair.com/api/docs#link_300
       // https://api.blockchair.com/{:btc_chain}/dashboards/address/{:address}₀
-      const addrInfo = yield request.get(self.recoveryBlockchainExplorerUrl(`/dashboards/address/${addressBase58}`)).result();
+      const key = self.transformExplorersApiKey(apiKey);
+      const addrInfo = yield request.get(self.recoveryBlockchainExplorerUrl(`/dashboards/address/${addressBase58}`) + key).result();
       addrInfo.txCount = addrInfo.data[addressBase58].address.transaction_count;
       addrInfo.totalBalance = addrInfo.data[addressBase58].address.balance;
 
@@ -84,14 +102,15 @@ export class Btc extends AbstractUtxoCoin {
     }).call(this);
   }
 
-  getUnspentInfoFromExplorer(addressBase58: string): Bluebird<any> {
+  getUnspentInfoFromExplorer(addressBase58: string, apiKey?: string): Bluebird<any> {
     const self = this;
     return co(function *getUnspentInfoFromExplorer() {
       // using blockchair api: https://blockchair.com/api/docs#link_300
       // https://api.blockchair.com/{:btc_chain}/dashboards/address/{:address}₀
       // example utxo from response:
       // {"block_id":-1,"transaction_hash":"cf5bcd42c688cb7c55b5811645e7f0d2a000a85564ca3d6b9fc20f57e14b30bb","index":1,"value":558},
-      const unspentInfo = yield request.get(self.recoveryBlockchainExplorerUrl(`/dashboards/address/${addressBase58}`)).result();
+      const key = self.transformExplorersApiKey(apiKey);
+      const unspentInfo = yield request.get(self.recoveryBlockchainExplorerUrl(`/dashboards/address/${addressBase58}`) + key).result();
 
       const unspents = unspentInfo.data[addressBase58].utxo;
 

--- a/modules/core/test/v2/lib/recovery-nocks.ts
+++ b/modules/core/test/v2/lib/recovery-nocks.ts
@@ -51,6 +51,11 @@ export function nockBtcRecovery(bitgo, isKrsRecovery, smartbitOnline = true) {
       });
   }
   nock(blockchairURL)
+    .get('/dashboards/address/2MztRFcJWkDTYsZmNjLu9pBWWviJmWjJ4hg?key=my_______SecretApiKey')
+    .reply(200, {
+      data: { '2MztRFcJWkDTYsZmNjLu9pBWWviJmWjJ4hg': emptyBlockchairBtcAddressData },
+      blockchairContext,
+    })
     .get('/dashboards/address/2MztRFcJWkDTYsZmNjLu9pBWWviJmWjJ4hg')
     .reply(200, {
       data: { '2MztRFcJWkDTYsZmNjLu9pBWWviJmWjJ4hg': emptyBlockchairBtcAddressData },
@@ -61,7 +66,19 @@ export function nockBtcRecovery(bitgo, isKrsRecovery, smartbitOnline = true) {
       data: { '2NB8Z1xr86m3sePYdFfJudNrrA8rKNkPEKr': emptyBlockchairBtcAddressData },
       blockchairContext,
     })
+    .get('/dashboards/address/2NB8Z1xr86m3sePYdFfJudNrrA8rKNkPEKr?key=my_______SecretApiKey')
+    .reply(200, {
+      data: { '2NB8Z1xr86m3sePYdFfJudNrrA8rKNkPEKr': emptyBlockchairBtcAddressData },
+      blockchairContext,
+    })
     .get('/dashboards/address/2NFNu2LUvV98d5rkKobkt1JwtFe8eKpePxj')
+    .reply(200, {
+      data: {
+        '2NFNu2LUvV98d5rkKobkt1JwtFe8eKpePxj': emptyBlockchairBtcAddressData,
+      },
+      blockchairContext,
+    })
+    .get('/dashboards/address/2NFNu2LUvV98d5rkKobkt1JwtFe8eKpePxj?key=my_______SecretApiKey')
     .reply(200, {
       data: {
         '2NFNu2LUvV98d5rkKobkt1JwtFe8eKpePxj': emptyBlockchairBtcAddressData,
@@ -103,7 +120,49 @@ export function nockBtcRecovery(bitgo, isKrsRecovery, smartbitOnline = true) {
       },
       blockchairContext,
     })
+    .get('/dashboards/address/2MzLAGkQVaDiW2Dbm22ETf4ePyLUcDroqdw?key=my_______SecretApiKey')
+    .reply(200, {
+      data: {
+        '2MzLAGkQVaDiW2Dbm22ETf4ePyLUcDroqdw': {
+          address: {
+            type: 'scripthash',
+            script_hex: 'a9144db7dbb57102a2e13e4474dbe38058431012e74587',
+            balance: 8125000,
+            balance_usd: 0,
+            received: 8125000,
+            received_usd: 0,
+            spent: 0,
+            spent_usd: 0,
+            output_count: 1,
+            unspent_output_count: 1,
+            first_seen_receiving: '2017-06-12 23:17:43',
+            last_seen_receiving: '2017-06-12 23:17:43',
+            first_seen_spending: null,
+            last_seen_spending: null,
+            scripthash_type: null,
+            transaction_count: 1,
+          },
+          transactions: ['e18283471a9374ef9812757ac70cd6660c66265cac7b19a87354d64937a7ed74'],
+          utxo: [
+            {
+              block_id: 1128383,
+              transaction_hash: 'e18283471a9374ef9812757ac70cd6660c66265cac7b19a87354d64937a7ed74',
+              index: 0,
+              value: 8125000,
+            },
+          ],
+        },
+      },
+      blockchairContext,
+    })
     .get('/dashboards/address/2NAY4N8bBCthmYDHKBab6gMnS2LwpbxdF2z')
+    .reply(200, {
+      data: {
+        '2NAY4N8bBCthmYDHKBab6gMnS2LwpbxdF2z': emptyBlockchairBtcAddressData,
+      },
+      blockchairContext,
+    })
+    .get('/dashboards/address/2NAY4N8bBCthmYDHKBab6gMnS2LwpbxdF2z?key=my_______SecretApiKey')
     .reply(200, {
       data: {
         '2NAY4N8bBCthmYDHKBab6gMnS2LwpbxdF2z': emptyBlockchairBtcAddressData,
@@ -117,7 +176,28 @@ export function nockBtcRecovery(bitgo, isKrsRecovery, smartbitOnline = true) {
       },
       blockchairContext,
     })
+    .get('/dashboards/address/2MsPSUv8yxy9SwFKWfaTSAGKwaGCBBbMuZA?key=my_______SecretApiKey')
+    .reply(200, {
+      data: {
+        '2MsPSUv8yxy9SwFKWfaTSAGKwaGCBBbMuZA': emptyBlockchairBtcAddressData,
+      },
+      blockchairContext,
+    })
+    .get('/dashboards/address/2N5txkg9k3pHe6zyyKV2dwztKdDPGdJdPch?key=my_______SecretApiKey')
+    .reply(200, {
+      data: {
+        '2N5txkg9k3pHe6zyyKV2dwztKdDPGdJdPch': emptyBlockchairBtcAddressData,
+      },
+      blockchairContext,
+    })
     .get('/dashboards/address/2N5txkg9k3pHe6zyyKV2dwztKdDPGdJdPch')
+    .reply(200, {
+      data: {
+        '2N5txkg9k3pHe6zyyKV2dwztKdDPGdJdPch': emptyBlockchairBtcAddressData,
+      },
+      blockchairContext,
+    })
+    .get('/dashboards/address/2N5txkg9k3pHe6zyyKV2dwztKdDPGdJdPch?key=my_______SecretApiKey')
     .reply(200, {
       data: {
         '2N5txkg9k3pHe6zyyKV2dwztKdDPGdJdPch': emptyBlockchairBtcAddressData,
@@ -131,7 +211,21 @@ export function nockBtcRecovery(bitgo, isKrsRecovery, smartbitOnline = true) {
       },
       blockchairContext,
     })
+    .get('/dashboards/address/2MzU1ze7cKUFPoQgNnsAmn4Vj7GGrN8HPCC?key=my_______SecretApiKey')
+    .reply(200, {
+      data: {
+        '2MzU1ze7cKUFPoQgNnsAmn4Vj7GGrN8HPCC': emptyBlockchairBtcAddressData,
+      },
+      blockchairContext,
+    })
     .get('/dashboards/address/2N3AYt6Bzqne1jagNi6Lnu42PVPshtgVQ9P')
+    .reply(200, {
+      data: {
+        '2N3AYt6Bzqne1jagNi6Lnu42PVPshtgVQ9P': emptyBlockchairBtcAddressData,
+      },
+      blockchairContext,
+    })
+    .get('/dashboards/address/2N3AYt6Bzqne1jagNi6Lnu42PVPshtgVQ9P?key=my_______SecretApiKey')
     .reply(200, {
       data: {
         '2N3AYt6Bzqne1jagNi6Lnu42PVPshtgVQ9P': emptyBlockchairBtcAddressData,
@@ -145,7 +239,21 @@ export function nockBtcRecovery(bitgo, isKrsRecovery, smartbitOnline = true) {
       },
       blockchairContext,
     })
+    .get('/dashboards/address/2N8pyHtgmrGrvndjteyDDrjQ2ogvUb6bqDT?key=my_______SecretApiKey')
+    .reply(200, {
+      data: {
+        '2N8pyHtgmrGrvndjteyDDrjQ2ogvUb6bqDT': emptyBlockchairBtcAddressData,
+      },
+      blockchairContext,
+    })
     .get('/dashboards/address/2MtruqBf39BiueH1pN34rk7Ti7FGxnKmu7X')
+    .reply(200, {
+      data: {
+        '2MtruqBf39BiueH1pN34rk7Ti7FGxnKmu7X': emptyBlockchairBtcAddressData,
+      },
+      blockchairContext,
+    })
+    .get('/dashboards/address/2MtruqBf39BiueH1pN34rk7Ti7FGxnKmu7X?key=my_______SecretApiKey')
     .reply(200, {
       data: {
         '2MtruqBf39BiueH1pN34rk7Ti7FGxnKmu7X': emptyBlockchairBtcAddressData,
@@ -159,10 +267,59 @@ export function nockBtcRecovery(bitgo, isKrsRecovery, smartbitOnline = true) {
       },
       blockchairContext,
     })
+    .get('/dashboards/address/2N4F1557TjZVN15AxPRb6CbaX7quyh5n1ym?key=my_______SecretApiKey')
+    .reply(200, {
+      data: {
+        '2N4F1557TjZVN15AxPRb6CbaX7quyh5n1ym': emptyBlockchairBtcAddressData,
+      },
+      blockchairContext,
+    })
     .get('/dashboards/address/2NB54XtZQcVBhQSCgVV8AqjiobXGbNDLkba')
     .reply(200, {
       data: {
         '2NB54XtZQcVBhQSCgVV8AqjiobXGbNDLkba': emptyBlockchairBtcAddressData,
+      },
+      blockchairContext,
+    })
+    .get('/dashboards/address/2NB54XtZQcVBhQSCgVV8AqjiobXGbNDLkba?key=my_______SecretApiKey')
+    .reply(200, {
+      data: {
+        '2NB54XtZQcVBhQSCgVV8AqjiobXGbNDLkba': emptyBlockchairBtcAddressData,
+      },
+      blockchairContext,
+    })
+    .get('/dashboards/address/2MzLAGkQVaDiW2Dbm22ETf4ePyLUcDroqdw?key=my_______SecretApiKey')
+    .reply(200, {
+      data: {
+        '2MzLAGkQVaDiW2Dbm22ETf4ePyLUcDroqdw': {
+          address: {
+            type: 'scripthash',
+            script_hex: 'a9144db7dbb57102a2e13e4474dbe38058431012e74587',
+            balance: 8125000,
+            balance_usd: 0,
+            received: 8125000,
+            received_usd: 0,
+            spent: 0,
+            spent_usd: 0,
+            output_count: 1,
+            unspent_output_count: 1,
+            first_seen_receiving: '2017-06-12 23:17:43',
+            last_seen_receiving: '2017-06-12 23:17:43',
+            first_seen_spending: null,
+            last_seen_spending: null,
+            scripthash_type: null,
+            transaction_count: 1,
+          },
+          transactions: ['e18283471a9374ef9812757ac70cd6660c66265cac7b19a87354d64937a7ed74'],
+          utxo: [
+            {
+              block_id: 1128383,
+              transaction_hash: 'e18283471a9374ef9812757ac70cd6660c66265cac7b19a87354d64937a7ed74',
+              index: 0,
+              value: 8125000,
+            },
+          ],
+        },
       },
       blockchairContext,
     })

--- a/modules/core/test/v2/unit/recovery.ts
+++ b/modules/core/test/v2/unit/recovery.ts
@@ -195,8 +195,23 @@ describe('Recovery:', function() {
         ignoreAddressTypes: ['p2wsh', 'p2shP2wsh']
       });
       recovery.transactionHex.should.equal('010000000174eda73749d65473a8197bac5c26660c66d60cc77a751298ef74931a478382e100000000fdfd00004730440220513ff3a0a4d72230a7ca9b1285d5fa19669d7cccef6a9c8408b06da666f4c51f022058e8cc58b9f9ca585c37a8353d87d0ab042ac081ebfcea86fda0da1b33bf474701483045022100e27c00394553513803e56e6623e06614cf053834a27ca925ed9727071d4411380220399ab1a0269e84beb4e8602fea3d617ffb0b649515892d470061a64217bad613014c69522102f5ca5d074093abf996278d1e82b64497333254c786e9a69d34909a785aa9af32210239125d1a21ba8ae375cd37a92e48700cbb3bc1b1268d3c3f7e1d95f42155e1a821031ab00568ea1522a55f277699110649f3b8d08022494af2cc475c09e8a43b3a3a53aeffffffff012c717b000000000017a914c39dcc27823a8bd42cd3318a1dac8c25789b7ac78700000000');
-    }))
+    }));
 
+    it('should allow the provision of an API key while doing recovery', co (function *() {
+      recoveryNocks.nockBtcRecovery(bitgo, false, false);
+      const basecoin = bitgo.coin('tbtc');
+      const recovery = yield basecoin.recover({
+        userKey: '{"iv":"fTcRIg7nlCf9fPSR4ID8XQ==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"pkIS5jVDi0Y=","ct":"SJQgP+ZzfOMf2fWxyQ2jpoWYioq6Tqfcw1xiKS1WpWAxLvXfH059sZvPrrYMdijJEbqA8EEaYXWmdgYSkMXdwckRMyvM3uWl9H8iKw1ZJmHyy2eDSy5r/pCtWICkcO3oi2I492I/3Op2YLfIX6XqKWs2mztu/OY="}',
+        backupKey: '{"iv":"0WkLaOsnO3M7qnV2DbSvWw==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"lGxBnvlGAoM=","ct":"cBalT6MGZ3TYIYHt4jys0WDTZEKK9qIubltKEqfW4zXtxYd1dYLz9qLve/yXPl7NF5Cb1lBNGBBGsfqzvpr0Q5824xiy5i9IKzRBI/69HIt3fC2RjJKDfB1EZUjoozi2O5FH4K7L6Ejq7qZhvi8iOd1ULVpBgnE="}',
+        bitgoKey: 'xpub661MyMwAqRbcGsSbYgWmr9G1dFgPE8HEb1ASRShbw9S1Mmu1dTQ7QStNwpaYFESq3MeKivGidN8twMeJzqh1veuSP1t2XLENL3mwpatfTst',
+        walletPassphrase: TestBitGo.V2.TEST_WALLET1_PASSCODE,
+        recoveryDestination: '2NB5Ynem6iNvA6GBLZwRxwid3Kui33729Nw',
+        scan: 5,
+        ignoreAddressTypes: ['p2wsh', 'p2shP2wsh'],
+        apiKey: 'my_______SecretApiKey',
+      });
+      recovery.transactionHex.should.equal('010000000174eda73749d65473a8197bac5c26660c66d60cc77a751298ef74931a478382e100000000fdfd00004730440220513ff3a0a4d72230a7ca9b1285d5fa19669d7cccef6a9c8408b06da666f4c51f022058e8cc58b9f9ca585c37a8353d87d0ab042ac081ebfcea86fda0da1b33bf474701483045022100e27c00394553513803e56e6623e06614cf053834a27ca925ed9727071d4411380220399ab1a0269e84beb4e8602fea3d617ffb0b649515892d470061a64217bad613014c69522102f5ca5d074093abf996278d1e82b64497333254c786e9a69d34909a785aa9af32210239125d1a21ba8ae375cd37a92e48700cbb3bc1b1268d3c3f7e1d95f42155e1a821031ab00568ea1522a55f277699110649f3b8d08022494af2cc475c09e8a43b3a3a53aeffffffff012c717b000000000017a914c39dcc27823a8bd42cd3318a1dac8c25789b7ac78700000000');
+    }));
   });
 
   describe('Recover Bitcoin Cash', function() {


### PR DESCRIPTION
Users are likely to get rate limited by blockchair while doing recovery, due to the number of calls they would have to make to blockchair. We add an option for them to add api key to the calls to blockchair. There will be a follow up PR in the WRW side to make the frontend flow with the backend changes done here.