### PR TITLE
refactor(core): use eth utils method from acctlib

### DIFF
--- a/modules/core/src/config.ts
+++ b/modules/core/src/config.ts
@@ -242,20 +242,6 @@ export const defaults = {
   minOutputSize: 2730,
   minInstantFeeRate: 10000,
   bitgoEthAddress: '0x0f47ea803926926f299b7f1afc8460888d850f47',
-
-  // TODO (BG-35734): move forwarderFactoryAddress and forwarderImplementationAddress to statics
-  teth: {
-    forwarderFactoryAddress: '0xa79a485294d226075ee65410bc94ea454f3e409d',
-    forwarderImplementationAddress: '0xa946e748f25a5ec6878eb1a9f2e902028174c0b3',
-  },
-  gteth: {
-    forwarderFactoryAddress: '0xf5caa5e3e93afbc21bd19ef4f2691a37121f7917',
-    forwarderImplementationAddress: '0x80d5c91e8cc21df69fc4d64f21dc2d83121c3999',
-  },
-  eth: {
-    forwarderFactoryAddress: '0xffa397285ce46fb78c588a9e993286aac68c37cd',
-    forwarderImplementationAddress: '0x059ffafdc6ef594230de44f824e2bd0a51ca5ded',
-  },
 };
 
 // Supported cross-chain recovery routes. The coin to be recovered is the index, the valid coins for recipient wallets

--- a/modules/core/src/v2/baseCoin.ts
+++ b/modules/core/src/v2/baseCoin.ts
@@ -178,6 +178,7 @@ export interface AddressCoinSpecific {
   witnessScript?: string;
   baseAddress?: string;
   pendingChainInitialization?: boolean;
+  forwarderVersion?: number;
 }
 
 export interface FullySignedTransaction {

--- a/modules/core/src/v2/internal/util.ts
+++ b/modules/core/src/v2/internal/util.ts
@@ -197,46 +197,4 @@ export class Util {
     const pubKey = ethUtil.ecrecover(Buffer.from(msgHash, 'hex'), v, r, s);
     return ethUtil.bufferToHex(ethUtil.pubToAddress(pubKey));
   }
-
-  // TODO (BG-35735): move getProxyInitcode, calculateEthAddress and calculateEthAddress2 to account-lib
-  /**
-   * Take the implementation address for the proxy contract, and get the binary initcode for the associated proxy
-   * @param implementationAddress The address of the implementation contract for the proxy
-   * @return {string} Binary hex string of the proxy
-   */
-  static getProxyInitcode = (implementationAddress) => {
-    const target = ethUtil.stripHexPrefix(implementationAddress.toLowerCase()).padStart(40, '0');
-
-    // bytecode of the proxy, from:
-    // https://github.com/BitGo/eth-multisig-v4/blob/d546a937f90f93e83b3423a5bf933d1d77c677c3/contracts/CloneFactory.sol#L42-L56
-    return `0x3d602d80600a3d3981f3363d3d373d3d3d363d73${target}5af43d82803e903d91602b57fd5bf3`;
-  };
-
-  /**
-   * Calculate the address that will be generated if `creatorAddress` creates it with nonce `creatorNonce
-   * @param creatorAddress The address that is sending the tx to create a new address
-   * @param creatorNonce The nonce of the tx where the address creation will happen
-   * @return {String} The calculated address
-   */
-  static calculateEthAddress = function (creatorAddress, creatorNonce) {
-    return ethUtil.bufferToHex(ethUtil.generateAddress(creatorAddress, creatorNonce));
-  };
-
-  /**
-   * Calculate the address that will be generated if `creatorAddress` creates it with salt `salt`
-   * and initcode `inicode using the create2 opcode
-   * @param creatorAddress The address that is sending the tx to create a new address, hex string
-   * @param salt The salt to create the address with using create2, hex string
-   * @param initcode The initcode that will be deployed to the address, hex string
-   * @return {String} The calculated address
-   */
-  static calculateEthAddress2 = function (creatorAddress, salt, initcode) {
-    return ethUtil.bufferToHex(
-      ethUtil.generateAddress2(
-        Buffer.from(ethUtil.stripHexPrefix(creatorAddress), 'hex'),
-        Buffer.from(ethUtil.stripHexPrefix(salt), 'hex'),
-        Buffer.from(ethUtil.stripHexPrefix(initcode), 'hex')
-      )
-    );
-  };
 }

--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -1329,7 +1329,9 @@ export class Wallet {
           throw new AddressGenerationError(verificationData.error);
         }
 
-        if (verificationData.coinSpecific && !verificationData.coinSpecific.pendingChainInitialization) {
+        // This condition was added in first place because in celo, when verifyAddress method was called on addresses which were having pendingChainInitialization as true, it used to throw some error
+        // In case of forwarder version 1 eth addresses, addresses need to be verified even if the pendingChainInitialization flag is true
+        if (verificationData.coinSpecific && (!verificationData.coinSpecific.pendingChainInitialization || verificationData.coinSpecific.forwarderVersion === 1)) {
           // can't verify addresses which are pending chain initialization, as the address is hidden
           self.baseCoin.verifyAddress(verificationData);
         }

--- a/modules/core/test/v2/unit/wallet.ts
+++ b/modules/core/test/v2/unit/wallet.ts
@@ -555,6 +555,23 @@ describe('V2 Wallet:', function () {
   });
 
   describe('Create Address', () => {
+    let ethWallet;
+
+    before(async function () {
+      const walletData = {
+        id: '598f606cd8fc24710d2ebadb1d9459bb',
+        coinSpecific: {
+          baseAddress: '0xdf07117705a9f8dc4c2a78de66b7f1797dba9d4e',
+        },
+        coin: 'teth',
+        keys: [
+          '598f606cd8fc24710d2ebad89dce86c2',
+          '598f606cc8e43aef09fcb785221d9dd2',
+          '5935d59cf660764331bafcade1855fd7',
+        ],
+      };
+      ethWallet = new Wallet(bitgo, bitgo.coin('teth'), walletData);
+    });
     it('should correctly validate arguments to create address', async function () {
       let message = 'gasPrice has to be an integer or numeric string';
       await wallet.createAddress({ gasPrice: {} }).should.be.rejectedWith(message);
@@ -573,6 +590,63 @@ describe('V2 Wallet:', function () {
       await wallet.createAddress({ count: -1 }).should.be.rejectedWith(message);
       await wallet.createAddress({ count: 0 }).should.be.rejectedWith(message);
       await wallet.createAddress({ count: 251 }).should.be.rejectedWith(message);
+    });
+
+    it('verify address when pendingChainInitialization is true in case of eth v1 forwarder', async function () {
+      nock(bgUrl)
+        .get(`/api/v2/${ethWallet.coin()}/key/${ethWallet.keyIds()[0]}`)
+        .reply(200, {
+          id: '598f606cd8fc24710d2ebad89dce86c2',
+          pub: 'xpub661MyMwAqRbcFXDcWD2vxuebcT1ZpTF4Vke6qmMW8yzddwNYpAPjvYEEL5jLfyYXW2fuxtAxY8TgjPUJLcf1C8qz9N6VgZxArKX4EwB8rH5',
+          ethAddress: '0x26a163ba9739529720c0914c583865dec0d37278',
+          source: 'user',
+          encryptedPrv: '{"iv":"15FsbDVI1zG9OggD8YX+Hg==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"hHbNH3Sz/aU=","ct":"WoNVKz7afiRxXI2w/YkzMdMyoQg/B15u1Q8aQgi96jJZ9wk6TIaSEc6bXFH3AHzD9MdJCWJQUpRhoQc/rgytcn69scPTjKeeyVMElGCxZdFVS/psQcNE+lue3//2Zlxj+6t1NkvYO+8yAezSMRBK5OdftXEjNQI="}',
+          coinSpecific: {},
+        });
+
+      nock(bgUrl)
+        .get(`/api/v2/${ethWallet.coin()}/key/${ethWallet.keyIds()[1]}`)
+        .reply(200, {
+          id: '598f606cc8e43aef09fcb785221d9dd2',
+          pub: 'xpub661MyMwAqRbcGhSaXikpuTC9KU88Xx9LrjKSw1JKsvXNgabpTdgjy7LSovh9ZHhcqhAHQu7uthu7FguNGdcC4aXTKK5gqTcPe4WvLYRbCSG',
+          ethAddress: '0xa1a88a502274073b1bc4fe06ea0f5fe77e151b91',
+          source: 'backup',
+          coinSpecific: {},
+        });
+
+      nock(bgUrl)
+        .get(`/api/v2/${ethWallet.coin()}/key/${ethWallet.keyIds()[2]}`)
+        .reply(200, {
+          id: '5935d59cf660764331bafcade1855fd7',
+          pub: 'xpub661MyMwAqRbcFsXShW8R3hJsHNTYTUwzcejnLkY7KCtaJbDqcGkcBF99BrEJSjNZHeHveiYUrsAdwnjUMGwpgmEbiKcZWRuVA9HxnRaA3r3',
+          ethAddress: '0x032821b7ea40ea5d446f47c29a0f777ee035aa10',
+          source: 'bitgo',
+          coinSpecific: {},
+        });
+
+      nock(bgUrl)
+        .post(`/api/v2/${ethWallet.coin()}/wallet/${ethWallet.id()}/address`, { chain: 0, forwarderVersion: 1 })
+        .reply(200, {
+          id: '615c643a98a2a100068e023c639c0f74',
+          address: '0x8c13cd0bb198858f628d5631ba4b2293fc08df49',
+          baseAddress: '0xdf07117705a9f8dc4c2a78de66b7f1797dba9d4e',
+          chain: 0,
+          index: 3179,
+          coin: 'teth',
+          lastNonce: 0,
+          wallet: '598f606cd8fc24710d2ebadb1d9459bb',
+          coinSpecific: {
+            nonce: -1,
+            updateTime: '2021-10-05T14:42:02.399Z',
+            txCount: 0,
+            pendingChainInitialization: true,
+            creationFailure: [],
+            salt: '0xc6b',
+            pendingDeployment: true,
+            forwarderVersion: 1,
+          },
+        });
+      await ethWallet.createAddress({ chain: 0, forwarderVersion: 1 }).should.be.rejectedWith('address validation failure: expected 0x32a226cda14e352a47bf4b1658648d8037736f80 but got 0x8c13cd0bb198858f628d5631ba4b2293fc08df49');
     });
   });
 


### PR DESCRIPTION
**Background**

In order to calculate forwarder version 1 address for Eth, we had to add calculateEthAddress2, getProxyInitcode methods and forwarderFactoryAddress, forwarderImplementationAddress constants in BitGoJS core module. But the same methods and constants were required in bitgo-admin as well. So we decided to add the methods in account lib and constants in @bitgo/statics

**Changes**

- Used calculateEthAddress2, getProxyInitcode  methods from account lib
- Used forwarderFactoryAddress, forwarderImplementationAddress from @bitgo/statics
- Modified the condition to invoke `verifyAddress()` method in `createAddress()` method. In case of Eth forwarder v1, if the address is pending onchain initialization, then need to verify the address
- Added unit test for this change in condition

Ticket: BG-35735