### PR TITLE
refactor(core): normalize import name to `utxolib`

### DIFF
--- a/modules/core/src/bitgo.ts
+++ b/modules/core/src/bitgo.ts
@@ -5,7 +5,7 @@
 //
 
 import * as superagent from 'superagent';
-import * as bitcoin from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 import { makeRandomKey } from './bitcoin';
 import * as bip32 from 'bip32';
 import * as secp256k1 from 'secp256k1';
@@ -141,7 +141,7 @@ export interface VerifyShardsOptions {
 
 export interface GetEcdhSecretOptions {
   otherPubKeyHex: string;
-  eckey: bitcoin.ECPair;
+  eckey: utxolib.ECPair;
 }
 
 export interface AccessTokenOptions {
@@ -350,7 +350,7 @@ export class BitGo {
   private readonly _proxy?: string;
   private _reqId?: IRequestTracer;
   private _ecdhXprv?: string;
-  private _extensionKey?: bitcoin.ECPair;
+  private _extensionKey?: utxolib.ECPair;
   private _markets?: any;
   private _blockchain?: any;
   private _travelRule?: any;
@@ -700,9 +700,9 @@ export class BitGo {
     this._token = json.token;
     if (json.extensionKey) {
       const network = common.Environments[this.getEnv()].network;
-      this._extensionKey = bitcoin.ECPair.fromWIF(
+      this._extensionKey = utxolib.ECPair.fromWIF(
         json.extensionKey,
-        bitcoin.networks[network]
+        utxolib.networks[network]
       );
     }
   }
@@ -727,13 +727,13 @@ export class BitGo {
 
     let address;
     try {
-      address = bitcoin.address.fromBase58Check(params.address);
+      address = utxolib.address.fromBase58Check(params.address);
     } catch (e) {
       return false;
     }
 
     const networkName = common.Environments[this.getEnv()].network;
-    const network = bitcoin.networks[networkName];
+    const network = utxolib.networks[networkName];
     return address.version === network.pubKeyHash || address.version === network.scriptHash;
   }
 
@@ -1675,7 +1675,7 @@ export class BitGo {
     const message = timestamp + '|' + this._token + '|' + duration;
     const privateKey = this._extensionKey.d.toBuffer(32);
     const isCompressed = this._extensionKey.compressed;
-    const prefix = bitcoin.networks.bitcoin.messagePrefix;
+    const prefix = utxolib.networks.bitcoin.messagePrefix;
     const signature = bitcoinMessage.sign(message, privateKey, isCompressed, prefix).toString('hex');
 
     return this.post(this.url('/user/extendtoken'))
@@ -1868,7 +1868,7 @@ export class BitGo {
     }
     const signingAddress = common.Environments[this.getEnv()].signingAddress;
     const signatureBuffer = Buffer.from(body.signature, 'hex');
-    const prefix = bitcoin.networks[common.Environments[this.getEnv()].network].messagePrefix;
+    const prefix = utxolib.networks[common.Environments[this.getEnv()].network].messagePrefix;
     const isValidSignature = bitcoinMessage.verify(body.guarantee, signingAddress, signatureBuffer, prefix);
     if (!isValidSignature) {
       throw new Error('incorrect signature');

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -11,15 +11,15 @@ import * as common from './common';
 export * from './bitgo';
 
 // Expose bitcoin and sjcl
-import * as utxoLib from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 import { hdPath, makeRandomKey } from './bitcoin';
 
 // can't add types for these since they are part of @bitgo/utxo-lib's default export
 // see https://github.com/Microsoft/TypeScript/issues/14080
-(utxoLib as any).hdPath = hdPath;
-(utxoLib as any).makeRandomKey = makeRandomKey;
+(utxolib as any).hdPath = hdPath;
+(utxolib as any).makeRandomKey = makeRandomKey;
 
-export const bitcoin = utxoLib;
+export const bitcoin = utxolib;
 export const sjcl = require('./vendor/sjcl.min.js');
 export const bs58 = require('bs58');
 

--- a/modules/core/src/pendingapproval.ts
+++ b/modules/core/src/pendingapproval.ts
@@ -10,7 +10,7 @@
 // Copyright 2015, BitGo, Inc.  All Rights Reserved.
 //
 import * as common from './common';
-import * as bitcoin from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 
 import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
@@ -169,12 +169,12 @@ PendingApproval.prototype.recreateAndSignTransaction = function (params, callbac
   params = _.extend({}, params);
   common.validateParams(params, ['txHex'], [], callback);
 
-  const transaction = bitcoin.Transaction.fromHex(params.txHex);
+  const transaction = utxolib.Transaction.fromHex(params.txHex);
   if (!transaction.outs) {
     throw new Error('transaction had no outputs or failed to parse successfully');
   }
 
-  const network = bitcoin.networks[common.Environments[this.bitgo.getEnv()].network];
+  const network = utxolib.networks[common.Environments[this.bitgo.getEnv()].network];
   params.recipients = {};
 
   const self = this;
@@ -187,7 +187,7 @@ PendingApproval.prototype.recreateAndSignTransaction = function (params, callbac
     }
     if (transaction.outs.length <= 2) {
       transaction.outs.forEach(function (out) {
-        const outAddress = bitcoin.address.fromOutputScript(out.script, network).toBase58Check();
+        const outAddress = utxolib.address.fromOutputScript(out.script, network).toBase58Check();
         if (self.info().transactionRequest.destinationAddress === outAddress) {
           // If this is the destination, then spend to it
           params.recipients[outAddress] = out.value;
@@ -202,7 +202,7 @@ PendingApproval.prototype.recreateAndSignTransaction = function (params, callbac
       .then(function (result) {
         const changeAddresses = _.keyBy(result.addresses, 'address');
         transaction.outs.forEach(function (out) {
-          const outAddress = bitcoin.address.fromOutputScript(out.script, network).toBase58Check();
+          const outAddress = utxolib.address.fromOutputScript(out.script, network).toBase58Check();
           if (!changeAddresses[outAddress]) {
           // If this is not a change address, then spend to it
             params.recipients[outAddress] = out.value;

--- a/modules/core/src/travelRule.ts
+++ b/modules/core/src/travelRule.ts
@@ -12,7 +12,7 @@
 //
 
 import * as bip32 from 'bip32';
-import * as bitcoin from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
 
@@ -35,7 +35,7 @@ interface DecryptReceivedTravelRuleOptions {
   keychain?: {
     xprv?: string;
   };
-  hdnode?: bitcoin.HDNode;
+  hdnode?: utxolib.HDNode;
 }
 
 interface Recipient {
@@ -175,7 +175,7 @@ TravelRule.prototype.prepareParams = function (params) {
   }
 
   // If a key was not provided, create a new random key
-  let fromKey = params.fromKey && bitcoin.ECPair.fromWIF(params.fromKey, getNetwork());
+  let fromKey = params.fromKey && utxolib.ECPair.fromWIF(params.fromKey, getNetwork());
   if (!fromKey) {
     fromKey = makeRandomKey();
   }

--- a/modules/core/src/v2/baseCoin.ts
+++ b/modules/core/src/v2/baseCoin.ts
@@ -2,7 +2,7 @@
  * @prettier
  */
 import { BigNumber } from 'bignumber.js';
-import * as bitcoin from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 import * as bip32 from 'bip32';
 import * as Bluebird from 'bluebird';
 import { BitGo } from '../bitgo';
@@ -332,7 +332,7 @@ export abstract class BaseCoin {
    */
   signMessage(key: { prv: string }, message: string, callback?: NodeCallback<Buffer>): Bluebird<Buffer> {
     return co<Buffer>(function* cosignMessage() {
-      return signMessage(message, bip32.fromBase58(key.prv), bitcoin.networks.bitcoin);
+      return signMessage(message, bip32.fromBase58(key.prv), utxolib.networks.bitcoin);
     })
       .call(this)
       .asCallback(callback);

--- a/modules/core/src/v2/coins/bch.ts
+++ b/modules/core/src/v2/coins/bch.ts
@@ -1,4 +1,4 @@
-import * as bitcoin from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 import * as Bluebird from 'bluebird';
 const cashaddress = require('cashaddress');
 import * as _ from 'lodash';
@@ -23,7 +23,7 @@ const containsMixedCaseCharacters = (str) => {
 export class Bch extends AbstractUtxoCoin {
 
   protected constructor(bitgo: BitGo, network?: UtxoNetwork) {
-    super(bitgo, network || bitcoin.networks.bitcoincash);
+    super(bitgo, network || utxolib.networks.bitcoincash);
   }
 
   static createInstance(bitgo: BitGo): BaseCoin {
@@ -122,7 +122,7 @@ export class Bch extends AbstractUtxoCoin {
         // no conversion needed
         return address;
       }
-      const addressDetails = bitcoin.address.fromBase58Check(address);
+      const addressDetails = utxolib.address.fromBase58Check(address);
 
       // JS annoyingly converts JSON Object variable keys to Strings, so we have to do so as well
       const addressVersionString = String(addressDetails.version);
@@ -140,7 +140,7 @@ export class Bch extends AbstractUtxoCoin {
     }
 
     const rawBytes = cashaddress.decode(address);
-    return bitcoin.address.toBase58Check(rawBytes.hash, this.network[scriptVersionMap[rawBytes.version]]);
+    return utxolib.address.toBase58Check(rawBytes.hash, this.network[scriptVersionMap[rawBytes.version]]);
   }
 
   /**
@@ -181,7 +181,7 @@ export class Bch extends AbstractUtxoCoin {
    * @returns {number}
    */
   public get defaultSigHashType() {
-    return bitcoin.Transaction.SIGHASH_ALL | bitcoin.Transaction.SIGHASH_BITCOINCASHBIP143;
+    return utxolib.Transaction.SIGHASH_ALL | utxolib.Transaction.SIGHASH_BITCOINCASHBIP143;
   }
 
   recoveryBlockchainExplorerUrl(url) {

--- a/modules/core/src/v2/coins/bsv.ts
+++ b/modules/core/src/v2/coins/bsv.ts
@@ -1,7 +1,7 @@
 /**
  * @prettier
  */
-import * as bitcoin from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 import * as Bluebird from 'bluebird';
 
 import { AddressInfo, UnspentInfo, UtxoNetwork } from './abstractUtxoCoin';
@@ -14,7 +14,7 @@ import { BlockchairApi } from '../recovery/blockchairApi';
 
 export class Bsv extends Bch {
   constructor(bitgo: BitGo, network?: UtxoNetwork) {
-    super(bitgo, network || bitcoin.networks.bitcoinsv);
+    super(bitgo, network || utxolib.networks.bitcoinsv);
   }
 
   static createInstance(bitgo: BitGo): BaseCoin {

--- a/modules/core/src/v2/coins/btc.ts
+++ b/modules/core/src/v2/coins/btc.ts
@@ -1,4 +1,4 @@
-import * as bitcoin from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
 import * as request from 'superagent';
@@ -20,7 +20,7 @@ export interface VerifyRecoveryTransactionOptions extends BaseVerifyRecoveryTran
 
 export class Btc extends AbstractUtxoCoin {
   constructor(bitgo: BitGo, network?: UtxoNetwork) {
-    super(bitgo, network || bitcoin.networks.bitcoin);
+    super(bitgo, network || utxolib.networks.bitcoin);
   }
 
   static createInstance(bitgo: BitGo): BaseCoin {
@@ -127,7 +127,7 @@ export class Btc extends AbstractUtxoCoin {
 
       const transactionDetails = res.transaction;
 
-      const tx = bitcoin.Transaction.fromHex(txInfo.transactionHex, this.network);
+      const tx = utxolib.Transaction.fromHex(txInfo.transactionHex, this.network);
       if (transactionDetails.TxId !== tx.getId()) {
         console.log('txhash/txid returned by blockexplorer: ', transactionDetails.TxId);
         console.log('txhash/txid of the transaction bitgo constructed', tx.getId());

--- a/modules/core/src/v2/coins/btg.ts
+++ b/modules/core/src/v2/coins/btg.ts
@@ -1,7 +1,7 @@
 import { BitGo } from '../../bitgo';
 import { BaseCoin, VerifyRecoveryTransactionOptions } from '../baseCoin';
 import { Btc } from './btc';
-import * as bitcoin from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 import * as Bluebird from 'bluebird';
 const co = Bluebird.coroutine;
 import * as common from '../../common';
@@ -10,7 +10,7 @@ const request = require('superagent');
 
 export class Btg extends Btc {
   constructor(bitgo: BitGo, network?: any) {
-    super(bitgo, network || bitcoin.networks.bitcoingold);
+    super(bitgo, network || utxolib.networks.bitcoingold);
   }
 
   static createInstance(bitgo): BaseCoin {
@@ -56,7 +56,7 @@ export class Btg extends Btc {
    * @returns {number}
    */
   get defaultSigHashType(): number {
-    return bitcoin.Transaction.SIGHASH_ALL | bitcoin.Transaction.SIGHASH_BITCOINCASHBIP143;
+    return utxolib.Transaction.SIGHASH_ALL | utxolib.Transaction.SIGHASH_BITCOINCASHBIP143;
   }
 
   /**

--- a/modules/core/src/v2/coins/ltc.ts
+++ b/modules/core/src/v2/coins/ltc.ts
@@ -19,7 +19,7 @@ export class Ltc extends AbstractUtxoCoin {
   constructor(bitgo: BitGo, network?: UtxoNetwork) {
     super(bitgo, network || utxolib.networks.litecoin);
     // use legacy script hash version, which is the current Bitcoin one
-    this.altScriptHash = this.getCoinLibrary().networks.bitcoin.scriptHash;
+    this.altScriptHash = utxolib.networks.bitcoin.scriptHash;
     // do not support alt destinations in prod
     this.supportAltScriptDestination = false;
   }
@@ -65,14 +65,14 @@ export class Ltc extends AbstractUtxoCoin {
 
     try {
       // try deserializing as bech32
-      this.getCoinLibrary().address.fromBech32(address);
+      utxolib.address.fromBech32(address);
       // address may be all uppercase, but canonical bech32 addresses are all lowercase
       return address.toLowerCase();
     } catch (e) {
       // not a valid bech32, try to decode as base58
     }
 
-    const addressDetails = this.getCoinLibrary().address.fromBase58Check(address);
+    const addressDetails = utxolib.address.fromBase58Check(address);
     if (addressDetails.version === this.network.pubKeyHash) {
       // the pub keys never changed
       return address;
@@ -88,11 +88,11 @@ export class Ltc extends AbstractUtxoCoin {
       2: this.network.scriptHash,
     };
     const newScriptHash = scriptHashMap[scriptHashVersion];
-    return this.getCoinLibrary().address.toBase58Check(addressDetails.hash, newScriptHash);
+    return utxolib.address.toBase58Check(addressDetails.hash, newScriptHash);
   }
 
   calculateRecoveryAddress(scriptHashScript: Buffer): string {
-    const bitgoAddress = this.getCoinLibrary().address.fromOutputScript(scriptHashScript, this.network);
+    const bitgoAddress = utxolib.address.fromOutputScript(scriptHashScript, this.network);
     return this.canonicalAddress(bitgoAddress, 1);
   }
 

--- a/modules/core/src/v2/coins/tbcha.ts
+++ b/modules/core/src/v2/coins/tbcha.ts
@@ -3,12 +3,12 @@
  */
 import { BitGo } from '../../bitgo';
 import { Bcha } from './bcha';
-import * as bitcoin from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 import { BaseCoin } from '../baseCoin';
 
 export class Tbcha extends Bcha {
   constructor(bitgo: BitGo) {
-    super(bitgo, bitcoin.networks.bitcoincashTestnet);
+    super(bitgo, utxolib.networks.bitcoincashTestnet);
   }
 
   static createInstance(bitgo: BitGo): BaseCoin {

--- a/modules/core/src/v2/coins/tbsv.ts
+++ b/modules/core/src/v2/coins/tbsv.ts
@@ -4,11 +4,11 @@
 import { BitGo } from '../../bitgo';
 import { BaseCoin } from '../baseCoin';
 import { Bsv } from './bsv';
-import * as bitcoin from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 
 export class Tbsv extends Bsv {
   constructor(bitgo: BitGo) {
-    super(bitgo, bitcoin.networks.bitcoinsvTestnet);
+    super(bitgo, utxolib.networks.bitcoinsvTestnet);
   }
 
   static createInstance(bitgo: BitGo): BaseCoin {

--- a/modules/core/src/v2/coins/tbtc.ts
+++ b/modules/core/src/v2/coins/tbtc.ts
@@ -4,11 +4,11 @@
 import { BitGo } from '../../bitgo';
 import { BaseCoin } from '../baseCoin';
 import { Btc } from './btc';
-import * as bitcoin from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 
 export class Tbtc extends Btc {
   constructor(bitgo) {
-    super(bitgo, bitcoin.networks.testnet);
+    super(bitgo, utxolib.networks.testnet);
   }
 
   static createInstance(bitgo: BitGo): BaseCoin {

--- a/modules/core/src/v2/coins/tltc.ts
+++ b/modules/core/src/v2/coins/tltc.ts
@@ -4,12 +4,12 @@
 import { BitGo } from '../../bitgo';
 import { BaseCoin } from '../baseCoin';
 import { Ltc } from './ltc';
-import * as bitcoin from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 
 export class Tltc extends Ltc {
   constructor(bitgo: BitGo) {
-    super(bitgo, bitcoin.networks.litecoinTest);
-    this.altScriptHash = bitcoin.networks.testnet.scriptHash;
+    super(bitgo, utxolib.networks.litecoinTest);
+    this.altScriptHash = utxolib.networks.testnet.scriptHash;
     // support alt destinations on test
     this.supportAltScriptDestination = false;
   }

--- a/modules/core/src/v2/coins/tzec.ts
+++ b/modules/core/src/v2/coins/tzec.ts
@@ -1,11 +1,11 @@
 import { BitGo } from '../../bitgo';
 import { BaseCoin } from '../baseCoin';
 import { Zec, ZecTransactionBuilder } from './zec';
-import * as bitGoUtxoLib from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 
 export class Tzec extends Zec {
   constructor(bitgo: BitGo) {
-    super(bitgo, bitGoUtxoLib.networks.zcashTest);
+    super(bitgo, utxolib.networks.zcashTest);
   }
 
   static createInstance(bitgo: BitGo): BaseCoin {

--- a/modules/core/src/v2/coins/utxo/recover.ts
+++ b/modules/core/src/v2/coins/utxo/recover.ts
@@ -4,7 +4,7 @@
 
 import * as _ from 'lodash';
 import * as bip32 from 'bip32';
-import * as bitcoin from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 import { Codes, VirtualSizes } from '@bitgo/unspents';
 
 import { BitGo } from '../../../bitgo';
@@ -284,7 +284,7 @@ export async function recover(coin: AbstractUtxoCoin, bitgo: BitGo, params: Reco
   }
 
   // Build the transaction
-  const transactionBuilder = new bitcoin.TransactionBuilder(coin.network);
+  const transactionBuilder = new utxolib.TransactionBuilder(coin.network);
   coin.prepareTransactionBuilder(transactionBuilder);
   const txInfo: any = {};
 

--- a/modules/core/src/v2/coins/xlm.ts
+++ b/modules/core/src/v2/coins/xlm.ts
@@ -2,7 +2,7 @@
  * @prettier
  */
 import * as _ from 'lodash';
-import * as bitcoin from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 import * as querystring from 'querystring';
 import * as url from 'url';
 import * as Bluebird from 'bluebird';
@@ -1043,7 +1043,7 @@ export class Xlm extends BaseCoin {
    * @param entropySeed random seed which is hashed to generate the derivation path
    */
   deriveKeyWithSeed({ key, seed }: { key: string; seed: string }): { derivationPath: string; key: string } {
-    const derivationPathInput = bitcoin.crypto.hash256(`${seed}`).toString('hex');
+    const derivationPathInput = utxolib.crypto.hash256(`${seed}`).toString('hex');
     const derivationPathParts = [
       999999,
       parseInt(derivationPathInput.slice(0, 7), 16),

--- a/modules/core/src/v2/coins/zec.ts
+++ b/modules/core/src/v2/coins/zec.ts
@@ -35,10 +35,6 @@ export class Zec extends AbstractUtxoCoin {
     return 'zec';
   }
 
-  getCoinLibrary() {
-    return bitGoUtxoLib;
-  }
-
   getFullName() {
     return 'ZCash';
   }

--- a/modules/core/src/v2/coins/zec.ts
+++ b/modules/core/src/v2/coins/zec.ts
@@ -1,7 +1,7 @@
 /**
  * @prettier
  */
-import * as bitGoUtxoLib from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 import * as Bluebird from 'bluebird';
 import * as request from 'superagent';
 import { BitGo } from '../../bitgo';
@@ -20,7 +20,7 @@ export interface ZecTransactionBuilder {
 
 export class Zec extends AbstractUtxoCoin {
   constructor(bitgo: BitGo, network?: UtxoNetwork) {
-    super(bitgo, network || bitGoUtxoLib.networks.zcash);
+    super(bitgo, network || utxolib.networks.zcash);
   }
 
   static createInstance(bitgo: BitGo): BaseCoin {

--- a/modules/core/src/v2/environments.ts
+++ b/modules/core/src/v2/environments.ts
@@ -1,14 +1,14 @@
 /**
  * @prettier
  */
-import * as bitcoin from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 import { V1Network } from './types';
 
 interface EnvironmentTemplate {
   uri?: string;
   networks: {
-    btc?: bitcoin.Network;
-    tbtc?: bitcoin.Network;
+    btc?: utxolib.Network;
+    tbtc?: utxolib.Network;
   };
   network: V1Network;
   signingAddress: string;
@@ -83,7 +83,7 @@ export const AliasEnvironments: { [k in AliasEnvironmentName]: EnvironmentName }
 
 const mainnetBase: EnvironmentTemplate = {
   networks: {
-    btc: bitcoin.networks.bitcoin,
+    btc: utxolib.networks.bitcoin,
   },
   network: 'bitcoin' as V1Network,
   signingAddress: '1BitGo3gxRZ6mQSEH52dvCKSUgVCAH4Rja',
@@ -110,7 +110,7 @@ const mainnetBase: EnvironmentTemplate = {
 
 const testnetBase: EnvironmentTemplate = {
   networks: {
-    tbtc: bitcoin.networks.testnet,
+    tbtc: utxolib.networks.testnet,
   },
   network: 'testnet' as V1Network,
   signingAddress: 'msignBdFXteehDEgB6DNm7npRt7AcEZJP3',
@@ -208,8 +208,8 @@ export const Environments: Environments = {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     uri: process.env.BITGO_CUSTOM_ROOT_URI!,
     networks: {
-      btc: bitcoin.networks.bitcoin,
-      tbtc: bitcoin.networks.testnet,
+      btc: utxolib.networks.bitcoin,
+      tbtc: utxolib.networks.testnet,
     },
     network: process.env.BITGO_CUSTOM_BITCOIN_NETWORK as V1Network,
     hsmXpub: hardcodedPublicKeys.hsmXpub.dev,

--- a/modules/core/src/v2/internal/util.ts
+++ b/modules/core/src/v2/internal/util.ts
@@ -5,7 +5,7 @@
 
 /**
  */
-import * as bitcoin from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 import * as Big from 'big.js';
 import * as _ from 'lodash';
 import { randomBytes } from 'crypto';
@@ -87,9 +87,9 @@ export class Util {
    * @deprecated
    */
   static p2shMultisigOutputScript(m: number, pubKeys: Buffer[]) {
-    const redeemScript = bitcoin.script.multisig.output.encode(m, pubKeys);
-    const hash = bitcoin.crypto.hash160(redeemScript);
-    return bitcoin.script.scriptHash.output.encode(hash);
+    const redeemScript = utxolib.script.multisig.output.encode(m, pubKeys);
+    const hash = utxolib.crypto.hash160(redeemScript);
+    return utxolib.script.scriptHash.output.encode(hash);
   }
 
   /**
@@ -130,7 +130,7 @@ export class Util {
     if (!isEthAvailable) {
       throw new EthereumLibraryUnavailableError(ethImport);
     }
-    const hdNode = bitcoin.HDNode.fromBase58(xpub);
+    const hdNode = utxolib.HDNode.fromBase58(xpub);
     const ethPublicKey = hdNode.keyPair.__Q.getEncoded(false).slice(1);
     return ethUtil.bufferToHex(ethUtil.publicToAddress(ethPublicKey, false));
   }
@@ -141,7 +141,7 @@ export class Util {
    * @deprecated
    */
   static xprvToEthPrivateKey(xprv: string): string {
-    const hdNode = bitcoin.HDNode.fromBase58(xprv);
+    const hdNode = utxolib.HDNode.fromBase58(xprv);
     const ethPrivateKey: Buffer = hdNode.keyPair.d.toBuffer(32);
     return ethPrivateKey.toString('hex');
   }

--- a/modules/core/src/v2/recovery.ts
+++ b/modules/core/src/v2/recovery.ts
@@ -7,7 +7,7 @@ import * as Bluebird from 'bluebird';
 const co = Bluebird.coroutine;
 import * as _ from 'lodash';
 import { BitGo } from '../bitgo';
-import * as bitcoin from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 import { AbstractUtxoCoin } from './coins/abstractUtxoCoin';
 import { Ltc } from './coins/ltc';
 import { Wallet } from './wallet';
@@ -104,7 +104,7 @@ export class CrossChainRecoveryTool {
       tltc: 100,
     };
 
-    this.recoveryTx = new bitcoin.TransactionBuilder(this.sourceCoin.network);
+    this.recoveryTx = new utxolib.TransactionBuilder(this.sourceCoin.network);
   }
 
   /**

--- a/modules/core/src/wallet.ts
+++ b/modules/core/src/wallet.ts
@@ -15,7 +15,7 @@ import { Codes, VirtualSizes } from '@bitgo/unspents';
 
 import * as bip32 from 'bip32';
 const TransactionBuilder = require('./transactionBuilder');
-import * as bitcoin from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 const PendingApproval = require('./pendingapproval');
 
 import * as common from './common';
@@ -313,22 +313,22 @@ Wallet.prototype.generateAddress = function ({ segwit, path, keychains, threshol
   };
 
   // redeem script normally, witness script for segwit
-  const inputScript = bitcoin.script.multisig.output.encode(signatureThreshold, derivedKeys);
-  const inputScriptHash = bitcoin.crypto.hash160(inputScript);
-  let outputScript = bitcoin.script.scriptHash.output.encode(inputScriptHash);
+  const inputScript = utxolib.script.multisig.output.encode(signatureThreshold, derivedKeys);
+  const inputScriptHash = utxolib.crypto.hash160(inputScript);
+  let outputScript = utxolib.script.scriptHash.output.encode(inputScriptHash);
   addressDetails.redeemScript = inputScript.toString('hex');
 
   if (isSegwit) {
-    const witnessScriptHash = bitcoin.crypto.sha256(inputScript);
-    const redeemScript = bitcoin.script.witnessScriptHash.output.encode(witnessScriptHash);
-    const redeemScriptHash = bitcoin.crypto.hash160(redeemScript);
-    outputScript = bitcoin.script.scriptHash.output.encode(redeemScriptHash);
+    const witnessScriptHash = utxolib.crypto.sha256(inputScript);
+    const redeemScript = utxolib.script.witnessScriptHash.output.encode(witnessScriptHash);
+    const redeemScriptHash = utxolib.crypto.hash160(redeemScript);
+    outputScript = utxolib.script.scriptHash.output.encode(redeemScriptHash);
     addressDetails.witnessScript = inputScript.toString('hex');
     addressDetails.redeemScript = redeemScript.toString('hex');
   }
 
   addressDetails.outputScript = outputScript.toString('hex');
-  addressDetails.address = bitcoin.address.fromOutputScript(outputScript, getNetwork(network));
+  addressDetails.address = utxolib.address.fromOutputScript(outputScript, getNetwork(network));
 
   return addressDetails;
 };
@@ -1169,7 +1169,7 @@ Wallet.prototype.sendMany = function (params, callback) {
       });
     })
     .then(function (result) {
-      const tx = bitcoin.Transaction.fromHex(result.tx);
+      const tx = utxolib.Transaction.fromHex(result.tx);
       const inputsSum = _.sumBy(unspentsUsed, 'value');
       const outputsSum = _.sumBy(tx.outs, 'value');
       const feeUsed = inputsSum - outputsSum;
@@ -1497,7 +1497,7 @@ Wallet.prototype.accelerateTransaction = function accelerateTransaction(params, 
 
     // get the full hex for the parent tx and decode it to get its vsize
     const parentTxHex = yield getParentTxHex({ parentTxId: params.transactionID });
-    const decodedParent = bitcoin.Transaction.fromHex(parentTxHex);
+    const decodedParent = utxolib.Transaction.fromHex(parentTxHex);
     const parentVSize = decodedParent.virtualSize();
 
     // make sure id from decoded tx and given tx id match

--- a/modules/core/src/wallets.ts
+++ b/modules/core/src/wallets.ts
@@ -12,7 +12,7 @@
 //
 
 import * as bip32 from 'bip32';
-import * as bitcoin from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 import { makeRandomKey, getNetwork } from './bitcoin';
 import * as common from './common';
 import * as _ from 'lodash';
@@ -438,7 +438,7 @@ Wallets.prototype.createForwardWallet = function (params, callback) {
   let addressFromPrivKey;
 
   try {
-    const key = bitcoin.ECPair.fromWIF(params.privKey, getNetwork());
+    const key = utxolib.ECPair.fromWIF(params.privKey, getNetwork());
     addressFromPrivKey = key.getAddress();
   } catch (e) {
     throw new Error('expecting a valid privKey');

--- a/modules/core/test/integration/wallets.ts
+++ b/modules/core/test/integration/wallets.ts
@@ -11,7 +11,7 @@ import 'should';
 const Q = require('q');
 
 const TestBitGo = require('../lib/test_bitgo');
-import * as bitcoin from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 import { getNetwork } from '../../src/bitcoin';
 import * as common from '../../src/common';
 import * as nock from 'nock';
@@ -356,7 +356,7 @@ describe('Wallets', function () {
     let key;
     let sourceAddress;
     before(() => {
-      key = bitcoin.ECPair.makeRandom({ network: getNetwork(common.Environments[bitgo.getEnv()].network) });
+      key = utxolib.ECPair.makeRandom({ network: getNetwork(common.Environments[bitgo.getEnv()].network) });
       sourceAddress = key.getAddress();
     });
 

--- a/modules/core/test/unit/bitgo.ts
+++ b/modules/core/test/unit/bitgo.ts
@@ -13,7 +13,7 @@ import { TestBitGo } from '../lib/test_bitgo';
 import * as common from '../../src/common';
 const rp = require('request-promise');
 import * as _ from 'lodash';
-import * as bitcoin from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 
 nock.disableNetConnect();
 
@@ -281,7 +281,7 @@ describe('BitGo Prototype Methods', function () {
 
   describe('ECDH sharing secret', () => {
     function getKey(seed: string) {
-      return bitcoin.HDNode.fromSeedBuffer(
+      return utxolib.HDNode.fromSeedBuffer(
         crypto.createHash('sha256').update(seed).digest()
       ).keyPair;
     }

--- a/modules/core/test/unit/wallet.ts
+++ b/modules/core/test/unit/wallet.ts
@@ -10,7 +10,7 @@ import * as _ from 'lodash';
 import * as Bluebird from 'bluebird';
 const co = Bluebird.coroutine;
 import * as common from '../../src/common';
-import * as bitcoin from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 import * as should from 'should';
 import * as nock from 'nock';
 import * as sinon from 'sinon';
@@ -1141,7 +1141,7 @@ describe('Wallet Prototype Methods', function () {
         // 1) The parent tx output is an input
         // 2) The child tx has exactly one output
         // 3) The child tx output meets the minimum change threshold
-        const decodedChild = bitcoin.Transaction.fromHex(childTx.tx);
+        const decodedChild = utxolib.Transaction.fromHex(childTx.tx);
         decodedChild.ins.length.should.equal(1);
         decodedChild.outs.length.should.equal(1);
 
@@ -1242,7 +1242,7 @@ describe('Wallet Prototype Methods', function () {
         // 2) The additional unspent output is an input
         // 3) The child tx has exactly one output
         // 4) The child tx output meets the minimum change threshold
-        const decodedChild = bitcoin.Transaction.fromHex(childTx.tx);
+        const decodedChild = utxolib.Transaction.fromHex(childTx.tx);
         decodedChild.ins.length.should.equal(2);
         decodedChild.outs.length.should.equal(1);
 
@@ -1361,7 +1361,7 @@ describe('Wallet Prototype Methods', function () {
         // 2) The additional unspent output is an input
         // 3) The child tx has exactly one output
         // 4) The child tx output meets the minimum change threshold
-        const decodedChild = bitcoin.Transaction.fromHex(childTx.tx);
+        const decodedChild = utxolib.Transaction.fromHex(childTx.tx);
         decodedChild.ins.length.should.equal(2);
         decodedChild.outs.length.should.equal(1);
 
@@ -1486,7 +1486,7 @@ describe('Wallet Prototype Methods', function () {
         // 1) The parent tx output is an input
         // 2) The child tx has exactly one output
         // 3) The child tx output meets the minimum change threshold
-        const decodedChild = bitcoin.Transaction.fromHex(childTx.tx);
+        const decodedChild = utxolib.Transaction.fromHex(childTx.tx);
         decodedChild.ins.length.should.equal(3);
         decodedChild.outs.length.should.equal(1);
 

--- a/modules/core/test/v2/unit/coins/abstractEthCoin.ts
+++ b/modules/core/test/v2/unit/coins/abstractEthCoin.ts
@@ -8,7 +8,7 @@ import { TestBitGo } from '../../../lib/test_bitgo';
 import { getBuilder, BaseCoin, Eth } from '@bitgo/account-lib';
 import * as ethAbi from 'ethereumjs-abi';
 import * as ethUtil from 'ethereumjs-util';
-import * as bitgoUtxoLib from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 import { coins, ContractAddressDefinedToken } from '@bitgo/statics';
 
 describe('ETH-like coins', () => {
@@ -199,7 +199,7 @@ describe('ETH-like coins', () => {
         it('Should generate valid keypair without seed', () => {
           const { pub, prv } = basecoin.generateKeyPair();
           basecoin.isValidPub(pub).should.equal(true);
-          const bitgoKey = bitgoUtxoLib.HDNode.fromBase58(prv);
+          const bitgoKey = utxolib.HDNode.fromBase58(prv);
           basecoin.isValidPub(bitgoKey.neutered().toBase58()).should.equal(true);
         });
 
@@ -207,7 +207,7 @@ describe('ETH-like coins', () => {
           const seed = Buffer.from('c3b09c24731be2851b641d9d5b3f60fa129695c24071768d15654bea207b7bb6', 'hex');
           const { pub, prv } = basecoin.generateKeyPair(seed);
           basecoin.isValidPub(pub).should.equal(true);
-          const bitgoKey = bitgoUtxoLib.HDNode.fromBase58(prv);
+          const bitgoKey = utxolib.HDNode.fromBase58(prv);
           basecoin.isValidPub(bitgoKey.neutered().toBase58()).should.equal(true);
         });
       });

--- a/modules/core/test/v2/unit/coins/abstractUtxoCoin.ts
+++ b/modules/core/test/v2/unit/coins/abstractUtxoCoin.ts
@@ -1,4 +1,4 @@
-const utxoLib = require('@bitgo/utxo-lib');
+const utxolib = require('@bitgo/utxo-lib');
 import * as nock from 'nock';
 import * as should from 'should';
 import * as sinon from 'sinon';
@@ -400,7 +400,7 @@ describe('Abstract UTXO Coin:', () => {
         needsCustomChangeKeySignatureVerification: false,
       });
 
-      const bitcoinMock = sinon.stub(utxoLib.Transaction, 'fromHex').returns({ ins: [] });
+      const bitcoinMock = sinon.stub(utxolib.Transaction, 'fromHex').returns({ ins: [] });
 
       await coin.verifyTransaction({
         txParams: {
@@ -457,7 +457,7 @@ describe('Abstract UTXO Coin:', () => {
         needsCustomChangeKeySignatureVerification: false,
       });
 
-      const bitcoinMock = sinon.stub(utxoLib.Transaction, 'fromHex').returns({ ins: [] });
+      const bitcoinMock = sinon.stub(utxolib.Transaction, 'fromHex').returns({ ins: [] });
 
       await coin.verifyTransaction({
         txParams: {
@@ -501,7 +501,7 @@ describe('Abstract UTXO Coin:', () => {
       const { params, expectedTxHex } = recoverBtcSegwitFixtures();
       recoveryNocks.nockBtcSegwitRecovery(bitgo);
       const tx = await coin.recover(params);
-      const transaction = utxoLib.Transaction.fromHex(tx.transactionHex);
+      const transaction = utxolib.Transaction.fromHex(tx.transactionHex);
       transaction.ins.length.should.equal(2);
       transaction.outs.length.should.equal(1);
       transaction.outs[0].value.should.equal(57112);

--- a/modules/core/test/v2/unit/coins/eos.ts
+++ b/modules/core/test/v2/unit/coins/eos.ts
@@ -1,6 +1,6 @@
 import * as should from 'should';
 import * as ecc from 'eosjs-ecc';
-import * as bitcoin from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 import * as sinon from 'sinon';
 import { Eos } from '../../../../src/v2/coins';
 import { EosResponses } from '../../fixtures/coins/eos';
@@ -186,7 +186,7 @@ describe('EOS:', function () {
 
       const { halfSigned } = await basecoin.signTransaction({ txPrebuild: tx, prv: keyPair.prv });
       const signature = halfSigned.transaction.signatures[0];
-      const hdNode = bitcoin.HDNode.fromBase58(keyPair.pub);
+      const hdNode = utxolib.HDNode.fromBase58(keyPair.pub);
       const eosPubkey = ecc.PublicKey.fromBuffer(hdNode.getPublicKeyBuffer()).toString();
       ecc.verify(signature, Buffer.from(signatureData, 'hex'), eosPubkey).should.eql(true);
     });

--- a/modules/core/test/v2/unit/coins/ltc.ts
+++ b/modules/core/test/v2/unit/coins/ltc.ts
@@ -1,6 +1,6 @@
 import * as should from 'should';
 import * as _ from 'lodash';
-const bitcoin = require('@bitgo/utxo-lib');
+const utxolib = require('@bitgo/utxo-lib');
 const { Codes } = require('@bitgo/unspents');
 import { TestBitGo } from '../../../lib/test_bitgo';
 import { Wallet } from '../../../../src';
@@ -420,7 +420,7 @@ describe('LTC:', function () {
 
     it('should verify full signatures correctly', () => {
       const txHex = '01000000000101ad26ff8d387cb1aff967fc76fd96c8036a5ad2f1e9aa5214bc07b019ec63b1830100000023220020c4138370d5d77d8d3ccf3dc7561d0232bc743b8d1c16074881b91556e296a9f8ffffffff0200e1f5050000000017a9144b422c82fef274b72106572af74097773b7dd56587180fe0110000000017a914139de7a47eb613076c790aaaee21d8bbe28942ab870400483045022100a8ae2918d0589bfad341f2d46499c118542537ce22f5cc199d96fc949bdd445302206f56289185e6f5d81a5531632c4985847af1df20f4a078f2290e331411f35f6c01483045022100b4b6c9e7b300f5362d82a69730983eea9de575106747fd424e179499fb78a74602206546801fb3f0f1fcc090003906020575d7b27c851e7fbea3b917480793180bb00169522102b4f2c26870cdd4fd6d93ac0fd89f536beaed2a4c59daeea318f7355d1b3420932102363a336031faf1506ee79c7939a44e3259b35fa25bd5ea7bcf0ce5359d8792c32103d18ae6a34e70400b303ea95cccca3e33a648f63624a52b306e2aedc6a4cfd63753ae00000000';
-      const tx = bitcoin.Transaction.fromHex(txHex);
+      const tx = utxolib.Transaction.fromHex(txHex);
       const areSignaturesValid = basecoin.verifySignature(tx, 0, prebuild.txInfo.unspents[0].value);
       areSignaturesValid.should.equal(true);
 
@@ -429,9 +429,9 @@ describe('LTC:', function () {
       isFirstSignatureValid.should.equal(true);
       isSecondSignatureValid.should.equal(true);
 
-      const userNode = bitcoin.HDNode.fromBase58(userKeychain.pub);
-      const backupNode = bitcoin.HDNode.fromBase58(backupKeychain.pub);
-      const bitgoNode = bitcoin.HDNode.fromBase58(bitgoKeychain.pub);
+      const userNode = utxolib.HDNode.fromBase58(userKeychain.pub);
+      const backupNode = utxolib.HDNode.fromBase58(backupKeychain.pub);
+      const bitgoNode = utxolib.HDNode.fromBase58(bitgoKeychain.pub);
       const derivationPath = `m/0/0/${prebuild.txInfo.unspents[0].chain}/${prebuild.txInfo.unspents[0].index}`;
       const userHex = userNode.derivePath(derivationPath).getPublicKeyBuffer().toString('hex');
       const backupHex = backupNode.derivePath(derivationPath).getPublicKeyBuffer().toString('hex');
@@ -448,7 +448,7 @@ describe('LTC:', function () {
     it('should verify half signatures correctly', () => {
       // signed with the backup key
       const txHex = '01000000000101ad26ff8d387cb1aff967fc76fd96c8036a5ad2f1e9aa5214bc07b019ec63b1830100000023220020c4138370d5d77d8d3ccf3dc7561d0232bc743b8d1c16074881b91556e296a9f8ffffffff0200e1f5050000000017a9144b422c82fef274b72106572af74097773b7dd56587180fe0110000000017a914139de7a47eb613076c790aaaee21d8bbe28942ab87050000483045022100b4b6c9e7b300f5362d82a69730983eea9de575106747fd424e179499fb78a74602206546801fb3f0f1fcc090003906020575d7b27c851e7fbea3b917480793180bb0010069522102b4f2c26870cdd4fd6d93ac0fd89f536beaed2a4c59daeea318f7355d1b3420932102363a336031faf1506ee79c7939a44e3259b35fa25bd5ea7bcf0ce5359d8792c32103d18ae6a34e70400b303ea95cccca3e33a648f63624a52b306e2aedc6a4cfd63753ae00000000';
-      const tx = bitcoin.Transaction.fromHex(txHex);
+      const tx = utxolib.Transaction.fromHex(txHex);
       const areSignaturesValid = basecoin.verifySignature(tx, 0, prebuild.txInfo.unspents[0].value);
       areSignaturesValid.should.equal(true);
 
@@ -457,8 +457,8 @@ describe('LTC:', function () {
       isFirstSignatureValid.should.equal(true);
       isSecondSignatureValid.should.equal(false);
 
-      const userNode = bitcoin.HDNode.fromBase58(userKeychain.pub);
-      const backupNode = bitcoin.HDNode.fromBase58(backupKeychain.pub);
+      const userNode = utxolib.HDNode.fromBase58(userKeychain.pub);
+      const backupNode = utxolib.HDNode.fromBase58(backupKeychain.pub);
       const derivationPath = `m/0/0/${prebuild.txInfo.unspents[0].chain}/${prebuild.txInfo.unspents[0].index}`;
       const userHex = userNode.derivePath(derivationPath).getPublicKeyBuffer().toString('hex');
       const backupHex = backupNode.derivePath(derivationPath).getPublicKeyBuffer().toString('hex');

--- a/modules/core/test/v2/unit/coins/zec.ts
+++ b/modules/core/test/v2/unit/coins/zec.ts
@@ -1,6 +1,6 @@
 import 'should';
 import * as _ from 'lodash';
-import * as bitGoUtxoLib from '@bitgo/utxo-lib';
+import * as utxolib from '@bitgo/utxo-lib';
 
 import { TestBitGo } from '../../../lib/test_bitgo';
 import { Wallet } from '../../../../src/v2/wallet';
@@ -108,7 +108,7 @@ describe('ZEC:', function () {
         };
         const [txHash, vout] = unspent.id.split(':');
 
-        const txb = new bitGoUtxoLib.TransactionBuilder(testCoin.network);
+        const txb = new utxolib.TransactionBuilder(testCoin.network);
         txb.addInput(txHash, parseInt(vout, 16), 0xffffffff);
         txb.addOutput(receiveAddress, unspent.value - 50000);
 
@@ -144,7 +144,7 @@ describe('ZEC:', function () {
           txPrebuild: prebuild,
           prv: keychains[0].prv,
         });
-        const halfSignedTx = bitGoUtxoLib.Transaction.fromHex(halfSigned.txHex, testCoin.network);
+        const halfSignedTx = utxolib.Transaction.fromHex(halfSigned.txHex, testCoin.network);
         halfSignedTx.network.coin.should.equal('zec');
         halfSignedTx.version.should.equal(4);
         halfSignedTx.versionGroupId.should.equal(2301567109);
@@ -160,7 +160,7 @@ describe('ZEC:', function () {
           prv: keychains[2].prv,
           isLastSignature: true,
         });
-        const fullySignedTx = bitGoUtxoLib.Transaction.fromHex(fullySigned.txHex, testCoin.network);
+        const fullySignedTx = utxolib.Transaction.fromHex(fullySigned.txHex, testCoin.network);
         fullySignedTx.network.coin.should.equal('zec');
         fullySignedTx.version.should.equal(4);
         fullySignedTx.versionGroupId.should.equal(2301567109);

--- a/modules/core/test/v2/unit/wallet.ts
+++ b/modules/core/test/v2/unit/wallet.ts
@@ -8,7 +8,7 @@ require('should-sinon');
 import '../lib/asserts';
 import * as nock from 'nock';
 import * as _ from 'lodash';
-const bitcoin = require('@bitgo/utxo-lib');
+const utxolib = require('@bitgo/utxo-lib');
 import { Wallet } from '../../../src/v2/wallet';
 import * as common from '../../../src/common';
 
@@ -351,12 +351,12 @@ describe('V2 Wallet:', function () {
 
     it('should verify a signed transaction', async function () {
       const unspent = prebuild.txInfo.unspents[0];
-      const signedTransaction = bitcoin.Transaction.fromHex(signedTxHex);
+      const signedTransaction = utxolib.Transaction.fromHex(signedTxHex);
       const areSignaturesValid = basecoin.verifySignature(signedTransaction, 0, unspent.value);
       areSignaturesValid.should.equal(true);
 
       // mangle first signature
-      const sigScript = bitcoin.script.decompile(signedTransaction.ins[0].script);
+      const sigScript = utxolib.script.decompile(signedTransaction.ins[0].script);
       sigScript.length.should.equal(5);
       const firstSignature = sigScript[1];
       const secondSignature = sigScript[2];
@@ -366,7 +366,7 @@ describe('V2 Wallet:', function () {
       // mangle random byte of first signature (modifying too much could make the sig script become misclassified)
       firstSignature[10] = 54;
       sigScript[1] = firstSignature;
-      signedTransaction.ins[0].script = bitcoin.script.compile(sigScript);
+      signedTransaction.ins[0].script = utxolib.script.compile(sigScript);
 
       const areMangledSignaturesValid = basecoin.verifySignature(signedTransaction, 0, unspent.value);
       areMangledSignaturesValid.should.equal(false);


### PR DESCRIPTION
Issue: BG-34381

61e9955f (Otto Allmendinger, 63 minutes ago)
refactor(core): deprecate `getCoinLibrary()`

Probably vestigial from RMG/prova times

Use `utxolib` everywhere. Use canonical import name in
`abstractUtxoCoin.ts`.

Issue: BG-34381