### PR TITLE
Bg 34791 teos explorer url

### DIFF
--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -294,7 +294,7 @@ class Eos extends Mainnet implements AccountNetwork {
 
 class EosTestnet extends Testnet implements AccountNetwork {
   family = CoinFamily.EOS;
-  explorerUrl = 'https://jungle.bloks.io/transaction/';
+  explorerUrl = 'https://local.bloks.io/transaction/';
 }
 
 class Hedera extends Mainnet implements AccountNetwork {

--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -9,6 +9,7 @@ export abstract class BaseNetwork {
   public abstract readonly type: NetworkType;
   public abstract readonly family: CoinFamily;
   public abstract readonly explorerUrl: string | undefined;
+  public readonly urlParams?: string;
 }
 
 /*
@@ -295,6 +296,8 @@ class Eos extends Mainnet implements AccountNetwork {
 class EosTestnet extends Testnet implements AccountNetwork {
   family = CoinFamily.EOS;
   explorerUrl = 'https://local.bloks.io/transaction/';
+  urlParams =
+    '?nodeUrl=http%3A%2F%2Fjungle3.cryptolions.io&systemDomain=eosio&hyperionUrl=https%3A%2F%2Fjungle3history.cryptolions.io';
 }
 
 class Hedera extends Mainnet implements AccountNetwork {


### PR DESCRIPTION
Addressing issue BG-34791. 

Explorer url for teos should have been local.bloks.io and new param optional field added since teos explorer url needs params appended after the txid.