### PR TITLE
feat(utxo-lib): add createSpendTransaction match

### DIFF
--- a/modules/utxo-lib/package.json
+++ b/modules/utxo-lib/package.json
@@ -21,7 +21,7 @@
     "build": "tsc --project tsconfig.build.json",
     "coverage-report": "nyc report --reporter=lcov",
     "coverage-html": "nyc report --reporter=html",
-    "coverage": "npm run build && BITGO_UTXO_LIB_TEST_EXPECTED_COUNT=3588 nyc --check-coverage --branches 89 --functions 90 mocha",
+    "coverage": "npm run build && BITGO_UTXO_LIB_TEST_EXPECTED_COUNT=3601 nyc --check-coverage --branches 89 --functions 90 mocha",
     "integration-test": "mocha test/integration/",
     "standard": "standard",
     "test": "npm run standard && npm run coverage",

--- a/modules/utxo-lib/test/bitgo/outputScripts.ts
+++ b/modules/utxo-lib/test/bitgo/outputScripts.ts
@@ -21,7 +21,7 @@ describe('createOutputScript2of3()', function () {
       const p2wsh = '002095ecaacb606b9ece3821c0111c0a1208dd1d35192809bf8cf6cbad4bbeaca67f';
 
       const { scriptPubKey, redeemScript, witnessScript } = createOutputScript2of3(
-        keys.map((k) => k.getPublicKeyBuffer()),
+        keys.map((k) => k.publicKey),
         scriptType
       );
 

--- a/modules/utxo-lib/test/integration_local_rpc/generate/fixtures.ts
+++ b/modules/utxo-lib/test/integration_local_rpc/generate/fixtures.ts
@@ -9,6 +9,7 @@ import { Network } from '../../../src/networkTypes';
 import { getNetworkName } from '../../../src/coins';
 import { RpcClient } from './RpcClient';
 import { RpcTransaction } from './RpcTypes';
+import { getKeyTriple } from './outputScripts.util';
 
 export function getFixtureDir(network: Network): string {
   const networkName = getNetworkName(network);
@@ -57,3 +58,5 @@ export async function writeTransactionFixtureWithInputs(
     inputs,
   });
 }
+
+export const fixtureKeys = getKeyTriple('rpctest');

--- a/modules/utxo-lib/test/integration_local_rpc/generate/main.ts
+++ b/modules/utxo-lib/test/integration_local_rpc/generate/main.ts
@@ -3,10 +3,11 @@
  */
 import * as assert from 'assert';
 
+const utxolib = require('../../../src');
+
 import { Network } from '../../../src/networkTypes';
 import { getMainnet, getNetworkName, isTestnet } from '../../../src/coins';
 
-const utxolib = require('../../../src');
 import { getRegtestNode, getRegtestNodeUrl, Node } from './regtestNode';
 import {
   createScriptPubKey,
@@ -18,7 +19,7 @@ import {
   scriptTypes,
 } from './outputScripts.util';
 import { RpcClient } from './RpcClient';
-import { wipeFixtures, writeTransactionFixtureWithInputs } from './fixtures';
+import { fixtureKeys, wipeFixtures, writeTransactionFixtureWithInputs } from './fixtures';
 
 async function initBlockchain(rpc: RpcClient, network: Network): Promise<void> {
   let minBlocks = 300;
@@ -72,8 +73,7 @@ async function createTransactionsForScriptType(
   }
   console.log(logTag);
 
-  const keys = getKeyTriple('rpctest');
-  const script = createScriptPubKey(keys, scriptType, network);
+  const script = createScriptPubKey(fixtureKeys, scriptType, network);
   const address = toRegtestAddress(network, scriptType, script);
   const depositTxid = await rpc.sendToAddress(address, 1);
   const depositTx = await rpc.getRawTransaction(depositTxid);
@@ -83,7 +83,7 @@ async function createTransactionsForScriptType(
     return;
   }
 
-  const spendTx = createSpendTransaction(keys, scriptType, depositTxid, depositTx, script, network);
+  const spendTx = createSpendTransaction(fixtureKeys, scriptType, depositTxid, depositTx, script, network);
   const spendTxid = await rpc.sendRawTransaction(spendTx.toBuffer());
   assert.strictEqual(spendTxid, spendTx.getId());
   await writeTransactionFixtureWithInputs(rpc, network, `spend_${scriptType}.json`, spendTxid);

--- a/modules/utxo-lib/test/integration_local_rpc/parse.ts
+++ b/modules/utxo-lib/test/integration_local_rpc/parse.ts
@@ -11,16 +11,32 @@ import {
   parseSignatureScript,
 } from '../../src/bitgo/signature';
 
-import { isSupportedDepositType, isSupportedSpendType, ScriptType, scriptTypes } from './generate/outputScripts.util';
-import { readFixture, TransactionFixtureWithInputs } from './generate/fixtures';
+import {
+  createSpendTransactionFromPrevOutputs,
+  isSupportedDepositType,
+  isSupportedSpendType,
+  ScriptType,
+  scriptTypes,
+} from './generate/outputScripts.util';
+import { fixtureKeys, readFixture, TransactionFixtureWithInputs } from './generate/fixtures';
 
 const utxolib = require('../../src');
 
 const fixtureTxTypes = ['deposit', 'spend'] as const;
 type FixtureTxType = typeof fixtureTxTypes[number];
 
+type Output = {
+  value: number;
+  script: Buffer;
+};
+
 interface Transaction extends TransactionVerifySignature {
+  outs: Output[];
   toBuffer(): Buffer;
+}
+
+function getTxidFromHash(buf: Buffer): string {
+  return Buffer.from(buf).reverse().toString('hex');
 }
 
 function runTestParse(network: Network, txType: FixtureTxType, scriptType: ScriptType) {
@@ -74,17 +90,28 @@ function runTestParse(network: Network, txType: FixtureTxType, scriptType: Scrip
       return;
     }
 
+    function getPrevOutput(input: { txid?: string; hash?: Buffer; index: number }) {
+      if (input.hash) {
+        input = {
+          ...input,
+          txid: getTxidFromHash(input.hash),
+        };
+      }
+
+      const inputTx = fixture.inputs.find((tx) => tx.txid === input.txid);
+      if (!inputTx) {
+        throw new Error(`could not find inputTx`);
+      }
+      const prevOutput = inputTx.vout[input.index];
+      if (!prevOutput) {
+        throw new Error(`could not prevOutput`);
+      }
+      return prevOutput;
+    }
+
     it(`verifySignatures`, function () {
       parsedTx.ins.forEach((input, i) => {
-        const inputTxid = Buffer.from(input.hash).reverse().toString('hex');
-        const inputTx = fixture.inputs.find((tx) => tx.txid === inputTxid);
-        if (!inputTx) {
-          throw new Error(`could not find inputTx`);
-        }
-        const prevOutput = inputTx.vout[input.index];
-        if (!prevOutput) {
-          throw new Error(`could not find prevOutput`);
-        }
+        const prevOutput = getPrevOutput(input);
         const { publicKeys } = parseSignatureScript(input);
         if (!publicKeys) {
           throw new Error(`expected publicKeys`);
@@ -101,6 +128,21 @@ function runTestParse(network: Network, txType: FixtureTxType, scriptType: Scrip
           assert.strictEqual(verifySignature(parsedTx, i, prevOutput.value * 1e8), true);
         });
       });
+    });
+
+    it('createSpendTransaction match', function () {
+      // Since we use fixed keys and use deterministic signing, we can create the exact same
+      // transaction from the same inputs.
+      assert.strict(parsedTx.outs.length === 1);
+      const recipientScript = parsedTx.outs[0].script;
+      const rebuiltTx = createSpendTransactionFromPrevOutputs(
+        fixtureKeys,
+        scriptType,
+        parsedTx.ins.map((i) => [getTxidFromHash(i.hash), i.index, getPrevOutput(i).value * 1e8]),
+        recipientScript,
+        network
+      );
+      assert.strictEqual(rebuiltTx.toBuffer().toString('hex'), fixture.transaction.hex);
     });
   });
 }


### PR DESCRIPTION
Assert that re-signing the transaction with the same inputs and keys
results in the exact same hex output.

Issue: BG-34381