### PR TITLE
Fix CUSD sign transaction

### DIFF
--- a/modules/core/src/v2/coins/celoToken.ts
+++ b/modules/core/src/v2/coins/celoToken.ts
@@ -54,7 +54,7 @@ export class CeloToken extends Celo {
   }
 
   getChain() {
-    return this.tokenConfig.type;
+    return this.tokenConfig.coin;
   }
 
   getFullName() {

--- a/modules/core/test/v2/unit/coins/celoToken.ts
+++ b/modules/core/test/v2/unit/coins/celoToken.ts
@@ -14,7 +14,7 @@ describe('Celo Token:', function() {
   });
 
   it('should return constants', function() {
-    celoTokenCoin.getChain().should.equal('tcusd');
+    celoTokenCoin.getChain().should.equal('tcelo');
     celoTokenCoin.getFullName().should.equal('Celo Token');
     celoTokenCoin.getBaseFactor().should.equal(1e18);
     celoTokenCoin.type.should.equal(tokenName);


### PR DESCRIPTION
A bug previously existed where signing transactions was invalid due to an issue getting a CELO token's chain. This fix resolves such bug
Ticket: BG-24642