### PR TITLE
refactor(core): remove extraneous spendAmount field

### DIFF
--- a/modules/core/src/v2/coins/erc20Token.ts
+++ b/modules/core/src/v2/coins/erc20Token.ts
@@ -253,7 +253,6 @@ export class Erc20Token extends Eth {
         gasPrice: gasPrice,
         gasLimit: gasLimit,
         data: sendData,
-        spendAmount: txAmount,
       };
 
       // Build contract call and sign it

--- a/modules/core/src/v2/coins/eth.ts
+++ b/modules/core/src/v2/coins/eth.ts
@@ -594,7 +594,6 @@ export class Eth extends BaseCoin {
       gasPrice: new optionalDeps.ethUtil.BN(txPrebuild.gasPrice),
       gasLimit: new optionalDeps.ethUtil.BN(txPrebuild.gasLimit),
       data: sendData,
-      spendAmount: params.recipients[0].amount,
     };
 
     const ethTx = optionalDeps.EthTx.Transaction.fromTxData(ethTxParams).sign(signingKey);
@@ -987,7 +986,6 @@ export class Eth extends BaseCoin {
         gasPrice: gasPrice,
         gasLimit: gasLimit,
         data: sendData,
-        spendAmount: txAmount,
       };
 
       // Build contract call and sign it


### PR DESCRIPTION
Removes the extraneous spendAmount field which is not used anywhere for constructing an eth transaction.

Not even used in the constructor: https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L71

ticket: BG-35058