### PR TITLE
fix(config): add BSV and BCHA as recoverable coin with coincover

### DIFF
--- a/modules/core/src/config.ts
+++ b/modules/core/src/config.ts
@@ -193,7 +193,7 @@ export const krsProviders = {
   dai: {
     feeType: 'flatUsd',
     feeAmount: 0, // dai will receive payments off-chain
-    supportedCoins: ['btc', 'eth', 'xlm', 'xrp', 'dash', 'zec', 'ltc', 'bch']
+    supportedCoins: ['btc', 'eth', 'xlm', 'xrp', 'dash', 'zec', 'ltc', 'bch', 'bsv', 'bcha']
   }
 };
 


### PR DESCRIPTION
We need to add bsv and bcha under the supportedCoins param of SDK, so that the recovery transaction can be initiated.