### PR TITLE
stx: add support for generating keypairs using extended public/private keys

### DIFF
--- a/modules/account-lib/src/coin/stx/utils.ts
+++ b/modules/account-lib/src/coin/stx/utils.ts
@@ -10,6 +10,7 @@ import {
   validateStacksAddress,
 } from '@stacks/transactions';
 import { ec } from 'elliptic';
+import { isValidXpub, isValidXprv } from '../../utils/crypto';
 
 /**
  * Encodes a buffer as a "0x" prefixed lower-case hex string.
@@ -106,7 +107,8 @@ export function isValidTransactionId(txId: string): boolean {
 }
 
 /**
- * Returns whether or not the string is a valid protocol public key
+ * Returns whether or not the string is a valid protocol public key or
+ * extended public key.
  *
  * The key format is documented at
  * https://github.com/stacksgov/sips/blob/main/sips/sip-005/sip-005-blocks-and-transactions.md#transaction-authorization
@@ -115,6 +117,8 @@ export function isValidTransactionId(txId: string): boolean {
  * @returns {boolean} - the validation result
  */
 export function isValidPublicKey(pub: string): boolean {
+  if (isValidXpub(pub)) return true;
+
   if (pub.length !== 66 && pub.length !== 130) return false;
 
   const firstByte = pub.slice(0, 2);
@@ -139,16 +143,19 @@ export function isValidPublicKey(pub: string): boolean {
 }
 
 /**
- * Returns whether or not the string is a valid protocol private key
+ * Returns whether or not the string is a valid protocol private key, or extended
+ * private key.
  *
- * The key format is described in the @stacks/transactions npm package, in the
+ * The protocol key format is described in the @stacks/transactions npm package, in the
  * createStacksPrivateKey function:
  * https://github.com/blockstack/stacks.js/blob/master/packages/transactions/src/keys.ts#L125
  *
- * @param {string} prv - the  private key to be validated
+ * @param {string} prv - the private key (or extended private key) to be validated
  * @returns {boolean} - the validation result
  */
 export function isValidPrivateKey(prv: string): boolean {
+  if (isValidXprv(prv)) return true;
+
   if (prv.length !== 64 && prv.length !== 66) return false;
 
   if (prv.length === 66 && prv.slice(64) !== '01') return false;

--- a/modules/account-lib/test/resources/stx/stx.ts
+++ b/modules/account-lib/test/resources/stx/stx.ts
@@ -23,6 +23,17 @@ export const pubKey2 =
 export const pubKey2Compressed = '0321d6f42c99f7d23ec2c0dc21208a9c5edfce4e5bc7b63972e68e86e3cea6f41a';
 export const address2 = 'SPS4HSXAD1WSD3943WZ52MPSY9WPK56SDG54HTAR';
 
+// extended private/public keys
+// STX does not use them
+export const xprv1 =
+  'xprv9s21ZrQH143K34bdhCWMuiuHfdjQB21gu95NwpeGEEfGMWs7tA5s3PMBBPeJmXn5DQ3vv8Hp8kq1KrsaJJnczW3BMztL2VGTnxVPgVjgq1H';
+export const xpub1 =
+  'xpub661MyMwAqRbcFYg6oE3NGrr2DfZtaUjYGMzykD3snaCFEKCGRhQ7bBff2g3CYvyYPQMGSwSe1DH8GXvP6uB3iiWsPGGMbXVZGkrk1UxQVk6';
+export const xprv1Protocol = '73ea19aea25e87c4ee8eaee21417442ac9eb6898f4538ade8f2091d1d2c5946d';
+export const xpub1Protocol =
+  '042794bc43d75db0e8589987818754aa2f820a350a5742efaf0d50518fcbc6a80c597aa51aa8e755fd10b753f7e36410849171a99d8533f6ea84a0c4dfbe6e2419';
+export const xpub1ProtocolCompressed = '032794bc43d75db0e8589987818754aa2f820a350a5742efaf0d50518fcbc6a80c';
+
 export const ACCOUNT_1 = {
   prv: secretKey1,
   pub: pubKey1,

--- a/modules/account-lib/test/unit/coin/stx/keyPair.ts
+++ b/modules/account-lib/test/unit/coin/stx/keyPair.ts
@@ -32,6 +32,21 @@ describe('Stx KeyPair', function() {
       should.equal(keyPair.getKeys(false).pub, testData.pubKey2);
       should.equal(keyPair.getKeys(true).pub, testData.pubKey2Compressed);
     });
+
+    it('from an extended private key', () => {
+      const keyPair = new Stx.KeyPair({ prv: testData.xprv1 });
+      should.equal(keyPair.getExtendedKeys().xpub, testData.xpub1);
+      should.equal(keyPair.getKeys(false).prv!, testData.xprv1Protocol);
+      should.equal(keyPair.getKeys(false).pub.length, 130);
+    });
+
+    it('from an extended public key', () => {
+      const keyPair = new Stx.KeyPair({ pub: testData.xpub1 });
+      should.equal(keyPair.getExtendedKeys().xpub, testData.xpub1);
+      should.equal(keyPair.getKeys(false).pub, testData.xpub1Protocol);
+      should.equal(keyPair.getKeys(true).pub, testData.xpub1ProtocolCompressed);
+      should.equal(keyPair.getKeys(false).pub.length, 130);
+    });
   });
 
   describe('should fail to create a KeyPair', function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -333,6 +333,38 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@bitgo/account-lib@^2.8.0-rc.1":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@bitgo/account-lib/-/account-lib-2.8.0.tgz#a774ecd1937bae36684cbd5c4359d5f11de84576"
+  integrity sha512-yJ7CyrCPAkqE32kBD75Ki9nRC+vpwc1Jm5HFn/XMu7XaSHHvdlCp0uAkzFXB1P/DCe6beyOtE0lTsn0HgcH+Vw==
+  dependencies:
+    "@bitgo/bls" "^0.1.0"
+    "@bitgo/statics" "^6.3.0"
+    "@bitgo/utxo-lib" "^1.7.1"
+    "@celo/contractkit" "0.4.11"
+    "@hashgraph/sdk" "1.4.6"
+    "@stablelib/hex" "^1.0.0"
+    "@stablelib/sha384" "^1.0.0"
+    "@stacks/transactions" "1.3.0"
+    "@taquito/local-forging" "6.3.5-beta.0"
+    "@taquito/signer" "6.3.5-beta.0"
+    "@types/lodash" "^4.14.151"
+    bignumber.js "^9.0.0"
+    blake2b "git+https://github.com/BitGo/blake2b.git#6268e6dd678661e0acc4359e9171b97eb1ebf8ac"
+    bs58check "^2.1.2"
+    casper-client-sdk "1.0.20"
+    elliptic "^6.5.2"
+    ethereumjs-abi "^0.6.5"
+    ethereumjs-tx "2.1.2"
+    ethereumjs-util "5.2.0"
+    libsodium-wrappers "^0.7.6"
+    lodash "^4.17.15"
+    protobufjs "^6.8.9"
+    secp256k1 "4.0.2"
+    stellar-sdk "^0.11.0"
+    tronweb "^2.7.2"
+    tweetnacl "^1.0.3"
+
 "@bitgo/bls@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@bitgo/bls/-/bls-0.1.0.tgz#8fb1ecaeeeb776a6678d3e58067f83ef7a29aad7"
@@ -348,6 +380,11 @@
   integrity sha512-EKu69JBVLQpRb131SCNhES8U6OQNn/tgdEY68w15DdMzUIbxDb1TIXTy1FgDzos1CPlXmcE/zXit0Escz7qJ+Q==
   dependencies:
     buffer "^5.4.3"
+
+"@bitgo/statics@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@bitgo/statics/-/statics-6.3.0.tgz#d69ffbbe2215cb43d3148ccb38dc3a00d9b5baa7"
+  integrity sha512-kLwy0q58g/jpdtxf1HdqIJAULkpSPbMmGLFKkZZUSYlYJqlx/lS7tdYrwMDeljBpFYl5+7NoqpeBeGRfrmgVGg==
 
 "@bitgo/unspents@^0.6.0":
   version "0.6.2"


### PR DESCRIPTION
`isValidPublicKey` and `isValidPrivateKey` also support extended keys.
    
While STX doesn't use extended keys anywhere, this looks like it's needed for functionality in `modules/core`.

Cc: @wesgraham 