### PR TITLE
fix(core): use `derivedFromParentWithSeed` from user keychain if present

### DIFF
--- a/modules/core/src/v2/keychains.ts
+++ b/modules/core/src/v2/keychains.ts
@@ -17,6 +17,7 @@ export interface Keychain {
   provider?: string;
   encryptedPrv?: string;
   derivationPath?: string;
+  derivedFromParentWithSeed?: string;
 }
 
 export interface ChangedKeychains {

--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -1729,6 +1729,17 @@ export class Wallet {
     if (userPrv && typeof userPrv !== 'string') {
       throw new Error('prv must be a string');
     }
+
+    // use the `derivedFromParentWithSeed` property from the user keychain as the `coldDerivationSeed`
+    // if no other `coldDerivationSeed` was explicitly provided
+    if (
+      params.coldDerivationSeed === undefined &&
+      params.keychain !== undefined &&
+      params.keychain.derivedFromParentWithSeed !== undefined
+    ) {
+      params.coldDerivationSeed = params.keychain.derivedFromParentWithSeed;
+    }
+
     if (userPrv && params.coldDerivationSeed) {
       // the derivation only makes sense when a key already exists
       const derivation = this.baseCoin.deriveKeyWithSeed({ key: userPrv, seed: params.coldDerivationSeed });

--- a/modules/core/test/v2/unit/wallet.ts
+++ b/modules/core/test/v2/unit/wallet.ts
@@ -190,12 +190,35 @@ describe('V2 Wallet:', function() {
   });
 
   describe('Get User Prv', () => {
+    const prv = 'xprv9s21ZrQH143K3hekyNj7TciR4XNYe1kMj68W2ipjJGNHETWP7o42AjDnSPgKhdZ4x8NBAvaL72RrXjuXNdmkMqLERZza73oYugGtbLFXG8g';
+    const derivedPrv = 'xprv9yoG67Td11uwjXwbV8zEmrySVXERu5FZAsLD9suBeEJbgJqANs8Yng5dEJoii7hag5JermK6PbfxgDmSzW7ewWeLmeJEkmPfmZUSLdETtHx';
     it('should use the cold derivation seed to derive the proper user private key', async () => {
-      const userKeychain = {
-        prv: 'xprv9s21ZrQH143K3hekyNj7TciR4XNYe1kMj68W2ipjJGNHETWP7o42AjDnSPgKhdZ4x8NBAvaL72RrXjuXNdmkMqLERZza73oYugGtbLFXG8g',
+      const userPrvOptions = {
+        prv,
         coldDerivationSeed: '123',
       };
-      wallet.getUserPrv(userKeychain).should.eql('xprv9yoG67Td11uwjXwbV8zEmrySVXERu5FZAsLD9suBeEJbgJqANs8Yng5dEJoii7hag5JermK6PbfxgDmSzW7ewWeLmeJEkmPfmZUSLdETtHx');
+      wallet.getUserPrv(userPrvOptions).should.eql(derivedPrv);
+    });
+
+    it('should use the user keychain derivedFromParentWithSeed as the cold derivation seed if none is provided', async () => {
+      const userPrvOptions = {
+        prv,
+        keychain: {
+          derivedFromParentWithSeed: '123',
+        },
+      };
+      wallet.getUserPrv(userPrvOptions).should.eql(derivedPrv);
+    });
+
+    it('should prefer the explicit cold derivation seed to the user keychain derivedFromParentWithSeed', async () => {
+      const userPrvOptions = {
+        prv,
+        coldDerivationSeed: '123',
+        keychain: {
+          derivedFromParentWithSeed: '456',
+        },
+      };
+      wallet.getUserPrv(userPrvOptions).should.eql(derivedPrv);
     });
   });
 


### PR DESCRIPTION
The BitGo server keeps the cold derivation seed on the
`derivedFromKeyWithSeed` property of a user keychain. Unless there's an
explicit `coldDerivationSeed` provided, use the `derivedFromKeyWithSeed`
property when deriving the signing private key.

Ticket: BG-30809