### PR TITLE
fix(core): hard code zcash transaction version

### DIFF
--- a/modules/core/src/v2/coins/zec.ts
+++ b/modules/core/src/v2/coins/zec.ts
@@ -49,7 +49,8 @@ export class Zec extends AbstractUtxoCoin {
    * @returns {*}
    */
   prepareTransactionBuilder(txBuilder: ZecTransactionBuilder): any {
-    txBuilder.setVersion(bitGoUtxoLib.Transaction.ZCASH_SAPLING_VERSION);
+    // sapling transaction version, see modules/utxo-lib/src/forks/zcash/version
+    txBuilder.setVersion(4);
     txBuilder.setVersionGroupId(0x892f2085);
     // Use "Canopy" consensus branch https://zips.z.cash/zip-0251
     // https://bitgoinc.atlassian.net/browse/BG-26072


### PR DESCRIPTION
This is not ideal, but the ZCASH_SAPLING_VERSION is missing from the
latest version of utxo lib, so zcash sends are not working currently.

Ticket: BG-31417