### PR TITLE
fix: use correct kovan testnet explorer urls

### DIFF
--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -228,8 +228,8 @@ class Pyrmont extends Testnet implements AccountNetwork {
 
 class Kovan extends Testnet implements AccountNetwork {
   family = CoinFamily.ETH;
-  explorerUrl = 'https://api-kovan.etherscan.io/tx/';
-  accountExplorerUrl = 'https://api-kovan.etherscan.io/address/';
+  explorerUrl = 'https://kovan.etherscan.io/tx/';
+  accountExplorerUrl = 'https://kovan.etherscan.io/address/';
 }
 
 class Goerli extends Testnet implements AccountNetwork {


### PR DESCRIPTION
Kovan moved the API endpoints to the `api-kovan` subdomain, but the block explorer UI is still on `kovan`.

Ticket: BG-30204
Refs: f83b5cd742149f81d2a9a2074f22d8aa812a964c