### PR TITLE
add support for IPC socket (unix socket) in Express

### DIFF
--- a/modules/express/src/args.ts
+++ b/modules/express/src/args.ts
@@ -18,6 +18,10 @@ parser.addArgument(['-b', '--bind'], {
   help: 'Bind to given address to listen for connections (default: localhost)',
 });
 
+parser.addArgument(['-i', '--ipc'], {
+  help: 'Bind to specified IPC path instead of TCP',
+});
+
 parser.addArgument(['-e', '--env'], {
   help: 'BitGo environment to proxy against (prod, test)',
 });

--- a/modules/express/src/config.ts
+++ b/modules/express/src/config.ts
@@ -19,6 +19,7 @@ function readEnvVar(name, ...deprecatedAliases): string | undefined {
 export interface Config {
   port: number;
   bind: string;
+  ipc?: string;
   env: EnvironmentName;
   debugNamespace: string[];
   keyPath?: string;
@@ -35,6 +36,7 @@ export interface Config {
 export const ArgConfig = (args): Partial<Config> => ({
   port: args.port,
   bind: args.bind,
+  ipc: args.ipc,
   env: args.env,
   debugNamespace: args.debugnamespace,
   keyPath: args.keypath,
@@ -51,6 +53,7 @@ export const ArgConfig = (args): Partial<Config> => ({
 export const EnvConfig = (): Partial<Config> => ({
   port: Number(readEnvVar('BITGO_PORT')),
   bind: readEnvVar('BITGO_BIND') || DefaultConfig.bind,
+  ipc: readEnvVar('BITGO_IPC'),
   env: (readEnvVar('BITGO_ENV') as EnvironmentName) || DefaultConfig.env,
   debugNamespace: (readEnvVar('BITGO_DEBUG_NAMESPACE') || '').split(','),
   keyPath: readEnvVar('BITGO_KEYPATH'),
@@ -97,6 +100,7 @@ function mergeConfigs(...configs: Partial<Config>[]): Config {
   return {
     port: get('port'),
     bind: get('bind'),
+    ipc: get('ipc'),
     env: get('env'),
     debugNamespace: get('debugNamespace'),
     keyPath: get('keyPath'),


### PR DESCRIPTION
Sometimes it can be desirable to further restrict access to the BitGo Express API endpoint beyond that of a localhost TCP connection. An effective low-effort way of accomplishing further restriction is by using a Unix domain socket instead. For example, the Unix domain socket can be placed in a part of the file hierarchy where only the Unix users/groups that require access to BitGo Express have access. Other users/groups will be unable to access the Unix socket.

This PR adds a new command line argument and environment variable to configure BitGo Express to listen on a Unix socket. Node.js refers to its API here as "IPC" due to the API working for both Unix sockets and named pipes on Win32. Thus, I've used this _IPC_ term for command line argument etc