### PR TITLE
Add eip1559 params in send/sendMany

### DIFF
--- a/modules/core/src/v2/coins/eth.ts
+++ b/modules/core/src/v2/coins/eth.ts
@@ -108,7 +108,8 @@ interface Recipient {
 
 interface SignFinalOptions {
   txPrebuild: {
-    gasPrice: string;
+    eip1559?: { maxPriorityFeePerGas: number; maxFeePerGas: number };
+    gasPrice?: string;
     gasLimit: string;
     recipients: Recipient[];
     halfSigned: {
@@ -652,6 +653,7 @@ export class Eth extends BaseCoin {
       const signature = Util.ethSignMsgHash(operationHash, Util.xprvToEthPrivateKey(userPrv));
 
       const txParams = {
+        eip1559: params.txPrebuild.eip1559,
         isBatch: params.txPrebuild.isBatch,
         recipients: params.recipients,
         expireTime: expireTime,

--- a/modules/core/src/v2/coins/eth.ts
+++ b/modules/core/src/v2/coins/eth.ts
@@ -612,8 +612,6 @@ export class Eth extends BaseCoin {
     return co<SignedTransaction>(function* () {
       const txPrebuild = params.txPrebuild;
 
-      console.log(txPrebuild);
-
       const userPrv = params.prv;
       const EXPIRETIME_DEFAULT = 60 * 60 * 24 * 7; // This signature will be valid for 1 week
 

--- a/modules/core/src/v2/coins/eth.ts
+++ b/modules/core/src/v2/coins/eth.ts
@@ -611,6 +611,9 @@ export class Eth extends BaseCoin {
     const self = this;
     return co<SignedTransaction>(function* () {
       const txPrebuild = params.txPrebuild;
+
+      console.log(txPrebuild);
+
       const userPrv = params.prv;
       const EXPIRETIME_DEFAULT = 60 * 60 * 24 * 7; // This signature will be valid for 1 week
 

--- a/modules/core/test/v2/unit/coins/eth.ts
+++ b/modules/core/test/v2/unit/coins/eth.ts
@@ -5,6 +5,7 @@ import * as nock from 'nock';
 import * as secp256k1 from 'secp256k1';
 import * as common from '../../../../src/common';
 import * as bitGoUtxoLib from '@bitgo/utxo-lib';
+import * as _ from 'lodash';
 
 nock.enableNetConnect();
 
@@ -37,6 +38,44 @@ describe('ETH:', function () {
   after(function () {
     nock.cleanAll();
   });
+
+  describe('EIP1559', function () {
+    it('should sign a transaction with EIP1559 fee params', async function () {
+      const coin = bitgo.coin('teth');
+
+      const userKeychain = {
+        prv: 'xprv9s21ZrQH143K3hekyNj7TciR4XNYe1kMj68W2ipjJGNHETWP7o42AjDnSPgKhdZ4x8NBAvaL72RrXjuXNdmkMqLERZza73oYugGtbLFXG8g',
+        pub: 'xpub661MyMwAqRbcGBjE5QG7pkf9cZD33UUD6K46q7ELrbuG7FqXfLNGiXYGHeEnGBb5AWREnk1eA28g8ArZvURbhshXWkTtddHRo54fgyVvLdb',
+        rawPub: '023636e68b7b204573abda2616aff6b584910dece2543f1cc6d842caac7d74974b',
+        rawPrv: '7438a50010ce7b1dfd86e68046cc78ba1ebd242d6d85d9904d3fcc08734bc172',
+      };
+
+      const halfSignedTransaction = await coin.signTransaction({
+        txPrebuild: {
+          eip1559: { maxPriorityFeePerGas: 10, maxFeePerGas: 10 },
+          isBatch: false,
+          recipients: [{
+            amount: '42',
+            address: '0xc93b13642d93b4218bb85f67317d6b37286e8028',
+          }],
+          expireTime: 1627949214,
+          contractSequenceId: 12,
+          gasLimit: undefined,
+          gasPrice: undefined,
+          hopTransaction: undefined,
+          backupKeyNonce: undefined,
+          sequenceId: undefined,
+          nextContractSequenceId: 0,
+        },
+        prv: userKeychain.prv,
+      });
+
+      halfSignedTransaction.halfSigned.eip1559.maxPriorityFeePerGas.should.equal(10);
+      halfSignedTransaction.halfSigned.eip1559.maxFeePerGas.should.equal(10);
+
+    });
+  });
+
 
   describe('Transaction Verification', function () {
     it('should verify a normal txPrebuild from the bitgo server that matches the client txParams', async function () {

--- a/modules/core/test/v2/unit/wallet.ts
+++ b/modules/core/test/v2/unit/wallet.ts
@@ -16,13 +16,13 @@ import { TestBitGo } from '../../lib/test_bitgo';
 
 nock.disableNetConnect();
 
-describe('V2 Wallet:', function() {
+describe('V2 Wallet:', function () {
   let bitgo;
   let wallet;
   let bgUrl;
   let basecoin;
 
-  before(async function() {
+  before(async function () {
     bitgo = new TestBitGo({ env: 'test' });
     bitgo.initializeTestVars();
     basecoin = bitgo.coin('tbtc');
@@ -30,30 +30,30 @@ describe('V2 Wallet:', function() {
       id: '5b34252f1bf349930e34020a',
       coin: 'tbtc',
       keys: [
-        '5b3424f91bf349930e340175'
-      ]
+        '5b3424f91bf349930e340175',
+      ],
     };
     wallet = new Wallet(bitgo, basecoin, walletData);
     bgUrl = common.Environments[bitgo.getEnv()].uri;
   });
 
-  describe('Wallet transfers', function() {
-    it('should search in wallet for a transfer', async function() {
+  describe('Wallet transfers', function () {
+    it('should search in wallet for a transfer', async function () {
       const params = { limit: 1, searchLabel: 'test' };
 
       const scope =
         nock(bgUrl)
-        .get(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/transfer`)
-        .query(params)
-        .reply(200, {
-          coin: 'tbch',
-          transfers: [
-            {
-              wallet: wallet.id(),
-              comment: 'tests'
-            }
-          ]
-        });
+          .get(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/transfer`)
+          .query(params)
+          .reply(200, {
+            coin: 'tbch',
+            transfers: [
+              {
+                wallet: wallet.id(),
+                comment: 'tests',
+              },
+            ],
+          });
 
       try {
         await wallet.transfers(params);
@@ -64,7 +64,7 @@ describe('V2 Wallet:', function() {
       scope.isDone().should.be.True();
     });
 
-    it('should forward all valid parameters', async function() {
+    it('should forward all valid parameters', async function () {
       const params = {
         limit: 1,
         address: ['address1', 'address2'],
@@ -76,7 +76,7 @@ describe('V2 Wallet:', function() {
         searchLabel: 'abc',
         includeHex: true,
         type: 'transfer_type',
-        state: 'transfer_state'
+        state: 'transfer_state',
       };
 
       // The actual api request will only send strings, but the SDK function expects numbers for some values
@@ -84,30 +84,30 @@ describe('V2 Wallet:', function() {
 
       const scope =
         nock(bgUrl)
-        .get(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/transfer`)
-        .query(_.matches(apiParams))
-        .reply(200);
+          .get(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/transfer`)
+          .query(_.matches(apiParams))
+          .reply(200);
 
       await wallet.transfers(params);
       scope.isDone().should.be.True();
     });
 
-    it('should accept a string argument for address', async function() {
+    it('should accept a string argument for address', async function () {
       const params = {
         limit: 1,
-        address: 'stringAddress'
+        address: 'stringAddress',
       };
 
       const apiParams = {
         limit: '1',
-        address: 'stringAddress'
+        address: 'stringAddress',
       };
 
       const scope =
         nock(bgUrl)
-        .get(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/transfer`)
-        .query(_.matches(apiParams))
-        .reply(200);
+          .get(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/transfer`)
+          .query(_.matches(apiParams))
+          .reply(200);
 
       try {
         await wallet.transfers(params);
@@ -118,7 +118,7 @@ describe('V2 Wallet:', function() {
       scope.isDone().should.be.True();
     });
 
-    it('should throw errors for invalid expected parameters', async function() {
+    it('should throw errors for invalid expected parameters', async function () {
       (() => {
         wallet.transfers({ address: 13375 });
       }).should.throw('invalid address argument, expecting string or array');
@@ -161,23 +161,23 @@ describe('V2 Wallet:', function() {
     });
   });
 
-  describe('Wallet addresses', function() {
-    it('should search in wallet addresses', async function() {
+  describe('Wallet addresses', function () {
+    it('should search in wallet addresses', async function () {
       const params = { limit: 1, labelContains: 'test' };
 
       const scope =
         nock(bgUrl)
-        .get(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/addresses`)
-        .query(params)
-        .reply(200, {
-          coin: 'tbch',
-          transfers: [
-            {
-              wallet: wallet.id(),
-              comment: 'tests'
-            }
-          ]
-        });
+          .get(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/addresses`)
+          .query(params)
+          .reply(200, {
+            coin: 'tbch',
+            transfers: [
+              {
+                wallet: wallet.id(),
+                comment: 'tests',
+              },
+            ],
+          });
 
       try {
         await wallet.addresses(params);
@@ -222,7 +222,7 @@ describe('V2 Wallet:', function() {
     });
   });
 
-  describe('Transaction Signature Verification', function() {
+  describe('Transaction Signature Verification', function () {
     let wallet;
     let basecoin;
 
@@ -230,13 +230,13 @@ describe('V2 Wallet:', function() {
       prv: 'xprv9s21ZrQH143K3hekyNj7TciR4XNYe1kMj68W2ipjJGNHETWP7o42AjDnSPgKhdZ4x8NBAvaL72RrXjuXNdmkMqLERZza73oYugGtbLFXG8g',
       pub: 'xpub661MyMwAqRbcGBjE5QG7pkf9cZD33UUD6K46q7ELrbuG7FqXfLNGiXYGHeEnGBb5AWREnk1eA28g8ArZvURbhshXWkTtddHRo54fgyVvLdb',
       rawPub: '023636e68b7b204573abda2616aff6b584910dece2543f1cc6d842caac7d74974b',
-      rawPrv: '7438a50010ce7b1dfd86e68046cc78ba1ebd242d6d85d9904d3fcc08734bc172'
+      rawPrv: '7438a50010ce7b1dfd86e68046cc78ba1ebd242d6d85d9904d3fcc08734bc172',
     };
     const backupKeychain = {
       prv: 'xprv9s21ZrQH143K4NtHwJ6oHbJpUiLygwx1xpyD24wwYcVcPZ7LqEGHY58EfT3vgnQWAvkw6AQ4Gnw1fVN4fiem5gjMf4rKHC1HzYRsXERfjVa',
       pub: 'xpub661MyMwAqRbcGrxm3KdoejFZ2kBU6QfsL3topTMZ6x2bGMSVNmaY5sSiWkNNK7QqShEWc5oeLVi74V8oMxr2uhCw1oRWMTCidLuPYVHHLzf',
       rawPub: '03fae58eed086af828279a626ce2ad7ef6424b76fa0fb7e1c8da5a7de222b79203',
-      rawPrv: 'cda3fb304f1e7ac4e599361577767b52c6c04fdea8ca44c0e360e6a0de7027bd'
+      rawPrv: 'cda3fb304f1e7ac4e599361577767b52c6c04fdea8ca44c0e360e6a0de7027bd',
     };
     const prebuild = {
       txHex: '01000000010fef30ca07288fb78659253227b8514ae9397faf76e53530118712d240bfb1060000000000ffffffff02255df4240000000017a9149799c321e46a9c7bb11835495a96d6ae31af36c58780c3c9010000000017a9144394c8c16c50397285830b449ceca588f5f359e98700000000',
@@ -251,25 +251,25 @@ describe('V2 Wallet:', function() {
             redeemScript: '5221032c227d73891b33c45f5f02ab7eebdc4f4ed9ffb5565aedbfb478abb1bfd9d467210266824ac31b6a9d6568c3f7ced9aee1c720cd85994dd41d43dc63b0977195729e21037c07484a5d2d3831d38df1b7b45a2459df6fb40b204bbbf24e0f11763c79a50953ae',
             id: '06b1bf40d21287113035e576af7f39e94a51b82732255986b78f2807ca30ef0f:0',
             address: '2MzKPdDF127CNb5h3g3wNXGD7QMSrobKsvV',
-            value: 650000000
-          }
+            value: 650000000,
+          },
         ],
         changeAddresses: [
-          '2N74pDqYayJq7PhtrvUvrt1t6ZX9C8ogUdk'
-        ]
+          '2N74pDqYayJq7PhtrvUvrt1t6ZX9C8ogUdk',
+        ],
       },
       feeInfo: {
         size: 373,
         fee: 5595,
         feeRate: 15000,
         payGoFee: 0,
-        payGoFeeString: '0'
+        payGoFeeString: '0',
       },
-      walletId: '5a78dd561c6258a907f1eeaee132f796'
+      walletId: '5a78dd561c6258a907f1eeaee132f796',
     };
     const signedTxHex = '02000000010fef30ca07288fb78659253227b8514ae9397faf76e53530118712d240bfb10600000000fdfd00004730440220140811e76ad440c863164a1f9c0956b7a7db17a29f3fe543576dd6279f975243022006ec7def583d18e8ac2de5bb7bf9c647b67d510c07fc7bdc2487ab06f08e3a684147304402205aa8e8646bc5fad6fda5565f8af5e304a5b5b7aa96690dc1562191365ba38a3202205ce0c8a7cbb3448ea4f6f69a8f4a1accae65021a0acc2d90292226c4615bb75b41004c695221032c227d73891b33c45f5f02ab7eebdc4f4ed9ffb5565aedbfb478abb1bfd9d467210266824ac31b6a9d6568c3f7ced9aee1c720cd85994dd41d43dc63b0977195729e21037c07484a5d2d3831d38df1b7b45a2459df6fb40b204bbbf24e0f11763c79a50953aeffffffff02255df4240000000017a9149799c321e46a9c7bb11835495a96d6ae31af36c58780c3c9010000000017a9144394c8c16c50397285830b449ceca588f5f359e98700000000';
 
-    before(async function() {
+    before(async function () {
       basecoin = bitgo.coin('tbch');
       const walletData = {
         id: '5a78dd561c6258a907f1eeaee132f796',
@@ -279,9 +279,9 @@ describe('V2 Wallet:', function() {
             permissions: [
               'admin',
               'view',
-              'spend'
-            ]
-          }
+              'spend',
+            ],
+          },
         ],
         coin: 'tbch',
         label: 'Signature Verification Wallet',
@@ -290,10 +290,10 @@ describe('V2 Wallet:', function() {
         keys: [
           '5a78dd56bfe424aa07aa068651b194fd',
           '5a78dd5674a70eb4079f58797dfe2f5e',
-          '5a78dd561c6258a907f1eea9f1d079e2'
+          '5a78dd561c6258a907f1eea9f1d079e2',
         ],
         tags: [
-          '5a78dd561c6258a907f1eeaee132f796'
+          '5a78dd561c6258a907f1eeaee132f796',
         ],
         disableTransactionNotifications: false,
         freeze: {},
@@ -307,8 +307,8 @@ describe('V2 Wallet:', function() {
             version: 0,
             date: '2018-02-05T22:40:22.761Z',
             mutableUpToDate: '2018-02-07T22:40:22.761Z',
-            rules: []
-          }
+            rules: [],
+          },
         },
         clientFlags: [],
         balance: 650000000,
@@ -325,31 +325,31 @@ describe('V2 Wallet:', function() {
           coin: 'tbch',
           wallet: '5a78dd561c6258a907f1eeaee132f796',
           coinSpecific: {
-            redeemScript: '52210276cfa62b997cb3a9c53579a31bf004af4aab070343800285ee737da175c9af1121028cd41b3df3ad36256da33f470bd75d9b70f05d4f10351a2c9fc5d37d94c9909921038b919223eba3ab96f189465b1cb1904b9eaafa2cbe428d14a918fca659aa136a53ae'
-          }
+            redeemScript: '52210276cfa62b997cb3a9c53579a31bf004af4aab070343800285ee737da175c9af1121028cd41b3df3ad36256da33f470bd75d9b70f05d4f10351a2c9fc5d37d94c9909921038b919223eba3ab96f189465b1cb1904b9eaafa2cbe428d14a918fca659aa136a53ae',
+          },
         },
-        pendingApprovals: []
+        pendingApprovals: [],
       };
       wallet = new Wallet(bitgo, basecoin, walletData);
     });
 
-    it('should sign a prebuild', async function() {
+    it('should sign a prebuild', async function () {
       // sign transaction
       const halfSignedTransaction = await wallet.signTransaction({
         txPrebuild: prebuild,
-        prv: userKeychain.prv
+        prv: userKeychain.prv,
       });
       halfSignedTransaction.txHex.should.equal('02000000010fef30ca07288fb78659253227b8514ae9397faf76e53530118712d240bfb10600000000b6004730440220140811e76ad440c863164a1f9c0956b7a7db17a29f3fe543576dd6279f975243022006ec7def583d18e8ac2de5bb7bf9c647b67d510c07fc7bdc2487ab06f08e3a684100004c695221032c227d73891b33c45f5f02ab7eebdc4f4ed9ffb5565aedbfb478abb1bfd9d467210266824ac31b6a9d6568c3f7ced9aee1c720cd85994dd41d43dc63b0977195729e21037c07484a5d2d3831d38df1b7b45a2459df6fb40b204bbbf24e0f11763c79a50953aeffffffff02255df4240000000017a9149799c321e46a9c7bb11835495a96d6ae31af36c58780c3c9010000000017a9144394c8c16c50397285830b449ceca588f5f359e98700000000');
 
       prebuild.txHex = halfSignedTransaction.txHex;
       const signedTransaction = await wallet.signTransaction({
         txPrebuild: prebuild,
-        prv: backupKeychain.prv
+        prv: backupKeychain.prv,
       });
       signedTransaction.txHex.should.equal(signedTxHex);
     });
 
-    it('should verify a signed transaction', async function() {
+    it('should verify a signed transaction', async function () {
       const unspent = prebuild.txInfo.unspents[0];
       const signedTransaction = bitcoin.Transaction.fromHex(signedTxHex);
       const areSignaturesValid = basecoin.verifySignature(signedTransaction, 0, unspent.value);
@@ -388,79 +388,95 @@ describe('V2 Wallet:', function() {
       isMismappedPublicKeySignatureValid.should.equal(false);
     });
 
-    it('should error when amount is zero', async function() {
+    it('should error eip1559 and gasPrice are passed', async function () {
+      const params = {
+        gasPrice: 100,
+        eip1559: {
+          maxPriorityFeePerGas: 10,
+          maxFeePerGas: 10,
+        },
+        amount: 10,
+        address: TestBitGo.V2.TEST_WALLET1_ADDRESS,
+        walletPassphrase: TestBitGo.V2.TEST_WALLET1_PASSCODE,
+      };
+      const error = await bitgo.getAsyncError(wallet.send(params));
+      should.exist(error);
+    });
+
+
+    it('should error when amount is zero', async function () {
       const params = {
         amount: 0,
         address: TestBitGo.V2.TEST_WALLET1_ADDRESS,
-        walletPassphrase: TestBitGo.V2.TEST_WALLET1_PASSCODE
+        walletPassphrase: TestBitGo.V2.TEST_WALLET1_PASSCODE,
       };
       (() => wallet.send(params)).should.throw(Error);
     });
 
-    it('should error when amount is negative', async function() {
+    it('should error when amount is negative', async function () {
       const params = {
         amount: -1,
         address: TestBitGo.V2.TEST_WALLET1_ADDRESS,
-        walletPassphrase: TestBitGo.V2.TEST_WALLET1_PASSCODE
+        walletPassphrase: TestBitGo.V2.TEST_WALLET1_PASSCODE,
       };
       (() => wallet.send(params)).should.throw(Error);
     });
 
-    it('should error when send many and amount is zero', async function() {
+    it('should error when send many and amount is zero', async function () {
       const params = {
         recipients: [{
           address: TestBitGo.V2.TEST_WALLET1_ADDRESS,
-          amount: 0
+          amount: 0,
         }, {
           address: TestBitGo.V2.TEST_WALLET2_ADDRESS,
-          amount: 10
+          amount: 10,
         }],
-        walletPassphrase: TestBitGo.V2.TEST_WALLET1_PASSCODE
+        walletPassphrase: TestBitGo.V2.TEST_WALLET1_PASSCODE,
       };
       const error = await bitgo.getAsyncError(wallet.sendMany(params));
       should.exist(error);
     });
 
-    it('should error when send many and amount is negative', async function() {
+    it('should error when send many and amount is negative', async function () {
       const params = {
         recipients: [{
           address: TestBitGo.V2.TEST_WALLET1_ADDRESS,
-          amount: 10
+          amount: 10,
         }, {
           address: TestBitGo.V2.TEST_WALLET2_ADDRESS,
-          amount: -1
+          amount: -1,
         }],
-        walletPassphrase: TestBitGo.V2.TEST_WALLET1_PASSCODE
+        walletPassphrase: TestBitGo.V2.TEST_WALLET1_PASSCODE,
       };
       const error = await bitgo.getAsyncError(wallet.sendMany(params));
       should.exist(error);
     });
   });
 
-  describe('Wallet Transactions', function() {
+  describe('Wallet Transactions', function () {
     let ethWallet;
 
-    before(async function() {
+    before(async function () {
       const walletData = {
         id: '598f606cd8fc24710d2ebadb1d9459bb',
         coin: 'teth',
         keys: [
           '598f606cd8fc24710d2ebad89dce86c2',
           '598f606cc8e43aef09fcb785221d9dd2',
-          '5935d59cf660764331bafcade1855fd7'
-        ]
+          '5935d59cf660764331bafcade1855fd7',
+        ],
       };
       ethWallet = new Wallet(bitgo, bitgo.coin('teth'), walletData);
     });
 
-    it('should search for pending transaction correctly', async function() {
+    it('should search for pending transaction correctly', async function () {
       const params = { walletId: wallet.id() };
 
       const scope =
         nock(bgUrl)
-        .get(`/api/v2/${wallet.coin()}/tx/pending/first`)
-        .query(params)
-        .reply(200);
+          .get(`/api/v2/${wallet.coin()}/tx/pending/first`)
+          .query(params)
+          .reply(200);
       try {
         await wallet.getFirstPendingTransaction();
         throw '';
@@ -470,13 +486,13 @@ describe('V2 Wallet:', function() {
       scope.isDone().should.be.True();
     });
 
-    it('should try to change the fee correctly', async function() {
+    it('should try to change the fee correctly', async function () {
       const params = { txid: '0xffffffff', fee: '10000000' };
 
       const scope =
         nock(bgUrl)
-        .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/changeFee`, params)
-        .reply(200);
+          .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/changeFee`, params)
+          .reply(200);
 
       try {
         await wallet.changeFee({ txid: '0xffffffff', fee: '10000000' });
@@ -487,17 +503,17 @@ describe('V2 Wallet:', function() {
       scope.isDone().should.be.True();
     });
 
-    it('should pass data parameter and amount: 0 when using sendTransaction', async function() {
+    it('should pass data parameter and amount: 0 when using sendTransaction', async function () {
       const path = `/api/v2/${ethWallet.coin()}/wallet/${ethWallet.id()}/tx/build`;
       const recipientAddress = '0x7db562c4dd465cc895761c56f83b6af0e32689ba';
       const recipients = [{
         address: recipientAddress,
         amount: 0,
-        data: '0x00110011'
+        data: '0x00110011',
       }];
       const response = nock(bgUrl)
-      .post(path, _.matches({ recipients })) // use _.matches to do a partial match on request body object instead of strict matching
-      .reply(200);
+        .post(path, _.matches({ recipients })) // use _.matches to do a partial match on request body object instead of strict matching
+        .reply(200);
 
       try {
         await ethWallet.send({ address: recipients[0].address, data: recipients[0].data, amount: recipients[0].amount });
@@ -507,17 +523,17 @@ describe('V2 Wallet:', function() {
       response.isDone().should.be.true();
     });
 
-    it('should pass data parameter and amount: 0 when using sendMany', async function() {
+    it('should pass data parameter and amount: 0 when using sendMany', async function () {
       const path = `/api/v2/${ethWallet.coin()}/wallet/${ethWallet.id()}/tx/build`;
       const recipientAddress = '0x7db562c4dd465cc895761c56f83b6af0e32689ba';
       const recipients = [{
         address: recipientAddress,
         amount: 0,
-        data: '0x00110011'
+        data: '0x00110011',
       }];
       const response = nock(bgUrl)
-      .post(path, _.matches({ recipients })) // use _.matches to do a partial match on request body object instead of strict matching
-      .reply(200);
+        .post(path, _.matches({ recipients })) // use _.matches to do a partial match on request body object instead of strict matching
+        .reply(200);
 
       try {
         await ethWallet.sendMany({ recipients });
@@ -529,7 +545,7 @@ describe('V2 Wallet:', function() {
   });
 
   describe('Create Address', () => {
-    it('should correctly validate arguments to create address', async function() {
+    it('should correctly validate arguments to create address', async function () {
       let message = 'gasPrice has to be an integer or numeric string';
       await wallet.createAddress({ gasPrice: {} }).should.be.rejectedWith(message);
       await wallet.createAddress({ gasPrice: 'abc' }).should.be.rejectedWith(message);
@@ -550,59 +566,59 @@ describe('V2 Wallet:', function() {
     });
   });
 
-  describe('Accelerate Transaction', function() {
-    it('fails if cpfpTxIds is not passed', async function() {
+  describe('Accelerate Transaction', function () {
+    it('fails if cpfpTxIds is not passed', async function () {
       await wallet.accelerateTransaction({})
-      .should.be.rejectedWith({ code: 'cpfptxids_not_array' });
+        .should.be.rejectedWith({ code: 'cpfptxids_not_array' });
     });
 
-    it('fails if cpfpTxIds is not an array', async function() {
+    it('fails if cpfpTxIds is not an array', async function () {
       await wallet.accelerateTransaction({ cpfpTxIds: {} })
-      .should.be.rejectedWith({ code: 'cpfptxids_not_array' });
+        .should.be.rejectedWith({ code: 'cpfptxids_not_array' });
     });
 
-    it('fails if cpfpTxIds is not of length 1', async function() {
+    it('fails if cpfpTxIds is not of length 1', async function () {
       await wallet.accelerateTransaction({ cpfpTxIds: [] })
-      .should.be.rejectedWith({ code: 'cpfptxids_not_array' });
+        .should.be.rejectedWith({ code: 'cpfptxids_not_array' });
       await wallet.accelerateTransaction({ cpfpTxIds: ['id1', 'id2'] })
-      .should.be.rejectedWith({ code: 'cpfptxids_not_array' });
+        .should.be.rejectedWith({ code: 'cpfptxids_not_array' });
     });
 
-    it('fails if cpfpFeeRate is not passed and neither is noCpfpFeeRate', async function() {
+    it('fails if cpfpFeeRate is not passed and neither is noCpfpFeeRate', async function () {
       await wallet.accelerateTransaction({ cpfpTxIds: ['id'] })
-      .should.be.rejectedWith({ code: 'cpfpfeerate_not_set' });
+        .should.be.rejectedWith({ code: 'cpfpfeerate_not_set' });
     });
 
-    it('fails if cpfpFeeRate is not an integer', async function() {
+    it('fails if cpfpFeeRate is not an integer', async function () {
       await wallet.accelerateTransaction({ cpfpTxIds: ['id'], cpfpFeeRate: 'one' })
-      .should.be.rejectedWith({ code: 'cpfpfeerate_not_nonnegative_integer' });
+        .should.be.rejectedWith({ code: 'cpfpfeerate_not_nonnegative_integer' });
     });
 
-    it('fails if cpfpFeeRate is negative', async function() {
+    it('fails if cpfpFeeRate is negative', async function () {
       await wallet.accelerateTransaction({ cpfpTxIds: ['id'], cpfpFeeRate: -1 })
-      .should.be.rejectedWith({ code: 'cpfpfeerate_not_nonnegative_integer' });
+        .should.be.rejectedWith({ code: 'cpfpfeerate_not_nonnegative_integer' });
     });
 
-    it('fails if maxFee is not passed and neither is noMaxFee', async function() {
+    it('fails if maxFee is not passed and neither is noMaxFee', async function () {
       await wallet.accelerateTransaction({ cpfpTxIds: ['id'], noCpfpFeeRate: true })
-      .should.be.rejectedWith({ code: 'maxfee_not_set' });
+        .should.be.rejectedWith({ code: 'maxfee_not_set' });
     });
 
-    it('fails if maxFee is not an integer', async function() {
+    it('fails if maxFee is not an integer', async function () {
       await wallet.accelerateTransaction({ cpfpTxIds: ['id'], noCpfpFeeRate: true, maxFee: 'one' })
-      .should.be.rejectedWith({ code: 'maxfee_not_nonnegative_integer' });
+        .should.be.rejectedWith({ code: 'maxfee_not_nonnegative_integer' });
     });
 
-    it('fails if maxFee is negative', async function() {
+    it('fails if maxFee is negative', async function () {
       await wallet.accelerateTransaction({ cpfpTxIds: ['id'], noCpfpFeeRate: true, maxFee: -1 })
-      .should.be.rejectedWith({ code: 'maxfee_not_nonnegative_integer' });
+        .should.be.rejectedWith({ code: 'maxfee_not_nonnegative_integer' });
     });
 
-    it('submits a transaction with all cpfp specific parameters', async function() {
+    it('submits a transaction with all cpfp specific parameters', async function () {
       const params = {
         cpfpTxIds: ['id'],
         cpfpFeeRate: 1,
-        maxFee: 1
+        maxFee: 1,
       };
 
       const prebuildReturn = Object.assign({ txHex: '123' }, params);
@@ -610,8 +626,8 @@ describe('V2 Wallet:', function() {
 
       const path = `/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/send`;
       nock(bgUrl)
-      .post(path, _.matches(prebuildReturn))
-      .reply(200);
+        .post(path, _.matches(prebuildReturn))
+        .reply(200);
 
       await wallet.accelerateTransaction(params);
 
@@ -621,30 +637,30 @@ describe('V2 Wallet:', function() {
     });
   });
 
-  describe('maxNumInputsToUse verification', function() {
+  describe('maxNumInputsToUse verification', function () {
     const address = '5b34252f1bf349930e34020a';
     const maxNumInputsToUse = 2;
     let basecoin;
     let wallet;
 
-    before(async function() {
+    before(async function () {
       basecoin = bitgo.coin('tbtc');
       const walletData = {
         id: '5b34252f1bf349930e34020a',
         coin: 'tbtc',
         keys: [
-          '5b3424f91bf349930e340175'
-        ]
+          '5b3424f91bf349930e340175',
+        ],
       };
       wallet = new Wallet(bitgo, basecoin, walletData);
     });
 
 
-    it('should pass maxNumInputsToUse parameter when calling fanout unspents', async function() {
+    it('should pass maxNumInputsToUse parameter when calling fanout unspents', async function () {
       const path = `/api/v2/${wallet.coin()}/wallet/${wallet.id()}/fanoutUnspents`;
       const response = nock(bgUrl)
-          .post(path, _.matches({ maxNumInputsToUse })) // use _.matches to do a partial match on request body object instead of strict matching
-          .reply(200);
+        .post(path, _.matches({ maxNumInputsToUse })) // use _.matches to do a partial match on request body object instead of strict matching
+        .reply(200);
 
       try {
         await wallet.fanoutUnspents({ address, maxNumInputsToUse });
@@ -657,33 +673,33 @@ describe('V2 Wallet:', function() {
     });
   });
 
-  describe('maxFeeRate verification', function() {
+  describe('maxFeeRate verification', function () {
     const address = '5b34252f1bf349930e34020a';
     const recipients = [{
       address,
-      amount: 0
+      amount: 0,
     }];
     const maxFeeRate = 10000;
     let basecoin;
     let wallet;
 
-    before(async function() {
+    before(async function () {
       basecoin = bitgo.coin('tbtc');
       const walletData = {
         id: '5b34252f1bf349930e34020a',
         coin: 'tbtc',
         keys: [
-          '5b3424f91bf349930e340175'
-        ]
+          '5b3424f91bf349930e340175',
+        ],
       };
       wallet = new Wallet(bitgo, basecoin, walletData);
     });
 
-    it('should pass maxFeeRate parameter when building transactions', async function() {
+    it('should pass maxFeeRate parameter when building transactions', async function () {
       const path = `/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/build`;
       const response = nock(bgUrl)
-      .post(path, _.matches({ recipients, maxFeeRate })) // use _.matches to do a partial match on request body object instead of strict matching
-      .reply(200);
+        .post(path, _.matches({ recipients, maxFeeRate })) // use _.matches to do a partial match on request body object instead of strict matching
+        .reply(200);
 
       try {
         await wallet.prebuildTransaction({ recipients, maxFeeRate });
@@ -695,15 +711,15 @@ describe('V2 Wallet:', function() {
       response.isDone().should.be.true();
     });
 
-    it('should pass maxFeeRate parameter when consolidating unspents', async function() {
+    it('should pass maxFeeRate parameter when consolidating unspents', async function () {
       const path = `/api/v2/${wallet.coin()}/wallet/${wallet.id()}/consolidateUnspents`;
       const response = nock(bgUrl)
-      .post(path, _.matches({ maxFeeRate })) // use _.matches to do a partial match on request body object instead of strict matching
-      .reply(200);
+        .post(path, _.matches({ maxFeeRate })) // use _.matches to do a partial match on request body object instead of strict matching
+        .reply(200);
 
       nock(bgUrl)
-      .get(`/api/v2/${wallet.coin()}/key/${wallet.keyIds()[0]}`)
-      .reply(200);
+        .get(`/api/v2/${wallet.coin()}/key/${wallet.keyIds()[0]}`)
+        .reply(200);
 
       try {
         await wallet.consolidateUnspents({ recipients, maxFeeRate });
@@ -715,11 +731,11 @@ describe('V2 Wallet:', function() {
       response.isDone().should.be.true();
     });
 
-    it('should pass maxFeeRate parameter when calling sweep wallets', async function() {
+    it('should pass maxFeeRate parameter when calling sweep wallets', async function () {
       const path = `/api/v2/${wallet.coin()}/wallet/${wallet.id()}/sweepWallet`;
       const response = nock(bgUrl)
-      .post(path, _.matches({ address, maxFeeRate })) // use _.matches to do a partial match on request body object instead of strict matching
-      .reply(200);
+        .post(path, _.matches({ address, maxFeeRate })) // use _.matches to do a partial match on request body object instead of strict matching
+        .reply(200);
 
       try {
         await wallet.sweep({ address, maxFeeRate });
@@ -731,11 +747,11 @@ describe('V2 Wallet:', function() {
       response.isDone().should.be.true();
     });
 
-    it('should pass maxFeeRate parameter when calling fanout unspents', async function() {
+    it('should pass maxFeeRate parameter when calling fanout unspents', async function () {
       const path = `/api/v2/${wallet.coin()}/wallet/${wallet.id()}/fanoutUnspents`;
       const response = nock(bgUrl)
-      .post(path, _.matches({ maxFeeRate })) // use _.matches to do a partial match on request body object instead of strict matching
-      .reply(200);
+        .post(path, _.matches({ maxFeeRate })) // use _.matches to do a partial match on request body object instead of strict matching
+        .reply(200);
 
       try {
         await wallet.fanoutUnspents({ address, maxFeeRate });
@@ -748,13 +764,13 @@ describe('V2 Wallet:', function() {
     });
   });
 
-  describe('allowPartialSweep verification', function() {
+  describe('allowPartialSweep verification', function () {
     const address = '5b34252f1bf349930e34020a';
     const allowPartialSweep = true;
     let basecoin;
     let wallet;
 
-    before(async function() {
+    before(async function () {
       basecoin = bitgo.coin('tbtc');
       const walletData = {
         id: '5b34252f1bf349930e34020a',
@@ -764,11 +780,11 @@ describe('V2 Wallet:', function() {
       wallet = new Wallet(bitgo, basecoin, walletData);
     });
 
-    it('should pass allowPartialSweep parameter when calling sweep wallets', async function() {
+    it('should pass allowPartialSweep parameter when calling sweep wallets', async function () {
       const path = `/api/v2/${wallet.coin()}/wallet/${wallet.id()}/sweepWallet`;
       const response = nock(bgUrl)
-          .post(path, _.matches({ address, allowPartialSweep })) // use _.matches to do a partial match on request body object instead of strict matching
-          .reply(200);
+        .post(path, _.matches({ address, allowPartialSweep })) // use _.matches to do a partial match on request body object instead of strict matching
+        .reply(200);
 
       try {
         await wallet.sweep({ address, allowPartialSweep });
@@ -781,8 +797,8 @@ describe('V2 Wallet:', function() {
     });
   });
 
-  describe('Transaction prebuilds', function() {
-    it('should pass offlineVerification=true query param if passed truthy value', async function() {
+  describe('Transaction prebuilds', function () {
+    it('should pass offlineVerification=true query param if passed truthy value', async function () {
       const params = { offlineVerification: true };
       const scope = nock(bgUrl)
         .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/build`)
@@ -803,7 +819,7 @@ describe('V2 Wallet:', function() {
       postProcessStub.restore();
     });
 
-    it('should not pass the offlineVerification query param if passed a falsey value', async function() {
+    it('should not pass the offlineVerification query param if passed a falsey value', async function () {
       const params = { offlineVerification: false };
       nock(bgUrl)
         .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/build`)
@@ -823,12 +839,12 @@ describe('V2 Wallet:', function() {
       postProcessStub.restore();
     });
 
-    it('prebuild should call build and getLatestBlockHeight for utxo coins', async function() {
+    it('prebuild should call build and getLatestBlockHeight for utxo coins', async function () {
       const params = {};
       nock(bgUrl)
-      .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/build`)
-      .query(params)
-      .reply(200, {});
+        .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/build`)
+        .query(params)
+        .reply(200, {});
       const blockHeight = 100;
       const blockHeightStub = sinon.stub(basecoin, 'getLatestBlockHeight').resolves(blockHeight);
       const postProcessStub = sinon.stub(basecoin, 'postProcessPrebuild').resolves({});
@@ -843,22 +859,22 @@ describe('V2 Wallet:', function() {
       postProcessStub.restore();
     });
 
-    it('prebuild should call build but not getLatestBlockHeight for account coins', async function() {
-      ['txrp', 'txlm', 'teth'].forEach(async function(coin) {
+    it('prebuild should call build but not getLatestBlockHeight for account coins', async function () {
+      ['txrp', 'txlm', 'teth'].forEach(async function (coin) {
         const accountcoin = bitgo.coin(coin);
         const walletData = {
           id: '5b34252f1bf349930e34021a',
           coin,
           keys: [
-            '5b3424f91bf349930e340175'
-          ]
+            '5b3424f91bf349930e340175',
+          ],
         };
         const accountWallet = new Wallet(bitgo, accountcoin, walletData);
         const params = {};
         nock(bgUrl)
-        .post(`/api/v2/${accountWallet.coin()}/wallet/${accountWallet.id()}/tx/build`)
-        .query(params)
-        .reply(200, {});
+          .post(`/api/v2/${accountWallet.coin()}/wallet/${accountWallet.id()}/tx/build`)
+          .query(params)
+          .reply(200, {});
         const postProcessStub = sinon.stub(accountcoin, 'postProcessPrebuild').resolves({});
         await accountWallet.prebuildTransaction(params);
         postProcessStub.should.have.been.calledOnceWith({
@@ -869,7 +885,7 @@ describe('V2 Wallet:', function() {
       });
     });
 
-    it('should pass unspent reservation parameter through when building transactions', async function() {
+    it('should pass unspent reservation parameter through when building transactions', async function () {
       const reservation = {
         expireTime: '2029-08-12',
       };
@@ -895,12 +911,12 @@ describe('V2 Wallet:', function() {
   describe('Maximum Spendable', function maximumSpendable() {
     let bgUrl;
 
-    before(async function() {
+    before(async function () {
       nock.pendingMocks().should.be.empty();
       bgUrl = common.Environments[bitgo.getEnv()].uri;
     });
 
-    it('arguments', async function() {
+    it('arguments', async function () {
       const optionalParams = {
         limit: '25',
         minValue: '0',
@@ -910,7 +926,7 @@ describe('V2 Wallet:', function() {
         enforceMinConfirmsForChange: 'false',
         feeRate: '10000',
         maxFeeRate: '100000',
-        recipientAddress: '2NCUFDLiUz9CVnmdVqQe9acVonoM89e76df'
+        recipientAddress: '2NCUFDLiUz9CVnmdVqQe9acVonoM89e76df',
       };
 
       const path = `/api/v2/${wallet.coin()}/wallet/${wallet.id()}/maximumSpendable`;
@@ -919,7 +935,7 @@ describe('V2 Wallet:', function() {
         .query(_.matches(optionalParams)) // use _.matches to do a partial match on request body object instead of strict matching
         .reply(200, {
           coin: 'tbch',
-          maximumSpendable: 65000
+          maximumSpendable: 65000,
         });
 
       try {
@@ -932,23 +948,23 @@ describe('V2 Wallet:', function() {
     });
   });
 
-  describe('Wallet Sharing', function() {
-    it('should share to cold wallet without passing skipKeychain', async function() {
+  describe('Wallet Sharing', function () {
+    it('should share to cold wallet without passing skipKeychain', async function () {
       const userId = '123';
       const email = 'shareto@sdktest.com';
       const permissions = 'view,spend';
 
       const getSharingKeyNock = nock(bgUrl)
-      .post('/api/v1/user/sharingkey', { email })
-      .reply(200, { userId });
+        .post('/api/v1/user/sharingkey', { email })
+        .reply(200, { userId });
 
       const getKeyNock = nock(bgUrl)
-      .get(`/api/v2/tbtc/key/${wallet._wallet.keys[0]}`)
-      .reply(200, {});
+        .get(`/api/v2/tbtc/key/${wallet._wallet.keys[0]}`)
+        .reply(200, {});
 
       const createShareNock = nock(bgUrl)
-      .post(`/api/v2/tbtc/wallet/${wallet._wallet.id}/share`, { user: userId, permissions, keychain: {} })
-      .reply(200, {});
+        .post(`/api/v2/tbtc/wallet/${wallet._wallet.id}/share`, { user: userId, permissions, keychain: {} })
+        .reply(200, {});
 
       await wallet.shareWallet({ email, permissions });
 
@@ -958,13 +974,13 @@ describe('V2 Wallet:', function() {
     });
   });
 
-  describe('Wallet Freezing', function() {
-    it('should freeze wallet for specified duration in seconds', async function() {
+  describe('Wallet Freezing', function () {
+    it('should freeze wallet for specified duration in seconds', async function () {
       const params = { duration: 60 };
       const scope =
         nock(bgUrl)
-        .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/freeze`, params)
-        .reply(200, {});
+          .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/freeze`, params)
+          .reply(200, {});
       await wallet.freeze(params);
       scope.isDone().should.be.True();
     });


### PR DESCRIPTION
Adds eip1559 params to send/sendMany routes. If we pass in the new params it will pass it /build and insert the new params as part of the halfSignedTx body to /send route.

Throws an error if a user passes both `gasPrice` and `eip1559` params