### PR TITLE
BG-32738-fix(core): use ltc explorer to get unspents during cross chain recovery

### DIFF
--- a/modules/core/src/v2/recovery.ts
+++ b/modules/core/src/v2/recovery.ts
@@ -191,7 +191,6 @@ export class CrossChainRecoveryTool {
       const faultyTxInfo = (yield self.sourceCoin.getTxInfoFromExplorer(faultyTxId)) as any;
 
       self._log('Getting unspents on output addresses..');
-
       // Get output addresses that do not belong to wallet
       // These are where the 'lost coins' live
       const txOutputAddresses = faultyTxInfo.outputs.map((input) => input.address);
@@ -239,10 +238,8 @@ export class CrossChainRecoveryTool {
 
       self._log(`Finding unspents for these output addresses: ${outputAddresses.join(', ')}`);
 
-      // Get unspents for addresses
-      const ADDRESS_UNSPENTS_URL = self.sourceCoin.url(`/public/addressUnspents/${_.uniq(outputAddresses).join(',')}`);
-      const addressRes = (yield request.get(ADDRESS_UNSPENTS_URL)) as any;
-      const unspents = addressRes.body;
+      // Get unspents for addresses. Calling source coin's method of fetching unspents
+      const unspents = (yield self.sourceCoin.getUnspentInfoForCrossChainRecovery(outputAddresses)) as any;
 
       self.unspents = unspents;
       return unspents;

--- a/modules/core/test/v2/lib/recovery-nocks.ts
+++ b/modules/core/test/v2/lib/recovery-nocks.ts
@@ -2497,7 +2497,20 @@ module.exports.nockLtcRecovery = function (isKrsRecovery) {
       size: 370,
       valueIn: 0.6,
       fees: 0.0004488,
-    });
+    })
+    .get('/addrs/QiSTRzBCS5UxVvdMiYVGfNn1wYkC9JrpmP/utxo')
+    .reply(200, [
+      {
+        address: 'QiSTRzBCS5UxVvdMiYVGfNn1wYkC9JrpmP',
+        txid: 'fe22e43e7894e91ec4b371bfbce02f49b2903cc535e4a2345eeda5271c81db39',
+        vout: 1,
+        scriptPubKey: 'a914ef856a40c6dc109591b7d4fad170986d0bb404af87',
+        amount: 0.4,
+        satoshis: 40000000,
+        height: 476097,
+        confirmations: 1497700,
+      },
+    ]);
 
   if (isKrsRecovery) {
     // unnecessary market data removed


### PR DESCRIPTION
Changes in this PR:

- Added function getUnspentInfoForCrossChainRecovery in abstractUtxoCoin.ts to get unspents using IMS API

- Added LTC block explorer to getUnspentInfoForCrossChainRecovery function in ltc.ts to get unspents

- Used getUnspentInfoForCrossChainRecovery inside findUnspents function in recovery.ts

- Added nock response for LTC block explorer unspents API

Link to the ticket: https://bitgoinc.atlassian.net/browse/BG-32738