### PR TITLE
fix(core): allow paygo outputs for empty verification options object

### DIFF
--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -726,6 +726,21 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
   }
 
   /**
+   * Get the maximum percentage limit for pay-as-you-go outputs
+   *
+   * @protected
+   */
+  protected getPayGoLimit(allowPaygoOutput?: boolean): number {
+    // allowing paygo outputs needs to be the default behavior, so only disallow paygo outputs if the
+    // relevant verification option is both set and false
+    if (!_.isNil(allowPaygoOutput) && !allowPaygoOutput) {
+      return 0;
+    }
+    // 150 basis points is the absolute permitted maximum if paygo outputs are allowed
+    return 0.015;
+  }
+
+  /**
    * Verify that a transaction prebuild complies with the original intention
    *
    * @param params
@@ -794,9 +809,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       const intendedExternalSpend = parsedTransaction.explicitExternalSpendAmount;
 
       // this is a limit we impose for the total value that is amended to the transaction beyond what was originally intended
-      const payAsYouGoLimit = verification.allowPaygoOutput ?
-        intendedExternalSpend * 0.015 : // 150 basis points is the absolute permitted maximum if paygo outputs are allowed
-        0;
+      const payAsYouGoLimit = intendedExternalSpend * self.getPayGoLimit(verification.allowPaygoOutput);
 
       /*
       Some explanation for why we're doing what we're doing:

--- a/modules/core/test/v2/unit/coins/abstractUtxoCoin.ts
+++ b/modules/core/test/v2/unit/coins/abstractUtxoCoin.ts
@@ -481,6 +481,35 @@ describe('Abstract UTXO Coin:', () => {
 
       coinMock.restore();
     });
+
+    it('should allow paygo outputs if empty verification object is passed', async () => {
+      const coinMock = sinon.stub(coin, 'parseTransaction').resolves({
+        keychains: {},
+        keySignatures: {},
+        outputs: [],
+        missingOutputs: [],
+        explicitExternalOutputs: [],
+        implicitExternalOutputs: [],
+        changeOutputs: [],
+        explicitExternalSpendAmount: 1000,
+        implicitExternalSpendAmount: 15,
+        needsCustomChangeKeySignatureVerification: false,
+      });
+
+      const bitcoinMock = sinon.stub(utxoLib.Transaction, 'fromHex').returns({ ins: [] });
+
+      await coin.verifyTransaction({
+        txParams: {
+          walletPassphrase: passphrase,
+        },
+        txPrebuild: {},
+        wallet: unsignedSendingWallet as any,
+        verification: {},
+      }).should.eventually.be.true();
+
+      coinMock.restore();
+      bitcoinMock.restore();
+    });
   });
 
   describe('Recover Wallet:', () => {


### PR DESCRIPTION
The UI will pass an empty object for the verifications options, so this
caused a breaking change in behavior for PayGo users who use the UI.

Instead, consider paygo outputs to be allowed unless the verification
option to allow them is both set and false.

Ticket: CR-296