### PR TITLE
feat(core): implement support for auth v3

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -77,7 +77,7 @@
     "require-yield": "off",
     "semi": ["error", "always"],
     "space-before-blocks": ["error"],
-    "space-before-function-paren": ["error", { "named": "never", "anonymous": "never", "asyncArrow": "always" }],
+    "space-before-function-paren": ["error", { "named": "never", "anonymous": "always", "asyncArrow": "always" }],
     "space-infix-ops": ["error"],
     "spaced-comment": ["error", "always"],
     "switch-colon-spacing": ["error", {"before": false, "after": true}],

--- a/modules/core/src/bitgo.ts
+++ b/modules/core/src/bitgo.ts
@@ -431,7 +431,7 @@ export class BitGo {
   private _travelRule?: any;
   private _pendingApprovals?: any;
   private _hmacVerification = true;
-  private _authVersion = 2;
+  private readonly _authVersion: Exclude<BitGoOptions['authVersion'], undefined> = 2;
   /**
    * Constructor for BitGo Object
    */
@@ -827,6 +827,13 @@ export class BitGo {
    */
   getEnv(): EnvironmentName {
     return this._env;
+  }
+
+  /**
+   * Return the current auth version used for requests to the BitGo server
+   */
+  getAuthVersion(): number {
+    return this._authVersion;
   }
 
   /**

--- a/modules/core/test/v2/unit/auth.ts
+++ b/modules/core/test/v2/unit/auth.ts
@@ -1,0 +1,126 @@
+import * as nock from 'nock';
+import 'should';
+import * as sinon from 'sinon';
+
+import { BitGo } from '../../../src';
+
+describe('Auth', () => {
+  describe('Auth V3', () => {
+    it('should set auth version to 3 when initializing a bitgo object with explicit auth version 3', () => {
+      const bitgo = new BitGo({ authVersion: 3 });
+      bitgo.getAuthVersion().should.eql(3);
+    });
+
+    it('should pass "3.0" as the bitgo-auth-version header when auth v3 is enabled', async () => {
+      const url = 'https://bitgo.invalid';
+      const bitgo = new BitGo({ authVersion: 3 });
+
+      const scope = nock(url, {
+        reqheaders: {
+          'bitgo-auth-version': '3.0',
+        },
+      })
+        .get('/')
+        .reply(200);
+
+      await bitgo.get(url).should.eventually.have.property('status', 200);
+      scope.done();
+    });
+
+    it('should reject responses outside the response validity window', async () => {
+      const url = 'https://bitgo.invalid';
+      const bitgo = new BitGo({ authVersion: 3, accessToken: `v2x${'0'.repeat(64)}` });
+
+      const verifyResponseStub = sinon.stub(bitgo, 'verifyResponse')
+        .returns({
+          isValid: true,
+          isInResponseValidityWindow: false,
+          expectedHmac: '',
+          signatureSubject: '',
+          verificationTime: 0,
+        });
+
+      const scope = nock(url)
+        .get('/')
+        .reply(200);
+
+      await bitgo.get(url).should.be.rejectedWith('server response outside response validity time window, possible man-in-the-middle-attack');
+      verifyResponseStub.restore();
+      scope.done();
+    });
+
+    it('should accept responses within the response validity window', async () => {
+      const url = 'https://bitgo.invalid';
+      const bitgo = new BitGo({ authVersion: 3, accessToken: `v2x${'0'.repeat(64)}` });
+
+      const verifyResponseStub = sinon.stub(bitgo, 'verifyResponse')
+        .returns({
+          isValid: true,
+          isInResponseValidityWindow: true,
+          expectedHmac: '',
+          signatureSubject: '',
+          verificationTime: 0,
+        });
+
+      const scope = nock(url)
+        .get('/')
+        .reply(200);
+
+      await bitgo.get(url).should.eventually.have.property('status', 200);
+      verifyResponseStub.restore();
+      scope.done();
+    });
+
+    it('should include the auth version in the hmac subject', async () => {
+      const url = 'https://bitgo.invalid';
+      const accessToken = `v2x${'0'.repeat(64)}`;
+      const bitgo = new BitGo({ authVersion: 3, accessToken });
+
+      const calculateHMACSpy = sinon.spy(bitgo, 'calculateHMAC');
+      const verifyResponseStub = sinon.stub(bitgo, 'verifyResponse')
+        .returns({
+          isValid: true,
+          isInResponseValidityWindow: true,
+          expectedHmac: '',
+          signatureSubject: '',
+          verificationTime: 0,
+        });
+
+      const scope = nock(url)
+        .get('/')
+        .reply(200);
+
+      await bitgo.get(url).should.eventually.have.property('status', 200);
+      calculateHMACSpy
+        .firstCall
+        .calledWith(accessToken, sinon.match('3.0'))
+        .should.be.true();
+      calculateHMACSpy.restore();
+      verifyResponseStub.restore();
+      scope.done();
+    });
+  });
+
+  describe('Auth V2', () => {
+    it('should default to auth version 2 when initializing a bitgo object', () => {
+      const bitgo = new BitGo();
+      bitgo.getAuthVersion().should.eql(2);
+    });
+
+    it('should pass "2.0" as the bitgo-auth-version header when auth v2 is enabled', async () => {
+      const url = 'https://bitgo.invalid';
+      const bitgo = new BitGo();
+
+      const scope = nock(url, {
+        reqheaders: {
+          'bitgo-auth-version': '2.0',
+        },
+      })
+        .get('/')
+        .reply(200);
+
+      await bitgo.get(url).should.eventually.have.property('status', 200);
+      scope.done();
+    });
+  });
+});

--- a/modules/express/README.md
+++ b/modules/express/README.md
@@ -184,6 +184,7 @@ BitGo Express is able to take configuration options from either command line arg
 | N/A             | --disableproxy         | `BITGO_DISABLE_PROXY` <sup>0</sup>       | N/A           | Disable proxying of routes not explicitly handled by bitgo-express                                                      |
 | N/A             | --disableenvcheck      | `BITGO_DISABLE_ENV_CHECK` <sup>0</sup>   | N/A           | Disable checking for correct `NODE_ENV` environment variable when running against BitGo production environment.         |
 | -i              | --ipc                  | `BITGO_IPC`                              | N/A           | If set, bind to the given IPC (unix domain) socket. Binding to an IPC socket can be useful if the caller of bitgo-express resides on the same host as the bitgo-express instance itself, since the socket can be secured using normal file permissions and ownership semantics. Note: This is not supported on Windows platforms. |
+| N/A             | --authversion          | `BITGO_AUTH_VERSION`                     | 2             | BitGo Authentication scheme version which should be used form making requests to the BitGo server. Please see the [BitGo API documentation](https://app.bitgo.com/docs) for more info on authentication scheme versions. |
 
 \[0]: BitGo will also check the additional environment variables for some options for backwards compatibility, but these environment variables should be considered deprecated:
 * Disable SSL

--- a/modules/express/src/args.ts
+++ b/modules/express/src/args.ts
@@ -80,4 +80,8 @@ parser.addArgument(['-t', '--timeout'], {
   help: 'Proxy server timeout in milliseconds',
 });
 
+parser.addArgument(['--authversion'], {
+  help: 'BitGo authentication scheme version to use (default 2). See BitGo documentation for more details on auth versions.',
+});
+
 export const args = () => parser.parseArgs();

--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -5,7 +5,7 @@ import * as bodyParser from 'body-parser';
 import * as bluebird from 'bluebird';
 import * as url from 'url';
 import * as debugLib from 'debug';
-import { BitGo, Coin, Errors } from 'bitgo';
+import { BitGo, BitGoOptions, Coin, Errors } from 'bitgo';
 import * as _ from 'lodash';
 import * as express from 'express';
 
@@ -684,7 +684,7 @@ function prepareBitGo(config: Config) {
     const userAgent = req.headers['user-agent']
       ? BITGOEXPRESS_USER_AGENT + ' ' + req.headers['user-agent']
       : BITGOEXPRESS_USER_AGENT;
-    const bitgoConstructorParams = {
+    const bitgoConstructorParams: BitGoOptions = {
       env,
       customRootURI: customRootUri,
       customBitcoinNetwork,

--- a/modules/express/src/config.ts
+++ b/modules/express/src/config.ts
@@ -31,6 +31,7 @@ export interface Config {
   timeout: number;
   customRootUri?: string;
   customBitcoinNetwork?: V1Network;
+  authVersion: number;
 }
 
 export const ArgConfig = (args): Partial<Config> => ({
@@ -48,6 +49,7 @@ export const ArgConfig = (args): Partial<Config> => ({
   timeout: args.timeout,
   customRootUri: args.customrooturi,
   customBitcoinNetwork: args.custombitcoinnetwork,
+  authVersion: args.authVersion,
 });
 
 export const EnvConfig = (): Partial<Config> => ({
@@ -66,6 +68,7 @@ export const EnvConfig = (): Partial<Config> => ({
   timeout: Number(readEnvVar('BITGO_TIMEOUT')),
   customRootUri: readEnvVar('BITGO_CUSTOM_ROOT_URI'),
   customBitcoinNetwork: (readEnvVar('BITGO_CUSTOM_BITCOIN_NETWORK') as V1Network),
+  authVersion: Number(readEnvVar('BITGO_AUTH_VERSION')),
 });
 
 export const DefaultConfig: Config = {
@@ -80,6 +83,7 @@ export const DefaultConfig: Config = {
   // This will require a major version bump, since this is a breaking change to default behavior.
   disableEnvCheck: true,
   timeout: 305 * 1000,
+  authVersion: 2,
 };
 
 /**
@@ -116,6 +120,7 @@ function mergeConfigs(...configs: Partial<Config>[]): Config {
     timeout: get('timeout'),
     customRootUri: get('customRootUri'),
     customBitcoinNetwork: get('customBitcoinNetwork'),
+    authVersion: get('authVersion'),
   };
 }
 

--- a/modules/express/test/unit/config.ts
+++ b/modules/express/test/unit/config.ts
@@ -85,6 +85,7 @@ describe('Config:', () => {
       timeout: 'argtimeout',
       customRootUri: 'argcustomRootUri',
       customBitcoinNetwork: 'argcustomBitcoinNetwork',
+      authVersion: 2,
     });
     argStub.restore();
     envStub.restore();


### PR DESCRIPTION
Auth v3 is an extension to the existing auth v2 authentication scheme,
which adds defenses against replay attacks and protocol downgrades.

This commit adds support for Auth v3 to the SDK, and adds flags for
enabling mandatory auth v3 to BitGo Express. Auth v2 is still the
default auth scheme for now until we gain more confidence that Auth v3
is working as intended.

Ticket: BG-30091