### PR TITLE
fix: Update freeze request to include sending params

### DIFF
--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -1096,6 +1096,7 @@ export class Wallet {
     }
 
     return this.bitgo.post(this.url('/freeze'))
+      .send(params)
       .result()
       .nodeify(callback);
   }

--- a/modules/core/test/v2/unit/wallet.ts
+++ b/modules/core/test/v2/unit/wallet.ts
@@ -957,4 +957,16 @@ describe('V2 Wallet:', function() {
       createShareNock.isDone().should.be.True();
     });
   });
+
+  describe('Wallet Freezing', function() {
+    it('should freeze wallet for specified duration in seconds', async function() {
+      const params = { duration: 60 };
+      const scope =
+        nock(bgUrl)
+        .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/freeze`, params)
+        .reply(200, {});
+      await wallet.freeze(params);
+      scope.isDone().should.be.True();
+    });
+  });
 });


### PR DESCRIPTION
Freeze wasn't sending the params with the post-call, so it always defaulted to 1 hour.