### PR TITLE
stacks: fix multi sig issue

### DIFF
--- a/modules/account-lib/src/coin/stx/transaction.ts
+++ b/modules/account-lib/src/coin/stx/transaction.ts
@@ -50,12 +50,9 @@ export class Transaction extends BaseTransaction {
     }
   }
 
-  async appendOrigin(keyPair: KeyPair): Promise<void> {
-    const keys = keyPair.getKeys(keyPair.getCompressed());
-    if (!keys.pub) {
-      throw new SigningError('Missing public key');
-    }
-    const pubKey = createStacksPublicKey(keys.pub);
+  async appendOrigin(pubKeyString: string): Promise<void> {
+
+    const pubKey = createStacksPublicKey(pubKeyString);
     const signer = new TransactionSigner(this._stxTransaction);
     signer.appendOrigin(pubKey);
   }

--- a/modules/account-lib/test/unit/coin/stx/transactionBuilder/contractBuilder.ts
+++ b/modules/account-lib/test/unit/coin/stx/transactionBuilder/contractBuilder.ts
@@ -1,9 +1,10 @@
 import should from 'should';
 import { StacksTestnet, StacksMainnet } from '@stacks/network';
 import { register } from '../../../../../src/index';
-import { TransactionBuilderFactory } from '../../../../../src/coin/stx';
+import { TransactionBuilderFactory, KeyPair } from '../../../../../src/coin/stx';
 import * as testData from '../../../../resources/stx/stx';
 import { TransactionType } from '../../../../../src/coin/baseCoin';
+
 
 describe('Stx Contract call Builder', () => {
   const factory = register('stx', TransactionBuilderFactory);
@@ -51,10 +52,12 @@ describe('Stx Contract call Builder', () => {
     it('a multisig transfer transaction', async () => {
       const builder = initTxBuilder();
       builder.network(new StacksTestnet());
-      builder.numberSignatures(2);
+
       builder.sign({ key: testData.prv1 });
       builder.sign({ key: testData.prv2 });
-      builder.sign({ key: testData.prv3 });
+      const kp = new KeyPair({ prv: testData.prv3 });
+      builder.fromPubKey(kp.getKeys(kp.getCompressed()).pub);
+      builder.numberSignatures(2);
       const tx = await builder.build();
       should.deepEqual(tx.toBroadcastFormat(), testData.MULTI_SIG_CONTRACT_CALL);
     });

--- a/modules/account-lib/test/unit/coin/stx/transactionBuilder/transferBuilder.ts
+++ b/modules/account-lib/test/unit/coin/stx/transactionBuilder/transferBuilder.ts
@@ -1,9 +1,10 @@
 import should from 'should';
 import { StacksTestnet } from '@stacks/network';
 import { register } from '../../../../../src/index';
-import { TransactionBuilderFactory } from '../../../../../src/coin/stx';
+import { TransactionBuilderFactory, KeyPair } from '../../../../../src/coin/stx';
 import * as testData from '../../../../resources/stx/stx';
 import { TransactionType } from '../../../../../src/coin/baseCoin';
+import { toHex } from '../../../../../src/coin/hbar/utils';
 
 describe('Stx Transfer Builder', () => {
   const factory = register('stx', TransactionBuilderFactory);
@@ -46,7 +47,7 @@ describe('Stx Transfer Builder', () => {
       const builder = initTxBuilder();
       builder.fromPubKey(testData.TX_SENDER.pub);
       builder.memo('This is an example');
-      builder.sign({ key: testData.TX_SENDER.prv })
+      builder.sign({ key: testData.TX_SENDER.prv });
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.payload.to, testData.TX_RECIEVER.address);
@@ -57,14 +58,49 @@ describe('Stx Transfer Builder', () => {
       should.deepEqual(txJson.fee.toString(), '180');
     });
 
+    it('an unsigned multisig signed and verified', async function() {
+      const destination = 'STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0';
+      const amount = '1000';
+      const memo = 'test';
+      const kp = new KeyPair({ prv: '21d43d2ae0da1d9d04cfcaac7d397a33733881081f0b2cd038062cf0ccbb752601' });
+      const kp1 = new KeyPair({ prv: 'c71700b07d520a8c9731e4d0f095aa6efb91e16e25fb27ce2b72e7b698f8127a01' });
+      const kp2 = new KeyPair({ prv: 'e75dcb66f84287eaf347955e94fa04337298dbd95aa0dbb985771104ef1913db01' });
+      const txBuilder = factory.getTransferBuilder();
+      txBuilder.fee({
+        fee: '180',
+      });
+      txBuilder.to(destination);
+      txBuilder.amount(amount);
+      txBuilder.nonce(1);
+      txBuilder.fromPubKey([kp.getKeys().pub, kp1.getKeys().pub, kp2.getKeys().pub]);
+      txBuilder.numberSignatures(2);
+      txBuilder.memo(memo);
+      const tx = await txBuilder.build(); // unsigned multisig tx
+
+      const txBuilder2 = factory.getTransferBuilder();
+      txBuilder2.from(tx.toBroadcastFormat());
+      txBuilder2.sign({ key: '21d43d2ae0da1d9d04cfcaac7d397a33733881081f0b2cd038062cf0ccbb752601' });
+      txBuilder2.sign({ key: 'c71700b07d520a8c9731e4d0f095aa6efb91e16e25fb27ce2b72e7b698f8127a01' });
+      txBuilder2.fromPubKey([kp2.getKeys(kp2.getCompressed()).pub]);
+      // txBuilder2.sign({ key: 'e75dcb66f84287eaf347955e94fa04337298dbd95aa0dbb985771104ef1913db01' });
+      txBuilder2.numberSignatures(2);
+      const signedTx = await txBuilder2.build(); // signed multisig tx
+
+      const txBuilder3 = factory.getTransferBuilder();
+      txBuilder3.from(signedTx.toBroadcastFormat());
+      const remake = await txBuilder3.build();
+      should.deepEqual(remake.toBroadcastFormat(), signedTx.toBroadcastFormat());
+    });
+
     it('a multisig transfer transaction', async () => {
       const builder = initTxBuilder();
       builder.network(new StacksTestnet());
       builder.memo('test memo');
-      builder.numberSignatures(2);
       builder.sign({ key: testData.prv1 });
       builder.sign({ key: testData.prv2 });
-      builder.sign({ key: testData.prv3 });
+      const kp = new KeyPair({ prv: testData.prv3 });
+      builder.fromPubKey(kp.getKeys(kp.getCompressed()).pub);
+      builder.numberSignatures(2);
       const tx = await builder.build();
       should.deepEqual(tx.toBroadcastFormat(), testData.MULTI_SIG_SINGED_TRANSACTION);
     });
@@ -78,10 +114,11 @@ describe('Stx Transfer Builder', () => {
     it('a transfer transaction signed multiple times', async () => {
       const builder = initTxBuilder();
       builder.memo('test memo');
-      builder.numberSignatures(2);
       builder.sign({ key: testData.prv1 });
       builder.sign({ key: testData.prv2 });
-      builder.sign({ key: testData.prv3 });
+      const kp = new KeyPair({ prv: testData.prv3 });
+      builder.fromPubKey(kp.getKeys(kp.getCompressed()).pub);
+      builder.numberSignatures(2);
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(tx.signature.length, 3);


### PR DESCRIPTION
this PR fixes issue of multi sig with spending conditions. 
A multisig tranaction when deserialized converted to SingleSigSpendingCondition instead of MultiSigSpendingCondition.
Include some tests improvement around multisig tx.

cc @wesgraham 