### PR TITLE
chore(core): deprecate hdPath in transactionBuilder

### DIFF
--- a/modules/core/src/transactionBuilder.ts
+++ b/modules/core/src/transactionBuilder.ts
@@ -921,8 +921,11 @@ exports.signTransaction = function (params) {
 
     const chainPath = currentUnspent.chainPath;
     if (rootExtKeyPath) {
-      const subPath = keychain.walletSubPath || '/0/0';
-      const path = keychain.path + subPath + chainPath;
+      let { walletSubPath = '/0/0' } = keychain;
+      if (walletSubPath === 'm') {
+        walletSubPath = ''
+      }
+      const path = keychain.path + walletSubPath + chainPath;
       privKey = rootExtKeyPath.deriveKey(path);
     }
 

--- a/modules/core/src/transactionBuilder.ts
+++ b/modules/core/src/transactionBuilder.ts
@@ -898,7 +898,6 @@ exports.signTransaction = function (params) {
   let rootExtKey;
   if (keychain) {
     rootExtKey = bitcoin.HDNode.fromBase58(keychain.xprv);
-    rootExtKeyPath = hdPath(rootExtKey);
   }
 
   const txb = bitcoin.TransactionBuilder.fromTransaction(transaction, network);
@@ -920,13 +919,13 @@ exports.signTransaction = function (params) {
     }
 
     const chainPath = currentUnspent.chainPath;
-    if (rootExtKeyPath) {
+    if (rootExtKey) {
       let { walletSubPath = '/0/0' } = keychain;
       if (walletSubPath === 'm') {
         walletSubPath = ''
       }
       const path = keychain.path + walletSubPath + chainPath;
-      privKey = rootExtKeyPath.deriveKey(path);
+      privKey = rootExtKey.derivePath(path).keyPair;
     }
 
     privKey.network = network;

--- a/modules/core/src/transactionBuilder.ts
+++ b/modules/core/src/transactionBuilder.ts
@@ -19,6 +19,7 @@ import { getNetwork, hdPath } from './bitcoin';
 import debugLib = require('debug');
 const debug = debugLib('bitgo:v1:txb');
 import * as common from './common';
+import { sanitizeLegacyPath } from "./bip32path";
 
 interface BaseOutput {
   amount: number;
@@ -894,7 +895,6 @@ exports.signTransaction = function (params) {
     transaction.ins.map((currentItem, index) => _.extend(currentItem, inputValues[index]));
   }
 
-  let rootExtKeyPath;
   let rootExtKey;
   if (keychain) {
     rootExtKey = bitcoin.HDNode.fromBase58(keychain.xprv);
@@ -920,11 +920,8 @@ exports.signTransaction = function (params) {
 
     const chainPath = currentUnspent.chainPath;
     if (rootExtKey) {
-      let { walletSubPath = '/0/0' } = keychain;
-      if (walletSubPath === 'm') {
-        walletSubPath = ''
-      }
-      const path = keychain.path + walletSubPath + chainPath;
+      const { walletSubPath = '/0/0' } = keychain;
+      const path = sanitizeLegacyPath(keychain.path + walletSubPath + chainPath);
       privKey = rootExtKey.derivePath(path).keyPair;
     }
 


### PR DESCRIPTION
The `hdPath()` wrapper is not needed any longer.

Issue: BG-34381

99ed890a (Otto Allmendinger, 6 minutes ago)
fix(core): transactionBuilder: ignore `walletSubPath === 'm'`

The `m` component is only allowed at the very beginning, but some of our
tests have it in the middle of a path.

Sadly our buggy `deriveKey` method allows it anywhere (and simply ignores
it).

Issue: BG-34381