### PR TITLE
refactor(core): deprecate coin method `initiateRecovery()`

### DIFF
--- a/modules/core/src/v2/baseCoin.ts
+++ b/modules/core/src/v2/baseCoin.ts
@@ -469,28 +469,9 @@ export abstract class BaseCoin {
 
   /**
    * @deprecated - use getBip32Keys() in conjunction with isValidAddress instead
-   * @param params
    */
-  initiateRecovery(params: InitiateRecoveryOptions): Bluebird<any> {
-    const self = this;
-    return co(function* initiateRecovery() {
-      // Validate the destination address
-      try {
-        if (!self.isValidAddress(params.recoveryDestination)) {
-          throw new Error('Invalid destination address!');
-        }
-      } catch (e) {
-        // if isValidAddress is not implemented, assume the destination
-        // address is valid and let the tx go through. If the destination
-        // is actually invalid (`isValidAddress` returns false and does
-        // not throw), this method will still throw
-        if (!(e instanceof errors.MethodNotImplementedError)) {
-          throw e;
-        }
-      }
-
-      return getBip32Keys(self.bitgo, params, { requireBitGoXpub: false });
-    }).call(this);
+  initiateRecovery(params: InitiateRecoveryOptions): never {
+    throw new Error('deprecated method');
   }
 
   // Some coins can have their tx info verified, if a public tx decoder is available

--- a/modules/core/src/v2/baseCoin.ts
+++ b/modules/core/src/v2/baseCoin.ts
@@ -23,6 +23,7 @@ import { Enterprises } from './enterprises';
 import { BaseCoin as AccountLibBasecoin } from '@bitgo/account-lib';
 import { signMessage } from '../bip32util';
 import * as crypto from 'crypto';
+import { InitiateRecoveryOptions } from './recovery/initiate';
 export type TransactionType = AccountLibBasecoin.TransactionType;
 
 export interface TransactionRecipient {
@@ -155,14 +156,6 @@ export interface ParsedTransaction {
 // TODO (SDKT-9): reverse engineer and add options
 export interface SignTransactionOptions {
   [index: string]: unknown;
-}
-
-export interface InitiateRecoveryOptions {
-  userKey: string;
-  backupKey: string;
-  bitgoKey?: string; // optional for xrp recoveries
-  recoveryDestination: string;
-  walletPassphrase?: string;
 }
 
 export interface KeychainsTriplet {
@@ -477,58 +470,9 @@ export abstract class BaseCoin {
   initiateRecovery(params: InitiateRecoveryOptions): Bluebird<any> {
     const self = this;
     return co(function* initiateRecovery() {
-      const keys: bitcoin.HDNode[] = [];
-      const userKey = params.userKey; // Box A
-      let backupKey = params.backupKey; // Box B
-      const bitgoXpub = params.bitgoKey; // Box C
-      const destinationAddress = params.recoveryDestination;
-      const passphrase = params.walletPassphrase;
-
-      const isKrsRecovery = backupKey.startsWith('xpub') && !userKey.startsWith('xpub');
-
-      function validatePassphraseKey(userKey: string, passphrase?: string): bitcoin.HDNode {
-        try {
-          if (!userKey.startsWith('xprv') && !userKey.startsWith('xpub')) {
-            userKey = self.bitgo.decrypt({
-              input: userKey,
-              password: passphrase,
-            });
-          }
-          return bitcoin.HDNode.fromBase58(userKey);
-        } catch (e) {
-          throw new Error('Failed to decrypt user key with passcode - try again!');
-        }
-      }
-
-      const key: bitcoin.HDNode = validatePassphraseKey(userKey, passphrase);
-
-      keys.push(key);
-
-      // Validate the backup key
-      try {
-        if (!backupKey.startsWith('xprv') && !isKrsRecovery && !backupKey.startsWith('xpub')) {
-          backupKey = self.bitgo.decrypt({
-            input: backupKey,
-            password: passphrase,
-          });
-        }
-        const backupHDNode = bitcoin.HDNode.fromBase58(backupKey);
-        keys.push(backupHDNode);
-      } catch (e) {
-        throw new Error('Failed to decrypt backup key with passcode - try again!');
-      }
-      try {
-        const bitgoHDNode = bitcoin.HDNode.fromBase58(bitgoXpub);
-        keys.push(bitgoHDNode);
-      } catch (e) {
-        if (self.getFamily() !== 'xrp') {
-          // in XRP recoveries, the BitGo xpub is optional
-          throw new Error('Failed to parse bitgo xpub!');
-        }
-      }
       // Validate the destination address
       try {
-        if (!self.isValidAddress(destinationAddress)) {
+        if (!self.isValidAddress(params.recoveryDestination)) {
           throw new Error('Invalid destination address!');
         }
       } catch (e) {
@@ -541,7 +485,7 @@ export abstract class BaseCoin {
         }
       }
 
-      return keys;
+      return getBip32Keys(self.bitgo, params, { requireBitGoXpub: false });
     }).call(this);
   }
 

--- a/modules/core/src/v2/baseCoin.ts
+++ b/modules/core/src/v2/baseCoin.ts
@@ -467,6 +467,10 @@ export abstract class BaseCoin {
     return;
   }
 
+  /**
+   * @deprecated - use getBip32Keys() in conjunction with isValidAddress instead
+   * @param params
+   */
   initiateRecovery(params: InitiateRecoveryOptions): Bluebird<any> {
     const self = this;
     return co(function* initiateRecovery() {

--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -1821,7 +1821,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
    * @param callback
    */
   recover(params: RecoverParams, callback?: NodeCallback<any>): Bluebird<any> {
-    return Bluebird.resolve(recover(this, params)).asCallback(callback);
+    return Bluebird.resolve(recover(this, this.bitgo, params)).asCallback(callback);
   }
 
   /**

--- a/modules/core/src/v2/coins/xlm.ts
+++ b/modules/core/src/v2/coins/xlm.ts
@@ -1,3 +1,6 @@
+/**
+ * @prettier
+ */
 import * as _ from 'lodash';
 import * as bitcoin from '@bitgo/utxo-lib';
 import * as querystring from 'querystring';
@@ -30,7 +33,8 @@ import {
   ParsedTransaction,
   VerifyTransactionOptions as BaseVerifyTransactionOptions,
   SignTransactionOptions as BaseSignTransactionOptions,
-  TransactionParams as BaseTransactionParams, ExtraPrebuildParamsOptions,
+  TransactionParams as BaseTransactionParams,
+  ExtraPrebuildParamsOptions,
 } from '../baseCoin';
 import { NodeCallback } from '../types';
 import { Wallet } from '../wallet';
@@ -87,7 +91,7 @@ interface SignTransactionOptions extends BaseSignTransactionOptions {
 interface HalfSignedTransaction {
   halfSigned: {
     txBase64: string;
-  }
+  };
 }
 
 interface SupplementGenerateWalletOptions {
@@ -267,7 +271,7 @@ export class Xlm extends BaseCoin {
       return false;
     }
 
-    return (memoIdNumber.gte(0) && memoIdNumber.lt(Xlm.maxMemoId));
+    return memoIdNumber.gte(0) && memoIdNumber.lt(Xlm.maxMemoId);
   }
 
   /**
@@ -298,14 +302,10 @@ export class Xlm extends BaseCoin {
    */
   getMinimumReserve(): Bluebird<number> {
     const self = this;
-    return co<number>(function *() {
+    return co<number>(function* () {
       const server = new stellar.Server(self.getHorizonUrl());
 
-      const horizonLedgerInfo = (yield server
-        .ledgers()
-        .order('desc')
-        .limit(1)
-        .call()) as any;
+      const horizonLedgerInfo = (yield server.ledgers().order('desc').limit(1).call()) as any;
 
       if (!horizonLedgerInfo) {
         throw new Error('unable to connect to Horizon for reserve requirement data');
@@ -324,14 +324,10 @@ export class Xlm extends BaseCoin {
    */
   getBaseTransactionFee(): Bluebird<number> {
     const self = this;
-    return co<number>(function *() {
+    return co<number>(function* () {
       const server = new stellar.Server(self.getHorizonUrl());
 
-      const horizonLedgerInfo = (yield server
-        .ledgers()
-        .order('desc')
-        .limit(1)
-        .call()) as any;
+      const horizonLedgerInfo = (yield server.ledgers().order('desc').limit(1).call()) as any;
 
       if (!horizonLedgerInfo) {
         throw new Error('unable to connect to Horizon for reserve requirement data');
@@ -471,9 +467,15 @@ export class Xlm extends BaseCoin {
    * @param {String} [address] - address to look up
    * @param {String} [accountId] - account id to look up
    */
-  private federationLookup({ address, accountId }: { address?: string, accountId?: string }): Bluebird<stellar.FederationServer.Record> {
+  private federationLookup({
+    address,
+    accountId,
+  }: {
+    address?: string;
+    accountId?: string;
+  }): Bluebird<stellar.FederationServer.Record> {
     const self = this;
-    return co<stellar.FederationServer.Record>(function *() {
+    return co<stellar.FederationServer.Record>(function* () {
       try {
         const federationServer = self.getBitGoFederationServer();
         if (address) {
@@ -501,7 +503,7 @@ export class Xlm extends BaseCoin {
    */
   federationLookupByName(address: string): Bluebird<stellar.FederationServer.Record> {
     const self = this;
-    return co<stellar.FederationServer.Record>(function *() {
+    return co<stellar.FederationServer.Record>(function* () {
       if (!address) {
         throw new Error('invalid Stellar address');
       }
@@ -518,7 +520,7 @@ export class Xlm extends BaseCoin {
    */
   federationLookupByAccountId(accountId: string): Bluebird<stellar.FederationServer.Record> {
     const self = this;
-    return co<stellar.FederationServer.Record>(function *() {
+    return co<stellar.FederationServer.Record>(function* () {
       if (!accountId) {
         throw new Error('invalid Stellar account');
       }
@@ -541,7 +543,9 @@ export class Xlm extends BaseCoin {
     const rootAddressDetails = this.getAddressDetails(rootAddress);
 
     if (addressDetails.address !== rootAddressDetails.address) {
-      throw new UnexpectedAddressError(`address validation failure: ${addressDetails.address} vs ${rootAddressDetails.address}`);
+      throw new UnexpectedAddressError(
+        `address validation failure: ${addressDetails.address} vs ${rootAddressDetails.address}`
+      );
     }
 
     return true;
@@ -551,7 +555,10 @@ export class Xlm extends BaseCoin {
    * Get extra parameters for prebuilding a tx
    * Set empty recipients array in trustline txs
    */
-  getExtraPrebuildParams(buildParams: ExtraPrebuildParamsOptions, callback?: NodeCallback<BuildOptions>): Bluebird<BuildOptions> {
+  getExtraPrebuildParams(
+    buildParams: ExtraPrebuildParamsOptions,
+    callback?: NodeCallback<BuildOptions>
+  ): Bluebird<BuildOptions> {
     const params: { recipients?: Record<string, string>[] } = {};
     if (buildParams.type === 'trustline') {
       params.recipients = [];
@@ -565,7 +572,7 @@ export class Xlm extends BaseCoin {
    */
   initiateRecovery(params: RecoveryOptions): Bluebird<stellar.Keypair[]> {
     const self = this;
-    return co<stellar.Keypair[]>(function *() {
+    return co<stellar.Keypair[]>(function* () {
       const keys: stellar.Keypair[] = [];
       let userKey = params.userKey;
       let backupKey = params.backupKey;
@@ -574,13 +581,18 @@ export class Xlm extends BaseCoin {
       const isKrsRecovery = backupKey.startsWith('G') && !userKey.startsWith('G');
       const isUnsignedSweep = backupKey.startsWith('G') && userKey.startsWith('G');
 
-
       if (isKrsRecovery && params.krsProvider && _.isUndefined(config.krsProviders[params.krsProvider])) {
         throw new KeyRecoveryServiceError(`Unknown key recovery service provider - ${params.krsProvider}`);
       }
 
-      if (isKrsRecovery && params.krsProvider && !config.krsProviders[params.krsProvider].supportedCoins.includes(self.getFamily())) {
-        throw new KeyRecoveryServiceError(`Specified key recovery service does not support recoveries for ${self.getChain()}`);
+      if (
+        isKrsRecovery &&
+        params.krsProvider &&
+        !config.krsProviders[params.krsProvider].supportedCoins.includes(self.getFamily())
+      ) {
+        throw new KeyRecoveryServiceError(
+          `Specified key recovery service does not support recoveries for ${self.getChain()}`
+        );
       }
 
       if (!self.isValidAddress(params.recoveryDestination)) {
@@ -595,9 +607,9 @@ export class Xlm extends BaseCoin {
           });
         }
 
-        const userKeyPair = isUnsignedSweep ?
-          stellar.Keypair.fromPublicKey(userKey) :
-          stellar.Keypair.fromSecret(userKey);
+        const userKeyPair = isUnsignedSweep
+          ? stellar.Keypair.fromPublicKey(userKey)
+          : stellar.Keypair.fromSecret(userKey);
         keys.push(userKeyPair);
       } catch (e) {
         throw new Error('Failed to decrypt user key with passcode - try again!');
@@ -637,7 +649,7 @@ export class Xlm extends BaseCoin {
    */
   recover(params: RecoveryOptions, callback: NodeCallback<RecoveryTransaction>): Bluebird<RecoveryTransaction> {
     const self = this;
-    return co<RecoveryTransaction>(function *() {
+    return co<RecoveryTransaction>(function* () {
       const [userKey, backupKey] = (yield self.initiateRecovery(params)) as any;
       const isKrsRecovery = params.backupKey.startsWith('G') && !params.userKey.startsWith('G');
       const isUnsignedSweep = params.backupKey.startsWith('G') && params.userKey.startsWith('G');
@@ -674,7 +686,7 @@ export class Xlm extends BaseCoin {
       const account = new stellar.Account(params.rootAddress, accountData.sequence);
 
       // Stellar supports multiple assets on chain, we're only interested in the balances entry whose type is "native" (XLM)
-      const nativeBalanceInfo = accountData.balances.find(assetBalance => assetBalance['asset_type'] === 'native');
+      const nativeBalanceInfo = accountData.balances.find((assetBalance) => assetBalance['asset_type'] === 'native');
 
       if (!nativeBalanceInfo) {
         throw new Error('Provided wallet has a balance of 0 XLM, recovery aborted');
@@ -686,19 +698,22 @@ export class Xlm extends BaseCoin {
       const recoveryAmount = walletBalance - minimumReserve - baseTxFee;
       const formattedRecoveryAmount = self.baseUnitsToBigUnits(recoveryAmount).toString();
 
-      const txBuilder = new stellar.TransactionBuilder(account, { fee: baseTxFee.toFixed(0), networkPassphrase: self.getStellarNetwork() });
-      const operation = unfundedDestination ?
-        // In this case, we need to create the account
-        stellar.Operation.createAccount({
-          destination: params.recoveryDestination,
-          startingBalance: formattedRecoveryAmount,
-        }) :
-        // Otherwise if the account already exists, we do a normal send
-        stellar.Operation.payment({
-          destination: params.recoveryDestination,
-          asset: stellar.Asset.native(),
-          amount: formattedRecoveryAmount,
-        });
+      const txBuilder = new stellar.TransactionBuilder(account, {
+        fee: baseTxFee.toFixed(0),
+        networkPassphrase: self.getStellarNetwork(),
+      });
+      const operation = unfundedDestination
+        ? // In this case, we need to create the account
+          stellar.Operation.createAccount({
+            destination: params.recoveryDestination,
+            startingBalance: formattedRecoveryAmount,
+          })
+        : // Otherwise if the account already exists, we do a normal send
+          stellar.Operation.payment({
+            destination: params.recoveryDestination,
+            asset: stellar.Asset.native(),
+            amount: formattedRecoveryAmount,
+          });
       const tx = txBuilder.addOperation(operation).setTimeout(stellar.TimeoutInfinite).build();
 
       if (!isUnsignedSweep) {
@@ -720,7 +735,9 @@ export class Xlm extends BaseCoin {
       }
 
       return transaction;
-    }).call(this).asCallback(callback);
+    })
+      .call(this)
+      .asCallback(callback);
   }
 
   /**
@@ -732,9 +749,12 @@ export class Xlm extends BaseCoin {
    * @param callback
    * @returns {Bluebird<HalfSignedTransaction>}
    */
-  signTransaction(params: SignTransactionOptions, callback?: NodeCallback<HalfSignedTransaction>): Bluebird<HalfSignedTransaction> {
+  signTransaction(
+    params: SignTransactionOptions,
+    callback?: NodeCallback<HalfSignedTransaction>
+  ): Bluebird<HalfSignedTransaction> {
     const self = this;
-    return co<HalfSignedTransaction>(function *() {
+    return co<HalfSignedTransaction>(function* () {
       const { txPrebuild, prv } = params;
 
       if (_.isUndefined(txPrebuild)) {
@@ -774,7 +794,7 @@ export class Xlm extends BaseCoin {
    */
   supplementGenerateWallet(walletParams: SupplementGenerateWalletOptions): Bluebird<SupplementGenerateWalletOptions> {
     const self = this;
-    return co<SupplementGenerateWalletOptions>(function *() {
+    return co<SupplementGenerateWalletOptions>(function* () {
       let seed;
       const rootPrv = walletParams.rootPrivateKey;
       if (rootPrv) {
@@ -837,9 +857,12 @@ export class Xlm extends BaseCoin {
    * @param params
    * @param callback
    */
-  explainTransaction(params: ExplainTransactionOptions, callback?: NodeCallback<TransactionExplanation>): Bluebird<TransactionExplanation> {
+  explainTransaction(
+    params: ExplainTransactionOptions,
+    callback?: NodeCallback<TransactionExplanation>
+  ): Bluebird<TransactionExplanation> {
     const self = this;
-    return co<TransactionExplanation>(function *() {
+    return co<TransactionExplanation>(function* () {
       const { txBase64 } = params;
       let tx: stellar.Transaction;
 
@@ -852,11 +875,13 @@ export class Xlm extends BaseCoin {
 
       // In a Stellar tx, the _memo property is an object with the methods:
       // value() and arm() that provide memo value and type, respectively.
-      const memo: TransactionMemo = _.result(tx, '_memo.value') && _.result(tx, '_memo.arm') ?
-        {
-          value: (_.result(tx, '_memo.value') as any).toString(),
-          type: _.result(tx, '_memo.arm'),
-        } : {};
+      const memo: TransactionMemo =
+        _.result(tx, '_memo.value') && _.result(tx, '_memo.arm')
+          ? {
+              value: (_.result(tx, '_memo.value') as any).toString(),
+              type: _.result(tx, '_memo.arm'),
+            }
+          : {};
 
       let spendAmount = new BigNumber(0); // amount of XLM used in XLM-only txs
       const spendAmounts = {}; // track both xlm and token amounts
@@ -867,13 +892,11 @@ export class Xlm extends BaseCoin {
       const outputs: TransactionOutput[] = [];
       const operations: TransactionOperation[] = []; // non-payment operations
 
-      _.forEach(tx.operations, op => {
+      _.forEach(tx.operations, (op) => {
         if (op.type === 'createAccount' || op.type === 'payment') {
           // TODO Remove memoId from address
           // Get memo to attach to address, if type is 'id'
-          const memoId = _.get(memo, 'type') === 'id' && ! _.get(memo, 'value') ?
-            `?memoId=${memo.value}` :
-            '';
+          const memoId = _.get(memo, 'type') === 'id' && !_.get(memo, 'value') ? `?memoId=${memo.value}` : '';
           const asset = op.type === 'payment' ? op.asset : stellar.Asset.native();
           const coin = self.getTokenNameFromStellarAsset(asset); // coin or token id
           const output: TransactionOutput = {
@@ -912,7 +935,17 @@ export class Xlm extends BaseCoin {
       };
 
       return {
-        displayOrder: ['id', 'outputAmount', 'outputAmounts', 'changeAmount', 'outputs', 'changeOutputs', 'fee', 'memo', 'operations'],
+        displayOrder: [
+          'id',
+          'outputAmount',
+          'outputAmounts',
+          'changeAmount',
+          'outputs',
+          'changeOutputs',
+          'fee',
+          'memo',
+          'operations',
+        ],
         id,
         outputs,
         outputAmount,
@@ -923,7 +956,9 @@ export class Xlm extends BaseCoin {
         fee,
         operations,
       };
-    }).call(this).asCallback(callback);
+    })
+      .call(this)
+      .asCallback(callback);
   }
 
   /**
@@ -936,9 +971,9 @@ export class Xlm extends BaseCoin {
     if (trustlineOperations.length !== _.get(txParams, 'trustlines', []).length) {
       throw new Error('transaction prebuild does not match expected trustline operations');
     }
-    _.forEach(trustlineOperations, op => {
+    _.forEach(trustlineOperations, (op) => {
       const opToken = this.getTokenNameFromStellarAsset(op.line);
-      const tokenTrustline = _.find(txParams.trustlines, trustline => {
+      const tokenTrustline = _.find(txParams.trustlines, (trustline) => {
         // trustline params use limits in base units
         const opLimitBaseUnits = this.bigUnitsToBaseUnits(op.limit);
         // Prepare the conditions to check for
@@ -946,9 +981,10 @@ export class Xlm extends BaseCoin {
         // 1. Action is 'add' - limit is set to Xlm.maxTrustlineLimit by default
         // 2. Action is 'remove' - limit is set to '0'
         const noLimit = _.isUndefined(trustline.limit);
-        const addTrustlineWithDefaultLimit = (trustline.action === 'add' && opLimitBaseUnits === Xlm.maxTrustlineLimit);
-        const removeTrustline = (trustline.action === 'remove' && opLimitBaseUnits === '0');
-        return (trustline.token === opToken &&
+        const addTrustlineWithDefaultLimit = trustline.action === 'add' && opLimitBaseUnits === Xlm.maxTrustlineLimit;
+        const removeTrustline = trustline.action === 'remove' && opLimitBaseUnits === '0';
+        return (
+          trustline.token === opToken &&
           (trustline.limit === opLimitBaseUnits || (noLimit && (addTrustlineWithDefaultLimit || removeTrustline)))
         );
       });
@@ -973,13 +1009,8 @@ export class Xlm extends BaseCoin {
   verifyTransaction(options: VerifyTransactionOptions, callback?: NodeCallback<boolean>): Bluebird<boolean> {
     // TODO BG-5600 Add parseTransaction / improve verification
     const self = this;
-    return co<boolean>(function *() {
-      const {
-        txParams,
-        txPrebuild,
-        wallet,
-        verification = {},
-      } = options;
+    return co<boolean>(function* () {
+      const { txParams, txPrebuild, wallet, verification = {} } = options;
       const disableNetworking = !!verification.disableNetworking;
 
       if (!txPrebuild.txBase64) {
@@ -993,8 +1024,9 @@ export class Xlm extends BaseCoin {
       }
 
       // Stellar txs are made up of operations. We only care about Create Account and Payment for sending funds.
-      const outputOperations = _.filter(tx.operations, operation =>
-        operation.type === 'createAccount' || operation.type === 'payment'
+      const outputOperations = _.filter(
+        tx.operations,
+        (operation) => operation.type === 'createAccount' || operation.type === 'payment'
       );
 
       if (txParams.type === 'trustline') {
@@ -1006,14 +1038,14 @@ export class Xlm extends BaseCoin {
 
         _.forEach(txParams.recipients, (expectedOutput, index) => {
           const expectedOutputAddress = self.getAddressDetails(expectedOutput.address);
-          const output = outputOperations[index] as (stellar.Operation.Payment | stellar.Operation.CreateAccount);
+          const output = outputOperations[index] as stellar.Operation.Payment | stellar.Operation.CreateAccount;
           if (output.destination !== expectedOutputAddress.address) {
             throw new Error('transaction prebuild does not match expected recipient');
           }
 
           const expectedOutputAmount = new BigNumber(expectedOutput.amount);
           // The output amount is expressed as startingBalance in createAccount operations and as amount in payment operations.
-          const outputAmountString = (output.type === 'createAccount') ? output.startingBalance : output.amount;
+          const outputAmountString = output.type === 'createAccount' ? output.startingBalance : output.amount;
           const outputAmount = new BigNumber(self.bigUnitsToBaseUnits(outputAmountString));
 
           if (!outputAmount.eq(expectedOutputAmount)) {
@@ -1050,7 +1082,9 @@ export class Xlm extends BaseCoin {
       }
 
       return true;
-    }).call(this).asCallback(callback);
+    })
+      .call(this)
+      .asCallback(callback);
   }
 
   /**
@@ -1069,9 +1103,7 @@ export class Xlm extends BaseCoin {
       parseInt(derivationPathInput.slice(0, 7), 16),
       parseInt(derivationPathInput.slice(7, 14), 16),
     ];
-    const derivationPath = 'm/' + derivationPathParts
-      .map((part) => `${part}'`)
-      .join('/');
+    const derivationPath = 'm/' + derivationPathParts.map((part) => `${part}'`).join('/');
     const derivedKey = Ed25519KeyDeriver.derivePath(derivationPath, key).key;
     const keypair = stellar.Keypair.fromRawEd25519Seed(derivedKey);
     return {
@@ -1085,9 +1117,13 @@ export class Xlm extends BaseCoin {
    * correct one to use, so we have to be very explicit as to which one we want.
    * @param tx transaction to convert
    */
-  protected static txToString = (tx: stellar.Transaction): string => (tx.toEnvelope().toXDR as ((_: string) => string))('base64');
+  protected static txToString = (tx: stellar.Transaction): string =>
+    (tx.toEnvelope().toXDR as (_: string) => string)('base64');
 
-  parseTransaction(params: ParseTransactionOptions, callback?: NodeCallback<ParsedTransaction>): Bluebird<ParsedTransaction> {
+  parseTransaction(
+    params: ParseTransactionOptions,
+    callback?: NodeCallback<ParsedTransaction>
+  ): Bluebird<ParsedTransaction> {
     return Bluebird.resolve({}).asCallback(callback);
   }
 }

--- a/modules/core/src/v2/coins/xrp.ts
+++ b/modules/core/src/v2/coins/xrp.ts
@@ -1,3 +1,6 @@
+/**
+ * @prettier
+ */
 import * as bip32 from 'bip32';
 import { BigNumber } from 'bignumber.js';
 import { HDNode, ECPair } from '@bitgo/utxo-lib';
@@ -81,8 +84,8 @@ export interface RecoveryOptions {
 
 interface HalfSignedTransaction {
   halfSigned: {
-    txHex: string
-  }
+    txHex: string;
+  };
 }
 
 interface SupplementGenerateWalletOptions {
@@ -155,7 +158,9 @@ export class Xrp extends BaseCoin {
 
     if (Array.isArray(queryDetails.dt)) {
       // if queryDetails.dt is an array, that means dt was given multiple times, which is not valid
-      throw new InvalidAddressError(`destination tag can appear at most once, but ${queryDetails.dt.length} destination tags were found`);
+      throw new InvalidAddressError(
+        `destination tag can appear at most once, but ${queryDetails.dt.length} destination tags were found`
+      );
     }
 
     const parsedTag = parseInt(queryDetails.dt, 10);
@@ -163,7 +168,7 @@ export class Xrp extends BaseCoin {
       throw new InvalidAddressError('invalid destination tag');
     }
 
-    if (parsedTag > 0xFFFFFFFF || parsedTag < 0) {
+    if (parsedTag > 0xffffffff || parsedTag < 0) {
       throw new InvalidAddressError('destination tag out of range');
     }
 
@@ -217,9 +222,7 @@ export class Xrp extends BaseCoin {
    * Get fee info from server
    */
   public getFeeInfo(_?, callback?): Bluebird<FeeInfo> {
-    return Bluebird.resolve(
-      this.bitgo.get(this.url('/public/feeinfo')).result()
-    ).nodeify(callback);
+    return Bluebird.resolve(this.bitgo.get(this.url('/public/feeinfo')).result()).nodeify(callback);
   }
 
   /**
@@ -230,8 +233,11 @@ export class Xrp extends BaseCoin {
    * @param callback
    * @returns Bluebird<HalfSignedTransaction>
    */
-  public signTransaction({ txPrebuild, prv }: SignTransactionOptions, callback?: NodeCallback<HalfSignedTransaction>): Bluebird<HalfSignedTransaction> {
-    return co<HalfSignedTransaction>(function *() {
+  public signTransaction(
+    { txPrebuild, prv }: SignTransactionOptions,
+    callback?: NodeCallback<HalfSignedTransaction>
+  ): Bluebird<HalfSignedTransaction> {
+    return co<HalfSignedTransaction>(function* () {
       if (_.isUndefined(txPrebuild) || !_.isObject(txPrebuild)) {
         if (!_.isUndefined(txPrebuild) && !_.isObject(txPrebuild)) {
           throw new Error(`txPrebuild must be an object, got type ${typeof txPrebuild}`);
@@ -251,7 +257,9 @@ export class Xrp extends BaseCoin {
       const userAddress = rippleKeypairs.deriveAddress(userKey.getPublicKeyBuffer().toString('hex'));
 
       const rippleLib = ripple();
-      const halfSigned = rippleLib.signWithPrivateKey(txPrebuild.txHex, userPrivateKey.toString('hex'), { signAs: userAddress });
+      const halfSigned = rippleLib.signWithPrivateKey(txPrebuild.txHex, userPrivateKey.toString('hex'), {
+        signAs: userAddress,
+      });
       return { halfSigned: { txHex: halfSigned.signedTransaction } };
     })
       .call(this)
@@ -265,7 +273,7 @@ export class Xrp extends BaseCoin {
    * - rootPrivateKey: optional hex-encoded Ripple private key
    */
   supplementGenerateWallet(walletParams: SupplementGenerateWalletOptions): Bluebird<SupplementGenerateWalletOptions> {
-    return co<SupplementGenerateWalletOptions>(function *() {
+    return co<SupplementGenerateWalletOptions>(function* () {
       if (walletParams.rootPrivateKey) {
         if (walletParams.rootPrivateKey.length !== 64) {
           throw new Error('rootPrivateKey needs to be a hexadecimal private key string');
@@ -283,8 +291,11 @@ export class Xrp extends BaseCoin {
    * @param params
    * @param callback
    */
-  explainTransaction(params: ExplainTransactionOptions = {}, callback?: NodeCallback<TransactionExplanation>): Bluebird<TransactionExplanation> {
-    return co<TransactionExplanation>(function *() {
+  explainTransaction(
+    params: ExplainTransactionOptions = {},
+    callback?: NodeCallback<TransactionExplanation>
+  ): Bluebird<TransactionExplanation> {
+    return co<TransactionExplanation>(function* () {
       if (!params.txHex) {
         throw new Error('missing required param txHex');
       }
@@ -322,7 +333,8 @@ export class Xrp extends BaseCoin {
         };
       }
 
-      const address = transaction.Destination + ((transaction.DestinationTag >= 0) ? '?dt=' + transaction.DestinationTag : '');
+      const address =
+        transaction.Destination + (transaction.DestinationTag >= 0 ? '?dt=' + transaction.DestinationTag : '');
       return {
         displayOrder: ['id', 'outputAmount', 'changeAmount', 'outputs', 'changeOutputs', 'fee'],
         id: id,
@@ -341,7 +353,9 @@ export class Xrp extends BaseCoin {
           size: txHex.length / 2,
         },
       };
-    }).call(this).asCallback(callback);
+    })
+      .call(this)
+      .asCallback(callback);
   }
 
   /**
@@ -354,7 +368,7 @@ export class Xrp extends BaseCoin {
    */
   public verifyTransaction({ txParams, txPrebuild }: VerifyTransactionOptions, callback): Bluebird<boolean> {
     const self = this;
-    return co<boolean>(function *() {
+    return co<boolean>(function* () {
       const explanation = (yield self.explainTransaction({
         txHex: txPrebuild.txHex,
       })) as any;
@@ -376,7 +390,9 @@ export class Xrp extends BaseCoin {
       }
 
       return true;
-    }).call(this).asCallback(callback);
+    })
+      .call(this)
+      .asCallback(callback);
   }
 
   /**
@@ -394,7 +410,9 @@ export class Xrp extends BaseCoin {
     const rootAddressDetails = this.getAddressDetails(rootAddress);
 
     if (addressDetails.address !== rootAddressDetails.address) {
-      throw new UnexpectedAddressError(`address validation failure: ${addressDetails.address} vs. ${rootAddressDetails.address}`);
+      throw new UnexpectedAddressError(
+        `address validation failure: ${addressDetails.address} vs. ${rootAddressDetails.address}`
+      );
     }
 
     return true;
@@ -419,22 +437,27 @@ export class Xrp extends BaseCoin {
    * - recoveryDestination: target address to send recovered funds to
    * @param callback
    */
-  public recover(params: RecoveryOptions, callback?: NodeCallback<RecoveryInfo | string>): Bluebird<RecoveryInfo | string> {
+  public recover(
+    params: RecoveryOptions,
+    callback?: NodeCallback<RecoveryInfo | string>
+  ): Bluebird<RecoveryInfo | string> {
     const self = this;
-    return co<RecoveryInfo | string>(function *explainTransaction(): any {
+    return co<RecoveryInfo | string>(function* explainTransaction(): any {
       const rippledUrl = self.getRippledUrl();
       const isKrsRecovery = params.backupKey.startsWith('xpub') && !params.userKey.startsWith('xpub');
       const isUnsignedSweep = params.backupKey.startsWith('xpub') && params.userKey.startsWith('xpub');
 
       const accountInfoParams = {
         method: 'account_info',
-        params: [{
-          account: params.rootAddress,
-          strict: true,
-          ledger_index: 'current',
-          queue: true,
-          signer_lists: true,
-        }],
+        params: [
+          {
+            account: params.rootAddress,
+            strict: true,
+            ledger_index: 'current',
+            queue: true,
+            signer_lists: true,
+          },
+        ],
       };
 
       const { keys, addressDetails, feeDetails, serverDetails } = yield Bluebird.props({
@@ -445,8 +468,12 @@ export class Xrp extends BaseCoin {
       });
 
       const openLedgerFee = new BigNumber(feeDetails.body.result.drops.open_ledger_fee);
-      const baseReserve = new BigNumber(serverDetails.body.result.info.validated_ledger.reserve_base_xrp).times(self.getBaseFactor());
-      const reserveDelta = new BigNumber(serverDetails.body.result.info.validated_ledger.reserve_inc_xrp).times(self.getBaseFactor());
+      const baseReserve = new BigNumber(serverDetails.body.result.info.validated_ledger.reserve_base_xrp).times(
+        self.getBaseFactor()
+      );
+      const reserveDelta = new BigNumber(serverDetails.body.result.info.validated_ledger.reserve_inc_xrp).times(
+        self.getBaseFactor()
+      );
       const currentLedger = serverDetails.body.result.info.validated_ledger.seq;
       const sequenceId = addressDetails.body.result.account_data.Sequence;
       const balance = new BigNumber(addressDetails.body.result.account_data.Balance);
@@ -521,7 +548,9 @@ export class Xrp extends BaseCoin {
         const queryDetails = querystring.parse(destinationDetails.query);
         if (Array.isArray(queryDetails.dt)) {
           // if queryDetails.dt is an array, that means dt was given multiple times, which is not valid
-          throw new InvalidAddressError(`destination tag can appear at most once, but ${queryDetails.dt.length} destination tags were found`);
+          throw new InvalidAddressError(
+            `destination tag can appear at most once, but ${queryDetails.dt.length} destination tags were found`
+          );
         }
 
         const parsedTag = parseInt(queryDetails.dt, 10);
@@ -570,7 +599,9 @@ export class Xrp extends BaseCoin {
         transactionExplanation.coin = self.getChain();
       }
       return transactionExplanation;
-    }).call(this).asCallback(callback);
+    })
+      .call(this)
+      .asCallback(callback);
   }
 
   /**
@@ -578,7 +609,7 @@ export class Xrp extends BaseCoin {
    */
   initiateRecovery(params: InitiateRecoveryOptions): Bluebird<HDNode[]> {
     const self = this;
-    return co<HDNode[]>(function *initiateRecovery() {
+    return co<HDNode[]>(function* initiateRecovery() {
       const keys: HDNode[] = [];
       const userKey = params.userKey; // Box A
       let backupKey = params.backupKey; // Box B
@@ -655,7 +686,10 @@ export class Xrp extends BaseCoin {
     };
   }
 
-  parseTransaction(params: ParseTransactionOptions, callback?: NodeCallback<ParsedTransaction>): Bluebird<ParsedTransaction> {
+  parseTransaction(
+    params: ParseTransactionOptions,
+    callback?: NodeCallback<ParsedTransaction>
+  ): Bluebird<ParsedTransaction> {
     return Bluebird.resolve({}).asCallback(callback);
   }
 }

--- a/modules/core/src/v2/recovery/initiate.ts
+++ b/modules/core/src/v2/recovery/initiate.ts
@@ -1,0 +1,73 @@
+/**
+ * @prettier
+ */
+
+import * as utxolib from '@bitgo/utxo-lib';
+import { BitGo } from '../../bitgo';
+
+export interface InitiateRecoveryOptions {
+  userKey: string;
+  backupKey: string;
+  bitgoKey?: string; // optional for xrp recoveries
+  recoveryDestination: string;
+  walletPassphrase?: string;
+}
+
+export function getIsKrsRecovery({ backupKey, userKey }: InitiateRecoveryOptions): boolean {
+  return backupKey.startsWith('xpub') && !userKey.startsWith('xpub');
+}
+
+export function getBip32Keys(
+  bitgo: BitGo,
+  params: InitiateRecoveryOptions,
+  { requireBitGoXpub }: { requireBitGoXpub: boolean }
+): utxolib.HDNode[] {
+  const keys: utxolib.HDNode[] = [];
+  const userKey = params.userKey; // Box A
+  let backupKey = params.backupKey; // Box B
+  const bitgoXpub = params.bitgoKey; // Box C
+  const passphrase = params.walletPassphrase;
+  const isKrsRecovery = getIsKrsRecovery(params);
+
+  const validatePassphraseKey = (userKey: string, passphrase?: string): utxolib.HDNode => {
+    try {
+      if (!userKey.startsWith('xprv') && !userKey.startsWith('xpub')) {
+        userKey = bitgo.decrypt({
+          input: userKey,
+          password: passphrase,
+        });
+      }
+      return utxolib.HDNode.fromBase58(userKey);
+    } catch (e) {
+      throw new Error('Failed to decrypt user key with passcode - try again!');
+    }
+  };
+
+  const key: utxolib.HDNode = validatePassphraseKey(userKey, passphrase);
+
+  keys.push(key);
+
+  // Validate the backup key
+  try {
+    if (!backupKey.startsWith('xprv') && !isKrsRecovery && !backupKey.startsWith('xpub')) {
+      backupKey = bitgo.decrypt({
+        input: backupKey,
+        password: passphrase,
+      });
+    }
+    const backupHDNode = utxolib.HDNode.fromBase58(backupKey);
+    keys.push(backupHDNode);
+  } catch (e) {
+    throw new Error('Failed to decrypt backup key with passcode - try again!');
+  }
+  try {
+    const bitgoHDNode = utxolib.HDNode.fromBase58(bitgoXpub);
+    keys.push(bitgoHDNode);
+  } catch (e) {
+    if (requireBitGoXpub) {
+      throw new Error('Failed to parse bitgo xpub!');
+    }
+  }
+
+  return keys;
+}

--- a/modules/core/src/v2/recovery/initiate.ts
+++ b/modules/core/src/v2/recovery/initiate.ts
@@ -21,11 +21,11 @@ export interface InitiateRecoveryOptions {
   walletPassphrase?: string;
 }
 
-export function getIsKrsRecovery({ backupKey, userKey }: InitiateRecoveryOptions): boolean {
+export function getIsKrsRecovery({ backupKey, userKey }: { backupKey: string; userKey: string }): boolean {
   return backupKey.startsWith('xpub') && !userKey.startsWith('xpub');
 }
 
-export function getIsUnsignedSweep({ backupKey, userKey }: InitiateRecoveryOptions): boolean {
+export function getIsUnsignedSweep({ backupKey, userKey }: { backupKey: string; userKey: string }): boolean {
   return backupKey.startsWith('xpub') && userKey.startsWith('xpub');
 }
 


### PR DESCRIPTION
This method has an awkward type signature that does not really fit well with
non-bip32 coins (XLM). It is also needlessly async.

Instead of messing around with complex generics we can simply define methods
`getBip32Keys()` and `getStellarKeys()` with good type signatures.

Outside of BitGoJS this method is only used in the Wallet-Recovery-Wizard, which can simply
use `getBip32Keys()` instead.

See individual commits for details.

Issue: BG-34381