### PR TITLE
BG 33901: Moved block exploring into coin controllers

### DIFF
--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -1700,6 +1700,14 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
   protected abstract getAddressInfoFromExplorer(address: string, apiKey?: string): Bluebird<AddressInfo>;
   protected abstract getUnspentInfoFromExplorer(address: string, apiKey?: string): Bluebird<UnspentInfo[]>;
 
+  getTxInfoFromExplorer(faultyTxId: string): any {
+    return co(function *getUnspentFromWrongChain() {
+      const TX_INFO_URL = this.url(`/public/tx/${faultyTxId}`);
+      const res = (yield request.get(TX_INFO_URL)) as any;
+      return res.body;
+    }).call(this);
+  }
+
   /**
    * Derive child keys at specific index, from provided parent keys
    * @param {bitcoin.HDNode[]} keyArray

--- a/modules/core/src/v2/recovery.ts
+++ b/modules/core/src/v2/recovery.ts
@@ -187,9 +187,8 @@ export class CrossChainRecoveryTool {
 
       self._log('Grabbing info for faulty tx...');
 
-      const TX_INFO_URL = self.sourceCoin.url(`/public/tx/${faultyTxId}`);
-      const res = (yield request.get(TX_INFO_URL)) as any;
-      const faultyTxInfo = res.body;
+      // calling source coin's method of exploring transactions
+      const faultyTxInfo = (yield self.sourceCoin.getTxInfoFromExplorer(faultyTxId)) as any;
 
       self._log('Getting unspents on output addresses..');
 


### PR DESCRIPTION
Card: BG 33901: https://bitgoinc.atlassian.net/browse/BG-33091?filter=-1
Abstracting the tx explorer from recovery to UTXO coin controller