### PR TITLE
Add BLS key generation for eth2

### DIFF
--- a/modules/account-lib/package.json
+++ b/modules/account-lib/package.json
@@ -35,6 +35,7 @@
     "@bitgo/statics": "^5.3.0",
     "@bitgo/utxo-lib": "^1.7.1",
     "@celo/contractkit": "0.4.11",
+    "@chainsafe/bls": "^4.0.0",
     "@hashgraph/sdk": "^1.2.1",
     "@stablelib/hex": "^1.0.0",
     "@stablelib/sha384": "^1.0.0",

--- a/modules/account-lib/src/coin/baseCoin/baseKeyPair.ts
+++ b/modules/account-lib/src/coin/baseCoin/baseKeyPair.ts
@@ -15,7 +15,7 @@ export interface BaseKeyPair {
   /**
    * Build a set of keys from a pub
    *
-   * @param {string} prv A raw pub key
+   * @param {string} pub A raw pub key
    */
   recordKeysFromPublicKey(pub: string): void;
 

--- a/modules/account-lib/src/coin/baseCoin/blsKeyPair.ts
+++ b/modules/account-lib/src/coin/baseCoin/blsKeyPair.ts
@@ -1,0 +1,66 @@
+import * as BLS from '@chainsafe/bls';
+import { KeyPairOptions, isPrivateKey } from './iface';
+import { BaseKeyPair } from './baseKeyPair';
+import { AddressFormat } from './enum';
+import { NotImplementedError } from './errors';
+
+/**
+ * Base class for BLS keypairs.
+ */
+export abstract class BlsKeyPair implements BaseKeyPair {
+  protected keyPair: BLS.Keypair;
+
+  /**
+   * Public constructor. By default, creates a key pair with a random master seed.
+   *
+   */
+  protected constructor() {
+    this.keyPair = BLS.generateKeyPair();
+  }
+
+  /**
+   * Build a keyPair from private key.
+   *
+   * @param {string} prv a hexadecimal private key
+   */
+  recordKeysFromPrivateKey(prv: string) {
+    if (this.isValidBLSPrv(prv)) {
+      const privateKey = BLS.PrivateKey.fromHexString(prv);
+      this.keyPair = new BLS.Keypair(privateKey);
+    } else {
+      throw new Error('Invalid private key');
+    }
+  }
+
+  /**
+   * Note - this is not possible using BLS. BLS does not support pubkey derived key gen
+   *
+   * @param {string} pub - An extended, compressed, or uncompressed public key
+   */
+  recordKeysFromPublicKey(pub: string): void {
+    throw new NotImplementedError('Public key derivation is not supported in bls');
+  }
+
+  getAddress(format?: AddressFormat): string {
+    throw new NotImplementedError('getAddress not implemented');
+  }
+
+  getKeys(): any {
+    throw new NotImplementedError('getKeys not implemented');
+  }
+
+  /**
+   * Whether the input is a valid BLS private key
+   *
+   * @param {string} prv A hexadecimal public key to validate
+   * @returns {boolean} Whether the input is a valid private key or not
+   */
+  isValidBLSPrv(prv: string): boolean {
+    try {
+      BLS.PrivateKey.fromHexString(prv);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+}

--- a/modules/account-lib/src/coin/eth2/index.ts
+++ b/modules/account-lib/src/coin/eth2/index.ts
@@ -1,0 +1,1 @@
+export { KeyPair } from './keyPair';

--- a/modules/account-lib/src/coin/eth2/keyPair.ts
+++ b/modules/account-lib/src/coin/eth2/keyPair.ts
@@ -1,0 +1,37 @@
+import * as BLS from '@chainsafe/bls';
+import { DefaultKeys } from '../baseCoin/iface';
+import { BlsKeyPair } from '../baseCoin/blsKeyPair';
+
+/**
+ * Ethereum keys and address management.
+ */
+export class KeyPair extends BlsKeyPair {
+  /**
+   * Public constructor. By default, creates a key pair with a random master seed.
+   *
+   */
+  constructor() {
+    super();
+  }
+
+  /**
+   * ETH2 default keys format is a pair of Uint8Array keys
+   *
+   * @returns { DefaultKeys } The keys in the defined format
+   */
+  getKeys(): BLS.Keypair {
+    if (this.keyPair) {
+      return this.keyPair;
+    }
+    throw new Error('KeyPair has not been specified');
+  }
+
+  /**
+   * Get an Ethereum public address
+   *
+   * @returns {string} The address derived from the public key
+   */
+  getAddress(): string {
+    return this.getKeys().publicKey.toHexString();
+  }
+}

--- a/modules/account-lib/src/index.ts
+++ b/modules/account-lib/src/index.ts
@@ -16,6 +16,9 @@ export { Xtz };
 import * as Eth from './coin/eth';
 export { Eth };
 
+import * as Eth2 from './coin/eth2';
+export { Eth2 };
+
 import * as Etc from './coin/etc';
 export { Etc };
 

--- a/modules/account-lib/test/resources/eth2/eth2.ts
+++ b/modules/account-lib/test/resources/eth2/eth2.ts
@@ -1,0 +1,18 @@
+import { KeyPair } from '../../../src/coin/hbar/keyPair';
+
+// ACCOUNT_1 has public and private keys with prefix
+export const ACCOUNT_1 = {
+  privateKey: '0x8fa1aa4aaa6c54aa2aacaafaaa23aCaa8fa1aa4aaa6c54aa2aacaafaaa23aCaa',
+  publicKey: '0x8fa1aa4aaa6c54aa2aacaafaaa23aCaa8fa1aa4aaa6c54aa2aacaafaaa23aCaa',
+  privateKeyBytes: Uint8Array.from(
+    Buffer.from('4fd90ae1b8f724a4902615c09145ae134617c325b98c6970dcf62ab9cc5e12f3', 'hex'),
+  ),
+};
+
+export const errorMessageInvalidPrivateKey = 'Invalid private key';
+
+export const errorMessageInvalidPublicKey = 'Public key derivation is not supported in bls';
+
+export const KEYPAIR_PRV = new KeyPair({
+  prv: '302e020100300506032b65700422042062b0b669de0ab5e91b4328e1431859a5ca47e7426e701019272f5c2d52825b01',
+});

--- a/modules/account-lib/test/unit/coin/eth2/keyPair.ts
+++ b/modules/account-lib/test/unit/coin/eth2/keyPair.ts
@@ -1,0 +1,81 @@
+import should from 'should';
+import * as BLS from '@chainsafe/bls';
+import { KeyPair } from '../../../../src/coin/eth2';
+import * as testData from '../../../resources/eth2/eth2';
+
+const pub = testData.ACCOUNT_1.publicKey;
+const prv = testData.ACCOUNT_1.privateKey;
+
+before(async function f() {
+  await BLS.initBLS();
+});
+
+describe('Eth2 Key Pair', () => {
+  describe('should create a valid KeyPair', () => {
+    it('from an empty value', () => {
+      const keyPair = new KeyPair();
+      should.exists(keyPair.getKeys().privateKey);
+      should.exists(keyPair.getKeys().publicKey);
+      should.equal(
+        keyPair
+          .getKeys()
+          .privateKey.toHexString()
+          .slice(0, 2),
+        '0x',
+      );
+      should.equal(
+        keyPair
+          .getKeys()
+          .publicKey.toHexString()
+          .slice(0, 2),
+        '0x',
+      );
+    });
+
+    it('without source', () => {
+      const keyPair = new KeyPair();
+      should.exists(keyPair.getKeys().privateKey);
+      should.exists(keyPair.getKeys().publicKey);
+    });
+
+    it('from a private key', () => {
+      const baseKeyPair = new KeyPair();
+      const inheritKeyPair = new KeyPair();
+      inheritKeyPair.recordKeysFromPrivateKey(baseKeyPair.getKeys().privateKey.toHexString());
+      should.equal(inheritKeyPair.getKeys().privateKey.toHexString(), baseKeyPair.getKeys().privateKey.toHexString());
+    });
+
+    it('from a byte array private key', () => {
+      const privateKey = '0x' + Buffer.from(testData.ACCOUNT_1.privateKeyBytes).toString('hex');
+      const keyPair = new KeyPair();
+      keyPair.recordKeysFromPrivateKey(privateKey);
+      should.equal(keyPair.getKeys().privateKey.toHexString(), privateKey);
+    });
+  });
+
+  describe('should fail to create a KeyPair', () => {
+    it('from a public key', () => {
+      should.throws(
+        () => new KeyPair().recordKeysFromPublicKey(pub),
+        e => e.message.includes(testData.errorMessageInvalidPublicKey),
+      );
+    });
+
+    it('from an invalid private key', () => {
+      const shorterPrv = '82A34E';
+      const longerPrv = prv + '1';
+      should.throws(
+        () => new KeyPair().recordKeysFromPrivateKey(shorterPrv),
+        e => e.message === testData.errorMessageInvalidPrivateKey,
+      );
+      should.throws(
+        () => new KeyPair().recordKeysFromPrivateKey(longerPrv),
+        e => e.message === testData.errorMessageInvalidPrivateKey,
+      );
+      should.throws(
+        () => new KeyPair().recordKeysFromPrivateKey(prv + pub),
+        e => e.message === testData.errorMessageInvalidPrivateKey,
+      );
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -529,6 +529,43 @@
     numeral "^2.0.6"
     web3-utils "1.2.4"
 
+"@chainsafe/bls-hd-key@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/bls-hd-key/-/bls-hd-key-0.1.0.tgz#5e51de16801f4b4b421e418f0d1ef0692df0c585"
+  integrity sha512-VZj+Ml4YTPz+d/K2n9q/9bLlIJnTr/xdAC5w1eCvIFtcQrZCY1Zw+bCcXKX1q6sbZpO9xhyuoepJzJX9VkMPqw==
+  dependencies:
+    assert "^2.0.0"
+    bcrypto "^5.0.4"
+    bn.js "^5.1.1"
+    buffer "^5.4.3"
+
+"@chainsafe/bls-keygen@^0.2.0":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/bls-keygen/-/bls-keygen-0.2.1.tgz#2ddbba1fdb79f893defb6b03a797e708e631d9a1"
+  integrity sha512-QEwFbkHUoEDKXbxJ7QObHAvvqfp31cYOQju3gXxGz4RxMDPSHCcUI+76IXrq0hxYHxN149eYGcEYM57Z2YxFuw==
+  dependencies:
+    "@chainsafe/bls-hd-key" "^0.1.0"
+    assert "^2.0.0"
+    bcrypto "^5.0.4"
+    bip39 "^3.0.2"
+    buffer "^5.4.3"
+
+"@chainsafe/bls@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/bls/-/bls-4.0.0.tgz#889ba5a04ebfd2e687302be46d3ea92102c9b94d"
+  integrity sha512-X3uG2nYGtc3WIyOBgn/HFdCkEq6V80JBHyVc9MJry+y1Hcs3lvxzd3n3AXo5mSf3/iVWyrfvt8J6KgWkFKDNQA==
+  dependencies:
+    "@chainsafe/bls-keygen" "^0.2.0"
+    "@chainsafe/eth2-bls-wasm" "^0.5.0"
+    assert "^1.4.1"
+
+"@chainsafe/eth2-bls-wasm@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/eth2-bls-wasm/-/eth2-bls-wasm-0.5.0.tgz#45d0cb8807b569537d1e0099922a9617e0410b3a"
+  integrity sha512-7aHphmg504W4YTvAEvGscODrr1Fo5Mf9NxB72fuFv2BKUS/0BPgkoxG9tA+KxcFQq1hs/VUeLhq6qVdI5WfNNA==
+  dependencies:
+    buffer "^5.4.3"
+
 "@commitlint/cli@^11.0.0":
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/@commitlint%2fcli/-/cli-11.0.0.tgz#698199bc52afed50aa28169237758fa14a67b5d3"
@@ -2895,7 +2932,7 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
-assert@^1.1.1:
+assert@^1.1.1, assert@^1.4.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.5.0.tgz#55c109aaf6e0aefdb3dc4b71240c70bf574b18eb"
   integrity sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==
@@ -3104,6 +3141,14 @@ bcrypt-pbkdf@^1.0.0:
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
+
+bcrypto@^5.0.4:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/bcrypto/-/bcrypto-5.3.0.tgz#d2d7d8a808b5efeb09fe529034a30bd772902d84"
+  integrity sha512-SP48cpoc4BkEPNOErdsZ1VjbtdXY/C0f5wAywWniLne/Fd/5oOBqLbC6ZavngLvk4oik76g4I7PO5KduJoqECQ==
+  dependencies:
+    bufio "~1.0.7"
+    loady "~0.0.5"
 
 bech32@0.0.3:
   version "0.0.3"
@@ -3636,6 +3681,11 @@ bufferutil@^3.0.5:
     bindings "~1.3.0"
     nan "~2.10.0"
     prebuild-install "~4.0.0"
+
+bufio@~1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/bufio/-/bufio-1.0.7.tgz#b7f63a1369a0829ed64cc14edf0573b3e382a33e"
+  integrity sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A==
 
 builtin-status-codes@^3.0.0:
   version "3.0.0"
@@ -8920,6 +8970,11 @@ loader-utils@^1.1.0, loader-utils@^1.2.3:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^1.0.1"
+
+loady@~0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/loady/-/loady-0.0.5.tgz#b17adb52d2fb7e743f107b0928ba0b591da5d881"
+  integrity sha512-uxKD2HIj042/HBx77NBcmEPsD+hxCgAtjEWlYNScuUjIsh/62Uyu39GOR68TBR68v+jqDL9zfftCWoUo4y03sQ==
 
 locate-path@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Adds ability to create user and backup keys for ETH2 wallets client-side.
Ticket: BG-26379