### PR TITLE
fix(core): fix verify sign parameters for Algorand

### DIFF
--- a/modules/core/src/v2/coins/algo.ts
+++ b/modules/core/src/v2/coins/algo.ts
@@ -328,9 +328,13 @@ export class Algo extends BaseCoin {
       throw new Error('missing addressVersion parameter to sign transaction');
     }
 
-    const signers = params.txPrebuild.keys.map((key) =>
-      accountLib.Algo.algoUtils.publicKeyToAlgoAddress(accountLib.Algo.algoUtils.toUint8Array(key))
-    );
+    const signers = params.txPrebuild.keys.map((key) => {
+      // if we are receiving addresses do not try to convert them
+      if (!accountLib.Algo.algoUtils.isValidAddress(key)) {
+        return accountLib.Algo.algoUtils.publicKeyToAlgoAddress(accountLib.Algo.algoUtils.toUint8Array(key));
+      }
+      return key;
+    });
     const numberSigners = signers.length;
     return { txHex, addressVersion, signers, prv, isHalfSigned, numberSigners };
   }

--- a/modules/core/test/v2/unit/coins/algo.ts
+++ b/modules/core/test/v2/unit/coins/algo.ts
@@ -302,7 +302,7 @@ describe('ALGO:', function () {
       txBuilder.sign({ key: AlgoResources.accounts.account1.secretKey.toString('hex') });
       return await txBuilder.build();
     };
-    
+
     it('should explain an unsigned asset transfer transaction hex', async function () {
       const explain = await basecoin.explainTransaction({
         txHex: AlgoResources.explainRawTx.assetTransfer.unsigned,
@@ -594,6 +594,42 @@ describe('ALGO:', function () {
             txHex: AlgoResources.rawTx.transfer.halfSigned,
           },
           keys: [AlgoResources.accounts.account1.pubKey.toString('hex'), AlgoResources.accounts.account3.pubKey.toString('hex')],
+          addressVersion: 1,
+        },
+        prv: AlgoResources.accounts.account3.secretKey.toString('hex'),
+      });
+      signed.txHex.should.equal(AlgoResources.rawTx.transfer.multisig);
+    });
+
+    it('should verify sign params if the key array contains addresses', function () {
+      const keys = [
+        AlgoResources.accounts.account1.address,
+        AlgoResources.accounts.account2.address,
+        AlgoResources.accounts.account3.address,
+      ];
+
+      const verifiedParams = basecoin.verifySignTransactionParams({
+        txPrebuild: {
+          txHex: AlgoResources.rawTx.transfer.unsigned,
+          keys,
+          addressVersion: 1,
+        },
+        prv: AlgoResources.accounts.account2.secretKey.toString('hex'),
+      });
+      verifiedParams.should.have.properties(['txHex', 'addressVersion', 'signers', 'prv', 'isHalfSigned', 'numberSigners']);
+      const { txHex, signers, isHalfSigned } = verifiedParams;
+      txHex.should.be.equal(AlgoResources.rawTx.transfer.unsigned);
+      signers.should.be.deepEqual(keys);
+      isHalfSigned.should.be.equal(false);
+    });
+
+    it('should sign half signed transaction if the key array contains addresses', async function () {
+      const signed = await basecoin.signTransaction({
+        txPrebuild: {
+          halfSigned: {
+            txHex: AlgoResources.rawTx.transfer.halfSigned,
+          },
+          keys: [AlgoResources.accounts.account1.address, AlgoResources.accounts.account3.address],
           addressVersion: 1,
         },
         prv: AlgoResources.accounts.account3.secretKey.toString('hex'),


### PR DESCRIPTION
Wallet platform is returning addresses within the pubs array and this causes an error when we try to sign a tx. This fix should allow us to sign and send enable token transactions.

[STLX-5074](https://bitgoinc.atlassian.net/browse/STLX-5074)