### PR TITLE
feat(express): add support for returning keychains with generated wallet

### DIFF
--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -366,7 +366,7 @@ export interface SendManyOptions {
   memo?: Memo;
 }
 
-interface WalletData {
+export interface WalletData {
   id: string;
   approvalsRequired: number;
   balance: number;
@@ -2210,6 +2210,13 @@ export class Wallet {
    */
   remove(params: {} = {}, callback?: NodeCallback<any>): Bluebird<any> {
     return this.bitgo.del(this.url()).result().asCallback(callback);
+  }
+
+  /**
+   * Extract a JSON representable version of this wallet
+   */
+  toJSON(): WalletData {
+    return this._wallet;
   }
 
   /**

--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -356,12 +356,14 @@ function handleCanonicalAddress(req: express.Request) {
  * handle new wallet creation
  * @param req
  */
-async function handleV2GenerateWallet(req: express.Request) {
+export async function handleV2GenerateWallet(req: express.Request) {
   const bitgo = req.bitgo;
   const coin = bitgo.coin(req.params.coin);
   const result = await coin.wallets().generateWallet(req.body);
-  // @ts-ignore
-  return result.wallet._wallet;
+  if (req.query.includeKeychains) {
+    return { ...result, wallet: result.wallet.toJSON() };
+  }
+  return result.wallet.toJSON();
 }
 
 /**

--- a/modules/express/test/unit/clientRoutes/consolidateAccount.ts
+++ b/modules/express/test/unit/clientRoutes/consolidateAccount.ts
@@ -3,11 +3,11 @@ import * as sinon from 'sinon';
 
 import 'should-http';
 import 'should-sinon';
-import '../lib/asserts';
+import '../../lib/asserts';
 
 import * as express from 'express';
 
-import { handleV2ConsolidateAccount } from '../../src/clientRoutes';
+import { handleV2ConsolidateAccount } from '../../../src/clientRoutes';
 
 import { BitGo } from 'bitgo';
 

--- a/modules/express/test/unit/clientRoutes/generateWallet.ts
+++ b/modules/express/test/unit/clientRoutes/generateWallet.ts
@@ -1,0 +1,55 @@
+import * as sinon from 'sinon';
+import * as Bluebird from 'bluebird';
+
+import 'should-http';
+import 'should-sinon';
+import '../../lib/asserts';
+
+import * as express from 'express';
+
+import { handleV2GenerateWallet } from '../../../src/clientRoutes';
+
+import { BaseCoin, BitGo, Wallets, WalletWithKeychains } from 'bitgo';
+
+describe('Generate Wallet', () => {
+  it('should return the internal wallet object by default', async () => {
+    const walletStub = sinon.stub<[], Bluebird<WalletWithKeychains>>().resolves(({ wallet: { toJSON: () => 'walletdata' } }) as any);
+    const walletsStub = sinon.createStubInstance(Wallets, { generateWallet: walletStub });
+    const coinStub = sinon.createStubInstance(BaseCoin, { wallets: sinon.stub<[], Wallets>().returns(walletsStub as any) });
+    const stubBitgo = sinon.createStubInstance(BitGo, { coin: sinon.stub<[string]>().returns(coinStub) });
+    const walletGenerateBody = {};
+    const coin = 'tbtc';
+    const req = {
+      bitgo: stubBitgo,
+      params: {
+        coin,
+      },
+      query: {},
+      body: walletGenerateBody,
+    } as unknown as express.Request;
+
+    await handleV2GenerateWallet(req)
+      .should.be.resolvedWith('walletdata');
+  });
+
+  it('should return the coin specific result directly if includeKeychains query param is true', async () => {
+    const walletsStub = sinon.createStubInstance(Wallets, { generateWallet: ({ wallet: { toJSON: () => 'walletdata with keychains' } }) as any });
+    const coinStub = sinon.createStubInstance(BaseCoin, { wallets: sinon.stub<[], Wallets>().returns(walletsStub as any) });
+    const stubBitgo = sinon.createStubInstance(BitGo, { coin: sinon.stub<[string]>().returns(coinStub) });
+    const walletGenerateBody = {};
+    const coin = 'tbtc';
+    const req = {
+      bitgo: stubBitgo,
+      params: {
+        coin,
+      },
+      query: {
+        includeKeychains: true,
+      },
+      body: walletGenerateBody,
+    } as unknown as express.Request;
+
+    await handleV2GenerateWallet(req)
+      .should.be.resolvedWith({ wallet: 'walletdata with keychains' });
+  });
+});


### PR DESCRIPTION
It's convenient for callers of `wallet/generate` to be able to get the
keychains for their newly generated wallet in the response, instead of
needing to make additional API calls.

To do this in a backwards-compatible way, this change adds a
`includeKeychains` query parameter which, if set, will return the return
of the SDK `generateWallet()` call directly, which includs the wallet
keychains.

Ticket: BG-28844