### PR TITLE
Allow param for userkey path for address derivation

### DIFF
--- a/modules/core/src/bitcoin.ts
+++ b/modules/core/src/bitcoin.ts
@@ -43,6 +43,32 @@ function getKey(network?: bitcoin.Network): bitcoin.ECPair {
 bitcoin.HDNode.prototype.getKey = getKey;
 
 /**
+ * Given a key and a path, derive the child key.
+ * @param {bitcoin.HDNode} userKey
+ * @param {string} path
+ * @returns {bitcoin.HDNode}
+ */
+export function deriveKeyByPath(userKey: bitcoin.HDNode, path: string): bitcoin.HDNode {
+  let key = userKey;
+  let splitPath = path.split('/');
+  // if a key path starts with "m", it is the path for a master node. derivePath() is used specifically for
+  // deriving master node and we can call it directly.
+  if (splitPath[0] === 'm') {
+    key = userKey.derivePath(path);
+  } else {
+    // if the path does not start with "m", it typically looks like "/x/y/...", and the splitPath
+    // would look like ['', 'x', 'y',...], and we need to get ride of the empty string at index 0.
+    // Then we continue deriving the child by calling derive() on the new child at each subsequent level.
+    splitPath = splitPath.slice(1);
+    for (const p of splitPath) {
+      const index = parseInt(p, 10);
+      key = key.derive(index);
+    }
+  }
+  return key;
+}
+
+/**
  * Derive a child HDNode from a parent HDNode and index. Uses secp256k1 to speed
  * up public key derivations by 100x vs. bitcoinjs-lib implementation.
  *

--- a/modules/core/src/bitcoin.ts
+++ b/modules/core/src/bitcoin.ts
@@ -7,6 +7,7 @@
 import * as common from './common';
 import * as bitcoin from '@bitgo/utxo-lib';
 import { V1Network } from './v2/types';
+import { InvalidKeyPathError } from './errors';
 const ecurve = require('ecurve');
 const curve = ecurve.getCurveByName('secp256k1');
 const BigInteger = require('bigi');
@@ -62,6 +63,9 @@ export function deriveKeyByPath(userKey: bitcoin.HDNode, path: string): bitcoin.
     splitPath = splitPath.slice(1);
     for (const p of splitPath) {
       const index = parseInt(p, 10);
+      if (isNaN(index) || index.toString() != p) {
+        throw new InvalidKeyPathError(path);
+      }
       key = key.derive(index);
     }
   }

--- a/modules/core/src/errors.ts
+++ b/modules/core/src/errors.ts
@@ -153,3 +153,10 @@ export class ErrorNoInputToRecover extends BitGoJsError {
     Object.setPrototypeOf(this, ErrorNoInputToRecover.prototype);
   }
 }
+
+export class InvalidKeyPathError extends BitGoJsError {
+  public constructor(keyPath: string) {
+    super(`invalid keypath: ${keyPath}`);
+    Object.setPrototypeOf(this, InvalidKeyPathError.prototype);
+  }
+}

--- a/modules/core/src/errors.ts
+++ b/modules/core/src/errors.ts
@@ -146,3 +146,10 @@ export class StellarFederationUserNotFoundError extends BitGoJsError {
     Object.setPrototypeOf(this, StellarFederationUserNotFoundError.prototype);
   }
 }
+
+export class ErrorNoInputToRecover extends BitGoJsError {
+  public constructor(message?: string) {
+    super(message || 'No input to recover - aborting!');
+    Object.setPrototypeOf(this, ErrorNoInputToRecover.prototype);
+  }
+}

--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -1835,7 +1835,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       const unspents: any[] = _.flatten(queryResponses); // this flattens the array (turns an array of arrays into just one array)
       const totalInputAmount = _.sumBy(unspents, 'amount');
       if (totalInputAmount <= 0) {
-        throw new Error('No input to recover - aborting!');
+        throw new errors.ErrorNoInputToRecover();
       }
 
       // Build the transaction

--- a/modules/core/test/unit/hdnode.ts
+++ b/modules/core/test/unit/hdnode.ts
@@ -6,7 +6,7 @@
 
 import 'should';
 import { HDNode } from '@bitgo/utxo-lib';
-import { hdPath } from '../../src/bitcoin';
+import { deriveKeyByPath, hdPath } from '../../src/bitcoin';
 
 describe('HDNode', function() {
 
@@ -49,6 +49,17 @@ describe('HDNode', function() {
         path.derive('m/0/1/2/3').toBase58().should.equal('xpub6F46ySPYeyfcJzEZVS2zWVnx4ai5eSRbFXkdm3DCezF8jT1zE35L4SJbsMPyCSbyWppi9tuSH6PzAMxe5vWHPR8Bpstt3tyw5GBqeSXQLB5');
       }
     });
-  });
 
+    it('deriveKeyByPath should derive correct key', function() {
+      const root = HDNode.fromSeedHex('dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd');
+      let child = root.derivePath("m/0/1/0");
+      // greatGrandChild is derived using the tested utxolib function
+      let greatGrandChild = child
+        .derive(9).derive(8);
+      // deriveKeyByPath(child, '/9/8') should effectively mean calling derive() on the result of child twice,
+      // first time with the index 9, the second time with the index 8:
+      let greatGrandChild2 = deriveKeyByPath(child, '/9/8');
+      greatGrandChild2.getAddress().should.equal(greatGrandChild.getAddress());
+    })
+  });
 });

--- a/modules/core/test/unit/hdnode.ts
+++ b/modules/core/test/unit/hdnode.ts
@@ -50,18 +50,42 @@ describe('HDNode', function() {
       }
     });
 
-    it('deriveKeyByPath should derive correct key', function() {
+    describe('deriveKeyByPath', function() {
       const root = HDNode.fromSeedHex('dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd');
       const basePath = 'm/0/1/0';
       let baseKey = root.derivePath(basePath);
-      let greatGrandChild0 = root.derivePath(`${basePath}/9/8`);
-      // greatGrandChild is derived using the tested utxolib function
-      let greatGrandChild1 = baseKey.derive(9).derive(8);
-      // deriveKeyByPath(baseKey, '/9/8') should effectively mean calling derive() on the result of baseKey twice,
-      // first time with the index 9, the second time with the index 8:
-      let greatGrandChild2 = deriveKeyByPath(baseKey, '/9/8');
-      greatGrandChild1.getAddress().should.equal(greatGrandChild0.getAddress());
-      greatGrandChild2.getAddress().should.equal(greatGrandChild1.getAddress());
-    })
+
+      it('deriveKeyByPath should derive correct key', function() {
+        let greatGrandChild0 = root.derivePath(`${basePath}/9/8`);
+        // greatGrandChild is derived using the tested utxolib function
+        let greatGrandChild1 = baseKey.derive(9).derive(8);
+        // deriveKeyByPath(baseKey, '/9/8') should effectively mean calling derive() on the result of baseKey twice,
+        // first time with the index 9, the second time with the index 8:
+        let greatGrandChild2 = deriveKeyByPath(baseKey, '/9/8');
+        greatGrandChild1.getAddress().should.equal(greatGrandChild0.getAddress());
+        greatGrandChild2.getAddress().should.equal(greatGrandChild1.getAddress());
+      });
+
+      it('should throw on invalid key path containing letters', function() {
+        try {
+          deriveKeyByPath(baseKey, '/9x/8')
+        } catch (e) {
+          e.message.should.equal('invalid keypath: /9x/8')
+        }
+      });
+
+      it('should throw on invalid key path', function() {
+        try {
+          deriveKeyByPath(baseKey, '//8')
+        } catch (e) {
+          e.message.should.equal('invalid keypath: //8')
+        }
+      });
+
+      it('should work for an emptry string as key path', function() {
+        const key =  deriveKeyByPath(baseKey, '');
+        key.getAddress().should.equal(baseKey.getAddress());
+      });
+    });
   });
 });

--- a/modules/core/test/unit/hdnode.ts
+++ b/modules/core/test/unit/hdnode.ts
@@ -52,14 +52,16 @@ describe('HDNode', function() {
 
     it('deriveKeyByPath should derive correct key', function() {
       const root = HDNode.fromSeedHex('dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd');
-      let child = root.derivePath("m/0/1/0");
+      const basePath = 'm/0/1/0';
+      let baseKey = root.derivePath(basePath);
+      let greatGrandChild0 = root.derivePath(`${basePath}/9/8`);
       // greatGrandChild is derived using the tested utxolib function
-      let greatGrandChild = child
-        .derive(9).derive(8);
-      // deriveKeyByPath(child, '/9/8') should effectively mean calling derive() on the result of child twice,
+      let greatGrandChild1 = baseKey.derive(9).derive(8);
+      // deriveKeyByPath(baseKey, '/9/8') should effectively mean calling derive() on the result of baseKey twice,
       // first time with the index 9, the second time with the index 8:
-      let greatGrandChild2 = deriveKeyByPath(child, '/9/8');
-      greatGrandChild2.getAddress().should.equal(greatGrandChild.getAddress());
+      let greatGrandChild2 = deriveKeyByPath(baseKey, '/9/8');
+      greatGrandChild1.getAddress().should.equal(greatGrandChild0.getAddress());
+      greatGrandChild2.getAddress().should.equal(greatGrandChild1.getAddress());
     })
   });
 });


### PR DESCRIPTION
The current address derivation logic assumes that all keys have paths that start with prefix `m/0/0`, which isn't true for all user keys of v1 wallets, as some might have different path param. 

This PR allows us to take an optional parameter for the user keypath that can override the default

Ticket: BG-24941