### PR TITLE
refactor(core): move utxo recover method to separate file

### DIFF
--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -1,3 +1,6 @@
+/**
+ * @prettier
+ */
 import { Codes, VirtualSizes } from '@bitgo/unspents';
 import { UnspentType } from '@bitgo/unspents/dist/codes';
 import * as bitcoin from '@bitgo/utxo-lib';
@@ -60,27 +63,27 @@ export interface Output {
 export interface TransactionFee {
   fee: number;
   feeRate?: number;
-  size: number
+  size: number;
 }
 
 export interface TransactionExplanation {
   displayOrder: string[];
   id: string;
-  outputs: Output[],
-  changeOutputs: Output[],
+  outputs: Output[];
+  changeOutputs: Output[];
   outputAmount: string;
   changeAmount: number;
   fee: TransactionFee;
 }
 
 export interface Unspent {
-  id: string,
-  value: string,
+  id: string;
+  value: string;
 }
 
 export interface ExplainTransactionOptions {
   txHex: string;
-  txInfo?: { changeAddresses: string[], unspents: Unspent[] };
+  txInfo?: { changeAddresses: string[]; unspents: Unspent[] };
   feeInfo?: string;
 }
 
@@ -108,7 +111,6 @@ export interface TransactionParams extends BaseTransactionParams {
   walletPassphrase?: string;
   changeAddress?: string;
 }
-
 
 export interface ParseTransactionOptions extends BaseParseTransactionOptions {
   txParams: TransactionParams;
@@ -173,7 +175,7 @@ export interface SignTransactionOptions extends BaseSignTransactionOptions {
         redeemScript?: string;
         witnessScript?: string;
       }[];
-    }
+    };
   };
   prv: string;
   isLastSignature?: boolean;
@@ -281,9 +283,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
     // https://github.com/Microsoft/TypeScript/issues/17198#issuecomment-423836658
     // this is a typescript rough corner for sure
     const unspentTypeKeys: string[] = Object.keys(UnspentType);
-    const unspentTypes: UnspentType[] = unspentTypeKeys
-      .map(k => UnspentType[k as any])
-      .map(v => v as UnspentType);
+    const unspentTypes: UnspentType[] = unspentTypeKeys.map((k) => UnspentType[k as any]).map((v) => v as UnspentType);
     for (const addressType of unspentTypes) {
       try {
         Codes.forType(addressType);
@@ -356,10 +356,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
    * @param forceAltScriptSupport
    */
   isValidAddress(address: string, forceAltScriptSupport = false): boolean {
-    const validVersions = [
-      this.network.pubKeyHash,
-      this.network.scriptHash,
-    ];
+    const validVersions = [this.network.pubKeyHash, this.network.scriptHash];
     if (this.altScriptHash && (forceAltScriptSupport || this.supportAltScriptDestination)) {
       validVersions.push(this.altScriptHash);
     }
@@ -400,13 +397,15 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
    */
   getLatestBlockHeight(reqId?: RequestTracer, callback?: NodeCallback<number>): Bluebird<number> {
     const self = this;
-    return co<number>(function *() {
+    return co<number>(function* () {
       if (reqId) {
         this.bitgo._reqId = reqId;
       }
       const chainhead = yield self.bitgo.get(self.url('/public/block/latest')).result();
       return (chainhead as any).height;
-    }).call(this).asCallback(callback);
+    })
+      .call(this)
+      .asCallback(callback);
   }
 
   /**
@@ -414,9 +413,12 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
    * @param prebuild
    * @param callback
    */
-  postProcessPrebuild(prebuild: TransactionPrebuild, callback?: NodeCallback<TransactionPrebuild>): Bluebird<TransactionPrebuild> {
+  postProcessPrebuild(
+    prebuild: TransactionPrebuild,
+    callback?: NodeCallback<TransactionPrebuild>
+  ): Bluebird<TransactionPrebuild> {
     const self = this;
-    return co<TransactionPrebuild>(function *(): any {
+    return co<TransactionPrebuild>(function* (): any {
       if (_.isUndefined(prebuild.txHex)) {
         throw new Error('missing required txPrebuild property txHex');
       }
@@ -428,7 +430,9 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       // See: https://github.com/bitcoin/bitcoin/blob/fb0ac482eee761ec17ed2c11df11e054347a026d/src/wallet/wallet.cpp#L2133
       transaction.locktime = prebuild.blockHeight;
       return _.extend({}, prebuild, { txHex: transaction.toHex() });
-    }).call(this).asCallback(callback);
+    })
+      .call(this)
+      .asCallback(callback);
   }
 
   /**
@@ -457,7 +461,10 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
    */
   static inferAddressType(addressDetails: { coinSpecific: AddressCoinSpecific }): string | null {
     if (_.isObject(addressDetails.coinSpecific)) {
-      if (_.isString(addressDetails.coinSpecific.redeemScript) && _.isString(addressDetails.coinSpecific.witnessScript)) {
+      if (
+        _.isString(addressDetails.coinSpecific.redeemScript) &&
+        _.isString(addressDetails.coinSpecific.witnessScript)
+      ) {
         return Codes.UnspentTypeTcomb('p2shP2wsh');
       } else if (_.isString(addressDetails.coinSpecific.redeemScript)) {
         return Codes.UnspentTypeTcomb('p2sh');
@@ -474,16 +481,13 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
    * @param callback
    * @returns {*}
    */
-  parseTransaction(params: ParseTransactionOptions, callback?: NodeCallback<ParsedTransaction>): Bluebird<ParsedTransaction> {
+  parseTransaction(
+    params: ParseTransactionOptions,
+    callback?: NodeCallback<ParsedTransaction>
+  ): Bluebird<ParsedTransaction> {
     const self = this;
-    return co<ParsedTransaction>(function *(): any {
-      const {
-        txParams,
-        txPrebuild,
-        wallet,
-        verification = {},
-        reqId,
-      } = params;
+    return co<ParsedTransaction>(function* (): any {
+      const { txParams, txPrebuild, wallet, verification = {}, reqId } = params;
 
       if (!_.isUndefined(verification.disableNetworking) && !_.isBoolean(verification.disableNetworking)) {
         throw new Error('verification.disableNetworking must be a boolean');
@@ -543,12 +547,20 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
         if (!customChangeKeys) {
           throw new Error('failed to fetch keychains for custom change wallet');
         }
-        const customChangeKeychains: [Keychain, Keychain, Keychain] = [customChangeKeys.user, customChangeKeys.backup, customChangeKeys.bitgo];
+        const customChangeKeychains: [Keychain, Keychain, Keychain] = [
+          customChangeKeys.user,
+          customChangeKeys.backup,
+          customChangeKeys.bitgo,
+        ];
 
         if (customChangeKeychains && customChangeWallet) {
           customChange = {
             keys: customChangeKeychains,
-            signatures: [customChangeKeySignatures.user, customChangeKeySignatures.backup, customChangeKeySignatures.bitgo],
+            signatures: [
+              customChangeKeySignatures.user,
+              customChangeKeySignatures.backup,
+              customChangeKeySignatures.bitgo,
+            ],
           };
         }
       }
@@ -571,7 +583,9 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
         });
       });
 
-      const needsCustomChangeKeySignatureVerification = allOutputDetails.some((output) => output.needsCustomChangeKeySignatureVerification);
+      const needsCustomChangeKeySignatureVerification = allOutputDetails.some(
+        (output) => output.needsCustomChangeKeySignatureVerification
+      );
 
       const changeOutputs = _.filter(allOutputDetails, { external: false });
 
@@ -614,7 +628,9 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
         customChange,
       };
       return result;
-    }).call(this).asCallback(callback);
+    })
+      .call(this)
+      .asCallback(callback);
   }
 
   /**
@@ -766,10 +782,16 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
    */
   verifyTransaction(params: VerifyTransactionOptions, callback?: NodeCallback<boolean>): Bluebird<boolean> {
     const self = this;
-    return co<boolean>(function *(): any {
+    return co<boolean>(function* (): any {
       const { txParams, txPrebuild, wallet, verification = { allowPaygoOutput: true }, reqId } = params;
       const disableNetworking = !!verification.disableNetworking;
-      const parsedTransaction: ParsedTransaction = yield self.parseTransaction({ txParams, txPrebuild, wallet, verification, reqId });
+      const parsedTransaction: ParsedTransaction = yield self.parseTransaction({
+        txParams,
+        txPrebuild,
+        wallet,
+        verification,
+        reqId,
+      });
 
       const keychains = parsedTransaction.keychains;
 
@@ -785,7 +807,8 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       // let's verify these keychains
       const keySignatures = parsedTransaction.keySignatures;
       if (!_.isEmpty(keySignatures)) {
-        const verify = (key, pub) => self.verifyKeySignature({ userKeychain: keychains.user, keychainToVerify: key, keySignature: pub });
+        const verify = (key, pub) =>
+          self.verifyKeySignature({ userKeychain: keychains.user, keychainToVerify: key, keySignature: pub });
         const isBackupKeySignatureValid = verify(keychains.backup, keySignatures.backupPub);
         const isBitgoKeySignatureValid = verify(keychains.bitgo, keySignatures.bitgoPub);
         if (!isBackupKeySignatureValid || !isBitgoKeySignatureValid) {
@@ -802,9 +825,14 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
         if (!keychains.user || !userPublicKeyVerified) {
           throw new Error('transaction requires verification of user public key, but it was unable to be verified');
         }
-        const customChangeKeySignaturesVerified = self.verifyCustomChangeKeySignatures(parsedTransaction, keychains.user);
+        const customChangeKeySignaturesVerified = self.verifyCustomChangeKeySignatures(
+          parsedTransaction,
+          keychains.user
+        );
         if (!customChangeKeySignaturesVerified) {
-          throw new Error('transaction requires verification of custom change key signatures, but they were unable to be verified');
+          throw new Error(
+            'transaction requires verification of custom change key signatures, but they were unable to be verified'
+          );
         }
         debug('successfully verified user public key and custom change key signatures');
       }
@@ -832,7 +860,12 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       // get all the additional external outputs the server added and calculate their values
       const nonChangeAmount = parsedTransaction.implicitExternalSpendAmount;
 
-      debug('Intended spend is %s, Non-change amount is %s, paygo limit is %s', intendedExternalSpend, nonChangeAmount, payAsYouGoLimit);
+      debug(
+        'Intended spend is %s, Non-change amount is %s, paygo limit is %s',
+        intendedExternalSpend,
+        nonChangeAmount,
+        payAsYouGoLimit
+      );
 
       // the additional external outputs can only be BitGo's pay-as-you-go fee, but we cannot verify the wallet address
       if (nonChangeAmount > payAsYouGoLimit) {
@@ -843,43 +876,50 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       const allOutputs = parsedTransaction.outputs;
       const transaction = bitcoin.Transaction.fromHex(txPrebuild.txHex, self.network);
       const transactionCache = {};
-      const inputs = yield Bluebird.map(transaction.ins, co(function *(currentInput) {
-        const transactionId = (Buffer.from(currentInput.hash).reverse() as Buffer).toString('hex');
-        const txHex = _.get(txPrebuild, `txInfo.txHexes.${transactionId}`);
-        if (txHex) {
-          const localTx = bitcoin.Transaction.fromHex(txHex, self.network);
-          if (localTx.getId() !== transactionId) {
-            throw new Error('input transaction hex does not match id');
+      const inputs = yield Bluebird.map(
+        transaction.ins,
+        co(function* (currentInput) {
+          const transactionId = (Buffer.from(currentInput.hash).reverse() as Buffer).toString('hex');
+          const txHex = _.get(txPrebuild, `txInfo.txHexes.${transactionId}`);
+          if (txHex) {
+            const localTx = bitcoin.Transaction.fromHex(txHex, self.network);
+            if (localTx.getId() !== transactionId) {
+              throw new Error('input transaction hex does not match id');
+            }
+            const currentOutput = localTx.outs[currentInput.index];
+            const address = bitcoin.address.fromOutputScript(currentOutput.script, self.network);
+            return {
+              address,
+              value: currentOutput.value,
+            };
+          } else if (!transactionCache[transactionId]) {
+            if (disableNetworking) {
+              throw new Error('attempting to retrieve transaction details externally with networking disabled');
+            }
+            if (reqId) {
+              self.bitgo.setRequestTracer(reqId);
+            }
+            transactionCache[transactionId] = yield self.bitgo.get(self.url(`/public/tx/${transactionId}`)).result();
           }
-          const currentOutput = localTx.outs[currentInput.index];
-          const address = bitcoin.address.fromOutputScript(currentOutput.script, self.network);
-          return {
-            address,
-            value: currentOutput.value,
-          };
-        } else if (!transactionCache[transactionId]) {
-          if (disableNetworking) {
-            throw new Error('attempting to retrieve transaction details externally with networking disabled');
-          }
-          if (reqId) {
-            self.bitgo.setRequestTracer(reqId);
-          }
-          transactionCache[transactionId] = yield self.bitgo.get(self.url(`/public/tx/${transactionId}`)).result();
-        }
-        const transactionDetails = transactionCache[transactionId];
-        return transactionDetails.outputs[currentInput.index];
-      }).bind(this));
+          const transactionDetails = transactionCache[transactionId];
+          return transactionDetails.outputs[currentInput.index];
+        }).bind(this)
+      );
 
       const inputAmount = _.sumBy(inputs, 'value');
       const outputAmount = _.sumBy(allOutputs, 'amount');
       const fee = inputAmount - outputAmount;
 
       if (fee < 0) {
-        throw new Error(`attempting to spend ${outputAmount} satoshis, which exceeds the input amount (${inputAmount} satoshis) by ${-fee}`);
+        throw new Error(
+          `attempting to spend ${outputAmount} satoshis, which exceeds the input amount (${inputAmount} satoshis) by ${-fee}`
+        );
       }
 
       return true;
-    }).call(this).asCallback(callback);
+    })
+      .call(this)
+      .asCallback(callback);
   }
 
   /**
@@ -901,12 +941,16 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       throw new errors.InvalidAddressError(`invalid address: ${address}`);
     }
 
-    if ((_.isUndefined(chain) && _.isUndefined(index)) || (!(_.isFinite(chain) && _.isFinite(index)))) {
-      throw new errors.InvalidAddressDerivationPropertyError(`address validation failure: invalid chain (${chain}) or index (${index})`);
+    if ((_.isUndefined(chain) && _.isUndefined(index)) || !(_.isFinite(chain) && _.isFinite(index))) {
+      throw new errors.InvalidAddressDerivationPropertyError(
+        `address validation failure: invalid chain (${chain}) or index (${index})`
+      );
     }
 
     if (!_.isObject(coinSpecific)) {
-      throw new errors.InvalidAddressVerificationObjectPropertyError('address validation failure: coinSpecific field must be an object');
+      throw new errors.InvalidAddressVerificationObjectPropertyError(
+        'address validation failure: coinSpecific field must be an object'
+      );
     }
 
     if (!keychains) {
@@ -922,7 +966,9 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
     });
 
     if (expectedAddress.address !== address) {
-      throw new errors.UnexpectedAddressError(`address validation failure: expected ${expectedAddress.address} but got ${address}`);
+      throw new errors.UnexpectedAddressError(
+        `address validation failure: expected ${expectedAddress.address} but got ${address}`
+      );
     }
 
     return true;
@@ -1030,10 +1076,13 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
 
     const path = 'm/0/0/' + derivationChain + '/' + derivationIndex;
     const hdNodes = keychains.map(({ pub }) => bitcoin.HDNode.fromBase58(pub));
-    const derivedKeys = hdNodes.map(hdNode => hdPath(hdNode).deriveKey(path).getPublicKeyBuffer());
+    const derivedKeys = hdNodes.map((hdNode) => hdPath(hdNode).deriveKey(path).getPublicKeyBuffer());
 
-    const { outputScript, redeemScript, witnessScript, address } =
-      this.createMultiSigAddress(addressType, signatureThreshold, derivedKeys);
+    const { outputScript, redeemScript, witnessScript, address } = this.createMultiSigAddress(
+      addressType,
+      signatureThreshold,
+      derivedKeys
+    );
 
     return {
       address,
@@ -1058,9 +1107,12 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
    * @param callback
    * @returns {Bluebird<SignedTransaction>}
    */
-  signTransaction(params: SignTransactionOptions, callback?: NodeCallback<SignedTransaction>): Bluebird<SignedTransaction> {
+  signTransaction(
+    params: SignTransactionOptions,
+    callback?: NodeCallback<SignedTransaction>
+  ): Bluebird<SignedTransaction> {
     const self = this;
-    return co<SignedTransaction>(function *() {
+    return co<SignedTransaction>(function* () {
       const txPrebuild = params.txPrebuild;
       const userPrv = params.prv;
 
@@ -1120,7 +1172,8 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
         if (signatureContext.isBitGoTaintedUnspent) {
           debug(
             'Skipping input %d of %d (unspent from replay protection address which is platform signed only)',
-            index + 1, transaction.ins.length
+            index + 1,
+            transaction.ins.length
           );
           continue;
         }
@@ -1149,7 +1202,6 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
               txb.sign(index, privKey, subscript, sigHashType, signatureContext.unspent.value);
             }
           }
-
         } catch (e) {
           debug('Failed to sign input:', e);
           signatureContext.error = e;
@@ -1172,7 +1224,8 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
         if (signatureContext.isBitGoTaintedUnspent) {
           debug(
             'Skipping input signature %d of %d (unspent from replay protection address which is platform signed only)',
-            index + 1, transaction.ins.length
+            index + 1,
+            transaction.ins.length
           );
           continue;
         }
@@ -1190,7 +1243,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       }
 
       if (signatureIssues.length > 0) {
-        const failedIndices = signatureIssues.map(currentIssue => currentIssue.inputIndex);
+        const failedIndices = signatureIssues.map((currentIssue) => currentIssue.inputIndex);
         const error: any = new Error(`Failed to sign inputs at indices ${failedIndices.join(', ')}`);
         error.code = 'input_signature_failure';
         error.signingErrors = signatureIssues;
@@ -1265,8 +1318,10 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       const pubScript = bitcoin.script.pubKeyHash.output.encode(bitcoin.crypto.hash160(publicKey));
 
       return { isSegwitInput, inputClassification, signatures, publicKeys, pubScript };
-    } else if (inputClassification === bitcoin.script.types.P2SH
-        || inputClassification === bitcoin.script.types.P2WSH) {
+    } else if (
+      inputClassification === bitcoin.script.types.P2SH ||
+      inputClassification === bitcoin.script.types.P2WSH
+    ) {
       // Note the assumption here that if we have a p2sh or p2wsh input it will be multisig (appropriate because the
       // BitGo platform only supports multisig within these types of inputs). Signatures are all but the last entry in
       // the decompiledSigScript. The redeemScript/witnessScript (depending on which type of input this is) is the last
@@ -1321,7 +1376,14 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
    * @param isSegwitInput
    * @returns {*}
    */
-  calculateSignatureHash(transaction: any, inputIndex: number, pubScript: Buffer, amount: number, hashType: number, isSegwitInput: boolean): Buffer {
+  calculateSignatureHash(
+    transaction: any,
+    inputIndex: number,
+    pubScript: Buffer,
+    amount: number,
+    hashType: number,
+    isSegwitInput: boolean
+  ): Buffer {
     if (isSegwitInput) {
       return transaction.hashForWitnessV0(inputIndex, pubScript, amount, hashType);
     } else {
@@ -1339,14 +1401,23 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
    * @param verificationSettings.publicKey The hex of the public key to verify (will verify all signatures)
    * @returns {boolean}
    */
-  verifySignature(transaction: any, inputIndex: number, amount: number, verificationSettings: {
-    signatureIndex?: number;
-    publicKey?: string;
-  } = {}): boolean {
-    const { signatures, publicKeys, isSegwitInput, inputClassification, pubScript } =
-        this.parseSignatureScript(transaction, inputIndex);
+  verifySignature(
+    transaction: any,
+    inputIndex: number,
+    amount: number,
+    verificationSettings: {
+      signatureIndex?: number;
+      publicKey?: string;
+    } = {}
+  ): boolean {
+    const { signatures, publicKeys, isSegwitInput, inputClassification, pubScript } = this.parseSignatureScript(
+      transaction,
+      inputIndex
+    );
 
-    if (![bitcoin.script.types.P2WSH, bitcoin.script.types.P2SH, bitcoin.script.types.P2PKH].includes(inputClassification)) {
+    if (
+      ![bitcoin.script.types.P2WSH, bitcoin.script.types.P2SH, bitcoin.script.types.P2PKH].includes(inputClassification)
+    ) {
       return false;
     }
 
@@ -1359,7 +1430,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
     }
 
     // get the first non-empty signature and verify it against all public keys
-    const nonEmptySignatures = _.filter(signatures, s => !_.isEmpty(s));
+    const nonEmptySignatures = _.filter(signatures, (s) => !_.isEmpty(s));
 
     /*
     We either want to verify all signature/pubkey combinations, or do an explicit combination
@@ -1384,7 +1455,6 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
 
     // go over all signatures
     for (const signatureBuffer of signaturesToCheck) {
-
       let isSignatureValid = false;
 
       const hasSignatureBuffer = Buffer.isBuffer(signatureBuffer) && signatureBuffer.length > 0;
@@ -1396,7 +1466,14 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
           // missing hashType byte - signature cannot be validated
           return false;
         }
-        const signatureHash = this.calculateSignatureHash(transaction, inputIndex, pubScript, amount, hashType, isSegwitInput);
+        const signatureHash = this.calculateSignatureHash(
+          transaction,
+          inputIndex,
+          pubScript,
+          amount,
+          hashType,
+          isSegwitInput
+        );
 
         for (let publicKeyIndex = 0; publicKeyIndex < publicKeys.length; publicKeyIndex++) {
           const publicKeyBuffer = publicKeys[publicKeyIndex];
@@ -1440,9 +1517,12 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
    * @param params
    * @param callback
    */
-  explainTransaction(params: ExplainTransactionOptions, callback?: NodeCallback<TransactionExplanation>): Bluebird<TransactionExplanation> {
+  explainTransaction(
+    params: ExplainTransactionOptions,
+    callback?: NodeCallback<TransactionExplanation>
+  ): Bluebird<TransactionExplanation> {
     const self = this;
-    return co<TransactionExplanation>(function *() {
+    return co<TransactionExplanation>(function* () {
       const txHex = _.get(params, 'txHex');
       if (!txHex || !_.isString(txHex) || !txHex.match(/^([a-f0-9]{2})+$/i)) {
         throw new Error('invalid transaction hex, must be a valid hex string');
@@ -1556,13 +1636,15 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
           }
         });
 
-        return validSignatures.reduce((validCount, isValid) => isValid ? validCount + 1 : validCount, 0);
+        return validSignatures.reduce((validCount, isValid) => (isValid ? validCount + 1 : validCount), 0);
       });
 
       explanation.inputSignatures = inputSignatures;
       explanation.signatures = _.max(inputSignatures);
       return explanation;
-    }).call(this).asCallback(callback);
+    })
+      .call(this)
+      .asCallback(callback);
   }
 
   /**
@@ -1645,7 +1727,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
    */
   getRecoveryMarketPrice(): Bluebird<string> {
     const self = this;
-    return co<string>(function *getRecoveryMarketPrice() {
+    return co<string>(function* getRecoveryMarketPrice() {
       const familyNamesToCoinGeckoIds = new Map()
         .set('BTC', 'bitcoin')
         .set('LTC', 'litecoin')
@@ -1710,7 +1792,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
   protected abstract getUnspentInfoFromExplorer(address: string, apiKey?: string): Bluebird<UnspentInfo[]>;
 
   getTxInfoFromExplorer(faultyTxId: string): any {
-    return co(function *getUnspentFromWrongChain() {
+    return co(function* getUnspentFromWrongChain() {
       const TX_INFO_URL = this.url(`/public/tx/${faultyTxId}`);
       const res = (yield request.get(TX_INFO_URL)) as any;
       return res.body;
@@ -1725,13 +1807,11 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
   getUnspentInfoForCrossChainRecovery(addresses: string[]): any {
     const self = this;
 
-    return co(function *getUnspentInfoForCrossChainRecovery() {
-      const ADDRESS_UNSPENTS_URL = self.url(
-          `/public/addressUnspents/${_.uniq(addresses).join(',')}`
-        );
-        const addressRes = (yield request.get(ADDRESS_UNSPENTS_URL)) as any;
-        const unspents = addressRes.body;
-        return unspents;
+    return co(function* getUnspentInfoForCrossChainRecovery() {
+      const ADDRESS_UNSPENTS_URL = self.url(`/public/addressUnspents/${_.uniq(addresses).join(',')}`);
+      const addressRes = (yield request.get(ADDRESS_UNSPENTS_URL)) as any;
+      const unspents = addressRes.body;
+      return unspents;
     }).call(this);
   }
 
@@ -1761,7 +1841,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
    */
   recover(params: RecoverParams, callback?: NodeCallback<any>): Bluebird<any> {
     const self = this;
-    return co(function *recover() {
+    return co(function* recover() {
       // ============================HELPER FUNCTIONS============================
       function queryBlockchainUnspentsPath(keyArray: bitcoin.HDNode[], basePath: string, addressesById) {
         return co(function* () {
@@ -1773,10 +1853,13 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
             const derivedKeys = self.deriveKeys(keyArray, addrIndex);
 
             const chain = Number(basePath.split('/').pop()); // extracts the chain from the basePath
-            const keys = derivedKeys.map(k => k.getPublicKeyBuffer());
+            const keys = derivedKeys.map((k) => k.getPublicKeyBuffer());
             const address: any = self.createMultiSigAddress(Codes.typeForCode(chain), 2, keys);
 
-            const addrInfo: AddressInfo = (yield self.getAddressInfoFromExplorer(address.address, params.apiKey)) as any;
+            const addrInfo: AddressInfo = (yield self.getAddressInfoFromExplorer(
+              address.address,
+              params.apiKey
+            )) as any;
             // we use txCount here because it implies usage - having tx'es means the addr was generated and used
             if (addrInfo.txCount === 0) {
               numSequentialAddressesWithoutTxs++;
@@ -1792,7 +1875,10 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
                 addressesById[address.address] = address;
 
                 // Try to find unspents on it.
-                const addressUnspents: UnspentInfo[] = (yield self.getUnspentInfoFromExplorer(address.address, params.apiKey)) as any;
+                const addressUnspents: UnspentInfo[] = (yield self.getUnspentInfoFromExplorer(
+                  address.address,
+                  params.apiKey
+                )) as any;
 
                 addressUnspents.forEach(function addAddressToUnspent(unspent) {
                   unspent.address = address.address;
@@ -1848,14 +1934,14 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
         throw new Error('unknown key recovery service provider');
       }
 
-      if (isKrsRecovery && !(krsProvider.supportedCoins.includes(self.getFamily()))) {
+      if (isKrsRecovery && !krsProvider.supportedCoins.includes(self.getFamily())) {
         throw new Error('specified key recovery service does not support recoveries for this coin');
       }
 
       // check whether key material and password authenticate the users and return parent keys of all three keys of the wallet
       const keys = yield self.initiateRecovery(params);
 
-      const [userKey, backupKey, bitgoKey] = (keys as any);
+      const [userKey, backupKey, bitgoKey] = keys as any;
       let derivedUserKey;
       let baseKeyPath;
       if (params.userKeyPath) {
@@ -1863,7 +1949,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
         const twoKeys = self.deriveKeys(self.deriveKeys([backupKey, bitgoKey], 0), 0);
         baseKeyPath = [derivedUserKey, ...twoKeys];
       } else {
-        baseKeyPath = self.deriveKeys(self.deriveKeys((keys as any), 0), 0);
+        baseKeyPath = self.deriveKeys(self.deriveKeys(keys as any, 0), 0);
       }
 
       const queries: any[] = [];
@@ -1920,7 +2006,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       // segwit overhead size and p2sh inputs for the same reason.
       const outputSize = (isKrsRecovery ? 2 : 1) * VirtualSizes.txP2wshOutputSize;
       const approximateSize =
-        VirtualSizes.txSegOverheadVSize + outputSize + (VirtualSizes.txP2shInputSize * unspents.length);
+        VirtualSizes.txSegOverheadVSize + outputSize + VirtualSizes.txP2shInputSize * unspents.length;
       const approximateFee = approximateSize * feePerByte;
 
       // Construct a transaction
@@ -1962,7 +2048,9 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
         const krsFeeAddress = krsProvider.feeAddresses[self.getChain()];
 
         if (!krsFeeAddress) {
-          throw new Error('this KRS provider has not configured their fee structure yet - recovery cannot be completed');
+          throw new Error(
+            'this KRS provider has not configured their fee structure yet - recovery cannot be completed'
+          );
         }
 
         transactionBuilder.addOutput(krsFeeAddress, krsFee);
@@ -1996,7 +2084,9 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       }
 
       return txInfo;
-    }).call(this).asCallback(callback);
+    })
+      .call(this)
+      .asCallback(callback);
   }
 
   /**
@@ -2031,7 +2121,14 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
 
       if (cosign) {
         try {
-          txb.sign(i, backupPrivateKey, address.redeemScript, this.defaultSigHashType, unspent.amount, address.witnessScript);
+          txb.sign(
+            i,
+            backupPrivateKey,
+            address.redeemScript,
+            this.defaultSigHashType,
+            unspent.amount,
+            address.witnessScript
+          );
         } catch (e) {
           currentSignatureIssue.error = e;
           signatureIssues.push(currentSignatureIssue);
@@ -2039,7 +2136,14 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       }
 
       try {
-        txb.sign(i, userPrivateKey, address.redeemScript, this.defaultSigHashType, unspent.amount, address.witnessScript);
+        txb.sign(
+          i,
+          userPrivateKey,
+          address.redeemScript,
+          this.defaultSigHashType,
+          unspent.amount,
+          address.witnessScript
+        );
       } catch (e) {
         currentSignatureIssue.error = e;
         signatureIssues.push(currentSignatureIssue);
@@ -2047,7 +2151,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
     });
 
     if (signatureIssues.length > 0) {
-      const failedIndices = signatureIssues.map(currentIssue => currentIssue.inputIndex);
+      const failedIndices = signatureIssues.map((currentIssue) => currentIssue.inputIndex);
       const error: any = new Error(`Failed to sign inputs at indices ${failedIndices.join(', ')}`);
       error.code = 'input_signature_failure';
       error.signingErrors = signatureIssues;
@@ -2065,9 +2169,9 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
    * @param callback
    * @returns {*}
    */
-  calculateFeeAmount(params: { provider: string, amount?: number }, callback?: NodeCallback<number>): Bluebird<number> {
+  calculateFeeAmount(params: { provider: string; amount?: number }, callback?: NodeCallback<number>): Bluebird<number> {
     const self = this;
-    return co<number>(function *calculateFeeAmount() {
+    return co<number>(function* calculateFeeAmount() {
       const krsProvider = config.krsProviders[params.provider];
 
       if (krsProvider === undefined) {
@@ -2078,12 +2182,14 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
         const feeAmountUsd = krsProvider.feeAmount;
         const currentPrice: number = (yield self.getRecoveryMarketPrice()) as any;
 
-        return Math.round(feeAmountUsd / currentPrice * self.getBaseFactor());
+        return Math.round((feeAmountUsd / currentPrice) * self.getBaseFactor());
       } else {
         // we can add more fee structures here as needed for different providers, such as percentage of recovery amount
         throw new Error('Fee structure not implemented');
       }
-    }).call(this).asCallback(callback);
+    })
+      .call(this)
+      .asCallback(callback);
   }
 
   /**
@@ -2101,14 +2207,8 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
    */
   recoverFromWrongChain(params: RecoverFromWrongChainOptions, callback?: NodeCallback<any>): Bluebird<any> {
     const self = this;
-    return co(function *recoverFromWrongChain() {
-      const {
-        txid,
-        recoveryAddress,
-        wallet,
-        walletPassphrase,
-        xprv,
-      } = params;
+    return co(function* recoverFromWrongChain() {
+      const { txid, recoveryAddress, wallet, walletPassphrase, xprv } = params;
 
       // params.recoveryCoin used to be params.coin, backwards compatibility
       const recoveryCoin = params.coin || params.recoveryCoin;
@@ -2123,7 +2223,9 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       const supportedRecoveryCoins = config.supportedCrossChainRecoveries[sourceCoinFamily];
 
       if (_.isUndefined(supportedRecoveryCoins) || !supportedRecoveryCoins.includes(recoveryCoinFamily)) {
-        throw new Error(`Recovery of ${sourceCoinFamily} balances from ${recoveryCoinFamily} wallets is not supported.`);
+        throw new Error(
+          `Recovery of ${sourceCoinFamily} balances from ${recoveryCoinFamily} wallets is not supported.`
+        );
       }
 
       const recoveryTool = new CrossChainRecoveryTool({
@@ -2145,7 +2247,9 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       } else {
         return yield recoveryTool.buildUnsigned();
       }
-    }).call(this).asCallback(callback);
+    })
+      .call(this)
+      .asCallback(callback);
   }
 
   /**
@@ -2154,7 +2258,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
    * @param seed
    * @returns {Object} object with generated pub and prv
    */
-  generateKeyPair(seed: Buffer): { pub: string, prv: string } {
+  generateKeyPair(seed: Buffer): { pub: string; prv: string } {
     if (!seed) {
       // An extended private key has both a normal 256 bit private key and a 256
       // bit chain code, both of which must be random. 512 bits is therefore the

--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -1,7 +1,7 @@
 /**
  * @prettier
  */
-import { Codes, VirtualSizes } from '@bitgo/unspents';
+import { Codes } from '@bitgo/unspents';
 import { UnspentType } from '@bitgo/unspents/dist/codes';
 import * as bitcoin from '@bitgo/utxo-lib';
 import * as bitcoinMessage from 'bitcoinjs-message';
@@ -11,10 +11,13 @@ import * as debugLib from 'debug';
 import * as _ from 'lodash';
 import * as request from 'superagent';
 
-import { deriveKeyByPath, hdPath } from '../../bitcoin';
+import { hdPath } from '../../bitcoin';
 import { BitGo } from '../../bitgo';
 import * as config from '../../config';
 import * as errors from '../../errors';
+
+import { recover, RecoverParams } from './utxo/recover';
+export { RecoverParams } from './utxo/recover';
 
 import {
   AddressCoinSpecific,
@@ -225,19 +228,6 @@ export interface AddressInfo {
 
 export interface UnspentInfo {
   address: string;
-}
-
-export interface RecoverParams {
-  scan?: number;
-  userKey: string;
-  backupKey: string;
-  recoveryDestination: string;
-  krsProvider: string;
-  ignoreAddressTypes: string[];
-  bitgoKey: string;
-  walletPassphrase?: string;
-  apiKey?: string;
-  userKeyPath?: string;
 }
 
 export interface VerifyKeySignaturesOptions {
@@ -1788,8 +1778,8 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
     return response;
   }
 
-  protected abstract getAddressInfoFromExplorer(address: string, apiKey?: string): Bluebird<AddressInfo>;
-  protected abstract getUnspentInfoFromExplorer(address: string, apiKey?: string): Bluebird<UnspentInfo[]>;
+  public abstract getAddressInfoFromExplorer(address: string, apiKey?: string): Bluebird<AddressInfo>;
+  public abstract getUnspentInfoFromExplorer(address: string, apiKey?: string): Bluebird<UnspentInfo[]>;
 
   getTxInfoFromExplorer(faultyTxId: string): any {
     return co(function* getUnspentFromWrongChain() {
@@ -1827,266 +1817,11 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
 
   /**
    * Builds a funds recovery transaction without BitGo
-   * @param params
-   * - userKey: [encrypted] xprv, or xpub
-   * - backupKey: [encrypted] xprv, or xpub if the xprv is held by a KRS provider
-   * - walletPassphrase: necessary if one of the xprvs is encrypted
-   * - bitgoKey: xpub
-   * - krsProvider: necessary if backup key is held by KRS
-   * - recoveryDestination: target address to send recovered funds to
-   * - scan: the amount of consecutive addresses without unspents to scan through before stopping
-   * - ignoreAddressTypes: (optional) array of AddressTypes to ignore, these are strings defined in Codes.UnspentTypeTcomb
-   *        for example: ['p2shP2wsh', 'p2wsh'] will prevent code from checking for wrapped-segwit and native-segwit chains on the public block explorers
+   * @param params - {@see recover}
    * @param callback
    */
   recover(params: RecoverParams, callback?: NodeCallback<any>): Bluebird<any> {
-    const self = this;
-    return co(function* recover() {
-      // ============================HELPER FUNCTIONS============================
-      function queryBlockchainUnspentsPath(keyArray: bitcoin.HDNode[], basePath: string, addressesById) {
-        return co(function* () {
-          const MAX_SEQUENTIAL_ADDRESSES_WITHOUT_TXS = params.scan || 20;
-          let numSequentialAddressesWithoutTxs = 0;
-
-          // get unspents for these addresses
-          const gatherUnspents = co(function* coGatherUnspents(addrIndex) {
-            const derivedKeys = self.deriveKeys(keyArray, addrIndex);
-
-            const chain = Number(basePath.split('/').pop()); // extracts the chain from the basePath
-            const keys = derivedKeys.map((k) => k.getPublicKeyBuffer());
-            const address: any = self.createMultiSigAddress(Codes.typeForCode(chain), 2, keys);
-
-            const addrInfo: AddressInfo = (yield self.getAddressInfoFromExplorer(
-              address.address,
-              params.apiKey
-            )) as any;
-            // we use txCount here because it implies usage - having tx'es means the addr was generated and used
-            if (addrInfo.txCount === 0) {
-              numSequentialAddressesWithoutTxs++;
-            } else {
-              numSequentialAddressesWithoutTxs = 0;
-
-              if (addrInfo.totalBalance > 0) {
-                console.log(`Found an address with balance: ${address.address} with balance ${addrInfo.totalBalance}`);
-                // This address has a balance.
-                address.chainPath = basePath + '/' + addrIndex;
-                address.userKey = derivedKeys[0];
-                address.backupKey = derivedKeys[1];
-                addressesById[address.address] = address;
-
-                // Try to find unspents on it.
-                const addressUnspents: UnspentInfo[] = (yield self.getUnspentInfoFromExplorer(
-                  address.address,
-                  params.apiKey
-                )) as any;
-
-                addressUnspents.forEach(function addAddressToUnspent(unspent) {
-                  unspent.address = address.address;
-                  walletUnspents.push(unspent);
-                });
-              }
-            }
-
-            if (numSequentialAddressesWithoutTxs >= MAX_SEQUENTIAL_ADDRESSES_WITHOUT_TXS) {
-              // stop searching for addresses with unspents in them, we've found ${MAX_SEQUENTIAL_ADDRESSES_WITHOUT_TXS} in a row with none
-              // we are done
-              return;
-            }
-
-            return gatherUnspents(addrIndex + 1);
-          });
-
-          const walletUnspents: UnspentInfo[] = [];
-          // This will populate walletAddresses
-          yield gatherUnspents(0);
-
-          if (walletUnspents.length === 0) {
-            // Couldn't find any addresses with funds
-            return [];
-          }
-
-          return walletUnspents;
-        }).call(this);
-      }
-
-      // ============================LOGIC============================
-      if (_.isUndefined(params.userKey)) {
-        throw new Error('missing userKey');
-      }
-
-      if (_.isUndefined(params.backupKey)) {
-        throw new Error('missing backupKey');
-      }
-
-      if (_.isUndefined(params.recoveryDestination) || !self.isValidAddress(params.recoveryDestination)) {
-        throw new Error('invalid recoveryDestination');
-      }
-
-      if (!_.isUndefined(params.scan) && (!_.isInteger(params.scan) || params.scan < 0)) {
-        throw new Error('scan must be a positive integer');
-      }
-
-      const isKrsRecovery = params.backupKey.startsWith('xpub') && !params.userKey.startsWith('xpub');
-      const isUnsignedSweep = params.backupKey.startsWith('xpub') && params.userKey.startsWith('xpub');
-      const krsProvider = config.krsProviders[params.krsProvider];
-
-      if (isKrsRecovery && _.isUndefined(krsProvider)) {
-        throw new Error('unknown key recovery service provider');
-      }
-
-      if (isKrsRecovery && !krsProvider.supportedCoins.includes(self.getFamily())) {
-        throw new Error('specified key recovery service does not support recoveries for this coin');
-      }
-
-      // check whether key material and password authenticate the users and return parent keys of all three keys of the wallet
-      const keys = yield self.initiateRecovery(params);
-
-      const [userKey, backupKey, bitgoKey] = keys as any;
-      let derivedUserKey;
-      let baseKeyPath;
-      if (params.userKeyPath) {
-        derivedUserKey = deriveKeyByPath(userKey, params.userKeyPath);
-        const twoKeys = self.deriveKeys(self.deriveKeys([backupKey, bitgoKey], 0), 0);
-        baseKeyPath = [derivedUserKey, ...twoKeys];
-      } else {
-        baseKeyPath = self.deriveKeys(self.deriveKeys(keys as any, 0), 0);
-      }
-
-      const queries: any[] = [];
-      const addressesById = {};
-
-      _.forEach(Object.keys(Codes.UnspentTypeTcomb.meta.map), function (addressType) {
-        // If we aren't ignoring the address type, we derive the public key and construct the query for the external and
-        // internal indices
-        if (!_.includes(params.ignoreAddressTypes, addressType)) {
-          if (addressType === Codes.UnspentTypeTcomb('p2shP2wsh') && !self.supportsP2shP2wsh()) {
-            // P2shP2wsh is not supported. Skip.
-            return;
-          }
-
-          if (addressType === Codes.UnspentTypeTcomb('p2wsh') && !self.supportsP2wsh()) {
-            // P2wsh is not supported. Skip.
-            return;
-          }
-
-          let codes;
-          try {
-            codes = Codes.forType(Codes.UnspentTypeTcomb(addressType) as any);
-          } catch (e) {
-            // The unspent type is not supported by bitgo so attempting to get its chain codes throws. Catch that error
-            // and continue.
-            return;
-          }
-          const externalChainCode = codes.external;
-          const internalChainCode = codes.internal;
-          const externalKey = self.deriveKeys(baseKeyPath, externalChainCode);
-          const internalKey = self.deriveKeys(baseKeyPath, internalChainCode);
-          queries.push(queryBlockchainUnspentsPath(externalKey, '/0/0/' + externalChainCode, addressesById));
-          queries.push(queryBlockchainUnspentsPath(internalKey, '/0/0/' + internalChainCode, addressesById));
-        }
-      });
-
-      // Execute the queries and gather the unspents
-      const queryResponses = yield Promise.all(queries);
-      const unspents: any[] = _.flatten(queryResponses); // this flattens the array (turns an array of arrays into just one array)
-      const totalInputAmount = _.sumBy(unspents, 'amount');
-      if (totalInputAmount <= 0) {
-        throw new errors.ErrorNoInputToRecover();
-      }
-
-      // Build the transaction
-      const transactionBuilder = new bitcoin.TransactionBuilder(self.network);
-      self.prepareTransactionBuilder(transactionBuilder);
-      const txInfo: any = {};
-
-      const feePerByte: number = (yield self.getRecoveryFeePerBytes()) as any;
-
-      // KRS recovery transactions have a 2nd output to pay the recovery fee, like paygo fees. Use p2wsh outputs because
-      // they are the largest outputs and thus the most conservative estimate to use in calculating fees. Also use
-      // segwit overhead size and p2sh inputs for the same reason.
-      const outputSize = (isKrsRecovery ? 2 : 1) * VirtualSizes.txP2wshOutputSize;
-      const approximateSize =
-        VirtualSizes.txSegOverheadVSize + outputSize + VirtualSizes.txP2shInputSize * unspents.length;
-      const approximateFee = approximateSize * feePerByte;
-
-      // Construct a transaction
-      txInfo.inputs = unspents.map(function addInputForUnspent(unspent) {
-        const address = addressesById[unspent.address];
-
-        transactionBuilder.addInput(unspent.txid, unspent.n, 0xffffffff, address.outputScript);
-
-        return {
-          chainPath: address.chainPath,
-          redeemScript: address.redeemScript && address.redeemScript.toString('hex'),
-          witnessScript: address.witnessScript && address.witnessScript.toString('hex'),
-          value: unspent.amount,
-        };
-      });
-
-      let recoveryAmount = totalInputAmount - approximateFee;
-      let krsFee;
-      if (isKrsRecovery) {
-        try {
-          krsFee = yield self.calculateFeeAmount({ provider: params.krsProvider, amount: recoveryAmount });
-          recoveryAmount -= krsFee;
-        } catch (err) {
-          // Don't let this error block the recovery -
-          console.dir(err);
-        }
-      }
-
-      if (recoveryAmount < 0) {
-        throw new Error(`this wallet\'s balance is too low to pay the fees specified by the KRS provider. 
-          Existing balance on wallet: ${totalInputAmount}. Estimated network fee for the recovery transaction
-          : ${approximateFee}, KRS fee to pay: ${krsFee}. After deducting fees, your total recoverable balance
-          is ${recoveryAmount}`);
-      }
-
-      transactionBuilder.addOutput(params.recoveryDestination, recoveryAmount);
-
-      if (isKrsRecovery && krsFee > 0) {
-        const krsFeeAddress = krsProvider.feeAddresses[self.getChain()];
-
-        if (!krsFeeAddress) {
-          throw new Error(
-            'this KRS provider has not configured their fee structure yet - recovery cannot be completed'
-          );
-        }
-
-        transactionBuilder.addOutput(krsFeeAddress, krsFee);
-      }
-
-      if (isUnsignedSweep) {
-        const txHex = transactionBuilder.buildIncomplete().toBuffer().toString('hex');
-        return self.formatForOfflineVault(txInfo, txHex);
-      } else {
-        const signedTx = self.signRecoveryTransaction(transactionBuilder, unspents, addressesById, !isKrsRecovery);
-        txInfo.transactionHex = signedTx.build().toBuffer().toString('hex');
-        try {
-          txInfo.tx = yield self.verifyRecoveryTransaction(txInfo);
-        } catch (e) {
-          // some coins don't have a reliable third party verification endpoint, or sometimes the third party endpoint
-          // could be unavailable due to service outage, so we continue without verification for those coins, but we will
-          // let users know that they should verify their own
-          // this message should be piped to WRW and displayed on the UI
-          if (e instanceof errors.MethodNotImplementedError || e instanceof errors.BlockExplorerUnavailable) {
-            console.log('Please verify your transaction by decoding the tx hex using a third-party api of your choice');
-          } else {
-            throw e;
-          }
-        }
-      }
-
-      if (isKrsRecovery) {
-        txInfo.coin = self.getChain();
-        txInfo.backupKey = params.backupKey;
-        txInfo.recoveryAmount = recoveryAmount;
-      }
-
-      return txInfo;
-    })
-      .call(this)
-      .asCallback(callback);
+    return Bluebird.resolve(recover(this, params)).asCallback(callback);
   }
 
   /**

--- a/modules/core/src/v2/coins/utxo/recover.ts
+++ b/modules/core/src/v2/coins/utxo/recover.ts
@@ -1,0 +1,284 @@
+/**
+ * @prettier
+ */
+
+import * as _ from 'lodash';
+import * as bitcoin from '@bitgo/utxo-lib';
+import { Codes, VirtualSizes } from '@bitgo/unspents';
+
+import * as config from '../../../config';
+import { deriveKeyByPath } from '../../../bitcoin';
+import * as errors from '../../../errors';
+import { AbstractUtxoCoin, AddressInfo, UnspentInfo } from '../abstractUtxoCoin';
+
+export interface RecoverParams {
+  scan?: number;
+  userKey: string;
+  backupKey: string;
+  recoveryDestination: string;
+  krsProvider: string;
+  ignoreAddressTypes: string[];
+  bitgoKey: string;
+  walletPassphrase?: string;
+  apiKey?: string;
+  userKeyPath?: string;
+}
+
+async function queryBlockchainUnspentsPath(
+  coin: AbstractUtxoCoin,
+  params: RecoverParams,
+  keyArray: bitcoin.HDNode[],
+  basePath: string,
+  addressesById
+) {
+  const MAX_SEQUENTIAL_ADDRESSES_WITHOUT_TXS = params.scan || 20;
+  let numSequentialAddressesWithoutTxs = 0;
+
+  async function gatherUnspents(addrIndex: number) {
+    const derivedKeys = coin.deriveKeys(keyArray, addrIndex);
+
+    const chain = Number(basePath.split('/').pop()); // extracts the chain from the basePath
+    const keys = derivedKeys.map((k) => k.getPublicKeyBuffer());
+    const address: any = coin.createMultiSigAddress(Codes.typeForCode(chain), 2, keys);
+
+    const addrInfo: AddressInfo = (await coin.getAddressInfoFromExplorer(address.address, params.apiKey)) as any;
+    // we use txCount here because it implies usage - having tx'es means the addr was generated and used
+    if (addrInfo.txCount === 0) {
+      numSequentialAddressesWithoutTxs++;
+    } else {
+      numSequentialAddressesWithoutTxs = 0;
+
+      if (addrInfo.totalBalance > 0) {
+        console.log(`Found an address with balance: ${address.address} with balance ${addrInfo.totalBalance}`);
+        // This address has a balance.
+        address.chainPath = basePath + '/' + addrIndex;
+        address.userKey = derivedKeys[0];
+        address.backupKey = derivedKeys[1];
+        addressesById[address.address] = address;
+
+        // Try to find unspents on it.
+        const addressUnspents: UnspentInfo[] = (await coin.getUnspentInfoFromExplorer(
+          address.address,
+          params.apiKey
+        )) as any;
+
+        addressUnspents.forEach(function addAddressToUnspent(unspent) {
+          unspent.address = address.address;
+          walletUnspents.push(unspent);
+        });
+      }
+    }
+
+    if (numSequentialAddressesWithoutTxs >= MAX_SEQUENTIAL_ADDRESSES_WITHOUT_TXS) {
+      // stop searching for addresses with unspents in them, we've found ${MAX_SEQUENTIAL_ADDRESSES_WITHOUT_TXS} in a row with none
+      // we are done
+      return;
+    }
+
+    return gatherUnspents(addrIndex + 1);
+  }
+
+  // get unspents for these addresses
+
+  const walletUnspents: UnspentInfo[] = [];
+  // This will populate walletAddresses
+  await gatherUnspents(0);
+
+  if (walletUnspents.length === 0) {
+    // Couldn't find any addresses with funds
+    return [];
+  }
+
+  return walletUnspents;
+}
+
+/**
+ * Builds a funds recovery transaction without BitGo
+ * @param coin
+ * @param params
+ * - userKey: [encrypted] xprv, or xpub
+ * - backupKey: [encrypted] xprv, or xpub if the xprv is held by a KRS provider
+ * - walletPassphrase: necessary if one of the xprvs is encrypted
+ * - bitgoKey: xpub
+ * - krsProvider: necessary if backup key is held by KRS
+ * - recoveryDestination: target address to send recovered funds to
+ * - scan: the amount of consecutive addresses without unspents to scan through before stopping
+ * - ignoreAddressTypes: (optional) array of AddressTypes to ignore, these are strings defined in Codes.UnspentTypeTcomb
+ *        for example: ['p2shP2wsh', 'p2wsh'] will prevent code from checking for wrapped-segwit and native-segwit chains on the public block explorers
+ */
+export async function recover(coin: AbstractUtxoCoin, params: RecoverParams) {
+  if (_.isUndefined(params.userKey)) {
+    throw new Error('missing userKey');
+  }
+
+  if (_.isUndefined(params.backupKey)) {
+    throw new Error('missing backupKey');
+  }
+
+  if (_.isUndefined(params.recoveryDestination) || !coin.isValidAddress(params.recoveryDestination)) {
+    throw new Error('invalid recoveryDestination');
+  }
+
+  if (!_.isUndefined(params.scan) && (!_.isInteger(params.scan) || params.scan < 0)) {
+    throw new Error('scan must be a positive integer');
+  }
+
+  const isKrsRecovery = params.backupKey.startsWith('xpub') && !params.userKey.startsWith('xpub');
+  const isUnsignedSweep = params.backupKey.startsWith('xpub') && params.userKey.startsWith('xpub');
+  const krsProvider = config.krsProviders[params.krsProvider];
+
+  if (isKrsRecovery && _.isUndefined(krsProvider)) {
+    throw new Error('unknown key recovery service provider');
+  }
+
+  if (isKrsRecovery && !krsProvider.supportedCoins.includes(coin.getFamily())) {
+    throw new Error('specified key recovery service does not support recoveries for this coin');
+  }
+
+  // check whether key material and password authenticate the users and return parent keys of all three keys of the wallet
+  const keys = await coin.initiateRecovery(params);
+
+  const [userKey, backupKey, bitgoKey] = keys as any;
+  let derivedUserKey;
+  let baseKeyPath;
+  if (params.userKeyPath) {
+    derivedUserKey = deriveKeyByPath(userKey, params.userKeyPath);
+    const twoKeys = coin.deriveKeys(coin.deriveKeys([backupKey, bitgoKey], 0), 0);
+    baseKeyPath = [derivedUserKey, ...twoKeys];
+  } else {
+    baseKeyPath = coin.deriveKeys(coin.deriveKeys(keys as any, 0), 0);
+  }
+
+  const queries: any[] = [];
+  const addressesById = {};
+
+  _.forEach(Object.keys(Codes.UnspentTypeTcomb.meta.map), function (addressType) {
+    // If we aren't ignoring the address type, we derive the public key and construct the query for the external and
+    // internal indices
+    if (!_.includes(params.ignoreAddressTypes, addressType)) {
+      if (addressType === Codes.UnspentTypeTcomb('p2shP2wsh') && !coin.supportsP2shP2wsh()) {
+        // P2shP2wsh is not supported. Skip.
+        return;
+      }
+
+      if (addressType === Codes.UnspentTypeTcomb('p2wsh') && !coin.supportsP2wsh()) {
+        // P2wsh is not supported. Skip.
+        return;
+      }
+
+      let codes;
+      try {
+        codes = Codes.forType(Codes.UnspentTypeTcomb(addressType) as any);
+      } catch (e) {
+        // The unspent type is not supported by bitgo so attempting to get its chain codes throws. Catch that error
+        // and continue.
+        return;
+      }
+      const externalChainCode = codes.external;
+      const internalChainCode = codes.internal;
+      const externalKey = coin.deriveKeys(baseKeyPath, externalChainCode);
+      const internalKey = coin.deriveKeys(baseKeyPath, internalChainCode);
+      queries.push(queryBlockchainUnspentsPath(coin, params, externalKey, '/0/0/' + externalChainCode, addressesById));
+      queries.push(queryBlockchainUnspentsPath(coin, params, internalKey, '/0/0/' + internalChainCode, addressesById));
+    }
+  });
+
+  // Execute the queries and gather the unspents
+  const queryResponses = await Promise.all(queries);
+  const unspents: any[] = _.flatten(queryResponses); // this flattens the array (turns an array of arrays into just one array)
+  const totalInputAmount = _.sumBy(unspents, 'amount');
+  if (totalInputAmount <= 0) {
+    throw new errors.ErrorNoInputToRecover();
+  }
+
+  // Build the transaction
+  const transactionBuilder = new bitcoin.TransactionBuilder(coin.network);
+  coin.prepareTransactionBuilder(transactionBuilder);
+  const txInfo: any = {};
+
+  const feePerByte: number = (await coin.getRecoveryFeePerBytes()) as any;
+
+  // KRS recovery transactions have a 2nd output to pay the recovery fee, like paygo fees. Use p2wsh outputs because
+  // they are the largest outputs and thus the most conservative estimate to use in calculating fees. Also use
+  // segwit overhead size and p2sh inputs for the same reason.
+  const outputSize = (isKrsRecovery ? 2 : 1) * VirtualSizes.txP2wshOutputSize;
+  const approximateSize = VirtualSizes.txSegOverheadVSize + outputSize + VirtualSizes.txP2shInputSize * unspents.length;
+  const approximateFee = approximateSize * feePerByte;
+
+  // Construct a transaction
+  txInfo.inputs = unspents.map(function addInputForUnspent(unspent) {
+    const address = addressesById[unspent.address];
+
+    transactionBuilder.addInput(unspent.txid, unspent.n, 0xffffffff, address.outputScript);
+
+    return {
+      chainPath: address.chainPath,
+      redeemScript: address.redeemScript && address.redeemScript.toString('hex'),
+      witnessScript: address.witnessScript && address.witnessScript.toString('hex'),
+      value: unspent.amount,
+    };
+  });
+
+  let recoveryAmount = totalInputAmount - approximateFee;
+  let krsFee;
+  if (isKrsRecovery) {
+    try {
+      krsFee = await coin.calculateFeeAmount({
+        provider: params.krsProvider,
+        amount: recoveryAmount,
+      });
+      recoveryAmount -= krsFee;
+    } catch (err) {
+      // Don't let this error block the recovery -
+      console.dir(err);
+    }
+  }
+
+  if (recoveryAmount < 0) {
+    throw new Error(`this wallet\'s balance is too low to pay the fees specified by the KRS provider. 
+          Existing balance on wallet: ${totalInputAmount}. Estimated network fee for the recovery transaction
+          : ${approximateFee}, KRS fee to pay: ${krsFee}. After deducting fees, your total recoverable balance
+          is ${recoveryAmount}`);
+  }
+
+  transactionBuilder.addOutput(params.recoveryDestination, recoveryAmount);
+
+  if (isKrsRecovery && krsFee > 0) {
+    const krsFeeAddress = krsProvider.feeAddresses[coin.getChain()];
+
+    if (!krsFeeAddress) {
+      throw new Error('this KRS provider has not configured their fee structure yet - recovery cannot be completed');
+    }
+
+    transactionBuilder.addOutput(krsFeeAddress, krsFee);
+  }
+
+  if (isUnsignedSweep) {
+    const txHex = transactionBuilder.buildIncomplete().toBuffer().toString('hex');
+    return coin.formatForOfflineVault(txInfo, txHex);
+  } else {
+    const signedTx = coin.signRecoveryTransaction(transactionBuilder, unspents, addressesById, !isKrsRecovery);
+    txInfo.transactionHex = signedTx.build().toBuffer().toString('hex');
+    try {
+      txInfo.tx = await coin.verifyRecoveryTransaction(txInfo);
+    } catch (e) {
+      // some coins don't have a reliable third party verification endpoint, or sometimes the third party endpoint
+      // could be unavailable due to service outage, so we continue without verification for those coins, but we will
+      // let users know that they should verify their own
+      // this message should be piped to WRW and displayed on the UI
+      if (e instanceof errors.MethodNotImplementedError || e instanceof errors.BlockExplorerUnavailable) {
+        console.log('Please verify your transaction by decoding the tx hex using a third-party api of your choice');
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  if (isKrsRecovery) {
+    txInfo.coin = coin.getChain();
+    txInfo.backupKey = params.backupKey;
+    txInfo.recoveryAmount = recoveryAmount;
+  }
+
+  return txInfo;
+}


### PR DESCRIPTION
The class method implementation was using deprecated coroutine wrappers and
was way too long.

Issue: BG-34381

5e89226e (Otto Allmendinger, 36 minutes ago)
chore(core): apply prettier to abstractUtxoCoin

Issue: BG-34381