### PR TITLE
ci: fix ci scripts to work for PR events

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -195,4 +195,8 @@ trigger:
   - rel/*
   - prod/production
 
+---
+kind: signature
+hmac: 920945bf8d2430c6c143f716593bf9aa023c35b954eab19a282c768373066c4a
+
 ...

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "generate-drone": "chmod 0666 .drone.yml && drone jsonnet --stream && chmod 0444 .drone.yml",
     "audit": "yarn audit ; test $? -lt 8",
     "lint": "lerna run lint --stream",
-    "lint-changed": "lerna run lint --since ${DRONE_REPO_BRANCH:-master}^..${DRONE_COMMIT:-HEAD} --stream",
-    "unit-test-changed": "lerna run unit-test --since ${DRONE_REPO_BRANCH:-master}^..${DRONE_COMMIT:-HEAD} --stream --parallel",
+    "lint-changed": "lerna run lint --since origin/${DRONE_REPO_BRANCH:-master}..${DRONE_COMMIT:-HEAD} --stream",
+    "unit-test-changed": "lerna run unit-test --since origin/${DRONE_REPO_BRANCH:-master}..${DRONE_COMMIT:-HEAD} --stream --parallel",
     "browser-tests": "lerna run --scope @bitgo/account-lib compile && lerna run --scope bitgo compile && lerna run --scope bitgo browser-test",
-    "gen-coverage-changed": "lerna run gen-coverage --since ${DRONE_REPO_BRANCH:-master}^..${DRONE_COMMIT:-HEAD} --stream --parallel",
-    "coverage-changed": "lerna run upload-coverage --since ${DRONE_REPO_BRANCH:-master}^..${DRONE_COMMIT:-HEAD} --stream --parallel --",
+    "gen-coverage-changed": "lerna run gen-coverage --since origin/${DRONE_REPO_BRANCH:-master}..${DRONE_COMMIT:-HEAD} --stream --parallel",
+    "coverage-changed": "lerna run upload-coverage --since origin/${DRONE_REPO_BRANCH:-master}..${DRONE_COMMIT:-HEAD} --stream --parallel --",
     "unit-test": "lerna run unit-test --stream --parallel",
     "integration-test": "lerna run integration-test --stream --parallel",
     "coverage": "yarn gen-coverage && yarn upload-coverage",
@@ -34,9 +34,9 @@
     "artifacts": "lerna run upload-artifacts --stream --parallel",
     "upload-docs": "lerna run upload-docs --stream --parallel",
     "gen-docs": "lerna run gen-docs --stream --parallel",
-    "check-fmt-changed": "lerna run check-fmt --since ${DRONE_REPO_BRANCH:-master}^..${DRONE_COMMIT:-HEAD} --stream --parallel",
+    "check-fmt-changed": "lerna run check-fmt --since origin/${DRONE_REPO_BRANCH:-master}..${DRONE_COMMIT:-HEAD} --stream --parallel",
     "check-fmt": "lerna run check-fmt --stream --parallel",
-    "check-commits": "yarn commitlint --from=${DRONE_REPO_BRANCH:-master}"
+    "check-commits": "yarn commitlint --from=origin/${DRONE_REPO_BRANCH:-master} -V"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "postinstall": "lerna run build --stream",
-    "generate-drone": "chmod 0666 .drone.yml && drone jsonnet --stream && chmod 0444 .drone.yml",
+    "gen-drone": "chmod 0666 .drone.yml && drone jsonnet --stream && drone sign BitGo/BitGoJS --save && chmod 0444 .drone.yml",
     "audit": "yarn audit ; test $? -lt 8",
     "lint": "lerna run lint --stream",
     "lint-changed": "lerna run lint --since origin/${DRONE_REPO_BRANCH:-master}..${DRONE_COMMIT:-HEAD} --stream",


### PR DESCRIPTION
These were making the assumption that the PR branch was not yet merged
to master, which isn't the case for PR builds (only push builds).

Please note that this isn't actually merging the PR into the master
branch as if the PR was accepted and merged - this is only a tentative
merge which exists ephemerally within drone during the build pipeline.

Additionally, improve the `generate-drone` script (now called `gen-drone` for
consistency with other scripts) to sign the updated .drone.yml. This should
prevent test secret leakage due to modifications to the .drone.yml from pull
requests.

Ticket: BG-30341