### PR TITLE
feat(account-lib): add algo txn validation methods to txn builder

### DIFF
--- a/modules/account-lib/package.json
+++ b/modules/account-lib/package.json
@@ -53,6 +53,7 @@
     "ethereumjs-tx": "2.1.2",
     "ethereumjs-util": "5.2.0",
     "ethers": "^5.1.3",
+    "joi": "^17.4.0",
     "libsodium-wrappers": "^0.7.6",
     "lodash": "^4.17.15",
     "long": "^4.0.0",

--- a/modules/account-lib/src/coin/algo/txnSchema.ts
+++ b/modules/account-lib/src/coin/algo/txnSchema.ts
@@ -1,0 +1,31 @@
+import joi from 'joi';
+import utils from './utils';
+
+export const BaseTransactionSchema = joi
+  .object({
+    fee: joi.number().required(),
+    firstRound: joi.number().positive().required(),
+    genesisHash: joi.string().base64().required(),
+    lastRound: joi.number().positive().required(),
+    sender: joi
+      .string()
+      .custom((addr) => utils.isValidAddress(addr))
+      .required(),
+    genesisId: joi.string().optional(),
+    lease: joi.optional(),
+    note: joi.optional(),
+    reKeyTo: joi
+      .string()
+      .custom((addr) => utils.isValidAddress(addr))
+      .optional(),
+  })
+  .custom((obj) => {
+    const firstRound: number = obj.firstRound;
+    const lastRound: number = obj.lastRound;
+
+    if (firstRound < lastRound) {
+      return obj;
+    }
+
+    throw new Error('lastRound cannot be greater than or equal to firstRound');
+  });

--- a/modules/account-lib/test/unit/coin/algo/transactionBuilder/base.ts
+++ b/modules/account-lib/test/unit/coin/algo/transactionBuilder/base.ts
@@ -232,4 +232,32 @@ describe('Algo Transaction Builder', () => {
       should.doesNotThrow(() => txnBuilder.getTransaction().toBroadcastFormat());
     }); */
   });
+
+  describe('transaction validation', () => {
+    it('should validate a normal transaction', () => {
+      txnBuilder
+        .fee({ fee: '1000' })
+        .isFlatFee(true)
+        .firstRound(1)
+        .lastRound(10)
+        .sender({ address: account1.address })
+        .genesisId(testnet.genesisID)
+        .genesisHash(testnet.genesisHash);
+
+      should.doesNotThrow(() => txnBuilder.validateTransaction(txnBuilder.getTransaction()));
+    });
+
+    it('should validate last round is after first round', () => {
+      txnBuilder
+        .fee({ fee: '1000' })
+        .isFlatFee(true)
+        .firstRound(10)
+        .lastRound(1)
+        .sender({ address: account1.address })
+        .genesisId(testnet.genesisID)
+        .genesisHash(testnet.genesisHash);
+
+      should.throws(() => txnBuilder.validateTransaction(txnBuilder.getTransaction()));
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1066,6 +1066,18 @@
   dependencies:
     "@types/node" ">=12.12.47"
 
+"@hapi/hoek@^9.0.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.2.0.tgz#f3933a44e365864f4dad5db94158106d511e8131"
+  integrity sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==
+
+"@hapi/topo@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.0.0.tgz#c19af8577fa393a06e9c77b60995af959be721e7"
+  integrity sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
 "@hashgraph/cryptography@^1.0.14":
   version "1.0.15"
   resolved "https://registry.yarnpkg.com/@hashgraph/cryptography/-/cryptography-1.0.15.tgz#707ce8527ef93bf3f6e8bd24c5816990daa23c78"
@@ -2133,6 +2145,23 @@
   integrity sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==
   dependencies:
     any-observable "^0.3.0"
+
+"@sideway/address@^4.1.0":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.2.tgz#811b84333a335739d3969cfc434736268170cad1"
+  integrity sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@sideway/formula@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
+  integrity sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==
+
+"@sideway/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -9761,6 +9790,17 @@ jest-worker@^26.6.2:
     "@types/node" "*"
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
+
+joi@^17.4.0:
+  version "17.4.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.4.0.tgz#b5c2277c8519e016316e49ababd41a1908d9ef20"
+  integrity sha512-F4WiW2xaV6wc1jxete70Rw4V/VuMd6IN+a5ilZsxG4uYtUXWu2kq9W5P2dz30e7Gmw8RCbY/u/uk+dMPma9tAg==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
+    "@sideway/address" "^4.1.0"
+    "@sideway/formula" "^3.0.0"
+    "@sideway/pinpoint" "^2.0.0"
 
 js-base64@^3.6.0:
   version "3.6.0"


### PR DESCRIPTION
Add transaction validation methods to transaction builder for algo. It uses a joi schema to validate to make things concise and predictable. 

Depends on #1179 

ticket: BG-31558