### PR TITLE
feat(eth2): add signMessage for ETH2

### DIFF
--- a/modules/account-lib/src/coin/baseCoin/blsKeyPair.ts
+++ b/modules/account-lib/src/coin/baseCoin/blsKeyPair.ts
@@ -1,4 +1,6 @@
+import assert from 'assert';
 import * as BLS from '@bitgo/bls';
+import { stripHexPrefix } from 'ethereumjs-util';
 import { BaseKeyPair } from './baseKeyPair';
 import { AddressFormat } from './enum';
 import { NotImplementedError } from './errors';
@@ -66,6 +68,15 @@ export abstract class BlsKeyPair implements BaseKeyPair {
   }
 
   /**
+   * Signs bytes using the key pair
+   * @param msg The message bytes to sign
+   * @return signature of the bytes using this keypair
+   */
+  sign(msg: Buffer): Buffer {
+    return BLS.sign(this.keyPair.privateKey.toBytes(), msg);
+  }
+
+  /**
    * Whether the input is a valid BLS private key
    *
    * @param {string} prv A hexadecimal public key to validate
@@ -104,5 +115,19 @@ export abstract class BlsKeyPair implements BaseKeyPair {
     } catch (e) {
       throw new Error('Error aggregating pubkeys: ' + e);
     }
+  }
+
+
+  /**
+   * Verifies the signature for this key pair
+   * @param pub The public key with which to verify the signature
+   * @param msg The message to verify the signature with
+   * @param signature the signature to verify
+   * @return true if the signature is valid, else false
+   */
+  public static verifySignature(pub: string, msg: Buffer, signature: Buffer): boolean {
+    ensureInitialized();
+    assert(BlsKeyPair.isValidBLSPub(pub), `Invalid public key: ${pub}`);
+    return BLS.verify(Buffer.from(stripHexPrefix(pub), 'hex'), msg, signature);
   }
 }

--- a/modules/account-lib/test/unit/coin/eth2/keyPair.ts
+++ b/modules/account-lib/test/unit/coin/eth2/keyPair.ts
@@ -128,17 +128,15 @@ describe('Eth2 Key Pair', () => {
   });
 
   describe('Signatures', () => {
-    it('should accept 2-of-2 aggregated signature', () => {
+    it('should accept 2-of-2 aggregated signature', async () => {
       const msg = Buffer.from('test message');
       const keyPair1 = new KeyPair();
       const pub1 = Uint8Array.from(Buffer.from(keyPair1.getKeys().pub.slice(2), 'hex'));
-      const sec1 = Uint8Array.from(Buffer.from(keyPair1.getKeys().prv!.slice(2), 'hex'));
-      const sig1 = BLS.sign(sec1, msg);
+      const sig1 = keyPair1.sign(msg);
 
       const keyPair2 = new KeyPair();
       const pub2 = Uint8Array.from(Buffer.from(keyPair2.getKeys().pub.slice(2), 'hex'));
-      const sec2 = Uint8Array.from(Buffer.from(keyPair2.getKeys().prv!.slice(2), 'hex'));
-      const sig2 = BLS.sign(sec2, msg);
+      const sig2 = keyPair2.sign(msg);
 
       const aggregatedKey = KeyPair.aggregatePubkeys([pub1, pub2]);
       const aggregatedSig = BLS.aggregateSignatures([sig1, sig2]);
@@ -146,12 +144,11 @@ describe('Eth2 Key Pair', () => {
       BLS.verify(aggregatedKey, msg, aggregatedSig).should.be.true();
     });
 
-    it('should reject 1-of-2 aggregated signature', () => {
+    it('should reject 1-of-2 aggregated signature', async () => {
       const msg = Buffer.from('test message');
       const keyPair1 = new KeyPair();
       const pub1 = Uint8Array.from(Buffer.from(keyPair1.getKeys().pub.slice(2), 'hex'));
-      const sec1 = Uint8Array.from(Buffer.from(keyPair1.getKeys().prv!.slice(2), 'hex'));
-      const sig1 = BLS.sign(sec1, msg);
+      const sig1 = keyPair1.sign(msg);
 
       const keyPair2 = new KeyPair();
       const pub2 = Uint8Array.from(Buffer.from(keyPair2.getKeys().pub.slice(2), 'hex'));
@@ -159,8 +156,8 @@ describe('Eth2 Key Pair', () => {
       const aggregatedKey = KeyPair.aggregatePubkeys([pub1, pub2]);
       const aggregatedSig = BLS.aggregateSignatures([sig1]);
 
-      BLS.verify(aggregatedKey, msg, aggregatedSig).should.be.false();
-      BLS.verify(aggregatedKey, msg, sig1).should.be.false();
+      KeyPair.verifySignature(aggregatedKey.toString('hex'), msg, aggregatedSig).should.be.false();
+      KeyPair.verifySignature(aggregatedKey.toString('hex'), msg, sig1).should.be.false();
     });
   });
 });

--- a/modules/core/src/v2/coins/eth2.ts
+++ b/modules/core/src/v2/coins/eth2.ts
@@ -344,4 +344,21 @@ export class Eth2 extends BaseCoin {
   verifyTransaction(params: VerifyTransactionOptions, callback?: NodeCallback<boolean>): Bluebird<boolean> {
     return Bluebird.resolve(true).asCallback(callback);
   }
+
+  /**
+   * Sign message with private key
+   *
+   * @param key
+   * @param message
+   * @param callback
+   */
+  signMessage(key: { prv: string }, message: string, callback?: NodeCallback<Buffer>): Bluebird<Buffer> {
+    return co<Buffer>(function* cosignMessage() {
+      const keyPair = new Eth2AccountLib.KeyPair();
+      keyPair.recordKeysFromPrivateKey(key.prv);
+      return keyPair.sign(Buffer.from(message));
+    })
+      .call(this)
+      .asCallback(callback);
+  }
 }

--- a/modules/core/test/v2/unit/coins/eth2.ts
+++ b/modules/core/test/v2/unit/coins/eth2.ts
@@ -1,3 +1,5 @@
+import { Eth2 as Eth2AccountLib } from '@bitgo/account-lib';
+
 import { TestBitGo } from '../../../lib/test_bitgo';
 import { Eth2, Teth2 } from '../../../../src/v2/coins';
 
@@ -56,5 +58,25 @@ describe('Ethereum 2.0', function() {
     const prv = Uint8Array.from(Buffer.from('', 'hex'));
     const localBaseCoin = bitgo.coin('teth2');
     (function() {localBaseCoin.generateKeyPair(prv);}).should.throw();
+  });
+
+  describe('Sign message:', () => {
+    it('should sign and validate a string message', async function() {
+      const keyPair = basecoin.generateKeyPair();
+      const message = 'hello world';
+      const signature = await basecoin.signMessage(keyPair, message);
+
+      Eth2AccountLib.KeyPair.verifySignature(keyPair.pub, Buffer.from(message), signature).should.be.true();
+    });
+
+    it('should fail to validate a string message with wrong public key', async function() {
+      const keyPair = basecoin.generateKeyPair();
+      const message = 'hello world';
+      const signature = await basecoin.signMessage(keyPair, message);
+
+      const otherKeyPair = basecoin.generateKeyPair();
+
+      Eth2AccountLib.KeyPair.verifySignature(otherKeyPair.pub, Buffer.from(message), signature).should.be.false();
+    });
   });
 });


### PR DESCRIPTION
This commit implements the signMessage functionality for ETH2 so that we can perform key signatures
while generating wallets