### PR TITLE
fix(account-lib): Fix validate algo address test.

### DIFF
--- a/modules/account-lib/test/unit/coin/algo/transactionBuilder/base.ts
+++ b/modules/account-lib/test/unit/coin/algo/transactionBuilder/base.ts
@@ -53,7 +53,7 @@ describe('Algo Transaction Builder', () => {
     });
 
     it('should validate sender address is a valid algo address', () => {
-      const spy = sinon.spy(txnBuilder, 'sender');
+      const spy = sinon.spy(txnBuilder, 'validateAddress');
       should.throws(
         () => txnBuilder.sender({ address: 'asdf' }),
         (e: Error) => e.name === AddressValidationError.name,


### PR DESCRIPTION
This change changes the spy to be put on the validateAddress method rather than sender because the latter is moot and doesn't do validation.

ticket: BG-31556