### PR TITLE
refactor(core): use bip32 in ecdh operations

### DIFF
--- a/modules/core/src/bitgo.ts
+++ b/modules/core/src/bitgo.ts
@@ -138,11 +138,6 @@ export interface VerifyShardsOptions {
   xpub: string;
 }
 
-export interface GetEcdhSecretOptions {
-  otherPubKeyHex: string;
-  eckey: bitcoin.ECPair;
-}
-
 export interface AccessTokenOptions {
   accessToken: string;
 }
@@ -941,29 +936,6 @@ export class BitGo {
     }
 
     return true;
-  }
-
-  /**
-   * Construct an ECDH secret from a private key and other user's public key
-   */
-  getECDHSecret({ otherPubKeyHex, eckey }: GetEcdhSecretOptions): string {
-    if (!_.isString(otherPubKeyHex)) {
-      throw new Error('otherPubKeyHex string required');
-    }
-    if (!_.isObject(eckey)) {
-      throw new Error('eckey object required');
-    }
-
-    const otherKeyPub = Buffer.from(otherPubKeyHex, 'hex');
-    const secretPoint = (eckey as bitcoin.ECPair).d.toBuffer(32);
-    return Buffer.from(
-      // FIXME(BG-34386): we should use `secp256k1.ecdh()` in the future
-      //                  see discussion here https://github.com/bitcoin-core/secp256k1/issues/352
-      secp256k1.publicKeyTweakMul(otherKeyPub, secretPoint)
-    )
-    // this implementation does not include the parity byte
-      .slice(1)
-      .toString('hex');
   }
 
   /**

--- a/modules/core/src/bitgo.ts
+++ b/modules/core/src/bitgo.ts
@@ -47,6 +47,7 @@ import {
   verifyResponse,
 } from './api';
 import { sanitizeLegacyPath } from './bip32path';
+import { getSharedSecret } from './ecdh';
 
 const debug = debugLib('bitgo:index');
 
@@ -136,6 +137,11 @@ export interface VerifyShardsOptions {
   passwords: string[];
   m: number;
   xpub: string;
+}
+
+export interface GetEcdhSecretOptions {
+  otherPubKeyHex: string;
+  eckey: bitcoin.ECPair;
 }
 
 export interface AccessTokenOptions {
@@ -936,6 +942,20 @@ export class BitGo {
     }
 
     return true;
+  }
+
+  /**
+   * @deprecated - use `getSharedSecret()`
+   */
+  getECDHSecret({ otherPubKeyHex, eckey }: GetEcdhSecretOptions): string {
+    if (!_.isString(otherPubKeyHex)) {
+      throw new Error('otherPubKeyHex string required');
+    }
+    if (!_.isObject(eckey)) {
+      throw new Error('eckey object required');
+    }
+
+    return getSharedSecret(eckey, Buffer.from(otherPubKeyHex, 'hex')).toString('hex');
   }
 
   /**

--- a/modules/core/src/ecdh.ts
+++ b/modules/core/src/ecdh.ts
@@ -1,0 +1,57 @@
+/**
+ * @prettier
+ *
+ * Utility methods for Ellipic-Curve Diffie-Hellman (ECDH) shared secret generation
+ *
+ * > Elliptic-curve Diffie–Hellman (ECDH) is a key agreement protocol that allows two parties, each having an
+ * > elliptic-curve public–private key pair, to establish a shared secret over an insecure channel.
+ * > This shared secret may be directly used as a key, or to derive another key. The key, or the derived key, can then
+ * > be used to encrypt subsequent communications using a symmetric-key cipher. It is a variant of the Diffie–Hellman
+ * > protocol using elliptic-curve cryptography.
+ *
+ * https://en.wikipedia.org/wiki/Elliptic-curve_Diffie%E2%80%93Hellman
+ */
+
+import * as assert from 'assert';
+import * as bip32 from 'bip32';
+import * as secp256k1 from 'secp256k1';
+import * as utxolib from '@bitgo/utxo-lib';
+
+/**
+ * Calculate the Elliptic Curve Diffie Hellman
+ * @param privateKey HDNode of private key
+ * @param publicKey [neutered] HDNode of public key
+ * @returns Buffer public key buffer that can be used as shared secret (see note)
+ */
+export function getSharedSecret(
+  privateKey: bip32.BIP32Interface | utxolib.ECPair | Buffer,
+  publicKey: bip32.BIP32Interface | Buffer
+): Buffer {
+  if (privateKey.constructor.name === 'BIP32') {
+    if (!privateKey.privateKey) {
+      throw new Error(`privateNode must be private key`);
+    }
+    privateKey = privateKey.privateKey;
+  } else if (privateKey instanceof utxolib.ECPair) {
+    privateKey = privateKey.d.toBuffer(32);
+  }
+
+  if (!Buffer.isBuffer(publicKey)) {
+    publicKey = publicKey.publicKey;
+  }
+
+  if (!Buffer.isBuffer(privateKey) || !Buffer.isBuffer(publicKey)) {
+    throw new Error(`invalid state`);
+  }
+
+  assert.strictEqual(privateKey.length, 32);
+  assert.strictEqual(publicKey.length, 33);
+
+  // FIXME(BG-34386): we should use `secp256k1.ecdh()` in the future
+  //                  see discussion here https://github.com/bitcoin-core/secp256k1/issues/352
+  const buffer = Buffer.from(secp256k1.publicKeyTweakMul(publicKey, privateKey))
+    // remove leading parity bit
+    .slice(1);
+  assert.strictEqual(buffer.length, 32);
+  return buffer;
+}

--- a/modules/core/src/travelRule.ts
+++ b/modules/core/src/travelRule.ts
@@ -11,6 +11,7 @@
 // Copyright 2014, BitGo, Inc.  All Rights Reserved.
 //
 
+import * as bip32 from 'bip32';
 import * as bitcoin from '@bitgo/utxo-lib';
 import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
@@ -18,6 +19,7 @@ import * as _ from 'lodash';
 import * as common from './common';
 import { getNetwork, makeRandomKey } from './bitcoin';
 import { sanitizeLegacyPath } from './bip32path';
+import { getSharedSecret } from './ecdh';
 
 interface DecryptReceivedTravelRuleOptions {
   tx?: {
@@ -114,7 +116,6 @@ TravelRule.prototype.validateTravelInfo = function (info) {
  * Parameters:
  *   tx: a transaction object
  *   keychain: keychain object (with xprv)
- *   hdnode: a bitcoin.HDNode object (may be provided instead of keychain)
  * Returns:
  *   the tx object, augmented with decrypted travelInfo fields
  */
@@ -128,24 +129,15 @@ TravelRule.prototype.decryptReceivedTravelInfo = function (params: DecryptReceiv
     return tx;
   }
 
-  let hdNode;
-  // Passing in hdnode is faster because it doesn't reconstruct the key every time
-  if (params.hdnode) {
-    hdNode = params.hdnode;
-  } else {
-    const keychain = params.keychain;
-    if (!_.isObject(keychain) || !_.isString(keychain.xprv)) {
-      throw new Error('expecting keychain param with xprv');
-    }
-    hdNode = bitcoin.HDNode.fromBase58(keychain.xprv);
+  const keychain = params.keychain;
+  if (!_.isObject(keychain) || !_.isString(keychain.xprv)) {
+    throw new Error('expecting keychain param with xprv');
   }
+  const hdNode = bip32.fromBase58(keychain.xprv);
 
   tx.receivedTravelInfo.forEach((info) => {
-    const key = hdNode.deriveKey(sanitizeLegacyPath(info.toPubKeyPath)).keyPair;
-    const secret = this.bitgo.getECDHSecret({
-      eckey: key,
-      otherPubKeyHex: info.fromPubKey,
-    });
+    const key = hdNode.derivePath(sanitizeLegacyPath(info.toPubKeyPath));
+    const secret = getSharedSecret(key, Buffer.from(info.fromPubKey, 'hex')).toString('hex');
     try {
       const decrypted = this.bitgo.decrypt({
         input: info.encryptedTravelInfo,
@@ -189,10 +181,7 @@ TravelRule.prototype.prepareParams = function (params) {
   }
 
   // Compute the shared key for encryption
-  const sharedSecret = this.bitgo.getECDHSecret({
-    eckey: fromKey,
-    otherPubKeyHex: recipient.pubKey,
-  });
+  const sharedSecret = getSharedSecret(fromKey, Buffer.from(recipient.pubKey, 'hex')).toString('hex');
 
   // JSON-ify and encrypt the payload
   const travelInfoJSON = JSON.stringify(travelInfo);

--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -21,6 +21,7 @@ import { TradingAccount } from './trading/tradingAccount';
 import { NodeCallback } from './types';
 import { PendingApproval, PendingApprovalData } from './pendingApproval';
 import { RequestTracer } from './internal/util';
+import { getSharedSecret } from '../ecdh';
 
 const debug = debugLib('bitgo:v2:wallet');
 const co = Bluebird.coroutine;
@@ -1583,7 +1584,7 @@ export class Wallet {
             }
 
             const eckey = makeRandomKey();
-            const secret = self.bitgo.getECDHSecret({ eckey: eckey, otherPubKeyHex: sharing.pubkey });
+            const secret = getSharedSecret(eckey, Buffer.from(sharing.pubkey, 'hex')).toString('hex');
             const newEncryptedPrv = self.bitgo.encrypt({ password: secret, input: keychain.prv });
 
             sharedKeychain = {

--- a/modules/core/src/wallet.ts
+++ b/modules/core/src/wallet.ts
@@ -24,6 +24,7 @@ const co = Bluebird.coroutine;
 import * as _ from 'lodash';
 import { makeRandomKey, getNetwork } from './bitcoin';
 import { sanitizeLegacyPath } from './bip32path';
+import { getSharedSecret } from './ecdh';
 const request = require('superagent');
 
 //
@@ -2193,7 +2194,7 @@ Wallet.prototype.shareWallet = function (params, callback) {
               }
 
               const eckey = makeRandomKey();
-              const secret = self.bitgo.getECDHSecret({ eckey: eckey, otherPubKeyHex: sharing.pubkey });
+              const secret = getSharedSecret(eckey, Buffer.from(sharing.pubkey, 'hex')).toString('hex');
               const newEncryptedXprv = self.bitgo.encrypt({ password: secret, input: keychain.xprv });
 
               sharedKeychain = {

--- a/modules/core/test/ecdh.ts
+++ b/modules/core/test/ecdh.ts
@@ -1,0 +1,37 @@
+/**
+ * @prettier
+ */
+import 'should';
+import * as bip32 from 'bip32';
+import * as crypto from 'crypto';
+import * as utxolib from '@bitgo/utxo-lib';
+
+import { getSharedSecret } from '../src/ecdh';
+
+describe('ECDH sharing secret', () => {
+  function getKey(seed: string) {
+    return bip32.fromSeed(crypto.createHash('sha256').update(seed).digest());
+  }
+
+  it('should calculate a new ECDH sharing secret correctly', () => {
+    for (let i = 0; i < 256; i++) {
+      const eckey1 = getKey(`${i}.a`);
+      const eckey2 = getKey(`${i}.b`);
+
+      [eckey1, utxolib.bitgo.keyutil.privateKeyBufferToECPair(eckey1.privateKey)].forEach((privateKey) => {
+        const sharingKey1 = getSharedSecret(privateKey, eckey2).toString('hex');
+        const sharingKey2 = getSharedSecret(eckey2, eckey1).toString('hex');
+        sharingKey1.should.equal(sharingKey2);
+
+        switch (i) {
+          case 0:
+            sharingKey1.should.eql('465ffe5745325998b83fb39631347148e24d4f21b3f3b54739c264d5c42db4b8');
+            break;
+          case 1:
+            sharingKey1.should.eql('61ff44fc1af8061a433a314b7b8be8ae352c10f62aac5887047dbaa5643b818d');
+            break;
+        }
+      });
+    }
+  });
+});

--- a/modules/core/test/unit/bitgo.ts
+++ b/modules/core/test/unit/bitgo.ts
@@ -2,7 +2,6 @@
 // Tests for BitGo Object
 //
 
-import * as crypto from 'crypto';
 import * as should from 'should';
 import * as nock from 'nock';
 import * as Bluebird from 'bluebird';
@@ -13,7 +12,6 @@ import { TestBitGo } from '../lib/test_bitgo';
 import * as common from '../../src/common';
 const rp = require('request-promise');
 import * as _ from 'lodash';
-import * as bitcoin from '@bitgo/utxo-lib';
 
 nock.disableNetConnect();
 
@@ -279,33 +277,6 @@ describe('BitGo Prototype Methods', function () {
 
   });
 
-  describe('ECDH sharing secret', () => {
-    function getKey(seed: string) {
-      return bitcoin.HDNode.fromSeedBuffer(
-        crypto.createHash('sha256').update(seed).digest()
-      ).keyPair;
-    }
-
-    it('should calculate a new ECDH sharing secret correctly', () => {
-      for (let i = 0; i < 256; i++) {
-        const bitgo = new TestBitGo();
-        const eckey1 = getKey(`${i}.a`);
-        const eckey2 = getKey(`${i}.b`);
-        const sharingKey1 = bitgo.getECDHSecret({ eckey: eckey1, otherPubKeyHex: eckey2.getPublicKeyBuffer().toString('hex') });
-        const sharingKey2 = bitgo.getECDHSecret({ eckey: eckey2, otherPubKeyHex: eckey1.getPublicKeyBuffer().toString('hex') });
-        sharingKey1.should.equal(sharingKey2);
-
-        switch (i) {
-          case 0:
-            sharingKey1.should.eql('465ffe5745325998b83fb39631347148e24d4f21b3f3b54739c264d5c42db4b8');
-            break;
-          case 1:
-            sharingKey1.should.eql('61ff44fc1af8061a433a314b7b8be8ae352c10f62aac5887047dbaa5643b818d');
-            break;
-        }
-      }
-    });
-  });
 
   describe('change password', function () {
     let bitgo;


### PR DESCRIPTION
* Move from class method to regular function (we don't use the bitgo
  object)
* Move tests
* Add support for bip32 arguments
* Return buffer, convert to `hex` at callsite

Issue: BG-34381