### PR TITLE
stacks: add fromPubKey in transaction builder

### DIFF
--- a/modules/account-lib/src/coin/stx/transferBuilder.ts
+++ b/modules/account-lib/src/coin/stx/transferBuilder.ts
@@ -53,20 +53,21 @@ export class TransferBuilder extends TransactionBuilder {
       fee: new BigNum(this._fee.fee),
       nonce: new BigNum(this._nonce),
     };
-    if (this._multiSignerKeyPairs.length === 0) {
-      throw new InvalidParameterValueError('supply at least 1 public key');
-    }
-    if (this._multiSignerKeyPairs.length === 1) {
-      return {
-        ...defaultOpts,
-        publicKey: this._multiSignerKeyPairs[0].getKeys(this._multiSignerKeyPairs[0].getCompressed()).pub,
-      };
+    if (this._fromPubKeys.length > 0) {
+      if (this._fromPubKeys.length === 1) {
+        return {
+          ...defaultOpts,
+          publicKey: this._fromPubKeys[0],
+        };
+      } else {
+        return {
+          ...defaultOpts,
+          publicKeys: this._fromPubKeys,
+          numSignatures: this._numberSignatures,
+        };
+      }
     } else {
-      return {
-        ...defaultOpts,
-        publicKeys: this._multiSignerKeyPairs.map(k => k.getKeys(k.getCompressed()).pub),
-        numSignatures: this._numberSignatures,
-      };
+      throw new InvalidParameterValueError('supply at least 1 public key');
     }
   }
 

--- a/modules/account-lib/test/unit/coin/stx/transactionBuilder/transferBuilder.ts
+++ b/modules/account-lib/test/unit/coin/stx/transactionBuilder/transferBuilder.ts
@@ -20,6 +20,7 @@ describe('Stx Transfer Builder', () => {
   describe('should build ', () => {
     it('a signed transfer transaction', async () => {
       const builder = initTxBuilder();
+      builder.fromPubKey(testData.TX_SENDER.pub);
       builder.sign({ key: testData.TX_SENDER.prv });
       const tx = await builder.build();
 
@@ -43,6 +44,7 @@ describe('Stx Transfer Builder', () => {
 
     it('a transfer transaction with memo', async () => {
       const builder = initTxBuilder();
+      builder.fromPubKey(testData.TX_SENDER.pub);
       builder.memo('This is an example');
       builder.sign({ key: testData.TX_SENDER.prv })
       const tx = await builder.build();
@@ -86,6 +88,7 @@ describe('Stx Transfer Builder', () => {
     it('a transfer transaction with amount 0', async () => {
       const builder = initTxBuilder();
       builder.amount('0');
+      builder.fromPubKey(testData.TX_SENDER.pub);
       builder.sign({ key: testData.TX_SENDER.prv });
       const tx = await builder.build();
       const txJson = tx.toJson();
@@ -111,7 +114,6 @@ describe('Stx Transfer Builder', () => {
         tx.type.should.equal(TransactionType.Send);
       });
     });
-
 
     describe('should fail', () => {
       it('a transfer transaction with an invalid key', () => {


### PR DESCRIPTION
This PR implements functionality to add sender public key in builder for unsigned transactions.
cc @wesgraham 