### PR TITLE
feat(accountlib): BGA-656 Implement KeyPair Generation and Unit Tests

### DIFF
--- a/modules/account-lib/package.json
+++ b/modules/account-lib/package.json
@@ -45,6 +45,7 @@
     "bignumber.js": "^9.0.0",
     "blake2b": "git+https://github.com/BitGo/blake2b.git#6268e6dd678661e0acc4359e9171b97eb1ebf8ac",
     "bs58check": "^2.1.2",
+    "casper-client-sdk": "^1.0.7",
     "elliptic": "^6.5.2",
     "ethereumjs-abi": "^0.6.5",
     "ethereumjs-tx": "2.1.2",

--- a/modules/account-lib/src/coin/cspr/keyPair.ts
+++ b/modules/account-lib/src/coin/cspr/keyPair.ts
@@ -1,8 +1,12 @@
-import { Ed25519KeyPair } from '../baseCoin/ed25519KeyPair';
-import { KeyPairOptions, DefaultKeys } from '../baseCoin/iface';
-import { NotImplementedError } from '../baseCoin/errors';
+import { randomBytes } from 'crypto';
+import { HDNode } from '@bitgo/utxo-lib';
+import { Keys } from 'casper-client-sdk';
+import { KeyPairOptions, DefaultKeys, isPrivateKey, isPublicKey, isSeed } from '../baseCoin/iface';
+import { Secp256k1ExtendedKeyPair } from '../baseCoin/secp256k1ExtendedKeyPair';
 
-export class KeyPair extends Ed25519KeyPair {
+const DEFAULT_SEED_SIZE_BYTES = 16;
+
+export class KeyPair extends Secp256k1ExtendedKeyPair {
   /**
    * Public constructor. By default, creates a key pair with a random master seed.
    *
@@ -10,34 +14,65 @@ export class KeyPair extends Ed25519KeyPair {
    */
   constructor(source?: KeyPairOptions) {
     super(source);
+    if (!source) {
+      const seed = randomBytes(DEFAULT_SEED_SIZE_BYTES);
+      this.hdNode = HDNode.fromSeedBuffer(seed);
+    } else if (isSeed(source)) {
+      this.hdNode = HDNode.fromSeedBuffer(source.seed);
+    } else if (isPrivateKey(source)) {
+      this.recordKeysFromPrivateKey(source.prv);
+    } else if (isPublicKey(source)) {
+      this.recordKeysFromPublicKey(source.pub);
+    } else {
+      throw new Error('Invalid key pair options');
+    }
+
+    if (this.hdNode) {
+      this.keyPair = this.hdNode.keyPair;
+    }
   }
 
   /**
    * Default keys format is a pair of Uint8Array keys
    *
-   * @param {boolean} raw defines if the key is returned in raw or protocol default format
    * @returns { DefaultKeys } The keys in the defined format
    */
-  getKeys(raw = false) {
-    throw new NotImplementedError('getKeys not implemented');
+  getKeys() {
+    if (this.hdNode) {
+      const { xpub, xprv } = this.getExtendedKeys();
+      return {
+        pub: HDNode.fromBase58(xpub)
+          .getPublicKeyBuffer()
+          .toString('hex')
+          .toUpperCase(),
+        prv: xprv
+          ? HDNode.fromBase58(xprv)
+              .keyPair.getPrivateKeyBuffer()
+              .toString('hex')
+              .toUpperCase()
+          : undefined,
+      };
+    } else {
+      return {
+        pub: this.keyPair.Q.getEncoded(true)
+          .toString('hex')
+          .toUpperCase(),
+        prv: this.keyPair.d
+          ? this.keyPair.d
+              .toBuffer(32)
+              .toString('hex')
+              .toUpperCase()
+          : undefined,
+      };
+    }
   }
 
   /** @inheritdoc */
-  getAddress(format?: string): string {
-    throw new NotImplementedError('getKeys not implemented');
-  }
-
-  /** @inheritdoc */
-  recordKeysFromPublicKeyInProtocolFormat(pub: string): DefaultKeys {
-    throw new NotImplementedError('recordKeysFromPublicKeyInProtocolFormat not implemented');
-  }
-
-  /** @inheritdoc */
-  recordKeysFromPrivateKeyInProtocolFormat(prv: string): DefaultKeys {
-    throw new NotImplementedError('recordKeysFromPrivateKeyInProtocolFormat not implemented');
-  }
-
-  generateKeyFromSeed() {
-    throw new NotImplementedError('generateKeyFromSeed not implemented');
+  getAddress(): string {
+    const keys = this.getKeys();
+    const publicKey = Buffer.from(keys.pub); // first two characters identify a public key
+    const privateKey = keys.prv ? Buffer.from(keys.prv) : undefined;
+    const accountHashByArray = new Keys.Secp256K1(publicKey, privateKey!).accountHash();
+    return Buffer.from(accountHashByArray).toString('hex');
   }
 }

--- a/modules/account-lib/src/index.ts
+++ b/modules/account-lib/src/index.ts
@@ -31,6 +31,9 @@ export { Celo };
 import * as Hbar from './coin/hbar';
 export { Hbar };
 
+import * as Cspr from './coin/cspr';
+export { Cspr };
+
 const coinBuilderMap = {
   trx: Trx.TransactionBuilder,
   ttrx: Trx.TransactionBuilder,
@@ -47,6 +50,8 @@ const coinBuilderMap = {
   tcelo: Celo.TransactionBuilder,
   hbar: Hbar.TransactionBuilderFactory,
   thbar: Hbar.TransactionBuilderFactory,
+  cspr: Cspr.TransactionBuilderFactory,
+  tcspr: Cspr.TransactionBuilderFactory,
 };
 
 /**

--- a/modules/account-lib/test/resources/cspr/cspr.ts
+++ b/modules/account-lib/test/resources/cspr/cspr.ts
@@ -1,16 +1,19 @@
+export const ACCOUNT_FROM_SEED = {
+  seed: 'cd1eac3bc52716f3177bc7f9c5d7de10b98c74c6c1ace2c874e0e09f47469023',
+  accountHash: 'f068b89fbd03587a1bedb79ead98d1c8f4c2f3181a6eddbc10ae98d0dd874e94',
+  xPublicKey:
+    'xpub661MyMwAqRbcEzDE55AJUGhMKJJ2nw1hnF1fBoaw2T47DQsJzhLXbygpggTXpkWPVENnzPYbgLRVPtmwjQQAiY9AbHX5Ys4KpLRuFtVNFtC',
+  xPrivateKey:
+    'xprv9s21ZrQH143K2W8ky3dJ78kcmGTYPUHrR264PRBKU7X8LcYATA2H4BNLqNDYi4mhSiJXRUAttHaJYBynN7iMU2vkJjEG4SK6xVJkymYUEyG',
+  publicKey: '03DC13CBBF29765C7745578D9E091280522F37684EF0E400B86B1C409BC454F1F3',
+  privateKey: '353ED4C9DB2A13B8EB319618EAF7A61DC5AB74AF79020C9C21D06E768A6D3E24',
+};
+
 export const ACCOUNT_1 = {
   accountHash: '019764f079d02768d704f286da630a1d3c7329330596c9561d403bed2d43c0e0c8',
   publicKey: 'MCowBQYDK2VwAyEAl2TwedAnaNcE8obaYwodPHMpMwWWyVYdQDvtLUPA4Mg=',
   privateKey: 'MC4CAQAwBQYDK2VwBCIEIG+yNyAN9sInKfXR2GOH5UN/f5a4bx/VL11lxW58wbRP',
 };
-
-export const INVALID_KEYPAIR_PRV = '';
-
-export const KEYPAIR_PRV = '';
-
-export const WALLET_TXDATA = '';
-
-export const WALLET_SIGNED_TRANSACTION = '';
 
 export const ACCOUNT_2 = {
   accountHash: '01e5c0f10bcc9197acc0567eb06de9ed6f1bf408194726bd2bcb603692b23b4817',
@@ -18,16 +21,12 @@ export const ACCOUNT_2 = {
   privateKey: 'MC4CAQAwBQYDK2VwBCIEIKAsNy6nMQFjyM/h6+zf8bgfDZplwjRzLFYs1WWSf+UH',
 };
 
-export const ACCOUNT_3 = {
-  accountHash: '0148ee479d0c677aecaab99a07558b39bd8064fd6acf97941f735e02c20fedfd44',
-  publicKey: 'MCowBQYDK2VwAyEASO5HnQxneuyquZoHVYs5vYBk/WrPl5Qfc14Cwg/t/UQ=',
-  privateKey: 'MC4CAQAwBQYDK2VwBCIEINISlL9FR1rzdcH1P1prLyemk1F+Z/XdVBOrDntE3lrt',
-};
-
 export const FEE = '123';
 
-export const SIGNED_TRANSFER_TRANSACTION = '';
+export const INVALID_SHORT_KEYPAIR_KEY = '82A34E';
 
-export const THREE_TIMES_SIGNED_TRANSACTION = '';
+export const INVALID_LONG_KEYPAIR_PRV = ACCOUNT_FROM_SEED.privateKey + 'F1';
 
-export const NON_SIGNED_TRANSFER_TRANSACTION = '';
+export const INVALID_PRIVATE_KEY_ERROR_MESSAGE = 'Unsupported private key';
+
+export const INVALID_PUBLIC_KEY_ERROR_MESSAGE = 'Unsupported public key:';

--- a/modules/account-lib/test/unit/coin/cspr/keyPair.ts
+++ b/modules/account-lib/test/unit/coin/cspr/keyPair.ts
@@ -1,0 +1,155 @@
+import should from 'should';
+import * as nacl from 'tweetnacl';
+import { KeyPair } from '../../../../src/coin/cspr';
+import * as testData from '../../../resources/cspr/cspr';
+
+const xPubKey = testData.ACCOUNT_FROM_SEED.xPublicKey;
+const xPrvKey = testData.ACCOUNT_FROM_SEED.xPrivateKey;
+const pubKey = testData.ACCOUNT_FROM_SEED.publicKey;
+const prvKey = testData.ACCOUNT_FROM_SEED.privateKey;
+const accountHash = testData.ACCOUNT_FROM_SEED.accountHash;
+const accountSeed = testData.ACCOUNT_FROM_SEED.seed;
+
+describe('Casper Key Pair', () => {
+
+  describe('should create a valid KeyPair', () => {
+    it('from an empty value', () => {
+      const keyPair = new KeyPair();
+      should.exists(keyPair.getKeys().prv);
+      should.exists(keyPair.getKeys().pub);
+      should.equal(keyPair.getKeys().prv!.length, 64);
+      should.equal(keyPair.getKeys().pub.length, 66);
+    });
+
+    it('from a seed', () => {
+      const keyPair = new KeyPair({ seed: Buffer.from(accountSeed) });
+      should.equal(keyPair.getKeys().prv!, prvKey);
+      should.equal(keyPair.getKeys().pub, pubKey);
+    });
+
+    it('from a public key', () => {
+      const keyPair = new KeyPair({ pub: pubKey });
+      should.equal(keyPair.getKeys().pub, pubKey);
+    });
+
+    it('from a private key', () => {
+      const keyPair = new KeyPair({ prv: prvKey });
+      should.equal(keyPair.getKeys().prv!, prvKey);
+      should.equal(keyPair.getKeys().pub, pubKey);
+    });
+
+    it('from an xpub', () => {
+      const keyPair = new KeyPair({ pub: xPubKey });
+      const keys = keyPair.getKeys();
+      should.not.exist(keys.prv);
+      should.equal(keys.pub, pubKey);
+
+      const extendedKeys = keyPair.getExtendedKeys();
+      should.not.exist(extendedKeys.xprv);
+      should.equal(extendedKeys.xpub, xPubKey);
+    });
+
+    it('from an xprv', () => {
+      const keyPair = new KeyPair({ prv: xPrvKey });
+      const keys = keyPair.getKeys();
+      should.equal(keys.prv, prvKey);
+      should.equal(keys.pub, pubKey);
+
+      const extendedKeys = keyPair.getExtendedKeys();
+      should.equal(extendedKeys.xprv, xPrvKey);
+      should.equal(extendedKeys.xpub, xPubKey);
+    });
+
+    it('from seed', () => {
+      const seed = nacl.randomBytes(32);
+      const keyPair = new KeyPair({ seed: Buffer.from(seed) });
+      keyPair.getKeys().should.have.property('pub');
+      keyPair.getKeys().should.have.property('prv');
+    });
+
+    it('without source', () => {
+      const keyPair = new KeyPair();
+      keyPair.getKeys().should.have.property('pub');
+      keyPair.getKeys().should.have.property('prv');
+    });
+  });
+
+  describe('should get address ', () => {
+    it('from a private key', () => {
+      const keyPair = new KeyPair({ prv: prvKey });
+      should.equal(keyPair.getAddress(), accountHash);
+    });
+
+    it('from a public key', () => {
+      const keyPair = new KeyPair({ pub: pubKey });
+      should.equal(keyPair.getAddress(), accountHash);
+    });
+
+    it('should get an address from xpub', () => {
+      const keyPair = new KeyPair({ pub: xPubKey });
+      should.equal(keyPair.getAddress(), accountHash);
+    });
+
+    it('should get an address from prv', () => {
+      const keyPair = new KeyPair({ prv: xPrvKey });
+      should.equal(keyPair.getAddress(), accountHash);
+    });
+
+    it('from a seed', () => {
+      const keyPair = new KeyPair({ seed: Buffer.from(accountSeed) });
+      should.equal(keyPair.getAddress(), accountHash);
+    });
+  });
+
+  describe('getExtendedKeys', function() {
+    it('should get the keys in extended format from xprv', () => {
+      const keyPair = new KeyPair({ prv: xPrvKey });
+      const { xprv: calculatedXprv, xpub: calculatedXpub } = keyPair.getExtendedKeys();
+      calculatedXprv!.should.equal(xPrvKey);
+      calculatedXpub.should.equal(xPubKey);
+    });
+
+    it('should get the keys in extended format from xpub', () => {
+      const keyPair = new KeyPair({ pub: xPubKey });
+      const { xprv: calculatedXprv, xpub: calculatedXpub } = keyPair.getExtendedKeys();
+      should.not.exist(calculatedXprv);
+      calculatedXpub.should.equal(xPubKey);
+    });
+
+    it('should not be able to get keys from prv', () => {
+      const keyPair = new KeyPair({ prv: prvKey });
+      should.throws(() => keyPair.getExtendedKeys());
+    });
+
+    it('should get the keys in extended format from pub', () => {
+      const keyPair = new KeyPair({ pub: pubKey });
+      should.throws(() => keyPair.getExtendedKeys());
+    });
+  });
+
+  describe('should fail to create a KeyPair', () => {
+    it('from an invalid public key', () => {
+      should.throws(
+        () => new KeyPair({ pub: testData.INVALID_SHORT_KEYPAIR_KEY }),
+        e => e.message.includes(testData.INVALID_PUBLIC_KEY_ERROR_MESSAGE),
+      );
+    });
+
+    it('from an invalid private key', () => {
+      should.throws(
+        () => new KeyPair({ prv: testData.INVALID_SHORT_KEYPAIR_KEY }),
+        e => e.message === testData.INVALID_PRIVATE_KEY_ERROR_MESSAGE,
+      );
+      should.throws(
+        () => {
+          new KeyPair({ prv: testData.INVALID_LONG_KEYPAIR_PRV });
+        },
+        e => e.message === testData.INVALID_PRIVATE_KEY_ERROR_MESSAGE,
+      );
+      should.throws(
+        () => new KeyPair({ prv: prvKey + pubKey }),
+        e => e.message === testData.INVALID_PRIVATE_KEY_ERROR_MESSAGE,
+      );
+    });
+  });
+});


### PR DESCRIPTION
BGA-656 KeyPair Generation Implemented along with Unit Tests.

**Notes**:
- @bitgo/statics version has been updated to 6.1.0-rc.1 since it's required for unit tests in this task. Previous version was v6.0.0.
- Build is failing in drone due to a version issue with secp256k1 lib between BitGoJs and casper-client.