### PR TITLE
Add stellar to account lib

### DIFF
--- a/modules/account-lib/package.json
+++ b/modules/account-lib/package.json
@@ -51,6 +51,7 @@
     "libsodium-wrappers": "^0.7.6",
     "lodash": "^4.17.15",
     "protobufjs": "^6.8.9",
+    "stellar-sdk": "^0.11.0",
     "tronweb": "^2.7.2",
     "tweetnacl": "^1.0.3"
   },


### PR DESCRIPTION
Fixes an issue where we import stellar in account-lib but it sources
from core. problematic for installs that only install account-lib

Ticket: BG-25637