### PR TITLE
Turn on logging of the crosschain recovery tool

### DIFF
--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -2060,7 +2060,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
         bitgo: self.bitgo,
         sourceCoin: self,
         recoveryCoin: recoveryCoin,
-        logging: false,
+        logging: true,
       });
 
       yield recoveryTool.buildTransaction({


### PR DESCRIPTION
  - Our current instantiation of the cross chain recovery tool diabled
    logging of recovery steps, which makes it hard to get error traces
    when debugging.
  - This PR enable logging by setting "logging" to true, logging info
    to console.log (default logger when none provided)

Ticket: BG-22261