### PR TITLE
fix(core): fix issue while signing eos transaction using OVC

### DIFF
--- a/modules/core/src/v2/coins/eos.ts
+++ b/modules/core/src/v2/coins/eos.ts
@@ -841,6 +841,8 @@ export class Eos extends BaseCoin {
         },
         txid: (transaction as any).transaction_id,
         recoveryAmount: accountBalance,
+        coin: self.getChain(),
+        txHex: '',
       };
       const signableTx = Buffer.concat([
         Buffer.from(self.getChainId(), 'hex'), // The ChainID representing the chain that we are on
@@ -849,6 +851,7 @@ export class Eos extends BaseCoin {
       ]).toString('hex');
 
       if (isUnsignedSweep) {
+        txObject.txHex = signableTx;
         return txObject;
       }
 

--- a/modules/core/test/v2/unit/coins/eos.ts
+++ b/modules/core/test/v2/unit/coins/eos.ts
@@ -142,6 +142,10 @@ describe('EOS:', function () {
     unsignedRecoveryTransaction.recoveryAmount.should.equal('5.0000');
     unsignedRecoveryTransaction.transaction.signatures.length.should.equal(0);
 
+    // coin and txHex fields are expected during recovery of unsigned transaction using OVC
+    unsignedRecoveryTransaction.coin.should.equal('teos');
+    unsignedRecoveryTransaction.txHex.should.equal('e70aaab8997e1dfce58fbfac80cbbb8fecec7b99cf982a9444273cbc64c414738cdcdb60f03cf4a9e53c000000000100a6823403ea3055000000572d3ccdcd013008c5709804717000000000a8ed3232213008c57098047170806321a22538028650c300000000000004454f530000000000000000000000000000000000000000000000000000000000000000000000000000');
+
     // destination address and root address can include memoId
     const unsignedRecoveryTransaction2 = await basecoin.recover({
       userKey,
@@ -152,6 +156,10 @@ describe('EOS:', function () {
     });
     unsignedRecoveryTransaction2.recoveryAmount.should.equal('5.0000');
     unsignedRecoveryTransaction2.transaction.signatures.length.should.equal(0);
+
+    // coin and txHex fields are expected during recovery of unsigned transaction using OVC
+    unsignedRecoveryTransaction.coin.should.equal('teos');
+    unsignedRecoveryTransaction.txHex.should.equal('e70aaab8997e1dfce58fbfac80cbbb8fecec7b99cf982a9444273cbc64c414738cdcdb60f03cf4a9e53c000000000100a6823403ea3055000000572d3ccdcd013008c5709804717000000000a8ed3232213008c57098047170806321a22538028650c300000000000004454f530000000000000000000000000000000000000000000000000000000000000000000000000000');
 
     sandBox.restore();
   });


### PR DESCRIPTION
During uploading an unsigned EOS transaction file in OVC, an issue was coming "coin undefined is not defined"
because field "coin" was expected in the recovery file but it was not being added while forming the
recovery transaction. I have added the coin field at the time of forming recovery transaction in function `recover()` in eos.ts

While signing the unsigned EOS transaction using EOS, an
issue was coming because `signTransaction()` function was expecting a field "txHex", but this field was
not there in the unsigned transaction. So I have added "txHex" field as well in unsigned recovery transaction
file

Ticket: BG-30012