### PR TITLE
Add optional constructor parameter to skip HMAC Verification

### DIFF
--- a/modules/core/src/bitgo.ts
+++ b/modules/core/src/bitgo.ts
@@ -157,6 +157,7 @@ export interface BitGoOptions {
   validate?: boolean;
   proxy?: string;
   etherscanApiToken?: string;
+  hmacVerification?: boolean;
 }
 
 export interface User {
@@ -421,7 +422,7 @@ export class BitGo {
   private _blockchain?: any;
   private _travelRule?: any;
   private _pendingApprovals?: any;
-
+  private _hmacVerification: boolean = true;
   /**
    * Constructor for BitGo Object
    */
@@ -514,6 +515,14 @@ export class BitGo {
     this._userAgent = params.userAgent || 'BitGoJS/' + this.version();
     this._promise = Bluebird;
     this._reqId = undefined;
+
+    if (!params.hmacVerification && params.hmacVerification !== undefined) {
+      if (common.Environments[env].hmacVerificationEnforced) {
+        throw new Error(`Cannot disable request HMAC verification in environment ${this.getEnv()}`);
+      }
+      debug('HMAC verification explicitly disabled by constructor option');
+      this._hmacVerification = params.hmacVerification;
+    }
 
     // whether to perform extra client-side validation for some things, such as
     // address validation or signature validation. defaults to true, but can be
@@ -662,6 +671,13 @@ export class BitGo {
       // right now, it is very permissive with the timestamp variance
       req.verifyResponse = function(response) {
         if (!req.isV2Authenticated || !req.authenticationToken) {
+          return response;
+        }
+
+        // HMAC verification is only allowed to be skipped in certain environments.
+        // This is checked in the constructor, but checking it again at request time
+        // will help prevent against tampering of this property after the object is created
+        if (!self._hmacVerification && !common.Environments[self.getEnv()].hmacVerificationEnforced) {
           return response;
         }
 

--- a/modules/core/src/v2/environments.ts
+++ b/modules/core/src/v2/environments.ts
@@ -32,6 +32,7 @@ interface EnvironmentTemplate {
     full: string;
     solidity: string;
   };
+  hmacVerificationEnforced: boolean;
 }
 
 export interface Environment extends EnvironmentTemplate {
@@ -108,6 +109,7 @@ const mainnetBase: EnvironmentTemplate = {
     full: 'https://api.trongrid.io',
     solidity: 'https://api.trongrid.io',
   },
+  hmacVerificationEnforced: true,
 };
 
 const testnetBase: EnvironmentTemplate = {
@@ -137,10 +139,12 @@ const testnetBase: EnvironmentTemplate = {
     full: 'http://47.252.81.135:8090',
     solidity: 'http://47.252.81.135:8091',
   },
+  hmacVerificationEnforced: true,
 };
 
 const devBase: EnvironmentTemplate = Object.assign({}, testnetBase, {
   hsmXpub: hardcodedPublicKeys.hsmXpub.dev,
+  hmacVerificationEnforced: false,
 });
 
 export const Environments: Environments = {


### PR DESCRIPTION
Disabling HMAC validation is useful in dev environments, but we must be
very careful to enforce HMAC validation in other environments.

This commit allows disabling HMAC verification for the development
environments only.

Ticket: BG-24938