### PR TITLE
chore(account-lib): accept only patch updates to `@hashgraph/sdk`

### DIFF
--- a/modules/account-lib/package.json
+++ b/modules/account-lib/package.json
@@ -40,7 +40,7 @@
     "@celo/contractkit": "^1.2.4",
     "@ethereumjs/common": "^2.4.0",
     "@ethereumjs/tx": "^3.3.0",
-    "@hashgraph/sdk": "^2.0.17",
+    "@hashgraph/sdk": "~2.3.0",
     "@stablelib/hex": "^1.0.0",
     "@stablelib/sha384": "^1.0.0",
     "@stacks/transactions": "2.0.1",


### PR DESCRIPTION
There's currently a breaking issue in `@hashgraph/sdk` which prevents us from
running the latest `bitgo` rc successfully.

https://github.com/hashgraph/hedera-sdk-js/issues/729

This pins the package version to the latest minor version + patch updates.

Ticket: BG-38554