### PR TITLE
chore: move check commits before running install

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,16 +15,22 @@ steps:
   - yarn --version
   - git --version
 
-- name: install
+- name: fetch
   image: node:10
   commands:
   - git fetch origin +refs/heads/$DRONE_REPO_BRANCH:$DRONE_REPO_BRANCH || true
-  - yarn install
 
 - name: check-commits
   image: node:10
   commands:
-  - yarn run check-commits
+  - COMMITLINT_VERSION=$(node -p "require('./package.json').devDependencies[\"@commitlint/cli\"]") && 
+      yarn global add @commitlint/cli@$COMMITLINT_VERSION @commitlint/config-conventional@$COMMITLINT_VERSION
+  - PATH=$(yarn global bin):$PATH yarn run check-commits
+
+- name: install
+  image: node:10
+  commands:
+  - yarn install
 
 - name: audit
   image: node:10

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "gen-docs": "lerna run gen-docs --stream --parallel",
     "check-fmt-changed": "lerna run check-fmt --since origin/${DRONE_REPO_BRANCH:-master}..${DRONE_COMMIT:-HEAD} --stream --parallel",
     "check-fmt": "lerna run check-fmt --stream --parallel",
-    "check-commits": "yarn commitlint --from=origin/${DRONE_REPO_BRANCH:-master} -V"
+    "check-commits": "PATH=$PATH yarn commitlint --from=origin/${DRONE_REPO_BRANCH:-master} -V"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Moving check commits before installing node modules means we will get faster build failures in drone.

ticket: BG-32748