### PR TITLE
chore(core): add example showing tx verification using provided keys

### DIFF
--- a/modules/core/example/ts/send-with-provided-public-keys.ts
+++ b/modules/core/example/ts/send-with-provided-public-keys.ts
@@ -1,0 +1,62 @@
+/**
+ * For users who would like to trustlessly verify transaction prebuilds created by BitGo,
+ * the BitGo SDK has the ability to perform verification of unsigned transactions for Bitcoin and other UTXO
+ * transactions.
+ *
+ * The only information needed is the extended public keys for the wallet. All addresses which are being spent
+ * to must be derivable using these keys, otherwise they will be considered external outputs.
+ *
+ * External outputs should exactly match the amount being sent to each recipient in the send request,
+ * with the possible exception of a pay-as-you-go (PayGo) output, which cannot exceed 150 basis points of the total output
+ * amount. For users who are on a post-paid plan and don't use the pay-as-you-go billing model, PayGo outputs can be
+ * disabled. If this is the case, then the input amount minus the fee amount must exactly equal the total amount
+ * being sent to requested recipients, plus the change amount.
+ *
+ * Copyright 2021, BitGo, Inc.  All Rights Reserved.
+ */
+import { BitGo } from 'bitgo';
+const bitgo = new BitGo({ env: 'test' });
+
+const debug = require('debug')('send-with-pubkeys*');
+
+// TODO: set your access token here
+const accessToken = '';
+// TODO: set your wallet id here
+const walletId = 'wallet_id';
+
+const coin = 'tltc';
+// TODO: set your passphrase here
+const walletPassphrase = null;
+
+const recipients = [
+  {
+    amount: '123412',
+    address: 'recipient_address_here',
+  },
+];
+
+// TODO: these are example public keys, please substitute them with the correct keys for your wallet
+const keychains = {
+  user: { pub: 'xpub661MyMwAqRbcG9jW7yGH5q3gniFXRiVm6eNodEXmGrUnE5k1gnFCfivEzL8PEkiYyMLiHx3mGdJk8ABZ4Aw1pthkEQbfnJjehxdZpaHb4AE' },
+  backup: { pub: 'xpub661MyMwAqRbcF47eVHSVcpnPwjvf4xnfH2PpnS9sPsjUwMBxYxqDbyJEYZ2Xpi5cyEirTpYc32GBXG8DRkU8DkAYUi6vCYTy5krvve5ZwVY' },
+  bitgo: { pub: 'xpub661MyMwAqRbcGt7gRtUMbV3K5f9wJjputbhCY4BM4BDEPpRyixAtiWCqNFsLeBdbStcKTGMgeX3pjvazz58r4WVFH1dXrUq7DfVmQSijgGL' },
+};
+
+async function main() {
+  bitgo.authenticateWithAccessToken({ accessToken });
+
+  const basecoin = bitgo.coin(coin);
+  const walletInstance = await basecoin.wallets().get({ id: walletId });
+
+  const transaction = await walletInstance.sendMany({
+    recipients,
+    walletPassphrase,
+    verification: {
+      keychains,
+    },
+  });
+
+  debug('%O', transaction);
+}
+
+main().catch((e) => console.error(e));


### PR DESCRIPTION
Some users may want to provide their wallet's keychains directly to the
SDK when sending transactions, so they don't have to trust (potentially
unsigned) keychains received from the BitGo server.

Addresses derivable from these keys will be considered to be part of the
wallet (change addresses), and won't be counted towards the external
send amount.

Ticket: BG-30090