### PR TITLE
refactor(statics): change trx test network from nile to shasta

### DIFF
--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -350,7 +350,7 @@ class Trx extends Mainnet implements AccountNetwork {
 
 class TrxTestnet extends Testnet implements AccountNetwork {
   family = CoinFamily.TRX;
-  explorerUrl = 'https://nile.tronscan.org/#/transaction/';
+  explorerUrl = 'https://shasta.tronscan.org/#/transaction/';
 }
 
 class Xrp extends Mainnet implements AccountNetwork {


### PR DESCRIPTION
Currently statics has Nile info instead Shasta testnet, we need Shasta explorer info to use it on
TAT on links

---
### Changes
- modules/statics/src/networks.ts
---
### Ticket
stlx-2264