### PR TITLE
fix(core): send `derivedFromParentWithSeed` when generating wallet

### DIFF
--- a/modules/core/src/v2/wallets.ts
+++ b/modules/core/src/v2/wallets.ts
@@ -392,6 +392,7 @@ export class Wallets {
             });
             derivationPath = derivation.derivationPath;
             userKeychain.pub = derivation.key;
+            userKeychain.derivedFromParentWithSeed = params.coldDerivationSeed;
           }
         } else {
           if (!canEncrypt) {

--- a/modules/core/test/v2/unit/wallet.ts
+++ b/modules/core/test/v2/unit/wallet.ts
@@ -189,6 +189,16 @@ describe('V2 Wallet:', function() {
     });
   });
 
+  describe('Get User Prv', () => {
+    it('should use the cold derivation seed to derive the proper user private key', async () => {
+      const userKeychain = {
+        prv: 'xprv9s21ZrQH143K3hekyNj7TciR4XNYe1kMj68W2ipjJGNHETWP7o42AjDnSPgKhdZ4x8NBAvaL72RrXjuXNdmkMqLERZza73oYugGtbLFXG8g',
+        coldDerivationSeed: '123',
+      };
+      wallet.getUserPrv(userKeychain).should.eql('xprv9yoG67Td11uwjXwbV8zEmrySVXERu5FZAsLD9suBeEJbgJqANs8Yng5dEJoii7hag5JermK6PbfxgDmSzW7ewWeLmeJEkmPfmZUSLdETtHx');
+    });
+  });
+
   describe('Transaction Signature Verification', function() {
     let wallet;
     let basecoin;


### PR DESCRIPTION
The `derivedFromParentWithSeed` parameter allows a user to provide a
seed for deriving a deterministic wallet public key from a cold master
key.

This was implemented directly in the UI wallet generation flow, but
wasn't supported when generating wallets with the SDK.

Ticket: BG-30809