### PR TITLE
test(utxo-lib): add support for bitcoin core 22

### DIFF
--- a/modules/utxo-lib/test/integration_local_rpc/generate/faucet.ts
+++ b/modules/utxo-lib/test/integration_local_rpc/generate/faucet.ts
@@ -1,0 +1,50 @@
+import { RpcClient, RpcClientWithWallet, RpcError } from './RpcClient';
+
+const walletName = 'utxolib-faucet';
+
+const errWalletNotFound = -18;
+
+let faucetWallet: RpcClientWithWallet;
+
+async function initFaucetRpc(rpc: RpcClient, { create }: { create: boolean }): Promise<RpcClientWithWallet> {
+  try {
+    await rpc.withWallet(walletName).getWalletInfo();
+    return rpc.withWallet(walletName);
+  } catch (e) {
+    if (!RpcError.isRpcErrorWithCode(e, errWalletNotFound)) {
+      throw e;
+    }
+  }
+
+  if (!create) {
+    throw new Error(`could not load faucet wallet and create=false.`);
+  }
+
+  try {
+    await rpc.loadWallet(walletName);
+  } catch (e) {
+    if (!RpcError.isRpcErrorWithCode(e, errWalletNotFound)) {
+      throw e;
+    }
+    await rpc.createWallet(walletName);
+  }
+  return await initFaucetRpc(rpc, { create: false });
+}
+
+async function getFaucetRpc(rpc: RpcClient): Promise<RpcClientWithWallet> {
+  if (!faucetWallet) {
+    faucetWallet = await initFaucetRpc(rpc, { create: true });
+  }
+  return faucetWallet;
+}
+
+export async function sendFromFaucet(rpc: RpcClient, address: string, amount: number): Promise<string> {
+  const faucetWallet = await getFaucetRpc(rpc);
+  return await faucetWallet.sendToAddress(address, amount);
+}
+
+export async function generateToFaucet(rpc: RpcClient, nBlocks: number): Promise<void> {
+  const faucetRpc = await getFaucetRpc(rpc);
+  const address = await faucetRpc.getNewAddress();
+  await faucetRpc.generateToAddress(nBlocks, address);
+}

--- a/modules/utxo-lib/test/integration_local_rpc/generate/fixtures.ts
+++ b/modules/utxo-lib/test/integration_local_rpc/generate/fixtures.ts
@@ -49,7 +49,10 @@ export async function writeTransactionFixtureWithInputs(
     (all: string[], input) => (all.includes(input.txid) ? all : [...all, input.txid]),
     []
   );
-  const inputs = await Promise.all(inputTransactionIds.map((inputTxid) => rpc.getRawTransactionVerbose(inputTxid)));
+  const inputs = await RpcClient.parallelMap(inputTransactionIds, (inputTxid) =>
+    rpc.getRawTransactionVerbose(inputTxid)
+  );
+  assert.strictEqual(inputs.length, inputTransactionIds.length);
   await writeFixture(network, filename, {
     transaction,
     inputs,


### PR DESCRIPTION
More recent bitcoin core versions do not have a default wallet set and
require `loadwallet` and `createwallet` calls.

The current bitcoind git master version also requires a scoped RPC
path for wallet operations.

This change supports Bitcoin 22.x.x in a backwards-compatible manner.

Issue: BG-38416