### PR TITLE
chore: update repository metadata in package.json

### DIFF
--- a/modules/account-lib/package.json
+++ b/modules/account-lib/package.json
@@ -27,7 +27,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/BitGo/bitgo-account-lib.git"
+    "url": "https://github.com/BitGo/BitGoJS.git",
+    "directory": "modules/account-lib"
   },
   "author": "",
   "license": "ISC",

--- a/modules/blake2b-wasm/package.json
+++ b/modules/blake2b-wasm/package.json
@@ -23,7 +23,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/mafintosh/blake2b-wasm.git"
+    "url": "https://github.com/BitGo/BitGoJS.git",
+    "directory": "modules/blake2b-wasm"
   },
   "author": "Mathias Buus (@mafintosh)",
   "license": "MIT",

--- a/modules/blake2b/package.json
+++ b/modules/blake2b/package.json
@@ -18,7 +18,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/emilbayes/blake2b.git"
+    "url": "https://github.com/BitGo/BitGoJS.git",
+    "directory": "modules/blake2b"
   },
   "keywords": [],
   "author": "Emil Bay <github@tixz.dk>",

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -11,7 +11,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/BitGo/BitGoJS.git"
+    "url": "https://github.com/BitGo/BitGoJS.git",
+    "directory": "modules/core"
   },
   "license": "Apache-2.0",
   "engines": {

--- a/modules/express/package.json
+++ b/modules/express/package.json
@@ -15,7 +15,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/BitGo/BitGoJS.git"
+    "url": "https://github.com/BitGo/BitGoJS.git",
+    "directory": "modules/express"
   },
   "scripts": {
     "test": "yarn unit-test",

--- a/modules/statics/package.json
+++ b/modules/statics/package.json
@@ -18,7 +18,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/BitGo/BitGoJS"
+    "url": "https://github.com/BitGo/BitGoJS.git",
+    "directory": "modules/statics"
   },
   "devDependencies": {
     "husky": "^1.3.1",

--- a/modules/utxo-lib/package.json
+++ b/modules/utxo-lib/package.json
@@ -29,7 +29,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/BitGo/bitgo-utxo-lib.git"
+    "url": "https://github.com/BitGo/BitGoJS.git",
+    "directory": "modules/utxo-lib"
   },
   "files": [
     "dist/src"


### PR DESCRIPTION
This updates the `repository` property in package.json for the various modules to ensure they point to the current repository and to refer to their directory within the monorepo.

I noticed that a few of these were pointing to old repository URLs that are no longer in use or which we have since forked from.