### PR TITLE
feat(express): add route for create address

### DIFF
--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -367,6 +367,17 @@ export async function handleV2GenerateWallet(req: express.Request) {
 }
 
 /**
+ * handle new address creation
+ * @param req
+ */
+export async function handleV2CreateAddress(req: express.Request) {
+  const bitgo = req.bitgo;
+  const coin = bitgo.coin(req.params.coin);
+  const wallet = await coin.wallets().get({ id: req.params.id });
+  return wallet.createAddress(req.body);
+}
+
+/**
  * handle v2 approve transaction
  * @param req
  */
@@ -847,6 +858,9 @@ export function setupRoutes(app: express.Application, config: Config): void {
 
   // generate wallet
   app.post('/api/v2/:coin/wallet/generate', parseBody, prepareBitGo(config), promiseWrapper(handleV2GenerateWallet));
+
+  // create address
+  app.post('/api/v2/:coin/wallet/:id/address', parseBody, prepareBitGo(config), promiseWrapper(handleV2CreateAddress));
 
   // share wallet
   app.post('/api/v2/:coin/wallet/:id/share', parseBody, prepareBitGo(config), promiseWrapper(handleV2ShareWallet));

--- a/modules/express/test/unit/clientRoutes/createAddress.ts
+++ b/modules/express/test/unit/clientRoutes/createAddress.ts
@@ -1,0 +1,45 @@
+import * as sinon from 'sinon';
+
+import 'should-http';
+import 'should-sinon';
+import '../../lib/asserts';
+
+import * as express from 'express';
+
+import { handleV2CreateAddress } from '../../../src/clientRoutes';
+
+import { BitGo } from 'bitgo';
+
+describe('Create Address', () => {
+  function createAddressMocks(res) {
+    const createAddressStub = sinon.stub().returns(res);
+    const walletStub = { createAddress: createAddressStub };
+    const coinStub = {
+      wallets: () => ({ get: () => Promise.resolve(walletStub) }),
+    };
+    return {
+      bitgoStub: sinon.createStubInstance(BitGo as any, { coin: coinStub }),
+      createAddressStub,
+    };
+  }
+
+  it('should return the address object', async () => {
+    const res = { address: 'addressdata' };
+    const { bitgoStub } = createAddressMocks(res);
+    const req = {
+      bitgo: bitgoStub,
+      params: {
+        coin: 'tbtc',
+        id: '23423423423423',
+      },
+      query: {},
+      body: {
+        chain: 0
+      },
+    } as unknown as express.Request;
+
+    await handleV2CreateAddress(req)
+      .should.be.resolvedWith(res);
+  });
+  
+});


### PR DESCRIPTION
This PR adds a route and unit test for wallet.createAddress in express

Ticket: BG-33701