### PR TITLE
feat(root): set tsconfig target to `es6`

### DIFF
--- a/modules/core/src/v2/baseCoin.ts
+++ b/modules/core/src/v2/baseCoin.ts
@@ -518,5 +518,5 @@ export abstract class BaseCoin {
   /**
    * Sign a transaction
    */
-  abstract signTransaction(params: SignTransactionOptions): Bluebird<SignedTransaction>;
+  abstract signTransaction(params: SignTransactionOptions): Promise<SignedTransaction>;
 }

--- a/modules/core/src/v2/coins/abstractEthLikeCoin.ts
+++ b/modules/core/src/v2/coins/abstractEthLikeCoin.ts
@@ -151,7 +151,7 @@ export abstract class AbstractEthLikeCoin extends BaseCoin {
   async signTransaction(
     params: EthSignTransactionOptions,
     callback?: NodeCallback<SignedTransaction>
-  ): Bluebird<SignedEthLikeTransaction> {
+  ): Promise<SignedEthLikeTransaction> {
     const txBuilder = this.getTransactionBuilder();
     txBuilder.from(params.txPrebuild.txHex);
     txBuilder.transfer().key(new Eth.KeyPair({ prv: params.prv }).getKeys().prv!);
@@ -199,7 +199,7 @@ export abstract class AbstractEthLikeCoin extends BaseCoin {
   async explainTransaction(
     params: ExplainTransactionOptions,
     callback?: NodeCallback<TransactionExplanation>
-  ): Bluebird<TransactionExplanation> {
+  ): Promise<TransactionExplanation> {
     const txHex = params.txHex || (params.halfSigned && params.halfSigned.txHex);
     if (!txHex || !params.feeInfo) {
       throw new Error('missing explain tx parameters');

--- a/modules/express/src/expressApp.ts
+++ b/modules/express/src/expressApp.ts
@@ -4,7 +4,6 @@
 import * as express from 'express';
 import * as httpProxy from 'http-proxy';
 import * as url from 'url';
-import * as Bluebird from 'bluebird';
 import * as path from 'path';
 import * as _ from 'lodash';
 import * as debugLib from 'debug';
@@ -324,7 +323,7 @@ export async function prepareIpc(ipcSocketFilePath: string) {
   }
 }
 
-export async function init(): Bluebird<void> {
+export async function init(): Promise<void> {
   const cfg = config();
   const expressApp = app(cfg);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es5",
+    "target": "es6",
     "lib": [
       "dom",
       "es2016"


### PR DESCRIPTION
This allows typescript to compile with native `async`/`await` syntax,
greatly improving stack traces.

Issue: BG-34381