### PR TITLE
feat(unspents): classify p2tr script path sigs

### DIFF
--- a/modules/unspents/src/dimensions.ts
+++ b/modules/unspents/src/dimensions.ts
@@ -399,6 +399,17 @@ Dimensions.fromInput = function (input: utxolib.TxInput, params = {}) {
       case 'witnessscripthash':
         return p2wshInput;
     }
+    if (utxolib.bitgo.isParsedSignatureScriptTaproot(parsed)) {
+      if (parsed.controlBlock.length === 65) {
+        // 33 bytes + 32 bytes for depth 1
+        return p2trScriptPathLevel1Input;
+      } else if (parsed.controlBlock.length === 97) {
+        // 33 bytes + 64 bytes for depth 2
+        return p2trScriptPathLevel2Input;
+      } else {
+        throw new Error(`unexpected control block length: ${parsed.controlBlock.length}`);
+      }
+    }
   }
 
   const { assumeUnsigned } = params;

--- a/modules/utxo-lib/src/bitgo/signature.ts
+++ b/modules/utxo-lib/src/bitgo/signature.ts
@@ -37,6 +37,8 @@ const inputTypes = [
   'scripthash',
   'witnesspubkeyhash',
   'witnessscripthash',
+  'taproot',
+  'taprootnofn',
   'witnesscommitment',
 ] as const;
 
@@ -71,6 +73,10 @@ export interface ParsedSignatureScriptTaproot extends ParsedSignatureScript {
   publicKeys: [Buffer, Buffer];
   pubScript: Buffer;
   controlBlock: Buffer;
+}
+
+export function isParsedSignatureScriptTaproot(parsed: ParsedSignatureScript): parsed is ParsedSignatureScriptTaproot {
+  return parsed.inputClassification === 'taproot';
 }
 
 export function getDefaultSigHash(network: Network, scriptType?: ScriptType2Of3): number {


### PR DESCRIPTION
This adds support for classifying a partially signed p2tr input after parsing the signature by checking for an `inputClassification` of `taproot` and checking the size of the control block to distinguish between a level 1 and level 2 depth script path spend.

Ticket: BG-37329

Note: This fixes the bug mentioned here: https://github.com/BitGo/bitgo-microservices/pull/13243/files#diff-2cc59901c8cb5f7eacecfab40a529dc3c0ac12387846622d9a6ab7423a9a8f46R1129