### PR TITLE
Do not throw error if bitcoinfee does not respond in recovery

### DIFF
--- a/modules/core/src/v2/coins/btc.ts
+++ b/modules/core/src/v2/coins/btc.ts
@@ -55,13 +55,18 @@ export class Btc extends AbstractUtxoCoin {
 
       const publicFeeDataReq = request.get(recoveryFeeUrl);
       publicFeeDataReq.forceV1Auth = true;
-      const publicFeeData = yield publicFeeDataReq.result();
-
-      if (_.isInteger(publicFeeData.hourFee)) {
-        return publicFeeData.hourFee;
-      } else {
-        return 100;
+      let publicFeeData;
+      try {
+        publicFeeData = yield publicFeeDataReq.result();
+        if (publicFeeData && publicFeeData.hourFee && _.isInteger(publicFeeData.hourFee)) {
+          return publicFeeData.hourFee;
+        }
+      } catch (e) {
+        // if bitcoinfees does not respond, we would resort to the default fee value, 100
+        // but we don't want to block the recovery process
+        console.dir(e);
       }
+      return 100;
     }).call(this);
   }
 

--- a/modules/core/test/v2/lib/recovery-nocks.ts
+++ b/modules/core/test/v2/lib/recovery-nocks.ts
@@ -36,6 +36,12 @@ export function nockbitcoinFees(fastestFee: number, halfHourFee: number, hourFee
     });
 }
 
+export function nockbitcoinFeesOffline(fastestFee: number, halfHourFee: number, hourFee: number) {
+  nock('https://bitcoinfees.earn.com')
+    .get('/api/v1/fees/recommended')
+    .replyWithError('please wait while predictions are being generated');
+}
+
 export function nockCoingecko(usd: number, coin: string) {
   nock('https://api.coingecko.com')
     .get('/api/v3/simple/price?ids=bitcoin&vs_currencies=USD')

--- a/modules/core/test/v2/unit/recovery.ts
+++ b/modules/core/test/v2/unit/recovery.ts
@@ -94,7 +94,7 @@ describe('Recovery:', function() {
       recovery.tx.Vout[0].ScriptPubKey.Addresses[0].should.equal('2NB5Ynem6iNvA6GBLZwRxwid3Kui33729Nw');
     }));
 
-    it('should generate BTC recovery tx with unencrypted keys', co(function *() { // TODO this is a test on the key derivation part
+    it('should generate BTC recovery tx with unencrypted keys', co(function* () {
       sandbox.stub(Btc.prototype, 'verifyRecoveryTransaction').resolves(btcNonKrsRecoveryDecodedTx.transaction);
       const basecoin = bitgo.coin('tbtc');
       const recovery = yield basecoin.recover({
@@ -229,6 +229,27 @@ describe('Recovery:', function() {
         scan: 5,
         ignoreAddressTypes: ['p2wsh', 'p2shP2wsh'],
         apiKey: 'my_______SecretApiKey',
+      });
+      recovery.transactionHex.should.equal('010000000174eda73749d65473a8197bac5c26660c66d60cc77a751298ef74931a478382e100000000fdfd00004730440220513ff3a0a4d72230a7ca9b1285d5fa19669d7cccef6a9c8408b06da666f4c51f022058e8cc58b9f9ca585c37a8353d87d0ab042ac081ebfcea86fda0da1b33bf474701483045022100e27c00394553513803e56e6623e06614cf053834a27ca925ed9727071d4411380220399ab1a0269e84beb4e8602fea3d617ffb0b649515892d470061a64217bad613014c69522102f5ca5d074093abf996278d1e82b64497333254c786e9a69d34909a785aa9af32210239125d1a21ba8ae375cd37a92e48700cbb3bc1b1268d3c3f7e1d95f42155e1a821031ab00568ea1522a55f277699110649f3b8d08022494af2cc475c09e8a43b3a3a53aeffffffff012c717b000000000017a914c39dcc27823a8bd42cd3318a1dac8c25789b7ac78700000000');
+    }));
+
+    it('should not throw if earn.com (bitcoinfees) fails to response to request to verifyreoverytransaction', co(function* () {
+      nock.removeInterceptor({
+        hostname: 'bitcoinfees.earn.com',
+        path: '/api/v1/fees/recommended',
+        method: 'GET',
+        proto: 'https',
+      });
+      recoveryNocks.nockbitcoinFeesOffline();
+      const basecoin = bitgo.coin('tbtc');
+      const recovery = yield basecoin.recover({
+        userKey: '{"iv":"fTcRIg7nlCf9fPSR4ID8XQ==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"pkIS5jVDi0Y=","ct":"SJQgP+ZzfOMf2fWxyQ2jpoWYioq6Tqfcw1xiKS1WpWAxLvXfH059sZvPrrYMdijJEbqA8EEaYXWmdgYSkMXdwckRMyvM3uWl9H8iKw1ZJmHyy2eDSy5r/pCtWICkcO3oi2I492I/3Op2YLfIX6XqKWs2mztu/OY="}',
+        backupKey: '{"iv":"0WkLaOsnO3M7qnV2DbSvWw==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"lGxBnvlGAoM=","ct":"cBalT6MGZ3TYIYHt4jys0WDTZEKK9qIubltKEqfW4zXtxYd1dYLz9qLve/yXPl7NF5Cb1lBNGBBGsfqzvpr0Q5824xiy5i9IKzRBI/69HIt3fC2RjJKDfB1EZUjoozi2O5FH4K7L6Ejq7qZhvi8iOd1ULVpBgnE="}',
+        bitgoKey: 'xpub661MyMwAqRbcGsSbYgWmr9G1dFgPE8HEb1ASRShbw9S1Mmu1dTQ7QStNwpaYFESq3MeKivGidN8twMeJzqh1veuSP1t2XLENL3mwpatfTst',
+        walletPassphrase: TestBitGo.V2.TEST_WALLET1_PASSCODE,
+        recoveryDestination: '2NB5Ynem6iNvA6GBLZwRxwid3Kui33729Nw',
+        scan: 5,
+        ignoreAddressTypes: ['p2wsh', 'p2shP2wsh']
       });
       recovery.transactionHex.should.equal('010000000174eda73749d65473a8197bac5c26660c66d60cc77a751298ef74931a478382e100000000fdfd00004730440220513ff3a0a4d72230a7ca9b1285d5fa19669d7cccef6a9c8408b06da666f4c51f022058e8cc58b9f9ca585c37a8353d87d0ab042ac081ebfcea86fda0da1b33bf474701483045022100e27c00394553513803e56e6623e06614cf053834a27ca925ed9727071d4411380220399ab1a0269e84beb4e8602fea3d617ffb0b649515892d470061a64217bad613014c69522102f5ca5d074093abf996278d1e82b64497333254c786e9a69d34909a785aa9af32210239125d1a21ba8ae375cd37a92e48700cbb3bc1b1268d3c3f7e1d95f42155e1a821031ab00568ea1522a55f277699110649f3b8d08022494af2cc475c09e8a43b3a3a53aeffffffff012c717b000000000017a914c39dcc27823a8bd42cd3318a1dac8c25789b7ac78700000000');
     }));


### PR DESCRIPTION
  - Currently, when bitcoinfee.earn.com goes down, we would let the
    error interfere with the recovery transaction. But since we have
    the default fee value anyways, we should just catch the error and
    use the default fee value to continue with the recovery

Ticket: BG-24305