### PR TITLE
ci: regenerate .drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -21,6 +21,11 @@ steps:
   - git fetch origin +refs/heads/$DRONE_REPO_BRANCH:$DRONE_REPO_BRANCH || true
   - yarn install
 
+- name: check-commits
+  image: node:10
+  commands:
+  - yarn run check-commits
+
 - name: audit
   image: node:10
   commands:


### PR DESCRIPTION
The check-commits step defined in the drone.jsonnet wasn't actually being run, since the drone.yml
is the file that drone actually executes.

Ticket: BG-25260