### PR TITLE
fix(statics): change Goerli ETH underlying asset from ETH to GTETH

### DIFF
--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -151,6 +151,7 @@ export enum UnderlyingAsset {
   USD = 'usd',
   ETH = 'eth',
   ETH2 = 'eth2',
+  GTETH = 'gteth',
   ETC = 'etc',
   EOS = 'eos',
   HBAR = 'hbar', // Hedera main coin

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -59,7 +59,7 @@ export const coins = CoinMap.fromCoins([
   account('tcspr', 'Testnet Casper', Networks.test.casper, 9, UnderlyingAsset.CSPR, CSPR_FEATURES),
   account('eth', 'Ethereum', Networks.main.ethereum, 18, UnderlyingAsset.ETH, ETH_FEATURES),
   account('teth', 'Testnet Ethereum', Networks.test.kovan, 18, UnderlyingAsset.ETH, ETH_FEATURES),
-  account('gteth', 'Goerli Testnet Ethereum', Networks.test.goerli, 18, UnderlyingAsset.ETH, ETH_FEATURES),
+  account('gteth', 'Goerli Testnet Ethereum', Networks.test.goerli, 18, UnderlyingAsset.GTETH, ETH_FEATURES),
   account('eth2', 'Ethereum 2.0', Networks.main.ethereum2, 18, UnderlyingAsset.ETH2, ETH2_FEATURES, KeyCurve.BLS),
   account(
     'teth2',


### PR DESCRIPTION
Relates to ticket: [BG-34816](https://bitgoinc.atlassian.net/browse/BG-34816)

For a given coin, we decide which icon to load for it based on its `assetStr` which comes from its UnderlyingAsset property here in statics. We want to load different icons for Kovan and Goerli on the frontend, so this PR changes Goerli to have a different underlying asset than Kovan. Note: it might also be worth changing Kovan's UnderlyingAsset to `TETH` or something like that for consistency (although this would require storing duplicate icons for TETH and ETH in the frontend src).