### PR TITLE
fix(core): ignore typescript errors from incompatible `@types/ethereumjs-util`

### DIFF
--- a/modules/core/src/v2/coins/eth2.ts
+++ b/modules/core/src/v2/coins/eth2.ts
@@ -3,7 +3,7 @@
  */
 import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
-import { stripHexPrefix } from 'ethereumjs-utils-old';
+import * as ethUtil from 'ethereumjs-util';
 import * as request from 'superagent';
 import { Eth2 as Eth2AccountLib } from '@bitgo/account-lib';
 import BigNumber from 'bignumber.js';
@@ -358,7 +358,9 @@ export class Eth2 extends BaseCoin {
       let messageToSign: Buffer = Buffer.from(message);
       if (Eth2AccountLib.KeyPair.isValidPub(message)) {
         // if we are doing a key signature, we should decode the message as a hex string
-        messageToSign = Buffer.from(stripHexPrefix(message), 'hex');
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore BG-34579: known compatibility issue with @types/ethereumjs-util
+        messageToSign = Buffer.from(ethUtil.stripHexPrefix(message), 'hex');
       }
 
       return keyPair.sign(messageToSign);

--- a/modules/core/test/v2/unit/coins/abstractEthCoin.ts
+++ b/modules/core/test/v2/unit/coins/abstractEthCoin.ts
@@ -7,7 +7,7 @@ import * as should from 'should';
 import { TestBitGo } from '../../../lib/test_bitgo';
 import { getBuilder, BaseCoin, Eth } from '@bitgo/account-lib';
 import * as ethAbi from 'ethereumjs-abi';
-import * as ethUtil from 'ethereumjs-utils-old';
+import * as ethUtil from 'ethereumjs-util';
 import * as bitgoUtxoLib from '@bitgo/utxo-lib';
 import * as bitcoinMessage from 'bitcoinjs-message';
 import { coins, ContractAddressDefinedToken } from '@bitgo/statics';
@@ -49,8 +49,12 @@ describe('ETH-like coins', () => {
               ['string', 'address', 'uint', 'address', 'uint', 'uint'],
               [
                 signatureSaltMap.token[coinName],
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore BG-34579: known compatibility issue with @types/ethereumjs-util
                 new ethUtil.BN(ethUtil.stripHexPrefix(to), 16),
                 amount,
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore BG-34579: known compatibility issue with @types/ethereumjs-util
                 new ethUtil.BN(ethUtil.stripHexPrefix(tokenContractAddress), 16),
                 expireTime,
                 sequenceId,
@@ -63,6 +67,8 @@ describe('ETH-like coins', () => {
               ['string', 'address', 'uint', 'uint', 'uint'],
               [
                 signatureSaltMap.native[coinName],
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore BG-34579: known compatibility issue with @types/ethereumjs-util
                 new ethUtil.BN(ethUtil.stripHexPrefix(to), 16),
                 amount,
                 expireTime,
@@ -82,6 +88,8 @@ describe('ETH-like coins', () => {
         const { signature } = Eth.Utils.decodeTransferData(tx.toJson().data);
         const { v, r, s } = ethUtil.fromRpcSig(signature);
         const operationHash = getOperationHash(tx);
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore known compatibility issue with @types/ethereumjs-util
         const pubKeyBuffer = ethUtil.ecrecover(operationHash, v, r, s);
         return ethUtil.bufferToHex(ethUtil.pubToAddress(ethUtil.importPublic(pubKeyBuffer)));
       };


### PR DESCRIPTION
After upgrading the `@celo/contractkit` package, a new version of the
`@types/ethereumjs-util` package was also installed. However, since we're using
an old version of `ethereumjs-util` from before it had built-in types support,
we were forced to start using the incompatible `@types` package.

To work around this, we added an alias for the old version of `ethereumjs-util`
in `account-lib` called `ethereumjs-utils-old`. This stopped typescript from
using the incompatible `@types/ethereumjs-util` types since the package names
no longer match. However, since that change was done only in `account-lib`,
that alias package is only resolvable within the `account-lib` source and
tests.

This caused an issue when code in the `core` library was modified to use the
`ethereumjs-utils-old` package. Since this is resolvable when running tests,
the tests passed, but when actually using the package in downstream software
the `ethereumjs-utils-old` package is not installed and therefore can't be
resolved.

Ticket: BG-27462