### PR TITLE
feat(express): log request method and url upon failed request

### DIFF
--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -756,7 +756,10 @@ function promiseWrapper(promiseRequestHandler: Function) {
         if (!(status >= 200 && status < 300)) {
           console.log('error %s: %s', status, err.message);
         }
-        if (status === 500) {
+        if (status >= 500 && status <= 599) {
+          if (err.response && err.response.request) {
+            console.log(`failed to make ${err.response.request.method} request to ${err.response.request.url}`);
+          }
           console.log(err.stack);
         }
         res.status(status).send(result);


### PR DESCRIPTION
This is useful to help narrow down failing requests within a single
proxied express call.

Also, print stack trace and error message for any type of 5xx error,
instead of only 500's.

Ticket: BG-29870