### PR TITLE
BG-24157: Use Blockstream as Default BTC Explorer

### DIFF
--- a/modules/core/src/v2/coins/btc.ts
+++ b/modules/core/src/v2/coins/btc.ts
@@ -7,7 +7,6 @@ import * as bitcoin from '@bitgo/utxo-lib';
 import * as request from 'superagent';
 import * as _ from 'lodash';
 import * as Bluebird from 'bluebird';
-import { BlockchairApi } from '../recovery/blockchairApi';
 import { BlockstreamApi } from '../recovery/blockstreamApi';
 import { RecoveryAccountData, RecoveryUnspent } from '../recovery/types';
 const co = Bluebird.coroutine;

--- a/modules/core/src/v2/coins/btc.ts
+++ b/modules/core/src/v2/coins/btc.ts
@@ -8,6 +8,7 @@ import * as request from 'superagent';
 import * as _ from 'lodash';
 import * as Bluebird from 'bluebird';
 import { BlockchairApi } from '../recovery/blockchairApi';
+import { BlockstreamApi } from '../recovery/blockstreamApi';
 import { RecoveryAccountData, RecoveryUnspent } from '../recovery/types';
 const co = Bluebird.coroutine;
 
@@ -75,13 +76,13 @@ export class Btc extends AbstractUtxoCoin {
 
   getAddressInfoFromExplorer(addressBase58: string, apiKey?: string): Bluebird<RecoveryAccountData> {
     // TODO: allow users to choose the API to use
-    const api = new BlockchairApi(this.bitgo, apiKey);
+    const api = new BlockstreamApi(this.bitgo, apiKey);
     return Bluebird.resolve(api.getAccountInfo(addressBase58));
   }
 
   getUnspentInfoFromExplorer(addressBase58: string, apiKey?: string): Bluebird<RecoveryUnspent[]> {
     // TODO: allow users to choose the API to use
-    const api = new BlockchairApi(this.bitgo, apiKey);
+    const api = new BlockstreamApi(this.bitgo, apiKey);
     return Bluebird.resolve(api.getUnspents(addressBase58));
   }
 

--- a/modules/core/test/v2/fixtures/coins/recovery.ts
+++ b/modules/core/test/v2/fixtures/coins/recovery.ts
@@ -165,3 +165,70 @@ module.exports.emptyBlockchairBtcAddressData = {
     transactions: [],
       utxo: [],
 }
+
+module.exports.emptyAddressInfo = {
+  txCount: 0,
+  totalBalance: 0,
+};
+
+module.exports.addressUnspents = {
+  "2MwvWgPCe6Ev9ikkXzidYB5WQqmhdfWMyVp": {
+    amount: 41000,
+    n: 1,
+    txid: "8040382653ee766f6c82361c8a19b333702fbb3faabc87e7b5fa0d6c9b8aa387",
+    address: "2MwvWgPCe6Ev9ikkXzidYB5WQqmhdfWMyVp",
+  },
+
+  "2MxZA7JFtNiQrET7JvywDisrZnKPEDAHf49": {
+    amount: 100000,
+    n: 0,
+    txid: "4bf4a792816cb4e25f0a4faea6ecb42ffd360bde293bfd8a4b6d2c255aa379f9",
+    address: "2MxZA7JFtNiQrET7JvywDisrZnKPEDAHf49",
+  },
+
+  "2MtHCVNaDed65jnq6YUN7qiHoef6xGDH4PR": {
+    amount: 100000,
+    n: 0,
+    txid: "4bf4a792816cb4e25f0a4faea6ecb42ffd360bde293bfd8a4b6d2c255aa379f9",
+    address: "2MtHCVNaDed65jnq6YUN7qiHoef6xGDH4PR",
+  },
+
+   "2N6swovegiiYQZpDHR7yYxvoNj8WUBmau3z": {
+     amount: 120000,
+     n: 1,
+     txid: "a9192dea1de9c79f4b6d4a4eeaf70542bd4eaec37206aab799b893d61c76552e",
+     address: "2N6swovegiiYQZpDHR7yYxvoNj8WUBmau3z",
+   },
+
+  '2N7kMMaUjmBYCiZqQV7GDJhBSnJuJoTuBws': {
+    amount: 20000,
+    n: 0,
+    txid: "9a57cdf7a8ce94c1cdad90f639fd8dcab8d20f68a117a7c30dbf468652fbf7e0",
+    address: "2N7kMMaUjmBYCiZqQV7GDJhBSnJuJoTuBws",
+  },
+
+  '2MzLAGkQVaDiW2Dbm22ETf4ePyLUcDroqdw': {
+    amount: 8125000,
+    n: 0,
+    txid: "e18283471a9374ef9812757ac70cd6660c66265cac7b19a87354d64937a7ed74",
+    address: "2MzLAGkQVaDiW2Dbm22ETf4ePyLUcDroqdw",
+  },
+
+};
+
+module.exports.addressInfos = {
+  '2N7kMMaUjmBYCiZqQV7GDJhBSnJuJoTuBws': {
+    txCount: 2,
+    totalBalance: 20000,
+  },
+
+  '2MwvWgPCe6Ev9ikkXzidYB5WQqmhdfWMyVp': {
+     txCount: 2,
+     totalBalance: 20000,
+  },
+
+  '2MzLAGkQVaDiW2Dbm22ETf4ePyLUcDroqdw': {
+    txCount: 1,
+    totalBalance: 8125000,
+  }
+};

--- a/modules/core/test/v2/fixtures/coins/recovery.ts
+++ b/modules/core/test/v2/fixtures/coins/recovery.ts
@@ -1,4 +1,4 @@
-module.exports.recoverBtcSegwitFixtures = function() {
+export const recoverBtcSegwitFixtures = function() {
   const userKey = '{"iv":"OVZx6VlJtv74kyE9gi5c0A==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"gY6e6MieSZ4=","ct":"O64y1HhJWxbST1 /KfiRXpSDBl3/d+Grphpq9IhWrXKI2m/V0H1fxRQPj4KCoCV0veEUAvvgSfi49vksEZ0PdXI66umlqWnTahqyQgddBiT05E8yB3HWzVBvwIoMfkL9acQhnL7phjwupZRy73EzeGEX9burWx3w="}';
   const backupKey = '{"iv":"sFkDFraiYrF6L+FNkN7gAQ==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"SIQYthT9wnw=","ct":"szZdOYRaeaDmHir1f21lC37z2taPNFCNYTUVURBOj19j3KGgMZY8VhWt+StS9U9qZN+kl4LshuQ1IP9oIbL0zyVC/mgfEcgOemgeC/PBACzTtcUy/qyDvv1TXGeqJWXVIuPlpLugTUAYm8B3C2lKloOawfhbWd4="}';
   const walletPassphrase = 'bitconnectisthefutureofmonee';
@@ -12,7 +12,7 @@ module.exports.recoverBtcSegwitFixtures = function() {
   };
 };
 
-module.exports.recoverBtcUnsignedFixtures = function() {
+export const recoverBtcUnsignedFixtures = function() {
   const userKey = 'xpub661MyMwAqRbcEc56gSK9UBdYL6FggedPtK7HGjDgmn9Hr8NdoED6q8YxJ5CCwdN6MtmRL8DsXiFrMoEEBJn8uNSkH4jgZGrWhWUVS4k4m51';
   const backupKey = 'xpub661MyMwAqRbcGyxYz3v8K7PiqYCpyJvrJW6u3fCTi8KKNJPEFkEuzx2vfX4JZpjdLP7uvuWAT9ESEAH2C9y7TduF7LsLvSGnefrgjXXPiZS';
   const recoveryDestination = '2N1KrBvGLcz8DjivbUjqq7N9eH7km6a8FtT';
@@ -29,7 +29,7 @@ module.exports.recoverBtcUnsignedFixtures = function() {
 /**
  * The invariant in every nock - some metadata that blockchair usually responds with
  */
-module.exports.blockchairContext = {
+export const blockchairContext = {
   context: {
     code: 200,
     source: 'D',
@@ -58,7 +58,7 @@ module.exports.blockchairContext = {
   },
 };
 
-module.exports.btcKrsRecoveryDecodedTx = {
+export const btcKrsRecoveryDecodedTx = {
   success: true,
   transaction: {
     Version: '1',
@@ -104,9 +104,9 @@ module.exports.btcKrsRecoveryDecodedTx = {
     ],
     TxId: '946dbefaefa5452daba373c0e0e3ada7d74bc4cf2a27518c9fcc581f19b0cb2b',
   },
-}
+};
 
-module.exports.btcNonKrsRecoveryDecodedTx =  {
+export const btcNonKrsRecoveryDecodedTx =  {
   success: true,
   transaction: {
     Version: '1',
@@ -141,9 +141,9 @@ module.exports.btcNonKrsRecoveryDecodedTx =  {
     ],
     TxId: '7cf7dc9e9abcb0bc4303332b128af4200b6b3730461a3bb579143b002739f51f',
   },
-}
+};
 
-module.exports.emptyBlockchairBtcAddressData = {
+export const emptyBlockchairBtcAddressData = {
     address: {
       type: null,
         script_hex: '',
@@ -164,59 +164,60 @@ module.exports.emptyBlockchairBtcAddressData = {
     },
     transactions: [],
       utxo: [],
-}
+};
 
-module.exports.emptyAddressInfo = {
+export const emptyAddressInfo = {
   txCount: 0,
   totalBalance: 0,
 };
 
-module.exports.addressUnspents = {
-  "2MwvWgPCe6Ev9ikkXzidYB5WQqmhdfWMyVp": {
+export const addressUnspents = {
+  '2MwvWgPCe6Ev9ikkXzidYB5WQqmhdfWMyVp': {
     amount: 41000,
     n: 1,
-    txid: "8040382653ee766f6c82361c8a19b333702fbb3faabc87e7b5fa0d6c9b8aa387",
-    address: "2MwvWgPCe6Ev9ikkXzidYB5WQqmhdfWMyVp",
+    txid: '8040382653ee766f6c82361c8a19b333702fbb3faabc87e7b5fa0d6c9b8aa387',
+    address: '2MwvWgPCe6Ev9ikkXzidYB5WQqmhdfWMyVp',
   },
 
-  "2MxZA7JFtNiQrET7JvywDisrZnKPEDAHf49": {
+  '2MxZA7JFtNiQrET7JvywDisrZnKPEDAHf49': {
     amount: 100000,
     n: 0,
-    txid: "4bf4a792816cb4e25f0a4faea6ecb42ffd360bde293bfd8a4b6d2c255aa379f9",
-    address: "2MxZA7JFtNiQrET7JvywDisrZnKPEDAHf49",
+    txid: '4bf4a792816cb4e25f0a4faea6ecb42ffd360bde293bfd8a4b6d2c255aa379f9',
+    address: '2MxZA7JFtNiQrET7JvywDisrZnKPEDAHf49',
   },
 
-  "2MtHCVNaDed65jnq6YUN7qiHoef6xGDH4PR": {
+  '2MtHCVNaDed65jnq6YUN7qiHoef6xGDH4PR': {
     amount: 100000,
     n: 0,
-    txid: "4bf4a792816cb4e25f0a4faea6ecb42ffd360bde293bfd8a4b6d2c255aa379f9",
-    address: "2MtHCVNaDed65jnq6YUN7qiHoef6xGDH4PR",
+    txid: '4bf4a792816cb4e25f0a4faea6ecb42ffd360bde293bfd8a4b6d2c255aa379f9',
+    address: '2MtHCVNaDed65jnq6YUN7qiHoef6xGDH4PR',
   },
 
-   "2N6swovegiiYQZpDHR7yYxvoNj8WUBmau3z": {
+   '2N6swovegiiYQZpDHR7yYxvoNj8WUBmau3z': {
      amount: 120000,
      n: 1,
-     txid: "a9192dea1de9c79f4b6d4a4eeaf70542bd4eaec37206aab799b893d61c76552e",
-     address: "2N6swovegiiYQZpDHR7yYxvoNj8WUBmau3z",
+     txid: 'a9192dea1de9c79f4b6d4a4eeaf70542bd4eaec37206aab799b893d61c76552e',
+     address: '2N6swovegiiYQZpDHR7yYxvoNj8WUBmau3z',
    },
 
   '2N7kMMaUjmBYCiZqQV7GDJhBSnJuJoTuBws': {
     amount: 20000,
     n: 0,
-    txid: "9a57cdf7a8ce94c1cdad90f639fd8dcab8d20f68a117a7c30dbf468652fbf7e0",
-    address: "2N7kMMaUjmBYCiZqQV7GDJhBSnJuJoTuBws",
+    txid: '9a57cdf7a8ce94c1cdad90f639fd8dcab8d20f68a117a7c30dbf468652fbf7e0',
+    address: '2N7kMMaUjmBYCiZqQV7GDJhBSnJuJoTuBws',
   },
 
   '2MzLAGkQVaDiW2Dbm22ETf4ePyLUcDroqdw': {
     amount: 8125000,
     n: 0,
-    txid: "e18283471a9374ef9812757ac70cd6660c66265cac7b19a87354d64937a7ed74",
-    address: "2MzLAGkQVaDiW2Dbm22ETf4ePyLUcDroqdw",
+    txid: 'e18283471a9374ef9812757ac70cd6660c66265cac7b19a87354d64937a7ed74',
+    address: '2MzLAGkQVaDiW2Dbm22ETf4ePyLUcDroqdw',
   },
 
 };
 
-module.exports.addressInfos = {
+
+export const addressInfos = {
   '2N7kMMaUjmBYCiZqQV7GDJhBSnJuJoTuBws': {
     txCount: 2,
     totalBalance: 20000,

--- a/modules/core/test/v2/lib/recovery-nocks.ts
+++ b/modules/core/test/v2/lib/recovery-nocks.ts
@@ -26,29 +26,37 @@ export function nockSmartbitDecodeTx(txHex, env, isKrsRecovery, smartbitOnline =
   }
 }
 
-export function nockBtcRecovery(bitgo, isKrsRecovery, smartbitOnline = true) {
-  const env = Environments[bitgo.getEnv()] as any;
-  const blockchairURL = `${env.blockchairBaseUrl}`;
+export function nockbitcoinFees(fastestFee: number, halfHourFee: number, hourFee: number) {
   nock('https://bitcoinfees.earn.com')
     .get('/api/v1/fees/recommended')
     .reply(200, {
-      fastestFee: 600,
-      halfHourFee: 600,
-      hourFee: 100,
+      fastestFee,
+      halfHourFee,
+      hourFee,
     });
+}
+
+export function nockCoingecko(usd: number, coin: string) {
+  nock('https://api.coingecko.com')
+    .get('/api/v3/simple/price?ids=bitcoin&vs_currencies=USD')
+    .reply(200, {
+      bitcoin: {
+        usd,
+      },
+    });
+}
+
+export function blockchairNockBtcRecovery(bitgo, isKrsRecovery, smartbitOnline = true) {
+  const env = Environments[bitgo.getEnv()] as any;
+  const blockchairURL = `${env.blockchairBaseUrl}`;
+  nockbitcoinFees(600, 600, 100);
   const txHex = isKrsRecovery
     ? '010000000174eda73749d65473a8197bac5c26660c66d60cc77a751298ef74931a478382e100000000b500483045022100ca835086284cb84e9cbf96464057dcd58fa9b4b37cf4c51171c109dae13ec9ee02203ca1b77600820e670d7bd0c6bd8fbfc003c2a67ffedab7950a1c7f9d0fc17b4c014c69522102f5ca5d074093abf996278d1e82b64497333254c786e9a69d34909a785aa9af32210239125d1a21ba8ae375cd37a92e48700cbb3bc1b1268d3c3f7e1d95f42155e1a821031ab00568ea1522a55f277699110649f3b8d08022494af2cc475c09e8a43b3a3a53aeffffffff0230456c000000000017a914c39dcc27823a8bd42cd3318a1dac8c25789b7ac787301b0f000000000017a9141b60c33def13c3eda4cf4835e11a633e4b3302ec8700000000'
     : '010000000174eda73749d65473a8197bac5c26660c66d60cc77a751298ef74931a478382e100000000fdfd00004730440220513ff3a0a4d72230a7ca9b1285d5fa19669d7cccef6a9c8408b06da666f4c51f022058e8cc58b9f9ca585c37a8353d87d0ab042ac081ebfcea86fda0da1b33bf474701483045022100e27c00394553513803e56e6623e06614cf053834a27ca925ed9727071d4411380220399ab1a0269e84beb4e8602fea3d617ffb0b649515892d470061a64217bad613014c69522102f5ca5d074093abf996278d1e82b64497333254c786e9a69d34909a785aa9af32210239125d1a21ba8ae375cd37a92e48700cbb3bc1b1268d3c3f7e1d95f42155e1a821031ab00568ea1522a55f277699110649f3b8d08022494af2cc475c09e8a43b3a3a53aeffffffff012c717b000000000017a914c39dcc27823a8bd42cd3318a1dac8c25789b7ac78700000000';
 
   if (isKrsRecovery) {
     // unnecessary market data removed
-    nock('https://api.coingecko.com')
-      .get('/api/v3/simple/price?ids=bitcoin&vs_currencies=USD')
-      .reply(200, {
-        bitcoin: {
-          usd: 10000,
-        },
-      });
+    nockCoingecko(10000, 'bitcoin');
   }
   nock(blockchairURL)
     .get('/dashboards/address/2MztRFcJWkDTYsZmNjLu9pBWWviJmWjJ4hg?key=my_______SecretApiKey')

--- a/modules/core/test/v2/unit/coins/abstractUtxoCoin.ts
+++ b/modules/core/test/v2/unit/coins/abstractUtxoCoin.ts
@@ -6,13 +6,18 @@ import { BitGo, VerificationOptions } from '../../../../src';
 import { Wallet } from '../../../../src/v2';
 import { AbstractUtxoCoin } from '../../../../src/v2/coins';
 const recoveryNocks = require('../../lib/recovery-nocks');
-const fixtures = require('../../fixtures/coins/recovery');
 import { TestBitGo } from '../../../lib/test_bitgo';
 import * as nock from 'nock';
 const utxoLib = require('@bitgo/utxo-lib');
 import * as errors from '../../../../src/errors';
-const { Btc } = require('../../../../src/v2/coins/btc');
-const { emptyAddressInfo, addressUnspents, addressInfos } = fixtures;
+import { Btc } from '../../../../src/v2/coins/btc';
+import { 
+  addressUnspents, 
+  addressInfos, 
+  emptyAddressInfo, 
+  recoverBtcUnsignedFixtures, 
+  recoverBtcSegwitFixtures 
+} from '../../fixtures/coins/recovery';
 
 describe('Abstract UTXO Coin:', () => {
   describe('Parse Transaction:', () => {
@@ -414,14 +419,14 @@ describe('Abstract UTXO Coin:', () => {
 
     it('should construct a recovery transaction with segwit unspents', co(function *() {
       const callBack1 = sandbox.stub(Btc.prototype, 'getAddressInfoFromExplorer');
-      callBack1.returns(Promise.resolve(emptyAddressInfo));
-      callBack1.withArgs('2N7kMMaUjmBYCiZqQV7GDJhBSnJuJoTuBws').returns(Promise.resolve(addressInfos['2N7kMMaUjmBYCiZqQV7GDJhBSnJuJoTuBws']));
-      callBack1.withArgs('2MwvWgPCe6Ev9ikkXzidYB5WQqmhdfWMyVp').returns(Promise.resolve(addressInfos['2MwvWgPCe6Ev9ikkXzidYB5WQqmhdfWMyVp']));
+      callBack1.resolves(emptyAddressInfo);
+      callBack1.withArgs('2N7kMMaUjmBYCiZqQV7GDJhBSnJuJoTuBws').resolves(addressInfos['2N7kMMaUjmBYCiZqQV7GDJhBSnJuJoTuBws']);
+      callBack1.withArgs('2MwvWgPCe6Ev9ikkXzidYB5WQqmhdfWMyVp').resolves(addressInfos['2MwvWgPCe6Ev9ikkXzidYB5WQqmhdfWMyVp']);
       const callBack2 = sandbox.stub(Btc.prototype, 'getUnspentInfoFromExplorer');
-      callBack2.withArgs('2N7kMMaUjmBYCiZqQV7GDJhBSnJuJoTuBws').returns(Promise.resolve([addressUnspents['2N7kMMaUjmBYCiZqQV7GDJhBSnJuJoTuBws']]));
-      callBack2.withArgs('2MwvWgPCe6Ev9ikkXzidYB5WQqmhdfWMyVp').returns(Promise.resolve([addressUnspents['2MwvWgPCe6Ev9ikkXzidYB5WQqmhdfWMyVp']]));
-      callBack2.returns(Promise.resolve([]));
-      const { params, expectedTxHex } = fixtures.recoverBtcSegwitFixtures();
+      callBack2.withArgs('2N7kMMaUjmBYCiZqQV7GDJhBSnJuJoTuBws').resolves([addressUnspents['2N7kMMaUjmBYCiZqQV7GDJhBSnJuJoTuBws']]);
+      callBack2.withArgs('2MwvWgPCe6Ev9ikkXzidYB5WQqmhdfWMyVp').resolves([addressUnspents['2MwvWgPCe6Ev9ikkXzidYB5WQqmhdfWMyVp']]);
+      callBack2.resolves([]);
+      const { params, expectedTxHex } = recoverBtcSegwitFixtures();
       recoveryNocks.nockBtcSegwitRecovery(bitgo);
       const tx = yield coin.recover(params);
       const transaction = utxoLib.Transaction.fromHex(tx.transactionHex);
@@ -433,18 +438,18 @@ describe('Abstract UTXO Coin:', () => {
 
     it('should construct an unsigned recovery transaction for the offline vault', co(function *() {
       const callBack1 = sandbox.stub(Btc.prototype, 'getAddressInfoFromExplorer');
-      callBack1.returns(Promise.resolve(emptyAddressInfo));
-      callBack1.withArgs('2N8cRxMypLRN3HV1ub3b9mu1bbBRYA4JTNx').returns(Promise.resolve({txCount: 2, totalBalance: 0}));
-      callBack1.withArgs('2MxZA7JFtNiQrET7JvywDisrZnKPEDAHf49').returns(Promise.resolve({txCount: 2, totalBalance: 100000}));
-      callBack1.withArgs('2MtHCVNaDed65jnq6YUN7qiHoef6xGDH4PR').returns(Promise.resolve({txCount: 2, totalBalance: 0}))
-      callBack1.withArgs('2N6swovegiiYQZpDHR7yYxvoNj8WUBmau3z').returns(Promise.resolve({txCount: 2, totalBalance: 120000}))
+      callBack1.resolves(emptyAddressInfo);
+      callBack1.withArgs('2N8cRxMypLRN3HV1ub3b9mu1bbBRYA4JTNx').resolves({txCount: 2, totalBalance: 0});
+      callBack1.withArgs('2MxZA7JFtNiQrET7JvywDisrZnKPEDAHf49').resolves({txCount: 2, totalBalance: 100000});
+      callBack1.withArgs('2MtHCVNaDed65jnq6YUN7qiHoef6xGDH4PR').resolves({txCount: 2, totalBalance: 0});
+      callBack1.withArgs('2N6swovegiiYQZpDHR7yYxvoNj8WUBmau3z').resolves({txCount: 2, totalBalance: 120000});
 
       const callBack2 = sandbox.stub(Btc.prototype, 'getUnspentInfoFromExplorer');
-      callBack2.withArgs('2MxZA7JFtNiQrET7JvywDisrZnKPEDAHf49').returns(Promise.resolve([addressUnspents['2MxZA7JFtNiQrET7JvywDisrZnKPEDAHf49']]));
-      callBack2.withArgs('2MtHCVNaDed65jnq6YUN7qiHoef6xGDH4PR').returns(Promise.resolve([addressUnspents['2MtHCVNaDed65jnq6YUN7qiHoef6xGDH4PR']]));
-      callBack2.withArgs('2N6swovegiiYQZpDHR7yYxvoNj8WUBmau3z').returns(Promise.resolve([addressUnspents['2N6swovegiiYQZpDHR7yYxvoNj8WUBmau3z']]));
-      callBack2.returns(Promise.resolve([]));
-      const { params, expectedTxHex } = fixtures.recoverBtcUnsignedFixtures();
+      callBack2.withArgs('2MxZA7JFtNiQrET7JvywDisrZnKPEDAHf49').resolves([addressUnspents['2MxZA7JFtNiQrET7JvywDisrZnKPEDAHf49']]);
+      callBack2.withArgs('2MtHCVNaDed65jnq6YUN7qiHoef6xGDH4PR').resolves([addressUnspents['2MtHCVNaDed65jnq6YUN7qiHoef6xGDH4PR']]);
+      callBack2.withArgs('2N6swovegiiYQZpDHR7yYxvoNj8WUBmau3z').resolves([addressUnspents['2N6swovegiiYQZpDHR7yYxvoNj8WUBmau3z']]);
+      callBack2.resolves([]);
+      const { params, expectedTxHex } = recoverBtcUnsignedFixtures();
       recoveryNocks.nockBtcUnsignedRecovery(bitgo);
       const txPrebuild = yield coin.recover(params);
       txPrebuild.txHex.should.equal(expectedTxHex);

--- a/modules/core/test/v2/unit/recovery.ts
+++ b/modules/core/test/v2/unit/recovery.ts
@@ -11,16 +11,15 @@ import { TestBitGo } from '../../lib/test_bitgo';
 const recoveryNocks = require('../lib/recovery-nocks');
 import * as config from '../../../src/config';
 import moment = require('moment');
-import sinon = require('sinon');
-const { Btc } = require('../../../src/v2/coins/btc');
-const fixtures = require('../fixtures/coins/recovery');
-const {
+import * as sinon from 'sinon';
+import { Btc } from '../../../src/v2/coins/btc';
+import { 
   addressInfos,
   addressUnspents,
   btcKrsRecoveryDecodedTx,
   btcNonKrsRecoveryDecodedTx,
-  emptyAddressInfo,
-} = fixtures;
+  emptyAddressInfo, 
+} from '../fixtures/coins/recovery';
 
 nock.disableNetConnect();
 
@@ -53,11 +52,11 @@ describe('Recovery:', function() {
       sandbox = sinon.createSandbox();
       recoveryNocks.nockbitcoinFees(600, 600, 100);
       const callBack1 = sandbox.stub(Btc.prototype, 'getAddressInfoFromExplorer');
-      callBack1.returns(Promise.resolve(emptyAddressInfo));
-      callBack1.withArgs('2MzLAGkQVaDiW2Dbm22ETf4ePyLUcDroqdw').returns(Promise.resolve(addressInfos['2MzLAGkQVaDiW2Dbm22ETf4ePyLUcDroqdw']));
+      callBack1.resolves(emptyAddressInfo);
+      callBack1.withArgs('2MzLAGkQVaDiW2Dbm22ETf4ePyLUcDroqdw').resolves(addressInfos['2MzLAGkQVaDiW2Dbm22ETf4ePyLUcDroqdw']);
       const callBack2 = sandbox.stub(Btc.prototype, 'getUnspentInfoFromExplorer');
-      callBack2.withArgs('2MzLAGkQVaDiW2Dbm22ETf4ePyLUcDroqdw').returns(Promise.resolve([addressUnspents['2MzLAGkQVaDiW2Dbm22ETf4ePyLUcDroqdw']]));
-      callBack2.returns(Promise.resolve([]));
+      callBack2.withArgs('2MzLAGkQVaDiW2Dbm22ETf4ePyLUcDroqdw').resolves([addressUnspents['2MzLAGkQVaDiW2Dbm22ETf4ePyLUcDroqdw']]);
+      callBack2.resolves([]);
 
     });
 
@@ -66,7 +65,7 @@ describe('Recovery:', function() {
     });
 
     it('should generate BTC recovery tx', co(function *() {
-      sandbox.stub(Btc.prototype, 'verifyRecoveryTransaction').returns(Promise.resolve(btcNonKrsRecoveryDecodedTx.transaction));
+      sandbox.stub(Btc.prototype, 'verifyRecoveryTransaction').resolves(btcNonKrsRecoveryDecodedTx.transaction);
       const basecoin = bitgo.coin('tbtc');
       const recovery = yield basecoin.recover({
         userKey: '{"iv":"fTcRIg7nlCf9fPSR4ID8XQ==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"pkIS5jVDi0Y=","ct":"SJQgP+ZzfOMf2fWxyQ2jpoWYioq6Tqfcw1xiKS1WpWAxLvXfH059sZvPrrYMdijJEbqA8EEaYXWmdgYSkMXdwckRMyvM3uWl9H8iKw1ZJmHyy2eDSy5r/pCtWICkcO3oi2I492I/3Op2YLfIX6XqKWs2mztu/OY="}',
@@ -96,7 +95,7 @@ describe('Recovery:', function() {
     }));
 
     it('should generate BTC recovery tx with unencrypted keys', co(function *() { // TODO this is a test on the key derivation part
-      sandbox.stub(Btc.prototype, 'verifyRecoveryTransaction').returns(Promise.resolve(btcNonKrsRecoveryDecodedTx.transaction));
+      sandbox.stub(Btc.prototype, 'verifyRecoveryTransaction').resolves(btcNonKrsRecoveryDecodedTx.transaction);
       const basecoin = bitgo.coin('tbtc');
       const recovery = yield basecoin.recover({
         userKey: 'xprv9s21ZrQH143K44auQTYjyFpU8aGEpbsbcU5yGjbwfyKpbBpvHPhUHEu3QR6G74rLPyM9ucop7oyXtKYDrjNkU8YeSryQbKU476ijp2qWcBm',
@@ -127,7 +126,7 @@ describe('Recovery:', function() {
 
     it('should generate BTC recovery tx with KRS', co(function *() {
       recoveryNocks.nockCoingecko(10000, 'bitcoin');
-      sandbox.stub(Btc.prototype, 'verifyRecoveryTransaction').returns(Promise.resolve(btcKrsRecoveryDecodedTx.transaction));
+      sandbox.stub(Btc.prototype, 'verifyRecoveryTransaction').resolves(btcKrsRecoveryDecodedTx.transaction);
       const basecoin = bitgo.coin('tbtc');
       const recovery = yield basecoin.recover({
         userKey: '{"iv":"fTcRIg7nlCf9fPSR4ID8XQ==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"pkIS5jVDi0Y=","ct":"SJQgP+ZzfOMf2fWxyQ2jpoWYioq6Tqfcw1xiKS1WpWAxLvXfH059sZvPrrYMdijJEbqA8EEaYXWmdgYSkMXdwckRMyvM3uWl9H8iKw1ZJmHyy2eDSy5r/pCtWICkcO3oi2I492I/3Op2YLfIX6XqKWs2mztu/OY="}',

--- a/modules/core/test/v2/unit/recovery.ts
+++ b/modules/core/test/v2/unit/recovery.ts
@@ -37,8 +37,7 @@ describe('Recovery:', function() {
 
   describe('Recover Bitcoin', function() {
     it('should generate BTC recovery tx', co(function *() {
-      recoveryNocks.nockBtcRecovery(bitgo, false);
-
+      recoveryNocks.blockchairNockBtcRecovery(bitgo, false);
       const basecoin = bitgo.coin('tbtc');
       const recovery = yield basecoin.recover({
         userKey: '{"iv":"fTcRIg7nlCf9fPSR4ID8XQ==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"pkIS5jVDi0Y=","ct":"SJQgP+ZzfOMf2fWxyQ2jpoWYioq6Tqfcw1xiKS1WpWAxLvXfH059sZvPrrYMdijJEbqA8EEaYXWmdgYSkMXdwckRMyvM3uWl9H8iKw1ZJmHyy2eDSy5r/pCtWICkcO3oi2I492I/3Op2YLfIX6XqKWs2mztu/OY="}',
@@ -68,8 +67,8 @@ describe('Recovery:', function() {
       recovery.tx.Vout[0].ScriptPubKey.Addresses[0].should.equal('2NB5Ynem6iNvA6GBLZwRxwid3Kui33729Nw');
     }));
 
-    it('should generate BTC recovery tx with unencrypted keys', co(function *() {
-      recoveryNocks.nockBtcRecovery(bitgo, false);
+    it('should generate BTC recovery tx with unencrypted keys', co(function *() { // TODO this is a test on the key derivation part
+      recoveryNocks.blockchairNockBtcRecovery(bitgo, false);
 
       const basecoin = bitgo.coin('tbtc');
       const recovery = yield basecoin.recover({
@@ -100,7 +99,8 @@ describe('Recovery:', function() {
     }));
 
     it('should generate BTC recovery tx with KRS', co(function *() {
-      recoveryNocks.nockBtcRecovery(bitgo, true);
+      //sinon.stub(object, 'getAddressInfoFromExplorer',)
+      recoveryNocks.blockchairNockBtcRecovery(bitgo, true);
 
       const basecoin = bitgo.coin('tbtc');
       const recovery = yield basecoin.recover({
@@ -141,7 +141,7 @@ describe('Recovery:', function() {
     }));
 
     it('should fail to generate a recovery tx if the KRS provider does not support the coin', co(function *() {
-      recoveryNocks.nockBtcRecovery(bitgo, true);
+      recoveryNocks.blockchairNockBtcRecovery(bitgo, true);
 
       const oldSupportedCoins = config.krsProviders.keyternal.supportedCoins;
       config.krsProviders.keyternal.supportedCoins = [];
@@ -162,8 +162,7 @@ describe('Recovery:', function() {
     }));
 
     it('should fail to generate a recovery tx if the fee address is not specified', co(function *() {
-      recoveryNocks.nockBtcRecovery(bitgo, true);
-
+      recoveryNocks.blockchairNockBtcRecovery(bitgo, true);
       const oldAddress = (config.krsProviders.keyternal.feeAddresses as any).tbtc;
       delete (config.krsProviders.keyternal.feeAddresses as any).tbtc;
 
@@ -183,7 +182,7 @@ describe('Recovery:', function() {
     }));
 
     it('should not throw if smartbit fails to response to request to verifyreoverytransaction', co (function *() {
-      recoveryNocks.nockBtcRecovery(bitgo, false, false);
+      recoveryNocks.blockchairNockBtcRecovery(bitgo, false, false);
       const basecoin = bitgo.coin('tbtc');
       const recovery = yield basecoin.recover({
         userKey: '{"iv":"fTcRIg7nlCf9fPSR4ID8XQ==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"pkIS5jVDi0Y=","ct":"SJQgP+ZzfOMf2fWxyQ2jpoWYioq6Tqfcw1xiKS1WpWAxLvXfH059sZvPrrYMdijJEbqA8EEaYXWmdgYSkMXdwckRMyvM3uWl9H8iKw1ZJmHyy2eDSy5r/pCtWICkcO3oi2I492I/3Op2YLfIX6XqKWs2mztu/OY="}',
@@ -198,7 +197,7 @@ describe('Recovery:', function() {
     }));
 
     it('should allow the provision of an API key while doing recovery', co (function *() {
-      recoveryNocks.nockBtcRecovery(bitgo, false, false);
+      recoveryNocks.blockchairNockBtcRecovery(bitgo, false, false);
       const basecoin = bitgo.coin('tbtc');
       const recovery = yield basecoin.recover({
         userKey: '{"iv":"fTcRIg7nlCf9fPSR4ID8XQ==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"pkIS5jVDi0Y=","ct":"SJQgP+ZzfOMf2fWxyQ2jpoWYioq6Tqfcw1xiKS1WpWAxLvXfH059sZvPrrYMdijJEbqA8EEaYXWmdgYSkMXdwckRMyvM3uWl9H8iKw1ZJmHyy2eDSy5r/pCtWICkcO3oi2I492I/3Op2YLfIX6XqKWs2mztu/OY="}',


### PR DESCRIPTION
This PR makes blockstream the default block explorer.

Additionally, it also refactored existing unit tests to be less coupled with the specific implementation of any block explorer by using mock function values.