### PR TITLE
refactor(core): add, use signAndVerifyWalletTransaction for utxo

### DIFF
--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -1021,6 +1021,10 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
     return this.supportsAddressType(utxolib.bitgo.outputScripts.scriptTypeForChain(chain));
   }
 
+  keyIdsForSigning(): number[] {
+    return [KeyIndices.USER, KeyIndices.BACKUP, KeyIndices.BITGO];
+  }
+
   /**
    * TODO(BG-11487): Remove addressType, segwit, and bech32 params in SDKv6
    * Generate an address for a wallet based on a set of configurations

--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -44,7 +44,7 @@ import {
 } from '../baseCoin';
 import { CustomChangeOptions, parseOutput } from '../internal/parseOutput';
 import { RequestTracer } from '../internal/util';
-import { Keychain, KeyIndices } from '../keychains';
+import { Keychain, KeyIndices, Triple } from '../keychains';
 import { promiseProps } from '../promise-utils';
 import { NodeCallback } from '../types';
 import { Wallet } from '../wallet';
@@ -54,8 +54,9 @@ const debug = debugLib('bitgo:v2:utxo');
 const co = Bluebird.coroutine;
 
 import ScriptType2Of3 = utxolib.bitgo.outputScripts.ScriptType2Of3;
+import { ReplayProtectionUnspent, Unspent } from './utxo/unspent';
 import { getReplayProtectionAddresses } from './utxo/replayProtection';
-import { Unspent } from './utxo/unspent';
+import { signAndVerifyWalletTransaction, WalletUnspentSigner } from './utxo/sign';
 
 export interface VerifyAddressOptions extends BaseVerifyAddressOptions {
   chain: number;
@@ -168,6 +169,7 @@ export interface AddressDetails {
 }
 
 export interface SignTransactionOptions extends BaseSignTransactionOptions {
+  /** Transaction prebuild from bitgo server */
   txPrebuild: {
     txHex: string;
     txInfo: {
@@ -182,11 +184,16 @@ export interface SignTransactionOptions extends BaseSignTransactionOptions {
       }[];
     };
   };
+  /** xprv of user key or backup key */
   prv: string;
-  userKeychain?: Keychain;
-  backupKeychain?: Keychain;
-  bitgoKeychain?: Keychain;
-  taprootRedeemIndex?: number;
+  /** xpubs triple for wallet (user, backup, bitgo) */
+  pubs: Triple<string>;
+  /** xpub for cosigner (defaults to bitgo) */
+  cosignerPub?: string;
+  /**
+   * When true, creates full-signed transaction without placeholder signatures.
+   * When false, creates half-signed transaction with placeholder signatures.
+   */
   isLastSignature?: boolean;
 }
 
@@ -1121,10 +1128,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
 
   /**
    * Assemble keychain and half-sign prebuilt transaction
-   * @param params
-   * @param params.txPrebuild transaction prebuild from bitgo server
-   * @param params.prv private key to be used for signing
-   * @param params.isLastSignature True if `TransactionBuilder.build()` should be called and not `TransactionBuilder.buildIncomplete()`
+   * @param params - {@see SignTransactionOptions}
    * @param callback
    * @returns {Bluebird<SignedTransaction>}
    */
@@ -1143,7 +1147,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
         }
         throw new Error('missing txPrebuild parameter');
       }
-      let transaction = self.createTransactionFromHex(txPrebuild.txHex);
+      const transaction = self.createTransactionFromHex(txPrebuild.txHex);
 
       if (transaction.ins.length !== txPrebuild.txInfo.unspents.length) {
         throw new Error('length of unspents array should equal to the number of transaction inputs');
@@ -1162,207 +1166,29 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
         throw new Error('missing prv parameter to sign transaction');
       }
 
-      // We won't pass `self.network` to `fromBase58()` because BitGo encodes bip32 keys for all
-      // utxo coins using the bitcoin mainnet parameters.
-      const keychain = Object.assign(bip32.fromBase58(userPrv, utxolib.networks.bitcoin), { network: self.network });
+      if (!params.pubs || params.pubs.length !== 3) {
+        throw new Error(`must provide xpub array`);
+      }
 
-      if (keychain.isNeutered()) {
+      const signerKeychain = bip32.fromBase58(userPrv, utxolib.networks.bitcoin);
+      if (signerKeychain.isNeutered()) {
         throw new Error('expected user private key but received public key');
       }
-      debug(`Here is the public key of the xprv you used to sign: ${keychain.neutered().toBase58()}`);
+      debug(`Here is the public key of the xprv you used to sign: ${signerKeychain.neutered().toBase58()}`);
 
-      const txb = utxolib.bitgo.createTransactionBuilderFromTransaction(transaction);
-      utxolib.bitgo.setTransactionBuilderDefaults(txb, self.network);
+      const cosignerPub = params.cosignerPub ?? params.pubs[2];
+      const keychains = params.pubs.map((pub) => bip32.fromBase58(pub)) as Triple<bip32.BIP32Interface>;
+      const cosignerKeychain = bip32.fromBase58(cosignerPub);
 
-      const getSignatureContext = (txPrebuild: TransactionPrebuild, index: number) => {
-        const currentUnspent = txPrebuild.txInfo.unspents[index];
-        return {
-          inputIndex: index,
-          unspent: currentUnspent,
-          path: '0/0/' + currentUnspent.chain + '/' + currentUnspent.index,
-          chain: currentUnspent.chain,
-          isBitGoTaintedUnspent: self.isBitGoTaintedUnspent(currentUnspent),
-          error: undefined as Error | undefined,
-        };
-      };
-
-      const prevOutputs: utxolib.TxOutput[] = []; // prev output scripts used for p2tr signature verification
-      const signatureIssues: ReturnType<typeof getSignatureContext>[] = [];
-      const signingData: { signParams?: utxolib.bitgo.TxbSignArg; signatureContext: any }[] = [];
-
-      // Sign inputs
-      for (let index = 0; index < transaction.ins.length; ++index) {
-        debug('Signing input %d of %d', index + 1, transaction.ins.length);
-        const signatureContext = getSignatureContext(txPrebuild, index);
-
-        prevOutputs.push({
-          script: utxolib.address.toOutputScript(signatureContext.unspent.address, self.network),
-          value: signatureContext.unspent.value,
-        });
-
-        if (signatureContext.isBitGoTaintedUnspent) {
-          debug(
-            'Skipping input %d of %d (unspent from replay protection address which is platform signed only)',
-            index + 1,
-            transaction.ins.length
-          );
-          signingData.push({ signParams: undefined, signatureContext });
-          continue;
-        }
-
-        const keyPair = keychain.derivePath(sanitizeLegacyPath(signatureContext.path));
-
-        debug('Input details: %O', signatureContext);
-
-        const scriptType = utxolib.bitgo.outputScripts.scriptTypeForChain(signatureContext.chain);
-        const sigHashType = utxolib.bitgo.getDefaultSigHash(self.network, scriptType);
-
-        if (Codes.isP2tr(signatureContext.chain)) {
-          // we default to signing for a p2tr-p2ns script path spend using
-          // the bitgo key and user key
-
-          // we need to provide the sign call with the control block and chosen tapscript
-          if (!params.userKeychain || !params.backupKeychain || !params.bitgoKeychain) {
-            throw new Error('missing keychain parameters');
-          }
-
-          // we expect that the first signature will always be with the user key
-          const userPubkey = bip32
-            .fromBase58(params.userKeychain.pub)
-            .derivePath(sanitizeLegacyPath(signatureContext.path)).publicKey;
-          const backupPubkey = bip32
-            .fromBase58(params.backupKeychain.pub)
-            .derivePath(sanitizeLegacyPath(signatureContext.path)).publicKey;
-          const bitgoPubkey = bip32
-            .fromBase58(params.bitgoKeychain.pub)
-            .derivePath(sanitizeLegacyPath(signatureContext.path)).publicKey;
-
-          const { controlBlock, redeem, output } = utxolib.bitgo.outputScripts.createPaymentP2tr(
-            [userPubkey, backupPubkey, bitgoPubkey],
-            params.taprootRedeemIndex ?? 0
-          );
-
-          const derivedAddress = utxolib.address.fromOutputScript(output!, self.network);
-
-          if (derivedAddress !== signatureContext.unspent.address) {
-            throw new Error(`address mismatch: unspent=${signatureContext.unspent.address} derived=${derivedAddress}`);
-          }
-
-          const signParams = {
-            controlBlock,
-            vin: index,
-            prevOutScriptType: 'p2tr-p2ns',
-            keyPair: keyPair,
-            hashType: sigHashType,
-            witnessScript: redeem?.output,
-            witnessValue: signatureContext.unspent.value,
-          };
-
-          signingData.push({ signParams, signatureContext });
-        } else {
-          const redeemScript = signatureContext.unspent.redeemScript
-            ? Buffer.from(signatureContext.unspent.redeemScript, 'hex')
-            : undefined;
-          const witnessScript = signatureContext.unspent.witnessScript
-            ? Buffer.from(signatureContext.unspent.witnessScript, 'hex')
-            : undefined;
-          const scriptType = witnessScript ? (redeemScript ? 'p2shP2wsh' : 'p2wsh') : 'p2sh';
-          debug(`Signing ${scriptType} input`);
-
-          const signParams: utxolib.bitgo.TxbSignArg = {
-            vin: index,
-            keyPair,
-            prevOutScriptType: utxolib.bitgo.outputScripts.scriptType2Of3AsPrevOutType(scriptType),
-            redeemScript,
-            hashType: sigHashType,
-            witnessValue: signatureContext.unspent.value,
-            witnessScript,
-          };
-
-          signingData.push({ signParams, signatureContext });
-        }
-      }
-
-      // this is a hacky workaround needed due to the fact that not all data
-      // is present on the transaction builder when signing is called the first time
-      // on multi-input transactions with p2tr inputs. the first failed signed attempt
-      // will populate the required data. we then attempt signing again for any sign
-      // calls that failed and expect it to succeed the second time
-      const signatureSuccesses: boolean[] = [];
-      for (let index = 0; index < transaction.ins.length; ++index) {
-        const { signParams } = signingData[index];
-        if (signParams === undefined) {
-          debug('Skipping signature for input %d of %d (RP input?)', index + 1, transaction.ins.length);
-          continue;
-        }
-        try {
-          txb.sign(signParams); // this may fail
-          debug('Successfully signed input %d of %d', index + 1, transaction.ins.length);
-          signatureSuccesses[index] = true;
-        } catch {
-          signatureSuccesses[index] = false;
-        }
-      }
-      for (let index = 0; index < transaction.ins.length; ++index) {
-        try {
-          const { signParams } = signingData[index];
-          if (signatureSuccesses[index] || signParams === undefined) continue; // already signed
-          txb.sign(signParams); // this should work
-          debug('Successfully signed input %d of %d', index + 1, transaction.ins.length);
-        } catch (e) {
-          debug('Failed to sign input:', e);
-          const { signatureContext } = signingData[index];
-          signatureContext.error = e;
-          signatureIssues.push(signatureContext);
-        }
-      }
-
-      if (isLastSignature) {
-        transaction = txb.build();
-      } else {
-        transaction = txb.buildIncomplete();
-      }
-
-      // Verify input signatures
-      for (let index = 0; index < transaction.ins.length; ++index) {
-        debug('Verifying input signature %d of %d', index + 1, transaction.ins.length);
-        const signatureContext = getSignatureContext(txPrebuild, index);
-        if (signatureContext.isBitGoTaintedUnspent) {
-          debug(
-            'Skipping input signature %d of %d (unspent from replay protection address which is platform signed only)',
-            index + 1,
-            transaction.ins.length
-          );
-          continue;
-        }
-
-        if (Codes.isP2wsh(signatureContext.chain)) {
-          transaction.setInputScript(index, Buffer.alloc(0));
-        }
-        const isValidSignature = utxolib.bitgo.verifySignature(
-          transaction,
-          index,
-          signatureContext.unspent.value,
-          undefined,
-          prevOutputs
-        );
-        if (!isValidSignature) {
-          debug('Invalid signature');
-          signatureContext.error = new Error('invalid signature');
-          signatureIssues.push(signatureContext);
-        }
-      }
-
-      if (signatureIssues.length > 0) {
-        const failedIndices = signatureIssues.map((currentIssue) => currentIssue.inputIndex);
-        const error: any = new Error(`Failed to sign inputs at indices ${failedIndices.join(', ')}`);
-        error.code = 'input_signature_failure';
-        error.signingErrors = signatureIssues;
-        throw error;
-      }
+      const signedTransaction = signAndVerifyWalletTransaction(
+        transaction,
+        txPrebuild.txInfo.unspents as Unspent[],
+        new WalletUnspentSigner(keychains, signerKeychain, cosignerKeychain),
+        { isLastSignature }
+      );
 
       return {
-        txHex: transaction.toBuffer().toString('hex'),
+        txHex: signedTransaction.toBuffer().toString('hex'),
       };
     })
       .call(this)
@@ -1373,7 +1199,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
    * @param unspent
    * @returns {boolean}
    */
-  isBitGoTaintedUnspent(unspent: Unspent) {
+  isBitGoTaintedUnspent(unspent: Unspent): unspent is ReplayProtectionUnspent {
     return getReplayProtectionAddresses(this.network).includes(unspent.address);
   }
 

--- a/modules/core/src/v2/coins/btc.ts
+++ b/modules/core/src/v2/coins/btc.ts
@@ -3,7 +3,6 @@ import * as utxolib from '@bitgo/utxo-lib';
 import { BitGo } from '../../bitgo';
 import { BaseCoin, VerifyRecoveryTransactionOptions as BaseVerifyRecoveryTransactionOptions } from '../baseCoin';
 import { AbstractUtxoCoin, UtxoNetwork } from './abstractUtxoCoin';
-import { KeyIndices } from '../keychains';
 
 export interface VerifyRecoveryTransactionOptions extends BaseVerifyRecoveryTransactionOptions {
   transactionHex: string,
@@ -44,10 +43,5 @@ export class Btc extends AbstractUtxoCoin {
 
   supportsP2tr(): boolean {
     return true;
-  }
-
-  /* BTC needs all keys to sign for P2TR */
-  keyIdsForSigning(): number[] {
-    return [KeyIndices.USER, KeyIndices.BACKUP, KeyIndices.BITGO];
   }
 }

--- a/modules/core/src/v2/coins/utxo/sign.ts
+++ b/modules/core/src/v2/coins/utxo/sign.ts
@@ -3,9 +3,12 @@
  */
 import * as bip32 from 'bip32';
 import * as utxolib from '@bitgo/utxo-lib';
+import * as debugLib from 'debug';
 
 import { Triple } from '../../keychains';
-import { WalletUnspent } from './unspent';
+import { isReplayProtectionUnspent, toOutput, Unspent, WalletUnspent } from './unspent';
+
+const debug = debugLib('bitgo:v2:utxo');
 
 export function deriveKey(k: bip32.BIP32Interface, chain: number, index: number): bip32.BIP32Interface {
   return k.derivePath(`0/0/${chain}/${index}`);
@@ -52,6 +55,15 @@ export class WalletUnspentSigner {
   }
 }
 
+/**
+ * Create utxo transaction input signature for a wallet unspent.
+ * Derives keys, compares scripts and throws error on mismatch.
+ *
+ * @param txBuilder
+ * @param inputIndex
+ * @param unspent
+ * @param walletSigner
+ */
 export function signWalletTransactionWithUnspent(
   txBuilder: utxolib.bitgo.UtxoTransactionBuilder,
   inputIndex: number,
@@ -77,4 +89,88 @@ export function signWalletTransactionWithUnspent(
     walletUnspentSigner.cosigner.publicKey,
     unspent.value
   );
+}
+
+export class InputSigningError extends Error {
+  constructor(public inputIndex: number, public unspent: Unspent, public reason: Error | string) {
+    super(`signing error at input ${inputIndex}: unspentId=${unspent.id}: ${reason}`);
+  }
+}
+
+export class TransactionSigningError extends Error {
+  constructor(signErrors: InputSigningError[], verifyError: InputSigningError[]) {
+    super(
+      `sign errors at inputs: [${signErrors.join(',')}], ` +
+        `verify errors at inputs: [${verifyError.join(',')}], see log for details`
+    );
+  }
+}
+
+/**
+ * Sign all inputs of a wallet transaction and verify signatures after signing.
+ * Collects and logs signing errors and verification errors, throws error in the end if any of them
+ * failed.
+ *
+ * @param transaction - wallet transactions to be signed
+ * @param unspents - transaction unspents
+ * @param walletSigner - signing parameters
+ * @param isLastSignature - Returns full-signed transaction when true. Builds half-signed when false.
+ */
+export function signAndVerifyWalletTransaction(
+  transaction: utxolib.bitgo.UtxoTransaction,
+  unspents: Unspent[],
+  walletSigner: WalletUnspentSigner,
+  { isLastSignature }: { isLastSignature: boolean }
+): utxolib.Transaction {
+  if (transaction.ins.length !== unspents.length) {
+    throw new Error(`transaction inputs must match unspents`);
+  }
+  const prevOutputs = unspents.map((u) => toOutput(u, transaction.network));
+  const txBuilder = utxolib.bitgo.createTransactionBuilderFromTransaction(transaction, prevOutputs);
+
+  const signErrors: InputSigningError[] = unspents
+    .map((unspent: Unspent, inputIndex: number) => {
+      try {
+        if (isReplayProtectionUnspent(unspent, transaction.network)) {
+          debug('Skipping signature for input %d of %d (RP input?)', inputIndex + 1, transaction.ins.length);
+          return;
+        }
+        signWalletTransactionWithUnspent(txBuilder, inputIndex, unspent, walletSigner);
+        debug('Successfully signed input %d of %d', inputIndex + 1, transaction.ins.length);
+      } catch (e) {
+        return new InputSigningError(inputIndex, unspent, e);
+      }
+    })
+    .filter((e): e is InputSigningError => e !== undefined);
+
+  const signedTransaction = isLastSignature ? txBuilder.build() : txBuilder.buildIncomplete();
+
+  const verifyErrors: InputSigningError[] = signedTransaction.ins
+    .map((input, inputIndex) => {
+      const unspent = unspents[inputIndex] as Unspent;
+      try {
+        if (isReplayProtectionUnspent(unspent, transaction.network)) {
+          debug(
+            'Skipping input signature %d of %d (unspent from replay protection address which is platform signed only)',
+            inputIndex + 1,
+            transaction.ins.length
+          );
+          return;
+        }
+        const publicKey = deriveKey(walletSigner.signer, unspent.chain, unspent.index).publicKey;
+        if (!utxolib.bitgo.verifySignature(signedTransaction, inputIndex, unspent.value, { publicKey }, prevOutputs)) {
+          return new InputSigningError(inputIndex, unspent, new Error(`invalid signature`));
+        }
+      } catch (e) {
+        debug('Invalid signature');
+        return new InputSigningError(inputIndex, unspent, e);
+      }
+    })
+    .filter((e): e is InputSigningError => e !== undefined);
+
+  if (signErrors.length || verifyErrors.length) {
+    throw new TransactionSigningError(signErrors, verifyErrors);
+  }
+
+  return signedTransaction;
 }

--- a/modules/core/test/v2/unit/coins/utxo/util/index.ts
+++ b/modules/core/test/v2/unit/coins/utxo/util/index.ts
@@ -1,6 +1,6 @@
 export { defaultBitGo, utxoCoins, getUtxoCoin, getUtxoCoinForNetwork } from './utxoCoins';
 export { getFixture, shouldEqualJSON } from './fixtures';
-export { keychains, keychainsBase58, Triple, KeychainBase58 } from './keychains';
+export { keychains, keychainsBase58, KeychainBase58 } from './keychains';
 export { getUtxoWallet } from './wallet';
-export { InputScriptType, mockUnspent, mockUnspentReplayProtection, deriveKey } from './unspents';
+export { InputScriptType, mockUnspent, mockUnspentReplayProtection } from './unspents';
 export { createPrebuildTransaction, TransactionObj, transactionToObj, transactionHexToObj } from './transaction';

--- a/modules/core/test/v2/unit/coins/utxo/util/keychains.ts
+++ b/modules/core/test/v2/unit/coins/utxo/util/keychains.ts
@@ -3,7 +3,7 @@
  */
 import * as bip32 from 'bip32';
 import { WalletUnspentSigner } from '../../../../../../src/v2/coins/utxo/sign';
-export type Triple<T> = [T, T, T];
+import { Triple } from '../../../../../../src';
 
 export type KeychainBase58 = {
   pub: string;

--- a/modules/core/test/v2/unit/coins/utxo/util/unspents.ts
+++ b/modules/core/test/v2/unit/coins/utxo/util/unspents.ts
@@ -3,18 +3,15 @@
  */
 import * as bip32 from 'bip32';
 import * as utxolib from '@bitgo/utxo-lib';
-
-import { ReplayProtectionUnspent, Unspent, WalletUnspent } from '../../../../../../src/v2/coins/utxo/unspent';
-
-import { getSeed } from '../../../../../lib/keys';
-
-import { keychains, Triple } from './keychains';
-import { getReplayProtectionAddresses } from '../../../../../../src/v2/coins/utxo/replayProtection';
 import { Codes } from '@bitgo/unspents';
 
-export function deriveKey(k: bip32.BIP32Interface, chain: number, index: number): bip32.BIP32Interface {
-  return k.derivePath(`0/0/${chain}/${index}`);
-}
+import { getSeed } from '../../../../../lib/keys';
+import { Triple } from '../../../../../../src';
+import { deriveKey } from '../../../../../../src/v2/coins/utxo/sign';
+import { getReplayProtectionAddresses } from '../../../../../../src/v2/coins/utxo/replayProtection';
+import { ReplayProtectionUnspent, Unspent, WalletUnspent } from '../../../../../../src/v2/coins/utxo/unspent';
+
+import { keychains } from './keychains';
 
 export type InputScriptType = utxolib.bitgo.outputScripts.ScriptType2Of3 | 'replayProtection';
 

--- a/modules/core/test/v2/unit/wallet.ts
+++ b/modules/core/test/v2/unit/wallet.ts
@@ -2,7 +2,6 @@
 // Tests for Wallets
 //
 
-import * as assert from 'assert';
 import * as should from 'should';
 import * as sinon from 'sinon';
 require('should-sinon');
@@ -10,13 +9,10 @@ import '../lib/asserts';
 import * as nock from 'nock';
 import * as _ from 'lodash';
 
-import * as utxolib from '@bitgo/utxo-lib';
-
 import { Wallet } from '../../../src/';
 import * as common from '../../../src/common';
 
 import { TestBitGo } from '../../lib/test_bitgo';
-import { HalfSignedUtxoTransaction } from '../../../src';
 
 nock.disableNetConnect();
 
@@ -228,242 +224,6 @@ describe('V2 Wallet:', function () {
     });
   });
 
-  describe('Transaction Signature Verification', function () {
-    let wallet: Wallet;
-    let basecoin;
-
-    const userKeychain = {
-      prv: 'xprv9s21ZrQH143K3hekyNj7TciR4XNYe1kMj68W2ipjJGNHETWP7o42AjDnSPgKhdZ4x8NBAvaL72RrXjuXNdmkMqLERZza73oYugGtbLFXG8g',
-      pub: 'xpub661MyMwAqRbcGBjE5QG7pkf9cZD33UUD6K46q7ELrbuG7FqXfLNGiXYGHeEnGBb5AWREnk1eA28g8ArZvURbhshXWkTtddHRo54fgyVvLdb',
-      rawPub: '023636e68b7b204573abda2616aff6b584910dece2543f1cc6d842caac7d74974b',
-      rawPrv: '7438a50010ce7b1dfd86e68046cc78ba1ebd242d6d85d9904d3fcc08734bc172',
-    };
-    const backupKeychain = {
-      prv: 'xprv9s21ZrQH143K4NtHwJ6oHbJpUiLygwx1xpyD24wwYcVcPZ7LqEGHY58EfT3vgnQWAvkw6AQ4Gnw1fVN4fiem5gjMf4rKHC1HzYRsXERfjVa',
-      pub: 'xpub661MyMwAqRbcGrxm3KdoejFZ2kBU6QfsL3topTMZ6x2bGMSVNmaY5sSiWkNNK7QqShEWc5oeLVi74V8oMxr2uhCw1oRWMTCidLuPYVHHLzf',
-      rawPub: '03fae58eed086af828279a626ce2ad7ef6424b76fa0fb7e1c8da5a7de222b79203',
-      rawPrv: 'cda3fb304f1e7ac4e599361577767b52c6c04fdea8ca44c0e360e6a0de7027bd',
-    };
-    const prebuild = {
-      txHex: '01000000010fef30ca07288fb78659253227b8514ae9397faf76e53530118712d240bfb1060000000000ffffffff02255df4240000000017a9149799c321e46a9c7bb11835495a96d6ae31af36c58780c3c9010000000017a9144394c8c16c50397285830b449ceca588f5f359e98700000000',
-      txInfo: {
-        nP2SHInputs: 1,
-        nSegwitInputs: 0,
-        nOutputs: 2,
-        unspents: [
-          {
-            chain: 0,
-            index: 0,
-            redeemScript: '5221032c227d73891b33c45f5f02ab7eebdc4f4ed9ffb5565aedbfb478abb1bfd9d467210266824ac31b6a9d6568c3f7ced9aee1c720cd85994dd41d43dc63b0977195729e21037c07484a5d2d3831d38df1b7b45a2459df6fb40b204bbbf24e0f11763c79a50953ae',
-            id: '06b1bf40d21287113035e576af7f39e94a51b82732255986b78f2807ca30ef0f:0',
-            address: '2MzKPdDF127CNb5h3g3wNXGD7QMSrobKsvV',
-            value: 650000000,
-          },
-        ],
-        changeAddresses: [
-          '2N74pDqYayJq7PhtrvUvrt1t6ZX9C8ogUdk',
-        ],
-      },
-      feeInfo: {
-        size: 373,
-        fee: 5595,
-        feeRate: 15000,
-        payGoFee: 0,
-        payGoFeeString: '0',
-      },
-      walletId: '5a78dd561c6258a907f1eeaee132f796',
-    };
-    const signedTxHex = '02000000010fef30ca07288fb78659253227b8514ae9397faf76e53530118712d240bfb10600000000fdfd00004730440220140811e76ad440c863164a1f9c0956b7a7db17a29f3fe543576dd6279f975243022006ec7def583d18e8ac2de5bb7bf9c647b67d510c07fc7bdc2487ab06f08e3a684147304402205aa8e8646bc5fad6fda5565f8af5e304a5b5b7aa96690dc1562191365ba38a3202205ce0c8a7cbb3448ea4f6f69a8f4a1accae65021a0acc2d90292226c4615bb75b41004c695221032c227d73891b33c45f5f02ab7eebdc4f4ed9ffb5565aedbfb478abb1bfd9d467210266824ac31b6a9d6568c3f7ced9aee1c720cd85994dd41d43dc63b0977195729e21037c07484a5d2d3831d38df1b7b45a2459df6fb40b204bbbf24e0f11763c79a50953aeffffffff02255df4240000000017a9149799c321e46a9c7bb11835495a96d6ae31af36c58780c3c9010000000017a9144394c8c16c50397285830b449ceca588f5f359e98700000000';
-
-    before(async function () {
-      basecoin = bitgo.coin('tbch');
-      const walletData = {
-        id: '5a78dd561c6258a907f1eeaee132f796',
-        users: [
-          {
-            user: '543c11ed356d00cb7600000b98794503',
-            permissions: [
-              'admin',
-              'view',
-              'spend',
-            ],
-          },
-        ],
-        coin: 'tbch',
-        label: 'Signature Verification Wallet',
-        m: 2,
-        n: 3,
-        keys: [
-          '5a78dd56bfe424aa07aa068651b194fd',
-          '5a78dd5674a70eb4079f58797dfe2f5e',
-          '5a78dd561c6258a907f1eea9f1d079e2',
-        ],
-        tags: [
-          '5a78dd561c6258a907f1eeaee132f796',
-        ],
-        disableTransactionNotifications: false,
-        freeze: {},
-        deleted: false,
-        approvalsRequired: 1,
-        isCold: true,
-        coinSpecific: {},
-        admin: {
-          policy: {
-            id: '5a78dd561c6258a907f1eeaf50991950',
-            version: 0,
-            date: '2018-02-05T22:40:22.761Z',
-            mutableUpToDate: '2018-02-07T22:40:22.761Z',
-            rules: [],
-          },
-        },
-        clientFlags: [],
-        balance: 650000000,
-        confirmedBalance: 650000000,
-        spendableBalance: 650000000,
-        balanceString: '650000000',
-        confirmedBalanceString: '650000000',
-        spendableBalanceString: '650000000',
-        receiveAddress: {
-          id: '5a78de2bbfe424aa07aa131ec03c8dc1',
-          address: '2MyQZVquvjL3ZPBgD8cGdHRkHgfzNQFkVyF',
-          chain: 0,
-          index: 3,
-          coin: 'tbch',
-          wallet: '5a78dd561c6258a907f1eeaee132f796',
-          coinSpecific: {
-            redeemScript: '52210276cfa62b997cb3a9c53579a31bf004af4aab070343800285ee737da175c9af1121028cd41b3df3ad36256da33f470bd75d9b70f05d4f10351a2c9fc5d37d94c9909921038b919223eba3ab96f189465b1cb1904b9eaafa2cbe428d14a918fca659aa136a53ae',
-          },
-        },
-        pendingApprovals: [],
-      };
-      wallet = new Wallet(bitgo, basecoin, walletData);
-    });
-
-    it('should sign a prebuild', async function () {
-      // sign transaction
-      const halfSignedTransaction = await wallet.signTransaction({
-        txPrebuild: prebuild,
-        prv: userKeychain.prv,
-      }) as HalfSignedUtxoTransaction;
-      assert(halfSignedTransaction.txHex);
-      halfSignedTransaction.txHex.should.equal('02000000010fef30ca07288fb78659253227b8514ae9397faf76e53530118712d240bfb10600000000b6004730440220140811e76ad440c863164a1f9c0956b7a7db17a29f3fe543576dd6279f975243022006ec7def583d18e8ac2de5bb7bf9c647b67d510c07fc7bdc2487ab06f08e3a684100004c695221032c227d73891b33c45f5f02ab7eebdc4f4ed9ffb5565aedbfb478abb1bfd9d467210266824ac31b6a9d6568c3f7ced9aee1c720cd85994dd41d43dc63b0977195729e21037c07484a5d2d3831d38df1b7b45a2459df6fb40b204bbbf24e0f11763c79a50953aeffffffff02255df4240000000017a9149799c321e46a9c7bb11835495a96d6ae31af36c58780c3c9010000000017a9144394c8c16c50397285830b449ceca588f5f359e98700000000');
-
-      prebuild.txHex = halfSignedTransaction.txHex;
-      const signedTransaction = await wallet.signTransaction({
-        txPrebuild: prebuild,
-        prv: backupKeychain.prv,
-      }) as HalfSignedUtxoTransaction;
-      assert(signedTransaction.txHex);
-      signedTransaction.txHex.should.equal(signedTxHex);
-    });
-
-    it('should verify a signed transaction', async function () {
-      const unspent = prebuild.txInfo.unspents[0];
-      const signedTransaction = utxolib.bitgo.createTransactionFromHex(signedTxHex, basecoin.network);
-      const areSignaturesValid = basecoin.verifySignature(signedTransaction, 0, unspent.value);
-      areSignaturesValid.should.equal(true);
-
-      // mangle first signature
-      const sigScript = utxolib.script.decompile(signedTransaction.ins[0].script);
-      assert(sigScript);
-      sigScript.length.should.equal(5);
-      const firstSignature = sigScript[1] as Buffer;
-      const secondSignature = sigScript[2] as Buffer;
-      assert(firstSignature);
-      assert(secondSignature);
-      firstSignature.length.should.equal(71);
-      secondSignature.length.should.equal(71);
-
-      // mangle random byte of first signature (modifying too much could make the sig script become misclassified)
-      firstSignature[10] = 54;
-      sigScript[1] = firstSignature;
-      signedTransaction.ins[0].script = utxolib.script.compile(sigScript);
-
-      const areMangledSignaturesValid = basecoin.verifySignature(signedTransaction, 0, unspent.value);
-      areMangledSignaturesValid.should.equal(false);
-
-      const isFirstSignatureValid = basecoin.verifySignature(signedTransaction, 0, unspent.value, { signatureIndex: 0 });
-      isFirstSignatureValid.should.equal(false);
-
-      // the second signature remains unmodifed and should still be valid
-      const isSecondSignatureValid = basecoin.verifySignature(signedTransaction, 0, unspent.value, { signatureIndex: 1 });
-      isSecondSignatureValid.should.equal(true);
-
-      const isPublicKeySignatureValid = basecoin.verifySignature(signedTransaction, 0, unspent.value, { publicKey: '0266824ac31b6a9d6568c3f7ced9aee1c720cd85994dd41d43dc63b0977195729e' });
-      isPublicKeySignatureValid.should.equal(true);
-
-      const isSignatureMappedPublicKeySignatureValid = basecoin.verifySignature(signedTransaction, 0, unspent.value, { publicKey: '0266824ac31b6a9d6568c3f7ced9aee1c720cd85994dd41d43dc63b0977195729e', signatureIndex: 1 });
-      isSignatureMappedPublicKeySignatureValid.should.equal(true);
-
-      const isMismappedPublicKeySignatureValid = basecoin.verifySignature(signedTransaction, 0, unspent.value, { publicKey: '0266824ac31b6a9d6568c3f7ced9aee1c720cd85994dd41d43dc63b0977195729e', signatureIndex: 0 });
-      isMismappedPublicKeySignatureValid.should.equal(false);
-    });
-
-    it('should error eip1559 and gasPrice are passed', async function () {
-      const params = {
-        gasPrice: 100,
-        eip1559: {
-          maxPriorityFeePerGas: 10,
-          maxFeePerGas: 10,
-        },
-        amount: 10,
-        address: TestBitGo.V2.TEST_WALLET1_ADDRESS,
-        walletPassphrase: TestBitGo.V2.TEST_WALLET1_PASSCODE,
-      };
-      const error = await bitgo.getAsyncError(wallet.send(params));
-      should.exist(error);
-    });
-
-
-    it('should error when amount is zero', async function () {
-      const params = {
-        amount: 0,
-        address: TestBitGo.V2.TEST_WALLET1_ADDRESS,
-        walletPassphrase: TestBitGo.V2.TEST_WALLET1_PASSCODE,
-      };
-      (() => wallet.send(params)).should.throw(Error);
-    });
-
-    it('should error when amount is negative', async function () {
-      const params = {
-        amount: -1,
-        address: TestBitGo.V2.TEST_WALLET1_ADDRESS,
-        walletPassphrase: TestBitGo.V2.TEST_WALLET1_PASSCODE,
-      };
-      (() => wallet.send(params)).should.throw(Error);
-    });
-
-    it('should error when send many and amount is zero', async function () {
-      const params = {
-        recipients: [{
-          address: TestBitGo.V2.TEST_WALLET1_ADDRESS,
-          amount: 0,
-        }, {
-          address: TestBitGo.V2.TEST_WALLET2_ADDRESS,
-          amount: 10,
-        }],
-        walletPassphrase: TestBitGo.V2.TEST_WALLET1_PASSCODE,
-      };
-      const error = await bitgo.getAsyncError(wallet.sendMany(params));
-      should.exist(error);
-    });
-
-    it('should error when send many and amount is negative', async function () {
-      const params = {
-        recipients: [{
-          address: TestBitGo.V2.TEST_WALLET1_ADDRESS,
-          amount: 10,
-        }, {
-          address: TestBitGo.V2.TEST_WALLET2_ADDRESS,
-          amount: -1,
-        }],
-        walletPassphrase: TestBitGo.V2.TEST_WALLET1_PASSCODE,
-      };
-      const error = await bitgo.getAsyncError(wallet.sendMany(params));
-      should.exist(error);
-    });
-  });
-
   describe('Wallet Transactions', function () {
     let ethWallet;
 
@@ -478,6 +238,21 @@ describe('V2 Wallet:', function () {
         ],
       };
       ethWallet = new Wallet(bitgo, bitgo.coin('teth'), walletData);
+    });
+
+    it('should error eip1559 and gasPrice are passed', async function () {
+      const params = {
+        gasPrice: 100,
+        eip1559: {
+          maxPriorityFeePerGas: 10,
+          maxFeePerGas: 10,
+        },
+        amount: 10,
+        address: TestBitGo.V2.TEST_WALLET1_ADDRESS,
+        walletPassphrase: TestBitGo.V2.TEST_WALLET1_PASSCODE,
+      };
+      const error = await bitgo.getAsyncError(ethWallet.send(params));
+      should.exist(error);
     });
 
     it('should search for pending transaction correctly', async function () {


### PR DESCRIPTION
* Change AbstractUtxoCoin SignTransactionOptions to accept a `pubs`
string triple and cosignerPub string.
This makes it more consistent with the `prv` parameter which is also
a string.
* Add, use `signAndVerifyWalletTransaction()` method which wraps
`signWalletTransactionWithUnspent`

Issue: BG-38773