### PR TITLE
Replace usages of new Buffer() with Buffer.from()

### DIFF
--- a/modules/account-lib/src/coin/baseCoin/secp256k1ExtendedKeyPair.ts
+++ b/modules/account-lib/src/coin/baseCoin/secp256k1ExtendedKeyPair.ts
@@ -34,7 +34,7 @@ export abstract class Secp256k1ExtendedKeyPair implements BaseKeyPair {
       this.hdNode = HDNode.fromBase58(prv);
     } else if (Crypto.isValidPrv(prv)) {
       // Cannot create the HD node without the chain code, so create a regular Key Chain
-      this.keyPair = ECPair.fromPrivateKeyBuffer(new Buffer(prv, 'hex'));
+      this.keyPair = ECPair.fromPrivateKeyBuffer(Buffer.from(prv, 'hex'));
     } else {
       throw new Error('Unsupported private key');
     }
@@ -50,7 +50,7 @@ export abstract class Secp256k1ExtendedKeyPair implements BaseKeyPair {
       this.hdNode = HDNode.fromBase58(pub);
     } else if (Crypto.isValidPub(pub)) {
       // Cannot create an HD node without the chain code, so create a regular Key Chain
-      this.keyPair = ECPair.fromPublicKeyBuffer(new Buffer(pub, 'hex'));
+      this.keyPair = ECPair.fromPublicKeyBuffer(Buffer.from(pub, 'hex'));
     } else {
       throw new Error('Unsupported public key: ' + pub);
     }

--- a/modules/account-lib/src/coin/eth/transferBuilder.ts
+++ b/modules/account-lib/src/coin/eth/transferBuilder.ts
@@ -155,7 +155,7 @@ export class TransferBuilder {
           this.getNativeOperationHashPrefix(),
           new ethUtil.BN(ethUtil.stripHexPrefix(this._toAddress), 16),
           this._amount,
-          new Buffer(ethUtil.stripHexPrefix(this._data) || '', 'hex'),
+          Buffer.from(ethUtil.stripHexPrefix(this._data) || '', 'hex'),
           this._expirationTime,
           this._sequenceId,
         ],
@@ -207,8 +207,8 @@ export class TransferBuilder {
   protected ethSignMsgHash(): string {
     const data = this.getOperationHash();
     const signatureInParts = ethUtil.ecsign(
-      new Buffer(ethUtil.stripHexPrefix(data), 'hex'),
-      new Buffer(this._signKey, 'hex'),
+      Buffer.from(ethUtil.stripHexPrefix(data), 'hex'),
+      Buffer.from(this._signKey, 'hex'),
     );
 
     // Assemble strings from r, s and v

--- a/modules/account-lib/src/coin/xtz/keyPair.ts
+++ b/modules/account-lib/src/coin/xtz/keyPair.ts
@@ -49,7 +49,7 @@ export class KeyPair extends Secp256k1ExtendedKeyPair {
       this.hdNode = HDNode.fromBase58(prv);
     } else if (CryptoUtils.isValidPrv(prv)) {
       // Cannot create the HD node without the chain code, so create a regular Key Chain
-      this.keyPair = ECPair.fromPrivateKeyBuffer(new Buffer(prv, 'hex'));
+      this.keyPair = ECPair.fromPrivateKeyBuffer(Buffer.from(prv, 'hex'));
     } else if (Utils.isValidKey(prv, Utils.hashTypes.spsk)) {
       this.keyPair = ECPair.fromPrivateKeyBuffer(Utils.decodeKey(prv, Utils.hashTypes.spsk));
     } else {
@@ -68,7 +68,7 @@ export class KeyPair extends Secp256k1ExtendedKeyPair {
       this.hdNode = HDNode.fromBase58(pub);
     } else if (CryptoUtils.isValidPub(pub)) {
       // Cannot create an HD node without the chain code, so create a regular Key Chain
-      this.keyPair = ECPair.fromPublicKeyBuffer(new Buffer(pub, 'hex'));
+      this.keyPair = ECPair.fromPublicKeyBuffer(Buffer.from(pub, 'hex'));
     } else if (Utils.isValidKey(pub, Utils.hashTypes.sppk)) {
       this.keyPair = ECPair.fromPublicKeyBuffer(Utils.decodeKey(pub, Utils.hashTypes.sppk));
     } else {

--- a/modules/account-lib/src/coin/xtz/utils.ts
+++ b/modules/account-lib/src/coin/xtz/utils.ts
@@ -113,7 +113,7 @@ export async function verifySignature(
   messageWithWatermark.set(messageBuffer, watermark.length);
 
   await sodium.ready;
-  const bytesHash = new Buffer(sodium.crypto_generichash(32, messageWithWatermark));
+  const bytesHash = Buffer.from(sodium.crypto_generichash(32, messageWithWatermark));
 
   const rawSignature = decodeSignature(signature, hashTypes.sig);
   return key.verify(bytesHash, { r: rawSignature.slice(0, 32), s: rawSignature.slice(32, 64) });
@@ -313,132 +313,132 @@ export const hashTypes = {
   /* 20 bytes long */
   // ed25519 public key hash
   tz1: {
-    prefix: new Buffer([6, 161, 159]),
+    prefix: Buffer.from([6, 161, 159]),
     byteLength: 20,
   },
   // secp256k1 public key hash
   tz2: {
-    prefix: new Buffer([6, 161, 161]),
+    prefix: Buffer.from([6, 161, 161]),
     byteLength: 20,
   },
   // p256 public key hash
   tz3: {
-    prefix: new Buffer([6, 161, 164]),
+    prefix: Buffer.from([6, 161, 164]),
     byteLength: 20,
   },
   KT: {
-    prefix: new Buffer([2, 90, 121]),
+    prefix: Buffer.from([2, 90, 121]),
     byteLength: 20,
   },
   /* 32 bytes long */
   // ed25519 public key
   edpk: {
-    prefix: new Buffer([13, 15, 37, 217]),
+    prefix: Buffer.from([13, 15, 37, 217]),
     byteLength: 32,
   },
   // ed25519 secret key
   edsk2: {
-    prefix: new Buffer([13, 15, 58, 7]),
+    prefix: Buffer.from([13, 15, 58, 7]),
     byteLength: 32,
   },
   // secp256k1 secret key
   spsk: {
-    prefix: new Buffer([17, 162, 224, 201]),
+    prefix: Buffer.from([17, 162, 224, 201]),
     byteLength: 32,
   },
   // p256 secret key
   p2sk: {
-    prefix: new Buffer([16, 81, 238, 189]),
+    prefix: Buffer.from([16, 81, 238, 189]),
     byteLength: 32,
   },
   // block hash
   b: {
-    prefix: new Buffer([1, 52]),
+    prefix: Buffer.from([1, 52]),
     byteLength: 32,
   },
   // operation hash
   o: {
-    prefix: new Buffer([5, 116]),
+    prefix: Buffer.from([5, 116]),
     byteLength: 32,
   },
   // operation list hash
   Lo: {
-    prefix: new Buffer([133, 233]),
+    prefix: Buffer.from([133, 233]),
     byteLength: 32,
   },
   // operation list list hash
   LLo: {
-    prefix: new Buffer([29, 159, 109]),
+    prefix: Buffer.from([29, 159, 109]),
     byteLength: 32,
   },
   // protocol hash
   P: {
-    prefix: new Buffer([2, 170]),
+    prefix: Buffer.from([2, 170]),
     byteLength: 32,
   },
   // context hash
   Co: {
-    prefix: new Buffer([79, 179]),
+    prefix: Buffer.from([79, 179]),
     byteLength: 32,
   },
   /* 33 bytes long */
   // secp256k1 public key
   sppk: {
-    prefix: new Buffer([3, 254, 226, 86]),
+    prefix: Buffer.from([3, 254, 226, 86]),
     byteLength: 33,
   },
   // p256 public key
   p2pk: {
-    prefix: new Buffer([3, 178, 139, 127]),
+    prefix: Buffer.from([3, 178, 139, 127]),
     byteLength: 33,
   },
   /* 56 bytes long */
   // ed25519 encrypted seed
   edesk: {
-    prefix: new Buffer([7, 90, 60, 179, 41]),
+    prefix: Buffer.from([7, 90, 60, 179, 41]),
     byteLength: 56,
   },
   /* 63 bytes long */
   // ed25519 secret key
   edsk: {
-    prefix: new Buffer([43, 246, 78, 7]),
+    prefix: Buffer.from([43, 246, 78, 7]),
     byteLength: 64,
   },
   // ed25519 signature
   edsig: {
-    prefix: new Buffer([9, 245, 205, 134, 18]),
+    prefix: Buffer.from([9, 245, 205, 134, 18]),
     byteLength: 64,
   },
   // secp256k1 signature
   spsig1: {
-    prefix: new Buffer([13, 115, 101, 19, 63]),
+    prefix: Buffer.from([13, 115, 101, 19, 63]),
     byteLength: 64,
   },
   // p256_signature
   p2sig: {
-    prefix: new Buffer([54, 240, 44, 52]),
+    prefix: Buffer.from([54, 240, 44, 52]),
     byteLength: 64,
   },
   // generic signature
   sig: {
-    prefix: new Buffer([4, 130, 43]),
+    prefix: Buffer.from([4, 130, 43]),
     byteLength: 64,
   },
   /* 15 bytes long */
   // network hash
   Net: {
-    prefix: new Buffer([87, 82, 0]),
+    prefix: Buffer.from([87, 82, 0]),
     byteLength: 15,
   },
   // nonce hash
   nce: {
-    prefix: new Buffer([69, 220, 169]),
+    prefix: Buffer.from([69, 220, 169]),
     byteLength: 15,
   },
   /* 4 bytes long */
   // chain id
   id: {
-    prefix: new Buffer([153, 103]),
+    prefix: Buffer.from([153, 103]),
     byteLength: 4,
   },
 };

--- a/modules/account-lib/src/utils/crypto.ts
+++ b/modules/account-lib/src/utils/crypto.ts
@@ -85,7 +85,7 @@ export function isValidXprv(xprv: string): boolean {
  */
 export function isValidPub(pub: string): boolean {
   try {
-    ECPair.fromPublicKeyBuffer(new Buffer(pub, 'hex'));
+    ECPair.fromPublicKeyBuffer(Buffer.from(pub, 'hex'));
   } catch (e) {
     return false;
   }
@@ -99,7 +99,7 @@ export function isValidPub(pub: string): boolean {
  */
 export function isValidPrv(prv: string): boolean {
   try {
-    ECPair.fromPrivateKeyBuffer(new Buffer(prv, 'hex'));
+    ECPair.fromPrivateKeyBuffer(Buffer.from(prv, 'hex'));
   } catch (e) {
     return false;
   }

--- a/modules/account-lib/test/unit/coin/hbar/keyPair.ts
+++ b/modules/account-lib/test/unit/coin/hbar/keyPair.ts
@@ -20,7 +20,7 @@ describe('Hedera Key Pair', () => {
     });
 
     it('from a seed', () => {
-      const keyPair = new KeyPair({ seed: new Buffer(toUint8Array(testData.ACCOUNT_1.prvKeyWithPrefix.slice(32))) });
+      const keyPair = new KeyPair({ seed: Buffer.from(toUint8Array(testData.ACCOUNT_1.prvKeyWithPrefix.slice(32))) });
       should.equal(keyPair.getKeys().prv!, testData.ACCOUNT_1.prvKeyWithPrefix);
       should.equal(keyPair.getKeys().pub, testData.ACCOUNT_1.pubKeyWithPrefix);
     });

--- a/modules/account-lib/test/unit/coin/hbar/transaction.ts
+++ b/modules/account-lib/test/unit/coin/hbar/transaction.ts
@@ -36,7 +36,7 @@ describe('Hbar Transaction', () => {
       const keypair = new KeyPair({ prv: testData.ACCOUNT_1.prvKeyWithPrefix });
       await tx.sign(keypair).should.be.fulfilled();
       should.equal(
-        new Buffer(tx.hederaTx.sigMap!.sigPair![0].pubKeyPrefix!).toString('hex'),
+        Buffer.from(tx.hederaTx.sigMap!.sigPair![0].pubKeyPrefix!).toString('hex'),
         testData.ACCOUNT_1.pubKeyWithPrefix.slice(24),
       );
     });
@@ -48,16 +48,16 @@ describe('Hbar Transaction', () => {
       const keypair2 = new KeyPair({ prv: testData.OPERATOR.privateKey });
       await tx.sign(keypair).should.be.fulfilled();
       should.equal(
-        new Buffer(tx.hederaTx.sigMap!.sigPair![0].pubKeyPrefix!).toString('hex'),
+        Buffer.from(tx.hederaTx.sigMap!.sigPair![0].pubKeyPrefix!).toString('hex'),
         testData.ACCOUNT_1.pubKeyWithPrefix.slice(24),
       );
       await tx.sign(keypair2).should.be.fulfilled();
       should.equal(
-        new Buffer(tx.hederaTx.sigMap!.sigPair![0].pubKeyPrefix!).toString('hex'),
+        Buffer.from(tx.hederaTx.sigMap!.sigPair![0].pubKeyPrefix!).toString('hex'),
         testData.ACCOUNT_1.pubKeyWithPrefix.slice(24),
       );
       should.equal(
-        new Buffer(tx.hederaTx.sigMap!.sigPair![1].pubKeyPrefix!).toString('hex'),
+        Buffer.from(tx.hederaTx.sigMap!.sigPair![1].pubKeyPrefix!).toString('hex'),
         testData.OPERATOR.publicKey.slice(24),
       );
     });

--- a/modules/account-lib/test/unit/coin/xtz/util.ts
+++ b/modules/account-lib/test/unit/coin/xtz/util.ts
@@ -139,7 +139,7 @@ describe('XTZ util library', function() {
 
     it('should validate a signature belongs to a public key for a string message', async function() {
       const message = 'helloworld';
-      const messageHex = new Buffer(message).toString('hex');
+      const messageHex = Buffer.from(message).toString('hex');
       const signatures = await Utils.sign(defaultKeyPairFromPrv, messageHex, new Uint8Array(0));
       const result = await Utils.verifySignature(
         messageHex,
@@ -151,7 +151,7 @@ describe('XTZ util library', function() {
     });
 
     it('should validate a signature belongs to a public key for dataToSign', async function() {
-      const messageHex = new Buffer(defaultDataToSign).toString('hex');
+      const messageHex = Buffer.from(defaultDataToSign).toString('hex');
       const signatures = await Utils.sign(defaultKeyPairFromPrv, messageHex, new Uint8Array(0));
       const result = await Utils.verifySignature(
         messageHex,
@@ -163,7 +163,7 @@ describe('XTZ util library', function() {
     });
 
     it('should fail to validate a signature with the wrong watermark', async function() {
-      const messageHex = new Buffer(defaultDataToSign).toString('hex');
+      const messageHex = Buffer.from(defaultDataToSign).toString('hex');
       const signatures = await Utils.sign(defaultKeyPairFromPrv, messageHex);
       const result = await Utils.verifySignature(
         messageHex,
@@ -175,7 +175,7 @@ describe('XTZ util library', function() {
     });
 
     it('should fail to validate a signature with the wrong public key', async function() {
-      const messageHex = new Buffer(defaultDataToSign).toString('hex');
+      const messageHex = Buffer.from(defaultDataToSign).toString('hex');
       const signatures = await Utils.sign(defaultKeyPairFromPrv, messageHex);
       const result = await Utils.verifySignature(
         messageHex,
@@ -186,9 +186,9 @@ describe('XTZ util library', function() {
     });
 
     it('should fail to validate a signature with the wrong message', async function() {
-      const messageHex = new Buffer(defaultDataToSign).toString('hex');
+      const messageHex = Buffer.from(defaultDataToSign).toString('hex');
       const signatures = await Utils.sign(defaultKeyPairFromPrv, messageHex);
-      const secondMessageHex = new Buffer('helloWorld').toString('hex');
+      const secondMessageHex = Buffer.from('helloWorld').toString('hex');
       const result = await Utils.verifySignature(secondMessageHex, defaultKeyPairFromPub.getKeys().pub, signatures.sig);
       result.should.be.false();
     });

--- a/modules/core/src/bitcoin.ts
+++ b/modules/core/src/bitcoin.ts
@@ -61,7 +61,7 @@ function deriveFast(hdnode: bitcoin.HDNode, index: number): bitcoin.HDNode {
     throw new Error('cannot derive hardened key from public key');
   }
 
-  const indexBuffer = new Buffer(4);
+  const indexBuffer = Buffer.alloc(4);
   indexBuffer.writeUInt32BE(index, 0);
 
   // data = serP(point(kpar)) || ser32(index)

--- a/modules/core/src/bitgo.ts
+++ b/modules/core/src/bitgo.ts
@@ -1090,10 +1090,10 @@ export class BitGo {
       throw new Error('eckey object required');
     }
 
-    const otherKeyPub = bitcoin.ECPair.fromPublicKeyBuffer(new Buffer(otherPubKeyHex, 'hex'));
+    const otherKeyPub = bitcoin.ECPair.fromPublicKeyBuffer(Buffer.from(otherPubKeyHex, 'hex'));
     const secretPoint = otherKeyPub.Q.multiply((eckey as bitcoin.ECPair).d);
     const secret = Util.bnToByteArrayUnsigned(secretPoint.affineX);
-    return new Buffer(secret).toString('hex');
+    return Buffer.from(secret).toString('hex');
   }
 
   /**
@@ -2064,7 +2064,7 @@ export class BitGo {
         throw new Error('no signature found in guarantee response body');
       }
       const signingAddress = common.Environments[self.getEnv()].signingAddress;
-      const signatureBuffer = new Buffer(body.signature, 'hex');
+      const signatureBuffer = Buffer.from(body.signature, 'hex');
       const prefix = bitcoin.networks[common.Environments[self.getEnv()].network].messagePrefix;
       const isValidSignature = bitcoinMessage.verify(body.guarantee, signingAddress, signatureBuffer, prefix);
       if (!isValidSignature) {

--- a/modules/core/src/ripple.ts
+++ b/modules/core/src/ripple.ts
@@ -25,7 +25,7 @@ function computeSignature(tx, privateKey, signAs) {
  * @returns {{signedTransaction: *, id}}
  */
 const signWithPrivateKey = function(txHex, privateKey, options) {
-  let privateKeyBuffer = new Buffer(privateKey, 'hex');
+  let privateKeyBuffer = Buffer.from(privateKey, 'hex');
   if (privateKeyBuffer.length === 33 && privateKeyBuffer[0] === 0) {
     privateKeyBuffer = privateKeyBuffer.slice(1, 33);
   }

--- a/modules/core/src/transactionBuilder.ts
+++ b/modules/core/src/transactionBuilder.ts
@@ -933,7 +933,7 @@ exports.signTransaction = function(params) {
     // subscript is the part of the output script after the OP_CODESEPARATOR.
     // Since we are only ever signing p2sh outputs, which do not have
     // OP_CODESEPARATORS, it is always the output script.
-    const subscript = new Buffer(currentUnspent.redeemScript, 'hex');
+    const subscript = Buffer.from(currentUnspent.redeemScript, 'hex');
     currentUnspent.validationScript = subscript;
 
     // In order to sign with bitcoinjs-lib, we must use its transaction
@@ -947,7 +947,7 @@ exports.signTransaction = function(params) {
           throw new Error('BCH does not support segwit inputs');
         }
         let signatures = _.cloneDeep(txb.inputs[index].signatures);
-        const witnessScript = new Buffer(currentUnspent.witnessScript, 'hex');
+        const witnessScript = Buffer.from(currentUnspent.witnessScript, 'hex');
         currentUnspent.validationScript = witnessScript;
 
         debug('Current unspent value: %d', currentUnspent.value);

--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -1105,7 +1105,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
             const prevOutScript = bitcoin.script.witnessScriptHash.output.encode(witnessScriptHash);
             txb.sign(index, privKey, prevOutScript, sigHashType, signatureContext.unspent.value, witnessScript);
           } else {
-            const subscript = new Buffer(signatureContext.unspent.redeemScript, 'hex');
+            const subscript = Buffer.from(signatureContext.unspent.redeemScript, 'hex');
             const isP2shP2wsh = !!signatureContext.unspent.witnessScript;
             if (isP2shP2wsh) {
               debug('Signing p2shP2wsh input');

--- a/modules/core/src/v2/coins/eth.ts
+++ b/modules/core/src/v2/coins/eth.ts
@@ -397,7 +397,7 @@ export class Eth extends BaseCoin {
         'ETHER',
         new optionalDeps.ethUtil.BN(optionalDeps.ethUtil.stripHexPrefix(recipient.address), 16),
         recipient.amount,
-        new Buffer(optionalDeps.ethUtil.stripHexPrefix(recipient.data) || '', 'hex'),
+        Buffer.from(optionalDeps.ethUtil.stripHexPrefix(recipient.data) || '', 'hex'),
         expireTime,
         contractSequenceId,
       ],

--- a/modules/core/src/v2/coins/xtz.ts
+++ b/modules/core/src/v2/coins/xtz.ts
@@ -192,7 +192,7 @@ export class Xtz extends BaseCoin {
   signMessage(key: KeyPair, message: string | Buffer, callback?: NodeCallback<Buffer>): Bluebird<Buffer> {
     return co<Buffer>(function* cosignMessage() {
       const keyPair = new bitgoAccountLib.Xtz.KeyPair({ prv: key.prv });
-      const messageHex = message instanceof Buffer ? message.toString('hex') : new Buffer(message).toString('hex');
+      const messageHex = message instanceof Buffer ? message.toString('hex') : Buffer.from(message).toString('hex');
       const signatureData = yield bitgoAccountLib.Xtz.Utils.sign(keyPair, messageHex);
       return Buffer.from(signatureData.sig).toString('hex');
     })

--- a/modules/core/src/v2/internal/util.ts
+++ b/modules/core/src/v2/internal/util.ts
@@ -156,8 +156,8 @@ export class Util {
       throw new EthereumLibraryUnavailableError(ethImport);
     }
     const signatureInParts = ethUtil.ecsign(
-      new Buffer(ethUtil.stripHexPrefix(msgHash), 'hex'),
-      new Buffer(privKey, 'hex')
+      Buffer.from(ethUtil.stripHexPrefix(msgHash), 'hex'),
+      Buffer.from(privKey, 'hex')
     );
 
     // Assemble strings from r, s and v
@@ -202,10 +202,10 @@ export class Util {
     signature = ethUtil.stripHexPrefix(signature);
 
     const v = parseInt(signature.slice(128, 130), 16);
-    const r = new Buffer(signature.slice(0, 64), 'hex');
-    const s = new Buffer(signature.slice(64, 128), 'hex');
+    const r = Buffer.from(signature.slice(0, 64), 'hex');
+    const s = Buffer.from(signature.slice(64, 128), 'hex');
 
-    const pubKey = ethUtil.ecrecover(new Buffer(msgHash, 'hex'), v, r, s);
+    const pubKey = ethUtil.ecrecover(Buffer.from(msgHash, 'hex'), v, r, s);
     return ethUtil.bufferToHex(ethUtil.pubToAddress(pubKey));
   }
 }

--- a/modules/core/src/v2/recovery.ts
+++ b/modules/core/src/v2/recovery.ts
@@ -317,8 +317,8 @@ export class CrossChainRecoveryTool {
 
         const [txHash, index] = unspent.id.split(':');
         const inputIndex = parseInt(index, 10);
-        let hash = new Buffer(txHash, 'hex');
-        hash = new Buffer(Array.prototype.reverse.call(hash));
+        let hash = Buffer.from(txHash, 'hex');
+        hash = Buffer.from(Array.prototype.reverse.call(hash));
 
         try {
           self.recoveryTx.addInput(hash, inputIndex);

--- a/modules/core/test/integration/keychains.ts
+++ b/modules/core/test/integration/keychains.ts
@@ -42,7 +42,7 @@ describe('Keychains', function() {
     it('create', function() {
       // must use seed of at least 128 bits
       // standard test vector taken from bip32 spec
-      const seed = new Buffer('000102030405060708090a0b0c0d0e0f', 'hex');
+      const seed = Buffer.from('000102030405060708090a0b0c0d0e0f', 'hex');
       assert.equal(keychains.create({ seed: seed }).xprv, 'xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi');
 
       // two keys created one after the other with no seed should have

--- a/modules/core/test/unit/hdnode.ts
+++ b/modules/core/test/unit/hdnode.ts
@@ -13,7 +13,7 @@ describe('HDNode', function() {
   describe('derive', function() {
 
     it('should derive these standard test vectors', function() {
-      let hdnode = HDNode.fromSeedBuffer(new Buffer('000102030405060708090a0b0c0d0e0f', 'hex'));
+      let hdnode = HDNode.fromSeedBuffer(Buffer.from('000102030405060708090a0b0c0d0e0f', 'hex'));
       let path = hdPath(hdnode);
       path.derive('m/0/0').toBase58().should.equal('xprv9ww7sMFLzJMzur2oEQDB642fbsMS4q6JRraMVTrM9bTWBq7NDS8ZpmsKVB4YF3mZecqax1fjnsPF19xnsJNfRp4RSyexacULXMKowSACTRc');
       path.derive("m/0'/1").toBase58().should.equal('xprv9wTYmMFdV23N2TdNG573QoEsfRrWKQgWeibmLntzniatZvR9BmLnvSxqu53Kw1UmYPxLgboyZQaXwTCg8MSY3H2EU4pWcQDnRnrVA1xe8fs');
@@ -24,7 +24,7 @@ describe('HDNode', function() {
       path.derive('m/2/1000000000').toBase58().should.equal('xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy');
 
       // make sure caching does not overcache
-      let hdnode2 = HDNode.fromSeedBuffer(new Buffer('000102030405060708090a0b0c0d0e0e', 'hex'));
+      let hdnode2 = HDNode.fromSeedBuffer(Buffer.from('000102030405060708090a0b0c0d0e0e', 'hex'));
       let path2 = hdPath(hdnode2);
       path2.derive('m/0/0').toBase58().should.equal('xprv9wTW8JGaw3LLpqYG35f4WdWA7yF5UFNsp5QptdwhU2uy7XarRUrZx2AbPft7VocxAdVmYxviYvhJbV1EeY2yiDKu8gSipwUE6TZoQsjLALL');
       hdnode2 = path2.derive("m/0'/1/2'").neutered();
@@ -33,7 +33,7 @@ describe('HDNode', function() {
     });
 
     it('uses caching for previously derived keys (hardened)', function() {
-      const hdnode = HDNode.fromSeedBuffer(new Buffer('000103030405060708090a0b0c0d0e0f', 'hex'));
+      const hdnode = HDNode.fromSeedBuffer(Buffer.from('000103030405060708090a0b0c0d0e0f', 'hex'));
       const path = hdPath(hdnode);
       path.derive("m/1/2'/3/4").toBase58().should.equal('xprvA1PudVPRZQFcfftzuHtMGwhs3siwHTKz2YjoJcVchrz7eugyW8riiaxYRyg1oXdzGxgFQ1Nz4Smokj7pi8NsWYTQwNqWXiRde2Jv37XwnDX');
       for (let i = 0; i < 1000; i++) {
@@ -42,7 +42,7 @@ describe('HDNode', function() {
     });
 
     it('uses caching for previously derived keys (public)', function() {
-      const hdnode = HDNode.fromSeedBuffer(new Buffer('000103030405060708090a0b0c0d0e0f', 'hex')).neutered();
+      const hdnode = HDNode.fromSeedBuffer(Buffer.from('000103030405060708090a0b0c0d0e0f', 'hex')).neutered();
       const path = hdPath(hdnode);
       path.derive('m/0/1/2/3').toBase58().should.equal('xpub6F46ySPYeyfcJzEZVS2zWVnx4ai5eSRbFXkdm3DCezF8jT1zE35L4SJbsMPyCSbyWppi9tuSH6PzAMxe5vWHPR8Bpstt3tyw5GBqeSXQLB5');
       for (let i = 0; i < 1000; i++) {

--- a/modules/core/test/v2/unit/coins/abstractEthCoin.ts
+++ b/modules/core/test/v2/unit/coins/abstractEthCoin.ts
@@ -269,7 +269,7 @@ describe('ETH-like coins', () => {
           if (coin instanceof ContractAddressDefinedToken) {
             decodedData = ethAbi.rawDecode(sendMultisigTokenTypes, Buffer.from(txJson.data.slice(10), 'hex'));
             [recipient, value, tokenContractAddress, expireTime, sequenceId] = decodedData;
-            data = new Buffer('');
+            data = Buffer.from('');
           } else {
             decodedData = ethAbi.rawDecode(sendMultisigTypes, Buffer.from(txJson.data.slice(10), 'hex'));
             [recipient, value, data, expireTime, sequenceId] = decodedData;
@@ -323,7 +323,7 @@ describe('ETH-like coins', () => {
           if (coin instanceof ContractAddressDefinedToken) {
             decodedData = ethAbi.rawDecode(sendMultisigTokenTypes, Buffer.from(txJson.data.slice(10), 'hex'));
             [recipient, value, tokenContractAddress, expireTime, sequenceId] = decodedData;
-            data = new Buffer('');
+            data = Buffer.from('');
           } else {
             decodedData = ethAbi.rawDecode(sendMultisigTypes, Buffer.from(txJson.data.slice(10), 'hex'));
             [recipient, value, data, expireTime, sequenceId] = decodedData;
@@ -389,7 +389,7 @@ describe('ETH-like coins', () => {
           if (coin instanceof ContractAddressDefinedToken) {
             decodedData = ethAbi.rawDecode(sendMultisigTokenTypes, Buffer.from(txJson.data.slice(10), 'hex'));
             [recipient, value, tokenContractAddress, expireTime, sequenceId] = decodedData;
-            data = new Buffer('');
+            data = Buffer.from('');
           } else {
             decodedData = ethAbi.rawDecode(sendMultisigTypes, Buffer.from(txJson.data.slice(10), 'hex'));
             [recipient, value, data, expireTime, sequenceId] = decodedData;

--- a/modules/core/test/v2/unit/coins/xlm.ts
+++ b/modules/core/test/v2/unit/coins/xlm.ts
@@ -171,7 +171,7 @@ describe('XLM:', function() {
   it('isValidMemoId should work', function() {
     basecoin.isValidMemo({ value: '1', type: 'id' }).should.equal(true);
     basecoin.isValidMemo({ value: 'uno', type: 'text' }).should.equal(true);
-    const buffer = new Buffer(32).fill(10);
+    const buffer = Buffer.alloc(32).fill(10);
     basecoin.isValidMemo({ value: buffer, type: 'hash' }).should.equal(true);
     basecoin.isValidMemo({ value: buffer.toString('hex'), type: 'hash' }).should.equal(true);
     basecoin.isValidMemo({ value: 1, type: 'id' }).should.equal(false);

--- a/modules/core/test/v2/unit/coins/xtz.ts
+++ b/modules/core/test/v2/unit/coins/xtz.ts
@@ -141,7 +141,7 @@ describe('Tezos:', function() {
       const message = 'hello world';
       const signature = yield basecoin.signMessage(keyPair, message);
 
-      const messageHex = new Buffer(message).toString('hex');
+      const messageHex = Buffer.from(message).toString('hex');
       const sig = Buffer.from(signature, 'hex').toString();
       const publicKey = new bitgoAccountLib.Xtz.KeyPair({ pub: keyPair.pub });
       const isValid = yield bitgoAccountLib.Xtz.Utils.verifySignature(messageHex, publicKey.getKeys().pub, sig);
@@ -153,7 +153,7 @@ describe('Tezos:', function() {
       const message = 'hello world';
       const signature = yield basecoin.signMessage(keyPair, message);
 
-      const messageHex = new Buffer(message).toString('hex');
+      const messageHex = Buffer.from(message).toString('hex');
 
       const sig = Buffer.from(signature, 'hex').toString();
       const publicKey = new bitgoAccountLib.Xtz.KeyPair();


### PR DESCRIPTION
Use of new Buffer() is deprecated and emits annoying warnings when used
for the first time on node.

Instead, use Buffer.from() for initializing new buffers with known
contents. For allocating buffers with new Buffer, use Buffer.alloc()
instead.

Ticket: BG-24579