### PR TITLE
fix(express): use gcompat instead of libc6-compat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN npm install npm@latest -g
 USER node
 RUN npm ci && npm prune --production
 FROM node:10-alpine
-RUN apk add --no-cache tini libc6-compat
+RUN apk add --no-cache tini gcompat
 COPY --from=builder /tmp/bitgo/modules/express /var/bitgo-express
 ENV NODE_ENV production
 ENV BITGO_BIND 0.0.0.0


### PR DESCRIPTION
gcompat installs to /lib, which is where loady looks for dynamic libraries, instead of /lib64.
Because it was in the wrong location, this was causing the library to still not be found when
starting up.

Ticket: BG-26745