### PR TITLE
AccountLib- BGA-655 Implement casper coin skeleton structure

### DIFF
--- a/modules/account-lib/package.json
+++ b/modules/account-lib/package.json
@@ -33,7 +33,7 @@
   "license": "ISC",
   "dependencies": {
     "@bitgo/bls": "^0.1.0",
-    "@bitgo/statics": "^6.0.0",
+    "@bitgo/statics": "^6.1.0-rc.0",
     "@bitgo/utxo-lib": "^1.7.1",
     "@celo/contractkit": "0.4.11",
     "@hashgraph/sdk": "^1.2.1",

--- a/modules/account-lib/src/coin/cspr/index.ts
+++ b/modules/account-lib/src/coin/cspr/index.ts
@@ -1,0 +1,2 @@
+export { TransactionBuilderFactory } from './transactionBuilderFactory';
+export { KeyPair } from './keyPair';

--- a/modules/account-lib/src/coin/cspr/keyPair.ts
+++ b/modules/account-lib/src/coin/cspr/keyPair.ts
@@ -1,0 +1,43 @@
+import { Ed25519KeyPair } from '../baseCoin/ed25519KeyPair';
+import { KeyPairOptions, DefaultKeys } from '../baseCoin/iface';
+import { NotImplementedError } from '../baseCoin/errors';
+
+export class KeyPair extends Ed25519KeyPair {
+  /**
+   * Public constructor. By default, creates a key pair with a random master seed.
+   *
+   * @param { KeyPairOptions } source Either a master seed, a private key, or a public key
+   */
+  constructor(source?: KeyPairOptions) {
+    super(source);
+  }
+
+  /**
+   * Default keys format is a pair of Uint8Array keys
+   *
+   * @param {boolean} raw defines if the key is returned in raw or protocol default format
+   * @returns { DefaultKeys } The keys in the defined format
+   */
+  getKeys(raw = false) {
+    throw new NotImplementedError('getKeys not implemented');
+  }
+
+  /** @inheritdoc */
+  getAddress(format?: string): string {
+    throw new NotImplementedError('getKeys not implemented');
+  }
+
+  /** @inheritdoc */
+  recordKeysFromPublicKeyInProtocolFormat(pub: string): DefaultKeys {
+    throw new NotImplementedError('recordKeysFromPublicKeyInProtocolFormat not implemented');
+  }
+
+  /** @inheritdoc */
+  recordKeysFromPrivateKeyInProtocolFormat(prv: string): DefaultKeys {
+    throw new NotImplementedError('recordKeysFromPrivateKeyInProtocolFormat not implemented');
+  }
+
+  generateKeyFromSeed() {
+    throw new NotImplementedError('generateKeyFromSeed not implemented');
+  }
+}

--- a/modules/account-lib/src/coin/cspr/transaction.ts
+++ b/modules/account-lib/src/coin/cspr/transaction.ts
@@ -1,0 +1,68 @@
+import { BaseCoin as CoinConfig } from '@bitgo/statics/dist/src/base';
+import { BaseTransaction, TransactionType } from '../baseCoin';
+import { BaseKey } from '../baseCoin/iface';
+import { NotImplementedError } from '../baseCoin/errors';
+
+export class Transaction extends BaseTransaction {
+  protected _type: TransactionType;
+
+  constructor(_coinConfig: Readonly<CoinConfig>) {
+    super(_coinConfig);
+  }
+
+  /** @inheritdoc */
+  canSign(key: BaseKey): boolean {
+    return true;
+  }
+
+  async sign(keyPair): Promise<void> {
+    throw new NotImplementedError('sign not implemented');
+  }
+
+  /**
+   * Add a signature to this transaction
+   * @param signature The signature to add, in string hex format
+   * @param key The key of the key that created the signature
+   */
+  addSignature(signature: string, key): void {
+    throw new NotImplementedError('addSignature not implemented');
+  }
+
+  /** @inheritdoc */
+  toBroadcastFormat() {
+    throw new NotImplementedError('toBroadcastFormat not implemented');
+  }
+
+  /** @inheritdoc */
+  toJson() {
+    throw new NotImplementedError('toJson not implemented');
+  }
+
+  /**
+   * Set the transaction type
+   *
+   * @param {TransactionType} transactionType The transaction type to be set
+   */
+  setTransactionType(transactionType: TransactionType): void {
+    throw new NotImplementedError('getTransferData not implemented');
+  }
+
+  /**
+   * Decode previous signatures from the inner transaction
+   * and save them into the base transaction signature list.
+   */
+  loadPreviousSignatures(): void {
+    throw new NotImplementedError('getTransferData not implemented');
+  }
+
+  /**
+   * Load the input and output data on this transaction using the transaction json
+   * if there are outputs. For transactions without outputs (e.g. wallet initializations),
+   * this function will not do anything
+   */
+  loadInputsAndOutputs(): void {
+    throw new NotImplementedError('loadInputsAndOutputs not implemented');
+  }
+
+  //endregion
+}

--- a/modules/account-lib/src/coin/cspr/transactionBuilder.ts
+++ b/modules/account-lib/src/coin/cspr/transactionBuilder.ts
@@ -1,0 +1,137 @@
+import BigNumber from 'bignumber.js';
+import { BaseCoin as CoinConfig } from '@bitgo/statics/dist/src/base';
+import { BaseTransactionBuilder } from '../baseCoin';
+import { BuildTransactionError, NotImplementedError } from '../baseCoin/errors';
+import { BaseAddress, BaseFee, BaseKey } from '../baseCoin/iface';
+import { Transaction } from './transaction';
+import { KeyPair } from './keyPair';
+
+export const DEFAULT_M = 3;
+export abstract class TransactionBuilder extends BaseTransactionBuilder {
+  private _source: BaseAddress;
+  private _fee: BaseFee;
+  private _transaction: Transaction;
+
+  constructor(_coinConfig: Readonly<CoinConfig>) {
+    super(_coinConfig);
+    this.transaction = new Transaction(_coinConfig);
+  }
+
+  // region Base Builder
+  /** @inheritdoc */
+  protected async buildImplementation(): Promise<Transaction> {
+    throw new NotImplementedError('buildImplementation not implemented');
+  }
+
+  /** @inheritdoc */
+  protected fromImplementation(rawTransaction: Uint8Array | string): Transaction {
+    throw new NotImplementedError('fromImplementation not implemented');
+  }
+
+  /** @inheritdoc */
+  protected signImplementation(key: BaseKey): Transaction {
+    throw new NotImplementedError('signImplementation not implemented');
+  }
+
+  /**
+   * Initialize the transaction builder fields using the decoded transaction data
+   *
+   * @param {Transaction} tx the transaction data
+   */
+  initBuilder(tx: Transaction): void {
+    throw new NotImplementedError('initBuilder not implemented');
+  }
+
+  // endregion
+
+  // region Common builder methods
+
+  /**
+   * Set the transaction fees
+   *
+   * @param {BaseFee} fee The maximum gas to pay
+   * @returns {TransactionBuilder} This transaction builder
+   */
+  fee(fee: BaseFee): this {
+    this.validateValue(new BigNumber(fee.fee));
+    this._fee = fee;
+    return this;
+  }
+
+  /**
+   * Set the transaction source
+   *
+   * @param {BaseAddress} address The source account
+   * @returns {TransactionBuilder} This transaction builder
+   */
+  source(address: BaseAddress): this {
+    this.validateAddress(address);
+    this._source = address;
+    return this;
+  }
+
+  /**
+   * Set an external transaction signature
+   *
+   * @param signature Hex encoded signature string
+   * @param keyPair The public key keypair that was used to create the signature
+   * @returns This transaction builder
+   */
+  signature(signature: string, keyPair: KeyPair): this {
+    throw new NotImplementedError('initializeBuilder not implemented');
+  }
+
+  // endregion
+
+  // region Validators
+  /** @inheritdoc */
+  validateAddress(address: BaseAddress, addressFormat?: string): void {
+    throw new NotImplementedError('validateAddress not implemented');
+    // if (!isValidAddress(address.address)) {
+    //   throw new BuildTransactionError('Invalid address ' + address.address);
+    // }
+  }
+
+  /** @inheritdoc */
+  validateKey(key: BaseKey): void {
+    if (!new KeyPair({ prv: key.key })) {
+      throw new BuildTransactionError('Invalid key');
+    }
+  }
+
+  /** @inheritdoc */
+  validateRawTransaction(rawTransaction: any): void {
+    throw new NotImplementedError('validateRawTransaction not implemented');
+    // if (!isValidRawTransactionFormat(rawTransaction)) {
+    //   throw new ParseTransactionError('Invalid raw transaction');
+    // }
+  }
+
+  /** @inheritdoc */
+  validateTransaction(transaction?: Transaction): void {
+    this.validateMandatoryFields();
+  }
+
+  /** @inheritdoc */
+  validateValue(value: BigNumber): void {
+    if (value.isLessThan(0)) {
+      throw new BuildTransactionError('Value cannot be less than zero');
+    }
+  }
+
+  validateMandatoryFields(): void {
+    throw new NotImplementedError('validateMandatoryFields not implemented');
+  }
+
+  // endregion
+
+  /** @inheritdoc */
+  protected get transaction(): Transaction {
+    return this._transaction;
+  }
+
+  /** @inheritdoc */
+  protected set transaction(transaction: Transaction) {
+    this._transaction = transaction;
+  }
+}

--- a/modules/account-lib/src/coin/cspr/transactionBuilderFactory.ts
+++ b/modules/account-lib/src/coin/cspr/transactionBuilderFactory.ts
@@ -1,0 +1,59 @@
+import { BaseCoin as CoinConfig } from '@bitgo/statics/dist/src/base';
+import { InvalidTransactionError, ParseTransactionError, NotImplementedError } from '../baseCoin/errors';
+import { BaseTransactionBuilderFactory } from '../baseCoin';
+import { WalletInitializationBuilder } from './walletInitializationBuilder';
+import { TransferBuilder } from './transferBuilder';
+import { TransactionBuilder } from './transactionBuilder';
+import { Transaction } from './transaction';
+
+export class TransactionBuilderFactory extends BaseTransactionBuilderFactory {
+  constructor(_coinConfig: Readonly<CoinConfig>) {
+    super(_coinConfig);
+  }
+
+  /** @inheritdoc */
+  getWalletInitializationBuilder(tx?: Transaction): WalletInitializationBuilder {
+    return this.initializeBuilder(tx, new WalletInitializationBuilder(this._coinConfig));
+  }
+
+  /** @inheritDoc */
+  getTransferBuilder(tx?: Transaction): TransferBuilder {
+    return this.initializeBuilder(tx, new TransferBuilder(this._coinConfig));
+  }
+
+  /** @inheritDoc */
+  from(raw: Uint8Array | string): TransactionBuilder {
+    throw new NotImplementedError('from not implemented');
+  }
+
+  /**
+   * Initialize the builder with the given transaction
+   *
+   * @param {Transaction | undefined} tx - the transaction used to initialize the builder
+   * @param {TransactionBuilder} builder - the builder to be initialized
+   * @returns {TransactionBuilder} the builder initialized
+   */
+  private initializeBuilder<T extends TransactionBuilder>(tx: Transaction | undefined, builder: T): T {
+    throw new NotImplementedError('initializeBuilder not implemented');
+  }
+
+  /**
+   * Returns a transaction instance from the encoded value
+   *
+   * @param {Uint8Array | string} rawTransaction - encoded transaction
+   * @returns {Transaction} the parsed transaction instance
+   */
+  private parseTransaction(rawTransaction: Uint8Array | string): Transaction {
+    // we dont know if this this will be implemented yet
+    throw new NotImplementedError('parseTransaction not implemented');
+  }
+
+  /**
+   * Check the raw transaction has a valid format in the blockchain context, throw otherwise.
+   *
+   * @param {any} rawTransaction - Transaction in any format
+   */
+  private validateRawTransaction(rawTransaction: any) {
+    throw new NotImplementedError('parseTransaction not implemented');
+  }
+}

--- a/modules/account-lib/src/coin/cspr/transferBuilder.ts
+++ b/modules/account-lib/src/coin/cspr/transferBuilder.ts
@@ -1,0 +1,68 @@
+import { BaseCoin as CoinConfig } from '@bitgo/statics/dist/src/base';
+import { BuildTransactionError, NotImplementedError, SigningError } from '../baseCoin/errors';
+import { BaseKey } from '../baseCoin/iface';
+import { TransactionBuilder, DEFAULT_M } from './transactionBuilder';
+import { Transaction } from './transaction';
+
+export class TransferBuilder extends TransactionBuilder {
+  private _toAddress: string;
+  private _amount: string;
+
+  constructor(_coinConfig: Readonly<CoinConfig>) {
+    super(_coinConfig);
+  }
+
+  /** @inheritdoc */
+  protected async buildImplementation(): Promise<Transaction> {
+    throw new NotImplementedError('buildImplementation not implemented');
+  }
+
+  /** @inheritdoc */
+  initBuilder(tx: Transaction): void {
+    throw new NotImplementedError('initBuilder not implemented');
+  }
+
+  /** @inheritdoc */
+  protected signImplementation(key: BaseKey): Transaction {
+    throw new NotImplementedError('signImplementation not implemented');
+  }
+
+  //region Transfer fields
+  /**
+   * Set the destination address where the funds will be sent,
+   *
+   * @param {string} address the address to transfer funds to
+   * @returns {TransferBuilder} the builder with the new parameter set
+   */
+  to(address: string): this {
+    // TODO : isValidAddress
+    this._toAddress = address;
+    return this;
+  }
+
+  /**
+   * Set the amount to be transferred
+   *
+   * @param {string} amount amount to transfer
+   * @returns {TransferBuilder} the builder with the new parameter set
+   */
+  amount(amount: string): this {
+    // TODO : isValidAmount
+    this._amount = amount;
+    return this;
+  }
+
+  //endregion
+
+  //region Validators
+  validateMandatoryFields(): void {
+    if (this._toAddress === undefined) {
+      throw new BuildTransactionError('Invalid transaction: missing to');
+    }
+    if (this._amount === undefined) {
+      throw new BuildTransactionError('Invalid transaction: missing amount');
+    }
+    super.validateMandatoryFields();
+  }
+  //endregion
+}

--- a/modules/account-lib/src/coin/cspr/walletInitializationBuilder.ts
+++ b/modules/account-lib/src/coin/cspr/walletInitializationBuilder.ts
@@ -1,0 +1,60 @@
+import { BaseCoin as CoinConfig } from '@bitgo/statics/dist/src/base';
+import { BuildTransactionError, NotImplementedError } from '../baseCoin/errors';
+import { TransactionBuilder, DEFAULT_M } from './transactionBuilder';
+import { Transaction } from './transaction';
+
+export class WalletInitializationBuilder extends TransactionBuilder {
+  private _owners: string[] = [];
+
+  constructor(_coinConfig: Readonly<CoinConfig>) {
+    super(_coinConfig);
+  }
+
+  // region Base Builder
+  /** @inheritdoc */
+  protected async buildImplementation(): Promise<Transaction> {
+    throw new NotImplementedError('buildImplementation not implemented');
+  }
+
+  /** @inheritdoc */
+  initBuilder(tx: Transaction): void {
+    throw new NotImplementedError('initBuilder not implemented');
+  }
+
+  // endregion
+
+  // region Common builder methods
+  /**
+   * Set one of the owners of the multisig wallet.
+   *
+   * @param {string} address The public key of the owner's account
+   * @returns {WalletInitializationBuilder} This wallet initialization builder
+   */
+  owner(address: string): this {
+    if (this._owners.length >= DEFAULT_M) {
+      throw new BuildTransactionError('A maximum of ' + DEFAULT_M + ' owners can be set for a multisig wallet');
+    }
+    // TODO : isValidPublicKey
+    if (this._owners.includes(address)) {
+      throw new BuildTransactionError('Repeated owner address: ' + address);
+    }
+    this._owners.push(address);
+    return this;
+  }
+  // endregion
+
+  // region Validators
+  validateMandatoryFields(): void {
+    if (this._owners === undefined) {
+      throw new BuildTransactionError('Invalid transaction: missing wallet owners');
+    }
+
+    if (this._owners.length !== DEFAULT_M) {
+      throw new BuildTransactionError(
+        `Invalid transaction: wrong number of owners -- required: ${DEFAULT_M}, found: ${this._owners.length}`,
+      );
+    }
+    super.validateMandatoryFields();
+  }
+  // endregion
+}

--- a/modules/account-lib/test/resources/cspr/cspr.ts
+++ b/modules/account-lib/test/resources/cspr/cspr.ts
@@ -1,0 +1,33 @@
+export const ACCOUNT_1 = {
+  accountHash: '019764f079d02768d704f286da630a1d3c7329330596c9561d403bed2d43c0e0c8',
+  publicKey: 'MCowBQYDK2VwAyEAl2TwedAnaNcE8obaYwodPHMpMwWWyVYdQDvtLUPA4Mg=',
+  privateKey: 'MC4CAQAwBQYDK2VwBCIEIG+yNyAN9sInKfXR2GOH5UN/f5a4bx/VL11lxW58wbRP',
+};
+
+export const INVALID_KEYPAIR_PRV = '';
+
+export const KEYPAIR_PRV = '';
+
+export const WALLET_TXDATA = '';
+
+export const WALLET_SIGNED_TRANSACTION = '';
+
+export const ACCOUNT_2 = {
+  accountHash: '01e5c0f10bcc9197acc0567eb06de9ed6f1bf408194726bd2bcb603692b23b4817',
+  publicKey: 'MCowBQYDK2VwAyEA5cDxC8yRl6zAVn6wbentbxv0CBlHJr0ry2A2krI7SBc=',
+  privateKey: 'MC4CAQAwBQYDK2VwBCIEIKAsNy6nMQFjyM/h6+zf8bgfDZplwjRzLFYs1WWSf+UH',
+};
+
+export const ACCOUNT_3 = {
+  accountHash: '0148ee479d0c677aecaab99a07558b39bd8064fd6acf97941f735e02c20fedfd44',
+  publicKey: 'MCowBQYDK2VwAyEASO5HnQxneuyquZoHVYs5vYBk/WrPl5Qfc14Cwg/t/UQ=',
+  privateKey: 'MC4CAQAwBQYDK2VwBCIEINISlL9FR1rzdcH1P1prLyemk1F+Z/XdVBOrDntE3lrt',
+};
+
+export const FEE = '123';
+
+export const SIGNED_TRANSFER_TRANSACTION = '';
+
+export const THREE_TIMES_SIGNED_TRANSACTION = '';
+
+export const NON_SIGNED_TRANSFER_TRANSACTION = '';

--- a/modules/account-lib/test/unit/coin/cspr/transaction.ts
+++ b/modules/account-lib/test/unit/coin/cspr/transaction.ts
@@ -1,0 +1,41 @@
+import should from 'should';
+import { coins } from '@bitgo/statics';
+import { Transaction } from '../../../../src/coin/cspr/transaction';
+
+describe('Cspr Transaction', () => {
+  const coin = coins.get('tcspr');
+
+  const getTransaction = (): Transaction => {
+    return new Transaction(coin);
+  };
+
+  it('should throw empty transaction', () => {
+    const tx = getTransaction();
+    should.throws(() => {
+      tx.toJson();
+    });
+    should.throws(() => {
+      tx.toBroadcastFormat();
+    });
+  });
+
+  describe('should sign if transaction is', () => {
+    it('invalid', function() {
+      // TODO
+    });
+
+    it('valid', async () => {
+      // TODO
+    });
+
+    it('multiple valid', async () => {
+      // TODO
+    });
+  });
+
+  describe('should return encoded tx', function() {
+    it('valid sign', async function() {
+      // TODO
+    });
+  });
+});

--- a/modules/account-lib/test/unit/coin/cspr/transactionBuilder/transferBuilder.ts
+++ b/modules/account-lib/test/unit/coin/cspr/transactionBuilder/transferBuilder.ts
@@ -1,0 +1,92 @@
+import should from 'should';
+import { register } from '../../../../../src/index';
+import { TransactionBuilderFactory } from '../../../../../src/coin/cspr/';
+import * as testData from '../../../../resources/cspr/cspr';
+
+describe('Casper Transfer Builder', () => {
+  const factory = register('tcspr', TransactionBuilderFactory);
+  it('get transfer builder', () => {
+    should.throws(() => {
+      factory.getTransferBuilder();
+    });
+  });
+
+  describe('Not yet implemented functionality', () => {
+    const initTxBuilder = () => {
+      const txBuilder = factory.getTransferBuilder();
+      txBuilder.fee({ fee: testData.FEE });
+      txBuilder.source({ address: testData.ACCOUNT_1.accountHash });
+      txBuilder.to(testData.ACCOUNT_2.accountHash);
+      txBuilder.amount('10');
+      return txBuilder;
+    };
+
+    describe('should build ', () => {
+      describe('non serialized transactions', () => {
+        it('a signed transfer transaction', async () => {
+          // TODO
+        });
+
+        it('a transfer transaction signed multiple times', async () => {
+          // TODO
+        });
+
+        it('a transfer transaction with amount 0', async () => {
+          // TODO
+        });
+
+        it('a non signed transfer transaction', async () => {
+          // TODO
+        });
+      });
+
+      describe('serialized transactions', () => {
+        it('a non signed transfer transaction from serialized', async () => {
+          // TODO
+        });
+
+        it('a signed transfer transaction from serilaized', async () => {
+          // TODO
+        });
+
+        it('an offline multisig transfer transaction', async () => {
+          // TODO
+        });
+      });
+    });
+
+    describe('should fail', () => {
+      it('a transfer transaction with an invalid key', () => {
+        // TODO
+      });
+
+      it('a transfer transaction with more signatures than allowed', () => {
+        // TODO
+      });
+
+      it('a transfer transaction with repeated sign', () => {
+        // TODO
+      });
+
+      it('a transfer transaction with an invalid destination address', () => {
+        // TODO
+      });
+
+      it('a transfer transaction with an invalid amount: text value', () => {
+        // TODO
+      });
+
+      it('a transfer transaction with an invalid amount: negative value', () => {
+        // TODO
+      });
+
+      it('a transfer transaction without destination param', async () => {
+        // TODO
+      });
+
+      it('a transfer transaction without amount', async () => {
+        // TODO
+      });
+    });
+  });
+});

--- a/modules/account-lib/test/unit/coin/cspr/transactionBuilder/walletInitialization.ts
+++ b/modules/account-lib/test/unit/coin/cspr/transactionBuilder/walletInitialization.ts
@@ -1,0 +1,12 @@
+import should from 'should';
+import { register } from '../../../../../src/index';
+import { TransactionBuilderFactory } from '../../../../../src/coin/cspr/';
+
+describe('Casper Wallet Initialization Builder', () => {
+  const factory = register('tcspr', TransactionBuilderFactory);
+  it('get wallet init builder', () => {
+    should.throws(() => {
+      factory.getWalletInitializationBuilder();
+    });
+  });
+});


### PR DESCRIPTION
Add casper coin skeleton structure, this include transactions skeletons, keyPair, index and finally
some unit test

This PR Add casper coin skeleton structure, this include transactions skeletons, keyPair, index and finally
some unit test

## Changes:
- Add transactions skeleton files
- Add keyPair skeleton file
- Add tentative unit tests

## Authors
- silvialvado
- ipelaez-simtlix
- FabianSimtlix

SimTLiX ticket: https://simtlix.atlassian.net/browse/BGA-655