### PR TITLE
Add Blockstream as a RecoveryProvider

### DIFF
--- a/modules/core/src/v2/environments.ts
+++ b/modules/core/src/v2/environments.ts
@@ -16,6 +16,7 @@ interface EnvironmentTemplate {
   serverXpub: string;
   hsmXpub: string;
   blockchairBaseUrl: string;
+  blockstreamBaseUrl: string;
   smartbitBaseUrl: string;
   btcExplorerBaseUrl: string;
   bchExplorerBaseUrl: string;
@@ -94,6 +95,7 @@ const mainnetBase: EnvironmentTemplate = {
   serverXpub: hardcodedPublicKeys.serverXpub.prod,
   hsmXpub: hardcodedPublicKeys.hsmXpub.prod,
   blockchairBaseUrl: 'https://api.blockchair.com/bitcoin',
+  blockstreamBaseUrl: 'https://blockstream.info/api',
   smartbitBaseUrl: 'https://api.smartbit.com.au/v1',
   btcExplorerBaseUrl: 'https://blockstream.info/api',
   bchExplorerBaseUrl: 'https://blockdozer.com/insight-api',
@@ -120,6 +122,7 @@ const testnetBase: EnvironmentTemplate = {
   serverXpub: hardcodedPublicKeys.serverXpub.test,
   hsmXpub: hardcodedPublicKeys.hsmXpub.test,
   blockchairBaseUrl: 'https://api.blockchair.com/bitcoin/testnet',
+  blockstreamBaseUrl: 'https://blockstream.info/testnet/api',
   smartbitBaseUrl: 'https://testnet-api.smartbit.com.au/v1',
   btcExplorerBaseUrl: 'https://blockstream.info/testnet/api',
   bchExplorerBaseUrl: 'https://test-bch-insight.bitpay.com/api',
@@ -175,6 +178,7 @@ export const Environments: Environments = {
   mock: Object.assign({}, devBase, {
     uri: 'https://bitgo.fakeurl',
     blockchairBaseUrl: 'https://api.blockchair.fakeurl/bitcoin/testnet',
+    blockstreamBaseUrl: 'https://blockstream.info.fakeurl/testnet/api',
     smartbitBaseUrl: 'https://testnet-api.smartbit.fakeurl/v1',
     btcExplorerBaseUrl: 'https://blockstream.fakeurl/testnet/api',
     bchExplorerBaseUrl: 'https://test-bch-insight.bitpay.fakeurl/api',
@@ -219,6 +223,10 @@ export const Environments: Environments = {
       process.env.BITGO_CUSTOM_BITCOIN_NETWORK !== 'bitcoin'
         ? 'https://api.blockchair.com/bitcoin/testnet'
         : 'https://api.blockchair.com/bitcoin',
+    blockstreamBaseUrl:
+      process.env.BITGO_CUSTOM_BITCOIN_NETWORK !== 'bitcoin'
+        ? 'https://blockstream.info/testnet/api'
+        : 'https://blockstream.info/api',
     btcExplorerBaseUrl:
       process.env.BITGO_CUSTOM_BITCOIN_NETWORK !== 'bitcoin'
         ? 'https://blockstream.info/testnet/api'

--- a/modules/core/src/v2/recovery/blockstreamApi.ts
+++ b/modules/core/src/v2/recovery/blockstreamApi.ts
@@ -50,7 +50,7 @@ export class BlockstreamApi implements RecoveryProvider {
         totalBalance,
       };
     } catch (e) {
-      let errorMessage = `Failed to get account information from ${this.getExplorerUrl('')}`;
+      let errorMessage = `Failed to get address information for ${address} from ${this.getExplorerUrl('')}`;
       errorMessage += (e.response.status) ? ` - ${e.response.status}` : '';
       errorMessage += (e.response.text) ? `: ${e.response.text}` : '';
       throw new BlockExplorerUnavailable(errorMessage);
@@ -87,7 +87,7 @@ export class BlockstreamApi implements RecoveryProvider {
         };
       });
     } catch (e) {
-      let errorMessage = `Failed to get unspents information from ${this.getExplorerUrl('')}`;
+      let errorMessage = `Failed to get unspents information for ${address} from ${this.getExplorerUrl('')}`;
       errorMessage += (e.response.status) ? ` - ${e.response.status}` : '';
       errorMessage += (e.response.text) ? `: ${e.response.text}` : '';
       throw new BlockExplorerUnavailable(errorMessage);

--- a/modules/core/src/v2/recovery/blockstreamApi.ts
+++ b/modules/core/src/v2/recovery/blockstreamApi.ts
@@ -1,0 +1,96 @@
+import { RecoveryAccountData, RecoveryUnspent, RecoveryProvider } from './types';
+import * as common from '../../common';
+import * as request from 'superagent';
+import { BitGo } from '../../bitgo';
+import { BlockExplorerUnavailable } from '../../errors';
+
+export class BlockstreamApi implements RecoveryProvider {
+  protected readonly bitgo: BitGo;
+  protected readonly apiToken?: string;
+
+  constructor(bitgo: BitGo, apiToken?: string) {
+    this.bitgo = bitgo;
+    this.apiToken = apiToken;
+  }
+
+  /** @inheritDoc */
+  getExplorerUrl(query: string): string {
+    if (this.apiToken) {
+      // TODO: Blockstream does not require an API key for now, howeveer, at some point they may
+    }
+    return common.Environments[this.bitgo.getEnv()].blockstreamBaseUrl + query;
+  }
+
+  /** @inheritDoc */
+  async getAccountInfo(address: string): Promise<RecoveryAccountData> {
+    // https://github.com/Blockstream/esplora/blob/master/API.md#get-addressaddress
+    // Example response:
+    // {
+    //    "address":"2NBWFbV93FQE52yEV6C7QYQ6DKTbiMoDKuT",
+    //    "chain_stats":{
+    //       "funded_txo_count":2,
+    //       "funded_txo_sum":2000000,
+    //       "spent_txo_count":1,
+    //       "spent_txo_sum":1000000,
+    //       "tx_count":3
+    //    },
+    //    "mempool_stats":{
+    //       "funded_txo_count":0,
+    //       "funded_txo_sum":0,
+    //       "spent_txo_count":0,
+    //       "spent_txo_sum":0,
+    //       "tx_count":0
+    //    }
+    // }
+    try {
+      const response = await request.get(this.getExplorerUrl(`/address/${address}`));
+      const totalBalance = response.body.chain_stats.funded_txo_sum - response.body.chain_stats.spent_txo_sum;
+      return {
+        txCount: response.body.chain_stats.tx_count,
+        totalBalance,
+      };
+    } catch (e) {
+      let errorMessage = `Failed to get account information from ${this.getExplorerUrl('')}`;
+      errorMessage += (e.response.status) ? ` - ${e.response.status}` : '';
+      errorMessage += (e.response.text) ? `: ${e.response.text}` : '';
+      throw new BlockExplorerUnavailable(errorMessage);
+    }
+  }
+
+  /** @inheritDoc */
+  async getUnspents(address: string): Promise<RecoveryUnspent[]> {
+    // https://github.com/Blockstream/esplora/blob/master/API.md#get-addressaddressutxo
+    // Example response:
+    // [
+    //    {
+    //       "txid":"5353100563d6a07d7d7085281222ced09cfb4dfd6e327da3168eac9de6b541fa",
+    //       "vout":0,
+    //       "status":{
+    //          "confirmed":true,
+    //          "block_height":1483577,
+    //          "block_hash":"00000000000000b992bfa11e06204c34065ea1e666b447646f2b546ac3d1e79a",
+    //          "block_time":1551823417
+    //       },
+    //       "value":1000000
+    //    }
+    // ]
+    try {
+      const response = await request.get(this.getExplorerUrl(`/address/${address}/utxo`));
+      const rawUnspents = response.body;
+
+      return rawUnspents.map(unspent => {
+        return {
+          amount: unspent.value,
+          n: unspent.vout,
+          txid: unspent.txid,
+          address,
+        };
+      });
+    } catch (e) {
+      let errorMessage = `Failed to get unspents information from ${this.getExplorerUrl('')}`;
+      errorMessage += (e.response.status) ? ` - ${e.response.status}` : '';
+      errorMessage += (e.response.text) ? `: ${e.response.text}` : '';
+      throw new BlockExplorerUnavailable(errorMessage);
+    }
+  }
+}

--- a/modules/core/test/v2/unit/recovery/blockstreamApi.ts
+++ b/modules/core/test/v2/unit/recovery/blockstreamApi.ts
@@ -81,13 +81,13 @@ describe('Blockstream API:', function() {
     it('to get an account information for an invalid address', async () => {
       const api = new BlockstreamApi(bitgo);
       await api.getAccountInfo('invalidAddress')
-        .should.be.rejectedWith('Failed to get account information from https://blockstream.info/testnet/api - 400: Invalid Bitcoin address');
+        .should.be.rejectedWith('Failed to get address information for invalidAddress from https://blockstream.info/testnet/api - 400: Invalid Bitcoin address');
     });
 
     it('to get an account unspents for an invalid address', async () => {
       const api = new BlockstreamApi(bitgo, 'randomKey');
       await api.getUnspents('invalidAddress')
-        .should.be.rejectedWith('Failed to get unspents information from https://blockstream.info/testnet/api - 400: Invalid Bitcoin address');
+        .should.be.rejectedWith('Failed to get unspents information for invalidAddress from https://blockstream.info/testnet/api - 400: Invalid Bitcoin address');
     });
   });
 });

--- a/modules/core/test/v2/unit/recovery/blockstreamApi.ts
+++ b/modules/core/test/v2/unit/recovery/blockstreamApi.ts
@@ -1,0 +1,93 @@
+import * as nock from 'nock';
+import { TestBitGo } from '../../../lib/test_bitgo';
+import { BlockstreamApi } from '../../../../src/v2/recovery/blockstreamApi';
+
+nock.disableNetConnect();
+
+describe('Blockstream API:', function() {
+  let bitgo;
+
+  before(function() {
+    bitgo = new TestBitGo({ env: 'test' });
+    const accountInfoResponse = {
+      address: '2NBWFbV93FQE52yEV6C7QYQ6DKTbiMoDKuT',
+      chain_stats: {
+        funded_txo_count: 2,
+        funded_txo_sum: 2000000,
+        spent_txo_count: 1,
+        spent_txo_sum: 1000000,
+        tx_count: 3,
+      },
+      mempool_stats: {
+        funded_txo_count: 0,
+        funded_txo_sum: 0,
+        spent_txo_count: 0,
+        spent_txo_sum: 0,
+        tx_count: 0,
+      },
+    };
+
+    const accountUnspentsResponse = [
+      {
+        txid: '5353100563d6a07d7d7085281222ced09cfb4dfd6e327da3168eac9de6b541fa',
+        vout: 0,
+        status: {
+          confirmed: true,
+          block_height: 1483577,
+          block_hash: '00000000000000b992bfa11e06204c34065ea1e666b447646f2b546ac3d1e79a',
+          block_time: 1551823417,
+        },
+        value: 1000000,
+      },
+    ];
+
+    const invalidBitcoinAddressResponse = 'Invalid Bitcoin address';
+
+    nock('https://blockstream.info/testnet/api')
+      .get('/address/2NBWFbV93FQE52yEV6C7QYQ6DKTbiMoDKuT')
+      .reply(200, accountInfoResponse)
+      .get('/address/2NBWFbV93FQE52yEV6C7QYQ6DKTbiMoDKuT/utxo')
+      .reply(200, accountUnspentsResponse)
+      .get('/address/invalidAddress')
+      .reply(400, invalidBitcoinAddressResponse)
+      .get('/address/invalidAddress/utxo')
+      .reply(400, invalidBitcoinAddressResponse);
+  });
+
+  after(function() {
+    nock.cleanAll();
+  });
+
+  describe('should succeed', function() {
+    it('to get an account information', async () => {
+      const api = new BlockstreamApi(bitgo);
+      const response = await api.getAccountInfo('2NBWFbV93FQE52yEV6C7QYQ6DKTbiMoDKuT');
+      response.txCount.should.equal(3);
+      response.totalBalance.should.equal(1000000);
+    });
+
+    it('to get an account unspents', async () => {
+      const api = new BlockstreamApi(bitgo, 'randomKey');
+      const response = await api.getUnspents('2NBWFbV93FQE52yEV6C7QYQ6DKTbiMoDKuT');
+      response.length.should.equal(1);
+      response[0].amount.should.equal(1000000);
+      response[0].n.should.equal(0);
+      response[0].txid.should.equal('5353100563d6a07d7d7085281222ced09cfb4dfd6e327da3168eac9de6b541fa');
+      response[0].address.should.equal('2NBWFbV93FQE52yEV6C7QYQ6DKTbiMoDKuT');
+    });
+  });
+
+  describe('should fail', function() {
+    it('to get an account information for an invalid address', async () => {
+      const api = new BlockstreamApi(bitgo);
+      await api.getAccountInfo('invalidAddress')
+        .should.be.rejectedWith('Failed to get account information from https://blockstream.info/testnet/api - 400: Invalid Bitcoin address');
+    });
+
+    it('to get an account unspents for an invalid address', async () => {
+      const api = new BlockstreamApi(bitgo, 'randomKey');
+      await api.getUnspents('invalidAddress')
+        .should.be.rejectedWith('Failed to get unspents information from https://blockstream.info/testnet/api - 400: Invalid Bitcoin address');
+    });
+  });
+});


### PR DESCRIPTION
We need an alternative for BTC that does not require payment. Blockstream does not require an API key.

CLOSES TICKET: BG-24147

This PR does not change the current recovery functionality since we should talk what's the best mechanism to allow the user to choose an API.