### PR TITLE
Fix ETH2 lib initialization and key signatures

### DIFF
--- a/modules/account-lib/src/coin/baseCoin/blsKeyPair.ts
+++ b/modules/account-lib/src/coin/baseCoin/blsKeyPair.ts
@@ -11,9 +11,7 @@ const initialize = async () => {
   initialized = true;
 };
 
-setImmediate(async () => {
-  await initialize();
-});
+initialize();
 
 function ensureInitialized() {
   if (!initialized) {


### PR DESCRIPTION
This commit fixes the key signatures by parsing the keys as hex rather
than utf-8, and fixes the BLS lib initialization by removing
setImmediate

CLOSES TICKET: BG-27361