### PR TITLE
fix(accountlib): fix getStxAddressFromPubKeys to add signatures required paramater

### DIFF
--- a/modules/account-lib/src/coin/stx/utils.ts
+++ b/modules/account-lib/src/coin/stx/utils.ts
@@ -282,12 +282,14 @@ export function padMemo(memo: string): string {
  * @param {string[]} pubKeys - list of public keys as strings
  * @param {AddressVersion} addressVersion - MainnetMultiSig, TestnetMultiSig
  * @param {AddressHashMode} addressHashMode - SerializeP2SH
+ * @param {number} [signaturesRequired] - number of signatures required, default value its 2
  * @returns {address: string, hash160: string} - a multisig address
  */
 export function getSTXAddressFromPubKeys(
   pubKeys: string[],
   addressVersion: AddressVersion = AddressVersion.MainnetMultiSig,
   addressHashMode: AddressHashMode = AddressHashMode.SerializeP2SH,
+  signaturesRequired: number = 2
 ): { address: string; hash160: string } {
   if (pubKeys.length === 0) {
     throw new Error('Invalid number of public keys');
@@ -295,9 +297,12 @@ export function getSTXAddressFromPubKeys(
   if (!pubKeys.every(isValidPublicKey)) {
     throw new Error('Invalid public keys');
   }
+  if (signaturesRequired > pubKeys.length) {
+    throw new Error('Number of signatures required must be lower or equal to the number of Public Keys');
+  }
 
   const stxPubKeys = pubKeys.map(createStacksPublicKey);
-  const address = addressFromPublicKeys(addressVersion, addressHashMode, stxPubKeys.length, stxPubKeys);
+  const address = addressFromPublicKeys(addressVersion, addressHashMode, signaturesRequired, stxPubKeys);
 
   return { address: addressToString(address), hash160: address.hash160 };
 }

--- a/modules/account-lib/test/unit/coin/stx/util.ts
+++ b/modules/account-lib/test/unit/coin/stx/util.ts
@@ -47,14 +47,14 @@ describe('Stx util library', function () {
 
       const address = Utils.getSTXAddressFromPubKeys(pubKeys);
 
-      address.address.should.equal('SM30NCRDKC2C3Q5RQ7RE6YK6A550JJPZJCP094ZQX');
-      address.hash160.should.equal('c15661b360983b97173e1c6f4cca2941295bf265');
+      address.address.should.equal('SM1W9PBVTZA9SRNBQJ2A05R3T0ZVYC94PD0AN9KDG');
+      address.hash160.should.equal('789b2f7afa939c5577909402e07a07f7e6249668');
 
       Utils.getSTXAddressFromPubKeys(pubKeys, AddressVersion.TestnetMultiSig).address.should.equal(
-        'SN30NCRDKC2C3Q5RQ7RE6YK6A550JJPZJCMHHRC3D',
+        'SN1W9PBVTZA9SRNBQJ2A05R3T0ZVYC94PD0A9GGMZ',
       );
       Utils.getSTXAddressFromPubKeys(pubKeys, AddressVersion.MainnetMultiSig).address.should.equal(
-        'SM30NCRDKC2C3Q5RQ7RE6YK6A550JJPZJCP094ZQX',
+        'SM1W9PBVTZA9SRNBQJ2A05R3T0ZVYC94PD0AN9KDG',
       );
     });
 
@@ -65,12 +65,12 @@ describe('Stx util library', function () {
         '042c608408352ab41477ad9dd1cabca9e712de2dff3c5c8bfa4b5f7f1a0f74a32402a826d2ce5f3a6b01c16aeebdd304e235791958bbf97a08b5d4e9dd4db399b7',
       ];
 
-      Utils.getSTXAddressFromPubKeys(pubKeys).address.should.equal('SM2G611SJ5X59SMZTB6APDAFMN8JM2CDNSA0CVBHH');
+      Utils.getSTXAddressFromPubKeys(pubKeys).address.should.equal('SM2TF8C003JE5YA8B43C2ZAY0K95QFVJNV86FCCQ4');
       Utils.getSTXAddressFromPubKeys(pubKeys, AddressVersion.TestnetMultiSig).address.should.equal(
-        'SN2G611SJ5X59SMZTB6APDAFMN8JM2CDNSBHW10HX',
+        'SN2TF8C003JE5YA8B43C2ZAY0K95QFVJNV90P7YGS',
       );
       Utils.getSTXAddressFromPubKeys(pubKeys, AddressVersion.MainnetMultiSig).address.should.equal(
-        'SM2G611SJ5X59SMZTB6APDAFMN8JM2CDNSA0CVBHH',
+        'SM2TF8C003JE5YA8B43C2ZAY0K95QFVJNV86FCCQ4',
       );
     });
 
@@ -81,12 +81,12 @@ describe('Stx util library', function () {
         '034c80f991410082824aee4ca48147082997d44e800da9877e694f9cb64b3cb64a',
       ];
 
-      Utils.getSTXAddressFromPubKeys(pubKeys).address.should.equal('SM3TNQA9N6J72TCWECS7E2AK7MCNE1ZWFVJEVCSST');
+      Utils.getSTXAddressFromPubKeys(pubKeys).address.should.equal('SME8PKRHSCB699FEK59F7T7CBB225KH1MCKM67EV');
       Utils.getSTXAddressFromPubKeys(pubKeys, AddressVersion.TestnetMultiSig).address.should.equal(
-        'SN3TNQA9N6J72TCWECS7E2AK7MCNE1ZWFVH2K9ZYJ',
+        'SNE8PKRHSCB699FEK59F7T7CBB225KH1MDPBVKF9',
       );
       Utils.getSTXAddressFromPubKeys(pubKeys, AddressVersion.MainnetMultiSig).address.should.equal(
-        'SM3TNQA9N6J72TCWECS7E2AK7MCNE1ZWFVJEVCSST',
+        'SME8PKRHSCB699FEK59F7T7CBB225KH1MCKM67EV',
       );
     });
 


### PR DESCRIPTION
Added a signatureRequired parameter to getSTXAddressFromPubKeys with a default value of 2, needed for a correct address generation
Fixed related unit Tests

Jira Ticket: [stlx-5754](https://bitgoinc.atlassian.net/browse/STLX-5754)