### PR TITLE
refactor(core): use secp256k1 for ECDH

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -74,6 +74,7 @@
     "ripple-lib": "^1.4.1",
     "sanitize-html": "^1.27.5",
     "secrets.js-grempe": "^1.1.0",
+    "secp256k1": "^4.0.2",
     "stellar-sdk": "^8.1.0",
     "superagent": "^3.8.3",
     "superagent-proxy": "^2.1.0"
@@ -121,8 +122,7 @@
   "optionalDependencies": {
     "ethereumjs-abi": "^0.6.5",
     "ethereumjs-tx": "^1.3.7",
-    "ethereumjs-util": "^4.4.1",
-    "secp256k1": "^4.0.2"
+    "ethereumjs-util": "^4.4.1"
   },
   "nyc": {
     "extension": [

--- a/modules/core/src/bitgo.ts
+++ b/modules/core/src/bitgo.ts
@@ -1049,9 +1049,13 @@ export class BitGo {
     const clientDerivedNode = hdPath(clientHDNode).derive(derivationPath);
     const serverDerivedNode = hdPath(serverHDNode).derive(derivationPath);
 
-    // calculating one-time ECDH key
-    const secretPoint = serverDerivedNode.keyPair.__Q.multiply(clientDerivedNode.keyPair.d);
-    const secret = secretPoint.getEncoded().toString('hex');
+    const publicKey = serverDerivedNode.keyPair.getPublicKeyBuffer();
+    const secretKey = clientDerivedNode.keyPair.d.toBuffer(32);
+    const secret = Buffer.from(
+        // FIXME(BG-34386): we should use `secp256k1.ecdh()` in the future
+        //                  see discussion here https://github.com/bitcoin-core/secp256k1/issues/352
+        secp256k1.publicKeyTweakMul(publicKey, secretKey)
+    ).toString('hex');
 
     // decrypt token with symmetric ECDH key
     let response: TokenIssuance;

--- a/modules/core/test/unit/bitgo.ts
+++ b/modules/core/test/unit/bitgo.ts
@@ -2,6 +2,7 @@
 // Tests for BitGo Object
 //
 
+import * as crypto from 'crypto';
 import * as should from 'should';
 import * as nock from 'nock';
 import * as Bluebird from 'bluebird';
@@ -279,13 +280,30 @@ describe('BitGo Prototype Methods', function() {
   });
 
   describe('ECDH sharing secret', () => {
+    function getKey(seed: string) {
+      return bitcoin.HDNode.fromSeedBuffer(
+          crypto.createHash('sha256').update(seed).digest()
+      ).keyPair;
+    }
+
     it('should calculate a new ECDH sharing secret correctly', () => {
-      const bitgo = new TestBitGo();
-      const eckey1 = bitcoin.ECPair.makeRandom({ network: bitcoin.networks[common.getNetwork()] });
-      const eckey2 = bitcoin.ECPair.makeRandom({ network: bitcoin.networks[common.getNetwork()] });
-      const sharingKey1 = bitgo.getECDHSecret({ eckey: eckey1, otherPubKeyHex: eckey2.getPublicKeyBuffer().toString('hex') });
-      const sharingKey2 = bitgo.getECDHSecret({ eckey: eckey2, otherPubKeyHex: eckey1.getPublicKeyBuffer().toString('hex') });
-      sharingKey1.should.equal(sharingKey2);
+      for (let i=0; i<256; i++) {
+        const bitgo = new TestBitGo();
+        const eckey1 = getKey(`${i}.a`);
+        const eckey2 = getKey(`${i}.b`);
+        const sharingKey1 = bitgo.getECDHSecret({ eckey: eckey1, otherPubKeyHex: eckey2.getPublicKeyBuffer().toString('hex') });
+        const sharingKey2 = bitgo.getECDHSecret({ eckey: eckey2, otherPubKeyHex: eckey1.getPublicKeyBuffer().toString('hex') });
+        sharingKey1.should.equal(sharingKey2);
+
+        switch (i) {
+          case 0:
+            sharingKey1.should.eql('465ffe5745325998b83fb39631347148e24d4f21b3f3b54739c264d5c42db4b8')
+            break;
+          case 1:
+            sharingKey1.should.eql('61ff44fc1af8061a433a314b7b8be8ae352c10f62aac5887047dbaa5643b818d');
+            break;
+        }
+      }
     });
   });
 


### PR DESCRIPTION
We have two separate places where we use ECDH: token issuance and wallet sharing.

They are mutually incompatible but internally compatible, which is what counts.

Issue:  BG-34381