### PR TITLE
feat(account-lib): Add number of signers setter to algo

### DIFF
--- a/modules/account-lib/src/coin/algo/transactionBuilder.ts
+++ b/modules/account-lib/src/coin/algo/transactionBuilder.ts
@@ -259,6 +259,24 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
   }
 
   /**
+   * Sets the number of signers required to sign the transaction.
+   *
+   * The number of signers cannot be set to a negative value.
+   *
+   * @param {number} n The number of signers.
+   * @returns {TransactionBuilder} This transaction builder.
+   */
+  numberOfSigners(n: number): this {
+    if (n < 0) {
+      throw new BuildTransactionError(`Number of signers: '${n}' cannot be negative`);
+    }
+
+    this._transaction.numberOfSigners(n);
+
+    return this;
+  }
+
+  /**
    * @inheritdoc
    * @see https://developer.algorand.org/docs/features/accounts/#transformation-private-key-to-base64-private-key
    */

--- a/modules/account-lib/test/unit/coin/algo/transactionBuilder/base.ts
+++ b/modules/account-lib/test/unit/coin/algo/transactionBuilder/base.ts
@@ -9,6 +9,8 @@ import { BaseKey } from '../../../../../src/coin/baseCoin/iface';
 
 import * as AlgoResources from '../../../../resources/algo';
 
+const STANDARD_REQUIRED_NUMBER_OF_SIGNERS = 2;
+
 class StubTransactionBuilder extends TransactionBuilder {
   constructor(coinConfig: Readonly<CoinConfig>) {
     super(coinConfig);
@@ -60,6 +62,14 @@ describe('Algo Transaction Builder', () => {
       );
       should.doesNotThrow(() => txnBuilder.sender({ address: account1.address }));
       assert.calledTwice(spy);
+    });
+
+    it('should validate number of signers is not less than 0', () => {
+      should.throws(() => txnBuilder.numberOfSigners(-1));
+
+      for (let i = 0; i < STANDARD_REQUIRED_NUMBER_OF_SIGNERS; i++) {
+        should.doesNotThrow(() => txnBuilder.numberOfSigners(i));
+      }
     });
   });
 


### PR DESCRIPTION
This change adds a number of signers setter to transaction builder. This is required because the client cannot access the transaction object for which the number of signers is set to before the transaction is built because it is [protected](https://github.com/BitGo/BitGoJS/blob/master/modules/account-lib/src/coin/algo/transactionBuilder.ts#L293).

ticket: BG-31556