### PR TITLE
add stx to account-lib's coinBuilderMap

### DIFF
--- a/modules/account-lib/src/index.ts
+++ b/modules/account-lib/src/index.ts
@@ -60,6 +60,8 @@ const coinBuilderMap = {
   tcspr: Cspr.TransactionBuilderFactory,
   xrp: Xrp.TransactionBuilderFactory,
   txrp: Xrp.TransactionBuilderFactory,
+  stx: Stx.TransactionBuilderFactory,
+  tstx: Stx.TransactionBuilderFactory,
 };
 
 /**


### PR DESCRIPTION
This adds an entry for STX to the `coinBuilderMap` in `account-lib`.  This lets the builder be used from `modules/core`.