### PR TITLE
test: use TxbSignArg in txb.sign()

### DIFF
--- a/modules/utxo-lib/src/bitgo/outputScripts.ts
+++ b/modules/utxo-lib/src/bitgo/outputScripts.ts
@@ -9,6 +9,23 @@ export function isScriptType2Of3(t: string): t is ScriptType2Of3 {
   return scriptTypes2Of3.includes(t as ScriptType2Of3);
 }
 
+/**
+ * @param t
+ * @return string prevOut as defined in PREVOUT_TYPES (bitcoinjs-lib/.../transaction_builder.js)
+ */
+export function scriptType2Of3AsPrevOutType(t: ScriptType2Of3): string {
+  switch (t) {
+    case 'p2sh':
+      return 'p2sh-p2ms';
+    case 'p2shP2wsh':
+      return 'p2sh-p2wsh-p2ms';
+    case 'p2wsh':
+      return 'p2wsh-p2ms';
+    default:
+      throw new Error(`unsupported script type ${t}`);
+  }
+}
+
 export type SpendableScript = {
   scriptPubKey: Buffer;
   redeemScript?: Buffer;

--- a/modules/utxo-lib/test/integration_local_rpc/generate/outputScripts.util.ts
+++ b/modules/utxo-lib/test/integration_local_rpc/generate/outputScripts.util.ts
@@ -2,7 +2,12 @@ import * as bip32 from 'bip32';
 import * as crypto from 'crypto';
 import { Network } from '../../../src/networkTypes';
 import { Triple } from './types';
-import { createOutputScript2of3, ScriptType2Of3, scriptTypes2Of3 } from '../../../src/bitgo/outputScripts';
+import {
+  createOutputScript2of3,
+  ScriptType2Of3,
+  scriptType2Of3AsPrevOutType,
+  scriptTypes2Of3,
+} from '../../../src/bitgo/outputScripts';
 import { isBitcoin, isBitcoinGold, isLitecoin } from '../../../src/coins';
 
 import { Transaction } from 'bitcoinjs-lib';
@@ -109,14 +114,15 @@ export function createSpendTransactionFromPrevOutputs<T extends UtxoTransaction>
 
   prevOutputs.forEach(([, , value], vin) => {
     signKeys.forEach((key) => {
-      txBuilder.sign(
+      txBuilder.sign({
+        prevOutScriptType: scriptType2Of3AsPrevOutType(scriptType),
         vin,
-        Object.assign(key, { network: null }),
+        keyPair: Object.assign(key, { network: null }),
         redeemScript,
-        getDefaultSigHash(network),
-        value,
-        witnessScript
-      );
+        hashType: getDefaultSigHash(network),
+        witnessValue: value,
+        witnessScript,
+      });
     });
   });
 

--- a/modules/utxo-lib/test/transaction_util.ts
+++ b/modules/utxo-lib/test/transaction_util.ts
@@ -12,7 +12,7 @@ import {
 } from '../src/bitgo';
 import { createScriptPubKey } from './integration_local_rpc/generate/outputScripts.util';
 import { fixtureKeys } from './integration_local_rpc/generate/fixtures';
-import { createOutputScript2of3, ScriptType2Of3 } from '../src/bitgo/outputScripts';
+import { createOutputScript2of3, ScriptType2Of3, scriptType2Of3AsPrevOutType } from '../src/bitgo/outputScripts';
 
 export function getSignKeyCombinations(length: number): bip32.BIP32Interface[][] {
   if (length === 0) {
@@ -85,14 +85,15 @@ export function getTransactionBuilder(
 
   prevOutputs.forEach(([, , value], vin) => {
     signKeys.forEach((key) => {
-      txBuilder.sign(
+      txBuilder.sign({
+        prevOutScriptType: scriptType2Of3AsPrevOutType(scriptType),
         vin,
-        Object.assign(key, { network }),
+        keyPair: Object.assign(key, { network }),
         redeemScript,
-        getDefaultSigHash(network),
-        value,
-        witnessScript
-      );
+        hashType: getDefaultSigHash(network),
+        witnessValue: value,
+        witnessScript,
+      });
     });
   });
 


### PR DESCRIPTION
While the other sign method is not directly tested anymore, it is easy to
check out the previous commit and verify that the old style works as well.

We will completely deprecate the other `sign()` call style soon enough.

Issue: BG-35578

f15fb36e6 (Otto Allmendinger, 6 minutes ago)
feat: add support for sign(signParams: TxbSignArg)

The other `sign()` calling style is being deprecated and results in 
deprecation warning spam in the console.

Issue: BG-35578