### PR TITLE
refactor(core): add, use getAddressP2PKH()

### DIFF
--- a/modules/core/src/bitcoin.ts
+++ b/modules/core/src/bitcoin.ts
@@ -2,8 +2,7 @@
  * @hidden
  */
 
-/**
- */
+import * as bip32 from 'bip32';
 import * as common from './common';
 import * as utxolib from '@bitgo/utxo-lib';
 import { V1Network } from './v2/types';
@@ -27,6 +26,14 @@ export function getNetwork(network?: V1Network): utxolib.Network {
 
 export function makeRandomKey(): utxolib.ECPair {
   return utxolib.ECPair.makeRandom({ network: getNetwork() });
+}
+
+export function getAddressP2PKH(key: utxolib.ECPair | bip32.BIP32Interface): string {
+  const pkHash = utxolib.crypto.hash160(key.publicKey);
+  return utxolib.address.fromOutputScript(
+    utxolib.script.pubKeyHash.output.encode(pkHash),
+    key.network,
+  );
 }
 
 /** @deprecated - use bip32 package instead */

--- a/modules/core/src/bitgo.ts
+++ b/modules/core/src/bitgo.ts
@@ -6,7 +6,7 @@
 
 import * as superagent from 'superagent';
 import * as utxolib from '@bitgo/utxo-lib';
-import { makeRandomKey } from './bitcoin';
+import { getAddressP2PKH, makeRandomKey } from './bitcoin';
 import * as bip32 from 'bip32';
 import * as secp256k1 from 'secp256k1';
 import bitcoinMessage = require('bitcoinjs-message');
@@ -1193,7 +1193,7 @@ export class BitGo {
     if (extensible) {
       this._extensionKey = makeRandomKey();
       authParams.extensible = true;
-      authParams.extensionAddress = this._extensionKey.getAddress();
+      authParams.extensionAddress = getAddressP2PKH(this._extensionKey);
     }
 
     return authParams;

--- a/modules/core/src/transactionBuilder.ts
+++ b/modules/core/src/transactionBuilder.ts
@@ -16,7 +16,7 @@ import * as Bluebird from 'bluebird';
 import * as utxolib from '@bitgo/utxo-lib';
 import * as _ from 'lodash';
 import { VirtualSizes } from '@bitgo/unspents';
-import { getNetwork } from './bitcoin';
+import { getAddressP2PKH, getNetwork } from './bitcoin';
 import debugLib = require('debug');
 const debug = debugLib('bitgo:v1:txb');
 import * as common from './common';
@@ -113,7 +113,7 @@ exports.createTransaction = function (params) {
 
   if (params.feeSingleKeyWIF) {
     const feeSingleKey = utxolib.ECPair.fromWIF(params.feeSingleKeyWIF, network);
-    feeSingleKeySourceAddress = feeSingleKey.getAddress();
+    feeSingleKeySourceAddress = getAddressP2PKH(feeSingleKey);
     // If the user specifies both, check to make sure the feeSingleKeySourceAddress corresponds to the address of feeSingleKeyWIF
     if (params.feeSingleKeySourceAddress &&
     params.feeSingleKeySourceAddress !== feeSingleKeySourceAddress) {

--- a/modules/core/src/wallets.ts
+++ b/modules/core/src/wallets.ts
@@ -13,7 +13,7 @@
 
 import * as bip32 from 'bip32';
 import * as utxolib from '@bitgo/utxo-lib';
-import { makeRandomKey, getNetwork } from './bitcoin';
+import { makeRandomKey, getNetwork, getAddressP2PKH } from './bitcoin';
 import * as common from './common';
 import * as _ from 'lodash';
 import * as Bluebird from 'bluebird';
@@ -279,7 +279,7 @@ Wallets.prototype.acceptShare = function (params, callback) {
 Wallets.prototype.createKey = function (params) {
   const key = makeRandomKey();
   return {
-    address: key.getAddress(),
+    address: getAddressP2PKH(key),
     key: key.toWIF(),
   };
 };
@@ -439,7 +439,7 @@ Wallets.prototype.createForwardWallet = function (params, callback) {
 
   try {
     const key = utxolib.ECPair.fromWIF(params.privKey, getNetwork());
-    addressFromPrivKey = key.getAddress();
+    addressFromPrivKey = getAddressP2PKH(key);
   } catch (e) {
     throw new Error('expecting a valid privKey');
   }

--- a/modules/core/test/integration/wallets.ts
+++ b/modules/core/test/integration/wallets.ts
@@ -12,7 +12,7 @@ const Q = require('q');
 
 const TestBitGo = require('../lib/test_bitgo');
 import * as utxolib from '@bitgo/utxo-lib';
-import { getNetwork } from '../../src/bitcoin';
+import { getAddressP2PKH, getNetwork } from '../../src/bitcoin';
 import * as common from '../../src/common';
 import * as nock from 'nock';
 
@@ -357,7 +357,7 @@ describe('Wallets', function () {
     let sourceAddress;
     before(() => {
       key = utxolib.ECPair.makeRandom({ network: getNetwork(common.Environments[bitgo.getEnv()].network) });
-      sourceAddress = key.getAddress();
+      sourceAddress = getAddressP2PKH(key);
     });
 
     it('arguments', function () {

--- a/modules/core/test/v2/unit/trading/payload.ts
+++ b/modules/core/test/v2/unit/trading/payload.ts
@@ -2,11 +2,11 @@
  * @prettier
  */
 
+import * as bip32 from 'bip32';
 import { coroutine as co } from 'bluebird';
 import * as should from 'should';
 import * as nock from 'nock';
 import * as bitcoinMessage from 'bitcoinjs-message';
-import { HDNode } from '@bitgo/utxo-lib';
 
 import fixtures from '../../fixtures/trading/payload';
 
@@ -14,6 +14,7 @@ import { Enterprise } from '../../../../src/v2/enterprise';
 import { Wallet } from '../../../../src/v2/wallet';
 import { TestBitGo } from '../../../lib/test_bitgo';
 import * as common from '../../../../src/common';
+import { getAddressP2PKH } from '../../../../src/bitcoin';
 
 describe('Trade Payloads', function () {
   const microservicesUri = common.Environments['mock'].uri;
@@ -104,7 +105,7 @@ describe('Trade Payloads', function () {
     // signature should be a hex string
     signature.should.match(/^[0-9a-f]+$/);
 
-    const address = HDNode.fromBase58(xpub).getAddress();
+    const address = getAddressP2PKH(bip32.fromBase58(xpub));
 
     bitcoinMessage.verify(JSON.stringify(payload), address, Buffer.from(signature, 'hex')).should.be.True();
 


### PR DESCRIPTION
The `ECPair.getAddress()` API will be deprecated soon

Issue: BG-34381