### PR TITLE
chore!(core): remove bluebird from bitgo object http methods

### DIFF
--- a/modules/core/src/api.ts
+++ b/modules/core/src/api.ts
@@ -1,0 +1,127 @@
+/**
+ * @prettier
+ */
+import * as superagent from 'superagent';
+import * as urlLib from 'url';
+import * as querystring from 'querystring';
+import Debug from 'debug';
+
+import { ApiResponseError } from './errors';
+import { BitGo, VerifyResponseOptions } from './bitgo';
+
+const debug = Debug('bitgo:api');
+
+/**
+ * Serialize request data based on the request content type
+ * Note: Not sure this is still needed or even useful. Consider removing.
+ * @param req
+ */
+export function serializeRequestData(req: superagent.Request): string | undefined {
+  let data: string | Record<string, unknown> = (req as any)._data;
+  if (typeof data !== 'string') {
+    let contentType = req.get('Content-Type');
+    // Parse out just the content type from the header (ignore the charset)
+    if (contentType) {
+      contentType = contentType.split(';')[0];
+    }
+    let serialize = superagent.serialize[contentType];
+    if (!serialize && /[\/+]json\b/.test(contentType)) {
+      serialize = superagent.serialize['application/json'];
+    }
+    if (serialize) {
+      data = serialize(data);
+      (req as any)._data = data;
+      return data;
+    }
+  }
+}
+
+/**
+ * Set the superagent query string correctly for browsers or node.
+ * @param req
+ */
+export function setRequestQueryString(req: superagent.SuperAgentRequest): void {
+  const urlDetails = urlLib.parse(req.url);
+
+  let queryString: string | undefined;
+  const query: string[] = (req as any)._query;
+  const qs: { [key: string]: string } = (req as any).qs;
+  if (query && query.length > 0) {
+    // browser version
+    queryString = query.join('&');
+    (req as any)._query = [];
+  } else if (qs) {
+    // node version
+    queryString = querystring.stringify(qs);
+    (req as any).qs = null;
+  }
+
+  if (queryString) {
+    if (urlDetails.search) {
+      urlDetails.search += '&' + queryString;
+    } else {
+      urlDetails.search = '?' + queryString;
+    }
+    req.url = urlLib.format(urlDetails);
+  }
+}
+
+/**
+ * Verify that the response received from the server is signed correctly.
+ * Right now, it is very permissive with the timestamp variance.
+ */
+export function verifyResponse(
+  bitgo: BitGo,
+  token: string | undefined,
+  method: VerifyResponseOptions['method'],
+  req: superagent.SuperAgentRequest,
+  response: superagent.Response
+): superagent.Response {
+  // we can't verify the response if we're not authenticated
+  if (!req.isV2Authenticated || !req.authenticationToken) {
+    return response;
+  }
+
+  const verificationResponse = bitgo.verifyResponse({
+    url: req.url,
+    hmac: response.header.hmac,
+    statusCode: response.status,
+    text: response.text,
+    timestamp: response.header.timestamp,
+    token: req.authenticationToken,
+    method,
+  });
+
+  if (!verificationResponse.isValid) {
+    // calculate the HMAC
+    const receivedHmac = response.header.hmac;
+    const expectedHmac = verificationResponse.expectedHmac;
+    const signatureSubject = verificationResponse.signatureSubject;
+    // Log only the first 10 characters of the token to ensure the full token isn't logged.
+    const partialBitgoToken = token ? token.substring(0, 10) : '';
+    const errorDetails = {
+      expectedHmac,
+      receivedHmac,
+      hmacInput: signatureSubject,
+      requestToken: req.authenticationToken,
+      bitgoToken: partialBitgoToken,
+    };
+    debug('Invalid response HMAC: %O', errorDetails);
+    throw new ApiResponseError('invalid response HMAC, possible man-in-the-middle-attack', 511, errorDetails);
+  }
+
+  if (bitgo.getAuthVersion() === 3 && !verificationResponse.isInResponseValidityWindow) {
+    const errorDetails = {
+      timestamp: response.header.timestamp,
+      verificationTime: verificationResponse.verificationTime,
+    };
+    debug('Server response outside response validity time window: %O', errorDetails);
+    const error: any = new Error(
+      'server response outside response validity time window, possible man-in-the-middle-attack'
+    );
+    error.result = errorDetails;
+    error.status = 511;
+    throw error;
+  }
+  return response;
+}

--- a/modules/core/src/blockchain.ts
+++ b/modules/core/src/blockchain.ts
@@ -12,8 +12,10 @@
 // Copyright 2014, BitGo, Inc.  All Rights Reserved.
 //
 
-import common = require('./common');
+import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
+
+import * as common from './common';
 
 //
 // Constructor
@@ -34,9 +36,9 @@ Blockchain.prototype.getAddress = function(params, callback) {
   params = params || {};
   common.validateParams(params, ['address'], [], callback);
 
-  return this.bitgo.get(this.bitgo.url('/address/' + params.address))
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.get(this.bitgo.url('/address/' + params.address)).result()
+  ).nodeify(callback);
 };
 
 //
@@ -50,9 +52,9 @@ Blockchain.prototype.getAddressTransactions = function(params, callback) {
   common.validateParams(params, ['address'], [], callback);
 
   // TODO: support start and limit params
-  return this.bitgo.get(this.bitgo.url('/address/' + params.address + '/tx'))
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.get(this.bitgo.url('/address/' + params.address + '/tx')).result()
+  ).nodeify(callback);
 };
 
 //
@@ -74,12 +76,11 @@ Blockchain.prototype.getAddressUnspents = function(params, callback) {
     url += '?limit=' + (params.limit * 1e8);
   }
 
-  return this.bitgo.get(url)
-  .result()
-  .then(function(body) {
+  return Bluebird.resolve(
+    this.bitgo.get(url).result()
+  ).then(function(body) {
     return body.unspents;
-  })
-  .nodeify(callback);
+  }).nodeify(callback);
 };
 
 //
@@ -93,9 +94,9 @@ Blockchain.prototype.getTransaction = function(params, callback) {
   params = params || {};
   common.validateParams(params, ['id'], [], callback);
 
-  return this.bitgo.get(this.bitgo.url('/tx/' + params.id))
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.get(this.bitgo.url('/tx/' + params.id)).result()
+  ).nodeify(callback);
 };
 
 //
@@ -112,9 +113,9 @@ Blockchain.prototype.getTransactionByInput = function(params, callback) {
   if (!_.isInteger(params.vout)) {
     throw new Error('invalid vout - number expected');
   }
-  return this.bitgo.get(this.bitgo.url('/tx/input/' + params.txid + '/' + params.vout))
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.get(this.bitgo.url('/tx/input/' + params.txid + '/' + params.vout)).result()
+  ).nodeify(callback);
 };
 
 //
@@ -128,9 +129,9 @@ Blockchain.prototype.getBlock = function(params, callback) {
   params = params || {};
   common.validateParams(params, ['id'], [], callback);
 
-  return this.bitgo.get(this.bitgo.url('/block/' + params.id))
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.get(this.bitgo.url('/block/' + params.id)).result()
+  ).nodeify(callback);
 };
 
 module.exports = Blockchain;

--- a/modules/core/src/errors.ts
+++ b/modules/core/src/errors.ts
@@ -174,3 +174,21 @@ export class InvalidTransactionError extends BitGoJsError {
     Object.setPrototypeOf(this, InvalidTransactionError.prototype);
   }
 }
+
+export class ApiResponseError<ResponseBodyType = any> extends BitGoJsError {
+  message: string;
+  status: number;
+  result?: ResponseBodyType;
+  invalidToken?: boolean;
+  needsOTP?: boolean;
+
+  public constructor(message: string, status: number, result?: ResponseBodyType, invalidToken?: boolean, needsOTP?: boolean) {
+    super(message);
+    this.message = message;
+    this.status = status;
+    this.result = result;
+    this.invalidToken = invalidToken;
+    this.needsOTP = needsOTP;
+    Object.setPrototypeOf(this, ApiResponseError.prototype);
+  }
+}

--- a/modules/core/src/keychains.ts
+++ b/modules/core/src/keychains.ts
@@ -166,17 +166,16 @@ Keychains.prototype.list = function(params, callback) {
   params = params || {};
   common.validateParams(params, [], [], callback);
 
-  return this.bitgo.get(this.bitgo.url('/keychain'))
-  .result('keychains')
-  .then(function(keychains) {
+  return Bluebird.resolve(
+    this.bitgo.get(this.bitgo.url('/keychain')).result('keychains')
+  ).then(function(keychains) {
     keychains.map(function(keychain) {
       if (keychain.xpub && keychain.ethAddress && Util.xpubToEthAddress && keychain.ethAddress !== Util.xpubToEthAddress(keychain.xpub)) {
         throw new Error('ethAddress and xpub do not match');
       }
     });
     return keychains;
-  })
-  .nodeify(callback);
+  }).nodeify(callback);
 };
 
 /**
@@ -221,22 +220,22 @@ Keychains.prototype.add = function(params, callback) {
   params = params || {};
   common.validateParams(params, ['xpub'], ['encryptedXprv', 'type', 'isLedger'], callback);
 
-  return this.bitgo.post(this.bitgo.url('/keychain'))
-  .send({
-    xpub: params.xpub,
-    encryptedXprv: params.encryptedXprv,
-    type: params.type,
-    originalPasscodeEncryptionCode: params.originalPasscodeEncryptionCode,
-    isLedger: params.isLedger
-  })
-  .result()
-  .then(function(keychain) {
+  return Bluebird.resolve(
+    this.bitgo.post(this.bitgo.url('/keychain'))
+      .send({
+        xpub: params.xpub,
+        encryptedXprv: params.encryptedXprv,
+        type: params.type,
+        originalPasscodeEncryptionCode: params.originalPasscodeEncryptionCode,
+        isLedger: params.isLedger,
+      })
+      .result()
+  ).then(function(keychain) {
     if (keychain.xpub && keychain.ethAddress && Util.xpubToEthAddress && keychain.ethAddress !== Util.xpubToEthAddress(keychain.xpub)) {
       throw new Error('ethAddress and xpub do not match');
     }
     return keychain;
-  })
-  .nodeify(callback);
+  }).nodeify(callback);
 };
 
 //
@@ -247,16 +246,14 @@ Keychains.prototype.createBitGo = function(params, callback) {
   params = params || {};
   common.validateParams(params, [], [], callback);
 
-  return this.bitgo.post(this.bitgo.url('/keychain/bitgo'))
-  .send(params)
-  .result()
-  .then(function(keychain) {
+  return Bluebird.resolve(
+    this.bitgo.post(this.bitgo.url('/keychain/bitgo')).send(params).result()
+  ).then(function(keychain) {
     if (keychain.xpub && keychain.ethAddress && Util.xpubToEthAddress && keychain.ethAddress !== Util.xpubToEthAddress(keychain.xpub)) {
       throw new Error('ethAddress and xpub do not match');
     }
     return keychain;
-  })
-  .nodeify(callback);
+  }).nodeify(callback);
 };
 
 //
@@ -267,17 +264,15 @@ Keychains.prototype.createBackup = function(params, callback) {
   params = params || {};
   common.validateParams(params, ['provider'], [], callback);
 
-  return this.bitgo.post(this.bitgo.url('/keychain/backup'))
-  .send(params)
-  .result()
-  .then(function(keychain) {
+  return Bluebird.resolve(
+    this.bitgo.post(this.bitgo.url('/keychain/backup')).send(params).result()
+  ).then(function(keychain) {
     // not all keychains have an xpub
     if (keychain.xpub && keychain.ethAddress && Util.xpubToEthAddress && keychain.ethAddress !== Util.xpubToEthAddress(keychain.xpub)) {
       throw new Error('ethAddress and xpub do not match');
     }
     return keychain;
-  })
-  .nodeify(callback);
+  }).nodeify(callback);
 };
 
 //
@@ -295,16 +290,14 @@ Keychains.prototype.get = function(params, callback) {
   }
 
   const id = params.xpub || params.ethAddress;
-  return this.bitgo.post(this.bitgo.url('/keychain/' + encodeURIComponent(id)))
-  .send({})
-  .result()
-  .then(function(keychain) {
+  return Bluebird.resolve(
+    this.bitgo.post(this.bitgo.url('/keychain/' + encodeURIComponent(id))).send({}).result()
+  ).then(function(keychain) {
     if (keychain.xpub && keychain.ethAddress && Util.xpubToEthAddress && keychain.ethAddress !== Util.xpubToEthAddress(keychain.xpub)) {
       throw new Error('ethAddress and xpub do not match');
     }
     return keychain;
-  })
-  .nodeify(callback);
+  }).nodeify(callback);
 };
 
 //
@@ -317,19 +310,18 @@ Keychains.prototype.update = function(params, callback) {
   params = params || {};
   common.validateParams(params, ['xpub'], ['encryptedXprv'], callback);
 
-  return this.bitgo.put(this.bitgo.url('/keychain/' + params.xpub))
-  .send({
-    encryptedXprv: params.encryptedXprv
-  })
-  .result()
-  .then(function(keychain) {
+  return Bluebird.resolve(
+    this.bitgo.put(this.bitgo.url('/keychain/' + params.xpub))
+      .send({
+        encryptedXprv: params.encryptedXprv,
+      })
+      .result()
+  ).then(function(keychain) {
     if (keychain.xpub && keychain.ethAddress && Util.xpubToEthAddress && keychain.ethAddress !== Util.xpubToEthAddress(keychain.xpub)) {
       throw new Error('ethAddress and xpub do not match');
     }
     return keychain;
-  })
-  .nodeify(callback);
+  }).nodeify(callback);
 };
-
 
 module.exports = Keychains;

--- a/modules/core/src/markets.ts
+++ b/modules/core/src/markets.ts
@@ -11,8 +11,9 @@
 // Copyright 2015, BitGo, Inc.  All Rights Reserved.
 //
 
+import * as Bluebird from 'bluebird';
 
-import common = require('./common');
+import * as common from './common';
 
 //
 // Constructor
@@ -32,9 +33,9 @@ Markets.prototype.latest = function(params, callback) {
   params = params || {};
   common.validateParams(params, [], [], callback);
 
-  return this.bitgo.get(this.bitgo.url('/market/latest'))
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.get(this.bitgo.url('/market/latest')).result()
+  ).nodeify(callback);
 };
 
 /**
@@ -48,9 +49,9 @@ Markets.prototype.yesterday = function(params, callback) {
   params = params || {};
   common.validateParams(params, [], [], callback);
 
-  return this.bitgo.get(this.bitgo.url('/market/yesterday'))
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.get(this.bitgo.url('/market/yesterday')).result()
+  ).nodeify(callback);
 };
 
 /**
@@ -69,9 +70,9 @@ Markets.prototype.lastDays = function(params, callback) {
     throw new Error('must use a non-negative number of days');
   }
 
-  return this.bitgo.get(this.bitgo.url('/market/last/' + days + '/' + params.currencyName))
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.get(this.bitgo.url('/market/last/' + days + '/' + params.currencyName)).result()
+  ).nodeify(callback);
 };
 
 module.exports = Markets;

--- a/modules/core/src/pendingapproval.ts
+++ b/modules/core/src/pendingapproval.ts
@@ -131,13 +131,12 @@ PendingApproval.prototype.get = function(params, callback) {
   common.validateParams(params, [], [], callback);
 
   const self = this;
-  return this.bitgo.get(this.url())
-  .result()
-  .then(function(res) {
+  return Bluebird.resolve(
+    this.bitgo.get(this.url()).result()
+  ).then(function(res) {
     self.pendingApproval = res;
     return self;
-  })
-  .nodeify(callback);
+  }).nodeify(callback);
 };
 
 //
@@ -147,12 +146,12 @@ PendingApproval.prototype.populateWallet = function() {
   const self = this;
   if (!self.wallet) {
     return self.bitgo.wallets().get({ id: self.info().transactionRequest.sourceWallet })
-    .then(function(wallet) {
-      if (!wallet) {
-        throw new Error('unexpected - unable to get wallet using sourcewallet');
-      }
-      self.wallet = wallet;
-    });
+      .then(function(wallet) {
+        if (!wallet) {
+          throw new Error('unexpected - unable to get wallet using sourcewallet');
+        }
+        self.wallet = wallet;
+      });
   }
 
   if (self.wallet.id() !== self.info().transactionRequest.sourceWallet) {
@@ -313,10 +312,9 @@ PendingApproval.prototype.approve = function(params, callback) {
     if (transaction) {
       approvalParams.tx = transaction.tx;
     }
-    return self.bitgo.put(self.url())
-    .send(approvalParams)
-    .result()
-    .nodeify(callback);
+    return Bluebird.resolve(
+      self.bitgo.put(self.url()).send(approvalParams).result()
+    ).nodeify(callback);
   })
   .catch(function(error) {
     if (!canRecreateTransaction &&
@@ -346,10 +344,9 @@ PendingApproval.prototype.reject = function(params, callback) {
   params = params || {};
   common.validateParams(params, [], [], callback);
 
-  return this.bitgo.put(this.url())
-  .send({ state: 'rejected' })
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.put(this.url()).send({ state: 'rejected' }).result()
+  ).nodeify(callback);
 };
 
 //

--- a/modules/core/src/pendingapprovals.ts
+++ b/modules/core/src/pendingapprovals.ts
@@ -11,9 +11,11 @@
 // Copyright 2015, BitGo, Inc.  All Rights Reserved.
 //
 
-import common = require('./common');
-const PendingApproval = require('./pendingapproval');
+import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
+
+import * as common from './common';
+const PendingApproval = require('./pendingapproval');
 
 //
 // Constructor
@@ -43,14 +45,12 @@ PendingApprovals.prototype.list = function(params, callback) {
   }
 
   const self = this;
-  return this.bitgo.get(this.bitgo.url('/pendingapprovals'))
-  .query(queryParams)
-  .result()
-  .then(function(body) {
+  return Bluebird.resolve(
+    this.bitgo.get(this.bitgo.url('/pendingapprovals')).query(queryParams).result()
+  ).then(function(body) {
     body.pendingApprovals = body.pendingApprovals.map(function(p) { return new PendingApproval(self.bitgo, p); });
     return body;
-  })
-  .nodeify(callback);
+  }).nodeify(callback);
 };
 
 //
@@ -64,12 +64,11 @@ PendingApprovals.prototype.get = function(params, callback) {
   common.validateParams(params, ['id'], [], callback);
 
   const self = this;
-  return this.bitgo.get(this.bitgo.url('/pendingapprovals/' + params.id))
-  .result()
-  .then(function(body) {
+  return Bluebird.resolve(
+    this.bitgo.get(this.bitgo.url('/pendingapprovals/' + params.id)).result()
+  ).then(function(body) {
     return new PendingApproval(self.bitgo, body);
-  })
-  .nodeify(callback);
+  }).nodeify(callback);
 };
 
 export = PendingApprovals;

--- a/modules/core/src/travelRule.ts
+++ b/modules/core/src/travelRule.ts
@@ -12,8 +12,10 @@
 //
 
 import * as bitcoin from '@bitgo/utxo-lib';
-import * as common from './common';
+import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
+
+import * as common from './common';
 import { getNetwork, makeRandomKey, hdPath } from './bitcoin';
 
 interface DecryptReceivedTravelRuleOptions {
@@ -65,9 +67,9 @@ TravelRule.prototype.getRecipients = function(params, callback) {
   common.validateParams(params, ['txid'], [], callback);
 
   const url = this.url(params.txid + '/recipients');
-  return this.bitgo.get(url)
-  .result('recipients')
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.get(url).result('recipients')
+  ).nodeify(callback);
 };
 
 TravelRule.prototype.validateTravelInfo = function(info) {
@@ -228,10 +230,9 @@ TravelRule.prototype.send = function(params, callback) {
     throw new Error('invalid outputIndex');
   }
 
-  return this.bitgo.post(this.url(params.txid + '/' + params.outputIndex))
-  .send(params)
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.post(this.url(params.txid + '/' + params.outputIndex)).send(params).result()
+  ).nodeify(callback);
 };
 
 /**

--- a/modules/core/src/v2/coins/xrp.ts
+++ b/modules/core/src/v2/coins/xrp.ts
@@ -216,10 +216,10 @@ export class Xrp extends BaseCoin {
   /**
    * Get fee info from server
    */
-  public getFeeInfo(_?, callback?): Promise<FeeInfo> {
-    return this.bitgo.get(this.url('/public/feeinfo'))
-      .result()
-      .nodeify(callback);
+  public getFeeInfo(_?, callback?): Bluebird<FeeInfo> {
+    return Bluebird.resolve(
+      this.bitgo.get(this.url('/public/feeinfo')).result()
+    ).nodeify(callback);
   }
 
   /**

--- a/modules/core/src/v2/enterprise.ts
+++ b/modules/core/src/v2/enterprise.ts
@@ -75,16 +75,16 @@ export class Enterprise {
    * @param callback
    */
   users(params: Record<string, never> = {}, callback?: NodeCallback<any>): Bluebird<any> {
-    return this.bitgo.get(this.url('/user')).result().asCallback(callback);
+    return Bluebird.resolve(this.bitgo.get(this.url('/user')).result()).asCallback(callback);
   }
 
   /**
    * Get the fee address balance for this Enterprise
-   * @param params
+   * @param _params
    * @param callback
    */
   getFeeAddressBalance(params: Record<string, never> = {}, callback?: NodeCallback<any>): Bluebird<any> {
-    return this.bitgo.get(this.coinUrl('/feeAddressBalance')).result().asCallback(callback);
+    return Bluebird.resolve(this.bitgo.get(this.coinUrl('/feeAddressBalance')).result()).asCallback(callback);
   }
 
   /**
@@ -93,7 +93,7 @@ export class Enterprise {
    * @param callback
    */
   addUser(params: any = {}, callback?: NodeCallback<any>): Bluebird<any> {
-    return this.bitgo.post(this.url('/user')).send(params).result().asCallback(callback);
+    return Bluebird.resolve(this.bitgo.post(this.url('/user')).send(params).result()).asCallback(callback);
   }
 
   /**
@@ -102,7 +102,7 @@ export class Enterprise {
    * @param callback
    */
   removeUser(params: any = {}, callback?: NodeCallback<any>): Bluebird<any> {
-    return this.bitgo.del(this.url('/user')).send(params).result().asCallback(callback);
+    return Bluebird.resolve(this.bitgo.del(this.url('/user')).send(params).result()).asCallback(callback);
   }
 
   /**

--- a/modules/core/src/v2/keychains.ts
+++ b/modules/core/src/v2/keychains.ts
@@ -122,9 +122,9 @@ export class Keychains {
     if (params.reqId) {
       this.bitgo.setRequestTracer(params.reqId);
     }
-    return this.bitgo.get(this.baseCoin.url('/key/' + encodeURIComponent(id)))
-        .result()
-        .nodeify(callback);
+    return Bluebird.resolve(
+      this.bitgo.get(this.baseCoin.url('/key/' + encodeURIComponent(id))).result()
+    ).nodeify(callback);
   }
 
   /**
@@ -274,21 +274,22 @@ export class Keychains {
     if (params.reqId) {
       this.bitgo.setRequestTracer(params.reqId);
     }
-    return this.bitgo.post(this.baseCoin.url('/key'))
-      .send({
-        pub: params.pub,
-        encryptedPrv: params.encryptedPrv,
-        type: params.type,
-        source: params.source,
-        provider: params.provider,
-        originalPasscodeEncryptionCode: params.originalPasscodeEncryptionCode,
-        enterprise: params.enterprise,
-        derivedFromParentWithSeed: params.derivedFromParentWithSeed,
-        disableKRSEmail: params.disableKRSEmail,
-        krsSpecific: params.krsSpecific
-      })
-      .result()
-      .nodeify(callback);
+    return Bluebird.resolve(
+      this.bitgo.post(this.baseCoin.url('/key'))
+        .send({
+          pub: params.pub,
+          encryptedPrv: params.encryptedPrv,
+          type: params.type,
+          source: params.source,
+          provider: params.provider,
+          originalPasscodeEncryptionCode: params.originalPasscodeEncryptionCode,
+          enterprise: params.enterprise,
+          derivedFromParentWithSeed: params.derivedFromParentWithSeed,
+          disableKRSEmail: params.disableKRSEmail,
+          krsSpecific: params.krsSpecific,
+        })
+        .result()
+    ).nodeify(callback);
   }
 
   /**

--- a/modules/core/src/v2/markets.ts
+++ b/modules/core/src/v2/markets.ts
@@ -46,7 +46,7 @@ export class Markets {
    * current day in a number of currencies
    **/
   latest(params: LatestOptions, callback: NodeCallback<any>): Bluebird<any> {
-    return this.bitgo.get(this.baseCoin.url('/market/latest')).result().asCallback(callback);
+    return Bluebird.resolve(this.bitgo.get(this.baseCoin.url('/market/latest')).result()).asCallback(callback);
   }
 
   /**
@@ -57,7 +57,7 @@ export class Markets {
    * previous day in a number of currencies
    */
   yesterday(params: YesterdayOptions, callback: NodeCallback<any>): Bluebird<any> {
-    return this.bitgo.get(this.baseCoin.url('/market/yesterday')).result().asCallback(callback);
+    return Bluebird.resolve(this.bitgo.get(this.baseCoin.url('/market/yesterday')).result()).asCallback(callback);
   }
 
   /**

--- a/modules/core/src/v2/pendingApproval.ts
+++ b/modules/core/src/v2/pendingApproval.ts
@@ -285,8 +285,10 @@ export class PendingApproval {
             approvalParams.halfSigned = transaction.halfSigned || transaction;
           }
           self.bitgo.setRequestTracer(reqId);
-          return self.bitgo.put(self.url()).send(approvalParams).result().nodeify(callback);
-        }).call(this);
+          return self.bitgo.put(self.url()).send(approvalParams).result();
+        })
+          .call(this)
+          .nodeify(callback);
       }
 
       try {
@@ -314,7 +316,7 @@ export class PendingApproval {
    * @param callback
    */
   reject(params: Record<string, never> = {}, callback?: NodeCallback<any>): Bluebird<any> {
-    return this.bitgo.put(this.url()).send({ state: 'rejected' }).result().nodeify(callback);
+    return Bluebird.resolve(this.bitgo.put(this.url()).send({ state: 'rejected' }).result()).nodeify(callback);
   }
 
   /**
@@ -324,7 +326,7 @@ export class PendingApproval {
    * @param params
    * @param callback
    */
-  cancel(params: {} = {}, callback?: NodeCallback<any>): Bluebird<any> {
+  cancel(params: Record<string, never> = {}, callback?: NodeCallback<any>): Bluebird<any> {
     return this.reject(params, callback);
   }
 

--- a/modules/core/src/v2/trading/tradingAccount.ts
+++ b/modules/core/src/v2/trading/tradingAccount.ts
@@ -178,7 +178,7 @@ export class TradingAccount {
       `/api/trade/v1/enterprise/${this.enterpriseId}/account/${this.id}/calculatefees`
     );
 
-    return this.bitgo.post(url).send(params).result().asCallback(callback);
+    return Bluebird.resolve(this.bitgo.post(url).send(params).result()).asCallback(callback);
   }
 
   /**
@@ -189,7 +189,7 @@ export class TradingAccount {
    * @param callback
    * @returns hex-encoded signature of the payload
    */
-  signPayload(params: SignPayloadParameters, callback?): Bluebird<string> {
+  signPayload(params: SignPayloadParameters, callback?: NodeCallback<string>): Bluebird<string> {
     const self = this;
     return co<string>(function* signPayload() {
       const key = (yield self.wallet.baseCoin.keychains().get({ id: self.wallet.keyIds()[0] })) as any;

--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -660,10 +660,11 @@ export class Wallet {
       query.limit = params.limit;
     }
 
-    return this.bitgo.get(this.baseCoin.url('/wallet/' + this._wallet.id + '/tx'))
-      .query(query)
-      .result()
-      .nodeify(callback);
+    return Bluebird.resolve(
+      this.bitgo.get(this.baseCoin.url('/wallet/' + this._wallet.id + '/tx'))
+        .query(query)
+        .result()
+    ).nodeify(callback);
   }
 
   /**
@@ -691,10 +692,11 @@ export class Wallet {
       query.limit = params.limit;
     }
 
-    return this.bitgo.get(this.url('/tx/' + params.txHash))
-      .query(query)
-      .result()
-      .nodeify(callback);
+    return Bluebird.resolve(
+      this.bitgo.get(this.url('/tx/' + params.txHash))
+        .query(query)
+        .result()
+    ).nodeify(callback);
   }
 
   /**
@@ -804,10 +806,11 @@ export class Wallet {
       query.type = params.type;
     }
 
-    return this.bitgo.get(this.url('/transfer'))
-      .query(query)
-      .result()
-      .nodeify(callback);
+    return Bluebird.resolve(
+      this.bitgo.get(this.url('/transfer'))
+        .query(query)
+        .result()
+    ).nodeify(callback);
   }
 
   /**
@@ -818,9 +821,9 @@ export class Wallet {
   getTransfer(params: GetTransferOptions = {}, callback?: NodeCallback<any>): Bluebird<any> {
     common.validateParams(params, ['id'], [], callback);
 
-    return this.bitgo.get(this.url('/transfer/' + params.id))
-      .result()
-      .nodeify(callback);
+    return Bluebird.resolve(
+      this.bitgo.get(this.url('/transfer/' + params.id)).result()
+    ).nodeify(callback);
   }
 
   /**
@@ -831,9 +834,9 @@ export class Wallet {
   transferBySequenceId(params: TransferBySequenceIdOptions = {}, callback?: NodeCallback<any>): Bluebird<any> {
     common.validateParams(params, ['sequenceId'], [], callback);
 
-    return this.bitgo.get(this.url('/transfer/sequenceId/' + params.sequenceId))
-      .result()
-      .nodeify(callback);
+    return Bluebird.resolve(
+      this.bitgo.get(this.url('/transfer/sequenceId/' + params.sequenceId)).result()
+    ).nodeify(callback);
   }
 
   /**
@@ -878,10 +881,11 @@ export class Wallet {
       'chains', 'limit', 'maxValue', 'minConfirms', 'minHeight', 'minValue', 'prevId', 'segwit', 'target',
     ]);
 
-    return this.bitgo.get(this.url('/unspents'))
-      .query(query)
-      .result()
-      .nodeify(callback);
+    return Bluebird.resolve(
+      this.bitgo.get(this.url('/unspents'))
+        .query(query)
+        .result()
+    ).nodeify(callback);
   }
 
   /**
@@ -1097,10 +1101,9 @@ export class Wallet {
       }
     }
 
-    return this.bitgo.post(this.url('/freeze'))
-      .send(params)
-      .result()
-      .nodeify(callback);
+    return Bluebird.resolve(
+      this.bitgo.post(this.url('/freeze')).send(params).result()
+    ).nodeify(callback);
   }
 
   /**
@@ -1112,10 +1115,11 @@ export class Wallet {
   transferComment(params: TransferCommentOptions = {}, callback?: NodeCallback<any>): Bluebird<any> {
     common.validateParams(params, ['id'], ['comment'], callback);
 
-    return this.bitgo.post(this.baseCoin.url('/wallet/' + this._wallet.id + '/transfer/' + params.id + '/comment'))
-      .send(params)
-      .result()
-      .nodeify(callback);
+    return Bluebird.resolve(
+      this.bitgo.post(this.baseCoin.url('/wallet/' + this._wallet.id + '/transfer/' + params.id + '/comment'))
+        .send(params)
+        .result()
+    ).nodeify(callback);
   }
 
   /**
@@ -1175,10 +1179,11 @@ export class Wallet {
       query.chains = params.chains;
     }
 
-    return this.bitgo.get(this.baseCoin.url('/wallet/' + this._wallet.id + '/addresses'))
-      .query(query)
-      .result()
-      .nodeify(callback);
+    return Bluebird.resolve(
+      this.bitgo.get(this.baseCoin.url('/wallet/' + this._wallet.id + '/addresses'))
+        .query(query)
+        .result()
+    ).nodeify(callback);
   }
 
   /**
@@ -1203,9 +1208,9 @@ export class Wallet {
       this.bitgo.setRequestTracer(params.reqId);
     }
 
-    return this.bitgo.get(this.baseCoin.url(`/wallet/${this._wallet.id}/address/${encodeURIComponent(query)}`))
-      .result()
-      .nodeify(callback);
+    return Bluebird.resolve(
+      this.bitgo.get(this.baseCoin.url(`/wallet/${this._wallet.id}/address/${encodeURIComponent(query)}`)).result()
+    ).nodeify(callback);
   }
 
   /**
@@ -1366,10 +1371,11 @@ export class Wallet {
       query.limit = params.limit;
     }
 
-    return this.bitgo.get(this.url('/webhooks'))
-      .query(query)
-      .result()
-      .nodeify(callback);
+    return Bluebird.resolve(
+      this.bitgo.get(this.url('/webhooks'))
+        .query(query)
+        .result()
+    ).nodeify(callback);
   }
 
   /**
@@ -1401,10 +1407,11 @@ export class Wallet {
     const filteredParams = _.pick(params, ['transferId', 'pendingApprovalId']);
 
     const webhookId = params.webhookId;
-    return this.bitgo.post(this.url('/webhooks/' + webhookId + '/simulate'))
-      .send(filteredParams)
-      .result()
-      .nodeify(callback);
+    return Bluebird.resolve(
+      this.bitgo.post(this.url('/webhooks/' + webhookId + '/simulate'))
+        .send(filteredParams)
+        .result()
+    ).nodeify(callback);
   }
 
   /**
@@ -1415,10 +1422,11 @@ export class Wallet {
   addWebhook(params: ModifyWebhookOptions = {}, callback?: NodeCallback<any>): Bluebird<any> {
     common.validateParams(params, ['url', 'type'], [], callback);
 
-    return this.bitgo.post(this.url('/webhooks'))
-      .send(params)
-      .result()
-      .nodeify(callback);
+    return Bluebird.resolve(
+      this.bitgo.post(this.url('/webhooks'))
+        .send(params)
+        .result()
+    ).nodeify(callback);
   }
 
   /**
@@ -1429,10 +1437,11 @@ export class Wallet {
   removeWebhook(params: ModifyWebhookOptions = {}, callback?: NodeCallback<any>): Bluebird<any> {
     common.validateParams(params, ['url', 'type'], [], callback);
 
-    return this.bitgo.del(this.url('/webhooks'))
-      .send(params)
-      .result()
-      .nodeify(callback);
+    return Bluebird.resolve(
+      this.bitgo.del(this.url('/webhooks'))
+        .send(params)
+        .result()
+    ).nodeify(callback);
   }
 
   /**
@@ -1520,10 +1529,11 @@ export class Wallet {
       }
     }
 
-    return this.bitgo.post(this.url('/share'))
+    return Bluebird.resolve(
+      this.bitgo.post(this.url('/share'))
       .send(params)
       .result()
-      .nodeify(callback);
+    ).nodeify(callback);
   }
 
   /**
@@ -1621,9 +1631,10 @@ export class Wallet {
     common.validateParams(params, ['userId'], [], callback);
 
     const userId = params.userId;
-    return this.bitgo.del(this.url('/user/' + userId))
+    return Bluebird.resolve(
+      this.bitgo.del(this.url('/user/' + userId))
       .result()
-      .nodeify(callback);
+    ).nodeify(callback);
   }
 
   /**
@@ -1931,10 +1942,11 @@ export class Wallet {
     if ((hasTxHex && hasHalfSigned) || (!hasTxHex && !hasHalfSigned)) {
       throw new Error('must supply either txHex or halfSigned, but not both');
     }
-    return this.bitgo.post(this.baseCoin.url('/wallet/' + this.id() + '/tx/send'))
-      .send(params)
-      .result()
-      .nodeify(callback);
+    return Bluebird.resolve(
+      this.bitgo.post(this.baseCoin.url('/wallet/' + this.id() + '/tx/send'))
+        .send(params)
+        .result()
+    ).nodeify(callback);
   }
 
   /**
@@ -2029,7 +2041,7 @@ export class Wallet {
       params.reqId = reqId;
       const coin = self.baseCoin;
       if (_.isObject(params.recipients)) {
-        params.recipients.map(function(recipient) {
+        params.recipients.map((recipient) => {
           const amount = new BigNumber(recipient.amount);
           if (amount.isNegative()) {
             throw new Error('invalid argument for amount - positive number greater than zero or numeric string expected');
@@ -2153,11 +2165,12 @@ export class Wallet {
    * @returns {Object} The info returned from the merchant server Payment Ack
    * @deprecated
    */
-  sendPaymentResponse(params: Record<string, never> = {}, callback?: NodeCallback<any>): Bluebird<any> {
-    return this.bitgo.post(this.url('/sendPayment'))
-      .send(params)
-      .result()
-      .asCallback(callback);
+  sendPaymentResponse(params: any = {}, callback?: NodeCallback<any>): Bluebird<any> {
+    return Bluebird.resolve(
+      this.bitgo.post(this.url('/sendPayment'))
+        .send(params)
+        .result()
+    ).asCallback(callback);
   }
 
   /**
@@ -2238,7 +2251,9 @@ export class Wallet {
    * @returns {*}
    */
   remove(params: Record<string, never> = {}, callback?: NodeCallback<any>): Bluebird<any> {
-    return this.bitgo.del(this.url()).result().asCallback(callback);
+    return Bluebird.resolve(
+      this.bitgo.del(this.url()).result()
+    ).asCallback(callback);
   }
 
   /**

--- a/modules/core/src/v2/wallets.ts
+++ b/modules/core/src/v2/wallets.ts
@@ -494,7 +494,7 @@ export class Wallets {
    * @param callback
    */
   listShares(params: Record<string, unknown> = {}, callback?: NodeCallback<any>): Bluebird<any> {
-    return this.bitgo.get(this.baseCoin.url('/walletshare')).result().asCallback(callback);
+    return Bluebird.resolve(this.bitgo.get(this.baseCoin.url('/walletshare')).result()).asCallback(callback);
   }
 
   /**
@@ -506,10 +506,9 @@ export class Wallets {
   getShare(params: { walletShareId?: string } = {}, callback?: NodeCallback<any>): Bluebird<any> {
     common.validateParams(params, ['walletShareId'], [], callback);
 
-    return this.bitgo
-      .get(this.baseCoin.url('/walletshare/' + params.walletShareId))
-      .result()
-      .nodeify(callback);
+    return Bluebird.resolve(this.bitgo.get(this.baseCoin.url('/walletshare/' + params.walletShareId)).result()).nodeify(
+      callback
+    );
   }
 
   /**
@@ -522,11 +521,12 @@ export class Wallets {
   updateShare(params: UpdateShareOptions = {}, callback?: NodeCallback<any>): Bluebird<any> {
     common.validateParams(params, ['walletShareId'], [], callback);
 
-    return this.bitgo
-      .post(this.baseCoin.url('/walletshare/' + params.walletShareId))
-      .send(params)
-      .result()
-      .nodeify(callback);
+    return Bluebird.resolve(
+      this.bitgo
+        .post(this.baseCoin.url('/walletshare/' + params.walletShareId))
+        .send(params)
+        .result()
+    ).nodeify(callback);
   }
 
   /**
@@ -556,11 +556,12 @@ export class Wallets {
   cancelShare(params: { walletShareId?: string } = {}, callback?: NodeCallback<any>): Bluebird<any> {
     common.validateParams(params, ['walletShareId'], [], callback);
 
-    return this.bitgo
-      .del(this.baseCoin.url('/walletshare/' + params.walletShareId))
-      .send()
-      .result()
-      .nodeify(callback);
+    return Bluebird.resolve(
+      this.bitgo
+        .del(this.baseCoin.url('/walletshare/' + params.walletShareId))
+        .send()
+        .result()
+    ).nodeify(callback);
   }
 
   /**
@@ -710,6 +711,6 @@ export class Wallets {
    * @returns {*}
    */
   getTotalBalances(params: Record<string, never> = {}, callback?: NodeCallback<any>): Bluebird<any> {
-    return this.bitgo.get(this.baseCoin.url('/wallet/balances')).result().asCallback(callback);
+    return Bluebird.resolve(this.bitgo.get(this.baseCoin.url('/wallet/balances')).result()).asCallback(callback);
   }
 }

--- a/modules/core/src/v2/webhooks.ts
+++ b/modules/core/src/v2/webhooks.ts
@@ -35,7 +35,12 @@ export interface SimulateOptions {
 }
 
 export class Webhooks {
-  public constructor(private bitgo: BitGo, private baseCoin: BaseCoin) {}
+  private bitgo: BitGo;
+  private baseCoin: BaseCoin;
+  public constructor(bitgo: BitGo, baseCoin: BaseCoin) {
+    this.bitgo = bitgo;
+    this.baseCoin = baseCoin;
+  }
 
   /**
    * Fetch list of user webhooks
@@ -44,7 +49,7 @@ export class Webhooks {
    * @returns {*}
    */
   list(callback: NodeCallback<any>): Bluebird<any> {
-    return this.bitgo.get(this.baseCoin.url('/webhooks')).result().nodeify(callback);
+    return Bluebird.resolve(this.bitgo.get(this.baseCoin.url('/webhooks')).result()).nodeify(callback);
   }
 
   /**

--- a/modules/core/src/wallet.ts
+++ b/modules/core/src/wallet.ts
@@ -161,13 +161,14 @@ Wallet.prototype.get = function(params, callback): Bluebird<any> {
 
   const self = this;
 
-  return this.bitgo.get(this.url())
-  .result()
-  .then(function(res) {
-    self.wallet = res;
-    return self;
-  })
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.get(this.url())
+      .result()
+      .then(function(res) {
+        self.wallet = res;
+        return self;
+      })
+  ).nodeify(callback);
 };
 
 //
@@ -193,13 +194,14 @@ Wallet.prototype.updateApprovalsRequired = function(params, callback): Bluebird<
     return Bluebird.try(function() {
       return self.wallet;
     })
-    .nodeify(callback);
+      .nodeify(callback);
   }
 
-  return this.bitgo.put(this.url())
-  .send(params)
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.put(this.url())
+      .send(params)
+      .result()
+  ).nodeify(callback);
 };
 
 /**
@@ -245,16 +247,17 @@ Wallet.prototype.createAddress = function(params, callback) {
   if (chain === null || chain === undefined) {
     chain = defaultChain;
   }
-  return this.bitgo.post(this.url('/address/' + chain))
-  .send(params)
-  .result()
-  .then(function(addr) {
-    if (shouldValidate) {
-      self.validateAddress(addr);
-    }
-    return addr;
-  })
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.post(this.url('/address/' + chain))
+      .send(params)
+      .result()
+      .then(function(addr) {
+        if (shouldValidate) {
+          self.validateAddress(addr);
+        }
+        return addr;
+      })
+  ).nodeify(callback);
 };
 
 /**
@@ -311,7 +314,7 @@ Wallet.prototype.generateAddress = function({ segwit, path, keychains, threshold
     path: path,
     chain: pathDetails[0],
     index: pathDetails[1],
-    wallet: this.id()
+    wallet: this.id(),
   };
 
   // redeem script normally, witness script for segwit
@@ -395,10 +398,11 @@ Wallet.prototype.addresses = function(params, callback) {
   }
 
   const url = this.url('/addresses');
-  return this.bitgo.get(url)
-  .query(query)
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.get(url)
+      .query(query)
+      .result()
+  ).nodeify(callback);
 };
 
 Wallet.prototype.stats = function(params, callback) {
@@ -418,9 +422,9 @@ Wallet.prototype.stats = function(params, callback) {
 
   const url = this.url('/stats' + query);
 
-  return this.bitgo.get(url)
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.get(url).result()
+  ).nodeify(callback);
 };
 
 /**
@@ -470,10 +474,11 @@ Wallet.prototype.freeze = function(params, callback) {
     }
   }
 
-  return this.bitgo.post(this.url('/freeze'))
-  .send(params)
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.post(this.url('/freeze'))
+      .send(params)
+      .result()
+  ).nodeify(callback);
 };
 
 //
@@ -484,9 +489,9 @@ Wallet.prototype.delete = function(params, callback) {
   params = params || {};
   common.validateParams(params, [], [], callback);
 
-  return this.bitgo.del(this.url())
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.del(this.url()).result()
+  ).nodeify(callback);
 };
 
 //
@@ -499,9 +504,9 @@ Wallet.prototype.labels = function(params, callback) {
 
   const url = this.bitgo.url('/labels/' + this.id());
 
-  return this.bitgo.get(url)
-  .result('labels')
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.get(url).result('labels')
+  ).nodeify(callback);
 };
 
 /**
@@ -516,10 +521,11 @@ Wallet.prototype.setWalletName = function(params, callback) {
   common.validateParams(params, ['label'], [], callback);
 
   const url = this.bitgo.url('/wallet/' + this.id());
-  return this.bitgo.put(url)
-  .send({ label: params.label })
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.put(url)
+      .send({ label: params.label })
+      .result()
+  ).nodeify(callback);
 };
 
 //
@@ -538,10 +544,11 @@ Wallet.prototype.setLabel = function(params, callback) {
 
   const url = this.bitgo.url('/labels/' + this.id() + '/' + params.address);
 
-  return this.bitgo.put(url)
-  .send({ label: params.label })
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.put(url)
+      .send({ label: params.label })
+      .result()
+  ).nodeify(callback);
 };
 
 //
@@ -560,9 +567,9 @@ Wallet.prototype.deleteLabel = function(params, callback) {
 
   const url = this.bitgo.url('/labels/' + this.id() + '/' + params.address);
 
-  return this.bitgo.del(url)
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.del(url).result()
+  ).nodeify(callback);
 };
 
 //
@@ -701,10 +708,9 @@ Wallet.prototype.unspentsPaged = function(params, callback) {
     queryObject.allowLedgerSegwit = params.allowLedgerSegwit;
   }
 
-  return this.bitgo.get(this.url('/unspents'))
-  .query(queryObject)
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.get(this.url('/unspents')).query(queryObject).result()
+  ).nodeify(callback);
 };
 
 //
@@ -760,9 +766,9 @@ Wallet.prototype.transactions = function(params, callback) {
 
   const url = this.url('/tx' + query);
 
-  return this.bitgo.get(url)
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.get(url).result()
+  ).nodeify(callback);
 };
 
 //
@@ -774,9 +780,9 @@ Wallet.prototype.getTransaction = function(params, callback) {
 
   const url = this.url('/tx/' + params.id);
 
-  return this.bitgo.get(url)
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.get(url).result()
+  ).nodeify(callback);
 };
 
 //
@@ -829,9 +835,9 @@ Wallet.prototype.getWalletTransactionBySequenceId = function(params, callback) {
 
   const url = this.url('/tx/sequence/' + params.sequenceId);
 
-  return this.bitgo.get(url)
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.get(url).result()
+  ).nodeify(callback);
 };
 
 //
@@ -958,10 +964,9 @@ Wallet.prototype.sendTransaction = function(params, callback) {
   params = params || {};
   common.validateParams(params, ['tx'], ['message', 'otp'], callback);
 
-  return this.bitgo.post(this.bitgo.url('/tx/send'))
-  .send(params)
-  .result()
-  .then(function(body) {
+  return Bluebird.resolve(
+    this.bitgo.post(this.bitgo.url('/tx/send')).send(params).result()
+  ).then(function(body) {
     if (body.pendingApproval) {
       return _.extend(body, { status: 'pendingApproval' });
     }
@@ -998,10 +1003,9 @@ Wallet.prototype.createShare = function(params, callback) {
     }
   }
 
-  return this.bitgo.post(this.url('/share'))
-  .send(params)
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.post(this.url('/share')).send(params).result()
+  ).nodeify(callback);
 };
 
 //
@@ -1025,10 +1029,9 @@ Wallet.prototype.createInvite = function(params, callback) {
     options.message = params.message;
   }
 
-  return this.bitgo.post(this.url('/invite'))
-  .send(options)
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.post(this.url('/invite')).send(options).result()
+  ).nodeify(callback);
 };
 
 //
@@ -2243,30 +2246,33 @@ Wallet.prototype.removeUser = function(params, callback) {
   params = params || {};
   common.validateParams(params, ['user'], [], callback);
 
-  return this.bitgo.del(this.url('/user/' + params.user))
-  .send()
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.del(this.url('/user/' + params.user))
+      .send()
+      .result()
+  ).nodeify(callback);
 };
 
 Wallet.prototype.getPolicy = function(params, callback) {
   params = params || {};
   common.validateParams(params, [], [], callback);
 
-  return this.bitgo.get(this.url('/policy'))
-  .send()
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.get(this.url('/policy'))
+      .send()
+      .result()
+  ).nodeify(callback);
 };
 
 Wallet.prototype.getPolicyStatus = function(params, callback) {
   params = params || {};
   common.validateParams(params, [], [], callback);
 
-  return this.bitgo.get(this.url('/policy/status'))
-  .send()
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.get(this.url('/policy/status'))
+      .send()
+      .result()
+  ).nodeify(callback);
 };
 
 Wallet.prototype.setPolicyRule = function(params, callback) {
@@ -2281,30 +2287,33 @@ Wallet.prototype.setPolicyRule = function(params, callback) {
     throw new Error('missing parameter: action object');
   }
 
-  return this.bitgo.put(this.url('/policy/rule'))
-  .send(params)
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.put(this.url('/policy/rule'))
+      .send(params)
+      .result()
+  ).nodeify(callback);
 };
 
 Wallet.prototype.removePolicyRule = function(params, callback) {
   params = params || {};
   common.validateParams(params, ['id'], ['message'], callback);
 
-  return this.bitgo.del(this.url('/policy/rule'))
-  .send(params)
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.del(this.url('/policy/rule'))
+      .send(params)
+      .result()
+  ).nodeify(callback);
 };
 
 Wallet.prototype.listWebhooks = function(params, callback) {
   params = params || {};
   common.validateParams(params, [], [], callback);
 
-  return this.bitgo.get(this.url('/webhooks'))
-  .send()
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.get(this.url('/webhooks'))
+      .send()
+      .result()
+  ).nodeify(callback);
 };
 
 /**
@@ -2334,30 +2343,33 @@ Wallet.prototype.simulateWebhook = function(params, callback) {
   const filteredParams = _.pick(params, ['txHash', 'pendingApprovalId']);
 
   const webhookId = params.webhookId;
-  return this.bitgo.post(this.url('/webhooks/' + webhookId + '/simulate'))
-  .send(filteredParams)
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.post(this.url('/webhooks/' + webhookId + '/simulate'))
+      .send(filteredParams)
+      .result()
+  ).nodeify(callback);
 };
 
 Wallet.prototype.addWebhook = function(params, callback) {
   params = params || {};
   common.validateParams(params, ['url', 'type'], [], callback);
 
-  return this.bitgo.post(this.url('/webhooks'))
-  .send(params)
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.post(this.url('/webhooks'))
+      .send(params)
+      .result()
+  ).nodeify(callback);
 };
 
 Wallet.prototype.removeWebhook = function(params, callback) {
   params = params || {};
   common.validateParams(params, ['url', 'type'], [], callback);
 
-  return this.bitgo.del(this.url('/webhooks'))
-  .send(params)
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.del(this.url('/webhooks'))
+      .send(params)
+      .result()
+  ).nodeify(callback);
 };
 
 Wallet.prototype.estimateFee = function(params, callback) {
@@ -2402,20 +2414,22 @@ Wallet.prototype.updatePolicyRule = function(params, callback) {
   params = params || {};
   common.validateParams(params, ['id', 'type'], [], callback);
 
-  return this.bitgo.put(this.url('/policy/rule'))
-  .send(params)
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.put(this.url('/policy/rule'))
+      .send(params)
+      .result()
+  ).nodeify(callback);
 };
 
 Wallet.prototype.deletePolicyRule = function(params, callback) {
   params = params || {};
   common.validateParams(params, ['id'], [], callback);
 
-  return this.bitgo.del(this.url('/policy/rule'))
-  .send(params)
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.del(this.url('/policy/rule'))
+      .send(params)
+      .result()
+  ).nodeify(callback);
 };
 
 //
@@ -2431,10 +2445,11 @@ Wallet.prototype.getBitGoFee = function(params, callback) {
   if (params.instant && !_.isBoolean(params.instant)) {
     throw new Error('invalid instant argument');
   }
-  return this.bitgo.get(this.url('/billing/fee'))
-  .query(params)
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.get(this.url('/billing/fee'))
+      .query(params)
+      .result()
+  ).nodeify(callback);
 };
 
 export = Wallet;

--- a/modules/core/src/wallets.ts
+++ b/modules/core/src/wallets.ts
@@ -67,13 +67,12 @@ Wallets.prototype.list = function(params, callback) {
   }
 
   const self = this;
-  return this.bitgo.get(this.bitgo.url('/wallet' + query))
-  .result()
-  .then(function(body) {
+  return Bluebird.resolve(
+    this.bitgo.get(this.bitgo.url('/wallet' + query)).result()
+  ).then(function(body) {
     body.wallets = body.wallets.map(function(w) { return new Wallet(self.bitgo, w); });
     return body;
-  })
-  .nodeify(callback);
+  }).nodeify(callback);
 };
 
 Wallets.prototype.getWallet = function(params, callback) {
@@ -87,12 +86,11 @@ Wallets.prototype.getWallet = function(params, callback) {
     query = '?gpk=1';
   }
 
-  return this.bitgo.get(this.bitgo.url('/wallet/' + params.id + query))
-  .result()
-  .then(function(wallet) {
+  return Bluebird.resolve(
+    this.bitgo.get(this.bitgo.url('/wallet/' + params.id + query)).result()
+  ).then(function(wallet) {
     return new Wallet(self.bitgo, wallet);
-  })
-  .nodeify(callback);
+  }).nodeify(callback);
 };
 
 //
@@ -103,9 +101,9 @@ Wallets.prototype.listInvites = function(params, callback) {
   params = params || {};
   common.validateParams(params, [], [], callback);
 
-  return this.bitgo.get(this.bitgo.url('/walletinvite'))
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.get(this.bitgo.url('/walletinvite')).result()
+  ).nodeify(callback);
 };
 
 //
@@ -116,9 +114,9 @@ Wallets.prototype.cancelInvite = function(params, callback) {
   params = params || {};
   common.validateParams(params, ['walletInviteId'], [], callback);
 
-  return this.bitgo.del(this.bitgo.url('/walletinvite/' + params.walletInviteId))
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.del(this.bitgo.url('/walletinvite/' + params.walletInviteId)).result()
+  ).nodeify(callback);
 };
 
 //
@@ -129,9 +127,9 @@ Wallets.prototype.listShares = function(params, callback) {
   params = params || {};
   common.validateParams(params, [], [], callback);
 
-  return this.bitgo.get(this.bitgo.url('/walletshare'))
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.get(this.bitgo.url('/walletshare')).result()
+  ).nodeify(callback);
 };
 
 //
@@ -161,9 +159,9 @@ Wallets.prototype.getShare = function(params, callback) {
   params = params || {};
   common.validateParams(params, ['walletShareId'], [], callback);
 
-  return this.bitgo.get(this.bitgo.url('/walletshare/' + params.walletShareId))
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.get(this.bitgo.url('/walletshare/' + params.walletShareId)).result()
+  ).nodeify(callback);
 };
 
 //
@@ -177,10 +175,9 @@ Wallets.prototype.updateShare = function(params, callback) {
   params = params || {};
   common.validateParams(params, ['walletShareId'], [], callback);
 
-  return this.bitgo.post(this.bitgo.url('/walletshare/' + params.walletShareId))
-  .send(params)
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.post(this.bitgo.url('/walletshare/' + params.walletShareId)).send(params).result()
+  ).nodeify(callback);
 };
 
 //
@@ -193,10 +190,9 @@ Wallets.prototype.cancelShare = function(params, callback) {
   params = params || {};
   common.validateParams(params, ['walletShareId'], [], callback);
 
-  return this.bitgo.del(this.bitgo.url('/walletshare/' + params.walletShareId))
-  .send()
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.del(this.bitgo.url('/walletshare/' + params.walletShareId)).send().result()
+  ).nodeify(callback);
 };
 
 //
@@ -465,10 +461,9 @@ Wallets.prototype.createForwardWallet = function(params, callback) {
       walletParams.enterprise = params.enterprise;
     }
 
-    return self.bitgo.post(self.bitgo.url('/wallet'))
-    .send(walletParams)
-    .result()
-    .nodeify(callback);
+    return Bluebird.resolve(
+      self.bitgo.post(self.bitgo.url('/wallet')).send(walletParams).result()
+    ).nodeify(callback);
   });
 };
 
@@ -513,13 +508,11 @@ Wallets.prototype.add = function(params, callback) {
     walletParams.disableTransactionNotifications = params.disableTransactionNotifications;
   }
 
-  return this.bitgo.post(this.bitgo.url('/wallet'))
-  .send(walletParams)
-  .result()
-  .then(function(body) {
+  return Bluebird.resolve(
+    this.bitgo.post(this.bitgo.url('/wallet')).send(walletParams).result()
+  ).then(function(body) {
     return new Wallet(self.bitgo, body);
-  })
-  .nodeify(callback);
+  }).nodeify(callback);
 };
 
 //
@@ -542,9 +535,9 @@ Wallets.prototype.remove = function(params, callback) {
   params = params || {};
   common.validateParams(params, ['id'], [], callback);
 
-  return this.bitgo.del(this.bitgo.url('/wallet/' + params.id))
-  .result()
-  .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.del(this.bitgo.url('/wallet/' + params.id)).result()
+  ).nodeify(callback);
 };
 
 module.exports = Wallets;

--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -630,13 +630,13 @@ function handleV2CoinSpecificREST(req: express.Request, res: express.Response, n
 function redirectRequest(bitgo: BitGo, method: string, url: string, req: express.Request, next: express.NextFunction) {
   switch (method) {
     case 'GET':
-      return bitgo.get(url).result().nodeify();
+      return bitgo.get(url).result();
     case 'POST':
-      return bitgo.post(url).send(req.body).result().nodeify();
+      return bitgo.post(url).send(req.body).result();
     case 'PUT':
-      return bitgo.put(url).send(req.body).result().nodeify();
+      return bitgo.put(url).send(req.body).result();
     case 'DELETE':
-      return bitgo.del(url).send(req.body).result().nodeify();
+      return bitgo.del(url).send(req.body).result();
   }
   // something has presumably gone wrong
   next();
@@ -703,7 +703,7 @@ function prepareBitGo(config: Config) {
  * Promise handler wrapper to handle sending responses and error cases
  * @param promiseRequestHandler
  */
-function promiseWrapper(promiseRequestHandler: Function) {
+function promiseWrapper(promiseRequestHandler: express.RequestHandler) {
   return function (req: express.Request, res: express.Response, next: express.NextFunction) {
     debug(`handle: ${req.method} ${req.originalUrl}`);
     bluebird
@@ -753,7 +753,7 @@ function promiseWrapper(promiseRequestHandler: Function) {
   };
 }
 
-export function setupRoutes(app: express.Application, config: Config) {
+export function setupRoutes(app: express.Application, config: Config): void {
   // When adding new routes to BitGo Express make sure that you also add the exact same routes to the server. Since
   // some customers were confused when calling a BitGo Express route on the BitGo server, we now handle all BitGo
   // Express routes on the BitGo server and return an error message that says that one should call BitGo Express

--- a/types/superagent/index.d.ts
+++ b/types/superagent/index.d.ts
@@ -1,11 +1,9 @@
-import * as superagent from 'superagent';
-import * as bluebird from 'bluebird';
+import 'superagent';
 
 declare module 'superagent' {
-  interface Request {
-    result: (optionalField?: string) => bluebird<any>;
+  interface Request<ResultType = any> {
+    result: (optionalField?: string) => Promise<ResultType>;
     proxy: (proxyUrl: string) => this;
-    verifyResponse: (response: superagent.Response) => superagent.Response;
     forceV1Auth: boolean;
     authenticationToken?: string;
     isV2Authenticated?: boolean;


### PR DESCRIPTION
BREAKING CHANGE: bluebird-specific promise methods are no longer present
on the `get`/`post`/`put`/`del`/`patch` request helper methods on BitGo
objects.

BREAKING CHANGE: remove support for callbacks to async fns

Native promises don't support the `asCallback` or `nodeify` helpers that
are on Bluebird promises. We will need to add a compatiblity layer for
these since we don't (yet) want to entirely deprecate support for
callback style usage of Bitgo object methods, but for now let's remove
all the callback params and make everything work correctly as regular
async functions.

We still want the current API surface to remain callback compatible for
the moment, so convert from raw promises to bluebird promises where
callbacks are needed.

Ticket; BG-31214