### PR TITLE
feat(account-lib): SignMessage and VerifySign for Casper

### DIFF
--- a/modules/account-lib/package.json
+++ b/modules/account-lib/package.json
@@ -55,7 +55,8 @@
     "protobufjs": "^6.8.9",
     "stellar-sdk": "^0.11.0",
     "tronweb": "^2.7.2",
-    "tweetnacl": "^1.0.3"
+    "tweetnacl": "^1.0.3",
+    "secp256k1": "4.0.2"
   },
   "devDependencies": {
     "@types/elliptic": "^6.4.12",

--- a/modules/account-lib/src/coin/cspr/ifaces.ts
+++ b/modules/account-lib/src/coin/cspr/ifaces.ts
@@ -50,3 +50,11 @@ export type ContractArgs = Record<
   'action' | 'deployment_thereshold' | 'key_management_threshold' | 'accounts' | 'weights',
   CLValue
 >;
+
+/**
+ * Secp256k1 return type for sign operations
+ */
+export interface SignResponse {
+  signature: Uint8Array;
+  recid: number;
+}

--- a/modules/account-lib/test/resources/cspr/cspr.ts
+++ b/modules/account-lib/test/resources/cspr/cspr.ts
@@ -69,6 +69,8 @@ export const ERROR_EMPTY_RAW_TRANSACTION = 'Raw transaction is empty';
 
 export const ERROR_JSON_PARSING = 'There was an error parsing the JSON string';
 
+export const ERROR_MISSING_PRIVATE_KEY = 'Missing private key';
+
 export const INVALID_RAW_TRANSACTION = 'This is an invalid raw transaction';
 
 export const VALID_ADDRESS = '025360ED570343B858C860801354EAAE4CDCD390EB3215A1C8C623CC55B63E442B';

--- a/modules/account-lib/test/unit/coin/cspr/signMessage.ts
+++ b/modules/account-lib/test/unit/coin/cspr/signMessage.ts
@@ -1,0 +1,25 @@
+import { randomBytes } from 'crypto';
+import should from 'should';
+import { KeyPair } from '../../../../src/coin/cspr/keyPair';
+import { isValidMessageSignature, signMessage } from '../../../../src/coin/cspr/utils';
+import * as testData from '../../../resources/cspr/cspr';
+
+describe('Sign Message', () => {
+  it('should be performed', async () => {
+    const keyPair = new KeyPair();
+    const messageToSign = Buffer.from(randomBytes(32)).toString('hex');
+    const { signature } = signMessage(keyPair, messageToSign);
+    isValidMessageSignature(Buffer.from(signature).toString('hex'), messageToSign, keyPair.getKeys().pub).should.equals(
+      true,
+    );
+  });
+
+  it('should fail with missing private key', async () => {
+    const keyPair = new KeyPair({ pub: testData.ACCOUNT_1.publicKey });
+    const messageToSign = Buffer.from(randomBytes(32)).toString('hex');
+    should.throws(
+      () => signMessage(keyPair, messageToSign),
+      e => e.message === testData.ERROR_MISSING_PRIVATE_KEY,
+    );
+  });
+});

--- a/modules/account-lib/test/unit/coin/cspr/transaction.ts
+++ b/modules/account-lib/test/unit/coin/cspr/transaction.ts
@@ -7,7 +7,12 @@ import * as testData from '../../../resources/cspr/cspr';
 import { KeyPair, TransactionBuilderFactory } from '../../../../src/coin/cspr';
 import { CHAIN_NAME, OWNER_PREFIX } from '../../../../src/coin/cspr/constants';
 import { register } from '../../../../src';
-import { getTransferAmount, getTransferDestinationAddress, getTransferId } from '../../../../src/coin/cspr/utils';
+import {
+  getTransferAmount,
+  getTransferDestinationAddress,
+  getTransferId,
+  isValidTransactionSignature,
+} from '../../../../src/coin/cspr/utils';
 
 describe('Cspr Transaction', () => {
   const factory = register('tcspr', TransactionBuilderFactory);
@@ -74,6 +79,14 @@ describe('Cspr Transaction', () => {
         tx.casperTx.approvals[0].signer.toUpperCase(),
         testData.SECP256K1_PREFIX + testData.ACCOUNT_1.publicKey,
       );
+      should.equal(
+        isValidTransactionSignature(
+          tx.casperTx.approvals[0].signature,
+          tx.casperTx.hash,
+          Buffer.from(tx.casperTx.header.account.rawPublicKey).toString('hex'),
+        ),
+        true,
+      );
     });
 
     it('multiple valid', async () => {
@@ -89,6 +102,11 @@ describe('Cspr Transaction', () => {
         tx.casperTx.approvals[0].signer.toUpperCase(),
         testData.SECP256K1_PREFIX + testData.ACCOUNT_1.publicKey,
       );
+      should.equal(
+        isValidTransactionSignature(tx.casperTx.approvals[0].signature, tx.casperTx.hash, testData.ACCOUNT_1.publicKey),
+        true,
+      );
+
       await tx.sign(keypair2).should.be.fulfilled();
       should.equal(
         tx.casperTx.approvals[0].signer.toUpperCase(),
@@ -97,6 +115,14 @@ describe('Cspr Transaction', () => {
       should.equal(
         tx.casperTx.approvals[1].signer.toUpperCase(),
         testData.SECP256K1_PREFIX + testData.ACCOUNT_2.publicKey,
+      );
+      should.equal(
+        isValidTransactionSignature(tx.casperTx.approvals[0].signature, tx.casperTx.hash, testData.ACCOUNT_1.publicKey),
+        true,
+      );
+      should.equal(
+        isValidTransactionSignature(tx.casperTx.approvals[1].signature, tx.casperTx.hash, testData.ACCOUNT_2.publicKey),
+        true,
       );
     });
   });


### PR DESCRIPTION
[STLX-676](https://bitgoinc.atlassian.net/browse/STLX-STLX-676) is a SDK-Core story. However, I need Account-Lib changes before so I decided to create this PR with those required changes.

Implemented signMessage and verifySignature methods on utils for Casper.
Used for signMessage on sdk-core.

[STLX-676](https://bitgoinc.atlassian.net/browse/STLX-STLX-676)