### PR TITLE
fix: wait a second between 2 subsequent API calls

### DIFF
--- a/modules/core/src/v2/coins/eth.ts
+++ b/modules/core/src/v2/coins/eth.ts
@@ -1162,6 +1162,10 @@ export class Eth extends BaseCoin {
       if (!response.ok) {
         throw new Error('could not reach Etherscan');
       }
+
+      if (response.body.status === '0' && response.body.message === 'NOTOK') {
+        throw new Error('Etherscan rate limit reached');
+      }
       return response.body;
     })
       .call(this)

--- a/modules/core/src/v2/coins/eth.ts
+++ b/modules/core/src/v2/coins/eth.ts
@@ -873,6 +873,8 @@ export class Eth extends BaseCoin {
       ];
 
       // Get sequence ID using contract call
+      // we need to wait between making two etherscan calls to avoid getting banned
+      yield new Promise(resolve => setTimeout(resolve, 1000));
       const sequenceId = yield self.querySequenceId(params.walletContractAddress);
 
       let operationHash, signature;

--- a/modules/core/test/v2/lib/recovery-nocks.ts
+++ b/modules/core/test/v2/lib/recovery-nocks.ts
@@ -2265,6 +2265,25 @@ module.exports.nockEthRecovery = function(bitgo) {
   });
 };
 
+module.exports.nockEtherscanRateLimitError = function() {
+  const response = {
+    status: '0',
+    message: 'NOTOK',
+    result: 'Max rate limit reached, rate limit of 3/1sec applied"',
+  };
+
+  const params = {
+    module: 'account',
+    action: 'txlist',
+    address: '0x74c2137d54b0fc9f907e13f14e0dd18485fee924',
+  };
+
+  nock('https://kovan.etherscan.io')
+    .get('/api')
+    .query(params)
+    .reply(200, response);
+};
+
 module.exports.nockLtcRecovery = function(isKrsRecovery) {
   nock('http://explorer.litecointools.com/api')
     .get('/addr/QPuiounBxPyL6hsMAjtNtCtjF99uN1Nh6d')

--- a/modules/core/test/v2/unit/recovery.ts
+++ b/modules/core/test/v2/unit/recovery.ts
@@ -1023,6 +1023,7 @@ describe('Recovery:', function() {
   });
 
   describe('Recover Ethereum', function() {
+
     const recoveryParams = {
       userKey: '{"iv":"+TkmT3GJ5msVWQjBrt3lsw==","v":1,"iter":10000,"ks":256,"ts":64,"mode"\n' +
       ':"ccm","adata":"","cipher":"aes","salt":"cCE20fGIobs=","ct":"NVIdYIh91J3aRI\n' +
@@ -1127,5 +1128,12 @@ describe('Recovery:', function() {
       should.exist(error);
       error.message.should.equal('Backup key address 0xba6d9d82cf2920c544b834b72f4c6d11a3ef3de6 has balance 0. This address must have a balance of at least 0.01 ETH to perform recoveries. Try sending some ETH to this address then retry.');
     }));
+
+    it('should throw error when the etherscan rate limit is reached', async function() {
+      nock.cleanAll()
+      const basecoin = bitgo.coin('teth');
+      recoveryNocks.nockEtherscanRateLimitError();
+      await basecoin.recover(recoveryParams).should.be.rejectedWith('Etherscan rate limit reached');
+    });
   });
 });


### PR DESCRIPTION
Recovery of an ETH transaction takes four calls to etherscan, but it bans the 4th call since it exceeds their rate limit of 3 calls per second. We wait one second between the 3rd and 4th call to avoid hitting this limit. 

Ticket: BG-29196