### PR TITLE
BitGoJS: remove numTx, numUnspents from nocks

### DIFF
--- a/modules/core/test/v2/lib/recovery-nocks.ts
+++ b/modules/core/test/v2/lib/recovery-nocks.ts
@@ -1581,8 +1581,6 @@ module.exports.nockWrongChainRecoveries = function(bitgo) {
       },
       balance: {
         updated: '2018-03-27T23:33:10.713Z',
-        numTx: 2,
-        numUnspents: 0,
         totalReceived: 60000000,
         totalSent: 60000000,
       },
@@ -1629,8 +1627,6 @@ module.exports.nockWrongChainRecoveries = function(bitgo) {
       },
       balance: {
         updated: '2018-03-27T23:29:42.799Z',
-        numTx: 2,
-        numUnspents: 0,
         totalReceived: 65000000,
         totalSent: 65000000,
       },


### PR DESCRIPTION
They are not needed and we are trying to phase them out

Issue: BG-23552