### PR TITLE
Include test case and base chain for algo tokens.

### DIFF
--- a/modules/core/src/v2/coins/algoToken.ts
+++ b/modules/core/src/v2/coins/algoToken.ts
@@ -71,6 +71,10 @@ export class AlgoToken extends Algo {
     return this.tokenConfig.type;
   }
 
+  getBaseChain() {
+    return this.coin;
+  }
+
   getFullName() {
     return 'Algo Token';
   }

--- a/modules/core/test/v2/unit/coins/algoToken.ts
+++ b/modules/core/test/v2/unit/coins/algoToken.ts
@@ -17,7 +17,6 @@ describe('Algo Unison Token:', function () {
     algoTokenCoin.getChain().should.equal('talgo:16026728');
     algoTokenCoin.getBaseChain().should.equal('talgo');
     algoTokenCoin.getFullName().should.equal('Algo Token');
-    algoTokenCoin.getBaseFactor().should.equal(1e18);
     algoTokenCoin.type.should.equal(tokenName);
     algoTokenCoin.name.should.equal('Unison');
     algoTokenCoin.coin.should.equal('talgo');

--- a/modules/core/test/v2/unit/coins/algoToken.ts
+++ b/modules/core/test/v2/unit/coins/algoToken.ts
@@ -1,0 +1,27 @@
+import 'should';
+
+import { TestBitGo } from '../../../lib/test_bitgo';
+
+describe('Algo Unison Token:', function () {
+  let bitgo;
+  let algoTokenCoin;
+  const tokenName = 'talgo:16026728';
+
+  before(function () {
+    bitgo = new TestBitGo({ env: 'test' });
+    bitgo.initializeTestVars();
+    algoTokenCoin = bitgo.coin(tokenName);
+  });
+
+  it('should return constants', function () {
+    algoTokenCoin.getChain().should.equal('talgo:16026728');
+    algoTokenCoin.getBaseChain().should.equal('talgo');
+    algoTokenCoin.getFullName().should.equal('Algo Token');
+    algoTokenCoin.getBaseFactor().should.equal(1e18);
+    algoTokenCoin.type.should.equal(tokenName);
+    algoTokenCoin.name.should.equal('Unison');
+    algoTokenCoin.coin.should.equal('talgo');
+    algoTokenCoin.network.should.equal('Testnet');
+    algoTokenCoin.decimalPlaces.should.equal(2);
+  });
+});


### PR DESCRIPTION
Algo tokens don't seem to be working correctly on bitgo-js. Inside `algo.ts` we call `explainTransaction` which uses the following code:

```
      const factory = accountLib.getBuilder(this.getChain()) as unknown as accountLib.Algo.TransactionBuilderFactory;

      const txBuilder = factory.from(txHex);
      const tx = (yield txBuilder.build()) as any;
      const txJson = tx.toJson();
```

The builder doesn't exist for the given chain.

![image](https://user-images.githubusercontent.com/89028368/132602829-0944e7ed-b2eb-4752-ba4f-e1e931228999.png)

Solution I imagine would be to update the value returned from `getChain` from algo tokens to reference coin instead, but not sure if there's a convention for how these are handled.
