### PR TITLE
feat: update secp256k1 in core to ^4

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -86,6 +86,7 @@
     "@types/mocha": "^5.2.6",
     "@types/nock": "^9.3.1",
     "@types/node": "^11.11.4",
+    "@types/secp256k1": "^4.0.1",
     "@types/sinon": "^7.0.6",
     "@types/stellar-sdk": "^0.11.1",
     "@typescript-eslint/eslint-plugin": "^1.4.2",
@@ -130,7 +131,7 @@
     "ethereumjs-abi": "^0.6.5",
     "ethereumjs-tx": "^1.3.7",
     "ethereumjs-util": "^4.4.1",
-    "secp256k1": "^3.6.1"
+    "secp256k1": "^4.0.2"
   },
   "nyc": {
     "extension": [

--- a/modules/core/src/v2/coins/eth.ts
+++ b/modules/core/src/v2/coins/eth.ts
@@ -1179,7 +1179,7 @@ export class Eth extends BaseCoin {
       ]);
 
       const userReqSig = optionalDeps.ethUtil.addHexPrefix(
-        secp256k1.sign(hopDigest, userPrvBuffer).signature.toString('hex')
+        Buffer.from(secp256k1.ecdsaSign(hopDigest, userPrvBuffer).signature).toString('hex')
       );
 
       const result: HopParams = {
@@ -1222,7 +1222,8 @@ export class Eth extends BaseCoin {
       const signatureBuffer: Buffer = Buffer.from(optionalDeps.ethUtil.stripHexPrefix(signature), 'hex');
       const messageBuffer: Buffer = Buffer.from(optionalDeps.ethUtil.stripHexPrefix(id), 'hex');
 
-      const isValidSignature: boolean = secp256k1.verify(messageBuffer, signatureBuffer.slice(1), serverPubkeyBuffer);
+      const sig = new Uint8Array(signatureBuffer.slice(1));
+      const isValidSignature: boolean = secp256k1.ecdsaVerify(sig, messageBuffer, serverPubkeyBuffer);
       if (!isValidSignature) {
         throw new Error(`Hop txid signature invalid`);
       }

--- a/modules/core/test/v2/unit/ethWallet.ts
+++ b/modules/core/test/v2/unit/ethWallet.ts
@@ -79,7 +79,7 @@ describe('Ethereum Hop Transactions', co(function *() {
     const bitgoKey = bitGoUtxoLib.HDNode.fromBase58(bitgoKeyXprv);
     const bitgoPrvBuffer = bitgoKey.getKey().getPrivateKeyBuffer();
     const bitgoXpub = bitgoKey.neutered().toBase58();
-    bitgoSignature = '0xaa' + secp256k1.sign(Buffer.from(txid.slice(2), 'hex'), bitgoPrvBuffer).signature.toString('hex');
+    bitgoSignature = '0xaa' + Buffer.from(secp256k1.ecdsaSign(Buffer.from(txid.slice(2), 'hex'), bitgoPrvBuffer).signature).toString('hex');
 
     env = 'test';
     bitgo = new TestBitGo({ env });
@@ -172,7 +172,7 @@ describe('Ethereum Hop Transactions', co(function *() {
       const badTxidBuffer = Buffer.from(badTxid.slice(2), 'hex');
       const xprvNode = bitGoUtxoLib.HDNode.fromBase58(bitgoKeyXprv);
 
-      const badSignature = '0xaa' + secp256k1.sign(badTxidBuffer, xprvNode.getKey().getPrivateKeyBuffer()).signature.toString('hex');
+      const badSignature = '0xaa' + Buffer.from(secp256k1.ecdsaSign(badTxidBuffer, xprvNode.getKey().getPrivateKeyBuffer()).signature).toString('hex');
       const badPrebuild = JSON.parse(JSON.stringify(prebuild));
       badPrebuild.signature = badSignature;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2158,6 +2158,13 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
+"@types/secp256k1@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/secp256k1/-/secp256k1-4.0.1.tgz#fb3aa61a1848ad97d7425ff9dcba784549fca5a4"
+  integrity sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==
+  dependencies:
+    "@types/node" "*"
+
 "@types/serve-static@*":
   version "1.13.4"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.4.tgz#6662a93583e5a6cabca1b23592eb91e12fa80e7c"
@@ -3044,6 +3051,11 @@ base64-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
   integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
 
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 base64id@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/base64id/-/base64id-2.0.0.tgz#2770ac6bc47d312af97a8bf9a634342e0cd25cb6"
@@ -3599,13 +3611,21 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-buffer@^5.0.5, buffer@^5.1.0, buffer@^5.2.1, buffer@^5.4.3, buffer@^5.5.0, buffer@^5.6.0:
+buffer@^5.0.5, buffer@^5.1.0, buffer@^5.2.1, buffer@^5.4.3, buffer@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
   integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
+
+buffer@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
 
 bufferutil@^3.0.5:
   version "3.0.5"
@@ -7612,6 +7632,11 @@ ieee-float@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/ieee-float/-/ieee-float-0.6.0.tgz#a68a856ba1ef511e7fa0e7e7e155c3a63642a55d"
   integrity sha1-poqFa6HvUR5/oOfn4VXDpjZCpV0=
+
+ieee754@^1.1.13:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ieee754@^1.1.4, ieee754@^1.1.8:
   version "1.1.13"
@@ -12272,7 +12297,7 @@ scryptsy@^2.1.0:
   resolved "https://registry.yarnpkg.com/scryptsy/-/scryptsy-2.1.0.tgz#8d1e8d0c025b58fdd25b6fa9a0dc905ee8faa790"
   integrity sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w==
 
-secp256k1@^3.0.1, secp256k1@^3.5.2, secp256k1@^3.6.1:
+secp256k1@^3.0.1, secp256k1@^3.5.2:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-3.8.0.tgz#28f59f4b01dbee9575f56a47034b7d2e3b3b352d"
   integrity sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==
@@ -12286,7 +12311,7 @@ secp256k1@^3.0.1, secp256k1@^3.5.2, secp256k1@^3.6.1:
     nan "^2.14.0"
     safe-buffer "^5.1.2"
 
-secp256k1@^4.0.0:
+secp256k1@^4.0.0, secp256k1@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-4.0.2.tgz#15dd57d0f0b9fdb54ac1fa1694f40e5e9a54f4a1"
   integrity sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==


### PR DESCRIPTION
The library needed to support casper in account-lib requires
@types/secp256k1@4, but this causes type errors when compiling core,
since it uses a much older version.

This PR updates secp256k1 to 4.0.2, and fixes all issues caused by
breaking changes in the new major version.

Ticket: BG-27646