### PR TITLE
revert: return master branch package versions to non-rc versions

### DIFF
--- a/modules/account-lib/package.json
+++ b/modules/account-lib/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@bitgo/blake2b": "^3.0.0",
     "@bitgo/bls": "^0.1.0",
-    "@bitgo/statics": "^6.12.0-rc.2",
+    "@bitgo/statics": "^6.11.0",
     "@bitgo/utxo-lib": "^1.9.5",
     "@celo/contractkit": "^1.2.4",
     "@ethereumjs/common": "^2.3.0",

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@bitgo/account-lib": "^2.14.0",
-    "@bitgo/statics": "^6.12.0-rc.2",
+    "@bitgo/statics": "^6.11.0",
     "@bitgo/unspents": "^0.6.0",
     "@bitgo/utxo-lib": "^1.9.5",
     "@types/bluebird": "^3.5.25",

--- a/modules/statics/package.json
+++ b/modules/statics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitgo/statics",
-  "version": "6.12.0-rc.2",
+  "version": "6.11.0",
   "description": "dependency-free static configuration for the bitgo platform",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",


### PR DESCRIPTION
Version numbers for packages inside the bitgojs monorepo are managed by lerna
and should not be updated except on the rel/rc branch during the release
process.

Ticket: NO-000