### PR TITLE
Enable batching eth transfers

### DIFF
--- a/modules/core/src/v2/coins/eth.ts
+++ b/modules/core/src/v2/coins/eth.ts
@@ -107,6 +107,7 @@ interface SignFinalOptions {
     nextContractSequenceId?: number;
     hopTransaction?: string;
     backupKeyNonce?: number;
+    isBatch?: boolean;
   };
   signingKeyNonce: number;
   walletContractAddress: string;
@@ -593,6 +594,7 @@ export class Eth extends BaseCoin {
       const signature = Util.ethSignMsgHash(operationHash, Util.xprvToEthPrivateKey(userPrv));
 
       const txParams = {
+        isBatch: params.txPrebuild.isBatch,
         recipients: params.recipients,
         expireTime: expireTime,
         contractSequenceId: sequenceId,

--- a/modules/core/test/v2/integration/coins/eth.ts
+++ b/modules/core/test/v2/integration/coins/eth.ts
@@ -4,6 +4,8 @@ import * as Bluebird from 'bluebird';
 const co = Bluebird.coroutine;
 
 import { TestBitGo } from '../../../lib/test_bitgo';
+import * as nock from 'nock';
+nock.restore();
 
 describe('ETH:', function() {
   let bitgo;
@@ -16,6 +18,38 @@ describe('ETH:', function() {
     yield bitgo.authenticateTestUser(bitgo.testUserOTP());
     wallet = yield bitgo.coin('teth').wallets().getWallet({ id: TestBitGo.V2.TEST_ETH_WALLET_ID });
   }));
+
+  describe('Send Transaction', function() {
+    it('should send to multiple recipients in single transaction', async function() {
+      await bitgo.unlock( { otp: '0000000' });
+
+      const transaction = await wallet.sendMany({
+        recipients: [
+          {
+            amount: '1',
+            address: '0x431745b89e73230b3bc8a19e019194efb4b99efd',
+          },
+          {
+            amount: '5',
+            address: '0x431745b89e73230b3bc8a19e019194efb4b99efd',
+          },
+        ],
+        walletPassphrase: TestBitGo.V2.TEST_ETH_WALLET_PASSPHRASE,
+      });
+
+      should.exist(transaction);
+      transaction.should.have.property('transfer');
+      transaction.should.have.property('txid');
+      transaction.should.have.property('tx');
+      transaction.status.should.containEql('signed');
+      transaction.transfer.entries.should.have.lengthOf(2);
+      transaction.transfer.entries[0].address.should.equal("0xdf07117705a9f8dc4c2a78de66b7f1797dba9d4e");
+      transaction.transfer.entries[0].value.should.equal(-6);
+      transaction.transfer.entries[1].address.should.equal("0x431745b89e73230b3bc8a19e019194efb4b99efd");
+      transaction.transfer.entries[1].value.should.equal(6);
+      transaction.transfer.value.should.equal(-6);
+    });
+  });
 
   describe('Keychains', function() {
     it('should fail to create a key without an enterprise ID', function() {
@@ -34,13 +68,13 @@ describe('ETH:', function() {
       const basecoin = bitgo.coin('teth');
       const recovery = yield basecoin.recover({
         userKey: '{"iv":"+TkmT3GJ5msVWQjBrt3lsw==","v":1,"iter":10000,"ks":256,"ts":64,"mode"\n' +
-        ':"ccm","adata":"","cipher":"aes","salt":"cCE20fGIobs=","ct":"NVIdYIh91J3aRI\n' +
-        '8GG0JE3DhXW3AUmz2G5RqMejdz1+t4/vovIP7lleegI7VYyWiiLvlM0OCFf3EVvV/RyXr8+2vsn\n' +
-        'Q0Vn8c2CV5FRZ80OjGYrW3A/6T/zpOz6E8CMvnD++iIpeO4r2eZJavejZxdzlxF0BRz7VI="}',
+          ':"ccm","adata":"","cipher":"aes","salt":"cCE20fGIobs=","ct":"NVIdYIh91J3aRI\n' +
+          '8GG0JE3DhXW3AUmz2G5RqMejdz1+t4/vovIP7lleegI7VYyWiiLvlM0OCFf3EVvV/RyXr8+2vsn\n' +
+          'Q0Vn8c2CV5FRZ80OjGYrW3A/6T/zpOz6E8CMvnD++iIpeO4r2eZJavejZxdzlxF0BRz7VI="}',
         backupKey: '{"iv":"asB356ofC7nZtg4NBvQkiQ==","v":1,"iter":10000,"ks":256,"ts":64,"mode"\n' +
-        ':"ccm","adata":"","cipher":"aes","salt":"1hr2HhBbBIk=","ct":"8CZc6upt+XNOto\n' +
-        'KDD38TUg3ZUjzW+DraZlkcku2bNp0JS2s1g/iC6YTGUGtPoxDxumDlXwlWQx+5WPjZu79M8DCrI\n' +
-        't9aZaOvHkGH9aFtMbavFX419TcrwDmpUeQFN0hRkfrIHXyHNbTpGSVAjHvHMtzDMaw+ACg="}',
+          ':"ccm","adata":"","cipher":"aes","salt":"1hr2HhBbBIk=","ct":"8CZc6upt+XNOto\n' +
+          'KDD38TUg3ZUjzW+DraZlkcku2bNp0JS2s1g/iC6YTGUGtPoxDxumDlXwlWQx+5WPjZu79M8DCrI\n' +
+          't9aZaOvHkGH9aFtMbavFX419TcrwDmpUeQFN0hRkfrIHXyHNbTpGSVAjHvHMtzDMaw+ACg="}',
         walletContractAddress: '0x5df5a96b478bb1808140d87072143e60262e8670',
         walletPassphrase: TestBitGo.V2.TEST_RECOVERY_PASSCODE,
         recoveryDestination: '0xac05da78464520aa7c9d4c19bd7a440b111b3054'
@@ -56,13 +90,13 @@ describe('ETH:', function() {
       const basecoin = bitgo.coin('teth');
       const error = yield bitgo.getAsyncError(basecoin.recover({
         userKey: '{"iv":"VNvG6t3fHfxMcfvNuafYYA==","v":1,"iter":10000,"ks":256,"ts":64,"mode"\n' +
-        ':"ccm","adata":"","cipher":"aes","salt":"mc9pCk3H43w=","ct":"Qe4Z1evaXcrOMC\n' +
-        'cQ/XMVVBO9M/99D1QQ6LxkG8z3fQtwwOVXM3/6doNrriprUqs+adpFC93KRcAaDroL1E6o17J2k\n' +
-        'mcpXRd2CuXRFORZmZ/6QBfjKfCJ3aq0kEkDVv37gZNVT3aNtGkNSQdCEWKQLwd1++r5AkA="}\n',
+          ':"ccm","adata":"","cipher":"aes","salt":"mc9pCk3H43w=","ct":"Qe4Z1evaXcrOMC\n' +
+          'cQ/XMVVBO9M/99D1QQ6LxkG8z3fQtwwOVXM3/6doNrriprUqs+adpFC93KRcAaDroL1E6o17J2k\n' +
+          'mcpXRd2CuXRFORZmZ/6QBfjKfCJ3aq0kEkDVv37gZNVT3aNtGkNSQdCEWKQLwd1++r5AkA="}\n',
         backupKey: '{"iv":"EjD7x0OJX9kNM/C3yEDvyQ==","v":1,"iter":10000,"ks":256,"ts":64,"mode"\n' +
-        ':"ccm","adata":"","cipher":"aes","salt":"Na9NvRRe3n8=","ct":"B/AtSLHolsdNLr\n' +
-        '4Dlij4kQ0E6NyUUs6wo6T2HtPDAPO0hyhPPbh1OAYqIS7VlL9xmJRFC2zPxwRJvzf6OWC/m48HX\n' +
-        'vgLoXYgahArhalzJVlRxcXUz4HOhozRWfv/eK3t5HJfm+25+WBOiW8YgSE7hVEYTbeBRD4="}',
+          ':"ccm","adata":"","cipher":"aes","salt":"Na9NvRRe3n8=","ct":"B/AtSLHolsdNLr\n' +
+          '4Dlij4kQ0E6NyUUs6wo6T2HtPDAPO0hyhPPbh1OAYqIS7VlL9xmJRFC2zPxwRJvzf6OWC/m48HX\n' +
+          'vgLoXYgahArhalzJVlRxcXUz4HOhozRWfv/eK3t5HJfm+25+WBOiW8YgSE7hVEYTbeBRD4="}',
         walletContractAddress: '0x22ff743216b58aeb3efc46985406b50112e9e176',
         walletPassphrase: TestBitGo.V2.TEST_RECOVERY_PASSCODE,
         recoveryDestination: '0xac05da78464520aa7c9d4c19bd7a440b111b3054'

--- a/modules/core/test/v2/unit/ethWallet.ts
+++ b/modules/core/test/v2/unit/ethWallet.ts
@@ -38,6 +38,7 @@ describe('Sign ETH Transaction', co(function *() {
     sinon.stub(Util, 'xprvToEthPrivateKey');
     sinon.stub(Util, 'ethSignMsgHash');
     sinon.stub(ethWallet.getOperationSha3ForExecuteAndConfirm);
+
     const { halfSigned } = yield ethWallet.signTransaction({ txPrebuild: tx, prv: 'my_user_prv' });
     halfSigned.should.have.property('recipients', recipients);
     sinon.restore();
@@ -51,6 +52,33 @@ describe('Sign ETH Transaction', co(function *() {
     yield ethWallet.signTransaction({ txPrebuild: { recipients: 'not-array' }, prv: 'my_user_prv' }).should.be.rejectedWith('recipients missing or not array');
   }));
 
+  it('should set isBatch to false if single recipient', co(function *() {
+    sinon.stub(Util, 'xprvToEthPrivateKey');
+    sinon.stub(Util, 'ethSignMsgHash');
+    sinon.stub(ethWallet.getOperationSha3ForExecuteAndConfirm);
+    let singleRecipientsTx = { recipients : recipients, nextContractSequenceId: 0, isBatch:false };
+    const { halfSigned } = yield ethWallet.signTransaction({ txPrebuild: singleRecipientsTx, prv: 'my_user_prv' });
+    halfSigned.should.have.property('recipients', recipients);
+    halfSigned.should.have.property('isBatch', false);
+    sinon.restore();
+  }));
+
+  it('should set isBatch to true if multiple recipients', co(function *() {
+    let multipleRecipients =  [{ address: '0x0c7f3bc5d2b2c0dbee1b45536b82569f41b54331',
+    amount: '200',
+    data:
+     '0xcf4c58e2000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000002000000000000000000000000431745b89e73230b3bc8a19e019194efb4b99efd000000000000000000000000431745b89e73230b3bc8a19e019194efb4b99efd000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000640000000000000000000000000000000000000000000000000000000000000064' }
+    ];
+
+    let multipleRecipientsTx = { recipients : multipleRecipients, nextContractSequenceId: 0, isBatch:true };
+
+    sinon.stub(Util, 'xprvToEthPrivateKey');
+    sinon.stub(Util, 'ethSignMsgHash');
+    sinon.stub(ethWallet.getOperationSha3ForExecuteAndConfirm);
+    const { halfSigned } = yield ethWallet.signTransaction({ txPrebuild: multipleRecipientsTx, prv: 'my_user_prv' });
+    halfSigned.should.have.property('isBatch', true);
+    sinon.restore();
+  }));
 }));
 
 describe('Ethereum Hop Transactions', co(function *() {
@@ -69,7 +97,7 @@ describe('Ethereum Hop Transactions', co(function *() {
     rawPub: '02c103ac74481874b5ef0f385d12725e4f14aedc9e00bc814ce96f47f62ce7adf2',
     rawPrv: '936c5af3f8af81f75cdad1b08f29e7d9c01e598e2db2d7be18b9e5a8646e87c6',
     path: 'm',
-    walletSubPath: '/0/0'
+    walletSubPath: '/0/0',
   };
 
   before(co(function *() {
@@ -239,31 +267,31 @@ describe('Ethereum Hop Transactions', co(function *() {
       };
     }));
 
-   it('should prebuild a hop transaction if given the correct args', co(function *() {
-     let error = undefined;
+    it('should prebuild a hop transaction if given the correct args', co(function *() {
+      let error = undefined;
 
-     nockUserKey();
-     const feeScope = nockFees();
-     nockBuild(ethWallet.id());
-     try {
-       const res = yield ethWallet.prebuildTransaction(buildParams);
-       should.exist(res.hopTransaction);
-       should.exist(res.hopTransaction.tx);
-       should.exist(res.hopTransaction.tx);
-       should.exist(res.hopTransaction.id);
-       should.exist(res.hopTransaction.signature);
-       should.not.exist(res.wallet);
-       should.not.exist(res.buildParams);
-     } catch (e) {
-       error = e.message;
-     }
-     should.not.exist(error);
-     feeScope.isDone().should.equal(true);
-     const feeReq = (feeScope as any).interceptors[0].req;
-     feeReq.path.should.containEql('hop=true');
-     feeReq.path.should.containEql('recipient=' + finalRecipient);
-     feeReq.path.should.containEql('amount=' + sendAmount);
-   }));
+      nockUserKey();
+      const feeScope = nockFees();
+      nockBuild(ethWallet.id());
+      try {
+        const res = yield ethWallet.prebuildTransaction(buildParams);
+        should.exist(res.hopTransaction);
+        should.exist(res.hopTransaction.tx);
+        should.exist(res.hopTransaction.tx);
+        should.exist(res.hopTransaction.id);
+        should.exist(res.hopTransaction.signature);
+        should.not.exist(res.wallet);
+        should.not.exist(res.buildParams);
+      } catch (e) {
+        error = e.message;
+      }
+      should.not.exist(error);
+      feeScope.isDone().should.equal(true);
+      const feeReq = (feeScope as any).interceptors[0].req;
+      feeReq.path.should.containEql('hop=true');
+      feeReq.path.should.containEql('recipient=' + finalRecipient);
+      feeReq.path.should.containEql('amount=' + sendAmount);
+    }));
   }));
 }));
 
@@ -310,7 +338,7 @@ describe('prebuildTransaction', function() {
     gasLimit = 2100000;
     recipients = [{
       address: '0xe59dfe5c67114b39a5662cc856be536c614124c0',
-      amount: '100000'
+      amount: '100000',
     }];
     bgUrl = common.Environments[bitgo.getEnv()].uri;
   });
@@ -346,17 +374,17 @@ describe('prebuildTransaction', function() {
 });
 
 describe('final-sign transaction from WRW', function() {
-  it('should add a second signature to unsigned sweep', (async function () {
+  it('should add a second signature to unsigned sweep', (async function() {
     const bitgo = new TestBitGo({ env: 'test' });
     const basecoin = bitgo.coin('teth');
     const gasPrice = 200000000000;
-    const gasLimit =  500000;
+    const gasLimit = 500000;
     const prv = 'xprv9s21ZrQH143K3D8TXfvAJgHVfTEeQNW5Ys9wZtnUZkqPzFzSjbEJrWC1vZ4GnXCvR7rQL2UFX3RSuYeU9MrERm1XBvACow7c36vnz5iYyj2'; // placeholder test prv
     const tx = {
       txPrebuild: fixtures.WRWUnsignedSweepETHTx,
       prv,
     };
-    ​// sign transaction once
+    // sign transaction once
     const halfSigned = await basecoin.signTransaction(tx);
 
     const wrapper = {} as SignTransactionOptions;
@@ -372,7 +400,7 @@ describe('final-sign transaction from WRW', function() {
     const finalSignedTx = await basecoin.signTransaction(wrapper);
     finalSignedTx.should.have.property('txHex');
     const txBuilder = getBuilder('eth') as Eth.TransactionBuilder;
-    txBuilder.from("0x" + finalSignedTx.txHex); // add a 0x in front of this txhex
+    txBuilder.from('0x' + finalSignedTx.txHex); // add a 0x in front of this txhex
     const rebuiltTx = await txBuilder.build();
     const outputs = rebuiltTx.outputs.map(output => {
       return {


### PR DESCRIPTION
Wallet platform was denying sendMany calls because the isBatch field was not included in the output of signTransaction. The isBatch param is returns when calling /tx/build in wallet platform and is set automatically if the length of recipients is more than 1.

This commit fixed this issue by adding isBatch to the output of signTransaction and would pass the param value from tx/build.

https://bitgoinc.atlassian.net/browse/BG-27047

Ticket: BG-27047