### PR TITLE
feat(utxo-lib): export address check types

### DIFF
--- a/modules/utxo-lib/src/address.ts
+++ b/modules/utxo-lib/src/address.ts
@@ -4,7 +4,7 @@ import * as zcashAddress from '../src/bitgo/zcash/address';
 
 import { Network } from './networkTypes';
 import { isValidNetwork, isZcash } from './coins';
-import { Base58CheckResult } from 'bitcoinjs-lib/types/address';
+import { Base58CheckResult, Bech32Result } from 'bitcoinjs-lib/types/address';
 
 export function fromOutputScript(outputScript: Buffer, network: Network): string {
   if (isValidNetwork(network) && isZcash(network)) {
@@ -35,3 +35,5 @@ export function fromBase58Check(address: string, network: Network): Base58CheckR
 }
 
 export const { fromBech32, toBech32 } = bitcoinjs.address;
+
+export { Base58CheckResult, Bech32Result };


### PR DESCRIPTION
This exports the `Base58CheckResult` and `Bech32Result` types from bitcoinjs-lib to make them available for use in external projects.

Ticket: BG-32852