### PR TITLE
docs: capitalize JavaScript and TypeScript properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BitGo Javascript SDK
+# BitGo JavaScript SDK
 
 The BitGo Platform and SDK makes it easy to build multi-signature crypto-currency applications today with support for Bitcoin, Ethereum and many other coins.
 The SDK is fully integrated with the BitGo co-signing service for managing all of your BitGo wallets.

--- a/modules/account-lib/DEVELOPER.md
+++ b/modules/account-lib/DEVELOPER.md
@@ -88,6 +88,6 @@ require a round of feedback.
 
 Take note:
 
-> Do not specify default accessors. In Typescript, the default accessor for a
+> Do not specify default accessors. In TypeScript, the default accessor for a
 > class attribute is `public`, so specifying it for functions and attributes is
 > redundant.

--- a/modules/blake2b-wasm/README.md
+++ b/modules/blake2b-wasm/README.md
@@ -62,7 +62,7 @@ The format of this file is S-Expressions that can be compiled to their binary WA
 wat2wasm blake2b.wat -o blake2b.wasm
 ```
 
-To build the thin Javascript wrapper for the WASM module use `wat2js`:
+To build the thin JavaScript wrapper for the WASM module use `wat2js`:
 
 ```
 # also available as `npm run compile`

--- a/modules/blake2b/README.md
+++ b/modules/blake2b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/emilbayes/blake2b.svg?branch=master)](https://travis-ci.org/emilbayes/blake2b)
 
-> Blake2b (64-bit version) in pure Javascript
+> Blake2b (64-bit version) in pure JavaScript
 
 This module is based on @dcposch
 [implementation of BLAKE2b](https://github.com/dcposch/blakejs), with some changes:
@@ -13,7 +13,7 @@ This module is based on @dcposch
 * Uses a WASM version (where it is supported) for massive performance boosts
 
 All credit goes to @dcposch for doing the hard work of porting the
-implementation from C to Javascript.
+implementation from C to JavaScript.
 
 ## Usage
 

--- a/modules/blake2b/index.js
+++ b/modules/blake2b/index.js
@@ -106,7 +106,7 @@ var SIGMA8 = [
 
 // These are offsets into a uint64 buffer.
 // Multiply them all by 2 to make them offsets into a uint32 buffer,
-// because this is Javascript and we don't have uint64s
+// because this is JavaScript and we don't have uint64s
 var SIGMA82 = new Uint8Array(SIGMA8.map(function (x) { return x * 2 }))
 
 // Compression function. 'last' flag indicates last block.

--- a/modules/blake2b/package.json
+++ b/modules/blake2b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bitgo/blake2b",
   "version": "3.0.1",
-  "description": "Blake2b (64-bit version) in pure Javascript",
+  "description": "Blake2b (64-bit version) in pure JavaScript",
   "main": "index.js",
   "dependencies": {
     "@bitgo/blake2b-wasm": "^3.0.1",

--- a/modules/core/README.md
+++ b/modules/core/README.md
@@ -1,4 +1,4 @@
-# BitGo Javascript SDK
+# BitGo JavaScript SDK
 
 The BitGo Platform and SDK makes it easy to build multi-signature crypto-currency applications today with support for Bitcoin, Ethereum and many other coins.
 The SDK is fully integrated with the BitGo co-signing service for managing all of your BitGo wallets.
@@ -18,7 +18,7 @@ We recommend using `nvm`, the [Node Version Manager](https://github.com/creation
 
 # Full Documentation
 
-Please see our [SDK Documentation](https://bitgo-sdk-docs.s3.amazonaws.com/core/11.3.0/index.html) for detailed information about the Typescript SDK and functionality.
+Please see our [SDK Documentation](https://bitgo-sdk-docs.s3.amazonaws.com/core/11.3.0/index.html) for detailed information about the TypeScript SDK and functionality.
 
 For more general information about the BitGo API, please see our [REST API Documentation](https://www.bitgo.com/api/v2).
 
@@ -69,7 +69,7 @@ console.dir(result);
 ```
 
 ## More examples
-Further demos and examples in both Javascript and Typescript can be found in the [example](example) directory.
+Further demos and examples in both JavaScript and TypeScript can be found in the [example](example) directory.
 
 # Enabling additional debugging output
 
@@ -104,7 +104,7 @@ To set debug namespaces in the browser, you should set `localStorage.debug` prop
 localStorage.debug = 'bitgo:*'; // enable all bitgo debug namespaces
 ```
 
-# Using with Typescript
+# Using with TypeScript
 
 `bitgo` is not yet compatible with the `noImplicitAny` compiler option. If you want to use this option in your project (and we recommend that you do), you must set the `skipLibCheck` option to supress errors about missing type definitions for dependencies of `bitgo`.
 

--- a/modules/core/example/README.md
+++ b/modules/core/example/README.md
@@ -2,8 +2,8 @@
 
 ## `ts` directory
 
-In this directory, you can find examples on how to use the BitGoJS SDK with Typescript. These examples use modern Typescript/ES6 syntax with `async`/`await`. This is the recommended way to use the BitGoJS SDK for new projects.
+In this directory, you can find examples on how to use the BitGoJS SDK with TypeScript. These examples use modern TypeScript/ES6 syntax with `async`/`await`. This is the recommended way to use the BitGoJS SDK for new projects.
 
 ## `js` directory
 
-In this directory, you can find examples on how to use the BitGoJS SDK with Javascript. These examples use coroutine syntax with `yield`.
+In this directory, you can find examples on how to use the BitGoJS SDK with JavaScript. These examples use coroutine syntax with `yield`.

--- a/modules/core/example/ts/README.md
+++ b/modules/core/example/ts/README.md
@@ -1,4 +1,4 @@
-# BitGo SDK Typescript Examples
+# BitGo SDK TypeScript Examples
 
 ## Prerequisites
 

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bitgo",
   "version": "13.1.0",
-  "description": "BitGo Javascript SDK",
+  "description": "BitGo JavaScript SDK",
   "main": "./dist/src/index.js",
   "types": "./dist/types/src/index.d.ts",
   "keywords": [

--- a/modules/statics/README.md
+++ b/modules/statics/README.md
@@ -15,7 +15,7 @@
 
 ### Get the number of decimal places in a Bitcoin
 
-#### Javascript
+#### JavaScript
 ```js
 const { coins } = require('@bitgo/statics');
 
@@ -23,7 +23,7 @@ const btc = coins.get('btc');
 console.log(btc.decimalPlaces);
 ```
 
-#### Typescript
+####typescript
 ```typescript
 import { coins } from '@bitgo/statics';
 
@@ -33,7 +33,7 @@ console.log(btc.decimalPlaces);
 
 ### Get the contract address for the OmiseGo ERC20 Token
 
-#### Javascript
+#### JavaScript
 ```js
 const { coins } = require('@bitgo/statics');
 
@@ -41,7 +41,7 @@ const omg = coins.get('omg');
 console.log(omg.contractAddress);
 ```
 
-#### Typescript
+####typescript
 ```typescript
 import { coins, Erc20Coin } from '@bitgo/statics';
 
@@ -53,7 +53,7 @@ if (omg instanceof Erc20Coin) {
 
 ### List full names of all defined coins
 
-#### Javascript
+#### JavaScript
 ```js
 const { coins } = require('@bitgo/statics');
 
@@ -62,7 +62,7 @@ coins.forEach((coin) => {
 });
 ```
 
-#### Typescript
+####typescript
 ```typescript
 import { coins } from '@bitgo/statics';
 
@@ -97,13 +97,13 @@ $ # (optionally) nvm use 8.6.0
 $ npm install
 ```
 
-To build the project (from TypeScript to Javascript):
+To build the project (from TypeScript to JavaScript):
 
 ```
 $ npm run build
 ```
 
-This builds the Javascript and adds it to `dist/src/`. You will receive compilation errors if you have invalid syntax.
+This builds the JavaScript and adds it to `dist/src/`. You will receive compilation errors if you have invalid syntax.
 
 
 ## Tests


### PR DESCRIPTION
As seen here[^1] and here[^2].

[^1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript
[^2]: https://www.typescriptlang.org/