### PR TITLE
fix(express): add libc6-compat alpine package to provide ld-linux-x86…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN npm install npm@latest -g
 USER node
 RUN npm ci && npm prune --production
 FROM node:10-alpine
-RUN apk add --no-cache tini
+RUN apk add --no-cache tini libc6-compat
 COPY --from=builder /tmp/bitgo/modules/express /var/bitgo-express
 ENV NODE_ENV production
 ENV BITGO_BIND 0.0.0.0


### PR DESCRIPTION
…-64.so.2

We need this dynamic library for a new dependency to load correctly.
Without it installed, bitgo express crashes on startup.

Ticket: BG-26745