### PR TITLE
feat(core): add `considerMigratedFromAddressInternal` verification flag

### DIFF
--- a/modules/core/src/v2/baseCoin.ts
+++ b/modules/core/src/v2/baseCoin.ts
@@ -84,6 +84,7 @@ export interface VerificationOptions {
   };
   addresses?: { [address: string]: AddressVerificationData };
   allowPaygoOutput?: boolean;
+  considerMigratedFromAddressInternal?: boolean;
 }
 
 export interface VerifyTransactionOptions {

--- a/modules/core/src/v2/internal/parseOutput.ts
+++ b/modules/core/src/v2/internal/parseOutput.ts
@@ -89,6 +89,7 @@ interface HandleVerifyAddressErrorOptions {
   coin: AbstractUtxoCoin;
   addressDetails?: any;
   addressType?: string;
+  considerMigratedFromAddressInternal?: boolean;
 }
 
 function handleVerifyAddressError({
@@ -100,6 +101,7 @@ function handleVerifyAddressError({
   coin,
   addressDetails,
   addressType,
+  considerMigratedFromAddressInternal,
 }: HandleVerifyAddressErrorOptions): { external: boolean; needsCustomChangeKeySignatureVerification?: boolean } {
   // Todo: name server-side errors to avoid message-based checking [BG-5124]
   const walletAddressNotFound = e.message.includes('wallet address not found');
@@ -109,7 +111,7 @@ function handleVerifyAddressError({
       // check to see if this is a migrated v1 bch address - it could be internal
       const isMigrated = isMigratedAddress(wallet, currentAddress);
       if (isMigrated) {
-        return { external: false };
+        return { external: considerMigratedFromAddressInternal === false };
       }
 
       debug('Address %s was found on wallet but could not be reconstructed', currentAddress);
@@ -253,6 +255,7 @@ export async function parseOutput({
         customChangeKeys: customChange && customChange.keys,
         addressDetails: currentAddressDetails,
         addressType: currentAddressType,
+        considerMigratedFromAddressInternal: verification.considerMigratedFromAddressInternal,
       })
     );
   }


### PR DESCRIPTION
This new transaction verification flag allows user to prevent the
transaction verification logic from considering "migrated from"
addresses as internal to the wallet. For more information on migrated
from addresses, please see the block comment on the `isMigratedAddress`
function in `internal/parseOutput.ts`.

Ticket: BG-30090