### PR TITLE
feat(core): add bip32path.fromLegacyPath()

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -54,6 +54,7 @@
     "big.js": "^3.1.3",
     "bigi": "^1.4.0",
     "bignumber.js": "^8.0.1",
+    "bip32": "^2.0.6",
     "bitcoinjs-message": "^2.0.0",
     "bluebird": "^3.5.3",
     "bs58": "^2.0.1",
@@ -72,8 +73,8 @@
     "ripple-keypairs": "^0.11.0",
     "ripple-lib": "^1.4.1",
     "sanitize-html": "^1.27.5",
-    "secrets.js-grempe": "^1.1.0",
     "secp256k1": "^4.0.2",
+    "secrets.js-grempe": "^1.1.0",
     "stellar-sdk": "^8.1.0",
     "superagent": "^3.8.3",
     "superagent-proxy": "^2.1.0"

--- a/modules/core/src/bip32path.ts
+++ b/modules/core/src/bip32path.ts
@@ -1,0 +1,44 @@
+/**
+ * @prettier
+ */
+
+/**
+ * BitGoJS includes some custom hand-rolled bip32 derivation logic in `bitcoin.ts`, which sadly
+ * has numerous bugs.
+ *
+ * One of the effects is that the methods accept invalid bip32 paths:
+ * - the `m` prefix is ignored ('m/0' === '0')
+ * - path components that cannot be parsed as base-10 numbers are mapped to `0` ('0/x' === '0/0')
+ * - path components with trailing characters after numerals are accepted, trailing characters
+ *   are ignored ('1x' === '1')
+ *
+ * This probably does not cover everything but it should cover most bugs encountered in our code.
+ *
+ * This method attempts to convert a "legacy path", which may be invalid, to a standard bip32 path:
+ * meaning the result should be equivalent to the input path when passed to either our custom
+ * derivation log or when passed to a standard bip32 library.
+ *
+ * @param path - legacy path
+ * @return string - somewhat sanitized path that can be passed to standard bip32 libraries
+ */
+export function fromLegacyPath(path: string): string {
+  const parts: string[] = path
+    .split('/')
+    .filter((p) => p !== '')
+    .filter((p, i) => i !== 0 || p !== 'm')
+    .map((p) => {
+      const hardened = p.slice(-1) === "'";
+      const v = parseInt(p.slice(0, hardened ? -1 : undefined), 10);
+      if (Number.isNaN(v)) {
+        return '0';
+      }
+      return String(v) + (hardened ? "'" : '');
+    });
+
+  parts.forEach((p, i) => {});
+
+  if (parts.length === 0) {
+    throw new Error(`empty path`);
+  }
+  return parts.join('/');
+}

--- a/modules/core/src/bip32path.ts
+++ b/modules/core/src/bip32path.ts
@@ -21,7 +21,7 @@
  * @param path - legacy path
  * @return string - somewhat sanitized path that can be passed to standard bip32 libraries
  */
-export function fromLegacyPath(path: string): string {
+export function sanitizeLegacyPath(path: string): string {
   const parts: string[] = path
     .split('/')
     .filter((p) => p !== '')

--- a/modules/core/src/bip32path.ts
+++ b/modules/core/src/bip32path.ts
@@ -35,8 +35,6 @@ export function sanitizeLegacyPath(path: string): string {
       return String(v) + (hardened ? "'" : '');
     });
 
-  parts.forEach((p, i) => {});
-
   if (parts.length === 0) {
     throw new Error(`empty path`);
   }

--- a/modules/core/src/bitcoin.ts
+++ b/modules/core/src/bitcoin.ts
@@ -134,13 +134,18 @@ function deriveFast(hdnode: bitcoin.HDNode, index: number): bitcoin.HDNode {
   return hd;
 }
 
+export interface Derivable {
+  derive(path: string): bitcoin.HDNode;
+  deriveKey(path: string): bitcoin.ECPair;
+}
+
 /**
  * Derive a BIP32 path, given a root key
  * We cache keys at each level of hierarchy we derive, to avoid re-deriving (approx 25ms per derivation)
  * @param rootKey key to derive off
  * @returns {*} function which can be used to derive a new HDNode from the root HDNode on a given path
  */
-export function hdPath(rootKey): { derive: (path: string) => bitcoin.HDNode; deriveKey: (path: string) => bitcoin.ECPair; } {
+export function hdPath(rootKey): Derivable {
   const cache = {};
   const derive = function(path: string): bitcoin.HDNode {
     const components = path.split('/').filter(function(c) {

--- a/modules/core/test/lib/keys.ts
+++ b/modules/core/test/lib/keys.ts
@@ -1,0 +1,8 @@
+import * as crypto from 'crypto';
+
+export function getSeed(s?: string): Buffer {
+  if (s === undefined) {
+    return crypto.randomBytes(32);
+  }
+  return crypto.createHash('sha256').update(s).digest();
+}

--- a/modules/core/test/unit/bip32path.ts
+++ b/modules/core/test/unit/bip32path.ts
@@ -3,7 +3,7 @@
  */
 import 'should';
 import * as bip32 from 'bip32';
-import { fromLegacyPath } from '../../src/bip32path';
+import { sanitizeLegacyPath } from '../../src/bip32path';
 import { getSeed } from '../lib/keys';
 import { Derivable, hdPath } from '../../src/bitcoin';
 
@@ -38,11 +38,11 @@ describe('bip32util', function () {
 
     const refPath = inputs[0];
 
-    fromLegacyPath(refPath).should.eql(refPath);
+    sanitizeLegacyPath(refPath).should.eql(refPath);
 
     inputs.forEach((p) => {
       // console.log(`legacyPath=${p} path=${refPath}`);
-      fromLegacyPath(p).should.eql(refPath);
+      sanitizeLegacyPath(p).should.eql(refPath);
       refBIP32
         .derivePath(refPath)
         .toBase58() //
@@ -60,7 +60,7 @@ describe('bip32util', function () {
     runTest(inputs, testKeyBip32Child, hdPath(testKeyHDPathChild));
   }
 
-  it('fromLegacyPath', function () {
+  it('sanitizeLegacyPath', function () {
     // public derivation is much too tolerant of invalid segments
     runTestDerivePublic(['0', '/0', '////m/0', '0m', 'lol', 'm/0', 'm/m', 'm/lol', '0x10']);
     runTestDerivePublic(['0/0', '/0/0', '0////0', '0/m', '/0/m', '0/0m']);

--- a/modules/core/test/unit/bip32path.ts
+++ b/modules/core/test/unit/bip32path.ts
@@ -38,11 +38,11 @@ describe('bip32util', function () {
 
     const refPath = inputs[0];
 
-    sanitizeLegacyPath(refPath).should.eql(refPath);
-
     inputs.forEach((p) => {
-      // console.log(`legacyPath=${p} path=${refPath}`);
-      sanitizeLegacyPath(p).should.eql(refPath);
+      sanitizeLegacyPath(p).should.eql(
+        refPath,
+        `sanitizeLegacyPath(${p})=${sanitizeLegacyPath(p)}, refPath=${refPath}`
+      );
       refBIP32
         .derivePath(refPath)
         .toBase58() //

--- a/modules/core/test/unit/hdnode.ts
+++ b/modules/core/test/unit/hdnode.ts
@@ -82,7 +82,7 @@ describe('HDNode', function() {
         }
       });
 
-      it('should work for an emptry string as key path', function() {
+      it('should work for an empty string as key path', function() {
         const key =  deriveKeyByPath(baseKey, '');
         key.getAddress().should.equal(baseKey.getAddress());
       });


### PR DESCRIPTION
Add helper for converting buggy invalid bip32 paths into somewhat
reasonable bip32 paths that can be used with standard libraries.

Issue: BG-34708