### PR TITLE
fix(core): rename feeInfo param in explain tx method for Casper

### DIFF
--- a/modules/core/src/v2/coins/cspr.ts
+++ b/modules/core/src/v2/coins/cspr.ts
@@ -43,7 +43,7 @@ export interface ExplainTransactionOptions {
   halfSigned?: {
     txHex: string;
   };
-  fee: TransactionFee;
+  feeInfo: TransactionFee;
 }
 
 interface SupplementGenerateWalletOptions {
@@ -240,7 +240,7 @@ export class Cspr extends BaseCoin {
     const self = this;
     return co<TransactionExplanation>(function*() {
       const txHex = params.txHex || (params.halfSigned && params.halfSigned.txHex);
-      if (!txHex || !params.fee) {
+      if (!txHex || !params.feeInfo) {
         throw new Error('missing explain tx parameters');
       }
       const txBuilder = accountLib.getBuilder(self.getChain()).from(txHex);
@@ -279,7 +279,7 @@ export class Cspr extends BaseCoin {
         changeOutputs: [], // account based does not use change outputs
         changeAmount: '0', // account base does not make change
         transferId,
-        fee: params.fee,
+        fee: params.feeInfo,
       };
     })
       .call(this)

--- a/modules/core/test/v2/unit/coins/cspr.ts
+++ b/modules/core/test/v2/unit/coins/cspr.ts
@@ -271,7 +271,7 @@ describe('Casper', function() {
         halfSigned: {
           txHex: halfSigned.txJson,
         },
-        fee: feeInfo,
+        feeInfo,
       };
       const explainedTx = await basecoin.explainTransaction(explainTxParams, () => {});
       explainedTx.should.have.properties([
@@ -293,6 +293,55 @@ describe('Casper', function() {
       });
       explainedTx.outputAmount.should.equal(transferAmount);
       explainedTx.transferId.should.equal(transferId);
+    });
+
+    it('should explain a signed transaction', async () => {
+      const builtTxInfo = {
+        txHex: '{"deploy":{"hash":"1f5683fa490f717318363995e4fc1956fbcba219ac356a261a5caa5886ce66c2","header":{"account":"0202865365d0c37d4bcdb47fd06a1d1a5f933725e2820def5cb24d33b1004326fcec","timestamp":"2021-03-19T18:03:09.082Z","ttl":"86400000ms","gas_price":1,"body_hash":"c7d70b14f4c56e1698a4540bcbc93ae8d5039bf26b69bccb74c86ed302fc66be","dependencies":[],"chain_name":"delta-10"},"payment":{"ModuleBytes":{"module_bytes":"","args":[["amount",{"cl_type":"U512","bytes":"02f82a","parsed":"null"}]]}},"session":{"Transfer":{"args":[["amount",{"cl_type":"U512","bytes":"021027","parsed":"10000"}],["target",{"cl_type":{"ByteArray":32},"bytes":"7ed4abba796fb70a335970ed1be187a7e8bbc107523df4b1f274a9591189b273","parsed":"null"}],["id",{"cl_type":{"Option":"U64"},"bytes":"01d204000000000000","parsed":"1234"}],["deploy_type",{"cl_type":"String","bytes":"0400000053656e64","parsed":"Send"}],["to_address",{"cl_type":"String","bytes":"42000000303341443039464441413333384345414232364639374546363038444244303133324646374242353730303835393936423631463730313438343037303146374633","parsed":"03AD09FDAA338CEAB26F97EF608DBD0132FF7BB570085996B61F7014840701F7F3"}]]}},"approvals":[]}}',
+        txInfo: {
+          hash: '1f5683fa490f717318363995e4fc1956fbcba219ac356a261a5caa5886ce66c2',
+          fee: {
+            gasLimit: '11000',
+            gasPrice: '1',
+          },
+          from: '02865365d0c37d4bcdb47fd06a1d1a5f933725e2820def5cb24d33b1004326fcec',
+          startTime: '2021-03-19T18:03:09.082Z',
+          expiration: 86400000,
+          deployType: 'Send',
+          to: '03AD09FDAA338CEAB26F97EF608DBD0132FF7BB570085996B61F7014840701F7F3',
+          amount: '10000',
+          transferId: 1234,
+        },
+        feeInfo: {
+          gasLimit: '11000',
+          gasPrice: '1',
+        },
+        recipients: [
+          {
+            address: '03AD09FDAA338CEAB26F97EF608DBD0132FF7BB570085996B61F7014840701F7F3',
+            amount: '10000',
+          },
+        ],
+      };
+      const explainTxParams: ExplainTransactionOptions = builtTxInfo;
+      const explainedTx = await basecoin.explainTransaction(explainTxParams, () => {});
+      explainedTx.should.have.properties([
+        'displayOrder',
+        'id',
+        'outputs',
+        'outputAmount',
+        'transferId',
+        'fee',
+        'changeOutputs',
+        'changeAmount',
+      ]);
+      explainedTx.fee.should.equal(builtTxInfo.feeInfo);
+      explainedTx.outputs.length.should.equal(1);
+      explainedTx.outputs[0].amount.should.equal(builtTxInfo.txInfo.amount);
+      explainedTx.outputs[0].address.should.equal(builtTxInfo.txInfo.to);
+      explainedTx.outputs[0].coin.should.equal(basecoin.getChain());
+      explainedTx.outputAmount.should.equal(builtTxInfo.txInfo.amount);
+      explainedTx.transferId.should.equal(builtTxInfo.txInfo.transferId);
     });
 
     it('should fail when a tx is not passed as parameter', async () => {


### PR DESCRIPTION
fee param was renamed to feeInfo in explainTransaction method for Casper. Unit test added.

Jira Ticket: [STLX-2278](https://bitgoinc.atlassian.net/browse/STLX-2278)

## Changes:
- fix fee information param name in explainTransaction method for Casper