### PR TITLE
feat: add STX back to statics

### DIFF
--- a/modules/core/src/v2/coinFactory.ts
+++ b/modules/core/src/v2/coinFactory.ts
@@ -22,6 +22,7 @@ import {
   Ofc,
   Rbtc,
   Rmg,
+  Stx,
   Susd,
   Talgo,
   Tbch,
@@ -39,8 +40,9 @@ import {
   Tltc,
   Trbtc,
   Trmg,
-  Tsusd,
   Trx,
+  Tstx,
+  Tsusd,
   Ttrx,
   Xtz,
   Txtz,
@@ -164,6 +166,8 @@ GlobalCoinFactory.registerCoinConstructor('susd', Susd.createInstance);
 GlobalCoinFactory.registerCoinConstructor('tsusd', Tsusd.createInstance);
 GlobalCoinFactory.registerCoinConstructor('cspr', Cspr.createInstance);
 GlobalCoinFactory.registerCoinConstructor('tcspr', Tcspr.createInstance);
+GlobalCoinFactory.registerCoinConstructor('stx', Stx.createInstance);
+GlobalCoinFactory.registerCoinConstructor('tstx', Tstx.createInstance);
 for (const token of [...tokens.bitcoin.eth.tokens, ...tokens.testnet.eth.tokens]) {
   const tokenConstructor = Erc20Token.createTokenConstructor(token);
   GlobalCoinFactory.registerCoinConstructor(token.type, tokenConstructor);

--- a/modules/core/src/v2/coins/index.ts
+++ b/modules/core/src/v2/coins/index.ts
@@ -48,3 +48,5 @@ export { Xrp } from './xrp';
 export { Zec } from './zec';
 export { Cspr } from './cspr';
 export { Tcspr } from './tcspr';
+export { Stx } from './stx';
+export { Tstx } from './tstx';

--- a/modules/core/src/v2/coins/stx.ts
+++ b/modules/core/src/v2/coins/stx.ts
@@ -1,0 +1,119 @@
+/**
+ * @prettier
+ */
+import * as Bluebird from 'bluebird';
+import * as accountLib from '@bitgo/account-lib';
+import { ECPair } from '@bitgo/utxo-lib';
+import { BaseCoin, KeyPair, SignedTransaction, VerifyAddressOptions, VerifyTransactionOptions } from '../baseCoin';
+import { NodeCallback } from '../types';
+import { BitGo } from '../../bitgo';
+import { BaseCoin as StaticsBaseCoin, CoinFamily } from '@bitgo/statics';
+
+const co = Bluebird.coroutine;
+
+interface SupplementGenerateWalletOptions {
+  rootPrivateKey?: string;
+}
+
+export class Stx extends BaseCoin {
+  protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
+
+  constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+    super(bitgo);
+
+    if (!staticsCoin) {
+      throw new Error('missing required constructor parameter staticsCoin');
+    }
+
+    this._staticsCoin = staticsCoin;
+  }
+
+  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+    return new Stx(bitgo, staticsCoin);
+  }
+
+  getChain(): string {
+    return this._staticsCoin.name;
+  }
+  getFamily(): CoinFamily {
+    return this._staticsCoin.family;
+  }
+  getFullName(): string {
+    return this._staticsCoin.fullName;
+  }
+  getBaseFactor(): string | number {
+    return Math.pow(10, this._staticsCoin.decimalPlaces);
+  }
+
+  verifyTransaction(params: VerifyTransactionOptions, callback?: NodeCallback<boolean>): Bluebird<boolean> {
+    // TODO: Implement when available on the SDK.
+    return Bluebird.resolve(true).asCallback(callback);
+  }
+  verifyAddress(params: VerifyAddressOptions): boolean {
+    // TODO: Implement when available on the SDK.
+    throw true;
+  }
+
+  /**
+   * Generate Stacks key pair
+   *
+   * @param {Buffer} seed - Seed from which the new keypair should be generated, otherwise a random seed is used
+   * @returns {Object} object with generated pub and prv
+   */
+  generateKeyPair(seed?: Buffer): KeyPair {
+    const keyPair = seed ? new accountLib.Stx.KeyPair({ seed }) : new accountLib.Stx.KeyPair();
+    const keys = keyPair.getExtendedKeys();
+
+    if (!keys.xprv) {
+      throw new Error('Missing xprv in key generation.');
+    }
+
+    return {
+      pub: keys.xpub,
+      prv: keys.xprv,
+    };
+  }
+
+  /**
+   * Return boolean indicating whether input is valid public key for the coin
+   *
+   * @param {string} pub the prv to be checked
+   * @returns is it valid?
+   */
+  isValidPub(pub: string): boolean {
+    try {
+      return accountLib.Stx.Utils.isValidPublicKey(pub);
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /**
+   * Return boolean indicating whether input is valid private key for the coin
+   *
+   * @param {string} prv the prv to be checked
+   * @returns is it valid?
+   */
+  isValidPrv(prv: string): boolean {
+    try {
+      return accountLib.Stx.Utils.isValidPrivateKey(prv);
+    } catch (e) {
+      return false;
+    }
+  }
+
+  isValidAddress(address: string): boolean {
+    try {
+      return accountLib.Stx.Utils.isValidAddress(address);
+    } catch (e) {
+      return false;
+    }
+  }
+
+  signTransaction(params: any): Bluebird<SignedTransaction> {
+    throw new Error('Method not implemented.');
+  }
+  parseTransaction(params: any, callback?: NodeCallback<any>): Bluebird<any> {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/modules/core/src/v2/coins/tstx.ts
+++ b/modules/core/src/v2/coins/tstx.ts
@@ -1,0 +1,31 @@
+import { BitGo } from '../../bitgo';
+import { BaseCoin } from '../baseCoin';
+import { Stx } from './stx';
+import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
+
+export class Tstx extends Stx {
+
+  protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
+
+  constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+    super(bitgo, staticsCoin);
+
+    if (!staticsCoin) {
+      throw new Error('missing required constructor parameter staticsCoin');
+    }
+
+    this._staticsCoin = staticsCoin;
+  }
+
+  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+    return new Tstx(bitgo, staticsCoin);
+  }
+
+  getChain() {
+    return this._staticsCoin.name;
+  }
+
+  getFullName() {
+    return this._staticsCoin.fullName;
+  }
+}

--- a/modules/core/test/v2/unit/keychains.ts
+++ b/modules/core/test/v2/unit/keychains.ts
@@ -50,7 +50,7 @@ describe('V2 Keychains', function v2keychains() {
   describe('Key generation enforcement for SECP256K1', function() {
     // iterate over non-fiat crypto secp coins
     const coinFamilyValues = Object.keys(CoinFamily).map(n => n.toLowerCase());
-    // TODO To change when method is implemented for this coin Ticket BGA-948  
+    // TODO To change when method is implemented for this coin Ticket BGA-948
     const cryptoSecpCoins = coins.filter(n => n.primaryKeyCurve === KeyCurve.Secp256k1
       && n.kind === CoinKind.CRYPTO
       && n.asset !== UnderlyingAsset.USD

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -33,6 +33,7 @@ export enum CoinFamily {
   OFC = 'ofc',
   RMG = 'rmg',
   RBTC = 'rbtc',
+  STX = 'stx',
   SUSD = 'susd',
   TRX = 'trx',
   XLM = 'xlm',
@@ -150,6 +151,7 @@ export enum UnderlyingAsset {
   HBAR = 'hbar', // Hedera main coin
   LTC = 'ltc',
   RBTC = 'rbtc', // RSK main coin
+  STX = 'stx',
   TRX = 'trx',
   XRP = 'xrp',
   XLM = 'xlm',

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -77,6 +77,8 @@ export const coins = CoinMap.fromCoins([
   account('txtz', 'Testnet Tezos', Networks.test.xtz, 6, UnderlyingAsset.XTZ, XTZ_FEATURES),
   account('susd', 'Silvergate USD', Networks.main.susd, 2, UnderlyingAsset.USD),
   account('tsusd', 'Testnet Silvergate USD', Networks.test.susd, 2, UnderlyingAsset.USD),
+  account('stx', 'Blockstack', Networks.main.stx, 6, UnderlyingAsset.STX),
+  account('tstx', 'Testnet Blockstack', Networks.test.stx, 6, UnderlyingAsset.STX),
   erc20CompatibleAccountCoin(
     'celo',
     'Celo Gold',

--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -322,6 +322,17 @@ class StellarTestnet extends Testnet implements AccountNetwork {
   family = CoinFamily.XLM;
   explorerUrl = 'https://stellar.expert/explorer/testnet/tx/';
 }
+
+class Stx extends Mainnet implements AccountNetwork {
+  family = CoinFamily.STX;
+  explorerUrl = 'https://explorer.stacks.co/';
+}
+
+class StxTestnet extends Testnet implements AccountNetwork {
+  family = CoinFamily.STX;
+  explorerUrl = 'https://explorer.stacks.co/?chain=testnet';
+}
+
 class SUSD extends Mainnet implements AccountNetwork {
   family = CoinFamily.SUSD;
   explorerUrl = undefined;
@@ -402,6 +413,7 @@ export const Networks = {
     ofc: Object.freeze(new Ofc()),
     rbtc: Object.freeze(new Rbtc()),
     stellar: Object.freeze(new Stellar()),
+    stx: Object.freeze(new Stx()),
     susd: Object.freeze(new SUSD()),
     trx: Object.freeze(new Trx()),
     xrp: Object.freeze(new Xrp()),
@@ -427,6 +439,7 @@ export const Networks = {
     ofc: Object.freeze(new OfcTestnet()),
     rbtc: Object.freeze(new RbtcTestnet()),
     stellar: Object.freeze(new StellarTestnet()),
+    stx: Object.freeze(new StxTestnet()),
     susd: Object.freeze(new SUSDTestnet()),
     trx: Object.freeze(new TrxTestnet()),
     xrp: Object.freeze(new XrpTestnet()),


### PR DESCRIPTION
STX was removed from statics (https://github.com/BitGo/BitGoJS/pull/1072) due to a behaviour break from other secp256k1 based coins. STX doesn't produce xpubs from it's generateKeyPair function, and instead produces derived keys directly. We have addressed and fixed this in https://github.com/BitGo/BitGoJS/pull/1076/ - and as such are ready again to add STX to statics
Ticket: BG-30487