### PR TITLE
Use right semantics to check for undefined var

### DIFF
--- a/modules/core/src/v2/coins/eth.ts
+++ b/modules/core/src/v2/coins/eth.ts
@@ -522,7 +522,8 @@ export class Eth extends BaseCoin {
 
     const ethTxParams = {
       to: params.walletContractAddress,
-      nonce: params.signingKeyNonce || params.txPrebuild.halfSigned.backupKeyNonce,
+      nonce:
+        params.signingKeyNonce !== undefined ? params.signingKeyNonce : params.txPrebuild.halfSigned.backupKeyNonce,
       value: 0,
       gasPrice: new optionalDeps.ethUtil.BN(txPrebuild.gasPrice),
       gasLimit: new optionalDeps.ethUtil.BN(txPrebuild.gasLimit),


### PR DESCRIPTION
 - We currently use the wrong comparator to check whether
   a keynonce is undefined. This could lead to the wrong
   keynonces to beUse right semantics to check for undefined var
 - This was introduced in BG-24643

Ticket: BG-25181