### PR TITLE
feat(utxo-lib): add tests for half-signed transactions

### DIFF
--- a/modules/utxo-lib/package.json
+++ b/modules/utxo-lib/package.json
@@ -21,7 +21,7 @@
     "build": "tsc --project tsconfig.build.json",
     "coverage-report": "nyc report --reporter=lcov",
     "coverage-html": "nyc report --reporter=html",
-    "coverage": "npm run build && BITGO_UTXO_LIB_TEST_EXPECTED_COUNT=3517 nyc --check-coverage --branches 88 --functions 90 mocha",
+    "coverage": "npm run build && BITGO_UTXO_LIB_TEST_EXPECTED_COUNT=3601 nyc --check-coverage --branches 89 --functions 90 mocha",
     "integration-test": "mocha test/integration/",
     "standard": "standard",
     "test": "npm run standard && npm run coverage",

--- a/modules/utxo-lib/package.json
+++ b/modules/utxo-lib/package.json
@@ -21,7 +21,7 @@
     "build": "tsc --project tsconfig.build.json",
     "coverage-report": "nyc report --reporter=lcov",
     "coverage-html": "nyc report --reporter=html",
-    "coverage": "npm run build && BITGO_UTXO_LIB_TEST_EXPECTED_COUNT=3601 nyc --check-coverage --branches 89 --functions 90 mocha",
+    "coverage": "npm run build && BITGO_UTXO_LIB_TEST_EXPECTED_COUNT=3543 nyc --check-coverage --branches 89 --functions 90 mocha",
     "integration-test": "mocha test/integration/",
     "standard": "standard",
     "test": "npm run standard && npm run coverage",

--- a/modules/utxo-lib/src/bitgo/index.ts
+++ b/modules/utxo-lib/src/bitgo/index.ts
@@ -1,2 +1,3 @@
 export * as keyutil from './keyutil';
 export * as outputScripts from './outputScripts';
+export { getDefaultSigHash, verifySignature } from './signature'

--- a/modules/utxo-lib/src/bitgo/outputScripts.ts
+++ b/modules/utxo-lib/src/bitgo/outputScripts.ts
@@ -7,6 +7,10 @@ import * as crypto from '../crypto';
 export const scriptTypes2Of3 = ['p2sh', 'p2shP2wsh', 'p2wsh'] as const;
 export type ScriptType2Of3 = typeof scriptTypes2Of3[number];
 
+export function isScriptType2Of3(t: string): t is ScriptType2Of3 {
+  return scriptTypes2Of3.includes(t as ScriptType2Of3);
+}
+
 export type SpendableScript = {
   scriptPubKey: Buffer;
   redeemScript?: Buffer;

--- a/modules/utxo-lib/src/bitgo/signature.ts
+++ b/modules/utxo-lib/src/bitgo/signature.ts
@@ -6,8 +6,11 @@ import * as opcodes from 'bitcoin-ops';
 import * as script from '../script';
 import * as crypto from '../crypto';
 import * as ECPair from '../ecpair';
+import * as Transaction from '../transaction';
 import * as ECSignature from '../ecsignature';
 import { Network } from '../networkTypes';
+import * as networks from '../networks';
+import { getMainnet } from '../coins';
 
 export interface Input {
   hash: Buffer;
@@ -38,6 +41,17 @@ export interface ParsedSignatureScript {
   signatures?: Buffer[];
   publicKeys?: Buffer[];
   pubScript?: Buffer;
+}
+
+export function getDefaultSigHash(network: Network): number {
+  switch (getMainnet(network)) {
+    case networks.bitcoincash:
+    case networks.bitcoinsv:
+    case networks.bitcoingold:
+      return Transaction.SIGHASH_ALL | Transaction.SIGHASH_BITCOINCASHBIP143;
+    default:
+      return Transaction.SIGHASH_ALL;
+  }
 }
 
 /**

--- a/modules/utxo-lib/src/bitgo/signature.ts
+++ b/modules/utxo-lib/src/bitgo/signature.ts
@@ -18,14 +18,6 @@ export interface Input {
   signScript: Buffer;
 }
 
-export interface Transaction {
-  network: Network;
-
-  ins: Input[];
-
-  hashForSignatureByNetwork(index: number, pubScript: Buffer, amount: number, hashType: number, isSegwit: boolean);
-}
-
 const inputTypes = [
   'multisig',
   'nonstandard',

--- a/modules/utxo-lib/test/bitgo/outputScripts.ts
+++ b/modules/utxo-lib/test/bitgo/outputScripts.ts
@@ -21,7 +21,7 @@ describe('createOutputScript2of3()', function () {
       const p2wsh = '002095ecaacb606b9ece3821c0111c0a1208dd1d35192809bf8cf6cbad4bbeaca67f';
 
       const { scriptPubKey, redeemScript, witnessScript } = createOutputScript2of3(
-        keys.map((k) => k.getPublicKeyBuffer()),
+        keys.map((k) => k.publicKey),
         scriptType
       );
 

--- a/modules/utxo-lib/test/integration_local_rpc/generate/fixtures.ts
+++ b/modules/utxo-lib/test/integration_local_rpc/generate/fixtures.ts
@@ -9,6 +9,7 @@ import { Network } from '../../../src/networkTypes';
 import { getNetworkName } from '../../../src/coins';
 import { RpcClient } from './RpcClient';
 import { RpcTransaction } from './RpcTypes';
+import { getKeyTriple } from './outputScripts.util';
 
 export function getFixtureDir(network: Network): string {
   const networkName = getNetworkName(network);
@@ -57,3 +58,5 @@ export async function writeTransactionFixtureWithInputs(
     inputs,
   });
 }
+
+export const fixtureKeys = getKeyTriple('rpctest');

--- a/modules/utxo-lib/test/integration_local_rpc/generate/main.ts
+++ b/modules/utxo-lib/test/integration_local_rpc/generate/main.ts
@@ -20,6 +20,7 @@ import {
 } from './outputScripts.util';
 import { RpcClient } from './RpcClient';
 import { fixtureKeys, wipeFixtures, writeTransactionFixtureWithInputs } from './fixtures';
+import { isScriptType2Of3 } from '../../../src/bitgo/outputScripts';
 
 async function initBlockchain(rpc: RpcClient, network: Network): Promise<void> {
   let minBlocks = 300;
@@ -78,7 +79,7 @@ async function createTransactionsForScriptType(
   const depositTxid = await rpc.sendToAddress(address, 1);
   const depositTx = await rpc.getRawTransaction(depositTxid);
   await writeTransactionFixtureWithInputs(rpc, network, `deposit_${scriptType}.json`, depositTxid);
-  if (!isSupportedSpendType(network, scriptType)) {
+  if (!isScriptType2Of3(scriptType) || !isSupportedSpendType(network, scriptType)) {
     console.log(logTag + ': spend not supported, skipping spend');
     return;
   }

--- a/modules/utxo-lib/test/integration_local_rpc/generate/main.ts
+++ b/modules/utxo-lib/test/integration_local_rpc/generate/main.ts
@@ -3,10 +3,11 @@
  */
 import * as assert from 'assert';
 
+const utxolib = require('../../../src');
+
 import { Network } from '../../../src/networkTypes';
 import { getMainnet, getNetworkName, isTestnet } from '../../../src/coins';
 
-const utxolib = require('../../../src');
 import { getRegtestNode, getRegtestNodeUrl, Node } from './regtestNode';
 import {
   createScriptPubKey,
@@ -18,7 +19,7 @@ import {
   scriptTypes,
 } from './outputScripts.util';
 import { RpcClient } from './RpcClient';
-import { wipeFixtures, writeTransactionFixtureWithInputs } from './fixtures';
+import { fixtureKeys, wipeFixtures, writeTransactionFixtureWithInputs } from './fixtures';
 
 async function initBlockchain(rpc: RpcClient, network: Network): Promise<void> {
   let minBlocks = 300;
@@ -72,8 +73,7 @@ async function createTransactionsForScriptType(
   }
   console.log(logTag);
 
-  const keys = getKeyTriple('rpctest');
-  const script = createScriptPubKey(keys, scriptType, network);
+  const script = createScriptPubKey(fixtureKeys, scriptType, network);
   const address = toRegtestAddress(network, scriptType, script);
   const depositTxid = await rpc.sendToAddress(address, 1);
   const depositTx = await rpc.getRawTransaction(depositTxid);
@@ -83,7 +83,7 @@ async function createTransactionsForScriptType(
     return;
   }
 
-  const spendTx = createSpendTransaction(keys, scriptType, depositTxid, depositTx, script, network);
+  const spendTx = createSpendTransaction(fixtureKeys, scriptType, depositTxid, depositTx, script, network);
   const spendTxid = await rpc.sendRawTransaction(spendTx.toBuffer());
   assert.strictEqual(spendTxid, spendTx.getId());
   await writeTransactionFixtureWithInputs(rpc, network, `spend_${scriptType}.json`, spendTxid);

--- a/modules/utxo-lib/test/integration_local_rpc/generate/outputScripts.util.ts
+++ b/modules/utxo-lib/test/integration_local_rpc/generate/outputScripts.util.ts
@@ -7,6 +7,7 @@ import { Network } from '../../../src/networkTypes';
 import { Transaction, Triple } from './types';
 import { createOutputScript2of3, ScriptType2Of3, scriptTypes2Of3 } from '../../../src/bitgo/outputScripts';
 import { getMainnet, isBitcoin, isBitcoinGold, isLitecoin } from '../../../src/coins';
+import { getDefaultSigHash } from '../../../src/bitgo/signature';
 
 const utxolib = require('../../../src');
 
@@ -119,18 +120,14 @@ export function createSpendTransactionFromPrevOutputs(
 
   prevOutputs.forEach(([, , value], vin) => {
     keys.slice(0, 2).forEach((key) => {
-      let sighash: number;
-      switch (getMainnet(network)) {
-        case utxolib.networks.bitcoincash:
-        case utxolib.networks.bitcoinsv:
-        case utxolib.networks.bitcoingold:
-          sighash = utxolib.Transaction.SIGHASH_ALL | utxolib.Transaction.SIGHASH_BITCOINCASHBIP143;
-          break;
-        default:
-          sighash = utxolib.Transaction.SIGHASH_ALL;
-      }
-
-      txBuilder.sign(vin, Object.assign(key, { network }), redeemScript, sighash, value, witnessScript);
+      txBuilder.sign(
+        vin,
+        Object.assign(key, { network }),
+        redeemScript,
+        getDefaultSigHash(network),
+        value,
+        witnessScript
+      );
     });
   });
 

--- a/modules/utxo-lib/test/integration_local_rpc/generate/outputScripts.util.ts
+++ b/modules/utxo-lib/test/integration_local_rpc/generate/outputScripts.util.ts
@@ -97,7 +97,7 @@ export function getTransactionBuilder(network: Network) {
 
 export function createSpendTransactionFromPrevOutputs(
   keys: bip32.BIP32Interface[],
-  scriptType: ScriptType,
+  scriptType: ScriptType2Of3,
   prevOutputs: [txid: string, index: number, value: number][],
   recipientScript: Buffer,
   network: Network,
@@ -120,7 +120,7 @@ export function createSpendTransactionFromPrevOutputs(
 
   const { redeemScript, witnessScript } = createOutputScript2of3(
     keys.map((k) => k.publicKey),
-    scriptType as ScriptType2Of3
+    scriptType
   );
 
   prevOutputs.forEach(([, , value], vin) => {
@@ -144,7 +144,7 @@ export function createSpendTransactionFromPrevOutputs(
 
 export function createSpendTransaction(
   keys: KeyTriple,
-  scriptType: ScriptType,
+  scriptType: ScriptType2Of3,
   inputTxid: string,
   inputTxBuffer: Buffer,
   recipientScript: Buffer,
@@ -153,10 +153,6 @@ export function createSpendTransaction(
   const inputTx = utxolib.Transaction.fromBuffer(inputTxBuffer, network);
   if (inputTx.getId() !== inputTxid) {
     throw new Error(`txid mismatch ${inputTx.get()} ${inputTxid}`);
-  }
-
-  if (!scriptTypes2Of3.includes(scriptType as ScriptType2Of3)) {
-    throw new Error(`invalid scriptType ${scriptType}`);
   }
 
   const { scriptPubKey } = createOutputScript2of3(

--- a/modules/utxo-lib/test/integration_local_rpc/generate/types.ts
+++ b/modules/utxo-lib/test/integration_local_rpc/generate/types.ts
@@ -1,8 +1,21 @@
 /**
  * @prettier
  */
+
+import { Network } from '../../../src/networkTypes';
+import { Input } from '../../../src/bitgo/signature';
+
+type Output = {
+  value: number;
+  script: Buffer;
+};
+
 export type Transaction = {
+  network: Network;
+  ins: Input[];
+  outs: Output[];
   getId(): string;
+  hashForSignatureByNetwork(index: number, pubScript: Buffer, amount: number, hashType: number, isSegwit: boolean);
   toBuffer(): Buffer;
 };
 

--- a/modules/utxo-lib/test/integration_local_rpc/parse.ts
+++ b/modules/utxo-lib/test/integration_local_rpc/parse.ts
@@ -17,24 +17,12 @@ import {
 } from './generate/outputScripts.util';
 import { fixtureKeys, readFixture, TransactionFixtureWithInputs } from './generate/fixtures';
 import { isScriptType2Of3 } from '../../src/bitgo/outputScripts';
+import { Transaction } from './generate/types';
 
 const utxolib = require('../../src');
 
 const fixtureTxTypes = ['deposit', 'spend'] as const;
 type FixtureTxType = typeof fixtureTxTypes[number];
-
-type Output = {
-  value: number;
-  script: Buffer;
-};
-
-interface Transaction {
-  network: Network;
-  ins: Input[];
-  outs: Output[];
-  hashForSignatureByNetwork(index: number, pubScript: Buffer, amount: number, hashType: number, isSegwit: boolean);
-  toBuffer(): Buffer;
-}
 
 function getTxidFromHash(buf: Buffer): string {
   return Buffer.from(buf).reverse().toString('hex');

--- a/modules/utxo-lib/test/integration_local_rpc/parse.ts
+++ b/modules/utxo-lib/test/integration_local_rpc/parse.ts
@@ -16,6 +16,7 @@ import {
   scriptTypes,
 } from './generate/outputScripts.util';
 import { fixtureKeys, readFixture, TransactionFixtureWithInputs } from './generate/fixtures';
+import { isScriptType2Of3 } from '../../src/bitgo/outputScripts';
 
 const utxolib = require('../../src');
 
@@ -132,6 +133,7 @@ function runTestParse(network: Network, txType: FixtureTxType, scriptType: Scrip
 
     function getRebuiltTransaction(signKeys?: bip32.BIP32Interface[]) {
       assert.strict(parsedTx.outs.length === 1);
+      assert.strict(isScriptType2Of3(scriptType));
       const recipientScript = parsedTx.outs[0].script;
       return createSpendTransactionFromPrevOutputs(
         fixtureKeys,

--- a/modules/utxo-lib/test/integration_local_rpc/parse.ts
+++ b/modules/utxo-lib/test/integration_local_rpc/parse.ts
@@ -2,6 +2,7 @@
  * @prettier
  */
 import * as assert from 'assert';
+import * as bip32 from 'bip32';
 
 import { Network } from '../../src/networkTypes';
 import { isTestnet } from '../../src/coins';
@@ -89,7 +90,7 @@ function runTestParse(network: Network, txType: FixtureTxType, scriptType: Scrip
       return;
     }
 
-    function getPrevOutput(input: { txid?: string; hash?: Buffer; index: number }) {
+    function getPrevOutputValue(input: { txid?: string; hash?: Buffer; index: number }) {
       if (input.hash) {
         input = {
           ...input,
@@ -105,12 +106,12 @@ function runTestParse(network: Network, txType: FixtureTxType, scriptType: Scrip
       if (!prevOutput) {
         throw new Error(`could not prevOutput`);
       }
-      return prevOutput;
+      return prevOutput.value * 1e8;
     }
 
-    it(`verifySignatures`, function () {
+    it(`verifySignatures for original transaction`, function () {
       parsedTx.ins.forEach((input, i) => {
-        const prevOutput = getPrevOutput(input);
+        const prevOutValue = getPrevOutputValue(input);
         const { publicKeys } = parseSignatureScript(input);
         if (!publicKeys) {
           throw new Error(`expected publicKeys`);
@@ -118,29 +119,52 @@ function runTestParse(network: Network, txType: FixtureTxType, scriptType: Scrip
         assert.strictEqual(publicKeys.length, 3);
         publicKeys.slice(0, 2).forEach((publicKey) => {
           assert.strictEqual(
-            verifySignature(parsedTx, i, prevOutput.value * 1e8, {
+            verifySignature(parsedTx, i, prevOutValue, {
               publicKey,
             }),
             true
           );
 
-          assert.strictEqual(verifySignature(parsedTx, i, prevOutput.value * 1e8), true);
+          assert.strictEqual(verifySignature(parsedTx, i, prevOutValue), true);
+        });
+      });
+    });
+
+    function getRebuiltTransaction(signKeys?: bip32.BIP32Interface[]) {
+      assert.strict(parsedTx.outs.length === 1);
+      const recipientScript = parsedTx.outs[0].script;
+      return createSpendTransactionFromPrevOutputs(
+        fixtureKeys,
+        scriptType,
+        parsedTx.ins.map((i) => [getTxidFromHash(i.hash), i.index, getPrevOutputValue(i)]),
+        recipientScript,
+        network,
+        { signKeys }
+      ) as unknown as Transaction;
+    }
+
+    it(`verifySignatures with one or two signatures`, function () {
+      fixtureKeys.forEach((key1) => {
+        const rebuiltTx = getRebuiltTransaction([key1]);
+        rebuiltTx.ins.forEach((input, i) => {
+          assert.strict(verifySignature(rebuiltTx, i, getPrevOutputValue(input)));
+        });
+
+        fixtureKeys.forEach((key2) => {
+          if (key1 === key2) {
+            return;
+          }
+
+          const rebuiltTx = getRebuiltTransaction([key1, key2]);
+          rebuiltTx.ins.forEach((input, i) => {
+            assert.strict(verifySignature(rebuiltTx, i, getPrevOutputValue(input)));
+          });
         });
       });
     });
 
     it('createSpendTransaction match', function () {
-      // Since we use fixed keys and use deterministic signing, we can create the exact same
-      // transaction from the same inputs.
-      assert.strict(parsedTx.outs.length === 1);
-      const recipientScript = parsedTx.outs[0].script;
-      const rebuiltTx = createSpendTransactionFromPrevOutputs(
-        fixtureKeys,
-        scriptType,
-        parsedTx.ins.map((i) => [getTxidFromHash(i.hash), i.index, getPrevOutput(i).value * 1e8]),
-        recipientScript,
-        network
-      );
+      const rebuiltTx = getRebuiltTransaction();
       assert.strictEqual(rebuiltTx.toBuffer().toString('hex'), fixture.transaction.hex);
     });
   });


### PR DESCRIPTION
We need to be able to support verification of half-signed (1-of-3)
transactions, so we must also support signing these kinds of transactions.

Issue: BG-34381

f7597ff9d
feat(utxo-lib): add getDefaultSigHash(network)

We can finally add a method that gives a good default `sigHash` value per
network.

Issue: BG-34381

52e31eb81
refactor(utxo-lib): use bip32 in outputScripts.util.ts

Issue: BG-34381

95f1c92e4
feat(utxo-lib): add createSpendTransaction match test

Assert that re-signing the transaction with the same inputs and keys 
results in the exact same hex output.

Issue: BG-34381