### PR TITLE
fix(account-lib): fix getTransferId method of cspr utils

### DIFF
--- a/modules/account-lib/src/coin/cspr/transaction.ts
+++ b/modules/account-lib/src/coin/cspr/transaction.ts
@@ -153,7 +153,10 @@ export class Transaction extends BaseTransaction {
       const transferValues = new Map();
       transferValues.set('amount', getTransferAmount(this.casperTx.session));
       transferValues.set('to_address', getTransferDestinationAddress(this.casperTx.session));
-      transferValues.set('id', getTransferId(this.casperTx.session).toString());
+      const transferId = getTransferId(this.casperTx.session);
+      if (transferId !== undefined) {
+        transferValues.set('id', transferId.toString());
+      }
 
       txJson['deploy']!['session']['Transfer']['args'].forEach(arg => {
         if (transferValues.has(arg[argName])) {

--- a/modules/account-lib/src/coin/cspr/transferBuilder.ts
+++ b/modules/account-lib/src/coin/cspr/transferBuilder.ts
@@ -48,7 +48,10 @@ export class TransferBuilder extends TransactionBuilder {
     this.transaction.setTransactionType(TransactionType.Send);
     this.to(getTransferDestinationAddress(tx.casperTx.session));
     this.amount(getTransferAmount(tx.casperTx.session));
-    this.transferId(getTransferId(tx.casperTx.session));
+    const transferId = getTransferId(tx.casperTx.session);
+    if (transferId !== undefined) {
+      this.transferId(transferId);
+    }
   }
 
   /** @inheritdoc */

--- a/modules/account-lib/src/coin/cspr/utils.ts
+++ b/modules/account-lib/src/coin/cspr/utils.ts
@@ -117,17 +117,17 @@ export function getTransferAmount(transferTx: ExecutableDeployItem): string {
  * Get transfer id from deploy transfer session
  *
  * @param {ExecutableDeployItem} transferTx transfer session
- * @returns {number} the transfer id
+ * @returns {number | undefined} the transferId if exists or undefined
  */
-export function getTransferId(transferTx: ExecutableDeployItem): number {
+export function getTransferId(transferTx: ExecutableDeployItem): number | undefined {
   const transferId = transferTx.getArgByName('id');
 
   if (!transferId || !transferId.isOption()) {
-    throw new InvalidTransactionError('Transfer does not have an id defined');
+    return; // no-op
   }
   const transferIdOption = transferId.asOption();
   if (transferIdOption.isNone()) {
-    throw new InvalidTransactionError('Transfer does not have an id defined');
+    return; // no-op
   }
   return transferIdOption
     .getSome()

--- a/modules/account-lib/test/unit/coin/cspr/transaction.ts
+++ b/modules/account-lib/test/unit/coin/cspr/transaction.ts
@@ -182,7 +182,10 @@ describe('Cspr Transaction', () => {
 
       transferValues.set('amount', getTransferAmount(transferTx.casperTx.session));
       transferValues.set('to_address', getTransferDestinationAddress(transferTx.casperTx.session));
-      transferValues.set('id', getTransferId(transferTx.casperTx.session).toString());
+      const transferId = getTransferId(transferTx.casperTx.session);
+      if (transferId !== undefined) {
+        transferValues.set('id', transferId.toString());
+      }
 
       const jsonOwnerArgs = transferJsonTx['deploy']['session']['Transfer']['args'].filter(arg =>
         transferValues.has(arg[argName]),

--- a/modules/account-lib/test/unit/coin/cspr/transactionBuilder/transferBuilder.ts
+++ b/modules/account-lib/test/unit/coin/cspr/transactionBuilder/transferBuilder.ts
@@ -217,36 +217,6 @@ describe('Casper Transfer Builder', () => {
         e => e.message === testData.ERROR_INVALID_DESTINATION_ADDRESS_ON_FROM,
       );
     });
-
-    it('a serialized transaction with invalid transfer id type', async () => {
-      const builder = initTxTransferBuilder().amount('10');
-      const tx = (await builder.build()) as Transaction;
-
-      tx.casperTx = DeployUtil.addArgToDeploy(tx.casperTx, 'id', CLValue.byteArray(Uint8Array.from([])));
-
-      const builder2 = factory.getTransferBuilder();
-      should.throws(
-        () => {
-          builder2.from(tx.toBroadcastFormat());
-        },
-        e => e.message === testData.ERROR_INVALID_TRANSFER_ID_ON_FROM,
-      );
-    });
-
-    it('a serialized transaction with empty transfer id value', async () => {
-      const builder = initTxTransferBuilder().amount('10');
-      const tx = (await builder.build()) as Transaction;
-
-      tx.casperTx = DeployUtil.addArgToDeploy(tx.casperTx, 'id', CLValue.option(null, CLTypeHelper.u64()));
-
-      const builder2 = factory.getTransferBuilder();
-      should.throws(
-        () => {
-          builder2.from(tx.toBroadcastFormat());
-        },
-        e => e.message === testData.ERROR_INVALID_TRANSFER_ID_ON_FROM,
-      );
-    });
   });
 
   describe('should fail', () => {


### PR DESCRIPTION
Return `undefined` if there's no transferId set on the deploy instead of throwing
The transferId value is optional

Depends on: #1047

Ticket: STLX-2082