### PR TITLE
fix(statics): ensure UnderlyingAssets values are unique

### DIFF
--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -627,6 +627,7 @@ export enum UnderlyingAsset {
   UQC = 'uqc',
   URHD = 'urhd',
   USDC = 'usdc',
+  // Also available on EOS
   USDT = 'usdt',
   USDX = 'usdx',
   USG = 'usg',
@@ -711,10 +712,9 @@ export enum UnderlyingAsset {
   'talgo:180447' = 'talgo:180447',
 
   // EOS tokens
-  CHEX = 'CHEX',
-  IQ = 'IQ',
-  EOS_BOX = 'BOX',
-  EOS_USDT = 'USDT',
+  CHEX = 'chex',
+  IQ = 'iq',
+  EOS_BOX = 'eos:box',
 }
 
 /**

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -1105,18 +1105,9 @@ export const coins = CoinMap.fromCoins([
   eosToken('eos:CHEX', 'Chintai', 8, 'chexchexchex', UnderlyingAsset.CHEX, AccountCoin.DEFAULT_FEATURES, '', 'CHEX'),
   eosToken('eos:IQ', 'Everipedia', 3, 'everipediaiq', UnderlyingAsset.IQ, AccountCoin.DEFAULT_FEATURES, '', 'IQ'),
   eosToken('eos:BOX', 'Box', 6, 'token.defi', UnderlyingAsset.EOS_BOX, AccountCoin.DEFAULT_FEATURES, '', 'BOX'),
-  eosToken('eos:USDT', 'Tether', 4, 'tethertether', UnderlyingAsset.EOS_USDT, AccountCoin.DEFAULT_FEATURES, '', 'USDT'),
+  eosToken('eos:USDT', 'Tether', 4, 'tethertether', UnderlyingAsset.USDT, AccountCoin.DEFAULT_FEATURES, '', 'USDT'),
   teosToken('teos:CHEX', 'Chintai', 8, 'testtoken111', UnderlyingAsset.CHEX, AccountCoin.DEFAULT_FEATURES, '', 'CHEX'),
   teosToken('teos:IQ', 'Everipedia', 3, 'testtoken112', UnderlyingAsset.IQ, AccountCoin.DEFAULT_FEATURES, '', 'IQ'),
   teosToken('teos:BOX', 'Box', 6, 'kvszn1xyz1bu', UnderlyingAsset.EOS_BOX, AccountCoin.DEFAULT_FEATURES, '', 'BOX'),
-  teosToken(
-    'teos:USDT',
-    'Tether',
-    4,
-    'lionteste212',
-    UnderlyingAsset.EOS_USDT,
-    AccountCoin.DEFAULT_FEATURES,
-    '',
-    'USDT'
-  ),
+  teosToken('teos:USDT', 'Tether', 4, 'lionteste212', UnderlyingAsset.USDT, AccountCoin.DEFAULT_FEATURES, '', 'USDT'),
 ]);

--- a/modules/statics/test/unit/base.ts
+++ b/modules/statics/test/unit/base.ts
@@ -1,0 +1,26 @@
+const should = require('should');
+const { UnderlyingAsset } = require('../../src/base');
+
+describe('UnderlyingAsset', function() {
+  it('UnderlyingAsset values should be unique', function() {
+    const underlyingAssetSet = new Set();
+    const duplicateAssets: typeof UnderlyingAsset[] = [];
+
+    for (const asset in UnderlyingAsset) {
+      const assetValue = UnderlyingAsset[asset].toUpperCase();
+      if (underlyingAssetSet.has(assetValue)) {
+        duplicateAssets.push(assetValue);
+      }
+      underlyingAssetSet.add(assetValue);
+    }
+
+    if (duplicateAssets.length !== 0) {
+      const failureMessage = `
+        Added duplicate UnderlyingAssets with values: ${duplicateAssets}
+        You should re-use the existing asset if this refers to the same asset, but on different chains.
+        If they are different assets, pick a unique name.
+        `;
+      should.fail(undefined, undefined, failureMessage);
+    }
+  });
+});


### PR DESCRIPTION
each value in UnderlyingAsset represents an asset and clients use the value to determine which icon to show. additionally, the same underlying asset may be used by multiple chains (e.g. USDT exists as an erc20 and eos token).

previously, we had two enum entries with the same value 'box'. one was meant for the erc20 token and the other for eos. this led to us showing the wrong icon for the eos box token. fix is to make sure BOX and EOS_BOX have different values.