### PR TITLE
stx: add util functions to check for valid memo strings and to pad them

### DIFF
--- a/modules/account-lib/src/coin/stx/transaction.ts
+++ b/modules/account-lib/src/coin/stx/transaction.ts
@@ -107,6 +107,8 @@ export class Transaction extends BaseTransaction {
       const payload = this._stxTransaction.payload;
       const txPayload: StacksTransactionPayload = {
         payloadType: PayloadType.TokenTransfer,
+        // result.payload.memo will be padded with \u0000 up to
+        // MEMO_MAX_LENGTH_BYTES as defined in @stacks/transactions
         memo: payload.memo.content,
         to: addressToString({
           type: StacksMessageType.Address,

--- a/modules/account-lib/src/coin/stx/transactionBuilder.ts
+++ b/modules/account-lib/src/coin/stx/transactionBuilder.ts
@@ -21,7 +21,7 @@ import { BaseAddress, BaseFee, BaseKey } from '../baseCoin/iface';
 import { Transaction } from './transaction';
 import { KeyPair } from './keyPair';
 import { SignatureData } from './iface';
-import { isValidAddress, removeHexPrefix } from './utils';
+import { isValidAddress, removeHexPrefix, isValidMemo } from './utils';
 
 export abstract class TransactionBuilder extends BaseTransactionBuilder {
   private _transaction: Transaction;
@@ -167,6 +167,9 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
    * @returns {TransactionBuilder} This transaction builder
    */
   memo(memo: string): this {
+    if (!isValidMemo(memo)) {
+      throw new BuildTransactionError('Memo is too long');
+    }
     this._memo = memo;
     return this;
   }

--- a/modules/account-lib/src/coin/stx/utils.ts
+++ b/modules/account-lib/src/coin/stx/utils.ts
@@ -10,6 +10,8 @@ import {
   validateStacksAddress,
   deserializeTransaction,
   BufferReader,
+  createMemoString,
+  MEMO_MAX_LENGTH_BYTES,
 } from '@stacks/transactions';
 import { ec } from 'elliptic';
 import { StacksNetwork } from '@stacks/network';
@@ -204,6 +206,23 @@ export function isValidRawTransaction(rawTransaction: unknown): boolean {
   } catch (e) {
     return false;
   }
+
+  return true;
+}
+
+/**
+ * Returns whether or not the memo string is valid
+ *
+ * @param {string} memo - the string to be validated
+ * @returns {boolean} - the validation result
+ */
+export function isValidMemo(memo: string): boolean {
+  try {
+    createMemoString(memo);
+  } catch (e) {
+    return false;
+  }
+
   return true;
 }
 
@@ -230,9 +249,17 @@ export function isValidContractAddress(addr: string, network: StacksNetwork): bo
  * @returns {boolean} - validation result
  */
 export function isValidContractFunctionName(name: string): boolean {
-  if (ContractFunctionNames.includes(name)) {
-    return true;
-  } else {
-    return false;
-  }
+  return ContractFunctionNames.includes(name);
+}
+
+/**
+ * Pads a memo string with nulls to fill up the length
+ *
+ * Useful when comparing a memo in a transaction against a string.
+ *
+ * @param {string} memo - the string to be validated
+ * @returns {boolean} - the validation result
+ */
+export function padMemo(memo: string): string {
+  return memo.padEnd(MEMO_MAX_LENGTH_BYTES, '\u0000');
 }

--- a/modules/account-lib/test/unit/coin/stx/transactionBuilder/transferBuilder.ts
+++ b/modules/account-lib/test/unit/coin/stx/transactionBuilder/transferBuilder.ts
@@ -145,6 +145,14 @@ describe('Stx Transfer Builder', () => {
           e => e.message === 'Invalid amount',
         );
       });
+
+      it('a transfer transaction with an invalid memo', async () => {
+        const txBuilder = factory.getTransferBuilder();
+        should.throws(
+          () => txBuilder.memo('This is a memo that is too long for a transaction'),
+          e => e.message === 'Memo is too long',
+        );
+      });
     });
   });
 });

--- a/modules/account-lib/test/unit/coin/stx/util.ts
+++ b/modules/account-lib/test/unit/coin/stx/util.ts
@@ -126,4 +126,19 @@ describe('Stx util library', function() {
       }
     });
   });
+
+  describe('transaction memo', function() {
+    it('check for valid memo strings', function() {
+      const memoStrings = ['', 'This is a test.', 'Okay', '!!This is thirty four bytes long!!'];
+      for (const memo of memoStrings) {
+        Utils.isValidMemo(memo).should.be.true();
+      }
+    });
+    it('check for valid memo strings', function() {
+      const memoStrings = ['ꜟꜟThis is thirty four chars long!!', 'It was the best of times, it was the worst of times'];
+      for (const memo of memoStrings) {
+        Utils.isValidMemo(memo).should.be.false();
+      }
+    });
+  });
 });


### PR DESCRIPTION
* `isValidMemo` ensures that the memo field is valid (not too long).
* `padMemo` right-pads the memo string with nulls (\u0000).  This is useful in tests when comparing a transaction's memo field with expected output.

