### PR TITLE
fix(core): Add transferId to sendMany options

### DIFF
--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -366,6 +366,7 @@ export interface SendManyOptions {
   changeAddress?: string;
   instant?: boolean;
   memo?: Memo;
+  transferId?: number;
 }
 
 export interface WalletData {


### PR DESCRIPTION
fix transferId issue by adding it to the expected sendMany options

[STLX-2967](https://bitgoinc.atlassian.net/browse/STLX-2967)