### PR TITLE
chore(root): set target to es2017

### DIFF
--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -301,7 +301,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
   }
 
   /**
-   * Get an instance of the library which can be used to perform low-level operations for this coin
+   * @deprecated
    */
   getCoinLibrary() {
     return utxolib;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6",
+    "target": "es2017",
     "lib": [
       "dom",
       "es2016"


### PR DESCRIPTION
Turns out even though es6 (aka 2015) supports async/await, we have to set
the target to es2017 to get it

See https://stackoverflow.com/a/50109624

Issue: BG-34381

chore(core): add deprecation marker to getCoinLibrary()

Issue: BG-34381