### PR TITLE
refactor(utxo-lib): use taproot script helper function

### DIFF
--- a/modules/utxo-lib/src/bitgo/outputScripts.ts
+++ b/modules/utxo-lib/src/bitgo/outputScripts.ts
@@ -33,6 +33,12 @@ export function createOutputScript2of3(pubkeys: Buffer[], scriptType: ScriptType
     }
   });
 
+  if (scriptType === 'p2tr') {
+    // p2tr addresses use a combination of 2 of 2 multisig scripts distinct from
+    // the 2 of 3 multisig used for other script types
+    return createTaprootScript2of3(pubkeys as [Buffer, Buffer, Buffer]);
+  }
+
   const script2of3 = bitcoinjs.payments.p2ms({ m: 2, pubkeys });
   assert(script2of3.output);
 
@@ -74,13 +80,7 @@ export function createOutputScript2of3(pubkeys: Buffer[], scriptType: ScriptType
  * @param pubkeys - a pubkey array containing the user key, backup key, and bitgo key in that order
  * @returns {{scriptPubKey}}
  */
-export function createTaprootScript2of3([userKey, backupKey, bitGoKey]: [Buffer, Buffer, Buffer]): SpendableScript {
-  [userKey, backupKey, bitGoKey].forEach((key) => {
-    if (key.length !== 33 && key.length !== 32) {
-      throw new Error(`Unexpected key length ${key.length}. Must use compressed keys.`);
-    }
-  });
-
+function createTaprootScript2of3([userKey, backupKey, bitGoKey]: [Buffer, Buffer, Buffer]): SpendableScript {
   const userBitGoScript = bitcoinjs.script.compile([userKey, OP_CHECKSIGVERIFY, bitGoKey, OP_CHECKSIGVERIFY]);
   const userBackupScript = bitcoinjs.script.compile([userKey, OP_CHECKSIGVERIFY, backupKey, OP_CHECKSIGVERIFY]);
   const backupBitGoScript = bitcoinjs.script.compile([backupKey, OP_CHECKSIGVERIFY, bitGoKey, OP_CHECKSIGVERIFY]);

--- a/modules/utxo-lib/test/bitgo/outputScripts.ts
+++ b/modules/utxo-lib/test/bitgo/outputScripts.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 
-import { createOutputScript2of3, createTaprootScript2of3, scriptTypes2Of3 } from '../../src/bitgo/outputScripts';
+import { createOutputScript2of3, scriptTypes2Of3 } from '../../src/bitgo/outputScripts';
 
 import { getKeyTriple } from '../integration_local_rpc/generate/outputScripts.util';
 
@@ -16,36 +16,32 @@ describe('createOutputScript2of3()', function () {
   const p2tr = '5120c7c8dee54b739f805aeaeb0458eedc3b153e8008f1b609bf79e8c887a9350e39';
 
   scriptTypes2Of3.forEach((scriptType) => {
-    if (scriptType === 'p2tr') {
-      it(`creates taproot script`, function () {
-        const output = createTaprootScript2of3(pubkeys);
-        assert.strictEqual(output.scriptPubKey.toString('hex'), p2tr);
-        // TODO: validate script control blocks once they are returned by payments.p2tr()
-      });
-    } else {
-      it(`creates output script (type=${scriptType})`, function () {
-        const { scriptPubKey, redeemScript, witnessScript } = createOutputScript2of3(pubkeys, scriptType);
+    it(`creates output script (type=${scriptType})`, function () {
+      const { scriptPubKey, redeemScript, witnessScript } = createOutputScript2of3(pubkeys, scriptType);
 
-        switch (scriptType) {
-          case 'p2sh':
-            assert.strictEqual(scriptPubKey.toString('hex'), 'a91491590bed8198ea7ca57ba68ab7cbfabc656cbbaf87');
-            assert.strictEqual(redeemScript && redeemScript.toString('hex'), p2ms);
-            assert.strictEqual(witnessScript, undefined);
-            break;
-          case 'p2shP2wsh':
-            assert.strictEqual(scriptPubKey.toString('hex'), 'a9140312dd6f801ab11d53c35f6a2bdac9c602a55d9d87');
-            assert.strictEqual(redeemScript && redeemScript.toString('hex'), p2wsh);
-            assert.strictEqual(witnessScript && witnessScript.toString('hex'), p2ms);
-            break;
-          case 'p2wsh':
-            assert.strictEqual(scriptPubKey.toString('hex'), p2wsh);
-            assert.strictEqual(redeemScript, undefined);
-            assert.strictEqual(witnessScript && witnessScript.toString('hex'), p2ms);
-            break;
-          default:
-            throw new Error(`unexpected type ${scriptType}`);
-        }
-      });
-    }
+      switch (scriptType) {
+        case 'p2sh':
+          assert.strictEqual(scriptPubKey.toString('hex'), 'a91491590bed8198ea7ca57ba68ab7cbfabc656cbbaf87');
+          assert.strictEqual(redeemScript && redeemScript.toString('hex'), p2ms);
+          assert.strictEqual(witnessScript, undefined);
+          break;
+        case 'p2shP2wsh':
+          assert.strictEqual(scriptPubKey.toString('hex'), 'a9140312dd6f801ab11d53c35f6a2bdac9c602a55d9d87');
+          assert.strictEqual(redeemScript && redeemScript.toString('hex'), p2wsh);
+          assert.strictEqual(witnessScript && witnessScript.toString('hex'), p2ms);
+          break;
+        case 'p2wsh':
+          assert.strictEqual(scriptPubKey.toString('hex'), p2wsh);
+          assert.strictEqual(redeemScript, undefined);
+          assert.strictEqual(witnessScript && witnessScript.toString('hex'), p2ms);
+          break;
+        case 'p2tr':
+          assert.strictEqual(scriptPubKey.toString('hex'), p2tr);
+          // TODO: validate script control blocks once they are returned by payments.p2tr()
+          break;
+        default:
+          throw new Error(`unexpected type ${scriptType}`);
+      }
+    });
   });
 });

--- a/modules/utxo-lib/test/integration_local_rpc/generate/outputScripts.util.ts
+++ b/modules/utxo-lib/test/integration_local_rpc/generate/outputScripts.util.ts
@@ -2,12 +2,7 @@ import * as bip32 from 'bip32';
 import * as crypto from 'crypto';
 import { Network } from '../../../src/networkTypes';
 import { Triple } from './types';
-import {
-  createOutputScript2of3,
-  createTaprootScript2of3,
-  ScriptType2Of3,
-  scriptTypes2Of3,
-} from '../../../src/bitgo/outputScripts';
+import { createOutputScript2of3, ScriptType2Of3, scriptTypes2Of3 } from '../../../src/bitgo/outputScripts';
 import { isBitcoin, isBitcoinGold, isLitecoin } from '../../../src/coins';
 
 import { Transaction } from 'bitcoinjs-lib';
@@ -67,25 +62,21 @@ export function isSupportedSpendType(network: Network, scriptType: ScriptType): 
  * @return {Buffer} scriptPubKey
  */
 export function createScriptPubKey(keys: KeyTriple, scriptType: ScriptType, network: Network): Buffer {
-  const pubkeys = keys.map((k) => k.publicKey) as [Buffer, Buffer, Buffer];
+  const pubkeys = keys.map((k) => k.publicKey);
 
   switch (scriptType) {
     case 'p2sh':
     case 'p2shP2wsh':
     case 'p2wsh':
-      return createOutputScript2of3(pubkeys, scriptType).scriptPubKey;
     case 'p2tr':
-      return createTaprootScript2of3(pubkeys).scriptPubKey;
-  }
-
-  switch (scriptType) {
+      return createOutputScript2of3(pubkeys, scriptType).scriptPubKey;
     case 'p2pkh':
       return utxolib.payments.p2pkh({ pubkey: keys[0].publicKey }).output;
     case 'p2wkh':
       return utxolib.payments.p2wpkh({ pubkey: keys[0].publicKey }).output;
+    default:
+      throw new Error(`unsupported output type ${scriptType}`);
   }
-
-  throw new Error(`unsupported output type ${scriptType}`);
 }
 
 export function createSpendTransactionFromPrevOutputs<T extends UtxoTransaction>(


### PR DESCRIPTION
This refactors the output script functions so `createTaprootScript2of3` is used as a helper function within `createOutputScript2of3` rather than being exported and used externally on its own. This restores the previous behavior of having a single function used to generate output scripts for all multisig 2-of-3 script types.

Ticket: BG-35573