### PR TITLE
fix(eos): fix deserialize transaction with OVC

### DIFF
--- a/modules/core/src/stringTextDecoder.ts
+++ b/modules/core/src/stringTextDecoder.ts
@@ -1,0 +1,22 @@
+/**
+ * @prettier
+ */
+import { StringDecoder } from 'string_decoder';
+
+/**
+ * Custom utf8 TextDecoder that uses StringDecoder under the hood.
+ * This should only be used with utf8 and does NOT support TextDecoder options, like streaming.
+ */
+export class StringTextDecoder extends TextDecoder {
+  public decode(input?: BufferSource, options?: TextDecodeOptions): string {
+    // Note: streaming is not necessary for deserializing EOS transactions.
+    const decoder = new StringDecoder('utf8');
+
+    if (input) {
+      const decoded = decoder.end(Buffer.from(input));
+      return decoded;
+    }
+
+    return '';
+  }
+}

--- a/modules/core/src/v2/coins/eos.ts
+++ b/modules/core/src/v2/coins/eos.ts
@@ -26,6 +26,7 @@ import * as querystring from 'querystring';
 import * as _ from 'lodash';
 import * as Bluebird from 'bluebird';
 import { OfflineAbiProvider } from './eosutil/eosabiprovider';
+import { StringTextDecoder } from '../../stringTextDecoder';
 const co = Bluebird.coroutine;
 import { InvalidAddressError, UnexpectedAddressError } from '../../errors';
 import { Environments } from '../environments';
@@ -541,7 +542,8 @@ export class Eos extends BaseCoin {
         rpc: new NoopJsonRpc(),
         signatureProvider: new NoopSignatureProvider(),
         chainId: self.getChainId(),
-        textDecoder: new TextDecoder(),
+        // Use a custom TextDecoder as the global TextDecoder leads to crashes in OVC / Electron.
+        textDecoder: new StringTextDecoder(),
         textEncoder: new TextEncoder(),
       });
 
@@ -579,6 +581,7 @@ export class Eos extends BaseCoin {
       // deserializeTransaction
       const serializedTxBuffer = Buffer.from(transaction.packed_trx, 'hex');
       const deserializedTxJsonFromPackedTrx = yield api.deserializeTransactionWithActions(serializedTxBuffer);
+
       if (!deserializedTxJsonFromPackedTrx) {
         throw new Error('could not process transaction from txHex');
       }

--- a/modules/core/test/v2/fixtures/coins/eos.ts
+++ b/modules/core/test/v2/fixtures/coins/eos.ts
@@ -374,6 +374,50 @@ const explainRefundOutput = {
   producers: undefined,
 };
 
+const unsignedTransaction = {
+  recipients: [
+    {
+      amount: '560000',
+      address: 'jzjkpn1bjnti',
+      recipientLabel: null,
+      memo: {
+        type: 'id',
+        value: 'Testing EOS Memo',
+      },
+    },
+  ],
+  headers: {
+    expiration: '2019-07-27T02:47:20.500Z',
+    ref_block_num: 21495,
+    ref_block_prefix: 3447713214,
+  },
+  txHex: 'e70aaab8997e1dfce58fbfac80cbbb8fecec7b99cf982a9444273cbc64c4147339bb3b5df753beed7fcd000000000100a6823403ea3055000000572d3ccdcd012012a6f68a5ed4bf00000000a8ed3232212012a6f68a5ed4bfe0f27c27cc0adf7f808b08000000000004454f530000000000000000000000000000000000000000000000000000000000000000000000000000',
+  transaction: {
+    compression: 'none',
+    packed_trx: '39bb3b5df753beed7fcd000000000100a6823403ea3055000000572d3ccdcd012012a6f68a5ed4bf00000000a8ed3232212012a6f68a5ed4bfe0f27c27cc0adf7f808b08000000000004454f53000000000000',
+    signatures: [],
+  },
+  txid: '8bb4dc888bad8108a6c2f1bb8a2b74fbd8f68fa7216f86545786850517754e25',
+  walletId: '5d39c7da66ce12715470c9b2fd6a639d',
+  amount: '560000',
+  address: 'jzjkpn1bjnti',
+  receivedCoin: {
+    name: 'teos',
+    svg: 'eos',
+    modifier: 10000,
+    modifierExp: 4,
+    fullDisplay: 'EOS',
+    shortDisplay: 'TEOS',
+    hasMarketData: false,
+    walletCreationPolling: true,
+  },
+  coin: 'teos',
+  memo: {
+    type: 'id',
+    value: 'Testing EOS Memo',
+  },
+};
+
 export const EosResponses = {
   getAccountResponseSuccess1,
   getAccountResponseSuccess2,
@@ -392,4 +436,5 @@ export const EosInputs = {
   explainUnstakeInput1,
   explainUnstakeInput2,
   explainRefundInput,
+  unsignedTransaction
 } as const;

--- a/modules/core/test/v2/unit/stringTextDecoder.ts
+++ b/modules/core/test/v2/unit/stringTextDecoder.ts
@@ -1,0 +1,61 @@
+/**
+ * @prettier
+ */
+
+import 'should';
+import { StringTextDecoder } from '../../../src/stringTextDecoder';
+import { EosInputs } from '../fixtures/coins/eos';
+
+describe('String Text Decoder', function () {
+  const stringTextDecoder = new StringTextDecoder();
+  const textDecoder = new TextDecoder();
+
+  it('should decode in utf8', function () {
+    const data = Buffer.from('abc');
+
+    const eosDecoded = stringTextDecoder.decode(data);
+    const decoded = textDecoder.decode(data);
+
+    eosDecoded.should.equal('abc');
+    eosDecoded.should.equal(decoded);
+  });
+
+  it('should have inconsistent results for non-utf8', function () {
+    const data = Buffer.from([0x0001d11e]);
+
+    const eosDecoded = stringTextDecoder.decode(data);
+    const decoded = new TextDecoder('utf-16').decode(data);
+
+    eosDecoded.should.not.equal(decoded);
+  });
+
+  it('should decode large inputs', function () {
+    const largeInput = 'a'.repeat(16384);
+    const data = Buffer.from(largeInput);
+
+    const eosDecoded = stringTextDecoder.decode(data);
+    const decoded = textDecoder.decode(data);
+
+    eosDecoded.should.equal(largeInput);
+    eosDecoded.should.equal(decoded);
+  });
+
+  it('should return empty string no data', function () {
+    const eosDecoded = stringTextDecoder.decode();
+    const decoded = textDecoder.decode();
+
+    eosDecoded.should.equal('');
+    eosDecoded.should.equal(decoded);
+  });
+
+  it('should encode and decode eos transaction', function () {
+    const packedTrxHex = EosInputs.unsignedTransaction.transaction.packed_trx;
+
+    const encoded = new TextEncoder().encode(packedTrxHex);
+    const decoded = stringTextDecoder.decode(Buffer.from(encoded));
+    const decoded2 = textDecoder.decode(Buffer.from(encoded));
+
+    decoded.should.equal(packedTrxHex);
+    decoded.should.equal(decoded2);
+  });
+});


### PR DESCRIPTION
OVC uses Electron to package their application. There is a known issue
with Electron apps crashing when using TextDecoder with large inputs.
Workaround is to implement our own decoder using StringDecoder.

Ticket: BG-38309

Verified OVC works with locally built BitGoJS
<img width="1569" alt="Screen Shot 2021-11-03 at 1 44 47 PM" src="https://user-images.githubusercontent.com/91087462/140189933-b97d766b-2730-407a-ad18-1a200de65a4d.png">
:
