### PR TITLE
fix(express): remove gcompat, switch to alpine build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
-FROM node:10 AS builder
+FROM node:10-alpine AS builder
 MAINTAINER Tyler Levine <tyler@bitgo.com>
+RUN apk add --no-cache git python make g++
 COPY --chown=node:node . /tmp/bitgo/
 WORKDIR /tmp/bitgo/modules/express
 RUN npm install npm@latest -g
 USER node
 RUN npm ci && npm prune --production
 FROM node:10-alpine
-RUN apk add --no-cache tini gcompat
+RUN apk add --no-cache tini
 COPY --from=builder /tmp/bitgo/modules/express /var/bitgo-express
 ENV NODE_ENV production
 ENV BITGO_BIND 0.0.0.0


### PR DESCRIPTION
gcompat is not meant to be a long term solution for providing glibc
compatibility for compiled binaries. Instead, we should compile these
binaries in an environment which has the same libc implementation as the
one which will be present in the final production container.

This change replaces the `node:10` build container with
`node:10-alpine`, removes `gcompat` from the production container.

Ticket: BG-26745