### PR TITLE
feat(core): allow disabling paygo outputs during utxo tx verification

### DIFF
--- a/modules/core/src/v2/baseCoin.ts
+++ b/modules/core/src/v2/baseCoin.ts
@@ -79,6 +79,7 @@ export interface VerificationOptions {
     bitgo?: Keychain;
   };
   addresses?: { [address: string]: AddressVerificationData };
+  allowPaygoOutput?: boolean;
 }
 
 export interface VerifyTransactionOptions {

--- a/modules/core/test/v2/unit/coins/abstractUtxoCoin.ts
+++ b/modules/core/test/v2/unit/coins/abstractUtxoCoin.ts
@@ -409,7 +409,7 @@ describe('Abstract UTXO Coin:', () => {
         explicitExternalOutputs: [],
         implicitExternalOutputs: [],
         changeOutputs: [],
-        explicitExternalSpendAmount: 1000,
+        explicitExternalSpendAmount: 10000,
         implicitExternalSpendAmount: 151,
         needsCustomChangeKeySignatureVerification: false,
       });

--- a/modules/core/test/v2/unit/coins/abstractUtxoCoin.ts
+++ b/modules/core/test/v2/unit/coins/abstractUtxoCoin.ts
@@ -11,12 +11,12 @@ import * as nock from 'nock';
 const utxoLib = require('@bitgo/utxo-lib');
 import * as errors from '../../../../src/errors';
 import { Btc } from '../../../../src/v2/coins/btc';
-import { 
-  addressUnspents, 
-  addressInfos, 
-  emptyAddressInfo, 
-  recoverBtcUnsignedFixtures, 
-  recoverBtcSegwitFixtures 
+import {
+  addressUnspents,
+  addressInfos,
+  emptyAddressInfo,
+  recoverBtcUnsignedFixtures,
+  recoverBtcSegwitFixtures
 } from '../../fixtures/coins/recovery';
 
 describe('Abstract UTXO Coin:', () => {
@@ -398,7 +398,88 @@ describe('Abstract UTXO Coin:', () => {
       }).should.be.rejectedWith(/expected outputs missing in transaction prebuild/);
 
       (coin.parseTransaction as any).restore();
+    });
 
+    it('should not allow more than 150 basis points of implicit external outputs (for paygo outputs)', async () => {
+      const coinMock = sinon.stub(coin, 'parseTransaction').resolves({
+        keychains: {},
+        keySignatures: {},
+        outputs: [],
+        missingOutputs: [],
+        explicitExternalOutputs: [],
+        implicitExternalOutputs: [],
+        changeOutputs: [],
+        explicitExternalSpendAmount: 1000,
+        implicitExternalSpendAmount: 151,
+        needsCustomChangeKeySignatureVerification: false,
+      });
+
+      await coin.verifyTransaction({
+        txParams: {
+          walletPassphrase: passphrase,
+        },
+        txPrebuild: {},
+        wallet: unsignedSendingWallet as any,
+      }).should.be.rejectedWith('prebuild attempts to spend to unintended external recipients');
+
+      coinMock.restore();
+    });
+
+    it('should allow 150 basis points of implicit external outputs (for paygo outputs)', async () => {
+      const coinMock = sinon.stub(coin, 'parseTransaction').resolves({
+        keychains: {},
+        keySignatures: {},
+        outputs: [],
+        missingOutputs: [],
+        explicitExternalOutputs: [],
+        implicitExternalOutputs: [],
+        changeOutputs: [],
+        explicitExternalSpendAmount: 1000,
+        implicitExternalSpendAmount: 15,
+        needsCustomChangeKeySignatureVerification: false,
+      });
+
+      const bitcoinMock = sinon.stub(utxoLib.Transaction, 'fromHex').returns({ ins: [] });
+
+      await coin.verifyTransaction({
+        txParams: {
+          walletPassphrase: passphrase,
+        },
+        txPrebuild: {},
+        wallet: unsignedSendingWallet as any,
+      }).should.eventually.be.true();
+
+      coinMock.restore();
+      bitcoinMock.restore();
+    });
+
+    it('should not allow any implicit external outputs if paygo outputs are disallowed', async () => {
+      const coinMock = sinon.stub(coin, 'parseTransaction').resolves({
+        keychains: {
+        },
+        keySignatures: {},
+        outputs: [],
+        missingOutputs: [],
+        explicitExternalOutputs: [],
+        implicitExternalOutputs: [],
+        changeOutputs: [],
+        explicitExternalSpendAmount: 0,
+        implicitExternalSpendAmount: 10,
+        needsCustomChangeKeySignatureVerification: false,
+      });
+
+      await coin.verifyTransaction({
+        txParams: {
+          walletPassphrase: passphrase,
+        },
+        txPrebuild: {},
+        wallet: unsignedSendingWallet as any,
+        verification: {
+          allowPaygoOutput: false,
+        },
+      }).should.be.rejectedWith('prebuild attempts to spend to unintended external recipients');
+
+      coinMock.restore();
     });
   });
 


### PR DESCRIPTION
Allow disabling implicit external outputs (aka PayGo outputs) during
utxo transaction verification. Some customers don't ever intend to use
the pay-as-you-go model and would like all spends to be explicit (either
to an intended recipient address specified by the customer, or to a
change address which can be provably derived from the wallet keys).

Ticket: BG-30090