### PR TITLE
chore(account-lib): update ecma version to 2021

### DIFF
--- a/modules/account-lib/.eslintrc.js
+++ b/modules/account-lib/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
   ],
   plugins: ['import', 'jsdoc'],
   parserOptions: {
-    ecmaVersion: 2018, // Allows for the parsing of modern ECMAScript features
+    ecmaVersion: 2021, // Allows for the parsing of modern ECMAScript features
     sourceType: 'module', // Allows for the use of imports
   },
   rules: {


### PR DESCRIPTION
Updates ecma version to 2021 to make use of the `BigInt` type.

CLOSES TICKET: BG-31991