### PR TITLE
fix(core): STLX-2929 Fix address validation for Casper

### DIFF
--- a/modules/core/src/v2/coins/cspr.ts
+++ b/modules/core/src/v2/coins/cspr.ts
@@ -91,8 +91,7 @@ export class Cspr extends BaseCoin {
     return Bluebird.resolve(true).asCallback(callback);
   }
   verifyAddress(params: VerifyAddressOptions): boolean {
-    // TODO: Implement when available on the SDK.
-    throw true;
+    return accountLib.Cspr.Utils.isValidAddress(params.address);
   }
 
   /**


### PR DESCRIPTION
Use account-lib utils method to validate Casper address

[STLX-2929](https://bitgoinc.atlassian.net/browse/STLX-2929).


**Instructions to test**

1. Download `bitgo-11.13.0.zip` and rename it to `bitgo-11.13.0.tgz`
2. Copy it to packages `clients` and `client-wallet-platform`.
3. Run the following command on both packages root folders:
`npm i bitgo-11.13.0.tgz`
4. Execute client and try to generate new address for a Casper Wallet.

Packaged bitgo build to install:
[bitgo-11.13.0.zip](https://github.com/BitGo/BitGoJS/files/6401082/bitgo-11.13.0.zip)
