### PR TITLE
fix(express): don't store false when boolean flags are not given

### DIFF
--- a/modules/express/src/args.ts
+++ b/modules/express/src/args.ts
@@ -59,18 +59,20 @@ parser.addArgument(['-l', '--logfile'], {
 });
 
 parser.addArgument(['--disablessl'], {
-  action: 'storeTrue',
+  action: 'storeConst',
+  constant: true,
   help: 'Allow running against production in non-SSL mode (at your own risk!)',
 });
 
 parser.addArgument(['--disableproxy'], {
-  action: 'storeTrue',
+  action: 'storeConst',
+  constant: true,
   help: 'disable the proxy, not routing any non-express routes',
 });
 
 parser.addArgument(['--disableenvcheck'], {
-  action: 'storeTrue',
-  defaultValue: true, // BG-9584: temporarily disable env check while we give users time to react to change in runtime behavior
+  action: 'storeConst',
+  constant: true,
   help: 'disable checking for proper NODE_ENV when running in prod environment',
 });
 

--- a/modules/express/src/config.ts
+++ b/modules/express/src/config.ts
@@ -76,7 +76,9 @@ export const DefaultConfig: Config = {
   logFile: '',
   disableSSL: false,
   disableProxy: false,
-  disableEnvCheck: false,
+  // BG-9584: temporarily disable env check while we give users time to react to change in runtime behavior
+  // This will require a major version bump, since this is a breaking change to default behavior.
+  disableEnvCheck: true,
   timeout: 305 * 1000,
 };
 

--- a/modules/express/test/unit/config.ts
+++ b/modules/express/test/unit/config.ts
@@ -2,7 +2,7 @@
 /// <reference types="mocha" />
 // eslint-disable-next-line
 /// <reference types="node" />
-import 'should';
+import * as should from 'should';
 import * as sinon from 'sinon';
 
 import { config, DefaultConfig } from '../../src/config';
@@ -152,5 +152,14 @@ describe('Config:', () => {
         consoleStub.calledOnceWithExactly(sinon.match(/deprecated environment variable/)).should.be.true();
       }
     }
+  });
+
+  it('should set omitted boolean command line args to null and not false', () => {
+    const argvStub = sinon.stub(process, 'argv').value([process.argv[0]]);
+    const parsed = args.args();
+    should.not.exist(parsed.disablessl);
+    should.not.exist(parsed.disableenvcheck);
+    should.not.exist(parsed.disableproxy);
+    argvStub.restore();
   });
 });


### PR DESCRIPTION
The config precedence system expects that command line options which
aren't present to not exist (ie, set to `null` or `undefined`), but when
we use the `storeTrue` action for argparse arguments, omitted options
get set to `false`, which causes them to override any values passed via
environment variables.

Instead, use `storeConst` and store `true` explicitly if the option is
given. This will cause argparse to set the argument value to `null` if
it is omitted.

Ticket: BG-30729