### PR TITLE
feat(avaxc): upgrade common fork to london

### DIFF
--- a/modules/account-lib/src/coin/avaxc/resources.ts
+++ b/modules/account-lib/src/coin/avaxc/resources.ts
@@ -12,7 +12,7 @@ export const testnetCommon = EthereumCommon.forCustomChain(
     networkId: 1,
     chainId: (coins.get('tavaxc').network as EthereumNetwork).chainId,
   },
-  'petersburg',
+  'london',
 );
 
 /**
@@ -26,5 +26,5 @@ export const mainnetCommon = EthereumCommon.forCustomChain(
     networkId: 1,
     chainId: (coins.get('avaxc').network as EthereumNetwork).chainId,
   },
-  'petersburg',
+  'london',
 );

--- a/modules/account-lib/test/unit/coin/avaxc/transactionBuilder/transfer.ts
+++ b/modules/account-lib/test/unit/coin/avaxc/transactionBuilder/transfer.ts
@@ -174,4 +174,34 @@ describe('Avax C-Chain Transfer Transaction', function () {
     should.equal(txJson.gasPrice, '280000000000');
     should.equal(txJson.v, '0x0150f5');
   });
+
+  it('Should build fee market transaction', async function () {
+    initTxBuilder();
+    txBuilder.fee({
+      fee: '280000000000',
+      eip1559: {
+        maxPriorityFeePerGas: '5',
+        maxFeePerGas: '30',
+      },
+      gasLimit: '7000000',
+    });
+    txBuilder
+      .transfer()
+      .amount('100000000000000000') // This represents 0.1 Avax = 0.1 Ether
+      .contractSequenceId(1)
+      .expirationTime(50000)
+      .to(testData.TEST_ACCOUNT_2.ethAddress)
+      .key(testData.OWNER_2.ethKey);
+    const tx = await txBuilder.build();
+    const txJson: TxData = tx.toJson();
+
+    txJson._type.should.equals(ETHTransactionType.EIP1559);
+    should.exists(txJson.chainId);
+    should.exists(txJson.to);
+    txJson.nonce.should.equals(1);
+    should.equal(txJson.chainId, '0xa869');
+    txJson.gasLimit.should.equals('7000000');
+    should.equal(txJson.maxPriorityFeePerGas, '5');
+    should.equal(txJson.maxFeePerGas, '30');
+  });
 });

--- a/modules/account-lib/test/unit/coin/avaxc/util.ts
+++ b/modules/account-lib/test/unit/coin/avaxc/util.ts
@@ -245,7 +245,7 @@ describe('AVAX util library', () => {
     it('getCommon for mainnet', () => {
       const common = getCommon(NetworkType.MAINNET);
       should.equal(common.chainName(), 'mainnet');
-      should.equal(common.hardfork(), 'petersburg');
+      should.equal(common.hardfork(), 'london');
       should.equal(common.chainIdBN().toString(), '43114');
       should.equal(common.networkIdBN().toString(), '1');
     });
@@ -253,7 +253,7 @@ describe('AVAX util library', () => {
     it('getCommon for testnet', () => {
       const common = getCommon(NetworkType.TESTNET);
       should.equal(common.chainName(), 'fuji');
-      should.equal(common.hardfork(), 'petersburg');
+      should.equal(common.hardfork(), 'london');
       should.equal(common.chainIdBN().toString(), '43113');
       should.equal(common.networkIdBN().toString(), '1');
     });

--- a/modules/core/test/v2/unit/keychains.ts
+++ b/modules/core/test/v2/unit/keychains.ts
@@ -54,7 +54,6 @@ describe('V2 Keychains', function () {
     const cryptoSecpCoins = coins.filter(n => n.primaryKeyCurve === KeyCurve.Secp256k1
       && n.kind === CoinKind.CRYPTO
       && n.asset !== UnderlyingAsset.USD
-      && n.asset !== UnderlyingAsset.AVAXC // TODO(STLX-STLX-5265): Remove when AVAXC is supported in SDK
       && coinFamilyValues.includes(n.name));
 
     const expectedXpub = 'xpub661MyMwAqRbcGpZf8mxNWhSPdWaLGvQzzage6vq2oQFzq8toVzmkjygYZ3HcZw6eCzAfn9ZdyGjKoKkcpKwackdgznVbiunpq7rkxDu7quS';


### PR DESCRIPTION
Avaxc require support to fee market transaction (EIP1559). To do it we need to update common fork. 
This PR does:
- change fork
- Add fee market transaction test
- remove SDK todo STLX-5265.

[STLX-8991](https://bitgoinc.atlassian.net/browse/STLX-8991)