### PR TITLE
fix(core): add route name as tx type for consolidate/fanout

### DIFF
--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -935,7 +935,7 @@ export class Wallet {
       const transactionParams = _.extend({}, params, { txPrebuild: response, keychain });
       const signedTransaction = yield self.signTransaction(transactionParams);
       const selectParams = _.pick(params, ['comment', 'otp']);
-      const finalTxParams = _.extend({}, signedTransaction, selectParams);
+      const finalTxParams = _.extend({}, signedTransaction, selectParams, { type: routeName });
 
       self.bitgo.setRequestTracer(reqId);
       return self.bitgo.post(self.baseCoin.url('/wallet/' + self._wallet.id + '/tx/send'))

--- a/modules/core/test/v2/unit/pendingApproval.ts
+++ b/modules/core/test/v2/unit/pendingApproval.ts
@@ -27,7 +27,9 @@ describe('Pending Approvals:', () => {
           [coin]: {},
         },
         recipients: [],
-        buildParams: {},
+        buildParams: {
+          type: 'consolidate',
+        },
         sourceWallet: walletId,
       },
     },


### PR DESCRIPTION
Explicitly tag these special types of self-sends, and only call the
specialized build routes for these types when that tag is set.

This prevents inadvertent consolidations due to approving a pending
approval with no recipients (self-sends, since only external recipients
appear in the recipients list).

Note: fanout pending approvals won't work correctly, since their
specialized build route is not implemented in the pending approval
rebuild process.

Ticket: BG-29732