### PR TITLE
fix(ethlike): add chainid to statics

### DIFF
--- a/modules/account-lib/src/coin/celo/resources.ts
+++ b/modules/account-lib/src/coin/celo/resources.ts
@@ -1,3 +1,4 @@
+import { coins, EthereumNetwork } from '@bitgo/statics';
 import EthereumCommon from 'ethereumjs-common';
 
 /**
@@ -7,8 +8,8 @@ export const testnetCommon = EthereumCommon.forCustomChain(
   'mainnet', // It's a test net based on the main ethereum net
   {
     name: 'alfajores',
-    networkId: 44787,
-    chainId: 44787,
+    networkId: (coins.get('tcelo').network as EthereumNetwork).chainId,
+    chainId: (coins.get('tcelo').network as EthereumNetwork).chainId,
   },
   'petersburg',
 );
@@ -20,8 +21,8 @@ export const mainnetCommon = EthereumCommon.forCustomChain(
   'mainnet',
   {
     name: 'rc1',
-    networkId: 42220,
-    chainId: 42220,
+    networkId: (coins.get('celo').network as EthereumNetwork).chainId,
+    chainId: (coins.get('celo').network as EthereumNetwork).chainId,
   },
   'petersburg',
 );

--- a/modules/account-lib/src/coin/etc/resources.ts
+++ b/modules/account-lib/src/coin/etc/resources.ts
@@ -1,3 +1,4 @@
+import { coins, EthereumNetwork } from '@bitgo/statics';
 import EthereumCommon from 'ethereumjs-common';
 
 /**
@@ -7,8 +8,8 @@ export const testnetCommon = EthereumCommon.forCustomChain(
   'kovan', // actual name is mordor, but ethereumjs-common does not recognize that name
   {
     name: 'testnet',
-    networkId: 7,
-    chainId: 63,
+    networkId: (coins.get('tetc').network as EthereumNetwork).chainId,
+    chainId: (coins.get('tetc').network as EthereumNetwork).chainId,
   },
   'petersburg',
 );
@@ -20,8 +21,8 @@ export const mainnetCommon = EthereumCommon.forCustomChain(
   'mainnet',
   {
     name: 'mainnet',
-    networkId: 61,
-    chainId: 61,
+    networkId: (coins.get('etc').network as EthereumNetwork).chainId,
+    chainId: (coins.get('etc').network as EthereumNetwork).chainId,
   },
   'petersburg',
 );

--- a/modules/account-lib/src/coin/eth/resources.ts
+++ b/modules/account-lib/src/coin/eth/resources.ts
@@ -1,3 +1,4 @@
+import { coins, EthereumNetwork } from '@bitgo/statics';
 import EthereumCommon from 'ethereumjs-common';
 
 /**
@@ -7,8 +8,8 @@ export const testnetCommon = EthereumCommon.forCustomChain(
   'kovan',
   {
     name: 'testnet',
-    networkId: 42,
-    chainId: 42,
+    networkId: (coins.get('teth').network as EthereumNetwork).chainId,
+    chainId: (coins.get('teth').network as EthereumNetwork).chainId,
   },
   'petersburg',
 );
@@ -20,8 +21,8 @@ export const mainnetCommon = EthereumCommon.forCustomChain(
   'mainnet',
   {
     name: 'mainnet',
-    networkId: 1,
-    chainId: 1,
+    networkId: (coins.get('eth').network as EthereumNetwork).chainId,
+    chainId: (coins.get('eth').network as EthereumNetwork).chainId,
   },
   'petersburg',
 );

--- a/modules/account-lib/src/coin/rbtc/resources.ts
+++ b/modules/account-lib/src/coin/rbtc/resources.ts
@@ -1,3 +1,4 @@
+import { coins, EthereumNetwork } from '@bitgo/statics';
 import EthereumCommon from 'ethereumjs-common';
 
 /**
@@ -7,8 +8,8 @@ export const testnetCommon = EthereumCommon.forCustomChain(
   'ropsten',
   {
     name: 'testnet',
-    networkId: 31,
-    chainId: 31,
+    networkId: (coins.get('trbtc').network as EthereumNetwork).chainId,
+    chainId: (coins.get('trbtc').network as EthereumNetwork).chainId,
   },
   'petersburg',
 );
@@ -20,8 +21,8 @@ export const mainnetCommon = EthereumCommon.forCustomChain(
   'mainnet',
   {
     name: 'mainnet',
-    networkId: 30,
-    chainId: 30,
+    networkId: (coins.get('rbtc').network as EthereumNetwork).chainId,
+    chainId: (coins.get('rbtc').network as EthereumNetwork).chainId,
   },
   'petersburg',
 );

--- a/modules/account-lib/test/unit/coin/eth/transactionBuilder/flushCoins.ts
+++ b/modules/account-lib/test/unit/coin/eth/transactionBuilder/flushCoins.ts
@@ -57,10 +57,6 @@ describe('Eth Transaction builder flush native coins', function() {
         contractAddress: '0x8f977e912ef500548a0c3be6ddde9899f1199b81',
       });
 
-      console.log('DEBUG tx type')
-      console.log(tx.type)
-      console.log(TransactionType.FlushCoins)
-      console.log(TransactionType)
       tx.type.should.equal(TransactionType.FlushCoins);
       const txJson = tx.toJson();
       txJson.gasLimit.should.equal('1000');

--- a/modules/statics/src/account.ts
+++ b/modules/statics/src/account.ts
@@ -1,6 +1,6 @@
 import { BaseCoin, CoinFeature, CoinKind, KeyCurve, UnderlyingAsset } from './base';
 import { InvalidContractAddressError, InvalidDomainError } from './errors';
-import { AccountNetwork, Networks } from './networks';
+import { AccountNetwork, EthereumNetwork, Networks } from './networks';
 
 export interface AccountConstructorOptions {
   fullName: string;
@@ -248,7 +248,7 @@ export function erc20(
   features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
   prefix: string = '',
   suffix: string = name.toUpperCase(),
-  network: AccountNetwork = Networks.main.ethereum,
+  network: EthereumNetwork = Networks.main.ethereum,
   primaryKeyCurve: KeyCurve = KeyCurve.Secp256k1
 ) {
   return Object.freeze(
@@ -290,7 +290,7 @@ export function terc20(
   features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
   prefix: string = '',
   suffix: string = name.toUpperCase(),
-  network: AccountNetwork = Networks.test.kovan
+  network: EthereumNetwork = Networks.test.kovan
 ) {
   return erc20(name, fullName, decimalPlaces, contractAddress, asset, features, prefix, suffix, network);
 }
@@ -312,7 +312,7 @@ export function terc20(
 export function erc20CompatibleAccountCoin(
   name: string,
   fullName: string,
-  network: AccountNetwork,
+  network: EthereumNetwork,
   decimalPlaces: number,
   contractAddress: string,
   asset: UnderlyingAsset,
@@ -361,7 +361,7 @@ export function celoToken(
   features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
   prefix: string = '',
   suffix: string = name.toUpperCase(),
-  network: AccountNetwork = Networks.main.celo,
+  network: EthereumNetwork = Networks.main.celo,
   primaryKeyCurve: KeyCurve = KeyCurve.Secp256k1
 ) {
   return Object.freeze(
@@ -403,7 +403,7 @@ export function tceloToken(
   features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
   prefix: string = '',
   suffix: string = name.toUpperCase(),
-  network: AccountNetwork = Networks.test.celo
+  network: EthereumNetwork = Networks.test.celo
 ) {
   return celoToken(name, fullName, decimalPlaces, contractAddress, asset, features, prefix, suffix, network);
 }

--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -42,6 +42,11 @@ export interface AccountNetwork extends BaseNetwork {
   readonly accountExplorerUrl?: string;
 }
 
+export interface EthereumNetwork extends AccountNetwork {
+  // unique chain id used for replay-protecting transactions
+  readonly chainId: number;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface OfcNetwork extends BaseNetwork {}
 
@@ -182,16 +187,18 @@ class DashTestnet extends BitcoinLikeTestnet {
   family = CoinFamily.DASH;
   explorerUrl = 'https://tbch.blockdozer.com/tx/';
 }
-class Celo extends Mainnet implements AccountNetwork {
+class Celo extends Mainnet implements EthereumNetwork {
   family = CoinFamily.CELO;
   explorerUrl = 'https://explorer.celo.org/tx/';
   accountExplorerUrl = 'https://explorer.celo.org/address/';
+  chainId = 42220;
 }
 
-class CeloTestnet extends Testnet implements AccountNetwork {
+class CeloTestnet extends Testnet implements EthereumNetwork {
   family = CoinFamily.CELO;
   explorerUrl = 'https://alfajores-blockscout.celo-testnet.org/tx/';
   accountExplorerUrl = 'https://alfajores-blockscout.celo-testnet.org/address/';
+  chainId = 44787;
 }
 
 //TODO update explorerUrl STLX-1657
@@ -208,10 +215,12 @@ class CasperTestnet extends Testnet implements AccountNetwork {
   accountExplorerUrl = '';
 }
 
-class Ethereum extends Mainnet implements AccountNetwork {
+class Ethereum extends Mainnet implements EthereumNetwork {
   family = CoinFamily.ETH;
   explorerUrl = 'https://etherscan.io/tx/';
   accountExplorerUrl = 'https://etherscan.io/address/';
+  // from https://github.com/ethereumjs/ethereumjs-common/blob/a978f630858f6843176bb20b277569785914e899/src/chains/index.ts
+  chainId = 1;
 }
 
 class Ethereum2 extends Mainnet implements AccountNetwork {
@@ -226,28 +235,36 @@ class Pyrmont extends Testnet implements AccountNetwork {
   accountExplorerUrl = 'https://beaconscan.com/pyrmont/address';
 }
 
-class Kovan extends Testnet implements AccountNetwork {
+class Kovan extends Testnet implements EthereumNetwork {
   family = CoinFamily.ETH;
   explorerUrl = 'https://kovan.etherscan.io/tx/';
   accountExplorerUrl = 'https://kovan.etherscan.io/address/';
+  // from https://github.com/ethereumjs/ethereumjs-common/blob/a978f630858f6843176bb20b277569785914e899/src/chains/index.ts
+  chainId = 42;
 }
 
-class Goerli extends Testnet implements AccountNetwork {
+class Goerli extends Testnet implements EthereumNetwork {
   family = CoinFamily.ETH;
   explorerUrl = 'https://goerli.etherscan.io/tx/';
   accountExplorerUrl = 'https://goerli.etherscan.io/address/';
+  // from https://github.com/ethereumjs/ethereumjs-common/blob/a978f630858f6843176bb20b277569785914e899/src/chains/index.ts
+  chainId = 5;
 }
 
-class EthereumClassic extends Mainnet implements AccountNetwork {
+class EthereumClassic extends Mainnet implements EthereumNetwork {
   family = CoinFamily.ETC;
   explorerUrl = 'https://blockscout.com/etc/mainnet/tx/';
   accountExplorerUrl = 'https://blockscout.com/etc/mainnet/address/';
+  // from  https://chainid.network/chains/
+  chainId = 61;
 }
 
-class EthereumClassicTestnet extends Testnet implements AccountNetwork {
+class EthereumClassicTestnet extends Testnet implements EthereumNetwork {
   family = CoinFamily.ETC;
   explorerUrl = 'https://blockscout.com/etc/mordor/tx/';
   accountExplorerUrl = 'https://blockscout.com/etc/mordor/address/';
+  // from  https://chainid.network/chains/
+  chainId = 63;
 }
 
 class Eos extends Mainnet implements AccountNetwork {
@@ -301,16 +318,18 @@ class OfcTestnet extends Testnet implements OfcNetwork {
   explorerUrl = undefined;
 }
 
-class Rbtc extends Mainnet implements AccountNetwork {
+class Rbtc extends Mainnet implements EthereumNetwork {
   family = CoinFamily.RBTC;
   explorerUrl = 'https://explorer.rsk.co/tx/';
   accountExplorerUrl = 'https://explorer.rsk.co/address/';
+  chainId = 30;
 }
 
-class RbtcTestnet extends Testnet implements AccountNetwork {
+class RbtcTestnet extends Testnet implements EthereumNetwork {
   family = CoinFamily.RBTC;
   explorerUrl = 'https://explorer.testnet.rsk.co/tx/';
   accountExplorerUrl = 'https://explorer.testnet.rsk.co/address/';
+  chainId = 31;
 }
 
 class Stellar extends Mainnet implements AccountNetwork {


### PR DESCRIPTION
This commit adds the Ethereum chainid to bitgo statics so we can include
it in our built transactions. Account-lib already does this, but
Ethereum does not use account-lib in platform currently. Adding the
field to statics will give us a single source of truth for these values
and allow us to do it in platform. This commit also updates
account-lib's store of chainids to use statics instead of its own
hard-coded values

Ticket: BG-30890