### PR TITLE
Fix cusd token sends

### DIFF
--- a/modules/core/src/v2/coins/celoToken.ts
+++ b/modules/core/src/v2/coins/celoToken.ts
@@ -54,7 +54,7 @@ export class CeloToken extends Celo {
   }
 
   getChain() {
-    return this.tokenConfig.coin;
+    return this.tokenConfig.type;
   }
 
   getFullName() {

--- a/modules/core/test/v2/unit/coins/celoToken.ts
+++ b/modules/core/test/v2/unit/coins/celoToken.ts
@@ -14,7 +14,7 @@ describe('Celo Token:', function() {
   });
 
   it('should return constants', function() {
-    celoTokenCoin.getChain().should.equal('tcelo');
+    celoTokenCoin.getChain().should.equal('tcusd');
     celoTokenCoin.getFullName().should.equal('Celo Token');
     celoTokenCoin.getBaseFactor().should.equal(1e18);
     celoTokenCoin.type.should.equal(tokenName);


### PR DESCRIPTION
CUSD token sends presently look at CELO balance to determine spendable balance requirements. This points spendable balance checks back to the balance of CUSD (or whatever celo token is in question)
Ticket: BG-24677