### PR TITLE
fix(accountlib): stx transactionBuilder network fix

### DIFF
--- a/modules/account-lib/src/coin/stx/transactionBuilder.ts
+++ b/modules/account-lib/src/coin/stx/transactionBuilder.ts
@@ -13,7 +13,7 @@ import {
   StacksMessageType,
   PubKeyEncoding,
 } from '@stacks/transactions';
-import { StacksNetwork, StacksTestnet } from '@stacks/network';
+import { StacksNetwork, StacksTestnet, StacksMainnet } from '@stacks/network';
 import { BaseTransactionBuilder } from '../baseCoin';
 import {
   BuildTransactionError,
@@ -46,7 +46,7 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
     this._fromPubKeys = [];
     this._signatures = [];
     this._numberSignatures = 2;
-    this._network = new StacksTestnet();
+    this._network = _coinConfig.network.type === 'mainnet' ? new StacksMainnet() : new StacksTestnet();
     this._transaction = new Transaction(_coinConfig);
   }
 

--- a/modules/account-lib/test/unit/coin/stx/transaction.ts
+++ b/modules/account-lib/test/unit/coin/stx/transaction.ts
@@ -5,7 +5,7 @@ import * as testData from '../../../resources/stx/stx';
 import { KeyPair } from '../../../../src/coin/stx/keyPair';
 
 describe('Stx Transaction', () => {
-  const coin = coins.get('stx');
+  const coin = coins.get('tstx');
 
   it('should throw empty transaction', () => {
     const tx = new Transaction(coin);

--- a/modules/account-lib/test/unit/coin/stx/transactionBuilder/contractBuilder.ts
+++ b/modules/account-lib/test/unit/coin/stx/transactionBuilder/contractBuilder.ts
@@ -9,7 +9,8 @@ import { bufferCV, noneCV, someCV, standardPrincipalCV, tupleCV, uintCV, intCV }
 import { stringifyCv } from '../../../../../src/coin/stx/utils';
 
 describe('Stx Contract call Builder', () => {
-  const factory = register('stx', TransactionBuilderFactory);
+  const factory = register('tstx', TransactionBuilderFactory);
+  const factoryProd = register('stx', TransactionBuilderFactory);
 
   const initTxBuilder = () => {
     const txBuilder = factory.getContractBuilder();
@@ -20,6 +21,19 @@ describe('Stx Contract call Builder', () => {
     txBuilder.functionName(testData.CONTRACT_FUNCTION_NAME);
     return txBuilder;
   };
+
+  describe('contract builder environment', function () {
+    it('should select the right network', function () {
+      should.equal(factory.getTransferBuilder().coinName(), 'tstx');
+      should.equal(factoryProd.getTransferBuilder().coinName(), 'stx');
+      // used type any to access protected properties
+      const txBuilder: any = factory.getTransferBuilder();
+      const txBuilderProd: any = factoryProd.getTransferBuilder();
+
+      txBuilder._network.should.deepEqual(new StacksTestnet());
+      txBuilderProd._network.should.deepEqual(new StacksMainnet());
+    });
+  });
 
   describe('should build ', () => {
     it('an unsigned contract call transaction', async () => {

--- a/modules/account-lib/test/unit/coin/stx/transactionBuilder/transferBuilder.ts
+++ b/modules/account-lib/test/unit/coin/stx/transactionBuilder/transferBuilder.ts
@@ -1,5 +1,5 @@
 import should from 'should';
-import { StacksTestnet } from '@stacks/network';
+import { StacksMainnet, StacksTestnet } from '@stacks/network';
 import { register } from '../../../../../src/index';
 import { TransactionBuilderFactory, KeyPair } from '../../../../../src/coin/stx';
 import * as testData from '../../../../resources/stx/stx';
@@ -8,7 +8,8 @@ import { rawPrvToExtendedKeys } from '../../../../../src/utils/crypto';
 import { padMemo } from '../../../../../src/coin/stx/utils';
 
 describe('Stx Transfer Builder', () => {
-  const factory = register('stx', TransactionBuilderFactory);
+  const factory = register('tstx', TransactionBuilderFactory);
+  const factoryProd = register('stx', TransactionBuilderFactory);
 
   const initTxBuilder = () => {
     const txBuilder = factory.getTransferBuilder();
@@ -18,6 +19,19 @@ describe('Stx Transfer Builder', () => {
     txBuilder.amount('1000');
     return txBuilder;
   };
+
+  describe('transfer builder environment', function () {
+    it('should select the right network', function () {
+      should.equal(factory.getTransferBuilder().coinName(), 'tstx');
+      should.equal(factoryProd.getTransferBuilder().coinName(), 'stx');
+      // used type any to access protected properties
+      const txBuilder: any = factory.getTransferBuilder();
+      const txBuilderProd: any = factoryProd.getTransferBuilder();
+
+      txBuilder._network.should.deepEqual(new StacksTestnet());
+      txBuilderProd._network.should.deepEqual(new StacksMainnet());
+    });
+  });
 
   describe('should build ', () => {
     it('a signed transfer transaction', async () => {


### PR DESCRIPTION
Fixed the transactionBuilder constructor to set the network based on the coin stx or tstx  
Added and fixed Unit test based on env

[stlx-7056](https://bitgoinc.atlassian.net/browse/STLX-7056)