### PR TITLE
fix(eth): restore fixed hop transaction verification

### DIFF
--- a/modules/core/src/v2/coins/eth.ts
+++ b/modules/core/src/v2/coins/eth.ts
@@ -1548,8 +1548,31 @@ export class Eth extends BaseCoin {
         throw new Error(`txPrebuild should only have 1 recipient but ${txPrebuild.recipients.length} found`);
       }
       if (txPrebuild.hopTransaction) {
-        // Temporarily do not verify hop transactions
-        return true;
+        // Check recipient amount for hop transaction
+        if (txParams.recipients.length !== 1) {
+          throw new Error(`hop transaction only supports 1 recipient but ${txParams.recipients.length} found`);
+        }
+
+        // Check tx sends to hop address
+        const decodedHopTx = new optionalDeps.EthTx(txPrebuild.hopTransaction.tx);
+        const expectedHopAddress = decodedHopTx.getSenderAddress().toString('hex');
+        if (
+          expectedHopAddress.toLowerCase() !==
+          optionalDeps.ethUtil.stripHexPrefix(txPrebuild.recipients[0].address.toLowerCase())
+        ) {
+          throw new Error('recipient address of txPrebuild does not match hop address');
+        }
+
+        // Convert TransactionRecipient array to Recipient array
+        const recipients: Recipient[] = txParams.recipients.map((r) => {
+          return {
+            address: r.address,
+            amount: typeof r.amount === 'number' ? r.amount.toString() : r.amount,
+          };
+        });
+
+        // Check destination address and amount
+        yield self.validateHopPrebuild(wallet, txPrebuild.hopTransaction, { recipients });
       } else if (txPrebuild.isBatch) {
         // Check total amount for batch transaction
         let expectedTotalAmount = new BigNumber(0);

--- a/modules/core/test/v2/unit/coins/eth.ts
+++ b/modules/core/test/v2/unit/coins/eth.ts
@@ -104,7 +104,7 @@ describe('ETH:', function () {
       };
 
       const txPrebuild = {
-        recipients: [{ amount: '1000000000000000', address: hopContractAddress }],
+        recipients: [{ amount: '5000000000000000', address: hopContractAddress }],
         nextContractSequenceId: 0,
         gasPrice: 20000000000,
         gasLimit: 500000,
@@ -167,7 +167,7 @@ describe('ETH:', function () {
       };
 
       const txPrebuild = {
-        recipients: [{ amount: '1000000000000', address: address1 }],
+        recipients: [{ amount: '5000000000000', address: address1 }],
         nextContractSequenceId: 0,
         gasPrice: 20000000000,
         gasLimit: 500000,
@@ -223,8 +223,7 @@ describe('ETH:', function () {
         .should.be.rejectedWith('txPrebuild should only have 1 recipient but 2 found');
     });
 
-    // CR-338: temporarily disable eth hop tx verification
-    xit('should reject a hop prebuild from the bitgo server that was not intended have exactly 1 recipient', async function () {
+    it('should reject a hop txPrebuild from the bitgo server that was not intended have exactly 1 recipient', async function () {
       const coin = bitgo.coin('teth');
       const wallet = new Wallet(bitgo, coin, {});
 
@@ -235,7 +234,7 @@ describe('ETH:', function () {
       };
 
       const txPrebuild = {
-        recipients: [{ amount: '1000000000000000', address: hopContractAddress }],
+        recipients: [{ amount: '5000000000000000', address: hopContractAddress }],
         nextContractSequenceId: 0,
         gasPrice: 20000000000,
         gasLimit: 500000,
@@ -264,8 +263,7 @@ describe('ETH:', function () {
         .should.be.rejectedWith('hop transaction only supports 1 recipient but 2 found');
     });
 
-    // CR-338: temporarily disable eth hop tx verification
-    xit('should reject a hop txPrebuild from the bitgo server with the wrong amount', async function () {
+    it('should reject a hop txPrebuild that does not send to its hop address', async function () {
       const coin = bitgo.coin('teth');
       const wallet = new Wallet(bitgo, coin, {});
 
@@ -276,48 +274,7 @@ describe('ETH:', function () {
       };
 
       const txPrebuild = {
-        recipients: [{ amount: '5000000000000000', address: hopContractAddress }],
-        nextContractSequenceId: 0,
-        gasPrice: 20000000000,
-        gasLimit: 500000,
-        isBatch: false,
-        coin: 'teth',
-        walletId: 'fakeWalletId',
-        walletContractAddress: 'fakeWalletContractAddress',
-        hopTransaction: {
-          tx: hopTx,
-          id: hopTxid,
-          signature: hopTxBitgoSignature,
-          paymentId: '0',
-          gasPrice: 20000000000,
-          gasLimit: 500000,
-          amount: '1000000000000000',
-          recipient: hopDestinationAddress,
-          nonce: 0,
-          userReqSig: userReqSig,
-          gasPriceMax: 500000000000,
-        },
-      };
-
-      const verification = {};
-
-      await coin.verifyTransaction({ txParams, txPrebuild, wallet, verification })
-        .should.be.rejectedWith('hop transaction amount in txPrebuild received from BitGo servers does not match txParams supplied by client');
-    });
-
-    // CR-338: temporarily disable eth hop tx verification
-    xit('should reject a hop txPrebuild that does not send to its hop address', async function () {
-      const coin = bitgo.coin('teth');
-      const wallet = new Wallet(bitgo, coin, {});
-
-      const txParams = {
-        recipients: [{ amount: '1000000000000000', address: hopDestinationAddress }],
-        wallet: wallet,
-        walletPassphrase: 'fakeWalletPassphrase',
-      };
-
-      const txPrebuild = {
-        recipients: [{ amount: '1000000000000000', address: address1 }],
+        recipients: [{ amount: '5000000000000000', address: address1 }],
         nextContractSequenceId: 0,
         gasPrice: 20000000000,
         gasLimit: 500000,
@@ -400,7 +357,7 @@ describe('ETH:', function () {
         .should.be.rejectedWith('recipient address of txPrebuild does not match batcher address');
     });
 
-    it('should reject a normal prebuild from the bitgo server that was not intended have exactly 1 recipient', async function () {
+    it('should reject a normal txPrebuild from the bitgo server that was not intended have exactly 1 recipient', async function () {
       const coin = bitgo.coin('teth');
       const wallet = new Wallet(bitgo, coin, {});
 


### PR DESCRIPTION
### Background

A bug in the new Eth verification logic for hop transactions caused valid Eth hop transactions to be rejected. As a result, the verification logic was temporarily disabled for hop transactions.

The bug was caused by the verification logic requiring the `txPrebuild` from the sender to the hop address to have an amount exactly equal to the amount the client wanted to send to the final recipient. This was incorrect as the sender actually needs to send an extra amount to the hop address for the hop address to pay the gas fees and still get the desired amount to the final recipient.

### Fix

This PR adds the non-buggy hop transaction verification logic back to the BitGoJS client. 

It omits the buggy check for the amount sent to the hop address as adding such a check in a robust way does not seem feasible. The client has no trust-less way for verifying what a reasonable additional amount for hop transaction gas fees are (the gas price estimate is currently given to the client by BitGo servers). The best alternative at the moment is hard-coding a maximum additional gas fee that is acceptable. However, this may result in transactions getting rejected if gas prices inflate too much and can still allow a malicious attacker of BitGo servers to inflate gas fees which is still quite bad. 

Moreover, if an attacker compromises BitGo servers, inflating amounts sent to hop addresses is unlikely to be the most appealing attack vector as an attacker does not benefit from extra funds in a hop address unless they also compromise the hop address by compromising the HSM.

Verification of hop transactions also was not specifically requested by Block.one who originally asked for Eth verification logic to be added client-side.

### Testing

In addition to unit test coverage, manual tests using `sendMany` from the SDK was used to verify that correct normal, hop, batch, and token Eth transactions are verified and signed as expected.

Each mock hop `txPreBuild` in the unit tests were also updated to have an amount greater than what is specified by the client sent to the hop address to more accurately reflect the values of a real transaction. The extra amount is to ensure the hop address can pay the gas fees and have enough to send the amount specified by the client to the final recipient.

There is a unit test case that ensures sending amounts above what is specified by the client to the hop address is correctly accepted, verified, and signed.

### Ticket: BG-33834