### PR TITLE
fix(express): always prefer command line arguments to env var args

### DIFF
--- a/modules/express/src/config.ts
+++ b/modules/express/src/config.ts
@@ -52,9 +52,9 @@ export const ArgConfig = (args): Partial<Config> => ({
 
 export const EnvConfig = (): Partial<Config> => ({
   port: Number(readEnvVar('BITGO_PORT')),
-  bind: readEnvVar('BITGO_BIND') || DefaultConfig.bind,
+  bind: readEnvVar('BITGO_BIND'),
   ipc: readEnvVar('BITGO_IPC'),
-  env: (readEnvVar('BITGO_ENV') as EnvironmentName) || DefaultConfig.env,
+  env: (readEnvVar('BITGO_ENV') as EnvironmentName),
   debugNamespace: (readEnvVar('BITGO_DEBUG_NAMESPACE') || '').split(','),
   keyPath: readEnvVar('BITGO_KEYPATH'),
   crtPath: readEnvVar('BITGO_CRTPATH'),
@@ -83,18 +83,20 @@ export const DefaultConfig: Config = {
 /**
  * Helper function to merge config sources into a single config object.
  *
- * Earlier configs have higher precedence over subsequent configs.
+ * Later configs have higher precedence over earlier configs.
  */
 function mergeConfigs(...configs: Partial<Config>[]): Config {
   function isNilOrNaN(val: unknown): val is null | undefined | number {
     return isNil(val) || (isNumber(val) && isNaN(val));
   }
-  // helper to get the first defined value for a given config key
-  // from the config sources in a type safe manner
+
+  // helper to get the last defined value for a given config key
+  // from each of the config sources in a type safe manner.
   function get<T extends keyof Config>(k: T): Config[T] {
-    return configs
-      .reverse()
-      .reduce((entry: Config[T], config) => !isNilOrNaN(config[k]) ? config[k] as Config[T] : entry, DefaultConfig[k]);
+    return configs.reduce(
+      (entry: Config[T], config) => !isNilOrNaN(config[k]) ? config[k] as Config[T] : entry,
+      DefaultConfig[k],
+    );
   }
 
   return {
@@ -118,5 +120,5 @@ function mergeConfigs(...configs: Partial<Config>[]): Config {
 export const config = () => {
   const arg = ArgConfig(args());
   const env = EnvConfig();
-  return mergeConfigs(arg, env);
+  return mergeConfigs(env, arg);
 };

--- a/modules/express/test/unit/config.ts
+++ b/modules/express/test/unit/config.ts
@@ -37,6 +37,59 @@ describe('Config:', () => {
     envStub.restore();
   });
 
+  it('should correctly handle config precedence for a complete config', () => {
+    const argStub = sinon.stub(args, 'args').returns({
+      port: 23456,
+      bind: 'argbind',
+      ipc: 'argipc',
+      env: 'argenv',
+      debugnamespace: 'argdebug',
+      keypath: 'argkeypath',
+      crtpath: 'argcrtpath',
+      logfile: 'arglogfile',
+      disablessl: 'argdisableSSL',
+      disableproxy: 'argdisableProxy',
+      disableenvcheck: 'argdisableEnvCheck',
+      timeout: 'argtimeout',
+      customrooturi: 'argcustomRootUri',
+      custombitcoinnetwork: 'argcustomBitcoinNetwork',
+    });
+    const envStub = sinon.stub(process, 'env').value({
+      BITGO_PORT: 'env12345',
+      BITGO_BIND: 'envbind',
+      BITGO_IPC: 'envipc',
+      BITGO_ENV: 'envenv',
+      BITGO_DEBUG_NAMESPACE: 'envdebug',
+      BITGO_KEYPATH: 'envkeypath',
+      BITGO_CRTPATH: 'envcrtpath',
+      BITGO_LOGFILE: 'envlogfile',
+      BITGO_DISABLE_SSL: 'envdisableSSL',
+      BITGO_DISABLE_PROXY: 'envdisableProxy',
+      BITGO_DISABLE_ENV_CHECK: 'envdisableEnvCheck',
+      BITGO_TIMEOUT: 'envtimeout',
+      BITGO_CUSTOM_ROOT_URI: 'envcustomRootUri',
+      BITGO_CUSTOM_BITCOIN_NETWORK: 'envcustomBitcoinNetwork',
+    });
+    config().should.eql({
+      port: 23456,
+      bind: 'argbind',
+      ipc: 'argipc',
+      env: 'argenv',
+      debugNamespace: 'argdebug',
+      keyPath: 'argkeypath',
+      crtPath: 'argcrtpath',
+      logFile: 'arglogfile',
+      disableSSL: 'argdisableSSL',
+      disableProxy: 'argdisableProxy',
+      disableEnvCheck: 'argdisableEnvCheck',
+      timeout: 'argtimeout',
+      customRootUri: 'argcustomRootUri',
+      customBitcoinNetwork: 'argcustomBitcoinNetwork',
+    });
+    argStub.restore();
+    envStub.restore();
+  });
+
   it('should correctly handle boolean config precedence', () => {
     const argStub = sinon.stub(args, 'args').returns({ disablessl: true });
     const envStub = sinon.stub(process, 'env').value({ BITGO_DISABLE_SSL: undefined });


### PR DESCRIPTION
When the "IPC" argument was added, all subsequent configs had their
index increased by one. This revealed a bug where odd-numbered config
item indexes incorrectly preferred the env var arguments to the command
line arguments. Because the env vars defaulted to testnet, this broke
the ability to start bitgo express in the production configuration with
the `-e` flag on the command line.

Instead of reversing the configs in the `get()` call, just provide the
configs in the correct order to start with.

Ticket: BG-29084