### PR TITLE
docs(developers.md): update the SDK & API doc link

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -6,7 +6,7 @@ $ yarn install
 ```
 
 # Documentation
-API and SDK documentation can be found at: https://platform.bitgo.com/.
+API and SDK documentation can be found at: https://app.bitgo.com/docs/.
 
 # Pull Requests
 


### PR DESCRIPTION
The platform [url](https://platform.bitgo.com/) is not reachable. From bitgo [homepage](https://www.bitgo.com/), the public Wallet SDK & API link points to this [url](https://app.bitgo.com/docs/). The updates for DEVELOPERS.md and the link in the About section in the repo homepage will be helpful for new developers.