### PR TITLE
fix(core): improve error response string creation

### DIFF
--- a/modules/core/src/api.ts
+++ b/modules/core/src/api.ts
@@ -93,29 +93,23 @@ export function handleResponseError(e: Error & { response?: superagent.Response 
  */
 function createResponseErrorString(res: superagent.Response): string {
   let errString = res.status.toString(); // at the very least we'll have the status code
-  if (res.body.error) {
+  if (res.body?.error) {
     // this is the case we hope for, where the server gives us a nice error from the JSON body
     errString = res.body.error;
-  } else {
-    if (res.text) {
-      // if the response came back as text, we try to parse it as HTML and remove all tags, leaving us
-      // just the bare text, which we then trim of excessive newlines and limit to a certain length
-      try {
-        let sanitizedText = sanitizeHtml(res.text, { allowedTags: [] });
-        sanitizedText = sanitizedText.trim();
-        sanitizedText = eol.lf(sanitizedText); // use '\n' for all newlines
-        sanitizedText = _.replace(sanitizedText, /\n[ |\t]{1,}\n/g, '\n\n'); // remove the spaces/tabs between newlines
-        sanitizedText = _.replace(sanitizedText, /[\n]{3,}/g, '\n\n'); // have at most 2 consecutive newlines
-        sanitizedText = sanitizedText.substring(0, 5000); // prevent message from getting too large
-        errString = errString + '\n' + sanitizedText; // add it to our existing errString (at this point the more info the better!)
-      } catch (e) {
-        // do nothing, the response's HTML was too wacky to be parsed cleanly
-        debug(
-          'got error with message "%s" while creating response error string from response: %s',
-          e.message,
-          res.text
-        );
-      }
+  } else if (res.text) {
+    // if the response came back as text, we try to parse it as HTML and remove all tags, leaving us
+    // just the bare text, which we then trim of excessive newlines and limit to a certain length
+    try {
+      let sanitizedText = sanitizeHtml(res.text, { allowedTags: [] });
+      sanitizedText = sanitizedText.trim();
+      sanitizedText = eol.lf(sanitizedText); // use '\n' for all newlines
+      sanitizedText = _.replace(sanitizedText, /\n[ |\t]{1,}\n/g, '\n\n'); // remove the spaces/tabs between newlines
+      sanitizedText = _.replace(sanitizedText, /[\n]{3,}/g, '\n\n'); // have at most 2 consecutive newlines
+      sanitizedText = sanitizedText.substring(0, 5000); // prevent message from getting too large
+      errString = errString + '\n' + sanitizedText; // add it to our existing errString (at this point the more info the better!)
+    } catch (e) {
+      // do nothing, the response's HTML was too wacky to be parsed cleanly
+      debug('got error with message "%s" while creating response error string from response: %s', e.message, res.text);
     }
   }
 


### PR DESCRIPTION
If there is no body on a response object, creating a string from the error
response will fail with: `TypeError: Cannot read property 'error' of null`.

Instead, check to make sure `res.body` exists before using.

Ticket: BG-38203