### PR TITLE
ci: run unit tests in node 12, 14, and 15

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -15,25 +15,27 @@ local BuildInfo(version) = {
   ],
 };
 
-local Install(version) = {
+local Install(version, allow_failure=false) = {
   name: "install",
   image: "node:" + version,
+  [if allow_failure then "failure"]: "ignore",
   commands: [
     "git fetch origin +refs/heads/$DRONE_REPO_BRANCH:$DRONE_REPO_BRANCH || true",
-    "yarn install" + (if (version == "6" || version == "8") then " --ignore-engines" else ""),
+    "yarn install",
   ],
 };
 
-local Command(command, version="lts") = {
+local Command(command, version="lts", allow_failure=false) = {
   name: command,
   image: "node:" + version,
+  [if allow_failure then "failure"]: "ignore",
   commands: [
     "yarn run " + command,
   ],
 };
 
-local CommandWithSecrets(command, version) =
-  Command(command, version) + {
+local CommandWithSecrets(command, version, allow_failure=false) =
+  Command(command, version, allow_failure) + {
   environment: {
     BITGOJS_TEST_PASSWORD: { from_secret: "password" },
   },
@@ -102,9 +104,10 @@ local UploadDocs(version) = {
   }
 };
 
-local UploadArtifacts(version, tag="untagged", only_changed=false) = {
+local UploadArtifacts(version, tag="untagged", only_changed=false, allow_failure=false) = {
   name: "upload artifacts",
   image: "bitgosdk/upload-tools:latest",
+  [if allow_failure then "failure"]: "ignore",
   environment: {
     CODECOV_TOKEN: { from_secret: "codecov" },
     CODECOV_FLAG: tag,
@@ -121,14 +124,14 @@ local UploadArtifacts(version, tag="untagged", only_changed=false) = {
   }
 };
 
-local UnitTest(version) = {
+local UnitTest(version, allow_failure=false) = {
   kind: "pipeline",
   name: "unit tests (node:" + version + ")",
   steps: [
     BuildInfo(version),
-    Install(version),
-    CommandWithSecrets("unit-test-changed", version),
-    UploadArtifacts(version, "unit", true),
+    Install(version, allow_failure),
+    CommandWithSecrets("unit-test-changed", version, allow_failure),
+    UploadArtifacts(version, "unit", true, allow_failure),
   ],
 };
 
@@ -226,7 +229,8 @@ local CheckPreconditions(version) = {
   ]
 };
 
-local UnitVersions = ["10", "12", "14", "15"];
+local UnitVersions = ["10"];
+local OptionalUnitVersions = ["12", "14", "15"];
 local IntegrationVersions = ["10"];
 
 [
@@ -235,6 +239,9 @@ local IntegrationVersions = ["10"];
 ] + [
   UnitTest(version)
   for version in UnitVersions
+] + [
+  UnitTest(version, true)
+  for version in OptionalUnitVersions
 # BG-23925 - reenable integration tests when testnet is stable
 # ] + [
 #  IncludeBranches(IntegrationTest(version))

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -226,7 +226,7 @@ local CheckPreconditions(version) = {
   ]
 };
 
-local UnitVersions = ["10"];
+local UnitVersions = ["10", "12", "14", "15"];
 local IntegrationVersions = ["10"];
 
 [

--- a/.drone.yml
+++ b/.drone.yml
@@ -159,6 +159,7 @@ steps:
   commands:
   - git fetch origin +refs/heads/$DRONE_REPO_BRANCH:$DRONE_REPO_BRANCH || true
   - yarn install
+  failure: ignore
 
 - name: unit-test-changed
   image: node:12
@@ -167,6 +168,7 @@ steps:
   environment:
     BITGOJS_TEST_PASSWORD:
       from_secret: password
+  failure: ignore
 
 - name: upload artifacts
   image: bitgosdk/upload-tools:latest
@@ -182,6 +184,7 @@ steps:
       from_secret: reports_s3_akid
     reports_s3_sak:
       from_secret: reports_s3_sak
+  failure: ignore
   when:
     status:
     - success
@@ -209,6 +212,7 @@ steps:
   commands:
   - git fetch origin +refs/heads/$DRONE_REPO_BRANCH:$DRONE_REPO_BRANCH || true
   - yarn install
+  failure: ignore
 
 - name: unit-test-changed
   image: node:14
@@ -217,6 +221,7 @@ steps:
   environment:
     BITGOJS_TEST_PASSWORD:
       from_secret: password
+  failure: ignore
 
 - name: upload artifacts
   image: bitgosdk/upload-tools:latest
@@ -232,6 +237,7 @@ steps:
       from_secret: reports_s3_akid
     reports_s3_sak:
       from_secret: reports_s3_sak
+  failure: ignore
   when:
     status:
     - success
@@ -259,6 +265,7 @@ steps:
   commands:
   - git fetch origin +refs/heads/$DRONE_REPO_BRANCH:$DRONE_REPO_BRANCH || true
   - yarn install
+  failure: ignore
 
 - name: unit-test-changed
   image: node:15
@@ -267,6 +274,7 @@ steps:
   environment:
     BITGOJS_TEST_PASSWORD:
       from_secret: password
+  failure: ignore
 
 - name: upload artifacts
   image: bitgosdk/upload-tools:latest
@@ -282,6 +290,7 @@ steps:
       from_secret: reports_s3_akid
     reports_s3_sak:
       from_secret: reports_s3_sak
+  failure: ignore
   when:
     status:
     - success
@@ -347,6 +356,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 627b9b4069cb241c084037dfb0284fbe47d42dd52d2c0053d99a948fdd892abe
+hmac: 4af11df3fb7d9b47a79b7224b77be21e6c8e42118d6cab12f3522d9a76603a79
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -139,6 +139,156 @@ steps:
 
 ---
 kind: pipeline
+name: unit tests (node:12)
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: build information
+  image: node:12
+  commands:
+  - node --version
+  - npm --version
+  - yarn --version
+  - git --version
+
+- name: install
+  image: node:12
+  commands:
+  - git fetch origin +refs/heads/$DRONE_REPO_BRANCH:$DRONE_REPO_BRANCH || true
+  - yarn install
+
+- name: unit-test-changed
+  image: node:12
+  commands:
+  - yarn run unit-test-changed
+  environment:
+    BITGOJS_TEST_PASSWORD:
+      from_secret: password
+
+- name: upload artifacts
+  image: bitgosdk/upload-tools:latest
+  commands:
+  - yarn run artifacts
+  - yarn run gen-coverage-changed
+  - yarn run coverage
+  environment:
+    CODECOV_FLAG: unit
+    CODECOV_TOKEN:
+      from_secret: codecov
+    reports_s3_akid:
+      from_secret: reports_s3_akid
+    reports_s3_sak:
+      from_secret: reports_s3_sak
+  when:
+    status:
+    - success
+    - failure
+
+---
+kind: pipeline
+name: unit tests (node:14)
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: build information
+  image: node:14
+  commands:
+  - node --version
+  - npm --version
+  - yarn --version
+  - git --version
+
+- name: install
+  image: node:14
+  commands:
+  - git fetch origin +refs/heads/$DRONE_REPO_BRANCH:$DRONE_REPO_BRANCH || true
+  - yarn install
+
+- name: unit-test-changed
+  image: node:14
+  commands:
+  - yarn run unit-test-changed
+  environment:
+    BITGOJS_TEST_PASSWORD:
+      from_secret: password
+
+- name: upload artifacts
+  image: bitgosdk/upload-tools:latest
+  commands:
+  - yarn run artifacts
+  - yarn run gen-coverage-changed
+  - yarn run coverage
+  environment:
+    CODECOV_FLAG: unit
+    CODECOV_TOKEN:
+      from_secret: codecov
+    reports_s3_akid:
+      from_secret: reports_s3_akid
+    reports_s3_sak:
+      from_secret: reports_s3_sak
+  when:
+    status:
+    - success
+    - failure
+
+---
+kind: pipeline
+name: unit tests (node:15)
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: build information
+  image: node:15
+  commands:
+  - node --version
+  - npm --version
+  - yarn --version
+  - git --version
+
+- name: install
+  image: node:15
+  commands:
+  - git fetch origin +refs/heads/$DRONE_REPO_BRANCH:$DRONE_REPO_BRANCH || true
+  - yarn install
+
+- name: unit-test-changed
+  image: node:15
+  commands:
+  - yarn run unit-test-changed
+  environment:
+    BITGOJS_TEST_PASSWORD:
+      from_secret: password
+
+- name: upload artifacts
+  image: bitgosdk/upload-tools:latest
+  commands:
+  - yarn run artifacts
+  - yarn run gen-coverage-changed
+  - yarn run coverage
+  environment:
+    CODECOV_FLAG: unit
+    CODECOV_TOKEN:
+      from_secret: codecov
+    reports_s3_akid:
+      from_secret: reports_s3_akid
+    reports_s3_sak:
+      from_secret: reports_s3_sak
+  when:
+    status:
+    - success
+    - failure
+
+---
+kind: pipeline
 name: Browser Tests
 
 platform:
@@ -197,6 +347,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 920945bf8d2430c6c143f716593bf9aa023c35b954eab19a282c768373066c4a
+hmac: 627b9b4069cb241c084037dfb0284fbe47d42dd52d2c0053d99a948fdd892abe
 
 ...


### PR DESCRIPTION
Node 10 is running out of support at the end of April. The clock is
ticking...

Since we don't yet know if these versions work and don't want to block
further PRs, ignore failures for the new versions for now.

Ticket: BG-30806