### PR TITLE
Fix CELO token transactionBuilder

### DIFF
--- a/modules/core/src/v2/coins/abstractEthLikeCoin.ts
+++ b/modules/core/src/v2/coins/abstractEthLikeCoin.ts
@@ -91,6 +91,13 @@ export abstract class AbstractEthLikeCoin extends BaseCoin {
     return this._staticsCoin.name;
   }
 
+  /**
+   * Get the base chain that the coin exists on.
+   */
+  getBaseChain() {
+    return this.getChain();
+  }
+
   getFamily(): CoinFamily {
     return this._staticsCoin.family;
   }
@@ -239,6 +246,6 @@ export abstract class AbstractEthLikeCoin extends BaseCoin {
    * @return a new transaction builder
    */
   private getTransactionBuilder(): Eth.TransactionBuilder {
-    return getBuilder(this.getChain()) as Eth.TransactionBuilder;
+    return getBuilder(this.getBaseChain()) as Eth.TransactionBuilder;
   }
 }

--- a/modules/core/src/v2/coins/celoToken.ts
+++ b/modules/core/src/v2/coins/celoToken.ts
@@ -57,6 +57,10 @@ export class CeloToken extends Celo {
     return this.tokenConfig.type;
   }
 
+  getBaseChain() {
+    return this.coin;
+  }
+
   getFullName() {
     return 'Celo Token';
   }

--- a/modules/core/test/v2/unit/coins/celoToken.ts
+++ b/modules/core/test/v2/unit/coins/celoToken.ts
@@ -15,6 +15,7 @@ describe('Celo Token:', function() {
 
   it('should return constants', function() {
     celoTokenCoin.getChain().should.equal('tcusd');
+    celoTokenCoin.getBaseChain().should.equal('tcelo');
     celoTokenCoin.getFullName().should.equal('Celo Token');
     celoTokenCoin.getBaseFactor().should.equal(1e18);
     celoTokenCoin.type.should.equal(tokenName);


### PR DESCRIPTION
BitGoJS is currently nonconformant with our standard naming scheme of:
- getChain() = the base chain that the coin lives on
- getName() = the coin name

Instead, getChain() returns the token name for tokens and the chain name
for native coins. This was causing an issue instantiating accountlib
transactionbuilder objects which expected the base chain. Ideally the
solution would involve refactoring the naming scheme to conform to
standard, though this would require changes to ERC20 and XLM tokens as
well, and be a breaking change. This would likely cause integration
issues both for us and clients.

This commit fixes the issue in a non-breaking way by adding a new
function getBaseChain() for abstractEthLike coins and tokens which
returns the expected base chain. This is the value used for
instantiating accountlib transactionBuilders now and should fix the
issue

CLOSES TICKET: BG-25905