### PR TITLE
feat(support flush coins): support flushing native ETH coin

### DIFF
--- a/modules/account-lib/src/coin/baseCoin/enum.ts
+++ b/modules/account-lib/src/coin/baseCoin/enum.ts
@@ -9,6 +9,8 @@ export enum TransactionType {
   AddressInitialization,
   // Flush tokens from a forwarder address to its base address
   FlushTokens,
+  // Flush native coins (eg. ETH) from a forwarder address to base address
+  FlushCoins,
   // Send a raw single-sig transaction
   SingleSigSend,
   // Update an account on-chain (e.g. Public key revelation operation for Tezos)

--- a/modules/account-lib/src/coin/eth/utils.ts
+++ b/modules/account-lib/src/coin/eth/utils.ts
@@ -30,7 +30,9 @@ import { KeyPair } from './keyPair';
 import {
   createForwarderMethodId,
   flushForwarderTokensMethodId,
+  flushCoinsMethodId,
   flushTokensTypes,
+  flushCoinsTypes,
   sendMultisigMethodId,
   sendMultisigTokenMethodId,
   sendMultiSigTokenTypes,
@@ -151,6 +153,16 @@ export function flushTokensData(forwarderAddress, tokenAddress): string {
   const params = [forwarderAddress, tokenAddress];
   const method = EthereumAbi.methodID('flushForwarderTokens', flushTokensTypes);
   const args = EthereumAbi.rawEncode(flushTokensTypes, params);
+  return addHexPrefix(Buffer.concat([method, args]).toString('hex'));
+}
+
+/**
+ * Get the data required to make a flush native coins contract call
+ */
+export function flushCoinsData(): string {
+  const params = [];
+  const method = EthereumAbi.methodID('flush', flushCoinsTypes);
+  const args = EthereumAbi.rawEncode(flushCoinsTypes, params);
   return addHexPrefix(Buffer.concat([method, args]).toString('hex'));
 }
 
@@ -337,6 +349,7 @@ const transactionTypesMap = {
   [createForwarderMethodId]: TransactionType.AddressInitialization,
   [sendMultisigMethodId]: TransactionType.Send,
   [flushForwarderTokensMethodId]: TransactionType.FlushTokens,
+  [flushCoinsMethodId]: TransactionType.FlushCoins,
   [sendMultisigTokenMethodId]: TransactionType.Send,
   [LockMethodId]: TransactionType.StakingLock,
   [VoteMethodId]: TransactionType.StakingVote,

--- a/modules/account-lib/src/coin/eth/walletUtil.ts
+++ b/modules/account-lib/src/coin/eth/walletUtil.ts
@@ -3,6 +3,7 @@ export const sendMultisigTokenMethodId = '0x0dcd7a6c';
 export const createForwarderMethodId = '0xa68a76cc';
 export const walletInitializationFirstBytes = '0x60606040';
 export const flushForwarderTokensMethodId = '0x2da03409';
+export const flushCoinsMethodId = '0x6b9f96ea';
 
 /*
   Steps to reproduce:
@@ -16,6 +17,7 @@ export const walletSimpleByteCode =
 
 export const walletSimpleConstructor = ['address[]'];
 export const flushTokensTypes = ['address', 'address'];
+export const flushCoinsTypes = [];
 
 export const walletSimpleAbi = [
   {

--- a/modules/account-lib/test/unit/coin/eth/transactionBuilder/flushCoins.ts
+++ b/modules/account-lib/test/unit/coin/eth/transactionBuilder/flushCoins.ts
@@ -1,0 +1,161 @@
+import should from 'should';
+import { TransactionType } from '../../../../../src/coin/baseCoin';
+import { getBuilder, Eth } from '../../../../../src';
+import { Transaction } from '../../../../../src/coin/eth';
+import { Fee } from '../../../../../src/coin/eth/iface';
+import { flushCoinsMethodId } from '../../../../../src/coin/eth/walletUtil';
+
+describe('Eth Transaction builder flush native coins', function() {
+  const sourcePrv =
+    'xprv9s21ZrQH143K3D8TXfvAJgHVfTEeQNW5Ys9wZtnUZkqPzFzSjbEJrWC1vZ4GnXCvR7rQL2UFX3RSuYeU9MrERm1XBvACow7c36vnz5iYyj2';
+  const pub1 =
+    'xpub661MyMwAqRbcGpyL5QvWah4XZYHuTK21mSQ4NVwYaX67A35Kzb42nmTdf2WArW4tettXrWpfpwFbEFdEVqcSvnHLB8F6p1D41ssmbnRMXpc';
+  const pub2 =
+    'xpub661MyMwAqRbcFWzoz8qnYRDYEFQpPLYwxVFoG6WLy3ck5ZupRGJTG4ju6yGb7Dj3ey6GsC4kstLRER2nKzgjLtmxyPgC4zHy7kVhUt6yfGn';
+  const defaultKeyPair = new Eth.KeyPair({
+    prv: 'FAC4D04AA0025ECF200D74BC9B5E4616E4B8338B69B61362AAAD49F76E68EF28',
+  });
+
+  interface FlushCoinsDetails {
+    contractAddress?: string;
+    counter?: number;
+    fee?: Fee;
+    key?: Eth.KeyPair;
+  }
+
+  const buildTransaction = async function(details: FlushCoinsDetails): Promise<Transaction> {
+    const txBuilder: any = getBuilder('teth');
+    txBuilder.type(TransactionType.FlushCoins);
+
+    if (details.fee !== undefined) {
+      txBuilder.fee(details.fee);
+    }
+
+    if (details.contractAddress !== undefined) {
+      txBuilder.contract(details.contractAddress);
+    }
+
+    if (details.counter !== undefined) {
+      txBuilder.counter(details.counter);
+    }
+
+    if (details.key !== undefined) {
+      txBuilder.sign({ key: details.key.getKeys().prv });
+    }
+
+    return await txBuilder.build();
+  };
+
+  describe('should build', () => {
+    it('a wallet flush forwarder transaction', async () => {
+      const tx = await buildTransaction({
+        fee: {
+          fee: '10',
+          gasLimit: '1000',
+        },
+        counter: 1,
+        contractAddress: '0x8f977e912ef500548a0c3be6ddde9899f1199b81',
+      });
+
+      console.log('DEBUG tx type')
+      console.log(tx.type)
+      console.log(TransactionType.FlushCoins)
+      console.log(TransactionType)
+      tx.type.should.equal(TransactionType.FlushCoins);
+      const txJson = tx.toJson();
+      txJson.gasLimit.should.equal('1000');
+      txJson.gasPrice.should.equal('10');
+      should.equal(txJson.nonce, 1);
+      txJson.data.should.startWith(flushCoinsMethodId);
+    });
+
+    it('a wallet flush forwarder transaction with nonce 0', async () => {
+      const tx = await buildTransaction({
+        fee: {
+          fee: '10',
+          gasLimit: '1000',
+        },
+        counter: 0,
+        contractAddress: '0x8f977e912ef500548a0c3be6ddde9899f1199b81',
+      });
+
+      tx.type.should.equal(TransactionType.FlushCoins);
+      const txJson = tx.toJson();
+      txJson.gasLimit.should.equal('1000');
+      txJson.gasPrice.should.equal('10');
+      should.equal(txJson.nonce, 0);
+    });
+
+    it('an unsigned flush transaction from serialized', async () => {
+      const tx = await buildTransaction({
+        fee: {
+          fee: '10',
+          gasLimit: '1000',
+        },
+        counter: 0,
+        contractAddress: '0x8f977e912ef500548a0c3be6ddde9899f1199b81',
+      });
+      const serialized = tx.toBroadcastFormat();
+
+      // now rebuild from the signed serialized tx and make sure it stays the same
+      const newTxBuilder: any = getBuilder('eth');
+      newTxBuilder.from(serialized);
+      const newTx = await newTxBuilder.build();
+      should.equal(newTx.toBroadcastFormat(), serialized);
+      newTx.toJson().data.should.startWith(flushCoinsMethodId);
+    });
+
+    it('a signed flush coin transaction from serialized', async () => {
+      const tx = await buildTransaction({
+        fee: {
+          fee: '10',
+          gasLimit: '1000',
+        },
+        counter: 0,
+        contractAddress: '0x8f977e912ef500548a0c3be6ddde9899f1199b81',
+        key: defaultKeyPair,
+      });
+      const serialized = tx.toBroadcastFormat();
+
+      // now rebuild from the signed serialized tx and make sure it stays the same
+      const newTxBuilder: any = getBuilder('teth');
+      newTxBuilder.from(serialized);
+      const newTx = await newTxBuilder.build();
+      should.equal(newTx.toBroadcastFormat(), serialized);
+      const txJson = newTx.toJson();
+      should.exist(txJson.v);
+      should.exist(txJson.r);
+      should.exist(txJson.s);
+      should.exist(txJson.from);
+    });
+  });
+
+  describe('should fail to build', () => {
+    it('a transaction without fee', async () => {
+      await buildTransaction({
+        counter: 0,
+        contractAddress: '0x8f977e912ef500548a0c3be6ddde9899f1199b81',
+      }).should.be.rejectedWith('Invalid transaction: missing fee');
+    });
+
+    it('a transaction without contractAddress', async () => {
+      await buildTransaction({
+        fee: {
+          fee: '10',
+          gasLimit: '10',
+        },
+        counter: 0,
+      }).should.be.rejectedWith('Invalid transaction: missing contract address');
+    });
+
+    it('a transaction with invalid counter', async () => {
+      await buildTransaction({
+        fee: {
+          fee: '10',
+          gasLimit: '10',
+        },
+        counter: -1,
+      }).should.be.rejectedWith('Invalid counter: -1');
+    });
+  });
+});


### PR DESCRIPTION
Sometimes, clients might send ETH to an address before the wallet deployment tx has been confirmed due to fee spike, which results in ETH stuck in forwarders that need to be flushed. 

This PR adds a transaction type to the ETH transaction builder. This allows us to build flush tx in Wallet Platform later.