### PR TITLE
fix(core): correctly handle ECPair case in `getAddressP2PKH`

### DIFF
--- a/modules/core/src/bitcoin.ts
+++ b/modules/core/src/bitcoin.ts
@@ -17,7 +17,7 @@ export function makeRandomKey(): utxolib.ECPair {
 }
 
 export function getAddressP2PKH(key: utxolib.ECPair | bip32.BIP32Interface): string {
-  const pkHash = utxolib.crypto.hash160(key.publicKey);
+  const pkHash = utxolib.crypto.hash160(key.publicKey ?? key.getPublicKeyBuffer());
   return utxolib.address.fromOutputScript(
     utxolib.script.pubKeyHash.output.encode(pkHash),
     key.network,

--- a/modules/core/test/v2/unit/bitcoin.ts
+++ b/modules/core/test/v2/unit/bitcoin.ts
@@ -1,0 +1,18 @@
+/**
+ * @prettier
+ */
+import 'should';
+import { ECPair } from '@bitgo/utxo-lib';
+
+import { getAddressP2PKH } from '../../../src/bitcoin';
+
+describe('Bitcoin utils:', function () {
+  it('should produce equivalent addresses when using getAddress() vs getAddressP2PKH() for an ECPair key', () => {
+    const key = ECPair.makeRandom();
+
+    const firstAddress = key.getAddress();
+    const secondAddress = getAddressP2PKH(key);
+
+    firstAddress.should.eql(secondAddress);
+  });
+});


### PR DESCRIPTION
The typescript types are broken somehow and the `key` parameter is getting
typed as `any`, which caused us to incorrectly handle the case where the `key`
was an ECPair instance.

Ticket: BG-36337