### PR TITLE
Create RecoveryProvider

### DIFF
--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -10,7 +10,6 @@ import { UnspentType } from '@bitgo/unspents/dist/codes';
 
 import { hdPath } from '../../bitcoin';
 import { BitGo } from '../../bitgo';
-import { BlockExplorerUnavailable } from '../../errors';
 import {
   BaseCoin, AddressCoinSpecific,
   ExtraPrebuildParamsOptions, KeychainsTriplet,
@@ -28,6 +27,7 @@ import { CrossChainRecoveryTool } from '../recovery';
 import * as errors from '../../errors';
 import { RequestTracer } from '../internal/util';
 import { Wallet } from '../wallet';
+import { RecoveryAccountData, RecoveryUnspent } from '../recovery/types';
 
 const debug = debugLib('bitgo:v2:utxo');
 const co = Bluebird.coroutine;

--- a/modules/core/src/v2/coins/btc.ts
+++ b/modules/core/src/v2/coins/btc.ts
@@ -7,6 +7,8 @@ import * as bitcoin from '@bitgo/utxo-lib';
 import * as request from 'superagent';
 import * as _ from 'lodash';
 import * as Bluebird from 'bluebird';
+import { BlockchairApi } from '../recovery/blockchairApi';
+import { RecoveryAccountData, RecoveryUnspent } from '../recovery/types';
 const co = Bluebird.coroutine;
 
 export interface TransactionInfo {
@@ -71,43 +73,16 @@ export class Btc extends AbstractUtxoCoin {
     return common.Environments[this.bitgo.getEnv()].blockchairBaseUrl + url;
   }
 
-  getAddressInfoFromExplorer(addressBase58: string, apiKey?: string): Bluebird<any> {
-    const self = this;
-    return co(function *getAddressInfoFromExplorer() {
-      // we are using blockchair api: https://blockchair.com/api/docs#link_300
-      // https://api.blockchair.com/{:btc_chain}/dashboards/address/{:address}₀
-      const addrInfo = yield request.get(self.recoveryBlockchainExplorerUrl(`/dashboards/address/${addressBase58}`))
-       .query({ key: apiKey })
-       .result();
-      addrInfo.txCount = addrInfo.data[addressBase58].address.transaction_count;
-      addrInfo.totalBalance = addrInfo.data[addressBase58].address.balance;
-      return addrInfo;
-    }).call(this);
+  getAddressInfoFromExplorer(addressBase58: string, apiKey?: string): Bluebird<RecoveryAccountData> {
+    // TODO: allow users to choose the API to use
+    const api = new BlockchairApi(this.bitgo, apiKey);
+    return Bluebird.resolve(api.getAccountInfo(addressBase58));
   }
 
-  getUnspentInfoFromExplorer(addressBase58: string, apiKey?: string): Bluebird<any> {
-    const self = this;
-    return co(function *getUnspentInfoFromExplorer() {
-      // using blockchair api: https://blockchair.com/api/docs#link_300
-      // https://api.blockchair.com/{:btc_chain}/dashboards/address/{:address}₀
-      // example utxo from response:
-      // {"block_id":-1,"transaction_hash":"cf5bcd42c688cb7c55b5811645e7f0d2a000a85564ca3d6b9fc20f57e14b30bb","index":1,"value":558},
-      const unspentInfo = yield request.get(self.recoveryBlockchainExplorerUrl(`/dashboards/address/${addressBase58}`))
-        .query({ key: apiKey })
-        .result();
-
-      const unspents = unspentInfo.data[addressBase58].utxo;
-
-      const unspentInfos = unspents.map(unspent => {
-        return {
-          amount: unspent.value,
-          n: unspent.index,
-          txid: unspent.transaction_hash,
-          address: addressBase58
-        }
-      });
-      return unspentInfos;
-    }).call(this);
+  getUnspentInfoFromExplorer(addressBase58: string, apiKey?: string): Bluebird<RecoveryUnspent[]> {
+    // TODO: allow users to choose the API to use
+    const api = new BlockchairApi(this.bitgo, apiKey);
+    return Bluebird.resolve(api.getUnspents(addressBase58));
   }
 
   /**

--- a/modules/core/src/v2/recovery/blockchairApi.ts
+++ b/modules/core/src/v2/recovery/blockchairApi.ts
@@ -1,0 +1,53 @@
+import { RecoveryAccountData, RecoveryUnspent, RecoveryProvider } from './types';
+import * as common from '../../common';
+import * as request from 'superagent';
+import { BitGo } from '../../bitgo';
+
+export class BlockchairApi implements RecoveryProvider {
+  protected readonly bitgo: BitGo;
+  protected readonly apiToken?: string;
+
+  constructor(bitgo: BitGo, apiToken?: string) {
+    this.bitgo = bitgo;
+    this.apiToken = apiToken;
+  }
+
+  /** @inheritDoc */
+  getExplorerUrl(query: string): string {
+    if (this.apiToken) {
+      return common.Environments[this.bitgo.getEnv()].blockchairBaseUrl + query + `?key=${this.apiToken}` ;
+    }
+    return common.Environments[this.bitgo.getEnv()].blockchairBaseUrl + query;
+  }
+
+  /** @inheritDoc */
+  async getAccountInfo(address: string): Promise<RecoveryAccountData> {
+    // we are using blockchair api: https://blockchair.com/api/docs#link_300
+    // https://api.blockchair.com/{:btc_chain}/dashboards/address/{:address}₀
+    const response = await request.get(this.getExplorerUrl(`/dashboards/address/${address}`));
+    return {
+      txCount: response.body.data[address].address.transaction_count,
+      totalBalance: response.body.data[address].address.balance,
+    };
+  }
+
+  /** @inheritDoc */
+  async getUnspents(address: string): Promise<RecoveryUnspent[]> {
+    // using blockchair api: https://blockchair.com/api/docs#link_300
+    // https://api.blockchair.com/{:btc_chain}/dashboards/address/{:address}₀
+    // example utxo from response:
+    // {block_id":-1,"transaction_hash":"cf5bcd42c688cb7c55b5811645e7f0d2a000a85564ca3d6b9fc20f57e14b30bb","index":1,"value":558},
+    const response = await request.get(this.getExplorerUrl(`/dashboards/address/${address}`));
+
+    const rawUnspents = response.body.data[address].utxo;
+
+    return rawUnspents.map(unspent => {
+      return {
+        amount: unspent.value,
+        n: unspent.index,
+        txid: unspent.transaction_hash,
+        address,
+      };
+    });
+  }
+}

--- a/modules/core/src/v2/recovery/types.ts
+++ b/modules/core/src/v2/recovery/types.ts
@@ -1,0 +1,29 @@
+import { UnspentInfo } from '../coins/abstractUtxoCoin';
+
+/**
+ * An unspent with bear minimum information required for recoveries.
+ */
+// TODO: consolidate RecoveryUnspent and UnspentInfo
+export interface RecoveryUnspent extends UnspentInfo {
+  amount: number,
+  n: number,
+  txid: string,
+  address: string,
+}
+
+/**
+ * An account with bear minimum information required for recoveries.
+ */
+export interface RecoveryAccountData {
+  txCount: number,
+  totalBalance: number,
+}
+
+/**
+ * Methods required to perform different recovery actions in UTXO coins.
+ */
+export interface RecoveryProvider {
+  getExplorerUrl(query: string): string;
+  getAccountInfo(address: string): Promise<RecoveryAccountData>
+  getUnspents(address: string): Promise<RecoveryUnspent[]>;
+}


### PR DESCRIPTION
The explorer calls used during recoveries are mixed with the recovery code making it hard to change.

Create an interface for 3rd party recovery info providers so that it is easier to add new ones in the future.

CLOSES TICKET: BG-24116