### PR TITLE
feat(core): add function for verifying ethereum addresses in bitgo express

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -52,6 +52,7 @@
     "@types/bluebird": "^3.5.25",
     "@types/superagent": "^4.1.3",
     "algosdk": "git+https://github.com/BitGo/algosdk-bitgo.git",
+    "assert": "^2.0.0",
     "big.js": "^3.1.3",
     "bigi": "^1.4.0",
     "bignumber.js": "^8.0.1",
@@ -124,7 +125,7 @@
     "@ethereumjs/common": "^2.4.0",
     "@ethereumjs/tx": "^3.3.0",
     "ethereumjs-abi": "^0.6.5",
-    "ethereumjs-util": "^4.4.1"
+    "ethereumjs-util": "6.2.1"
   },
   "nyc": {
     "extension": [

--- a/modules/core/src/config.ts
+++ b/modules/core/src/config.ts
@@ -215,6 +215,20 @@ export const defaults = {
   minOutputSize: 2730,
   minInstantFeeRate: 10000,
   bitgoEthAddress: '0x0f47ea803926926f299b7f1afc8460888d850f47',
+
+  // TODO (BG-35734): move forwarderFactoryAddress and forwarderImplementationAddress to statics
+  teth: {
+    forwarderFactoryAddress: '0xa79a485294d226075ee65410bc94ea454f3e409d',
+    forwarderImplementationAddress: '0xa946e748f25a5ec6878eb1a9f2e902028174c0b3',
+  },
+  gteth: {
+    forwarderFactoryAddress: '0xf5caa5e3e93afbc21bd19ef4f2691a37121f7917',
+    forwarderImplementationAddress: '0x80d5c91e8cc21df69fc4d64f21dc2d83121c3999',
+  },
+  eth: {
+    forwarderFactoryAddress: '0xffa397285ce46fb78c588a9e993286aac68c37cd',
+    forwarderImplementationAddress: '0x059ffafdc6ef594230de44f824e2bd0a51ca5ded',
+  },
 };
 
 // Supported cross-chain recovery routes. The coin to be recovered is the index, the valid coins for recipient wallets

--- a/modules/core/src/v2/coins/erc20Token.ts
+++ b/modules/core/src/v2/coins/erc20Token.ts
@@ -327,7 +327,7 @@ export class Erc20Token extends Eth {
       {
         name: 'signature',
         type: 'bytes',
-        value: optionalDeps.ethUtil.toBuffer(txInfo.signature),
+        value: optionalDeps.ethUtil.toBuffer(optionalDeps.ethUtil.addHexPrefix(txInfo.signature)),
       },
     ];
   }

--- a/modules/core/src/v2/internal/util.ts
+++ b/modules/core/src/v2/internal/util.ts
@@ -197,4 +197,46 @@ export class Util {
     const pubKey = ethUtil.ecrecover(Buffer.from(msgHash, 'hex'), v, r, s);
     return ethUtil.bufferToHex(ethUtil.pubToAddress(pubKey));
   }
+
+  // TODO (BG-35735): move getProxyInitcode, calculateEthAddress and calculateEthAddress2 to account-lib
+  /**
+   * Take the implementation address for the proxy contract, and get the binary initcode for the associated proxy
+   * @param implementationAddress The address of the implementation contract for the proxy
+   * @return {string} Binary hex string of the proxy
+   */
+  static getProxyInitcode = (implementationAddress) => {
+    const target = ethUtil.stripHexPrefix(implementationAddress.toLowerCase()).padStart(40, '0');
+
+    // bytecode of the proxy, from:
+    // https://github.com/BitGo/eth-multisig-v4/blob/d546a937f90f93e83b3423a5bf933d1d77c677c3/contracts/CloneFactory.sol#L42-L56
+    return `0x3d602d80600a3d3981f3363d3d373d3d3d363d73${target}5af43d82803e903d91602b57fd5bf3`;
+  };
+
+  /**
+   * Calculate the address that will be generated if `creatorAddress` creates it with nonce `creatorNonce
+   * @param creatorAddress The address that is sending the tx to create a new address
+   * @param creatorNonce The nonce of the tx where the address creation will happen
+   * @return {String} The calculated address
+   */
+  static calculateEthAddress = function (creatorAddress, creatorNonce) {
+    return ethUtil.bufferToHex(ethUtil.generateAddress(creatorAddress, creatorNonce));
+  };
+
+  /**
+   * Calculate the address that will be generated if `creatorAddress` creates it with salt `salt`
+   * and initcode `inicode using the create2 opcode
+   * @param creatorAddress The address that is sending the tx to create a new address, hex string
+   * @param salt The salt to create the address with using create2, hex string
+   * @param initcode The initcode that will be deployed to the address, hex string
+   * @return {String} The calculated address
+   */
+  static calculateEthAddress2 = function (creatorAddress, salt, initcode) {
+    return ethUtil.bufferToHex(
+      ethUtil.generateAddress2(
+        Buffer.from(ethUtil.stripHexPrefix(creatorAddress), 'hex'),
+        Buffer.from(ethUtil.stripHexPrefix(salt), 'hex'),
+        Buffer.from(ethUtil.stripHexPrefix(initcode), 'hex')
+      )
+    );
+  };
 }

--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -1312,6 +1312,8 @@ export class Wallet {
         }
 
         newAddress.keychains = keychains;
+        newAddress.baseAddress = _.get(self._wallet, 'coinSpecific.baseAddress');
+
         const verificationData: VerifyAddressOptions = _.merge({}, newAddress, { rootAddress });
 
         if (verificationData.error) {

--- a/modules/core/test/v2/unit/coins/eth.ts
+++ b/modules/core/test/v2/unit/coins/eth.ts
@@ -5,6 +5,12 @@ import * as nock from 'nock';
 import * as bip32 from 'bip32';
 import * as secp256k1 from 'secp256k1';
 import * as common from '../../../../src/common';
+import * as assert from 'assert';
+import {
+  InvalidAddressError,
+  InvalidAddressVerificationObjectPropertyError,
+  UnexpectedAddressError
+} from '../../../../src/errors';
 
 nock.enableNetConnect();
 
@@ -468,4 +474,197 @@ describe('ETH:', function () {
         .should.be.rejectedWith('coin in txPrebuild did not match that in txParams supplied by client');
     });
   });
+
+  describe('Address Verification', function () {
+
+    it('should verify an address generated using forwarder version 0', async function () {
+      const coin = bitgo.coin('teth');
+
+      const params = {
+        id: '6127bff4ecd84c0006cd9a0e5ccdc36f',
+        chain: 0,
+        index: 3174,
+        coin: 'teth',
+        lastNonce: 0,
+        wallet: '598f606cd8fc24710d2ebadb1d9459bb',
+        baseAddress: '0xdf07117705a9f8dc4c2a78de66b7f1797dba9d4e',
+        coinSpecific: {
+          nonce: -1,
+          updateTime: '2021-08-26T16:23:16.563Z',
+          txCount: 0,
+          pendingChainInitialization: true,
+          creationFailure: [],
+          pendingDeployment: false,
+          forwarderVersion: 0
+        }
+      };
+
+      const isAddressVerified = await coin.verifyAddress(params);
+      isAddressVerified.should.equal(true);
+    });
+
+    it('should verify an address generated using forwarder version 1', async function () {
+      const coin = bitgo.coin('teth');
+
+      const params = {
+        id: '61250217c8c02b000654b15e7af6f618',
+        address: '0xb0b56eeae1b283918caca02a14ada2df17a98e6d',
+        chain: 0,
+        index: 3162,
+        coin: 'teth',
+        lastNonce: 0,
+        wallet: '598f606cd8fc24710d2ebadb1d9459bb',
+        baseAddress: '0xdf07117705a9f8dc4c2a78de66b7f1797dba9d4e',
+        coinSpecific: {
+          nonce: -1,
+          updateTime: '2021-08-24T14:28:39.841Z',
+          txCount: 0,
+          pendingChainInitialization: true,
+          creationFailure: [],
+          salt: '0xc5a',
+          pendingDeployment: true,
+          forwarderVersion: 1,
+        },
+      };
+
+      const isAddressVerified = await coin.verifyAddress(params);
+      isAddressVerified.should.equal(true);
+    });
+
+    it('should reject address verification if coinSpecific field is not an object', async function () {
+      const coin = bitgo.coin('teth');
+
+      const params = {
+        id: '61250217c8c02b000654b15e7af6f618',
+        address: '0xb0b56eeae1b283918caca02a14ada2df17a98e6d',
+        chain: 0,
+        index: 3162,
+        coin: 'teth',
+        lastNonce: 0,
+        wallet: '598f606cd8fc24710d2ebadb1d9459bb',
+        baseAddress: '0xdf07117705a9f8dc4c2a78de66b7f1797dba9d4e',
+      };
+
+      assert.throws(function () {
+        coin.verifyAddress(params);
+      }, InvalidAddressVerificationObjectPropertyError);
+    });
+
+    it('should reject address verification when an actual address is different from expected address', async function () {
+      const coin = bitgo.coin('teth');
+
+      const params = {
+        id: '61250217c8c02b000654b15e7af6f618',
+        address: '0x28904591f735994f050804fda3b61b813b16e04c',
+        chain: 0,
+        index: 3162,
+        coin: 'teth',
+        lastNonce: 0,
+        baseAddress: '0xdf07117705a9f8dc4c2a78de66b7f1797dba9d4e',
+        wallet: '598f606cd8fc24710d2ebadb1d9459bb',
+        coinSpecific: {
+          nonce: -1,
+          updateTime: '2021-08-24T14:28:39.841Z',
+          txCount: 0,
+          pendingChainInitialization: true,
+          creationFailure: [],
+          salt: '0xc5a',
+          pendingDeployment: true,
+          forwarderVersion: 1,
+        },
+      };
+
+      assert.throws(function () {
+        coin.verifyAddress(params);
+      }, UnexpectedAddressError);
+    });
+
+    it('should reject address verification if the derived address is in invalid format', async function () {
+      const coin = bitgo.coin('teth');
+
+      const params = {
+        id: '61250217c8c02b000654b15e7af6f618',
+        address: '0xe0b56eeae1b283918caca02a14ada2df17a98bvf',
+        chain: 0,
+        index: 3162,
+        coin: 'teth',
+        lastNonce: 0,
+        wallet: '598f606cd8fc24710d2ebadb1d9459bb',
+        baseAddress: '0xdf07117705a9f8dc4c2a78de66b7f1797dba9d4e',
+        coinSpecific: {
+          nonce: -1,
+          updateTime: '2021-08-24T14:28:39.841Z',
+          txCount: 0,
+          pendingChainInitialization: true,
+          creationFailure: [],
+          salt: '0xc5a',
+          pendingDeployment: true,
+          forwarderVersion: 1,
+        },
+      };
+
+      assert.throws(function () {
+        coin.verifyAddress(params);
+      }, InvalidAddressError);
+    });
+
+    it('should reject address verification if base address is undefined', async function () {
+      const coin = bitgo.coin('teth');
+
+      const params = {
+        id: '61250217c8c02b000654b15e7af6f618',
+        address: '0xb0b56eeae1b283918caca02a14ada2df17a98e6d',
+        chain: 0,
+        index: 3162,
+        coin: 'teth',
+        lastNonce: 0,
+        wallet: '598f606cd8fc24710d2ebadb1d9459bb',
+        coinSpecific: {
+          nonce: -1,
+          updateTime: '2021-08-24T14:28:39.841Z',
+          txCount: 0,
+          pendingChainInitialization: true,
+          creationFailure: [],
+          salt: '0xc5a',
+          pendingDeployment: true,
+          forwarderVersion: 1,
+        },
+      };
+
+      assert.throws(function () {
+        coin.verifyAddress(params);
+      }, InvalidAddressError);
+    });
+
+    it('should reject address verification if base address is in invalid format', async function () {
+      const coin = bitgo.coin('teth');
+
+      const params = {
+        id: '61250217c8c02b000654b15e7af6f618',
+        address: '0xb0b56eeae1b283918caca02a14ada2df17a98e6d',
+        chain: 0,
+        index: 3162,
+        coin: 'teth',
+        lastNonce: 0,
+        wallet: '598f606cd8fc24710d2ebadb1d9459bb',
+        baseAddress: '0xe0b56eeae1b283918caca02a14ada2df17a98bvf',
+        coinSpecific: {
+          nonce: -1,
+          updateTime: '2021-08-24T14:28:39.841Z',
+          txCount: 0,
+          pendingChainInitialization: true,
+          creationFailure: [],
+          salt: '0xc5a',
+          pendingDeployment: true,
+          forwarderVersion: 1,
+        },
+      };
+
+      assert.throws(function () {
+        coin.verifyAddress(params);
+      }, InvalidAddressError);
+    });
+
+  });
+
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3946,7 +3946,7 @@ bn.js@^3.1.1:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-3.3.0.tgz#1138e577889fdc97bbdab51844f2190dfc0ae3d7"
   integrity sha1-ETjld4if3Je72rUYRPIZDfwK49c=
 
-bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.0, bn.js@^4.11.1, bn.js@^4.11.6, bn.js@^4.11.8, bn.js@^4.11.9, bn.js@^4.12.0, bn.js@^4.4.0, bn.js@^4.8.0:
+bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.0, bn.js@^4.11.1, bn.js@^4.11.6, bn.js@^4.11.8, bn.js@^4.11.9, bn.js@^4.12.0, bn.js@^4.4.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
@@ -6849,16 +6849,18 @@ ethereumjs-util@5.2.0, "ethereumjs-utils-old@npm:ethereumjs-util@5.2.0":
     safe-buffer "^5.1.1"
     secp256k1 "^3.0.1"
 
-ethereumjs-util@^4.4.1:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-4.5.1.tgz#f4bf9b3b515a484e3cc8781d61d9d980f7c83bd0"
-  integrity sha512-WrckOZ7uBnei4+AKimpuF1B3Fv25OmoRgmYCpGsP7u8PFxXAmAgiJSYT2kRWnt6fVIlKaQlZvuwXp7PIrmn3/w==
+ethereumjs-util@6.2.1, ethereumjs-util@^6.0.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz#fcb4e4dd5ceacb9d2305426ab1a5cd93e3163b69"
+  integrity sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==
   dependencies:
-    bn.js "^4.8.0"
+    "@types/bn.js" "^4.11.3"
+    bn.js "^4.11.0"
     create-hash "^1.1.2"
     elliptic "^6.5.2"
     ethereum-cryptography "^0.1.3"
-    rlp "^2.0.0"
+    ethjs-util "0.1.6"
+    rlp "^2.2.3"
 
 ethereumjs-util@^5.2.0:
   version "5.2.1"
@@ -6872,19 +6874,6 @@ ethereumjs-util@^5.2.0:
     ethjs-util "^0.1.3"
     rlp "^2.0.0"
     safe-buffer "^5.1.1"
-
-ethereumjs-util@^6.0.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz#fcb4e4dd5ceacb9d2305426ab1a5cd93e3163b69"
-  integrity sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==
-  dependencies:
-    "@types/bn.js" "^4.11.3"
-    bn.js "^4.11.0"
-    create-hash "^1.1.2"
-    elliptic "^6.5.2"
-    ethereum-cryptography "^0.1.3"
-    ethjs-util "0.1.6"
-    rlp "^2.2.3"
 
 ethereumjs-util@^7.0.10:
   version "7.0.10"


### PR DESCRIPTION
**Background**

BitGo Express does not adequately verify the addresses returned by BitGo Servers while building transactions. If the BitGo servers are compromised, the address verification logic ensures that BitGo Express cannot be tricked by providing a wrong address. 

**Changes**

- Added function `verifyAddress()` for Ethereum.

- Added `calculateEthAddress2()`: function to create ethereum address for forwarder version 1, `calculateEthAddress()`: function to create ethereum address for forwarder version 0, `getProxyInitcode()`: function to get the initcode which is used to create address with forwarder version 1  in utils file

- Added constants for forwarderFactoryAddress and forwarderImplementationAddress in config file

- Added unit tests for the Address verification function

- Added assert package for test cases of address verification function

- Upgraded version of ethereumjs-util because generateAddress2 function which is used to calculate ethereum address for forwarder version 1 was not in the 4.x.x version. Upgraded the version to 6.2.1 to make it in sync with bitgo-microservices

- Make a minor change in the `getSendMethodArgs()` method in ERC20Token and Eth class because of ethereumjs-util's version update

Ticket: BG-33701