### PR TITLE
feat(eth): verify pre-built eth txns

### DIFF
--- a/modules/core/src/v2/coins/erc20Token.ts
+++ b/modules/core/src/v2/coins/erc20Token.ts
@@ -7,7 +7,7 @@ import * as _ from 'lodash';
 import { BitGo } from '../../bitgo';
 import { NodeCallback } from '../types';
 
-import { Eth, RecoverOptions, RecoveryInfo, optionalDeps } from './eth';
+import { Eth, RecoverOptions, RecoveryInfo, optionalDeps, TransactionPrebuild } from './eth';
 import { CoinConstructor } from '../coinFactory';
 import { Util } from '../internal/util';
 import * as config from '../../config';
@@ -328,5 +328,9 @@ export class Erc20Token extends Eth {
         value: optionalDeps.ethUtil.toBuffer(txInfo.signature),
       },
     ];
+  }
+
+  verifyCoin(txPrebuild: TransactionPrebuild): boolean {
+    return txPrebuild.coin === this.tokenConfig.coin && txPrebuild.token === this.tokenConfig.type;
   }
 }

--- a/modules/core/src/v2/coins/eth.ts
+++ b/modules/core/src/v2/coins/eth.ts
@@ -23,6 +23,8 @@ import {
   TransactionPrebuild as BaseTransactionPrebuild,
   VerifyAddressOptions,
   VerifyTransactionOptions,
+  TransactionParams,
+  TransactionRecipient,
 } from '../baseCoin';
 import { Erc20Token } from './erc20Token';
 import { BitGo } from '../../bitgo';
@@ -32,6 +34,7 @@ import * as common from '../../common';
 import * as config from '../../config';
 import { Util } from '../internal/util';
 import { EthereumLibraryUnavailableError } from '../../errors';
+import { BaseCoin as StaticsBaseCoin, EthereumNetwork } from '@bitgo/statics';
 
 const co = Bluebird.coroutine;
 const debug = debugLib('bitgo:v2:eth');
@@ -87,6 +90,14 @@ interface HopPrebuild {
   tx: string;
   id: string;
   signature: string;
+  paymentId: string;
+  gasPrice: number;
+  gasLimit: number;
+  amount: number;
+  recipient: string;
+  nonce: number;
+  userReqSig: string;
+  gasPriceMax: number;
 }
 
 interface Recipient {
@@ -224,11 +235,30 @@ interface FeeEstimate {
   feeEstimate: number;
 }
 
-interface TransactionPrebuild extends BaseTransactionPrebuild {
+export interface TransactionPrebuild extends BaseTransactionPrebuild {
   hopTransaction?: HopPrebuild;
   buildParams: {
     recipients: Recipient[];
   };
+  recipients: TransactionRecipient[];
+  nextContractSequenceId: string;
+  gasPrice: number;
+  gasLimit: number;
+  isBatch: boolean;
+  coin: string;
+  token?: string;
+}
+
+// TODO: This interface will need to be updated for the new fee model introduced in the London Hard Fork
+interface EthTransactionParams extends TransactionParams {
+  gasPrice?: number;
+  gasLimit?: number;
+  hopParams?: HopParams;
+}
+
+interface VerifyEthTransactionOptions extends VerifyTransactionOptions {
+  txPrebuild: TransactionPrebuild;
+  txParams: EthTransactionParams;
 }
 
 interface PresignTransactionOptions extends TransactionPrebuild, BasePresignTransactionOptions {
@@ -252,8 +282,15 @@ interface RecoverTokenTransaction {
 export class Eth extends BaseCoin {
   static hopTransactionSalt = 'bitgoHopAddressRequestSalt';
 
-  static createInstance(bitgo: BitGo): BaseCoin {
-    return new Eth(bitgo);
+  readonly staticsCoin?: Readonly<StaticsBaseCoin>;
+
+  protected constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+    super(bitgo);
+    this.staticsCoin = staticsCoin;
+  }
+
+  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+    return new Eth(bitgo, staticsCoin);
   }
 
   /**
@@ -1483,7 +1520,109 @@ export class Eth extends BaseCoin {
     return true;
   }
 
-  verifyTransaction(params: VerifyTransactionOptions, callback?: NodeCallback<boolean>): Bluebird<boolean> {
-    return Bluebird.resolve(true).asCallback(callback);
+  verifyCoin(txPrebuild: TransactionPrebuild): boolean {
+    return txPrebuild.coin === this.getChain();
+  }
+
+  /**
+   * Verify that a transaction prebuild complies with the original intention
+   *
+   * @param params
+   * @param params.txParams params object passed to send
+   * @param params.txPrebuild prebuild object returned by server
+   * @param params.wallet Wallet object to obtain keys to verify against
+   * @param callback
+   * @returns {boolean}
+   */
+  verifyTransaction(params: VerifyEthTransactionOptions, callback?: NodeCallback<boolean>): Bluebird<boolean> {
+    const self = this;
+    return co<boolean>(function* (): any {
+      const { txParams, txPrebuild, wallet } = params;
+      if (!txParams?.recipients || !txPrebuild?.recipients || !wallet) {
+        throw new Error(`missing params`);
+      }
+      if (txPrebuild.hopTransaction && txPrebuild.isBatch) {
+        throw new Error(`tx cannot be both a batch and hop transaction`);
+      }
+      if (txPrebuild.recipients.length !== 1) {
+        throw new Error(`txPrebuild should only have 1 recipient but ${txPrebuild.recipients.length} found`);
+      }
+      if (txPrebuild.hopTransaction) {
+        // Check recipient amount for hop transaction
+        if (txParams.recipients.length !== 1) {
+          throw new Error(`hop transaction only supports 1 recipient but ${txParams.recipients.length} found`);
+        }
+        const expectedAmount = new BigNumber(txParams.recipients[0].amount);
+        if (!expectedAmount.isEqualTo(txPrebuild.recipients[0].amount)) {
+          throw new Error(
+            'hop transaction amount in txPrebuild received from BitGo servers does not match txParams supplied by client'
+          );
+        }
+
+        // Check tx sends to hop address
+        const decodedHopTx = new optionalDeps.EthTx(txPrebuild.hopTransaction.tx);
+        const expectedHopAddress = decodedHopTx.getSenderAddress().toString('hex');
+        if (
+          expectedHopAddress.toLowerCase() !==
+          optionalDeps.ethUtil.stripHexPrefix(txPrebuild.recipients[0].address.toLowerCase())
+        ) {
+          throw new Error('recipient address of txPrebuild does not match hop address');
+        }
+
+        // Convert TransactionRecipient array to Recipient array
+        const recipients: Recipient[] = txParams.recipients.map((r) => {
+          return {
+            address: r.address,
+            amount: typeof r.amount === 'number' ? r.amount.toString() : r.amount,
+          };
+        });
+
+        // Check destination address and amount
+        yield self.validateHopPrebuild(wallet, txPrebuild.hopTransaction, { recipients });
+      } else if (txPrebuild.isBatch) {
+        // Check total amount for batch transaction
+        let expectedTotalAmount = new BigNumber(0);
+        for (let i = 0; i < txParams.recipients.length; i++) {
+          expectedTotalAmount = expectedTotalAmount.plus(txParams.recipients[i].amount);
+        }
+        if (!expectedTotalAmount.isEqualTo(txPrebuild.recipients[0].amount)) {
+          throw new Error(
+            'batch transaction amount in txPrebuild received from BitGo servers does not match txParams supplied by client'
+          );
+        }
+
+        // Check batch transaction is sent to the batcher contract address for the chain
+        const batcherContractAddress = (self.staticsCoin?.network as EthereumNetwork).batcherContractAddress;
+        if (
+          !batcherContractAddress ||
+          batcherContractAddress.toLowerCase() !== txPrebuild.recipients[0].address.toLowerCase()
+        ) {
+          throw new Error('recipient address of txPrebuild does not match batcher address');
+        }
+      } else {
+        // Check recipient address and amount for normal transaction
+        if (txParams.recipients.length !== 1) {
+          throw new Error(`normal transaction only supports 1 recipient but ${txParams.recipients.length} found`);
+        }
+        const expectedAmount = new BigNumber(txParams.recipients[0].amount);
+        if (!expectedAmount.isEqualTo(txPrebuild.recipients[0].amount)) {
+          throw new Error(
+            'normal transaction amount in txPrebuild received from BitGo servers does not match txParams supplied by client'
+          );
+        }
+        if (txParams.recipients[0].address !== txPrebuild.recipients[0].address) {
+          throw new Error(
+            'destination address in normal txPrebuild does not match that in txParams supplied by client'
+          );
+        }
+      }
+      // Check coin is correct for all transaction types
+      if (!self.verifyCoin(txPrebuild)) {
+        throw new Error(`coin in txPrebuild did not match that in txParams supplied by client`);
+      }
+      return true;
+    })
+      .call(this)
+      .asCallback(callback);
   }
 }

--- a/modules/core/src/v2/coins/gteth.ts
+++ b/modules/core/src/v2/coins/gteth.ts
@@ -1,10 +1,15 @@
 import { BitGo } from '../../bitgo';
 import { BaseCoin } from '../baseCoin';
 import { Eth } from './eth';
+import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 
 export class Gteth extends Eth {
-  static createInstance(bitgo: BitGo): BaseCoin {
-    return new Gteth(bitgo);
+  protected constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+    super(bitgo, staticsCoin);
+  }
+
+  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+    return new Gteth(bitgo, staticsCoin);
   }
 
   getChain() {

--- a/modules/core/src/v2/coins/teth.ts
+++ b/modules/core/src/v2/coins/teth.ts
@@ -1,10 +1,15 @@
 import { BitGo } from '../../bitgo';
 import { BaseCoin } from '../baseCoin';
 import { Eth } from './eth';
+import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 
 export class Teth extends Eth {
-  static createInstance(bitgo: BitGo): BaseCoin {
-    return new Teth(bitgo);
+  protected constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+    super(bitgo, staticsCoin);
+  }
+
+  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+    return new Teth(bitgo, staticsCoin);
   }
 
   getChain() {

--- a/modules/core/test/v2/unit/coins/eth.ts
+++ b/modules/core/test/v2/unit/coins/eth.ts
@@ -1,0 +1,536 @@
+import { TestBitGo } from '../../../lib/test_bitgo';
+import { Wallet } from '../../../../src/v2/wallet';
+
+import * as nock from 'nock';
+import * as secp256k1 from 'secp256k1';
+import * as common from '../../../../src/common';
+import * as bitGoUtxoLib from '@bitgo/utxo-lib';
+
+nock.enableNetConnect();
+
+describe('ETH:', function () {
+  let bitgo;
+  let bitgoPrvBuffer;
+  let hopTxBitgoSignature;
+
+  const address1 = '0x174cfd823af8ce27ed0afee3fcf3c3ba259116be';
+  const address2 = '0x7e85bdc27c050e3905ebf4b8e634d9ad6edd0de6';
+  const hopContractAddress = '0x47ce7cc86efefef19f8fb516b11735d183da8635';
+  const hopDestinationAddress = '0x9c7e8ce6825bD48278B3Ab59228EE26f8BE7925b';
+  const hopTx = '0xf86b808504a817c8ff8252ff949c7e8ce6825bd48278b3ab59228ee26f8be7925b87038d7ea4c68000801ca011bc22c664570133dfca4f08a0b8d02339cf467046d6a4152f04f368d0eaf99ea01d6dc5cf0c897c8d4c3e1df53d0d042784c424536a4cc5b802552b7d64fee8b5';
+  const hopTxid = '0x4af65143bc77da2b50f35b3d13cacb4db18f026bf84bc0743550bc57b9b53351';
+  const userReqSig = '0x404db307f6147f0d8cd338c34c13906ef46a6faa7e0e119d5194ef05aec16e6f3d710f9b7901460f97e924066b62efd74443bd34402c6d40b49c203a559ff2c8';
+
+  before(function () {
+    const bitgoKeyXprv = 'xprv9s21ZrQH143K3tpWBHWe31sLoXNRQ9AvRYJgitkKxQ4ATFQMwvr7hHNqYRUnS7PsjzB7aK1VxqHLuNQjj1sckJ2Jwo2qxmsvejwECSpFMfC';
+    const bitgoKey = bitGoUtxoLib.HDNode.fromBase58(bitgoKeyXprv);
+    const bitgoXpub = bitgoKey.neutered().toBase58();
+    bitgoPrvBuffer = bitgoKey.getKey().getPrivateKeyBuffer();
+    hopTxBitgoSignature = '0xaa' + Buffer.from(secp256k1.ecdsaSign(Buffer.from(hopTxid.slice(2), 'hex'), bitgoPrvBuffer).signature).toString('hex');
+
+    const env = 'test';
+    bitgo = new TestBitGo({ env: 'test' });
+    common.Environments[env].hsmXpub = bitgoXpub;
+    bitgo.initializeTestVars();
+  });
+
+  after(function () {
+    nock.cleanAll();
+  });
+
+  describe('Transaction Verification', function () {
+    it('should verify a normal txPrebuild from the bitgo server that matches the client txParams', async function () {
+      const coin = bitgo.coin('teth');
+      const wallet = new Wallet(bitgo, coin, {});
+
+      const txParams = {
+        recipients: [{ amount: '1000000000000', address: address1 }],
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+      };
+
+      const txPrebuild = {
+        recipients: [{ amount: '1000000000000', address: address1 }],
+        nextContractSequenceId: 0,
+        gasPrice: 20000000000,
+        gasLimit: 500000,
+        isBatch: false,
+        coin: 'teth',
+        walletId: 'fakeWalletId',
+        walletContractAddress: 'fakeWalletContractAddress',
+      };
+
+      const verification = {};
+
+      const isTransactionVerified = await coin.verifyTransaction({ txParams, txPrebuild, wallet, verification });
+      isTransactionVerified.should.equal(true);
+    });
+
+    it('should verify a batch txPrebuild from the bitgo server that matches the client txParams', async function () {
+      const coin = bitgo.coin('teth');
+      const wallet = new Wallet(bitgo, coin, {});
+
+      const txParams = {
+        recipients: [{ amount: '1000000000000', address: address1 }, { amount: '2500000000000', address: address2 }],
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+      };
+
+      const txPrebuild = {
+        recipients: [{ amount: '3500000000000', address: coin.staticsCoin.network.batcherContractAddress }],
+        nextContractSequenceId: 0,
+        gasPrice: 20000000000,
+        gasLimit: 500000,
+        isBatch: true,
+        coin: 'teth',
+        walletId: 'fakeWalletId',
+        walletContractAddress: 'fakeWalletContractAddress',
+      };
+
+      const verification = {};
+
+      const isTransactionVerified = await coin.verifyTransaction({ txParams, txPrebuild, wallet, verification });
+      isTransactionVerified.should.equal(true);
+    });
+
+    it('should verify a hop txPrebuild from the bitgo server that matches the client txParams', async function () {
+      const coin = bitgo.coin('teth');
+      const wallet = new Wallet(bitgo, coin, {});
+
+      const txParams = {
+        recipients: [{ amount: 1000000000000000, address: hopDestinationAddress }],
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+      };
+
+      const txPrebuild = {
+        recipients: [{ amount: '1000000000000000', address: hopContractAddress }],
+        nextContractSequenceId: 0,
+        gasPrice: 20000000000,
+        gasLimit: 500000,
+        isBatch: false,
+        coin: 'teth',
+        walletId: 'fakeWalletId',
+        walletContractAddress: 'fakeWalletContractAddress',
+        hopTransaction: {
+          tx: hopTx,
+          id: hopTxid,
+          signature: hopTxBitgoSignature,
+          paymentId: '2773928196',
+          gasPrice: 20000000000,
+          gasLimit: 500000,
+          amount: '1000000000000000',
+          recipient: hopDestinationAddress,
+          nonce: 0,
+          userReqSig: userReqSig,
+          gasPriceMax: 500000000000,
+        },
+      };
+
+      const verification = {};
+
+      const isTransactionVerified = await coin.verifyTransaction({ txParams, txPrebuild, wallet, verification });
+      isTransactionVerified.should.equal(true);
+    });
+
+    it('should reject when client txParams are missing', async function () {
+      const coin = bitgo.coin('teth');
+      const wallet = new Wallet(bitgo, coin, {});
+
+      const txParams = null;
+
+      const txPrebuild = {
+        recipients: [{ amount: '1000000000000', address: address1 }],
+        nextContractSequenceId: 0,
+        gasPrice: 20000000000,
+        gasLimit: 500000,
+        isBatch: false,
+        coin: 'teth',
+        walletId: 'fakeWalletId',
+        walletContractAddress: 'fakeWalletContractAddress',
+      };
+
+      const verification = {};
+
+      await coin.verifyTransaction({ txParams, txPrebuild, wallet, verification })
+        .should.be.rejectedWith('missing params');
+    });
+
+    it('should reject txPrebuild that is both batch and hop', async function () {
+      const coin = bitgo.coin('teth');
+      const wallet = new Wallet(bitgo, coin, {});
+
+      const txParams = {
+        recipients: [{ amount: '1000000000000', address: address1 }],
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+      };
+
+      const txPrebuild = {
+        recipients: [{ amount: '1000000000000', address: address1 }],
+        nextContractSequenceId: 0,
+        gasPrice: 20000000000,
+        gasLimit: 500000,
+        isBatch: true,
+        coin: 'teth',
+        walletId: 'fakeWalletId',
+        walletContractAddress: 'fakeWalletContractAddress',
+        hopTransaction: {
+          tx: hopTx,
+          id: hopTxid,
+          signature: hopTxBitgoSignature,
+          paymentId: '2773928196',
+          gasPrice: 20000000000,
+          gasLimit: 500000,
+          amount: '1000000000000000',
+          recipient: hopDestinationAddress,
+          nonce: 0,
+          userReqSig: userReqSig,
+          gasPriceMax: 500000000000,
+        },
+      };
+
+      const verification = {};
+
+      await coin.verifyTransaction({ txParams, txPrebuild, wallet, verification })
+        .should.be.rejectedWith('tx cannot be both a batch and hop transaction');
+    });
+
+    it('should reject a txPrebuild with more than one recipient', async function () {
+      const coin = bitgo.coin('teth');
+      const wallet = new Wallet(bitgo, coin, {});
+
+      const txParams = {
+        recipients: [{ amount: '1000000000000', address: address1 }, { amount: '2500000000000', address: address2 }],
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+      };
+
+      const txPrebuild = {
+        recipients: [{ amount: '1000000000000', address: address1 }, { amount: '2500000000000', address: address2 }],
+        nextContractSequenceId: 0,
+        gasPrice: 20000000000,
+        gasLimit: 500000,
+        isBatch: true,
+        coin: 'teth',
+        walletId: 'fakeWalletId',
+        walletContractAddress: 'fakeWalletContractAddress',
+      };
+
+      const verification = {};
+
+      await coin.verifyTransaction({ txParams, txPrebuild, wallet, verification })
+        .should.be.rejectedWith('txPrebuild should only have 1 recipient but 2 found');
+    });
+
+    it('should reject a hop prebuild from the bitgo server that was not intended have exactly 1 recipient', async function () {
+      const coin = bitgo.coin('teth');
+      const wallet = new Wallet(bitgo, coin, {});
+
+      const txParams = {
+        recipients: [{ amount: '1000000000000000', address: hopDestinationAddress }, { amount: '1000000000000000', address: address1 }],
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+      };
+
+      const txPrebuild = {
+        recipients: [{ amount: '1000000000000000', address: hopContractAddress }],
+        nextContractSequenceId: 0,
+        gasPrice: 20000000000,
+        gasLimit: 500000,
+        isBatch: false,
+        coin: 'teth',
+        walletId: 'fakeWalletId',
+        walletContractAddress: 'fakeWalletContractAddress',
+        hopTransaction: {
+          tx: hopTx,
+          id: hopTxid,
+          signature: hopTxBitgoSignature,
+          paymentId: '2773928196',
+          gasPrice: 20000000000,
+          gasLimit: 500000,
+          amount: '1000000000000000',
+          recipient: hopDestinationAddress,
+          nonce: 0,
+          userReqSig: userReqSig,
+          gasPriceMax: 500000000000,
+        },
+      };
+
+      const verification = {};
+
+      await coin.verifyTransaction({ txParams, txPrebuild, wallet, verification })
+        .should.be.rejectedWith('hop transaction only supports 1 recipient but 2 found');
+    });
+
+    it('should reject a hop txPrebuild from the bitgo server with the wrong amount', async function () {
+      const coin = bitgo.coin('teth');
+      const wallet = new Wallet(bitgo, coin, {});
+
+      const txParams = {
+        recipients: [{ amount: '1000000000000000', address: hopDestinationAddress }],
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+      };
+
+      const txPrebuild = {
+        recipients: [{ amount: '5000000000000000', address: hopContractAddress }],
+        nextContractSequenceId: 0,
+        gasPrice: 20000000000,
+        gasLimit: 500000,
+        isBatch: false,
+        coin: 'teth',
+        walletId: 'fakeWalletId',
+        walletContractAddress: 'fakeWalletContractAddress',
+        hopTransaction: {
+          tx: hopTx,
+          id: hopTxid,
+          signature: hopTxBitgoSignature,
+          paymentId: '0',
+          gasPrice: 20000000000,
+          gasLimit: 500000,
+          amount: '1000000000000000',
+          recipient: hopDestinationAddress,
+          nonce: 0,
+          userReqSig: userReqSig,
+          gasPriceMax: 500000000000,
+        },
+      };
+
+      const verification = {};
+
+      await coin.verifyTransaction({ txParams, txPrebuild, wallet, verification })
+        .should.be.rejectedWith('hop transaction amount in txPrebuild received from BitGo servers does not match txParams supplied by client');
+    });
+
+    it('should reject a hop txPrebuild that does not send to its hop address', async function () {
+      const coin = bitgo.coin('teth');
+      const wallet = new Wallet(bitgo, coin, {});
+
+      const txParams = {
+        recipients: [{ amount: '1000000000000000', address: hopDestinationAddress }],
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+      };
+
+      const txPrebuild = {
+        recipients: [{ amount: '1000000000000000', address: address1 }],
+        nextContractSequenceId: 0,
+        gasPrice: 20000000000,
+        gasLimit: 500000,
+        isBatch: false,
+        coin: 'teth',
+        walletId: 'fakeWalletId',
+        walletContractAddress: 'fakeWalletContractAddress',
+        hopTransaction: {
+          tx: hopTx,
+          id: hopTxid,
+          signature: hopTxBitgoSignature,
+          paymentId: '0',
+          gasPrice: 20000000000,
+          gasLimit: 500000,
+          amount: '1000000000000000',
+          recipient: hopDestinationAddress,
+          nonce: 0,
+          userReqSig: userReqSig,
+          gasPriceMax: 500000000000,
+        },
+      };
+
+      const verification = {};
+
+      await coin.verifyTransaction({ txParams, txPrebuild, wallet, verification })
+        .should.be.rejectedWith('recipient address of txPrebuild does not match hop address');
+    });
+
+    it('should reject a batch txPrebuild from the bitgo server with the wrong total amount', async function () {
+      const coin = bitgo.coin('teth');
+      const wallet = new Wallet(bitgo, coin, {});
+
+      const txParams = {
+        recipients: [{ amount: '1000000000000', address: address1 }, { amount: '2500000000000', address: address2 }],
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+      };
+
+      const txPrebuild = {
+        recipients: [{ amount: '5500000000000', address: coin.staticsCoin.network.batcherContractAddress }],
+        nextContractSequenceId: 0,
+        gasPrice: 20000000000,
+        gasLimit: 500000,
+        isBatch: true,
+        coin: 'teth',
+        walletId: 'fakeWalletId',
+        walletContractAddress: 'fakeWalletContractAddress',
+      };
+
+      const verification = {};
+
+      await coin.verifyTransaction({ txParams, txPrebuild, wallet, verification })
+        .should.be.rejectedWith('batch transaction amount in txPrebuild received from BitGo servers does not match txParams supplied by client');
+    });
+
+    it('should reject a batch txPrebuild from the bitgo server that does not send to the batcher contract address', async function () {
+      const coin = bitgo.coin('teth');
+      const wallet = new Wallet(bitgo, coin, {});
+
+      const txParams = {
+        recipients: [{ amount: '1000000000000', address: address1 }, { amount: '2500000000000', address: address2 }],
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+      };
+
+      const txPrebuild = {
+        recipients: [{ amount: '3500000000000', address: hopContractAddress }],
+        nextContractSequenceId: 0,
+        gasPrice: 20000000000,
+        gasLimit: 500000,
+        isBatch: true,
+        coin: 'teth',
+        walletId: 'fakeWalletId',
+        walletContractAddress: 'fakeWalletContractAddress',
+      };
+
+      const verification = {};
+
+      await coin.verifyTransaction({ txParams, txPrebuild, wallet, verification })
+        .should.be.rejectedWith('recipient address of txPrebuild does not match batcher address');
+    });
+
+    it('should reject a normal prebuild from the bitgo server that was not intended have exactly 1 recipient', async function () {
+      const coin = bitgo.coin('teth');
+      const wallet = new Wallet(bitgo, coin, {});
+
+      const txParams = {
+        recipients: [{ amount: '1000000000000', address: address1 }, { amount: '2500000000000', address: address2 }],
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+      };
+
+      const txPrebuild = {
+        recipients: [{ amount: '1000000000000', address: address1 }],
+        nextContractSequenceId: 0,
+        gasPrice: 20000000000,
+        gasLimit: 500000,
+        isBatch: false,
+        coin: 'teth',
+        walletId: 'fakeWalletId',
+        walletContractAddress: 'fakeWalletContractAddress',
+      };
+
+      const verification = {};
+
+      await coin.verifyTransaction({ txParams, txPrebuild, wallet, verification })
+        .should.be.rejectedWith('normal transaction only supports 1 recipient but 2 found');
+    });
+
+    it('should reject a normal txPrebuild from the bitgo server with the wrong amount', async function () {
+      const coin = bitgo.coin('teth');
+      const wallet = new Wallet(bitgo, coin, {});
+
+      const txParams = {
+        recipients: [{ amount: '1000000000000', address: address1 }],
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+      };
+
+      const txPrebuild = {
+        recipients: [{ amount: '2000000000000', address: address1 }],
+        nextContractSequenceId: 0,
+        gasPrice: 20000000000,
+        gasLimit: 500000,
+        isBatch: false,
+        coin: 'teth',
+        walletId: 'fakeWalletId',
+        walletContractAddress: 'fakeWalletContractAddress',
+      };
+
+      const verification = {};
+
+      await coin.verifyTransaction({ txParams, txPrebuild, wallet, verification })
+        .should.be.rejectedWith('normal transaction amount in txPrebuild received from BitGo servers does not match txParams supplied by client');
+    });
+
+    it('should reject a normal txPrebuild from the bitgo server with the wrong recipient', async function () {
+      const coin = bitgo.coin('teth');
+      const wallet = new Wallet(bitgo, coin, {});
+
+      const txParams = {
+        recipients: [{ amount: '1000000000000', address: address1 }],
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+      };
+
+      const txPrebuild = {
+        recipients: [{ amount: '1000000000000', address: address2 }],
+        nextContractSequenceId: 0,
+        gasPrice: 20000000000,
+        gasLimit: 500000,
+        isBatch: false,
+        coin: 'teth',
+        walletId: 'fakeWalletId',
+        walletContractAddress: 'fakeWalletContractAddress',
+      };
+
+      const verification = {};
+
+      await coin.verifyTransaction({ txParams, txPrebuild, wallet, verification })
+        .should.be.rejectedWith('destination address in normal txPrebuild does not match that in txParams supplied by client');
+    });
+
+    it('should verify a token txPrebuild from the bitgo server that matches the client txParams', async function () {
+      const coin = bitgo.coin('test');
+      const wallet = new Wallet(bitgo, coin, {});
+
+      const txParams = {
+        recipients: [{ amount: '1000000000000', address: address1 }],
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+      };
+
+      const txPrebuild = {
+        recipients: [{ amount: '1000000000000', address: address1 }],
+        nextContractSequenceId: 0,
+        gasPrice: 20000000000,
+        gasLimit: 500000,
+        isBatch: false,
+        coin: 'teth',
+        token: 'test',
+        walletId: 'fakeWalletId',
+        walletContractAddress: 'fakeWalletContractAddress',
+      };
+
+      const verification = {};
+
+      const isTransactionVerified = await coin.verifyTransaction({ txParams, txPrebuild, wallet, verification });
+      isTransactionVerified.should.equal(true);
+    });
+
+    it('should reject a txPrebuild from the bitgo server with the wrong coin', async function () {
+      const coin = bitgo.coin('teth');
+      const wallet = new Wallet(bitgo, coin, {});
+
+      const txParams = {
+        recipients: [{ amount: '1000000000000', address: address1 }],
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+      };
+
+      const txPrebuild = {
+        recipients: [{ amount: '1000000000000', address: address1 }],
+        nextContractSequenceId: 0,
+        gasPrice: 20000000000,
+        gasLimit: 500000,
+        isBatch: false,
+        coin: 'btc',
+        walletId: 'fakeWalletId',
+        walletContractAddress: 'fakeWalletContractAddress',
+      };
+
+      const verification = {};
+
+      await coin.verifyTransaction({ txParams, txPrebuild, wallet, verification })
+        .should.be.rejectedWith('coin in txPrebuild did not match that in txParams supplied by client');
+    });
+  });
+});

--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -45,6 +45,7 @@ export interface AccountNetwork extends BaseNetwork {
 export interface EthereumNetwork extends AccountNetwork {
   // unique chain id used for replay-protecting transactions
   readonly chainId: number;
+  readonly batcherContractAddress?: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -221,6 +222,7 @@ class Ethereum extends Mainnet implements EthereumNetwork {
   accountExplorerUrl = 'https://etherscan.io/address/';
   // from https://github.com/ethereumjs/ethereumjs-common/blob/a978f630858f6843176bb20b277569785914e899/src/chains/index.ts
   chainId = 1;
+  batcherContractAddress = '0x92c44c271a53f5cec699549c531d595c9692f663';
 }
 
 class Ethereum2 extends Mainnet implements AccountNetwork {
@@ -241,6 +243,7 @@ class Kovan extends Testnet implements EthereumNetwork {
   accountExplorerUrl = 'https://kovan.etherscan.io/address/';
   // from https://github.com/ethereumjs/ethereumjs-common/blob/a978f630858f6843176bb20b277569785914e899/src/chains/index.ts
   chainId = 42;
+  batcherContractAddress = '0xc0aaf2649e7b0f3950164681eca2b1a8f654a478';
 }
 
 class Goerli extends Testnet implements EthereumNetwork {
@@ -249,6 +252,7 @@ class Goerli extends Testnet implements EthereumNetwork {
   accountExplorerUrl = 'https://goerli.etherscan.io/address/';
   // from https://github.com/ethereumjs/ethereumjs-common/blob/a978f630858f6843176bb20b277569785914e899/src/chains/index.ts
   chainId = 5;
+  batcherContractAddress = '0xc0aaf2649e7b0f3950164681eca2b1a8f654a478';
 }
 
 class EthereumClassic extends Mainnet implements EthereumNetwork {


### PR DESCRIPTION
### Feature Description 

Client-side verification of transaction pre-builds received from BitGo servers should be verified to match transaction parameters specified by the client before the client signs the transaction.

This is an extra safeguard to protect the client from blindly signing malicious transaction pre-builds from the BitGo servers that do not match the transaction parameters specified by the client. An example of when this can be an issue is if BItGo servers were to be compromised and pre-builds are getting sent to the client that try to send funds to an attacker instead of the recipient address provided by the client.

### Implementation

This PR implements the `verifyTransaction` function for Eth which accepts `txParams` supplied by the client, `txPrebuild` supplied by the BitGo server, and the `wallet` for the transaction as parameters. The function returns true if the transaction is verified, and fails to verify throwing an error with the reason for failing otherwise.

It first checks that the parameters required exist, that the `txPrebuild` only has one recipient (note even multi-recipient transactions specified by the client `txParams` get squashed into a single recipient send to a batcher contract address with a data payload), and that the `txPrebuild` is not both a hop transaction and a batcher transaction.

Then, depending on the type of `txPrebuild` (hop, batcher, or normal), we perform different verification logic.

For a hop transaction, we check that there is only one recipient in the `txParams` and that the recipient amounts match those in `txParams`.  Then, we verify that the `txPrebuild` actually sends to the hop contract address corresponding to the `hopTransaction` in the `txPrebuild`. Finally, we convert the `txParams` `TransactionRecipient` array into a `Recipient` array by retyping the `amount` field from `string | number` to `string` to leverage the existing `validateHopPrebuild` function which checks the `hopTransaction` sends the correct amount to the recipient specified in `txParams`.

For a batch transaction, we verify that the `txPrebuild` is sending the correct total amount to a batcher contract address.

For a normal transaction (that is neither of the above), we check that there is only one recipient in the `txParams` and that the recipient amounts and address match those in `txParams`.

Lastly, we always check the coin of the `txPrebuild` matches the coin we are sending from the wallet.

### Testing

This PR includes unit tests covering all lines in the `verifyTransaction` function.

### Future Considerations

We do not yet fully verify batch transactions as we do not verify the data payload sent to the batcher contract address dictating how the total funds are re-distributed to the multiple recipients. Batch contracts are not yet in prod and parsing the data payload to verify this would be challenging and not worth doing at the moment. We do verify we are sending to a batcher contract address with the correct total amount though.

### Ticket: https://bitgoinc.atlassian.net/browse/BG-31542

<!--

Jira Ticket: Ticket: https://bitgoinc.atlassian.net/browse/BG-12345

Test URL: https://JIRA_12345-app.bitgo-dev.com/login

## Changes:

- Change list

## Test:

- Test Instructions

-->
