### PR TITLE
feat(utxo-lib): add property `scriptType` to ParsedSignatureScript

### DIFF
--- a/modules/utxo-lib/src/bitgo/index.ts
+++ b/modules/utxo-lib/src/bitgo/index.ts
@@ -7,3 +7,4 @@ export * from './UtxoTransaction';
 export * from './UtxoTransactionBuilder';
 export * from './zcash';
 export * from './dash';
+export * from './types';

--- a/modules/utxo-lib/src/bitgo/outputScripts.ts
+++ b/modules/utxo-lib/src/bitgo/outputScripts.ts
@@ -2,12 +2,17 @@ import * as assert from 'assert';
 import * as bitcoinjs from 'bitcoinjs-lib';
 import { isTriple, Triple, Tuple } from './types';
 
+export const scriptTypeP2shP2pk = 'p2shP2pk';
+export type ScriptTypeP2shP2pk = typeof scriptTypeP2shP2pk;
+
 export const scriptTypes2Of3 = ['p2sh', 'p2shP2wsh', 'p2wsh', 'p2tr'] as const;
 export type ScriptType2Of3 = typeof scriptTypes2Of3[number];
 
 export function isScriptType2Of3(t: string): t is ScriptType2Of3 {
   return scriptTypes2Of3.includes(t as ScriptType2Of3);
 }
+
+export type ScriptType = ScriptTypeP2shP2pk | ScriptType2Of3;
 
 export function scriptTypeForChain(chain: number): ScriptType2Of3 {
   switch (chain) {


### PR DESCRIPTION
This allows easy type discrimination.

Add more `parseSignatureScript` tests.

Issue: BG-37883