### PR TITLE
fix(stx): resolves toJSON for stx

### DIFF
--- a/modules/account-lib/src/coin/stx/contractBuilder.ts
+++ b/modules/account-lib/src/coin/stx/contractBuilder.ts
@@ -169,18 +169,15 @@ export class ContractBuilder extends TransactionBuilder {
           return tupleCV(data);
         }
         throw new InvalidParameterValueError('tuple require Array val');
-
       case 'buffer':
-        if (typeof arg.val === 'string') {
-          const nval = Number(arg.val);
-          if (nval) {
-            return bufferCV(Buffer.of(nval));
-          }
-          return bufferCVFromString(arg.val);
-        } else if (arg.val instanceof Buffer) {
+        if (arg.val instanceof Buffer) {
           return bufferCV(arg.val);
         }
-        throw new InvalidParameterValueError('buffer require string or Buffer val');
+        const nval = Number(arg.val);
+        if (nval) {
+          return bufferCV(Buffer.of(nval));
+        }
+        return bufferCVFromString(arg.val);
       default:
         return encodeClarityValue(arg.type as ClarityAbiType, arg.val);
     }

--- a/modules/account-lib/src/coin/stx/transaction.ts
+++ b/modules/account-lib/src/coin/stx/transaction.ts
@@ -18,7 +18,7 @@ import { SigningError, ParseTransactionError, InvalidTransactionError, NotSuppor
 import { BaseKey } from '../baseCoin/iface';
 import { BaseTransaction, TransactionType } from '../baseCoin';
 import { SignatureData, StacksContractPayload, StacksTransactionPayload, TxData } from './iface';
-import { getTxSenderAddress, removeHexPrefix } from './utils';
+import { getTxSenderAddress, removeHexPrefix, stringifyCv } from './utils';
 import { KeyPair } from './keyPair';
 
 export class Transaction extends BaseTransaction {
@@ -133,7 +133,7 @@ export class Transaction extends BaseTransaction {
         contractAddress: addressToString(payload.contractAddress),
         contractName: payload.contractName.content,
         functionName: payload.functionName.content,
-        functionArgs: payload.functionArgs,
+        functionArgs: payload.functionArgs.map(stringifyCv),
       };
       return contractPayload;
     } else {

--- a/modules/account-lib/src/coin/stx/utils.ts
+++ b/modules/account-lib/src/coin/stx/utils.ts
@@ -22,6 +22,8 @@ import {
   PubKeyEncoding,
   publicKeyFromSignature,
   createMessageSignature,
+  ClarityValue,
+  ClarityType,
 } from '@stacks/transactions';
 import { ec } from 'elliptic';
 import { StacksNetwork } from '@stacks/network';
@@ -419,5 +421,21 @@ export function isValidAddressWithPaymentId(address: string): boolean {
     return address === normalizeAddress(addressDetails);
   } catch (e) {
     return false;
+  }
+}
+
+/**
+ * Return string representation of clarity value input
+ *
+ * @param {ClarityValue} cv clarity value function argument
+ * @returns {String} stringified clarity value
+ */
+export function stringifyCv(cv: ClarityValue): any {
+  switch (cv.type) {
+    case ClarityType.Int:
+    case ClarityType.UInt:
+      return { type: cv.type, value: cv.value.toString() };
+    default:
+      return cv;
   }
 }


### PR DESCRIPTION
The latest version bump of stacks/transactions changed the use of bignumbers to the
use of bigInt. This type doesnt serialize well in toJson() calls
This fix uses cvToJson(), converting clarity values that might be storing bigints
to a more json friendly format before we call toJson()
Ticket: STLX-6198