### PR TITLE
BG-26001 support Bitcoin-ABC (BCHA) recovery in SDK

### DIFF
--- a/modules/core/src/v2/coinFactory.ts
+++ b/modules/core/src/v2/coinFactory.ts
@@ -55,6 +55,8 @@ import {
 import { tokens } from '../config';
 
 import * as errors from '../errors';
+import { Bcha } from './coins/bcha';
+import { Tbcha } from './coins/tbcha';
 
 export type CoinConstructor = (bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) => BaseCoin;
 
@@ -116,6 +118,8 @@ GlobalCoinFactory.registerCoinConstructor('btc', Btc.createInstance);
 GlobalCoinFactory.registerCoinConstructor('tbtc', Tbtc.createInstance);
 GlobalCoinFactory.registerCoinConstructor('bch', Bch.createInstance);
 GlobalCoinFactory.registerCoinConstructor('tbch', Tbch.createInstance);
+GlobalCoinFactory.registerCoinConstructor('bcha', Bcha.createInstance);
+GlobalCoinFactory.registerCoinConstructor('tbcha', Tbcha.createInstance);
 GlobalCoinFactory.registerCoinConstructor('bsv', Bsv.createInstance);
 GlobalCoinFactory.registerCoinConstructor('tbsv', Tbsv.createInstance);
 GlobalCoinFactory.registerCoinConstructor('btg', Btg.createInstance);

--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -1602,6 +1602,14 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
 
   /**
    * Get the current market price from a third party to be used for recovery
+   * This function is only intended for non-bitgo recovery transactions, when it is necessary
+   * to calculate the rough fee needed to pay to Keyternal. We are okay with approximating,
+   * because the resulting price of this function only has less than 1 dollar influence on the
+   * fee that needs to be paid to Keyternal.
+   *
+   * See calculateFeeAmount function:  return Math.round(feeAmountUsd / currentPrice * self.getBaseFactor());
+   *
+   * This end function should not be used as an accurate endpoint, since some coins' prices are missing from the provider
    */
   getRecoveryMarketPrice(): Bluebird<string> {
     const self = this;
@@ -1612,8 +1620,11 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
         .set('BCH', 'bitcoin-cash')
         .set('ZEC', 'zcash')
         .set('DASH', 'dash')
-        .set('BSV', 'bitcoin-sv')
-        .set('BCHA', 'bitcoin-cash-abc');
+        // note: we don't have a source for price data of BCHA and BSV, but we will use BCH as a proxy. We will substitute
+        // it out for a better source when it becomes available.  TODO BG-26359.
+        .set('BCHA', 'bitcoin-cash')
+        .set('BSV', 'bitcoin-cash')
+
       const coinGeckoId = familyNamesToCoinGeckoIds.get(self.getFamily().toUpperCase());
       if (!coinGeckoId) {
         throw new Error(`There is no CoinGecko id for family name ${self.getFamily().toUpperCase()}.`);

--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -1612,7 +1612,8 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
         .set('BCH', 'bitcoin-cash')
         .set('ZEC', 'zcash')
         .set('DASH', 'dash')
-        .set('BSV', 'bitcoin-sv');
+        .set('BSV', 'bitcoin-sv')
+        .set('BCHA', 'bitcoin-cash-abc');
       const coinGeckoId = familyNamesToCoinGeckoIds.get(self.getFamily().toUpperCase());
       if (!coinGeckoId) {
         throw new Error(`There is no CoinGecko id for family name ${self.getFamily().toUpperCase()}.`);

--- a/modules/core/src/v2/coins/bcha.ts
+++ b/modules/core/src/v2/coins/bcha.ts
@@ -1,0 +1,40 @@
+/**
+ * @prettier
+ */
+import { BitGo } from '../../bitgo';
+import { Bch } from './bch';
+import * as bitcoin from '@bitgo/utxo-lib';
+const request = require('superagent');
+import * as Bluebird from 'bluebird';
+import { BaseCoin } from '../baseCoin';
+import { AddressInfo, UnspentInfo, UtxoNetwork } from './abstractUtxoCoin';
+const co = Bluebird.coroutine;
+import { BlockchairApi } from '../recovery/blockchairApi';
+
+export class Bcha extends Bch {
+  static createInstance(bitgo: BitGo): BaseCoin {
+    return new Bcha(bitgo);
+  }
+
+  getChain(): string {
+    return 'bcha';
+  }
+
+  getFamily(): string {
+    return 'bcha';
+  }
+
+  getFullName(): string {
+    return 'Bitcoin ABC';
+  }
+
+  getAddressInfoFromExplorer(addressBase58: string, apiKey: string): Bluebird<AddressInfo> {
+    const explorer = new BlockchairApi(this.bitgo, 'bitcoin-abc', apiKey);
+    return Bluebird.resolve(explorer.getAccountInfo(addressBase58));
+  }
+
+  getUnspentInfoFromExplorer(addressBase58: string, apiKey: string): Bluebird<UnspentInfo[]> {
+    const explorer = new BlockchairApi(this.bitgo, 'bitcoin-abc', apiKey);
+    return Bluebird.resolve(explorer.getUnspents(addressBase58));
+  }
+}

--- a/modules/core/src/v2/coins/tbcha.ts
+++ b/modules/core/src/v2/coins/tbcha.ts
@@ -1,0 +1,28 @@
+/**
+ * @prettier
+ */
+import { BitGo } from '../../bitgo';
+import { Bcha } from './bcha';
+import * as bitcoin from '@bitgo/utxo-lib';
+import * as Bluebird from 'bluebird';
+import { BaseCoin } from '../baseCoin';
+import { UtxoNetwork } from './abstractUtxoCoin';
+const co = Bluebird.coroutine;
+
+export class Tbcha extends Bcha {
+  constructor(bitgo: BitGo) {
+    super(bitgo, bitcoin.networks.bitcoincashTestnet);
+  }
+
+  static createInstance(bitgo: BitGo): BaseCoin {
+    return new Tbcha(bitgo);
+  }
+
+  getChain(): string {
+    return 'tbcha';
+  }
+
+  getFullName(): string {
+    return 'Testnet Bitcoin ABC';
+  }
+}

--- a/modules/core/src/v2/recovery/blockchairApi.ts
+++ b/modules/core/src/v2/recovery/blockchairApi.ts
@@ -7,6 +7,7 @@ const BlockchairCoin = [
   'bitcoin',
   'bitcoin-sv',
   'bitcoin-cash',
+  'bitcoin-abc'
 ];
 
 const devBase = ['dev', 'latest', 'local', 'localNonSecure', 'adminDev', 'adminLatest'];

--- a/modules/core/test/v2/unit/recovery.ts
+++ b/modules/core/test/v2/unit/recovery.ts
@@ -306,7 +306,7 @@ describe('Recovery:', function() {
     }));
 
     it('should generate BSV recovery tx with KRS', co(function *() {
-      nockCoingecko(1000,'bitcoin-sv');
+      nockCoingecko(1000,'bitcoin-cash');
       const basecoin = bitgo.coin('tbsv');
       const recovery = yield basecoin.recover({
         userKey: '{"iv":"A3HVSDow6/GjbU8ZUlq5GA==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"D1V4aD1HVto=","ct":"C5c0uFBH6BuB11ikKnso9zaTpZbdk1I7c3GwVHdoOj2iEMl2jfKq30K0fL3pKueyQ5S412a+kbeDC0/IiZAE2sDIZt4HQQ91ivGE6bRS/PJ9Pv4E2y44plH05YTNPdz9bZhf2NCvSve5+TPS4iZuptOeO2lXE1w="}',
@@ -346,7 +346,7 @@ describe('Recovery:', function() {
           callBack2.withArgs('2N3XcQGSrdZPDwj6z3tu3iaA3msrdzVoPXT').resolves([addressUnspents['2N3XcQGSrdZPDwj6z3tu3iaA3msrdzVoPXT']]);
           callBack2.resolves([]);
         } else {
-          nockCoingecko(1000, 'bitcoin-cash-abc');
+          nockCoingecko(1000, 'bitcoin-cash');
           sandbox = sinon.createSandbox();
           const callBack1bcha = sandbox.stub(Bcha.prototype, 'getAddressInfoFromExplorer');
           callBack1bcha.resolves(emptyAddressInfo);

--- a/modules/core/test/v2/unit/recovery.ts
+++ b/modules/core/test/v2/unit/recovery.ts
@@ -5,6 +5,7 @@
 import * as should from 'should';
 import { coroutine as co } from 'bluebird';
 import * as nock from 'nock';
+import { Bcha } from '../../../src/v2/coins/bcha';
 import { RecoveryAccountData } from '../../../src/v2/recovery/types';
 
 import { TestBitGo } from '../../lib/test_bitgo';
@@ -34,11 +35,12 @@ describe('Recovery:', function() {
     bitgo.initializeTestVars();
 
     // pretend that Keyternal accepts recoveries for all coins
-    config.krsProviders.keyternal.supportedCoins = ['btc', 'eth', 'xrp', 'bch', 'ltc', 'zec', 'dash', 'xlm', 'bsv'];
+    config.krsProviders.keyternal.supportedCoins = ['btc', 'eth', 'xrp', 'bch', 'bcha', 'ltc', 'zec', 'dash', 'xlm', 'bsv'];
     (config.krsProviders.keyternal.feeAddresses as any) = {
       tbtc: '2Mujz9eicmgpPcdScRJTywVK3EQNHDJG3yN',
       tbch: '2Mujz9eicmgpPcdScRJTywVK3EQNHDJG3yN',
       tbsv: '2Mujz9eicmgpPcdScRJTywVK3EQNHDJG3yN',
+      tbcha: '2Mujz9eicmgpPcdScRJTywVK3EQNHDJG3yN',
       tltc: 'QffXMViM8DYgPRf1Hoczjw7BS5CVdSWaBL',
       tzec: 't2ATLAhBP1uTuyiWs5DY5CPH1VuYkGUindt',
       tdash: '8euHug4dbmPy3CLawwWdeTjGLqPYEGz3Kt'
@@ -328,74 +330,91 @@ describe('Recovery:', function() {
     }));
   });
 
-  describe('Recover Bitcoin Cash', function() {
+  describe('Recover Bitcoin Cash And Bitcoin ABC (BCHA)', function() {
     // Todo (kevin): fix test for other recovery source
-    let sandbox: sinon.SinonSandbox;
-
-    beforeEach(() => {
-      sandbox = sinon.createSandbox();
-      recoveryNocks.nockbitcoinFees(600, 600, 100);
-      const callBack1 = sandbox.stub(Bch.prototype, 'getAddressInfoFromExplorer');
-      callBack1.resolves(emptyAddressInfo);
-      callBack1.withArgs('2NEXK4AjYnUCkdUDJQgbbEGGks5pjkfhcRN').resolves(addressInfos['2NEXK4AjYnUCkdUDJQgbbEGGks5pjkfhcRN']);
-      callBack1.withArgs('2N3XcQGSrdZPDwj6z3tu3iaA3msrdzVoPXT').resolves(addressInfos['2N3XcQGSrdZPDwj6z3tu3iaA3msrdzVoPXT']);
-      const callBack2 = sandbox.stub(Bch.prototype, 'getUnspentInfoFromExplorer');
-      callBack2.withArgs('2N3XcQGSrdZPDwj6z3tu3iaA3msrdzVoPXT').resolves([addressUnspents['2N3XcQGSrdZPDwj6z3tu3iaA3msrdzVoPXT']]);
-      callBack2.resolves([]);
-    });
-
-    afterEach(() => {
-      sandbox.restore();
-    });
-  
-    it('should generate BCH recovery tx', co(function *() {
-      const basecoin = bitgo.coin('tbch');
-      const recovery = yield basecoin.recover({
-        userKey: '{"iv":"A3HVSDow6/GjbU8ZUlq5GA==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"D1V4aD1HVto=","ct":"C5c0uFBH6BuB11ikKnso9zaTpZbdk1I7c3GwVHdoOj2iEMl2jfKq30K0fL3pKueyQ5S412a+kbeDC0/IiZAE2sDIZt4HQQ91ivGE6bRS/PJ9Pv4E2y44plH05YTNPdz9bZhf2NCvSve5+TPS4iZuptOeO2lXE1w="}',
-        backupKey: '{"iv":"JG0lyUpjHs7k2UVN9ox31w==","v":1,"iter":10000,"ks":256,"ts":64,"mode"\n' +
-        ':"ccm","adata":"","cipher":"aes","salt":"kEdza1Fy82E=","ct":"54fBDIs7EWVUp1\n' +
-        '6slxuM6nQsLJCrwgxXB3lzS6GMbAptVtHSDPURUnZnbRYl0CN9LnNGZEqfl7w4GbCbDeCe2IvyZ\n' +
-        'dgeFCVPRYiAL/0VZeC97/pAkP4tuybqho0XELLyrYOgwgGAtoqYs5gqmfexu8R/9wEp2iI="}\n',
-        bitgoKey: 'xpub661MyMwAqRbcFwmW1HYESGP4x6tKWhYCgSK3J9T3y1eaLXkGszcbBSd4h4tM6Nt17JkcZV768RWHYrqjeEpyYabj2gv9XtdNJyww4LnJZVK',
-        walletPassphrase: TestBitGo.V2.TEST_RECOVERY_PASSCODE,
-        recoveryDestination: '2MztSo6jqjLWcvH4g6QoMChbrWkJ3HHzQua',
-        scan: 5,
-        ignoreAddressTypes: ['p2wsh', 'p2shP2wsh']
+    for (const coinName of ['tbch', 'tbcha']) {
+      let sandbox: sinon.SinonSandbox;
+      beforeEach(() => {
+        if (coinName === 'tbch') {
+          nockCoingecko(1000,'bitcoin-cash');
+          sandbox = sinon.createSandbox();
+          const callBack1 = sandbox.stub(Bch.prototype, 'getAddressInfoFromExplorer');
+          callBack1.resolves(emptyAddressInfo);
+          callBack1.withArgs('2NEXK4AjYnUCkdUDJQgbbEGGks5pjkfhcRN').resolves(addressInfos['2NEXK4AjYnUCkdUDJQgbbEGGks5pjkfhcRN']);
+          callBack1.withArgs('2N3XcQGSrdZPDwj6z3tu3iaA3msrdzVoPXT').resolves(addressInfos['2N3XcQGSrdZPDwj6z3tu3iaA3msrdzVoPXT']);
+          const callBack2 = sandbox.stub(Bch.prototype, 'getUnspentInfoFromExplorer');
+          callBack2.withArgs('2N3XcQGSrdZPDwj6z3tu3iaA3msrdzVoPXT').resolves([addressUnspents['2N3XcQGSrdZPDwj6z3tu3iaA3msrdzVoPXT']]);
+          callBack2.resolves([]);
+        } else {
+          nockCoingecko(1000, 'bitcoin-cash-abc');
+          sandbox = sinon.createSandbox();
+          const callBack1bcha = sandbox.stub(Bcha.prototype, 'getAddressInfoFromExplorer');
+          callBack1bcha.resolves(emptyAddressInfo);
+          callBack1bcha.withArgs('2NEXK4AjYnUCkdUDJQgbbEGGks5pjkfhcRN', 'myKey').resolves(addressInfos['2NEXK4AjYnUCkdUDJQgbbEGGks5pjkfhcRN']);
+          callBack1bcha.withArgs('2N3XcQGSrdZPDwj6z3tu3iaA3msrdzVoPXT', 'myKey').resolves(addressInfos['2N3XcQGSrdZPDwj6z3tu3iaA3msrdzVoPXT']);
+          const callBack2bcha = sandbox.stub(Bcha.prototype, 'getUnspentInfoFromExplorer');
+          callBack2bcha.withArgs('2N3XcQGSrdZPDwj6z3tu3iaA3msrdzVoPXT', 'myKey').resolves([addressUnspents['2N3XcQGSrdZPDwj6z3tu3iaA3msrdzVoPXT']]);
+          callBack2bcha.resolves([]);
+        }
       });
 
-      should.exist(recovery);
-      recovery.transactionHex.should.equal('02000000015a3319949e2a3741bbb062f63543f4327db3ce47d26eb3adb4bcdc31fbe8a6df00000000fc004730440220228be29971b67a9f60191a59a417fdb05208d40611d6413d3ea36eaedf8cbd060220677b5cfed4f3cc5005f9e4310bff76c8b40aacba632e681527aaebad529debe04147304402202abe3f2b32da44e8103c6b0aef9c2506f7f4ecdbbca2529dc5c76b3976b1ba3202206141148c87b4a657b5a597de287ede78ea3d57b9425013230ef03966c9622412414c69522103b11db31fb294b8757cf6849631dc6b23e56db0ed4e55d14edf3a8cb8c0eebff42103129bdad9e9a954d2b8c4a375b020b012b634a3641c5f3a0404af4ce99fd23c9521023015ea25115d67e49424248552491cf6b5e47eddb387fad1d652811e02cd53f453aeffffffff01faec85470000000017a91453d2f642f1e40f888ba0ef57c359983ccfd40f908700000000');
-      recovery.should.have.property('inputs');
-      recovery.inputs.length.should.equal(1);
-      recovery.inputs[0].should.have.property('chainPath');
-      recovery.inputs[0].chainPath.should.equal('/0/0/1/1');
-      recovery.inputs[0].should.have.property('redeemScript');
-      recovery.inputs[0].redeemScript.should.equal('522103b11db31fb294b8757cf6849631dc6b23e56db0ed4e55d14edf3a8cb8c0eebff42103129bdad9e9a954d2b8c4a375b020b012b634a3641c5f3a0404af4ce99fd23c9521023015ea25115d67e49424248552491cf6b5e47eddb387fad1d652811e02cd53f453ae');
-    }));
-
-    it('should generate BCH recovery tx with KRS', co(function *() {
-      nockCoingecko(1000,'bitcoin-cash');
-      const basecoin = bitgo.coin('tbch');
-      const recovery = yield basecoin.recover({
-        userKey: '{"iv":"A3HVSDow6/GjbU8ZUlq5GA==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"D1V4aD1HVto=","ct":"C5c0uFBH6BuB11ikKnso9zaTpZbdk1I7c3GwVHdoOj2iEMl2jfKq30K0fL3pKueyQ5S412a+kbeDC0/IiZAE2sDIZt4HQQ91ivGE6bRS/PJ9Pv4E2y44plH05YTNPdz9bZhf2NCvSve5+TPS4iZuptOeO2lXE1w="}',
-        backupKey: 'xpub661MyMwAqRbcGMSGJsrhpqUhvCQqMUvwshCLfPDXrweN15ce8g96WbfdrDbhKKDx9pwKz9yenwexTFx7ofDchmT2zJZW8eshGKWKwrJrkNp',
-        bitgoKey: 'xpub661MyMwAqRbcFwmW1HYESGP4x6tKWhYCgSK3J9T3y1eaLXkGszcbBSd4h4tM6Nt17JkcZV768RWHYrqjeEpyYabj2gv9XtdNJyww4LnJZVK',
-        walletPassphrase: TestBitGo.V2.TEST_RECOVERY_PASSCODE,
-        krsProvider: 'keyternal',
-        recoveryDestination: '2MztSo6jqjLWcvH4g6QoMChbrWkJ3HHzQua',
-        scan: 5,
-        ignoreAddressTypes: ['p2wsh', 'p2shP2wsh']
+      afterEach(() => {
+        sandbox.restore();
       });
 
-      should.exist(recovery);
-      recovery.transactionHex.should.equal('02000000015a3319949e2a3741bbb062f63543f4327db3ce47d26eb3adb4bcdc31fbe8a6df00000000b500483045022100c5b93fee72ecf0e8c918f9b847cbdf6d36b8b4ad2c8463c87b3c2e689027e42e02205e83b4c89b57651dc746f50416e86a48334b8f345511a9d1530ebdb5bb17bd5c414c69522103b11db31fb294b8757cf6849631dc6b23e56db0ed4e55d14edf3a8cb8c0eebff42103129bdad9e9a954d2b8c4a375b020b012b634a3641c5f3a0404af4ce99fd23c9521023015ea25115d67e49424248552491cf6b5e47eddb387fad1d652811e02cd53f453aeffffffff024eccee460000000017a91453d2f642f1e40f888ba0ef57c359983ccfd40f9087e00f97000000000017a9141b60c33def13c3eda4cf4835e11a633e4b3302ec8700000000');
-      recovery.should.have.property('inputs');
-      recovery.inputs.length.should.equal(1);
-      recovery.inputs[0].should.have.property('chainPath');
-      recovery.inputs[0].chainPath.should.equal('/0/0/1/1');
-      recovery.inputs[0].should.have.property('redeemScript');
-      recovery.inputs[0].redeemScript.should.equal('522103b11db31fb294b8757cf6849631dc6b23e56db0ed4e55d14edf3a8cb8c0eebff42103129bdad9e9a954d2b8c4a375b020b012b634a3641c5f3a0404af4ce99fd23c9521023015ea25115d67e49424248552491cf6b5e47eddb387fad1d652811e02cd53f453ae');
-    }));
+      it(`should generate recovery tx for ${coinName}`, co(function *() {
+        const basecoin = bitgo.coin(coinName);
+        const recovery = yield basecoin.recover({
+          userKey: '{"iv":"A3HVSDow6/GjbU8ZUlq5GA==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"D1V4aD1HVto=","ct":"C5c0uFBH6BuB11ikKnso9zaTpZbdk1I7c3GwVHdoOj2iEMl2jfKq30K0fL3pKueyQ5S412a+kbeDC0/IiZAE2sDIZt4HQQ91ivGE6bRS/PJ9Pv4E2y44plH05YTNPdz9bZhf2NCvSve5+TPS4iZuptOeO2lXE1w="}',
+          backupKey: '{"iv":"JG0lyUpjHs7k2UVN9ox31w==","v":1,"iter":10000,"ks":256,"ts":64,"mode"\n' +
+            ':"ccm","adata":"","cipher":"aes","salt":"kEdza1Fy82E=","ct":"54fBDIs7EWVUp1\n' +
+            '6slxuM6nQsLJCrwgxXB3lzS6GMbAptVtHSDPURUnZnbRYl0CN9LnNGZEqfl7w4GbCbDeCe2IvyZ\n' +
+            'dgeFCVPRYiAL/0VZeC97/pAkP4tuybqho0XELLyrYOgwgGAtoqYs5gqmfexu8R/9wEp2iI="}\n',
+          bitgoKey: 'xpub661MyMwAqRbcFwmW1HYESGP4x6tKWhYCgSK3J9T3y1eaLXkGszcbBSd4h4tM6Nt17JkcZV768RWHYrqjeEpyYabj2gv9XtdNJyww4LnJZVK',
+          walletPassphrase: TestBitGo.V2.TEST_RECOVERY_PASSCODE,
+          recoveryDestination: '2MztSo6jqjLWcvH4g6QoMChbrWkJ3HHzQua',
+          scan: 5,
+          ignoreAddressTypes: ['p2wsh', 'p2shP2wsh'],
+          apiKey: 'myKey',
+        });
+
+        should.exist(recovery);
+        recovery.transactionHex.should.equal('02000000015a3319949e2a3741bbb062f63543f4327db3ce47d26eb3adb4bcdc31fbe8a6df00000000fc004730440220228be29971b67a9f60191a59a417fdb05208d40611d6413d3ea36eaedf8cbd060220677b5cfed4f3cc5005f9e4310bff76c8b40aacba632e681527aaebad529debe04147304402202abe3f2b32da44e8103c6b0aef9c2506f7f4ecdbbca2529dc5c76b3976b1ba3202206141148c87b4a657b5a597de287ede78ea3d57b9425013230ef03966c9622412414c69522103b11db31fb294b8757cf6849631dc6b23e56db0ed4e55d14edf3a8cb8c0eebff42103129bdad9e9a954d2b8c4a375b020b012b634a3641c5f3a0404af4ce99fd23c9521023015ea25115d67e49424248552491cf6b5e47eddb387fad1d652811e02cd53f453aeffffffff01faec85470000000017a91453d2f642f1e40f888ba0ef57c359983ccfd40f908700000000');
+        recovery.should.have.property('inputs');
+        recovery.inputs.length.should.equal(1);
+        recovery.inputs[0].should.have.property('chainPath');
+        recovery.inputs[0].chainPath.should.equal('/0/0/1/1');
+        recovery.inputs[0].should.have.property('redeemScript');
+        recovery.inputs[0].redeemScript.should.equal('522103b11db31fb294b8757cf6849631dc6b23e56db0ed4e55d14edf3a8cb8c0eebff42103129bdad9e9a954d2b8c4a375b020b012b634a3641c5f3a0404af4ce99fd23c9521023015ea25115d67e49424248552491cf6b5e47eddb387fad1d652811e02cd53f453ae');
+      }));
+
+      it(`should generate ${coinName} recovery tx with KRS`, co(function *() {
+
+        const basecoin = bitgo.coin(coinName);
+        const recovery = yield basecoin.recover({
+          userKey: '{"iv":"A3HVSDow6/GjbU8ZUlq5GA==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"D1V4aD1HVto=","ct":"C5c0uFBH6BuB11ikKnso9zaTpZbdk1I7c3GwVHdoOj2iEMl2jfKq30K0fL3pKueyQ5S412a+kbeDC0/IiZAE2sDIZt4HQQ91ivGE6bRS/PJ9Pv4E2y44plH05YTNPdz9bZhf2NCvSve5+TPS4iZuptOeO2lXE1w="}',
+          backupKey: 'xpub661MyMwAqRbcGMSGJsrhpqUhvCQqMUvwshCLfPDXrweN15ce8g96WbfdrDbhKKDx9pwKz9yenwexTFx7ofDchmT2zJZW8eshGKWKwrJrkNp',
+          bitgoKey: 'xpub661MyMwAqRbcFwmW1HYESGP4x6tKWhYCgSK3J9T3y1eaLXkGszcbBSd4h4tM6Nt17JkcZV768RWHYrqjeEpyYabj2gv9XtdNJyww4LnJZVK',
+          walletPassphrase: TestBitGo.V2.TEST_RECOVERY_PASSCODE,
+          krsProvider: 'keyternal',
+          recoveryDestination: '2MztSo6jqjLWcvH4g6QoMChbrWkJ3HHzQua',
+          scan: 5,
+          ignoreAddressTypes: ['p2wsh', 'p2shP2wsh'],
+          apiKey: "myKey",
+        });
+
+        should.exist(recovery);
+        recovery.transactionHex.should.equal('02000000015a3319949e2a3741bbb062f63543f4327db3ce47d26eb3adb4bcdc31fbe8a6df00000000b500483045022100c5b93fee72ecf0e8c918f9b847cbdf6d36b8b4ad2c8463c87b3c2e689027e42e02205e83b4c89b57651dc746f50416e86a48334b8f345511a9d1530ebdb5bb17bd5c414c69522103b11db31fb294b8757cf6849631dc6b23e56db0ed4e55d14edf3a8cb8c0eebff42103129bdad9e9a954d2b8c4a375b020b012b634a3641c5f3a0404af4ce99fd23c9521023015ea25115d67e49424248552491cf6b5e47eddb387fad1d652811e02cd53f453aeffffffff024eccee460000000017a91453d2f642f1e40f888ba0ef57c359983ccfd40f9087e00f97000000000017a9141b60c33def13c3eda4cf4835e11a633e4b3302ec8700000000');
+        recovery.should.have.property('inputs');
+        recovery.inputs.length.should.equal(1);
+        recovery.inputs[0].should.have.property('chainPath');
+        recovery.inputs[0].chainPath.should.equal('/0/0/1/1');
+        recovery.inputs[0].should.have.property('redeemScript');
+        recovery.inputs[0].redeemScript.should.equal('522103b11db31fb294b8757cf6849631dc6b23e56db0ed4e55d14edf3a8cb8c0eebff42103129bdad9e9a954d2b8c4a375b020b012b634a3641c5f3a0404af4ce99fd23c9521023015ea25115d67e49424248552491cf6b5e47eddb387fad1d652811e02cd53f453ae');
+        console.log(recovery)
+      }));
+    }
+
   });
 
   describe('Recover Ripple', function() {

--- a/modules/core/test/v2/unit/recovery/blockchairApi.ts
+++ b/modules/core/test/v2/unit/recovery/blockchairApi.ts
@@ -4,7 +4,7 @@ import { Environments } from '../../../../src/v2/environments';
 import { TestBitGo } from '../../../lib/test_bitgo';
 import { BlockchairApi } from '../../../../src/v2/recovery/blockchairApi';
 
-const coinNames = ['bitcoin', 'bitcoin-sv'];
+const coinNames = ['bitcoin', 'bitcoin-sv', 'bitcoin-abc'];
 
 function nockBlockchair(env, coinName) {
   const baseUrl = BlockchairApi.getBaseUrl(env, coinName);

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -17,6 +17,7 @@ export enum CoinKind {
 export enum CoinFamily {
   ALGO = 'algo',
   BCH = 'bch',
+  BCHA = 'bcha',
   BSV = 'bsv',
   BTC = 'btc',
   BTG = 'btg',
@@ -132,6 +133,7 @@ export enum CoinFeature {
 export enum UnderlyingAsset {
   ALGO = 'algo',
   BCH = 'bch',
+  BCHA = 'bcha',
   BSV = 'bsv',
   BTC = 'btc',
   BTG = 'btg',

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -23,6 +23,8 @@ const XTZ_FEATURES = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.ENTERPRISE_PA
 export const coins = CoinMap.fromCoins([
   utxo('bch', 'Bitcoin Cash', Networks.main.bitcoinCash, UnderlyingAsset.BCH),
   utxo('tbch', 'Testnet Bitcoin Cash', Networks.test.bitcoinCash, UnderlyingAsset.BCH),
+  utxo('bcha', 'Bitcoin ABC', Networks.main.bitcoinABC, UnderlyingAsset.BCHA),
+  utxo('tbcha', 'Testnet Bitcoin ABC', Networks.test.bitcoinABC, UnderlyingAsset.BCHA),
   utxo('bsv', 'Bitcoin SV', Networks.main.bitcoinSV, UnderlyingAsset.BSV),
   utxo('tbsv', 'Testnet Bitcoin SV', Networks.test.bitcoinSV, UnderlyingAsset.BSV),
   utxo('btc', 'Bitcoin', Networks.main.bitcoin, UnderlyingAsset.BTC),

--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -133,12 +133,12 @@ class BitcoinCashTestnet extends BitcoinLikeTestnet {
 
 class BitcoinABC extends BitcoinLikeMainnet {
   family = CoinFamily.BCHA;
-  explorerUrl = 'https://api.cryptoapis.io/v1/bc/bch/mainnet';
+  explorerUrl = 'https://api.blockchair.com/bitcoin-abc';
 }
 
 class BitcoinABCTestnet extends BitcoinLikeTestnet {
   family = CoinFamily.BCHA;
-  explorerUrl = 'https://api.cryptoapis.io/v1/bc/bch/testnet';
+  explorerUrl = 'https://api.blockchair.com/bitcoin-abc';
 }
 
 // https://github.com/bitcoin-sv/bitcoin-sv/blob/master/src/validation.cpp

--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -131,6 +131,16 @@ class BitcoinCashTestnet extends BitcoinLikeTestnet {
   explorerUrl = 'https://tbch.blockdozer.com/tx/';
 }
 
+class BitcoinABC extends BitcoinLikeMainnet {
+  family = CoinFamily.BCHA;
+  explorerUrl = 'https://api.cryptoapis.io/v1/bc/bch/mainnet';
+}
+
+class BitcoinABCTestnet extends BitcoinLikeTestnet {
+  family = CoinFamily.BCHA;
+  explorerUrl = 'https://api.cryptoapis.io/v1/bc/bch/testnet';
+}
+
 // https://github.com/bitcoin-sv/bitcoin-sv/blob/master/src/validation.cpp
 // https://github.com/bitcoin-sv/bitcoin-sv/blob/master/src/chainparams.cpp
 class BitcoinSV extends BitcoinLikeMainnet {
@@ -351,6 +361,7 @@ export const Networks = {
     algorand: Object.freeze(new Algorand()),
     bitcoin: Object.freeze(new Bitcoin()),
     bitcoinCash: Object.freeze(new BitcoinCash()),
+    bitcoinABC: Object.freeze(new BitcoinABC()),
     bitcoinGold: Object.freeze(new BitcoinGold()),
     bitcoinSV: Object.freeze(new BitcoinSV()),
     celo: Object.freeze(new Celo()),
@@ -373,6 +384,7 @@ export const Networks = {
     algorand: Object.freeze(new AlgorandTestnet()),
     bitcoin: Object.freeze(new BitcoinTestnet()),
     bitcoinCash: Object.freeze(new BitcoinCashTestnet()),
+    bitcoinABC: Object.freeze(new BitcoinABCTestnet()),
     bitcoinSV: Object.freeze(new BitcoinSVTestnet()),
     celo: Object.freeze(new CeloTestnet()),
     dash: Object.freeze(new DashTestnet()),

--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -138,7 +138,7 @@ class BitcoinABC extends BitcoinLikeMainnet {
 
 class BitcoinABCTestnet extends BitcoinLikeTestnet {
   family = CoinFamily.BCHA;
-  explorerUrl = 'https://api.blockchair.com/bitcoin-abc';
+  explorerUrl = undefined;
 }
 
 // https://github.com/bitcoin-sv/bitcoin-sv/blob/master/src/validation.cpp
@@ -150,7 +150,7 @@ class BitcoinSV extends BitcoinLikeMainnet {
 
 class BitcoinSVTestnet extends BitcoinLikeTestnet {
   family = CoinFamily.BSV;
-  explorerUrl = 'https://testnet.bitcoincloud.net/tx/';
+  explorerUrl = undefined;
 }
 
 // https://github.com/BTCGPU/BTCGPU/blob/master/src/validation.cpp


### PR DESCRIPTION
This PR adds BCHA as a new coin in the SDK, so we could recover it with non bitgo recovery functions after the fork.

Please note that the chain params of BCHA and BCHN are identical, so we are reusing the same set of params defined on the UTXO lib. (Since UTXO Lib is a bit messy anyhow.) Therefore, BCHA does not need to override the constructor of BCHN. 
