### PR TITLE
fix(core): fix cspr address validation to account for transferId

### DIFF
--- a/modules/account-lib/src/coin/cspr/ifaces.ts
+++ b/modules/account-lib/src/coin/cspr/ifaces.ts
@@ -82,3 +82,8 @@ export interface SignResponse {
   signature: Uint8Array;
   recid: number;
 }
+
+export interface AddressDetails {
+  address: string;
+  transferId?: string;
+}

--- a/modules/account-lib/src/coin/cspr/utils.ts
+++ b/modules/account-lib/src/coin/cspr/utils.ts
@@ -1,11 +1,14 @@
+import * as _ from 'lodash';
+import * as querystring from 'querystring';
+import * as url from 'url';
 import { createHash } from 'crypto';
 import BigNumber from 'bignumber.js';
 import { Keys, PublicKey, DeployUtil } from 'casper-client-sdk';
 import * as hex from '@stablelib/hex';
 import { ecdsaSign, ecdsaVerify } from 'secp256k1';
-import { InvalidTransactionError, SigningError } from '../baseCoin/errors';
+import { InvalidTransactionError, SigningError, UtilsError } from '../baseCoin/errors';
 import { DefaultKeys } from '../baseCoin/iface';
-import { Ed25519KeyPair, TransactionType } from '../baseCoin';
+import { TransactionType } from '../baseCoin';
 import * as Crypto from './../../utils/crypto';
 import {
   SECP256K1_PREFIX,
@@ -18,7 +21,7 @@ import {
   UNDELEGATE_CONTRACT_ACTION,
   ED25519_PREFIX,
 } from './constants';
-import { SignResponse } from './ifaces';
+import { SignResponse, AddressDetails } from './ifaces';
 import { KeyPair } from '.';
 
 const MAX_MOTES_AMOUNT = new BigNumber(10).pow(154).minus(1);
@@ -57,6 +60,37 @@ export function isValidPublicKey(pub: string): boolean {
 }
 
 /**
+ * Indicates whether the passed string is a safe hex string
+ *
+ * @param hex the hex value to validate
+ */
+export function isValidHex(hex: string): boolean {
+  return /^([0-9a-f])+$/i.test(hex);
+}
+
+/**
+ * validate ed25519 address
+ * @param {string} address hex string composed of a prefix and an ed25519 public key
+ * @returns {boolean} true if address is valid
+ */
+export function isValidEd25519Address(address: string): boolean {
+  return isValidHex(address) &&
+    address.startsWith(ED25519_PREFIX) &&
+    Crypto.isValidEd25519PublicKey(address.slice(ED25519_PREFIX.length));
+}
+
+/**
+ * validate secp256k1 address
+ * @param {string} address hex string composed of a prefix and an secp256k1 public key
+ * @returns {boolean} true if address is valid
+ */
+export function isValidSecp256k1Address(address: string): boolean {
+  return isValidHex(address) &&
+    address.startsWith(SECP256K1_PREFIX) &&
+    Crypto.isValidPub(address.slice(SECP256K1_PREFIX.length));
+}
+
+/**
  * validate address.
  *
  * @param {string} address composed of a prefix and a Secp256k1 or Ed25519 public key
@@ -67,21 +101,73 @@ export function isValidAddress(address: string): boolean {
 }
 
 /**
- * validate ed25519 address
- * @param {string} address hex string composed of a prefix and an ed25519 public key
- * @returns {boolean} true if address is valid
+ * Process address into address and transfer id
+ *
+ * @param {String} address the address to process
+ * @returns {Object} object containing address and transfer id
  */
-export function isValidEd25519Address(address: string): boolean {
-  return address.startsWith(ED25519_PREFIX) && Crypto.isValidEd25519PublicKey(address.slice(ED25519_PREFIX.length));
+export function getAddressDetails(address: string): AddressDetails {
+  const addressDetails = url.parse(address);
+  const queryDetails = addressDetails.query ? querystring.parse(addressDetails.query) : {};
+  const baseAddress = <string>addressDetails.pathname;
+  if (!isValidAddress(baseAddress)) {
+    throw new UtilsError(`invalid address: ${address}`);
+  }
+  // address doesn't have a transfer id
+  if (baseAddress === address) {
+    return {
+      address: address,
+      transferId: undefined,
+    };
+  }
+
+  if (_.isUndefined(queryDetails.transferId)) {
+    // if there are more properties, the query details need to contain the transfer id property
+    throw new UtilsError(`invalid address with transfer id: ${address}`);
+  }
+  const transferId = <string>queryDetails.transferId;
+  if (isNaN(parseInt(transferId))) {
+    throw new UtilsError(`invalid transfer id: ${transferId}`);
+  }
+
+  return {
+    address: baseAddress,
+    transferId,
+  };
 }
 
 /**
- * validate secp256k1 address
- * @param {string} address hex string composed of a prefix and an secp256k1 public key
- * @returns {boolean} true if address is valid
+ * Validate and return address with appended transfer id
+ *
+ * @param {AddressDetails} addressDetails
+ * @returns {String} address with transfer id
  */
-export function isValidSecp256k1Address(address: string): boolean {
-  return address.startsWith(SECP256K1_PREFIX) && Crypto.isValidPub(address.slice(SECP256K1_PREFIX.length));
+export function normalizeAddress({ address, transferId }: AddressDetails): string {
+  if (!isValidAddress(address)) {
+    throw new UtilsError(`invalid address: ${address}`);
+  }
+  if (!_.isUndefined(transferId)) {
+    if (isNaN(parseInt(transferId))) {
+      throw new Error(`invalid transfer id: ${transferId}`);
+    }
+    return `${address}?transferId=${transferId}`;
+  }
+  return address;
+}
+
+/**
+ * Return boolean indicating whether input is a valid address with transfer id
+ *
+ * @param {String} address address in the form <address>?transferId=<transferId>
+ * @returns {Boolean} true is input is a valid address
+ */
+export function isValidAddressWithPaymentId(address: string): boolean {
+  try {
+    const addressDetails = getAddressDetails(address);
+    return address === normalizeAddress(addressDetails);
+  } catch (e) {
+    return false;
+  }
 }
 
 /**
@@ -323,7 +409,7 @@ function isValidSignature(signature: string, data: Uint8Array | string, publicKe
  * @param {string} publicKey Public Key as hex string used to verify the signature.
  */
 export function verifySignature(signature: string, data: Uint8Array | string, publicKey: string) {
-  if (!this.isValidPublicKey(publicKey)) {
+  if (!isValidPublicKey(publicKey)) {
     throw new SigningError(`invalid pub: ${publicKey}`);
   }
   if (

--- a/modules/account-lib/test/unit/coin/cspr/util.ts
+++ b/modules/account-lib/test/unit/coin/cspr/util.ts
@@ -109,5 +109,30 @@ describe('CSPR util library', function() {
         Utils.verifySignature(Buffer.from(signature).toString('hex'), messageToSign, keyPair.getKeys().pub),
       );
     });
+
+    it('should fail to validate invalid address with payment id', function() {
+      const invalidAddresses = [
+        '0203DC13CBBF29765C7745578D9E091280522F37684EF0E400B86B1C409BC454F1F3?transferId=x',
+        '0203DC13CBBF29765C7745578D9E091280522F37684EF0E400B86B1C409BC454F1F3?memoId=1',
+        'X0203DC13CBBF29765C7745578D9E091280522F37684EF0E400B86B1C409BC454F1F3?transferId=1',
+      ];
+
+      for (const address of invalidAddresses) {
+        should.doesNotThrow(() => Utils.isValidAddress(address));
+        Utils.isValidAddressWithPaymentId(address).should.be.false();
+      }
+    });
+
+    it('should validate address with payment id', function () {
+      const validAddresses = [
+        '0203DC13CBBF29765C7745578D9E091280522F37684EF0E400B86B1C409BC454F1F3?transferId=0',
+        '020385D724A9A3E7E32BADF40F3279AF5A190CB2CFCAB6639BF532A0069E0E3824D0?transferId=1',
+        '01513fa90c1a74c34a8958dd86055e9736edb1ead918bd4d4d750ca851946be7aa?transferId=999999999', // ed25519
+      ];
+
+      for (const address of validAddresses) {
+        Utils.isValidAddressWithPaymentId(address).should.be.true();
+      }
+    });
   });
 });

--- a/modules/core/src/errors.ts
+++ b/modules/core/src/errors.ts
@@ -119,6 +119,13 @@ export class InvalidMemoIdError extends InvalidAddressError {
   }
 }
 
+export class InvalidPaymentIdError extends InvalidAddressError {
+  public constructor(message?: string) {
+    super(message || 'invalid payment id');
+    Object.setPrototypeOf(this, InvalidPaymentIdError.prototype);
+  }
+}
+
 export class KeyRecoveryServiceError extends BitGoJsError {
   public constructor(message?: string) {
     super(message || 'key recovery service encountered an error');

--- a/modules/core/src/v2/coins/cspr.ts
+++ b/modules/core/src/v2/coins/cspr.ts
@@ -10,19 +10,19 @@ import {
   BaseCoin,
   KeyPair,
   SignedTransaction,
-  VerifyAddressOptions,
   VerifyTransactionOptions,
   SignTransactionOptions as BaseSignTransactionOptions,
   TransactionPrebuild as BaseTransactionPrebuild,
   TransactionExplanation,
   ParseTransactionOptions,
   ParsedTransaction,
+  VerifyAddressOptions as BaseVerifyAddressOptions,
 } from '../baseCoin';
 
 import { NodeCallback } from '../types';
 import { BitGo } from '../../bitgo';
 import { BaseCoin as StaticsBaseCoin, CoinFamily } from '@bitgo/statics';
-import { InvalidTransactionError } from '../../errors';
+import { InvalidAddressError, InvalidTransactionError, UnexpectedAddressError } from '../../errors';
 
 const co = Bluebird.coroutine;
 
@@ -65,6 +65,10 @@ interface TransactionOperation {
   validator: string;
 }
 
+interface VerifyAddressOptions extends BaseVerifyAddressOptions {
+  rootAddress: string;
+}
+
 export class Cspr extends BaseCoin {
   protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
 
@@ -99,8 +103,26 @@ export class Cspr extends BaseCoin {
     // TODO: Implement when available on the SDK.
     return Bluebird.resolve(true).asCallback(callback);
   }
+
+  /**
+   * Check if address is valid, then make sure it matches the root address.
+   *
+   * @param {VerifyAddressOptions} params address and rootAddress to verify
+   */
   verifyAddress(params: VerifyAddressOptions): boolean {
-    return accountLib.Cspr.Utils.isValidAddress(params.address);
+    const { address, rootAddress } = params;
+    if (!this.isValidAddress(address)) {
+      throw new InvalidAddressError(`invalid address: ${address}`);
+    }
+
+    const addressDetails = accountLib.Cspr.Utils.getAddressDetails(address);
+    const rootAddressDetails = accountLib.Cspr.Utils.getAddressDetails(rootAddress);
+    if (addressDetails.address !== rootAddressDetails.address) {
+      throw new UnexpectedAddressError(
+        `address validation failure: ${addressDetails.address} vs ${rootAddressDetails.address}`
+      );
+    }
+    return true;
   }
 
   /**
@@ -151,10 +173,17 @@ export class Cspr extends BaseCoin {
     }
   }
 
+  /**
+   * Return boolean indicating whether input is valid CSPR address
+   *
+   * @param address the pub to be checked
+   * @returns true if the address is valid
+   */
   isValidAddress(address: string): boolean {
     try {
-      return accountLib.Cspr.Utils.isValidAddress(address);
-    } catch (error) {
+      const addressDetails = accountLib.Cspr.Utils.getAddressDetails(address);
+      return address === accountLib.Cspr.Utils.normalizeAddress(addressDetails);
+    } catch (e) {
       return false;
     }
   }

--- a/modules/core/test/v2/unit/coins/cspr.ts
+++ b/modules/core/test/v2/unit/coins/cspr.ts
@@ -4,6 +4,7 @@ import { Cspr, Tcspr } from '../../../../src/v2/coins';
 import { ExplainTransactionOptions, TransactionFee } from '../../../../src/v2/coins/cspr';
 import { Transaction } from '@bitgo/account-lib/dist/src/coin/cspr/transaction';
 import { randomBytes } from 'crypto';
+import * as should from "should";
 
 describe('Casper', function () {
   const coinName = 'tcspr';
@@ -553,6 +554,70 @@ describe('Casper', function () {
         },
       };
       await basecoin.explainTransaction(explainTxParams).should.be.rejectedWith('missing explain tx parameters');
+    });
+  });
+
+  describe('Validation', function() {
+    it('should fail to validate invalid address with payment id', function() {
+      const invalidAddresses = [
+        '0203DC13CBBF29765C7745578D9E091280522F37684EF0E400B86B1C409BC454F1F3?transferId=x',
+        '0203DC13CBBF29765C7745578D9E091280522F37684EF0E400B86B1C409BC454F1F3?memoId=1',
+        'X0203DC13CBBF29765C7745578D9E091280522F37684EF0E400B86B1C409BC454F1F3?transferId=1',
+      ];
+
+      for (const address of invalidAddresses) {
+        should.doesNotThrow(() => basecoin.isValidAddress(address));
+        basecoin.isValidAddress(address).should.be.false();
+      }
+    });
+
+    it('should validate address with payment id', function () {
+      const validAddresses = [
+        '0203DC13CBBF29765C7745578D9E091280522F37684EF0E400B86B1C409BC454F1F3?transferId=0',
+        '020385D724A9A3E7E32BADF40F3279AF5A190CB2CFCAB6639BF532A0069E0E3824D0?transferId=1',
+        '01513fa90c1a74c34a8958dd86055e9736edb1ead918bd4d4d750ca851946be7aa?transferId=999999999', // ed25519
+      ];
+
+      for (const address of validAddresses) {
+        basecoin.isValidAddress(address).should.be.true();
+      }
+    });
+
+    it('should fail to verify invalid address with payment id', function() {
+      const invalidAddresses = [
+        '0203DC13CBBF29765C7745578D9E091280522F37684EF0E400B86B1C409BC454F1F3?transferId=x',
+        '0203DC13CBBF29765C7745578D9E091280522F37684EF0E400B86B1C409BC454F1F3?memoId=1',
+        'X0203DC13CBBF29765C7745578D9E091280522F37684EF0E400B86B1C409BC454F1F3?transferId=1',
+      ];
+
+      for (const address of invalidAddresses) {
+        should.throws(() => basecoin.verifyAddress(address));
+      }
+    });
+
+    it('should verify address with payment id', function () {
+      const validAddresses = [
+        {
+          address: '0203DC13CBBF29765C7745578D9E091280522F37684EF0E400B86B1C409BC454F1F3',
+          rootAddress: '0203DC13CBBF29765C7745578D9E091280522F37684EF0E400B86B1C409BC454F1F3',
+        },
+        {
+          address: '0203DC13CBBF29765C7745578D9E091280522F37684EF0E400B86B1C409BC454F1F3?transferId=0',
+          rootAddress: '0203DC13CBBF29765C7745578D9E091280522F37684EF0E400B86B1C409BC454F1F3',
+        },
+        {
+          address: '020385D724A9A3E7E32BADF40F3279AF5A190CB2CFCAB6639BF532A0069E0E3824D0?transferId=1',
+          rootAddress: '020385D724A9A3E7E32BADF40F3279AF5A190CB2CFCAB6639BF532A0069E0E3824D0',
+        },
+        {
+          address: '01513fa90c1a74c34a8958dd86055e9736edb1ead918bd4d4d750ca851946be7aa?transferId=999999999', // ed25519
+          rootAddress: '01513fa90c1a74c34a8958dd86055e9736edb1ead918bd4d4d750ca851946be7aa',
+        }
+      ];
+
+      for (const addressParams of validAddresses) {
+        basecoin.verifyAddress(addressParams).should.be.true();
+      }
     });
   });
 });


### PR DESCRIPTION
Change isValidAddress method for cspr in core to validate address with transferId
Add isValidAddressWithPaymentId method to account-lib to validate address with transferId

