### PR TITLE
fix(core): request body not being included in HMAC

### DIFF
--- a/modules/core/test/unit/bitgo.ts
+++ b/modules/core/test/unit/bitgo.ts
@@ -452,6 +452,29 @@ describe('BitGo Prototype Methods', function() {
       responseData.isValid.should.equal(true);
     }));
 
+    it('should include request body as part of the hmac', co(function* () {
+      const url = 'https://bitgo.fakeurl';
+      const body = { test: 'test' };
+
+      const fixedUnixTime = 1627374646;
+      const originalDateNow = Date.now;
+      Date.now = () => fixedUnixTime;
+
+      try {
+        nock(url)
+          .post('/', body)
+          .reply(201, undefined, {
+            hmac: '677e0c9a65ca384415945cb19b40ae38eaadfbce3ccce8c5d7bf37c1973b2553',
+            timestamp: String(fixedUnixTime),
+          });
+
+        const resp = (yield bitgo.post(url).send(body)) as any;
+        resp.req.headers['hmac'].should.equal('4425a4004ef2724add25b4dd019d21c66394653a049d82e37df3a2c356b5706d');
+      } finally {
+        Date.now = originalDateNow;
+      }
+    }));
+
     it('should recognize trailing slash inconsistency', () => {
       const verificationParams = {
         url: 'https://google.com/api',


### PR DESCRIPTION
The request body for an authenticated request was always `undefined`because it wasn't wrapped in the `then` callback of the request. This fixes that.

ticket: BG-34460