### PR TITLE
chore(account-lib): upgrade stellar-sdk dependency version

### DIFF
--- a/modules/account-lib/package.json
+++ b/modules/account-lib/package.json
@@ -56,7 +56,7 @@
     "long": "^4.0.0",
     "protobufjs": "^6.8.9",
     "secp256k1": "4.0.2",
-    "stellar-sdk": "^0.11.0",
+    "stellar-sdk": "^8.1.1",
     "tronweb": "^2.7.2",
     "tweetnacl": "^1.0.3"
   },


### PR DESCRIPTION
We have been on a really outdated version and I have a hunch that it might be causing some issues when upgrading other services to Node 14.