### PR TITLE
fix(utxo-lib): use OP_CHECKSIG for 2nd p2tr opcode

### DIFF
--- a/modules/utxo-lib/src/bitgo/outputScripts.ts
+++ b/modules/utxo-lib/src/bitgo/outputScripts.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import * as bitcoinjs from 'bitcoinjs-lib';
-import { OP_CHECKSIGVERIFY } from 'bitcoin-ops';
+import { OP_CHECKSIG, OP_CHECKSIGVERIFY } from 'bitcoin-ops';
 
 export const scriptTypes2Of3 = ['p2sh', 'p2shP2wsh', 'p2wsh', 'p2tr'] as const;
 export type ScriptType2Of3 = typeof scriptTypes2Of3[number];
@@ -81,9 +81,9 @@ export function createOutputScript2of3(pubkeys: Buffer[], scriptType: ScriptType
  * @returns {{scriptPubKey}}
  */
 function createTaprootScript2of3([userKey, backupKey, bitGoKey]: [Buffer, Buffer, Buffer]): SpendableScript {
-  const userBitGoScript = bitcoinjs.script.compile([userKey, OP_CHECKSIGVERIFY, bitGoKey, OP_CHECKSIGVERIFY]);
-  const userBackupScript = bitcoinjs.script.compile([userKey, OP_CHECKSIGVERIFY, backupKey, OP_CHECKSIGVERIFY]);
-  const backupBitGoScript = bitcoinjs.script.compile([backupKey, OP_CHECKSIGVERIFY, bitGoKey, OP_CHECKSIGVERIFY]);
+  const userBitGoScript = bitcoinjs.script.compile([userKey, OP_CHECKSIGVERIFY, bitGoKey, OP_CHECKSIG]);
+  const userBackupScript = bitcoinjs.script.compile([userKey, OP_CHECKSIGVERIFY, backupKey, OP_CHECKSIG]);
+  const backupBitGoScript = bitcoinjs.script.compile([backupKey, OP_CHECKSIGVERIFY, bitGoKey, OP_CHECKSIG]);
 
   assert(userBitGoScript);
   assert(userBackupScript);

--- a/modules/utxo-lib/test/address/fixtures/bitcoin.json
+++ b/modules/utxo-lib/test/address/fixtures/bitcoin.json
@@ -26,8 +26,8 @@
   ],
   [
     "p2tr",
-    "512076850b78e72534e785664f34ce698f39d206c2f660517d2f87c6c72e944b0238",
-    "bc1pw6zsk788y56w0ptxfu6vu6v088fqdshkvpgh6tu8cmrja9ztqguq4lmq8a"
+    "512099185bedeb453f47b9b45fd8a5290b8d448b720fd5d6495d4a52c414e5f7be00",
+    "bc1pnyv9hm0tg5l50wd5tlv222gt34zgkus06htyjh222tzpfe0hhcqqsyxn3a"
   ],
   [
     "p2pkh",
@@ -56,8 +56,8 @@
   ],
   [
     "p2tr",
-    "5120eae04ccdd4bb54c8794b307d6ba676301dbc7df969e916f6cf1a7ce6ad896fef",
-    "bc1patsyenw5hd2vs72txp7khfnkxqwmcl0ed853dak0rf7wdtvfdlhszu65x5"
+    "5120d8f7563da63b34a74cd809cc22c497eefd430379e6bc7e21bacfa67037ab1b4b",
+    "bc1pmrm4v0dx8v62wnxcp8xz93yham75xqmeu678ugd6e7n8qdatrd9s6n4vsz"
   ],
   [
     "p2pkh",
@@ -86,8 +86,8 @@
   ],
   [
     "p2tr",
-    "51203a64de9326c5dd917437bda81c4a2f5dd770e6649fde53ed5b7621438266db37",
-    "bc1p8fjdayexchwezaphhk5pcj30ththpenynl098m2mwcs58qnxmvmseg0egq"
+    "5120a39680c2558107fd52599f480f74283b803890487e733c0e2bcf22d454e138df",
+    "bc1p5wtgpsj4syrl65jenayq7apg8wqr3yzg0eencr3teu3dg48p8r0slrnpvg"
   ],
   [
     "p2pkh",
@@ -116,7 +116,7 @@
   ],
   [
     "p2tr",
-    "512092f93b6bfe23b8f09364eda8391466dcd786d66cb95d160f2bcd82a16eaba01e",
-    "bc1pjtunk6l7ywu0pymyak5rj9rxmntcd4nvh9w3vretekp2zm4t5q0qu907lv"
+    "512050dd5623906bed5a6c8805bc418387e88cfeacdb90656c09d521e5227e0f2d35",
+    "bc1p2rw4vgusd0k45mygqk7yrqu8azx0atxmjpjkczw4y8jjyls0956s5nsanm"
   ]
 ]

--- a/modules/utxo-lib/test/address/fixtures/testnet.json
+++ b/modules/utxo-lib/test/address/fixtures/testnet.json
@@ -26,8 +26,8 @@
   ],
   [
     "p2tr",
-    "512076850b78e72534e785664f34ce698f39d206c2f660517d2f87c6c72e944b0238",
-    "tb1pw6zsk788y56w0ptxfu6vu6v088fqdshkvpgh6tu8cmrja9ztqguqzhd0aj"
+    "512099185bedeb453f47b9b45fd8a5290b8d448b720fd5d6495d4a52c414e5f7be00",
+    "tb1pnyv9hm0tg5l50wd5tlv222gt34zgkus06htyjh222tzpfe0hhcqq8vsutj"
   ],
   [
     "p2pkh",
@@ -56,8 +56,8 @@
   ],
   [
     "p2tr",
-    "5120eae04ccdd4bb54c8794b307d6ba676301dbc7df969e916f6cf1a7ce6ad896fef",
-    "tb1patsyenw5hd2vs72txp7khfnkxqwmcl0ed853dak0rf7wdtvfdlhs45vmum"
+    "5120d8f7563da63b34a74cd809cc22c497eefd430379e6bc7e21bacfa67037ab1b4b",
+    "tb1pmrm4v0dx8v62wnxcp8xz93yham75xqmeu678ugd6e7n8qdatrd9sdmrr2d"
   ],
   [
     "p2pkh",
@@ -86,8 +86,8 @@
   ],
   [
     "p2tr",
-    "51203a64de9326c5dd917437bda81c4a2f5dd770e6649fde53ed5b7621438266db37",
-    "tb1p8fjdayexchwezaphhk5pcj30ththpenynl098m2mwcs58qnxmvmswqekj0"
+    "5120a39680c2558107fd52599f480f74283b803890487e733c0e2bcf22d454e138df",
+    "tb1p5wtgpsj4syrl65jenayq7apg8wqr3yzg0eencr3teu3dg48p8r0sgt9wk8"
   ],
   [
     "p2pkh",
@@ -116,7 +116,7 @@
   ],
   [
     "p2tr",
-    "512092f93b6bfe23b8f09364eda8391466dcd786d66cb95d160f2bcd82a16eaba01e",
-    "tb1pjtunk6l7ywu0pymyak5rj9rxmntcd4nvh9w3vretekp2zm4t5q0qtde39r"
+    "512050dd5623906bed5a6c8805bc418387e88cfeacdb90656c09d521e5227e0f2d35",
+    "tb1p2rw4vgusd0k45mygqk7yrqu8azx0atxmjpjkczw4y8jjyls0956srmxjf5"
   ]
 ]

--- a/modules/utxo-lib/test/bitgo/outputScripts.ts
+++ b/modules/utxo-lib/test/bitgo/outputScripts.ts
@@ -13,7 +13,7 @@ describe('createOutputScript2of3()', function () {
     '27d7de660a2103c79183d6641585179d25bbc091b2a7fce86c9f15d311e5aca0' +
     'a020478d8f208753ae';
   const p2wsh = '002095ecaacb606b9ece3821c0111c0a1208dd1d35192809bf8cf6cbad4bbeaca67f';
-  const p2tr = '5120c7c8dee54b739f805aeaeb0458eedc3b153e8008f1b609bf79e8c887a9350e39';
+  const p2tr = '51203f29b88ff391432ffaa2475497ec0eebe28e19b0dca62a620526dbc21ffae307';
 
   scriptTypes2Of3.forEach((scriptType) => {
     it(`creates output script (type=${scriptType})`, function () {


### PR DESCRIPTION
This fixes the tapscript construction to use `OP_CHECKSIG` instead of another `OP_CHECKSIGVERIFY` for the second op code used in the script. This ensures that there is a `true` value in the stack after the script is executed.

Ticket: BG-35573