### PR TITLE
fix(core): change type of `sequenceId` to string

### DIFF
--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -81,7 +81,7 @@ export interface PrebuildTransactionOptions {
     targetWalletUnspents?: number;
     minValue?: number;
     maxValue?: number;
-    sequenceId?: number;
+    sequenceId?: string;
     lastLedgerSequence?: number;
     ledgerSequenceDelta?: string;
     gasPrice?: number;
@@ -366,7 +366,7 @@ export interface SendManyOptions {
   message?: string;
   minValue?: number;
   maxValue?: number;
-  sequenceId?: number;
+  sequenceId?: string;
   lastLedgerSequence?: number;
   ledgerSequenceDelta?: string;
   gasPrice?: number;


### PR DESCRIPTION
This parameter is a free-form string and not a number.

Ticket: BG-35021