### PR TITLE
feat: BG-29057: Add non participant keyreg transaction support for Algorand

### DIFF
--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -87,6 +87,8 @@ export interface PrebuildTransactionOptions {
     noSplitChange?: boolean;
     unspents?: any[];
     changeAddress?: string;
+    type?: string;
+    nonParticipation?: boolean;
     validFromBlock?: number;
     validToBlock?: number;
     instant?: boolean;
@@ -491,7 +493,7 @@ export class Wallet {
       'feeRate', 'gasLimit', 'gasPrice', 'idfSignedTimestamp', 'idfUserId', 'idfVersion', 'instant',
       'lastLedgerSequence', 'ledgerSequenceDelta', 'maxFee', 'maxFeeRate', 'maxValue', 'memo', 'message', 'minConfirms',
       'minValue', 'noSplitChange', 'numBlocks', 'recipients', 'reservation', 'sequenceId', 'strategy',
-      'targetWalletUnspents', 'trustlines', 'type', 'unspents', 'validFromBlock', 'validToBlock', 'messageKey',
+      'targetWalletUnspents', 'trustlines', 'type', 'unspents', 'nonParticipation', 'validFromBlock', 'validToBlock', 'messageKey',
     ];
   }
 
@@ -1633,6 +1635,7 @@ export class Wallet {
    * @param {Boolean} params.noSplitChange - Set to true to disable automatic change splitting for purposes of unspent management
    * @param {Array} params.unspents - The unspents to use in the transaction. Each unspent should be in the form prevTxId:nOutput
    * @param {String} params.changeAddress - Specifies the destination of the change output
+   * @param {Boolean} params.nonParticipation - (Algorand) Non participating key reg transaction
    * @param {Number} params.validFromBlock - (Algorand) The minimum round this will run on
    * @param {Number} params.validToBlock - (Algorand) The maximum round this will run on
    * @param {Boolean} params.instant - Build this transaction to conform with instant sending coin-specific method (if available)

--- a/modules/core/test/lib/test_bitgo.ts
+++ b/modules/core/test/lib/test_bitgo.ts
@@ -185,6 +185,9 @@ BitGo.prototype.initializeTestVars = function() {
     BitGo.V2.TEST_WEBHOOK_TRANSFER_SIMULATION_ID = '59b7041619dd52cd0737a4cbf39dbd44';
 
     BitGo.V2.OFC_TEST_WALLET_ID = '5cbe3563afc275b40369e096073b8a16';
+
+    // Algo wallet for non participating key reg transaction
+    BitGo.V2.TEST_ALGO_WALLET_ID = '602566f550a05c0006fe13a03b57141f';
   }
 
   BitGo.TEST_FEE_SINGLE_KEY_WIF = 'cRVQ6cbUyGHVvByPKF9GnEhaB4HUBFgLQ2jVX1kbQARHaTaD7WJ2';

--- a/modules/core/test/v2/integration/coins/algo.ts
+++ b/modules/core/test/v2/integration/coins/algo.ts
@@ -1,0 +1,39 @@
+import * as should from 'should';
+import { TestBitGo } from '../../../lib/test_bitgo';
+
+describe('ALGO:', function() {
+  let bitgo;
+  let algocoin;
+
+  before(function() {
+    bitgo = bitgo = new TestBitGo({ env: 'test' });
+    algocoin = bitgo.coin('talgo');
+  });
+
+  describe('Algo non partipation key reg transaction', function() {
+    // TODO: The test currently works against 'testnet-01' environment as the accompanying platform changes are not
+    // yet available in 'test' environment.
+    // Once the platform updates are available in 'test', this test will be enabled, updated and a separate PR will be submitted
+    xit('should successfully submit non paticipating key reg transaction', async function() {
+      const algoWallet = await algocoin.wallets().getWallet({ id: TestBitGo.V2.TEST_ALGO_WALLET_ID });
+
+      // Build and sign the transaction
+      const preBuiltSignedTx: any = await algoWallet.prebuildAndSignTransaction({
+        type: 'keyreg',
+        nonParticipation: true,
+        walletPassphrase: TestBitGo.V2.BITGOJS_TEST_PASSWORD
+      });
+      preBuiltSignedTx.should.have.property('txHex');
+      preBuiltSignedTx.should.have.propertyByPath('txInfo', 'type').eql('keyreg');
+      preBuiltSignedTx.should.have.propertyByPath('txInfo', 'nonParticipation').eql(true);
+
+      // submit the transaction
+      const txResponse = await algoWallet.submitTransaction({ halfSigned: preBuiltSignedTx.halfSigned });
+      should.exist(txResponse);
+      txResponse.should.have.property('transfer', 'id');
+      txResponse.should.have.property('txid');
+      txResponse.should.have.property('tx');
+      txResponse.should.have.property('status').eql('signed');
+    });
+  });
+});


### PR DESCRIPTION
[BG-29057](https://bitgoinc.atlassian.net/browse/BG-29057)

This enhancement adds support for Algorand non-participating key registration transaction. Marking an account non-participating makes an account to not earn rewards.
https://developer.algorand.org/docs/reference/transactions/#key-registration-transaction

The updates are done for "/tx/build" and "tx/initiate" routes which accept an additional nonParticipation flag which generates non-participating key registration transactions. These transactions can then be signed as submitted similar to any other transaction.

Requirements documentation:
https://docs.google.com/document/d/1ZemGLPmf5E9YY1cvqEoNZ7K4wOXxwj75_uQFyDQ09lM/edit?ts=600faba5#