### PR TITLE
chore: add step to drone to check managed package version numbers 

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -221,6 +221,7 @@ local CheckPreconditions(version) = {
     BuildInfo(version),
     Install(version),
     Command("check-commits", version),
+    Command("check-versions", version),
     Command("audit", version),
     Command("lint", version),
     Command("check-fmt", version),

--- a/.drone.yml
+++ b/.drone.yml
@@ -26,6 +26,11 @@ steps:
   commands:
   - yarn run check-commits
 
+- name: check-versions
+  image: node:10
+  commands:
+  - yarn run check-versions
+
 - name: audit
   image: node:10
   commands:
@@ -350,6 +355,6 @@ trigger:
 
 ---
 kind: signature
-hmac: f1c45a1cbba728220d523f0906220f22c9e64b24c9effc1aee824d9ead61d522
+hmac: b77a90131736635740e4a80bf46c5d72faa952694883a31e3153f953e456b722
 
 ...

--- a/check-package-versions.js
+++ b/check-package-versions.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+// Check versions of in-repo packages to make sure they match with the package.json version.
+// This is to prevent inadvertent updates of dependency versions for packages which are symlinked
+// by lerna. The dependency versions of these packages should only ever be updated in the release branch.
+
+const execa = require('execa');
+const path = require('path');
+
+/**
+ * Create a function which can run lerna commands
+ * @param lernaPath {string} path to lerna binary
+ * @returns {function(string, string[], Object.<string, string>): Promise<string>}
+ */
+function getLernaRunner(lernaPath) {
+  return async (command, args = [], options = {}) => {
+    const { stdout } = await execa(
+      lernaPath,
+      [command, ...args],
+      options,
+    );
+    return stdout;
+  };
+}
+
+/**
+ * Get information on the modules in this repo that are managed by lerna.
+ * @param lerna {function}
+ * @returns {Promise<{path: *, name: *, deps: *, version: *}[]>}
+ */
+async function getLernaManagedModules(lerna) {
+  const depGraph = JSON.parse(await lerna('list', ['--loglevel', 'silent', '--graph', '--all']));
+  const managedModules = JSON.parse(await lerna('list', ['--loglevel', 'silent', '--json', '--all']));
+  const managedModuleNames = managedModules.map(({ name }) => name);
+  return Object.entries(depGraph).map(([name, deps]) => {
+    const mod = managedModules.find((mod) => mod.name === name);
+    return {
+      name,
+      deps: deps.filter((d) => managedModuleNames.includes(d)),
+      path: mod.location,
+      version: mod.version,
+    };
+  });
+}
+
+/**
+ * Build a dictionary from package name to the expected version of that package.
+ * @param modules
+ * @returns {Object.<string, string>}
+ */
+function getExpectedVersions(modules) {
+  return Object.values(modules).reduce((acc, mod) => {
+    return Object.assign(acc, { [mod.name]: mod.version });
+  }, {});
+}
+
+/**
+ * For the module at `modPath`, get the version of the dependency `depName`.
+ * If the version is prefixed with a carat or tilde, it will be stripped.
+ * @param modPath {string}
+ * @param depName {string}
+ * @returns {string | undefined}
+ */
+function getDependencyVersion(modPath, depName) {
+  const packageJsonPath = path.join(modPath, 'package.json');
+  const {
+    dependencies = {},
+    devDependencies = {},
+    optionalDependencies = {},
+    peerDependencies = {},
+  } = require(packageJsonPath);
+
+  const deps = { ...dependencies, ...devDependencies, ...optionalDependencies, ...peerDependencies };
+  if (deps[depName]) {
+    const matches = deps[depName].match(/^([^~])?(.*)$/);
+    return matches[matches.length - 1];
+  }
+}
+
+async function main() {
+  const { stdout: lernaBinary } = await execa('yarn', ['bin', 'lerna'], { cwd: process.cwd() });
+
+  const lerna = getLernaRunner(lernaBinary);
+
+  const modules = await getLernaManagedModules(lerna);
+  const expectedVersions = getExpectedVersions(modules);
+
+  let exitCode = 0;
+
+  for (const mod of modules) {
+    for (const dep of mod.deps) {
+      const depVersion = getDependencyVersion(mod.path, dep);
+      if (depVersion && depVersion !== expectedVersions[dep]) {
+        console.log(`error: expected lerna-managed module ${mod.name} to depend on package ${dep} using version ${expectedVersions[dep]}, but found version ${depVersion} instead`);
+        exitCode = 1;
+      }
+    }
+  }
+
+  return exitCode;
+}
+
+main().then(process.exit).catch((e) => console.error(e));

--- a/modules/utxo-lib/package.json
+++ b/modules/utxo-lib/package.json
@@ -33,7 +33,7 @@
     "src"
   ],
   "dependencies": {
-    "@bitgo/blake2b": "^3.0.0-rc.2",
+    "@bitgo/blake2b": "^3.0.0",
     "bech32": "0.0.3",
     "bigi": "^1.4.0",
     "bip66": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "eslint": "^7.26.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^3.4.0",
+    "execa": "^5.0.0",
     "glob": "^7.1.6",
     "husky": "^4.3.0",
     "lerna": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "gen-docs": "lerna run gen-docs --stream --parallel",
     "check-fmt-changed": "lerna run check-fmt --since origin/${DRONE_REPO_BRANCH:-master}..${DRONE_COMMIT:-HEAD} --stream --parallel",
     "check-fmt": "lerna run check-fmt --stream --parallel",
-    "check-commits": "yarn commitlint --from=origin/${DRONE_REPO_BRANCH:-master} -V"
+    "check-commits": "yarn commitlint --from=origin/${DRONE_REPO_BRANCH:-master} -V",
+    "check-versions": "node ./check-package-versions.js"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Check versions of in-repo packages to make sure they match with the package.json version.
This is to prevent inadvertent updates of dependency versions for packages which are symlinked
by lerna. The dependency versions of these packages should only ever be updated in the release branch.

Ticket: BG-31227