### PR TITLE
refactor(core): deprecate hdPath

### DIFF
--- a/modules/core/src/bitcoin.ts
+++ b/modules/core/src/bitcoin.ts
@@ -140,10 +140,7 @@ export interface Derivable {
 }
 
 /**
- * Derive a BIP32 path, given a root key
- * We cache keys at each level of hierarchy we derive, to avoid re-deriving (approx 25ms per derivation)
- * @param rootKey key to derive off
- * @returns {*} function which can be used to derive a new HDNode from the root HDNode on a given path
+ * @deprecated - use `derivePath(p)` or `derivePath(sanitizeLegacyPath(p))` instead
  */
 export function hdPath(rootKey): Derivable {
   const cache = {};

--- a/modules/core/src/bitgo.ts
+++ b/modules/core/src/bitgo.ts
@@ -6,7 +6,7 @@
 
 import * as superagent from 'superagent';
 import * as bitcoin from '@bitgo/utxo-lib';
-import { makeRandomKey, hdPath } from './bitcoin';
+import { makeRandomKey } from './bitcoin';
 import * as secp256k1 from 'secp256k1';
 import bitcoinMessage = require('bitcoinjs-message');
 import { BaseCoin } from './v2/baseCoin';
@@ -45,6 +45,7 @@ import {
   toBitgoRequest,
   verifyResponse,
 } from './api';
+import { sanitizeLegacyPath } from './bip32path';
 
 const debug = debugLib('bitgo:index');
 
@@ -1045,8 +1046,8 @@ export class BitGo {
 
     // BIP32 derivation path is applied to both client and server master keys
     const derivationPath = responseBody.derivationPath;
-    const clientDerivedNode = hdPath(clientHDNode).derive(derivationPath);
-    const serverDerivedNode = hdPath(serverHDNode).derive(derivationPath);
+    const clientDerivedNode = clientHDNode.derivePath(sanitizeLegacyPath(derivationPath));
+    const serverDerivedNode = serverHDNode.derivePath(sanitizeLegacyPath(derivationPath));
 
     const publicKey = serverDerivedNode.keyPair.getPublicKeyBuffer();
     const secretKey = clientDerivedNode.keyPair.d.toBuffer(32);

--- a/modules/core/src/keychains.ts
+++ b/modules/core/src/keychains.ts
@@ -15,10 +15,10 @@ import { randomBytes } from 'crypto';
 import * as common from './common';
 import { Util } from './v2/internal/util';
 import * as bitcoin from '@bitgo/utxo-lib';
-import { hdPath } from './bitcoin';
 const _ = require('lodash');
 let ethereumUtil;
 import * as Bluebird from 'bluebird';
+import { sanitizeLegacyPath } from './bip32path';
 const co = Bluebird.coroutine;
 
 try {
@@ -57,8 +57,7 @@ Keychains.prototype.isValid = function (params) {
     if (!params.key.path) {
       bitcoin.HDNode.fromBase58(params.key);
     } else {
-      const hdnode = bitcoin.HDNode.fromBase58(params.key.xpub);
-      hdPath(hdnode).derive(params.key.path);
+      bitcoin.HDNode.fromBase58(params.key.xpub).derivePath(sanitizeLegacyPath(params.key.path));
     }
     return true;
   } catch (e) {
@@ -136,7 +135,7 @@ Keychains.prototype.deriveLocal = function (params) {
 
   let derivedNode;
   try {
-    derivedNode = hdPath(hdNode).derive(params.path);
+    derivedNode = hdNode.derivePath(sanitizeLegacyPath(params.path));
   } catch (e) {
     throw apiResponse(400, {}, 'Unable to derive HD key from path');
   }

--- a/modules/core/src/transactionBuilder.ts
+++ b/modules/core/src/transactionBuilder.ts
@@ -15,11 +15,11 @@ import * as Bluebird from 'bluebird';
 import * as bitcoin from '@bitgo/utxo-lib';
 import * as _ from 'lodash';
 import { VirtualSizes } from '@bitgo/unspents';
-import { getNetwork, hdPath } from './bitcoin';
+import { getNetwork } from './bitcoin';
 import debugLib = require('debug');
 const debug = debugLib('bitgo:v1:txb');
 import * as common from './common';
-import { sanitizeLegacyPath } from "./bip32path";
+import { sanitizeLegacyPath } from './bip32path';
 
 interface BaseOutput {
   amount: number;

--- a/modules/core/src/travelRule.ts
+++ b/modules/core/src/travelRule.ts
@@ -16,7 +16,8 @@ import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
 
 import * as common from './common';
-import { getNetwork, makeRandomKey, hdPath } from './bitcoin';
+import { getNetwork, makeRandomKey } from './bitcoin';
+import { sanitizeLegacyPath } from './bip32path';
 
 interface DecryptReceivedTravelRuleOptions {
   tx?: {
@@ -139,11 +140,9 @@ TravelRule.prototype.decryptReceivedTravelInfo = function (params: DecryptReceiv
     hdNode = bitcoin.HDNode.fromBase58(keychain.xprv);
   }
 
-  const self = this;
-  const hdPathNode = hdPath(hdNode);
-  tx.receivedTravelInfo.forEach(function (info) {
-    const key = hdPathNode.deriveKey(info.toPubKeyPath);
-    const secret = self.bitgo.getECDHSecret({
+  tx.receivedTravelInfo.forEach((info) => {
+    const key = hdNode.deriveKey(sanitizeLegacyPath(info.toPubKeyPath)).keyPair;
+    const secret = this.bitgo.getECDHSecret({
       eckey: key,
       otherPubKeyHex: info.fromPubKey,
     });

--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -11,7 +11,6 @@ import * as debugLib from 'debug';
 import * as _ from 'lodash';
 import * as request from 'superagent';
 
-import { hdPath } from '../../bitcoin';
 import { BitGo } from '../../bitgo';
 import * as config from '../../config';
 import * as errors from '../../errors';
@@ -1064,9 +1063,9 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       derivationIndex = index;
     }
 
-    const path = 'm/0/0/' + derivationChain + '/' + derivationIndex;
+    const path = '0/0/' + derivationChain + '/' + derivationIndex;
     const hdNodes = keychains.map(({ pub }) => bitcoin.HDNode.fromBase58(pub));
-    const derivedKeys = hdNodes.map((hdNode) => hdPath(hdNode).deriveKey(path).getPublicKeyBuffer());
+    const derivedKeys = hdNodes.map((hdNode) => hdNode.derivePath(path).keyPair.getPublicKeyBuffer());
 
     const { outputScript, redeemScript, witnessScript, address } = this.createMultiSigAddress(
       addressType,
@@ -1138,7 +1137,6 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       }
       debug(`Here is the public key of the xprv you used to sign: ${keychain.neutered().toBase58()}`);
 
-      const keychainHdPath = hdPath(keychain);
       const txb = bitcoin.TransactionBuilder.fromTransaction(transaction, self.network);
       self.prepareTransactionBuilder(txb);
 
@@ -1147,7 +1145,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
         return {
           inputIndex: index,
           unspent: currentUnspent,
-          path: 'm/0/0/' + currentUnspent.chain + '/' + currentUnspent.index,
+          path: '0/0/' + currentUnspent.chain + '/' + currentUnspent.index,
           isP2wsh: !currentUnspent.redeemScript,
           isBitGoTaintedUnspent: self.isBitGoTaintedUnspent(currentUnspent),
           error: undefined as Error | undefined,
@@ -1167,7 +1165,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
           );
           continue;
         }
-        const privKey = keychainHdPath.deriveKey(signatureContext.path);
+        const privKey = keychain.derivePath(signatureContext.path).keyPair;
         privKey.network = self.network;
 
         debug('Input details: %O', signatureContext);

--- a/modules/core/src/v2/coins/xtz.ts
+++ b/modules/core/src/v2/coins/xtz.ts
@@ -25,7 +25,6 @@ import { BitGo } from '../../bitgo';
 import { NodeCallback } from '../types';
 import BigNumber from 'bignumber.js';
 import { MethodNotImplementedError } from '../../errors';
-import { hdPath } from '../../bitcoin';
 import * as bitcoin from '@bitgo/utxo-lib';
 
 export interface XtzSignTransactionOptions extends SignTransactionOptions {
@@ -170,7 +169,7 @@ export class Xtz extends BaseCoin {
    */
   deriveKeyWithPath({ key, path }: { key: string; path: string }): string {
     const keychain = bitcoin.HDNode.fromBase58(key);
-    const derivedKeyNode = hdPath(keychain).derive(path);
+    const derivedKeyNode = keychain.derivePath(path);
     return derivedKeyNode.toBase58();
   }
 
@@ -203,7 +202,7 @@ export class Xtz extends BaseCoin {
       if (chain === 0 && index === 0) {
         key = params.prv;
       } else {
-        const derivationPath = `/0/0/${chain}/${index}`;
+        const derivationPath = `0/0/${chain}/${index}`;
         key = self.deriveKeyWithPath({ key: params.prv, path: derivationPath });
       }
       txBuilder.sign({ key });

--- a/modules/core/src/v2/wallets.ts
+++ b/modules/core/src/v2/wallets.ts
@@ -9,8 +9,8 @@ import { NodeCallback, RequestTracer as IRequestTracer } from './types';
 import { PaginationOptions, Wallet } from './wallet';
 import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
-import { hdPath } from '../bitcoin';
 import { RequestTracer } from './internal/util';
+import { sanitizeLegacyPath } from '../bip32path';
 
 const co = Bluebird.coroutine;
 
@@ -617,7 +617,7 @@ export class Wallets {
       const rootExtKey = bitcoin.HDNode.fromBase58(sharingKeychain.prv);
 
       // Derive key by path (which is used between these 2 users only)
-      const privKey = hdPath(rootExtKey).deriveKey(walletShare.keychain.path);
+      const privKey = rootExtKey.derivePath(sanitizeLegacyPath(walletShare.keychain.path)).keyPair;
       const secret = self.bitgo.getECDHSecret({
         eckey: privKey,
         otherPubKeyHex: walletShare.keychain.fromPubKey,

--- a/modules/core/src/wallets.ts
+++ b/modules/core/src/wallets.ts
@@ -12,10 +12,11 @@
 //
 
 import * as bitcoin from '@bitgo/utxo-lib';
-import { makeRandomKey, hdPath, getNetwork } from './bitcoin';
+import { makeRandomKey, getNetwork } from './bitcoin';
 import * as common from './common';
 import * as _ from 'lodash';
 import * as Bluebird from 'bluebird';
+import { sanitizeLegacyPath } from './bip32path';
 const co = Bluebird.coroutine;
 const Wallet = require('./wallet');
 
@@ -236,7 +237,7 @@ Wallets.prototype.acceptShare = function (params, callback) {
           const rootExtKey = bitcoin.HDNode.fromBase58(sharingKeychain.xprv);
 
           // Derive key by path (which is used between these 2 users only)
-          const privKey = hdPath(rootExtKey).deriveKey(walletShare.keychain.path);
+          const privKey = rootExtKey.derivePath(sanitizeLegacyPath(walletShare.keychain.path)).keyPair;
           const secret = self.bitgo.getECDHSecret({ eckey: privKey, otherPubKeyHex: walletShare.keychain.fromPubKey });
 
           // Yes! We got the secret successfully here, now decrypt the shared wallet xprv

--- a/modules/core/test/integration/travelRule.ts
+++ b/modules/core/test/integration/travelRule.ts
@@ -7,7 +7,6 @@
 import { strict as assert } from 'assert';
 import 'should';
 import * as _ from 'lodash';
-import { hdPath } from '../../src/bitcoin';
 
 const BitGoJS = require('../../src/index');
 const bitcoin = BitGoJS.bitcoin;
@@ -103,8 +102,8 @@ describe('Travel Rule API', function () {
     it('decrypts successfully', function () {
       const toPrivate = bitcoin.HDNode.fromSeedHex('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
       const fromPrivate = bitcoin.makeRandomKey();
-      const path = '/99/99';
-      const toPubKey = hdPath(toPrivate).deriveKey(path).getPublicKeyBuffer().toString('hex');
+      const path = '99/99';
+      const toPubKey = toPrivate.derivePath(path).keyPair.getPublicKeyBuffer().toString('hex');
       const secret = bitgo.getECDHSecret({
         eckey: fromPrivate,
         otherPubKeyHex: toPubKey,


### PR DESCRIPTION
Instead of `hdPath(v).derive(p)` use `v.derivePath(p)` or
`v.derivePath(sanitizeLegacyPath(v))` depending on context.

Instead of `deriveKey(p)` use `derivePath(p).keyPair`.

Issue: BG-34381