### PR TITLE
fix(core): use mempool.space instead of earn.com for recovery fee

### DIFF
--- a/modules/core/src/v2/coins/btc.ts
+++ b/modules/core/src/v2/coins/btc.ts
@@ -72,7 +72,7 @@ export class Btc extends AbstractUtxoCoin {
   }
 
   getRecoveryFeeRecommendationApiBaseUrl(): Bluebird<string> {
-    return Bluebird.resolve('https://bitcoinfees.earn.com/api/v1/fees/recommended');
+    return Bluebird.resolve('https://mempool.space/api/v1/fees/recommended');
   }
 
   recoveryBlockchainExplorerUrl(url: string): string {

--- a/modules/core/test/v2/lib/recovery-nocks.ts
+++ b/modules/core/test/v2/lib/recovery-nocks.ts
@@ -3333,7 +3333,7 @@ module.exports.nockBtcSegwitRecovery = function(bitgo) {
       blockchairContext,
     });
 
-  nock('https://bitcoinfees.earn.com')
+  nock('https://mempool.space')
     .get('/api/v1/fees/recommended')
     .reply(200, { fastestFee: 20, halfHourFee: 20, hourFee: 6 });
 };
@@ -3564,7 +3564,7 @@ module.exports.nockBtcUnsignedRecovery = function(bitgo) {
         blockchairContext,
       },
     });
-  nock('https://bitcoinfees.earn.com')
+  nock('https://mempool.space')
     .get('/api/v1/fees/recommended')
     .reply(200, { fastestFee: 20, halfHourFee: 20, hourFee: 6 });
 };


### PR DESCRIPTION
The earn.com endpoint is provided inaccurate data and doesn't appear to
be maintained any longer. The mempool.space endpoint is API-compatible
with our use case and provides a more accurate fee estimation.

Closes: #1126
Ticket: BG-31192