### PR TITLE
test(core): add tests for `isValidAddress` for tbtc coin

### DIFF
--- a/modules/core/test/v2/unit/coins/btc.ts
+++ b/modules/core/test/v2/unit/coins/btc.ts
@@ -449,4 +449,27 @@ describe('BTC:', function () {
       });
     });
   });
+
+  describe('Address validation:', () => {
+    let coin: AbstractUtxoCoin;
+    before(() => {
+      coin = bitgo.coin('tbtc');
+    });
+
+    it('should validate a base58 address', () => {
+      const validBase58Address = '2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn';
+      coin.isValidAddress(validBase58Address).should.be.true();
+    });
+
+    it('should validate a bech32 address', () => {
+      const validBech32Address = 'tb1qtxxqmkkdx4n4lcp0nt2cct89uh3h3dlcu940kw9fcqyyq36peh0st94hfp';
+      coin.isValidAddress(validBech32Address).should.be.true();
+    });
+
+    it('should validate a bech32m address', () => {
+      // https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki#Test_vectors_for_Bech32m
+      const validBech32mAddress = 'tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7';
+      coin.isValidAddress(validBech32mAddress).should.be.true();
+    });
+  });
 });


### PR DESCRIPTION
Includes tests for the following address formats:
* `base58`
* `bech32`
* `bech32m`

There are going to be more changes needed for the `verifyAddress`
function to correctly handle `bech32m`, but these tests were not present
and we should have some basic coverage for `isValidAddress`.

Ticket: BG-35567