### PR TITLE
ci: require unit tests to pass with node 12, 14, 15

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -229,8 +229,8 @@ local CheckPreconditions(version) = {
   ]
 };
 
-local UnitVersions = ["10"];
-local OptionalUnitVersions = ["12", "14", "15"];
+local UnitVersions = ["10", "12", "14", "15"];
+local OptionalUnitVersions = [];
 local IntegrationVersions = ["10"];
 
 [

--- a/.drone.yml
+++ b/.drone.yml
@@ -159,7 +159,6 @@ steps:
   commands:
   - git fetch origin +refs/heads/$DRONE_REPO_BRANCH:$DRONE_REPO_BRANCH || true
   - yarn install
-  failure: ignore
 
 - name: unit-test-changed
   image: node:12
@@ -168,7 +167,6 @@ steps:
   environment:
     BITGOJS_TEST_PASSWORD:
       from_secret: password
-  failure: ignore
 
 - name: upload artifacts
   image: bitgosdk/upload-tools:latest
@@ -184,7 +182,6 @@ steps:
       from_secret: reports_s3_akid
     reports_s3_sak:
       from_secret: reports_s3_sak
-  failure: ignore
   when:
     status:
     - success
@@ -212,7 +209,6 @@ steps:
   commands:
   - git fetch origin +refs/heads/$DRONE_REPO_BRANCH:$DRONE_REPO_BRANCH || true
   - yarn install
-  failure: ignore
 
 - name: unit-test-changed
   image: node:14
@@ -221,7 +217,6 @@ steps:
   environment:
     BITGOJS_TEST_PASSWORD:
       from_secret: password
-  failure: ignore
 
 - name: upload artifacts
   image: bitgosdk/upload-tools:latest
@@ -237,7 +232,6 @@ steps:
       from_secret: reports_s3_akid
     reports_s3_sak:
       from_secret: reports_s3_sak
-  failure: ignore
   when:
     status:
     - success
@@ -265,7 +259,6 @@ steps:
   commands:
   - git fetch origin +refs/heads/$DRONE_REPO_BRANCH:$DRONE_REPO_BRANCH || true
   - yarn install
-  failure: ignore
 
 - name: unit-test-changed
   image: node:15
@@ -274,7 +267,6 @@ steps:
   environment:
     BITGOJS_TEST_PASSWORD:
       from_secret: password
-  failure: ignore
 
 - name: upload artifacts
   image: bitgosdk/upload-tools:latest
@@ -290,7 +282,6 @@ steps:
       from_secret: reports_s3_akid
     reports_s3_sak:
       from_secret: reports_s3_sak
-  failure: ignore
   when:
     status:
     - success
@@ -356,6 +347,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 4af11df3fb7d9b47a79b7224b77be21e6c8e42118d6cab12f3522d9a76603a79
+hmac: 627b9b4069cb241c084037dfb0284fbe47d42dd52d2c0053d99a948fdd892abe
 
 ...


### PR DESCRIPTION
Otherwise, we might see some regressions which break these
newly-supported versions.

Ticket: BG-23173