### PR TITLE
fix(core): replace bitcoin-abc with ecash in blockchair apis

### DIFF
--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -1719,7 +1719,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
 
   /**
    * Fetch unspent transaction outputs using IMS unspents API
-   * @params addresses
+   * @param addresses
    * @returns {*}
    */
   getUnspentInfoForCrossChainRecovery(addresses: string[]): any {

--- a/modules/core/src/v2/coins/bcha.ts
+++ b/modules/core/src/v2/coins/bcha.ts
@@ -26,12 +26,12 @@ export class Bcha extends Bch {
   }
 
   getAddressInfoFromExplorer(addressBase58: string, apiKey: string): Bluebird<AddressInfo> {
-    const explorer = new BlockchairApi(this.bitgo, 'bitcoin-abc', apiKey);
+    const explorer = new BlockchairApi(this.bitgo, 'ecash', apiKey);
     return Bluebird.resolve(explorer.getAccountInfo(addressBase58));
   }
 
   getUnspentInfoFromExplorer(addressBase58: string, apiKey: string): Bluebird<UnspentInfo[]> {
-    const explorer = new BlockchairApi(this.bitgo, 'bitcoin-abc', apiKey);
+    const explorer = new BlockchairApi(this.bitgo, 'ecash', apiKey);
     return Bluebird.resolve(explorer.getUnspents(addressBase58));
   }
 }

--- a/modules/core/src/v2/recovery/blockchairApi.ts
+++ b/modules/core/src/v2/recovery/blockchairApi.ts
@@ -1,5 +1,4 @@
 import { RecoveryAccountData, RecoveryUnspent, RecoveryProvider } from './types';
-import * as common from '../../common';
 import * as request from 'superagent';
 import { BitGo } from '../../bitgo';
 
@@ -7,7 +6,7 @@ const BlockchairCoin = [
   'bitcoin',
   'bitcoin-sv',
   'bitcoin-cash',
-  'bitcoin-abc'
+  'ecash',
 ];
 
 const devBase = ['dev', 'latest', 'local', 'localNonSecure', 'adminDev', 'adminLatest'];
@@ -29,7 +28,7 @@ export class BlockchairApi implements RecoveryProvider {
     this.apiToken = apiToken;
   }
 
-   static getBaseUrl(env: string, coin: string): string {
+  static getBaseUrl(env: string, coin: string): string {
     let url;
     if (mainnetBase.includes(env)) {
       url = `https://api.blockchair.com/${coin}`;
@@ -58,7 +57,7 @@ export class BlockchairApi implements RecoveryProvider {
   async getAccountInfo(address: string): Promise<RecoveryAccountData> {
     // we are using blockchair api: https://blockchair.com/api/docs#link_300
     // https://api.blockchair.com/{:btc_chain}/dashboards/address/{:address}₀
-    if(!address || address.length === 0) {
+    if (!address || address.length === 0) {
       throw new Error('invalid address');
     }
     const response = await request.get(this.getExplorerUrl(`/dashboards/address/${address}`));
@@ -74,7 +73,7 @@ export class BlockchairApi implements RecoveryProvider {
     // https://api.blockchair.com/{:btc_chain}/dashboards/address/{:address}₀
     // example utxo from response:
     // {block_id":-1,"transaction_hash":"cf5bcd42c688cb7c55b5811645e7f0d2a000a85564ca3d6b9fc20f57e14b30bb","index":1,"value":558},
-    if(!address || address.length === 0) {
+    if (!address || address.length === 0) {
       throw new Error('invalid address');
     }
     const response = await request.get(this.getExplorerUrl(`/dashboards/address/${address}`));

--- a/modules/core/test/v2/unit/recovery/blockchairApi.ts
+++ b/modules/core/test/v2/unit/recovery/blockchairApi.ts
@@ -2,7 +2,7 @@ import * as nock from 'nock';
 import { TestBitGo } from '../../../lib/test_bitgo';
 import { BlockchairApi } from '../../../../src/v2/recovery/blockchairApi';
 
-const coinNames = ['bitcoin', 'bitcoin-sv', 'bitcoin-abc'];
+const coinNames = ['bitcoin', 'bitcoin-sv', 'ecash'];
 
 function nockBlockchair(env, coinName) {
   const baseUrl = BlockchairApi.getBaseUrl(env, coinName);
@@ -42,24 +42,24 @@ function nockBlockchair(env, coinName) {
             },
           ],
         },
-      }
+      },
     });
 }
 
-describe('blockchair api', function() {
+describe('blockchair api', function () {
   const apiKey = 'my____ApiKey';
   const bitgo = new TestBitGo({ env: 'test' });
   const env = bitgo.getEnv() as string;
   for (const coinName of coinNames) {
-    describe(`${coinName} should succeed`, function() {
-      it('should get address information from blockchair', async function() {
+    describe(`${coinName} should succeed`, function () {
+      it('should get address information from blockchair', async function () {
         nockBlockchair(env, coinName);
         const blockchair = new BlockchairApi(bitgo, coinName, apiKey);
         const address = await blockchair.getAccountInfo('2N7kMMaUjmBYCiZqQV7GDJhBSnJuJoTuBws');
         address.txCount.should.equal(2);
         address.totalBalance.should.equal(20000);
       });
-      it('should get utxo information from blockchair', async function() {
+      it('should get utxo information from blockchair', async function () {
         nockBlockchair(env, coinName);
         const blockchair = new BlockchairApi(bitgo, coinName, apiKey);
         const response = await blockchair.getUnspents('2N7kMMaUjmBYCiZqQV7GDJhBSnJuJoTuBws');
@@ -70,8 +70,8 @@ describe('blockchair api', function() {
         response[0].address.should.equal('2N7kMMaUjmBYCiZqQV7GDJhBSnJuJoTuBws');
       });
     });
-    describe(`${coinName} should fail`, function() {
-      it('should throw if the address value is an empty string', async function() {
+    describe(`${coinName} should fail`, function () {
+      it('should throw if the address value is an empty string', async function () {
         const blockchair = new BlockchairApi(bitgo, coinName);
         await blockchair.getUnspents('').should.be.rejectedWith('invalid address');
       });


### PR DESCRIPTION
Changes in this PR:

- Bitcoin Cash ABC has been rebranded to eCash. Blockchair has changed the routes related to Bitcoin Cash ABC. Replaced "bitcoin-abc" with "ecash" in blockchair related code and tests

- Fixed a typo in JSDoc comment for the function getUnspentInfoForCrossChainRecovery

- Clean up formatting errors in touched files

Ticket: BG-32764

