### PR TITLE
Use blockchair as the BCH block explorer

### DIFF
--- a/modules/core/src/v2/coins/bch.ts
+++ b/modules/core/src/v2/coins/bch.ts
@@ -9,6 +9,7 @@ import { BaseCoin } from '../baseCoin';
 import { AbstractUtxoCoin, AddressInfo, UnspentInfo } from './abstractUtxoCoin';
 import * as common from '../../common';
 const co = Bluebird.coroutine;
+import { BlockchairApi } from '../recovery/blockchairApi';
 
 const VALID_ADDRESS_VERSIONS = {
   base58: 'base58',
@@ -189,27 +190,13 @@ export class Bch extends AbstractUtxoCoin {
     return common.Environments[this.bitgo.env].bchExplorerBaseUrl + url;
   }
 
-  getAddressInfoFromExplorer(addressBase58) {
-    return co<AddressInfo>(function *getAddressInfoFromExplorer() {
-      const addrInfo = yield request.get(this.recoveryBlockchainExplorerUrl(`/addr/${addressBase58}`)).result();
-
-      addrInfo.txCount = addrInfo.txApperances;
-      addrInfo.totalBalance = addrInfo.balanceSat;
-
-      return addrInfo;
-    }).call(this);
+  getAddressInfoFromExplorer(addressBase58: string, apiKey?: string): Bluebird<AddressInfo> {
+    const explorer = new BlockchairApi(this.bitgo, 'bitcoin-cash', apiKey);
+    return Bluebird.resolve(explorer.getAccountInfo(addressBase58));
   }
 
-  getUnspentInfoFromExplorer(addressBase58) {
-    return co<UnspentInfo[]>(function *getUnspentInfoFromExplorer() {
-      const unspents = yield request.get(this.recoveryBlockchainExplorerUrl(`/addr/${addressBase58}/utxo`)).result();
-
-      unspents.forEach(function processUnspent(unspent) {
-        unspent.amount = unspent.satoshis;
-        unspent.n = unspent.vout;
-      });
-
-      return unspents;
-    }).call(this);
+  getUnspentInfoFromExplorer(addressBase58: string, apiKey?: string): Bluebird<UnspentInfo[]> {
+    const explorer = new BlockchairApi(this.bitgo, 'bitcoin-cash', apiKey);
+    return Bluebird.resolve(explorer.getUnspents(addressBase58));
   }
 }

--- a/modules/core/src/v2/recovery/blockchairApi.ts
+++ b/modules/core/src/v2/recovery/blockchairApi.ts
@@ -5,7 +5,8 @@ import { BitGo } from '../../bitgo';
 
 const BlockchairCoin = [
   'bitcoin',
-  'bitcoin-sv'
+  'bitcoin-sv',
+  'bitcoin-cash',
 ];
 
 const devBase = ['dev', 'latest', 'local', 'localNonSecure', 'adminDev', 'adminLatest'];


### PR DESCRIPTION
Our current blockexplorers for BCH mainnet and testnet recovery are both down. Changing them to blockchair. We will only have mainnet support for BCH recovery as a result. 
https://blockdozer.com/insight-api/addr/3CkKr9gykRKP8V5sE2zZS5L8c32TVX3mvg
https://test-bch-insight.bitpay.com/api/addr/3Fn25AxxbzRu4g4mJH1TdXmo4hTfkxfAz7 
Ticket: BG-24863