### PR TITLE
fix(core): improve logging when encountering prebuild validation error

### DIFF
--- a/modules/core/src/v2/internal/parseOutput.ts
+++ b/modules/core/src/v2/internal/parseOutput.ts
@@ -134,7 +134,8 @@ function handleVerifyAddressError({
     return { external: false };
   }
 
-  debug('Address %s verification failed', currentAddress);
+  console.error('Address classification failed for address', currentAddress);
+  console.trace(e);
   /**
    * It might be a completely invalid address or a bad validation attempt or something else completely, in
    * which case we do not proceed and rather rethrow the error, which is safer than assuming that the address

--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -1792,8 +1792,10 @@ export class Wallet {
           reqId: params.reqId,
         });
       } catch (e) {
-        debug('Transaction prebuild failure:', e);
-        console.error('transaction prebuild failed local validation:');
+        console.error('transaction prebuild failed local validation:', e.message);
+        console.error('transaction params:', _.omit(params, ['keychain', 'prv', 'passphrase', 'walletPassphrase', 'key']));
+        console.error('transaction prebuild:', txPrebuild);
+        console.trace(e);
         throw e;
       }
 


### PR DESCRIPTION
This log info is currently behind a debug namespace flag, but we should
log these unconditionally, because it means something is wrong with the
prebuild that requires investigation.

Ticket: BG-29890