### PR TITLE
feat(express): add support for binding to an IPC socket (unix socket)

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -226,7 +226,7 @@ local CheckPreconditions(version) = {
   ]
 };
 
-local UnitVersions = ["8", "10"];
+local UnitVersions = ["10"];
 local IntegrationVersions = ["10"];
 
 [

--- a/.drone.yml
+++ b/.drone.yml
@@ -89,56 +89,6 @@ trigger:
 
 ---
 kind: pipeline
-name: unit tests (node:8)
-
-platform:
-  os: linux
-  arch: amd64
-
-steps:
-- name: build information
-  image: node:8
-  commands:
-  - node --version
-  - npm --version
-  - yarn --version
-  - git --version
-
-- name: install
-  image: node:8
-  commands:
-  - git fetch origin +refs/heads/$DRONE_REPO_BRANCH:$DRONE_REPO_BRANCH || true
-  - yarn install --ignore-engines
-
-- name: unit-test-changed
-  image: node:8
-  commands:
-  - yarn run unit-test-changed
-  environment:
-    BITGOJS_TEST_PASSWORD:
-      from_secret: password
-
-- name: upload artifacts
-  image: bitgosdk/upload-tools:latest
-  commands:
-  - yarn run artifacts
-  - yarn run gen-coverage-changed
-  - yarn run coverage
-  environment:
-    CODECOV_FLAG: unit
-    CODECOV_TOKEN:
-      from_secret: codecov
-    reports_s3_akid:
-      from_secret: reports_s3_akid
-    reports_s3_sak:
-      from_secret: reports_s3_sak
-  when:
-    status:
-    - success
-    - failure
-
----
-kind: pipeline
 name: unit tests (node:10)
 
 platform:

--- a/modules/express/README.md
+++ b/modules/express/README.md
@@ -183,6 +183,7 @@ BitGo Express is able to take configuration options from either command line arg
 | N/A             | --disablessl           | `BITGO_DISABLE_SSL` <sup>0</sup>         | N/A           | Disable requiring SSL when accessing bitgo production environment. **USE AT YOUR OWN RISK, NOT RECOMMENDED**.           |
 | N/A             | --disableproxy         | `BITGO_DISABLE_PROXY` <sup>0</sup>       | N/A           | Disable proxying of routes not explicitly handled by bitgo-express                                                      |
 | N/A             | --disableenvcheck      | `BITGO_DISABLE_ENV_CHECK` <sup>0</sup>   | N/A           | Disable checking for correct `NODE_ENV` environment variable when running against BitGo production environment.         |
+| -i              | --ipc                  | `BITGO_IPC`                              | N/A           | If set, bind to the given IPC (unix domain) socket. Binding to an IPC socket can be useful if the caller of bitgo-express resides on the same host as the bitgo-express instance itself, since the socket can be secured using normal file permissions and ownership semantics. Note: This is not supported on Windows platforms. |
 
 \[0]: BitGo will also check the additional environment variables for some options for backwards compatibility, but these environment variables should be considered deprecated:
 * Disable SSL

--- a/modules/express/src/args.ts
+++ b/modules/express/src/args.ts
@@ -18,6 +18,10 @@ parser.addArgument(['-b', '--bind'], {
   help: 'Bind to given address to listen for connections (default: localhost)',
 });
 
+parser.addArgument(['-i', '--ipc'], {
+  help: 'Bind to specified IPC path instead of TCP',
+});
+
 parser.addArgument(['-e', '--env'], {
   help: 'BitGo environment to proxy against (prod, test)',
 });

--- a/modules/express/src/config.ts
+++ b/modules/express/src/config.ts
@@ -19,6 +19,7 @@ function readEnvVar(name, ...deprecatedAliases): string | undefined {
 export interface Config {
   port: number;
   bind: string;
+  ipc?: string;
   env: EnvironmentName;
   debugNamespace: string[];
   keyPath?: string;
@@ -35,6 +36,7 @@ export interface Config {
 export const ArgConfig = (args): Partial<Config> => ({
   port: args.port,
   bind: args.bind,
+  ipc: args.ipc,
   env: args.env,
   debugNamespace: args.debugnamespace,
   keyPath: args.keypath,
@@ -51,6 +53,7 @@ export const ArgConfig = (args): Partial<Config> => ({
 export const EnvConfig = (): Partial<Config> => ({
   port: Number(readEnvVar('BITGO_PORT')),
   bind: readEnvVar('BITGO_BIND') || DefaultConfig.bind,
+  ipc: readEnvVar('BITGO_IPC'),
   env: (readEnvVar('BITGO_ENV') as EnvironmentName) || DefaultConfig.env,
   debugNamespace: (readEnvVar('BITGO_DEBUG_NAMESPACE') || '').split(','),
   keyPath: readEnvVar('BITGO_KEYPATH'),
@@ -97,6 +100,7 @@ function mergeConfigs(...configs: Partial<Config>[]): Config {
   return {
     port: get('port'),
     bind: get('bind'),
+    ipc: get('ipc'),
     env: get('env'),
     debugNamespace: get('debugNamespace'),
     keyPath: get('keyPath'),

--- a/modules/express/src/errors.ts
+++ b/modules/express/src/errors.ts
@@ -31,3 +31,9 @@ export class ApiResponseError extends Errors.BitGoJsError {
   }
 }
 
+export class IpcError extends Errors.BitGoJsError {
+  public constructor(message: string) {
+    super(message);
+    Object.setPrototypeOf(this, IpcError.prototype);
+  }
+}


### PR DESCRIPTION
Sometimes it can be desirable to further restrict access to the BitGo
Express API endpoint beyond that of a localhost TCP connection. An
effective low-effort way of accomplishing further restriction is by
using a Unix domain socket instead. For example, the Unix domain socket
can be placed in a part of the file hierarchy where only the Unix
users/groups that require access to BitGo Express have access. Other
users/groups will be unable to access the Unix socket.

Ticket: BG-28829