### PR TITLE
refactor(core): use utxolib.bitgo.verifySignature()

### DIFF
--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -78,16 +78,19 @@ export interface TransactionExplanation {
   outputAmount: string;
   changeAmount: number;
   fee: TransactionFee;
+
+  inputSignatures: number[];
+  signatures: number | false;
 }
 
 export interface Unspent {
   id: string;
-  value: string;
+  value: number;
 }
 
 export interface ExplainTransactionOptions {
   txHex: string;
-  txInfo?: { changeAddresses: string[]; unspents: Unspent[] };
+  txInfo?: { changeAddresses?: string[]; unspents: Unspent[] };
   feeInfo?: string;
 }
 

--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -106,14 +106,6 @@ export interface UtxoNetwork {
   };
 }
 
-export interface ParsedSignatureScript {
-  isSegwitInput: boolean;
-  inputClassification: string;
-  signatures?: Buffer[];
-  publicKeys?: Buffer[];
-  pubScript?: Buffer;
-}
-
 export interface TransactionPrebuild extends BaseTransactionPrebuild {
   txInfo?: any;
   blockHeight?: number;
@@ -1239,7 +1231,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
           transaction.setInputScript(index, Buffer.alloc(0));
         }
 
-        const isValidSignature = self.verifySignature(transaction, index, signatureContext.unspent.value);
+        const isValidSignature = utxolib.bitgo.verifySignature(transaction, index, signatureContext.unspent.value);
         if (!isValidSignature) {
           debug('Invalid signature');
           signatureContext.error = new Error('invalid signature');
@@ -1290,96 +1282,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
   }
 
   /**
-   * Parse a transaction's signature script to obtain public keys, signatures, the sig script, and other properties
-   * @param transaction
-   * @param inputIndex
-   * @returns { isSegwitInput: boolean, inputClassification: string, signatures: [Buffer], publicKeys: [Buffer], pubScript: Buffer }
-   */
-  parseSignatureScript(transaction: any, inputIndex: number): ParsedSignatureScript {
-    const currentInput = transaction.ins[inputIndex];
-    const isSegwitInput = currentInput.witness.length > 0;
-    const isNativeSegwitInput = currentInput.script.length === 0;
-    let decompiledSigScript, inputClassification;
-    if (isSegwitInput) {
-      // The decompiledSigScript is the script containing the signatures, public keys, and the script that was committed
-      // to (pubScript). If this is a segwit input the decompiledSigScript is in the witness, regardless of whether it
-      // is native or not. The inputClassification is determined based on whether or not the input is native to give an
-      // accurate classification. Note that p2shP2wsh inputs will be classified as p2sh and not p2wsh.
-      decompiledSigScript = currentInput.witness;
-      if (isNativeSegwitInput) {
-        inputClassification = utxolib.script.classifyWitness(utxolib.script.compile(decompiledSigScript), true);
-      } else {
-        inputClassification = utxolib.script.classifyInput(currentInput.script, true);
-      }
-    } else {
-      inputClassification = utxolib.script.classifyInput(currentInput.script, true);
-      decompiledSigScript = utxolib.script.decompile(currentInput.script);
-    }
-
-    if (inputClassification === utxolib.script.types.P2PKH) {
-      const [signature, publicKey] = decompiledSigScript;
-      const publicKeys = [publicKey];
-      const signatures = [signature];
-      const pubScript = utxolib.script.pubKeyHash.output.encode(utxolib.crypto.hash160(publicKey));
-
-      return { isSegwitInput, inputClassification, signatures, publicKeys, pubScript };
-    } else if (
-      inputClassification === utxolib.script.types.P2SH ||
-      inputClassification === utxolib.script.types.P2WSH
-    ) {
-      // Note the assumption here that if we have a p2sh or p2wsh input it will be multisig (appropriate because the
-      // BitGo platform only supports multisig within these types of inputs). Signatures are all but the last entry in
-      // the decompiledSigScript. The redeemScript/witnessScript (depending on which type of input this is) is the last
-      // entry in the decompiledSigScript (denoted here as the pubScript). The public keys are the second through
-      // antepenultimate entries in the decompiledPubScript. See below for a visual representation of the typical 2-of-3
-      // multisig setup:
-      //
-      // decompiledSigScript = 0 <sig1> <sig2> <pubScript>
-      // decompiledPubScript = 2 <pub1> <pub2> <pub3> 3 OP_CHECKMULTISIG
-      const signatures = decompiledSigScript.slice(0, -1);
-      const pubScript = _.last<Buffer>(decompiledSigScript);
-      const decompiledPubScript = utxolib.script.decompile(pubScript);
-      const publicKeys = decompiledPubScript.slice(1, -2);
-
-      // Op codes 81 through 96 represent numbers 1 through 16 (see https://en.bitcoin.it/wiki/Script#Opcodes), which is
-      // why we subtract by 80 to get the number of signatures (n) and the number of public keys (m) in an n-of-m setup.
-      const len = decompiledPubScript.length;
-      const nSignatures = decompiledPubScript[0] - 80;
-      const nPubKeys = decompiledPubScript[len - 2] - 80;
-
-      // Due to a bug in the implementation of multisignature in the bitcoin protocol, a 0 is added to the signature
-      // script, so we add 1 when asserting the number of signatures matches the number of signatures expected by the
-      // pub script. Also, note that we consider a signature script with the the same number of signatures as public
-      // keys (+1 as noted above) valid because we use placeholder signatures when parsing a half-signed signature
-      // script.
-      if (signatures.length !== nSignatures + 1 && signatures.length !== nPubKeys + 1) {
-        throw new Error(`expected ${nSignatures} or ${nPubKeys} signatures, got ${signatures.length - 1}`);
-      }
-
-      if (publicKeys.length !== nPubKeys) {
-        throw new Error(`expected ${nPubKeys} public keys, got ${publicKeys.length}`);
-      }
-
-      const lastOpCode = decompiledPubScript[len - 1];
-      if (lastOpCode !== utxolib.opcodes.OP_CHECKMULTISIG) {
-        throw new Error(`expected opcode #${utxolib.opcodes.OP_CHECKMULTISIG}, got opcode #${lastOpCode}`);
-      }
-
-      return { isSegwitInput, inputClassification, signatures, publicKeys, pubScript };
-    } else {
-      return { isSegwitInput, inputClassification };
-    }
-  }
-
-  /**
-   * Verify the signature on a (half-signed) transaction
-   * @param transaction bitcoinjs-lib tx object
-   * @param inputIndex The input whererfore to check the signature
-   * @param amount For segwit and BCH, the input amount needs to be known for signature verification
-   * @param verificationSettings
-   * @param verificationSettings.signatureIndex The index of the signature to verify (only iterates over non-empty signatures)
-   * @param verificationSettings.publicKey The hex of the public key to verify (will verify all signatures)
-   * @returns {boolean}
+   * @deprecated - use utxolib.bitcoin.verifySignature() instead
    */
   verifySignature(
     transaction: any,
@@ -1393,104 +1296,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
     if (transaction.network !== this.network) {
       throw new Error(`network mismatch`);
     }
-    const { signatures, publicKeys, isSegwitInput, inputClassification, pubScript } = this.parseSignatureScript(
-      transaction,
-      inputIndex
-    );
-
-    if (
-      ![utxolib.script.types.P2WSH, utxolib.script.types.P2SH, utxolib.script.types.P2PKH].includes(inputClassification)
-    ) {
-      return false;
-    }
-
-    if (!publicKeys || publicKeys.length === 0) {
-      return false;
-    }
-
-    if (isSegwitInput && !amount) {
-      return false;
-    }
-
-    // get the first non-empty signature and verify it against all public keys
-    const nonEmptySignatures = _.filter(signatures, (s) => !_.isEmpty(s));
-
-    /*
-    We either want to verify all signature/pubkey combinations, or do an explicit combination
-
-    If a signature index is specified, only that signature is checked. It's verified against all public keys.
-    If a single public key is found to be valid, the function returns true.
-
-    If a public key is specified, we iterate over all signatures. If a single one matches the public key, the function
-    returns true.
-
-    If neither is specified, all signatures are checked against all public keys. Each signature must have its own distinct
-    public key that it matches for the function to return true.
-     */
-    let signaturesToCheck = nonEmptySignatures;
-    if (!_.isUndefined(verificationSettings.signatureIndex)) {
-      signaturesToCheck = [nonEmptySignatures[verificationSettings.signatureIndex]];
-    }
-
-    const publicKeyHex = verificationSettings.publicKey;
-    const matchedPublicKeyIndices = {};
-    let areAllSignaturesValid = true;
-
-    // go over all signatures
-    for (const signatureBuffer of signaturesToCheck) {
-      let isSignatureValid = false;
-
-      const hasSignatureBuffer = Buffer.isBuffer(signatureBuffer) && signatureBuffer.length > 0;
-      if (hasSignatureBuffer && Buffer.isBuffer(pubScript) && pubScript.length > 0) {
-        // slice the last byte from the signature hash input because it's the hash type
-        const signature = utxolib.ECSignature.fromDER(signatureBuffer.slice(0, -1));
-        const hashType = _.last(signatureBuffer);
-        if (!hashType) {
-          // missing hashType byte - signature cannot be validated
-          return false;
-        }
-        const signatureHash = transaction.hashForSignatureByNetwork(
-          inputIndex,
-          pubScript,
-          amount,
-          hashType,
-          isSegwitInput
-        );
-
-        for (let publicKeyIndex = 0; publicKeyIndex < publicKeys.length; publicKeyIndex++) {
-          const publicKeyBuffer = publicKeys[publicKeyIndex];
-          if (!_.isUndefined(publicKeyHex) && publicKeyBuffer.toString('hex') !== publicKeyHex) {
-            // we are only looking to verify one specific public key's signature (publicKeyHex)
-            // this particular public key is not the one whose signature we're trying to verify
-            continue;
-          }
-
-          if (matchedPublicKeyIndices[publicKeyIndex]) {
-            continue;
-          }
-
-          const publicKey = utxolib.ECPair.fromPublicKeyBuffer(publicKeyBuffer);
-          if (publicKey.verify(signatureHash, signature)) {
-            isSignatureValid = true;
-            matchedPublicKeyIndices[publicKeyIndex] = true;
-            break;
-          }
-        }
-      }
-
-      if (!_.isUndefined(publicKeyHex) && isSignatureValid) {
-        // We were trying to see if any of the signatures was valid for the given public key. Evidently yes.
-        return true;
-      }
-
-      if (!isSignatureValid && _.isUndefined(publicKeyHex)) {
-        return false;
-      }
-
-      areAllSignaturesValid = isSignatureValid && areAllSignaturesValid;
-    }
-
-    return areAllSignaturesValid;
+    return utxolib.bitgo.verifySignature(transaction, inputIndex, amount, verificationSettings);
   }
 
   /**
@@ -1581,7 +1387,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
 
         let parsedSigScript;
         try {
-          parsedSigScript = self.parseSignatureScript(transaction, idx);
+          parsedSigScript = utxolib.bitgo.parseSignatureScript(transaction.ins[idx]);
         } catch (e) {
           return false;
         }
@@ -1612,7 +1418,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
           const amount = unspentValues[inputId];
 
           try {
-            return self.verifySignature(transaction, idx, amount, { signatureIndex: sigIndex });
+            return utxolib.bitgo.verifySignature(transaction, idx, amount, { signatureIndex: sigIndex });
           } catch (e) {
             return false;
           }

--- a/modules/core/test/v2/unit/coins/btc.ts
+++ b/modules/core/test/v2/unit/coins/btc.ts
@@ -3,6 +3,7 @@ const { Codes } = require('@bitgo/unspents');
 
 import { TestBitGo } from '../../../lib/test_bitgo';
 import { Wallet } from '../../../../src/v2/wallet';
+import { AbstractUtxoCoin } from '../../../../src/v2/coins';
 
 describe('BTC:', function () {
   let bitgo;
@@ -320,20 +321,20 @@ describe('BTC:', function () {
         },
       };
 
-      let coin;
+      let coin: AbstractUtxoCoin;
       before(() => {
         coin = bitgo.coin('btc');
       });
 
       describe('failure', () => {
         it('should fail for invalid transaction hexes', async function () {
-          await coin.explainTransaction().should.be.rejectedWith('invalid transaction hex, must be a valid hex string');
+          await (coin as any).explainTransaction().should.be.rejectedWith('invalid transaction hex, must be a valid hex string');
 
           await coin.explainTransaction({ txHex: '' }).should.be.rejectedWith('invalid transaction hex, must be a valid hex string');
 
           await coin.explainTransaction({ txHex: 'nonsense' }).should.be.rejectedWith('invalid transaction hex, must be a valid hex string');
 
-          await coin.explainTransaction({ txHex: 1234 }).should.be.rejectedWith('invalid transaction hex, must be a valid hex string');
+          await (coin as any).explainTransaction({ txHex: 1234 }).should.be.rejectedWith('invalid transaction hex, must be a valid hex string');
 
           await coin.explainTransaction({ txHex: '1234a' }).should.be.rejectedWith('invalid transaction hex, must be a valid hex string');
 

--- a/modules/utxo-lib/src/bitgo/index.ts
+++ b/modules/utxo-lib/src/bitgo/index.ts
@@ -1,3 +1,3 @@
 export * as keyutil from './keyutil';
 export * as outputScripts from './outputScripts';
-export { getDefaultSigHash, verifySignature } from './signature'
+export { getDefaultSigHash, verifySignature, parseSignatureScript } from './signature'

--- a/modules/utxo-lib/src/bitgo/signature.ts
+++ b/modules/utxo-lib/src/bitgo/signature.ts
@@ -171,9 +171,18 @@ export function verifySignature(
     });
   }
 
-  const { signatures, publicKeys, isSegwitInput, inputClassification, pubScript } = parseSignatureScript(
-    transaction.ins[inputIndex]
-  );
+  /* istanbul ignore next */
+  if (!transaction.ins) {
+    throw new Error(`invalid transaction`);
+  }
+
+  const input = transaction.ins[inputIndex];
+  /* istanbul ignore next */
+  if (!input) {
+    throw new Error(`no input at index ${inputIndex}`);
+  }
+
+  const { signatures, publicKeys, isSegwitInput, inputClassification, pubScript } = parseSignatureScript(input);
 
   if (![script.types.P2WSH, script.types.P2SH, script.types.P2PKH].includes(inputClassification)) {
     return false;


### PR DESCRIPTION
Use functionally identical `verifySignature()` method from utxolib.

Issue: BG-34381