### PR TITLE
fix(eth): goerli coins now set to gteth in core/src/config.ts

### DIFF
--- a/modules/core/src/config.ts
+++ b/modules/core/src/config.ts
@@ -4,7 +4,7 @@ import { OfcTokenConfig } from './v2/coins/ofcToken';
 import { Erc20TokenConfig } from './v2/coins/erc20Token';
 import { StellarTokenConfig } from './v2/coins/stellarToken';
 import { CeloTokenConfig } from './v2/coins/celoToken';
-import { coins, Erc20Coin, StellarCoin, OfcCoin, CeloCoin, CoinKind, NetworkType } from '@bitgo/statics';
+import { coins, Erc20Coin, StellarCoin, OfcCoin, CeloCoin, CoinKind, NetworkType, Networks } from '@bitgo/statics';
 
 export interface Tokens {
   bitcoin: {
@@ -40,9 +40,24 @@ export interface Tokens {
 // Get the list of ERC-20 tokens from statics and format it properly
 const formattedErc20Tokens = coins.reduce((acc: Erc20TokenConfig[], coin) => {
   if (coin instanceof Erc20Coin) {
+    let baseCoin: string;
+    switch (coin.network) {
+      case Networks.main.ethereum:
+        baseCoin = 'eth';
+        break;
+      case Networks.test.kovan:
+        baseCoin = 'teth';
+        break;
+      case Networks.test.goerli:
+        baseCoin = 'gteth';
+        break;
+      default:
+        throw new Error(`Erc20 token ${coin.name} has an unsupported network`);
+    }
+
     acc.push({
       type: coin.name,
-      coin: coin.network.type === NetworkType.MAINNET ? 'eth' : 'teth',
+      coin: baseCoin,
       network: coin.network.type === NetworkType.MAINNET ? 'Mainnet' : 'Testnet',
       name: coin.fullName,
       tokenContractAddress: coin.contractAddress.toString().toLowerCase(),

--- a/modules/core/test/v2/unit/baseCoin.ts
+++ b/modules/core/test/v2/unit/baseCoin.ts
@@ -97,6 +97,19 @@ describe('V2 Base Coin:', function() {
       (baseCoinStellarToken instanceof StellarToken).should.equal(true);
       (baseCoinStellarToken instanceof StellarToken).should.equal(true);
     });
+
+    it('Goerli ERC20 Tokens set to gteth and Kovan ERC20 Tokens set to teth', function () {
+      // goerli token
+      const goerliToken = bitgo.coin('gusdt');
+      goerliToken.coin.should.equal('gteth');
+      goerliToken.network.should.equal('Testnet');
+      goerliToken.getFamily().should.equal('eth');
+      // kovan token
+      const kovanToken = bitgo.coin('terc');
+      kovanToken.coin.should.equal('teth');
+      kovanToken.network.should.equal('Testnet');
+      kovanToken.getFamily().should.equal('eth');
+    });
   });
 
   describe('Missing output detection', function() {


### PR DESCRIPTION
Before, we assumed erc20 tokens are either mainnet or kovan (If it is not eth, then it is teth).
erc20 tokens now can be eth, teth, and gteth

More information can be found on this related PR on the WP: https://github.com/BitGo/BitGoJS/pull/1351

Ticket: BG-34419