### PR TITLE
fix(core): sign multi-input p2tr script path txs

### DIFF
--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -1879,7 +1879,7 @@ export class Wallet {
           addressVersion: self._wallet.coinSpecific.addressVersion,
         },
         keychain: keychains[0],
-        userKeychain: (keychains.length > 0) ? keychains[0] : null,
+        userKeychain: keychains[0],
         backupKeychain: (keychains.length > 1) ? keychains[1] : null,
         bitgoKeychain: (keychains.length > 2) ? keychains[2] : null,
       });


### PR DESCRIPTION
This fixes p2tr script path signing for transactions with multiple inputs. Previously, the prevout scripts needed for signing were missing on p2tr inputs besides the one that was actively being signed for. However, attempting to sign an input would populate all data required for signing that input, includuing its prevout script. This introduces a workaround that makes a second pass at sign attempts for any sign calls that failed on the first attempt. On the second attempt, each input will have had its signing data and prevout scripts populated.

This also adds a test case that creates two p2tr addresses using `createMultiSigAddress` and then creates unsigned tx hex using inputs from both addresses. The unsigned tx is then signed twice using the user and backup keys. The resulting signed tx has been broadcast and confirmed on the testnet blockchain. This test case goes beyond the scope of unit testing the btc coin class, and will be refactored in a future PR.

Ticket: BG-35578

Signed & broadcast tx from the test case can be seen here: https://blockstream.info/testnet/tx/a9736d27287220b83d7e43f93477d4c2902ad7187eeeac0af665020b866c13ec

TY to @brandonblack & @OttoAllmendinger for helping debug & workaround the issue.