### PR TITLE
remove _microservicesUrl and always use auth route

### DIFF
--- a/modules/core/src/bitgo.ts
+++ b/modules/core/src/bitgo.ts
@@ -152,7 +152,6 @@ export interface BitGoOptions {
   serverXpub?: string;
   stellarFederationServerUrl?: string;
   useProduction?: boolean;
-  microservicesUri?: string;
   refreshToken?: string;
   validate?: boolean;
   proxy?: string;
@@ -401,7 +400,6 @@ export class BitGo {
    */
   public readonly env: EnvironmentName;
   private readonly _baseUrl: string;
-  private readonly _microservicesUrl?: string;
   private readonly _baseApiUrl: string;
   private readonly _baseApiUrlV2: string;
   private _user?: User;
@@ -505,7 +503,6 @@ export class BitGo {
     common.setNetwork(common.Environments[env].network);
     common.setRmgNetwork(common.Environments[env].rmgNetwork);
 
-    this._microservicesUrl = params.microservicesUri;
     this._baseApiUrl = this._baseUrl + '/api/v1';
     this._baseApiUrlV2 = this._baseUrl + '/api/v2';
     this._keychains = null;
@@ -1362,9 +1359,7 @@ export class BitGo {
         return self.reject('already logged in', callback);
       }
 
-      const authUrl = self._microservicesUrl ?
-        self.microservicesUrl('/api/auth/v1/session') :
-        self.url('/user/login');
+      const authUrl = self.microservicesUrl('/api/auth/v1/session');
       const request = self.post(authUrl);
 
       if (forceV1Auth) {
@@ -1635,9 +1630,7 @@ export class BitGo {
         throw new Error('must specify scope for token');
       }
 
-      const authUrl = self._microservicesUrl ?
-        self.microservicesUrl('/api/auth/v1/accesstoken') :
-        self.url('/user/accesstoken');
+      const authUrl = self.microservicesUrl('/api/auth/v1/accesstoken');
       const request = self.post(authUrl);
 
       if (!self._ecdhXprv) {
@@ -2001,7 +1994,7 @@ export class BitGo {
    * Create a url for calling BitGo microservice APIs
    */
   microservicesUrl(path: string): string {
-    return this._microservicesUrl + path;
+    return this._baseUrl + path;
   }
 
   /**

--- a/modules/core/test/unit/bitgo.ts
+++ b/modules/core/test/unit/bitgo.ts
@@ -111,7 +111,6 @@ describe('BitGo Prototype Methods', function() {
 
   describe('Authenticate in Microservices', () => {
     let bitgo;
-    const microservicesUri = 'https://microservices.uri';
     const authenticateRequest = {
       username: 'test@bitgo.com',
       password: 'password',
@@ -122,8 +121,8 @@ describe('BitGo Prototype Methods', function() {
     };
 
     it('goes to microservices', co(function *() {
-      bitgo = new TestBitGo({ env: 'mock', microservicesUri });
-      const scope = nock(microservicesUri)
+      bitgo = new TestBitGo({ env: 'mock', microservicesUri: 'https://microservices.uri' });
+      const scope = nock(Environments[bitgo.getEnv()].uri)
         .post('/api/auth/v1/session')
         .reply(200, { user: 'test@bitgo.com', access_token: 'token12356' });
 
@@ -131,10 +130,10 @@ describe('BitGo Prototype Methods', function() {
       scope.isDone().should.be.true();
     }));
 
-    it('goes to normal uri', co(function *() {
+    it('goes to microservices even when microservicesUri is not specified', co(function *() {
       bitgo = new TestBitGo({ env: 'mock' });
       const scope = nock(Environments[bitgo.getEnv()].uri)
-        .post('/api/v1/user/login')
+        .post('/api/auth/v1/session')
         .reply(200, { user: 'test@bitgo.com', access_token: 'token12356' });
 
       yield bitgo.authenticate(authenticateRequest);
@@ -297,7 +296,7 @@ describe('BitGo Prototype Methods', function() {
 
     before(co(function *coBeforeChangePassword() {
       nock('https://bitgo.fakeurl')
-      .post('/api/v1/user/login')
+      .post('/api/auth/v1/session')
       .reply(200, {
         access_token: 'access_token',
         user: { username: 'update_pw_tester@bitgo.com' }

--- a/modules/core/test/v2/unit/trading/affirmation.ts
+++ b/modules/core/test/v2/unit/trading/affirmation.ts
@@ -9,9 +9,10 @@ import { Wallet } from '../../../../src/v2/wallet';
 import { Enterprise } from '../../../../src/v2/enterprise';
 import { TestBitGo } from '../../../lib/test_bitgo';
 import * as common from '../../../../src/common';
+import { Environments } from '../../../../src';
 
 describe('Affirmations', function() {
-  const microservicesUri = 'https://bitgo-microservices.example';
+  const microservicesUri = Environments['mock'].uri;
   let bitgo;
   let basecoin;
   let enterprise;

--- a/modules/core/test/v2/unit/trading/payload.ts
+++ b/modules/core/test/v2/unit/trading/payload.ts
@@ -16,7 +16,7 @@ import { TestBitGo } from '../../../lib/test_bitgo';
 import * as common from '../../../../src/common';
 
 describe('Trade Payloads', function() {
-  const microservicesUri = 'https://bitgo-microservices.example';
+  const microservicesUri = common.Environments['mock'].uri;
   let bitgo;
   let basecoin;
   let enterprise;

--- a/modules/core/test/v2/unit/trading/settlement.ts
+++ b/modules/core/test/v2/unit/trading/settlement.ts
@@ -13,7 +13,7 @@ import { TestBitGo } from '../../../lib/test_bitgo';
 import * as common from '../../../../src/common';
 
 describe('Settlements', function() {
-  const microservicesUri = 'https://bitgo-microservices.example';
+  const microservicesUri = common.Environments['mock'].uri;
   let bitgo;
   let basecoin;
   let enterprise;

--- a/modules/core/test/v2/unit/trading/tradingAccount.ts
+++ b/modules/core/test/v2/unit/trading/tradingAccount.ts
@@ -5,9 +5,10 @@ import * as nock from 'nock';
 import { Enterprise } from '../../../../src/v2/enterprise';
 import { Wallet } from '../../../../src/v2/wallet';
 import { TestBitGo } from '../../../lib/test_bitgo';
+import { Environments } from '../../../../src/common';
 
 describe('Trading Accounts', function() {
-  const microservicesUri = 'https://bitgo-microservices.example';
+  const microservicesUri = Environments['mock'].uri;
   let bitgo;
   let basecoin;
   let enterprise;

--- a/modules/core/test/v2/unit/trading/tradingPartner.ts
+++ b/modules/core/test/v2/unit/trading/tradingPartner.ts
@@ -9,9 +9,10 @@ import { TradingReferralRequesterSide } from '../../../../src/v2/trading/trading
 import { Enterprise } from '../../../../src/v2/enterprise';
 import { Wallet } from '../../../../src/v2/wallet';
 import { TestBitGo } from '../../../lib/test_bitgo';
+import { Environments } from '../../../../src/common';
 
 describe('Trading Partners', function() {
-  const microservicesUri = 'https://bitgo-microservices.example';
+  const microservicesUri = Environments['mock'].uri;
   let bitgo;
   let basecoin;
   let enterprise;


### PR DESCRIPTION
BitGoJS will no longer use `/user/login` to login in any environment and will instead always use the `/api/auth` routes for authenticating.