### PR TITLE
fix(core): don't log wallet upon tx prebuild validation failure

### DIFF
--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -1796,7 +1796,7 @@ export class Wallet {
         });
       } catch (e) {
         console.error('transaction prebuild failed local validation:', e.message);
-        console.error('transaction params:', _.omit(params, ['keychain', 'prv', 'passphrase', 'walletPassphrase', 'key']));
+        console.error('transaction params:', _.omit(params, ['keychain', 'prv', 'passphrase', 'walletPassphrase', 'key', 'wallet']));
         console.error('transaction prebuild:', txPrebuild);
         console.trace(e);
         throw e;


### PR DESCRIPTION
There's not much useful info we can glean from the wallet object, and
it's a big object that creates a lot of logging noise.

Ticket: BG-30841