### PR TITLE
feat(utxo-lib): export createOutputScript2Of3

### DIFF
--- a/modules/utxo-lib/src/bitgo/index.js
+++ b/modules/utxo-lib/src/bitgo/index.js
@@ -1,3 +1,0 @@
-module.exports = {
-  keyutil: require('./keyutil')
-}

--- a/modules/utxo-lib/src/bitgo/index.ts
+++ b/modules/utxo-lib/src/bitgo/index.ts
@@ -1,1 +1,2 @@
 export * as keyutil from './keyutil';
+export * as outputScripts from './outputScripts';

--- a/modules/utxo-lib/src/bitgo/index.ts
+++ b/modules/utxo-lib/src/bitgo/index.ts
@@ -1,0 +1,1 @@
+export * as keyutil from './keyutil';

--- a/modules/utxo-lib/src/bitgo/keyutil.ts
+++ b/modules/utxo-lib/src/bitgo/keyutil.ts
@@ -7,7 +7,7 @@ const ECPair = require('../ecpair')
  * @param {Object} [network] - Network for the ECPair. Defaults to bitcoin.
  * @return {ECPair}
  */
-function privateKeyBufferToECPair (buffer, network) {
+export function privateKeyBufferToECPair (buffer, network) {
   if (!Buffer.isBuffer(buffer) || buffer.length !== 32) {
     throw new Error('invalid private key buffer')
   }
@@ -21,7 +21,7 @@ function privateKeyBufferToECPair (buffer, network) {
  * @param {ECPair} ecPair
  * @return {Buffer} 32 bytes
  */
-function privateKeyBufferFromECPair (ecPair) {
+export function privateKeyBufferFromECPair (ecPair) {
   if (!(ecPair instanceof ECPair)) {
     throw new TypeError(`invalid argument ecpair`)
   }
@@ -29,9 +29,4 @@ function privateKeyBufferFromECPair (ecPair) {
   if (!ecPair.d) throw new Error('Missing private key')
 
   return ecPair.d.toBuffer(32)
-}
-
-module.exports = {
-  privateKeyBufferToECPair,
-  privateKeyBufferFromECPair
 }

--- a/modules/utxo-lib/src/bitgo/outputScripts.ts
+++ b/modules/utxo-lib/src/bitgo/outputScripts.ts
@@ -1,0 +1,51 @@
+/**
+ * @prettier
+ */
+import * as script from '../script';
+import * as crypto from '../crypto';
+
+export const scriptTypes2Of3 = ['p2sh', 'p2shP2wsh', 'p2wsh'] as const;
+export type ScriptType2Of3 = typeof scriptTypes2Of3[number];
+
+export type SpendableScript = {
+  scriptPubKey: Buffer;
+  redeemScript?: Buffer;
+  witnessScript?: Buffer;
+};
+
+/**
+ * Return scripts for 2-of-3 multisig output
+ * @param pubkeys - the key array for multisig
+ * @param scriptType
+ * @returns {{redeemScript, witnessScript, address}}
+ */
+export function createOutputScript2of3(pubkeys: Buffer[], scriptType: ScriptType2Of3): SpendableScript {
+  const script2of3 = script.multisig.output.encode(2, pubkeys);
+  const p2wshOutputScript = script.witnessScriptHash.output.encode(crypto.sha256(script2of3));
+  let redeemScript;
+  let witnessScript;
+  switch (scriptType) {
+    case 'p2sh':
+      redeemScript = script2of3;
+      break;
+    case 'p2shP2wsh':
+      witnessScript = script2of3;
+      redeemScript = p2wshOutputScript;
+      break;
+    case 'p2wsh':
+      witnessScript = script2of3;
+      break;
+    default:
+      throw new Error(`unknown multisig script type ${scriptType}`);
+  }
+
+  let scriptPubKey;
+  if (scriptType === 'p2wsh') {
+    scriptPubKey = p2wshOutputScript;
+  } else {
+    const redeemScriptHash = crypto.hash160(redeemScript);
+    scriptPubKey = script.scriptHash.output.encode(redeemScriptHash);
+  }
+
+  return { redeemScript, witnessScript, scriptPubKey };
+}

--- a/modules/utxo-lib/src/bitgo/outputScripts.ts
+++ b/modules/utxo-lib/src/bitgo/outputScripts.ts
@@ -20,6 +20,15 @@ export type SpendableScript = {
  * @returns {{redeemScript, witnessScript, address}}
  */
 export function createOutputScript2of3(pubkeys: Buffer[], scriptType: ScriptType2Of3): SpendableScript {
+  if (pubkeys.length !== 3) {
+    throw new Error(`must provide 3 pubkeys`);
+  }
+  pubkeys.forEach((key) => {
+    if (key.length !== 33) {
+      throw new Error(`Unexpected key length ${key.length}. Must use compressed keys.`);
+    }
+  });
+
   const script2of3 = script.multisig.output.encode(2, pubkeys);
   const p2wshOutputScript = script.witnessScriptHash.output.encode(crypto.sha256(script2of3));
   let redeemScript;

--- a/modules/utxo-lib/test/bitgo/outputScripts.ts
+++ b/modules/utxo-lib/test/bitgo/outputScripts.ts
@@ -2,7 +2,10 @@
  * @prettier
  */
 import * as assert from 'assert';
-import { createOutputScript2of3, getKeyTriple, scriptTypes2Of3 } from './outputScripts.util';
+
+import { createOutputScript2of3, scriptTypes2Of3 } from '../../src/bitgo/outputScripts';
+
+import { getKeyTriple } from '../integration_local_rpc/generate/outputScripts.util';
 
 describe('createOutputScript2of3()', function () {
   const keys = getKeyTriple('utxo');
@@ -17,7 +20,10 @@ describe('createOutputScript2of3()', function () {
 
       const p2wsh = '002095ecaacb606b9ece3821c0111c0a1208dd1d35192809bf8cf6cbad4bbeaca67f';
 
-      const { scriptPubKey, redeemScript, witnessScript } = createOutputScript2of3(keys, scriptType);
+      const { scriptPubKey, redeemScript, witnessScript } = createOutputScript2of3(
+        keys.map((k) => k.getPublicKeyBuffer()),
+        scriptType
+      );
 
       switch (scriptType) {
         case 'p2sh':


### PR DESCRIPTION
We want utxo-lib to provide some wrappers around lower-level methods.

The method `createOutputScript2Of3()` can be used in many different places.


Issue: BG-7478