### PR TITLE
fix(core): don't pick individual tx verification options

### DIFF
--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -1810,12 +1810,11 @@ export class Wallet {
       const txPrebuild = (yield txPrebuildQuery) as any;
 
       try {
-        const verificationParams = _.pick(params.verification || {}, ['disableNetworking', 'keychains', 'addresses']);
         yield self.baseCoin.verifyTransaction({
           txParams: params,
           txPrebuild,
           wallet: self,
-          verification: verificationParams,
+          verification: params.verification ?? {},
           reqId: params.reqId,
         });
       } catch (e) {


### PR DESCRIPTION
We're not getting much from whitelisting the tx verification options,
since it's too easy to add a new param and not add it to the whitelist.
Failing to do so silently drops the new parameter and doesn't produce
any warnings or errors about an unknown property.

Instead, let's just pass the whole object to `verifyTransaction` and let
it use any properties on the object that it knows how to handle.

Ticket: BG-30090