### PR TITLE
feat(core): add bip32util with signMessage/verifyMessage

### DIFF
--- a/modules/core/src/bip32util.ts
+++ b/modules/core/src/bip32util.ts
@@ -1,0 +1,46 @@
+import * as utxolib from '@bitgo/utxo-lib';
+import * as _ from 'lodash';
+import * as bitcoinMessage from 'bitcoinjs-message';
+import * as bip32 from 'bip32';
+/**
+ * bip32-aware wrapper around bitcoin-message package
+ * @see {bitcoinMessage.sign}
+ */
+export function signMessage(
+    message: string,
+    privateKey: bip32.BIP32Interface | Buffer,
+    network: { messagePrefix: string },
+): Buffer {
+  if (!Buffer.isBuffer(privateKey)) {
+    privateKey = privateKey.privateKey as Buffer;
+    if (!privateKey) {
+      throw new Error(`must provide privateKey`)
+    }
+  }
+  if (!_.isObject(network) || !_.isString(network.messagePrefix)) {
+    throw new Error(`invalid argument 'network'`);
+  }
+  const compressed = true;
+  return bitcoinMessage.sign(message, privateKey, compressed, network.messagePrefix);
+}
+
+/**
+ * bip32-aware wrapper around bitcoin-message package
+ * @see {bitcoinMessage.verify}
+ */
+export function verifyMessage(
+    message: string,
+    publicKey: bip32.BIP32Interface | Buffer,
+    signature: Buffer,
+    network: { messagePrefix: string },
+): boolean {
+  if (!Buffer.isBuffer(publicKey)) {
+    publicKey = publicKey.publicKey;
+  }
+  if (!_.isObject(network) || !_.isString(network.messagePrefix)) {
+    throw new Error(`invalid argument 'network'`);
+  }
+
+  const address = utxolib.address.toBase58Check(utxolib.crypto.hash160(publicKey), utxolib.networks.bitcoin.pubKeyHash);
+  return bitcoinMessage.verify(message, address, signature, network.messagePrefix);
+}

--- a/modules/core/src/v2/coins/abstractEthLikeCoin.ts
+++ b/modules/core/src/v2/coins/abstractEthLikeCoin.ts
@@ -4,7 +4,6 @@
 import { CoinFamily, BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 import { getBuilder, Eth } from '@bitgo/account-lib';
 import * as Bluebird from 'bluebird';
-import * as bitcoinMessage from 'bitcoinjs-message';
 import * as bitgoUtxoLib from '@bitgo/utxo-lib';
 import { randomBytes } from 'crypto';
 
@@ -170,14 +169,6 @@ export abstract class AbstractEthLikeCoin extends BaseCoin {
         expiration: params.txPrebuild.expireTime,
       },
     };
-  }
-
-  async signMessage(key: { prv: string }, message: string | Buffer, callback?: NodeCallback<Buffer>): Bluebird<Buffer> {
-    const privateKey = bitgoUtxoLib.HDNode.fromBase58(key.prv).getKey();
-    const privateKeyBuffer = privateKey.d.toBuffer(32);
-    const isCompressed = privateKey.compressed;
-    const prefix = bitgoUtxoLib.networks.bitcoin.messagePrefix;
-    return bitcoinMessage.sign(message, privateKeyBuffer, isCompressed, prefix);
   }
 
   isValidPub(pub: string): boolean {

--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -2196,16 +2196,4 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
   verifyRecoveryTransaction(txInfo: VerifyRecoveryTransactionOptions): Bluebird<any> {
     return Bluebird.reject(new errors.MethodNotImplementedError());
   }
-
-  signMessage(key: { prv: string }, message: string | Buffer, callback?: NodeCallback<Buffer>): Bluebird<Buffer> {
-    return co<Buffer>(function* cosignMessage() {
-      const privateKey = bitcoin.HDNode.fromBase58(key.prv).getKey();
-      const privateKeyBuffer = privateKey.d.toBuffer(32);
-      const isCompressed = privateKey.compressed;
-      const prefix = bitcoin.networks.bitcoin.messagePrefix;
-      return bitcoinMessage.sign(message, privateKeyBuffer, isCompressed, prefix);
-    })
-      .call(this)
-      .asCallback(callback);
-  }
 }

--- a/modules/core/test/unit/bip32util.ts
+++ b/modules/core/test/unit/bip32util.ts
@@ -1,0 +1,32 @@
+/**
+ * @prettier
+ */
+import * as crypto from 'crypto';
+import * as bip32 from 'bip32';
+import 'should';
+
+import * as utxolib from '@bitgo/utxo-lib';
+import * as bip32util from '../../src/bip32util';
+
+describe('bip32util', function () {
+  function getSeedBuffers(length: number) {
+    return Array.from({ length }).map((_, i) => crypto.createHash('sha256').update(`${i}`).digest());
+  }
+  it('signMessage/verifyMessage', function () {
+    const keys = getSeedBuffers(4).map((seed) => bip32.fromSeed(seed));
+    const messages = ['hello', 'goodbye'];
+    keys.forEach((key) => {
+      messages.forEach((message) => {
+        const signature = bip32util.signMessage(message, key, utxolib.networks.bitcoin);
+
+        keys.forEach((otherKey) => {
+          messages.forEach((otherMessage) => {
+            bip32util
+              .verifyMessage(otherMessage, otherKey, signature, utxolib.networks.bitcoin)
+              .should.eql(message === otherMessage && key === otherKey);
+          });
+        });
+      });
+    });
+  });
+});

--- a/modules/core/test/v2/unit/coins/abstractEthCoin.ts
+++ b/modules/core/test/v2/unit/coins/abstractEthCoin.ts
@@ -9,7 +9,6 @@ import { getBuilder, BaseCoin, Eth } from '@bitgo/account-lib';
 import * as ethAbi from 'ethereumjs-abi';
 import * as ethUtil from 'ethereumjs-util';
 import * as bitgoUtxoLib from '@bitgo/utxo-lib';
-import * as bitcoinMessage from 'bitcoinjs-message';
 import { coins, ContractAddressDefinedToken } from '@bitgo/statics';
 
 describe('ETH-like coins', () => {
@@ -210,27 +209,6 @@ describe('ETH-like coins', () => {
           basecoin.isValidPub(pub).should.equal(true);
           const bitgoKey = bitgoUtxoLib.HDNode.fromBase58(prv);
           basecoin.isValidPub(bitgoKey.neutered().toBase58()).should.equal(true);
-        });
-      });
-
-      describe('Sign message:', () => {
-        it('should sign and validate a string message', async function () {
-          const keyPair = basecoin.generateKeyPair();
-          const message = 'hello world';
-          const signature = await basecoin.signMessage(keyPair, message);
-          const hdNode = bitgoUtxoLib.HDNode.fromBase58(keyPair.pub);
-
-          bitcoinMessage.verify(message, hdNode.keyPair.getAddress(), signature).should.equal(true);
-        });
-
-        it('should fail to validate a string message with wrong public key', async function () {
-          const keyPair = basecoin.generateKeyPair();
-          const message = 'hello world';
-          const signature = await basecoin.signMessage(keyPair, message);
-
-          const otherKeyPair = basecoin.generateKeyPair();
-          const hdNode = bitgoUtxoLib.HDNode.fromBase58(otherKeyPair.pub);
-          bitcoinMessage.verify(message, hdNode.keyPair.getAddress(), signature).should.equal(false);
         });
       });
 


### PR DESCRIPTION
Add bip32-aware signMessage/verifyMessage wrappers.

Remove redundant implementations and tests.

Issue: BG-34381