### PR TITLE
fix(eos): fix issue verifying EOS transactions

### DIFF
--- a/modules/core/test/v2/unit/coins/eos.ts
+++ b/modules/core/test/v2/unit/coins/eos.ts
@@ -21,8 +21,9 @@ describe('EOS:', function () {
 
   it('should get address details', function () {
     let addressDetails = basecoin.getAddressDetails('i1skda3kso43');
+
     addressDetails.address.should.equal('i1skda3kso43');
-    should.not.exist(addressDetails.memoId);
+    should(addressDetails.memoId).be.empty();
 
     addressDetails = basecoin.getAddressDetails('ks13k3hdui24?memoId=1');
     addressDetails.address.should.equal('ks13k3hdui24');
@@ -285,22 +286,22 @@ describe('EOS:', function () {
       const txPrebuild = {
         recipients: [
           {
-            address: 'asdfasdfasdf',
-            amount: '100',
+            address: 'lionteste212',
+            amount: '1000',
           },
         ],
         headers: {
-          expiration: '2021-09-15T17:10:28.346',
-          ref_block_num: 1,
-          ref_block_prefix: 100,
+          expiration: '2021-10-28T02:34:05.848',
+          ref_block_num: 42915,
+          ref_block_prefix: 1204086709,
         },
-        txHex: 'e70aaab8997e1dfce58fbfac80cbbb8fecec7b99cf982a9444273cbc64c41473042942610100640000000000000100408c7a02ea3055000000000085269d000201310100a6823403ea3055000000572d3ccdcd01d0f9ce64f437f7cf00000000a8ed323222d0f9ce64f437f7cfb012362b61b31236640000000000000004454f53000000000131000000000000000000000000000000000000000000000000000000000000000000',
+        txHex: '2a02a0053e5a8cf73a56ba0fda11e4d92e0238a4a2aa74fccf46d5a9107468401e0c7a61a3a7b5e7c4470000000100408c7a02ea3055000000000085269d00030233330100a6823403ea3055000000572d3ccdcd0120ceb8437333427c00000000a8ed32322220ceb8437333427c20825019ab3ca98be80300000000000004454f53000000000131000000000000000000000000000000000000000000000000000000000000000000',
         transaction: {
           compression: 'none',
-          packed_trx: '042942610100640000000000000100408c7a02ea3055000000000085269d000201310100a6823403ea3055000000572d3ccdcd01d0f9ce64f437f7cf00000000a8ed323222d0f9ce64f437f7cfb012362b61b31236640000000000000004454f5300000000013100',
+          packed_trx: '1e0c7a61a3a7b5e7c4470000000100408c7a02ea3055000000000085269d00030233330100a6823403ea3055000000572d3ccdcd0120ceb8437333427c00000000a8ed32322220ceb8437333427c20825019ab3ca98be80300000000000004454f5300000000013100',
           signatures: [],
         },
-        txid: '0492e8cf6275b9ee7c0685fc22211b174dd5bc8834b1963b52ae6486c41dad25',
+        txid: '586c5b59b10b134d04c16ac1b273fe3c5529f34aef75db4456cd469c5cdac7e2',
         isVotingTransaction: false,
         coin: 'teos',
       };
@@ -318,8 +319,8 @@ describe('EOS:', function () {
         prv: keyPair.prv,
         recipients: [
           {
-            address: 'asdfasdfasdf?memoId=1',
-            amount: '100',
+            address: 'lionteste212?memoId=1',
+            amount: '1000',
           },
         ],
       };
@@ -352,8 +353,20 @@ describe('EOS:', function () {
       validTransaction.should.equal(true);
     });
 
-    it('should throw if different prebuilds are provided in txParams and txPrebuild', async function() {
+    it('should verify a transaction without a memoId', async function() {
+      const txPrebuild = newTxPrebuild();
 
+      // txParams with different txPrebuild
+      const txPrebuild2 = newTxPrebuild();
+      txPrebuild2.recipients[0].address = 'lionteste212';
+      const txParams = newTxParams();
+      txParams.txPrebuild = txPrebuild2;
+
+      const validTransaction = await basecoin.verifyTransaction({ txParams, txPrebuild, wallet, verification });
+      validTransaction.should.equal(true);
+    });
+
+    it('should throw if different prebuilds are provided in txParams and txPrebuild', async function() {
       const txPrebuild = newTxPrebuild();
 
       // txParams with different txPrebuild
@@ -398,9 +411,8 @@ describe('EOS:', function () {
     it('should throw if the expected memo is different than actual memo', async function() {
       const txPrebuild = newTxPrebuild();
       const txParams = newTxParams();
-      txParams.recipients[0].address = 'asdfasdfasdf?memoId=10';
+      txParams.recipients[0].address = 'lionteste212?memoId=10';
       await basecoin.verifyTransaction({ txParams, txPrebuild, wallet, verification }).should.be.rejectedWith('txHex receive memoId does not match expected recipient memoId');
     });
-
   });
 });

--- a/modules/core/test/v2/unit/coins/eosToken.ts
+++ b/modules/core/test/v2/unit/coins/eosToken.ts
@@ -1,16 +1,22 @@
 import 'should';
 
+import * as _ from 'lodash';
+
 import { TestBitGo } from '../../../lib/test_bitgo';
+import { Wallet } from '../../../../src';
+
 
 describe('EOS Token:', function () {
   let bitgo;
   let eosTokenCoin;
+  let baseCoin;
   const tokenName = 'teos:CHEX';
 
   before(function () {
     bitgo = new TestBitGo({ env: 'test' });
     bitgo.initializeTestVars();
     eosTokenCoin = bitgo.coin(tokenName);
+    baseCoin = bitgo.coin('teos');
   });
 
   it('should return constants', function () {
@@ -21,5 +27,132 @@ describe('EOS Token:', function () {
     eosTokenCoin.coin.should.equal('teos');
     eosTokenCoin.decimalPlaces.should.equal(8);
     eosTokenCoin.tokenContractAddress.should.equal('testtoken111');
+  });
+
+  describe('verify transaction', function() {
+    let wallet;
+    let verification;
+    let newTxPrebuild;
+    let newTxParams;
+
+    before(function() {
+      const walletData = {
+        id: '5a78dd561c6258a907f1eeaee132f796',
+        users: [
+          {
+            user: '543c11ed356d00cb7600000b98794503',
+            permissions: [
+              'admin',
+              'view',
+              'spend',
+            ],
+          },
+        ],
+        coin: 'teos',
+        label: 'Verification Wallet',
+        m: 2,
+        n: 3,
+        keys: [
+          '5a78dd56bfe424aa07aa068651b194fd',
+          '5a78dd5674a70eb4079f58797dfe2f5e',
+          '5a78dd561c6258a907f1eea9f1d079e2',
+        ],
+        tags: [
+          '5a78dd561c6258a907f1eeaee132f796',
+        ],
+        disableTransactionNotifications: false,
+        freeze: {},
+        deleted: false,
+        approvalsRequired: 1,
+        isCold: true,
+        coinSpecific: {},
+        clientFlags: [],
+        balance: 650000000,
+        confirmedBalance: 650000000,
+        spendableBalance: 650000000,
+        balanceString: '650000000',
+        confirmedBalanceString: '650000000',
+        spendableBalanceString: '650000000',
+        receiveAddress: {
+          id: '5a78de2bbfe424aa07aa131ec03c8dc1',
+          address: '78xczhaijyhek2',
+          chain: 0,
+          index: 0,
+          coin: 'teos',
+          wallet: '5a78dd561c6258a907f1eeaee132f796',
+          coinSpecific: {},
+        },
+        pendingApprovals: [],
+      };
+      wallet = new Wallet(bitgo, eosTokenCoin, walletData);
+      const userKeychain = {
+        prv: '5KJq565HTrgEJG9EbvJH5BLYTgioAyY27dT9am1kCtn2YVAJEYK',
+        pub: 'EOS6g7AAMQkhXp8j73E8BD4KRwtQevEsFgYx8htaQkRVhhXJMgkMZ',
+      };
+      const backupKeychain = {
+        prv: '5KZ1nXXCi5yXH8AjCJqjnCYHCVnhQa9YWGV2D14i8g221dxNwLW',
+        pub: 'EOS7gyDLNk12faVb1aqNxj1L2DpBerFkhAsxBs95yW3yxJpqvg9Mt',
+      };
+      const txPrebuild = {
+        recipients: [
+          {
+            address: 'lionteste212',
+            amount: '1000',
+          },
+        ],
+        headers: {
+          expiration: '2021-10-28T03:56:09.180',
+          ref_block_num: 52755,
+          ref_block_prefix: 54626512,
+        },
+        txHex: '2a02a0053e5a8cf73a56ba0fda11e4d92e0238a4a2aa74fccf46d5a910746840591f7a6113ced08841030000000100408c7a02ea3055000000000085269d0003023432011042980ad29cb1ca000000572d3ccdcd0120ceb8437333427c00000000a8ed32322120ceb8437333427c20825019ab3ca98be803000000000000084348455800000000000000000000000000000000000000000000000000000000000000000000000000',
+        transaction: {
+          compression: 'none',
+          packed_trx: '591f7a6113ced08841030000000100408c7a02ea3055000000000085269d0003023432011042980ad29cb1ca000000572d3ccdcd0120ceb8437333427c00000000a8ed32322120ceb8437333427c20825019ab3ca98be80300000000000008434845580000000000',
+          signatures: [],
+        },
+        txid: '0bc7d8026af6710680e0f3e819ff7ddbbb3dff8a740846c76fd47f9386832edc',
+        isVotingTransaction: false,
+        coin: 'teos',
+        token: tokenName,
+      };
+      verification = {
+        disableNetworking: true,
+        keychains: {
+          user: { pub: userKeychain.pub },
+          backup: { pub: backupKeychain.pub },
+        },
+      };
+      const seed = Buffer.from('c3b09c24731be2851b624d9d5b3f60fa129695c24071768d15654bea207b7bb6', 'hex');
+      const keyPair = baseCoin.generateKeyPair(seed);
+      const txParams = {
+        txPrebuild,
+        prv: keyPair.prv,
+        recipients: [
+          {
+            address: 'lionteste212',
+            amount: '1000',
+          },
+        ],
+      };
+
+      newTxPrebuild = () => { return _.cloneDeep(txPrebuild); };
+      newTxParams = () => { return _.cloneDeep(txParams); };
+    });
+
+    it('should verify token transaction', async function() {
+      const txParams = newTxParams();
+      const txPrebuild = newTxPrebuild();
+      const validTransaction = await eosTokenCoin.verifyTransaction({ txParams, txPrebuild, wallet, verification });
+      validTransaction.should.equal(true);
+    });
+
+    it('should throw if expected receive symbol is different than actual receive symbol', async function() {
+      const txPrebuild = newTxPrebuild();
+      const txParams = newTxParams();
+      txParams.txPrebuild = txPrebuild;
+      txParams.txPrebuild.token = 'teos:IQ';
+      await eosTokenCoin.verifyTransaction({ txParams, txPrebuild, wallet, verification }).should.be.rejectedWith('txHex receive symbol does not match expected recipient symbol');
+    });
   });
 });


### PR DESCRIPTION
**fixes the following issues**:
- we would always set expiration header's milliseconds to 0 when we
  should be rounding (this will fail verification if milliseconds is > 500)
- we set memoId to undefined when absent instead of empty string (leads to `undefined !== ''` check)
- we incorrectly parse for token symbol (`coin` is always teos or eos; need to check `token` property instead)

Ticket: BG-38309

additional manual verification:
EOS
```
async function test() {
  const wallet = await bitgo.coin('teos').wallets().get({ id: '61521886121c030006d523b8553d972a' });
  const res = await wallet.prebuildAndSignTransaction({
    recipients: [
      {
        amount: '1000',
        address: 'lionteste212',
      },
    ],
    walletPassphrase: passphrase,
  });
}
```

Token
```
async function test() {
  const wallet = await bitgo.coin('teos:CHEX').wallets().get({ id: '61521886121c030006d523b8553d972a' });
  const res = await wallet.prebuildAndSignTransaction({
    recipients: [
      {
        amount: '1000',
        address: 'lionteste212',
      },
    ],
    walletPassphrase: passphrase,
  });
}
```
