### PR TITLE
refactor(core): move encrypt/decrypt to separate file, add tests

### DIFF
--- a/modules/core/src/encrypt.ts
+++ b/modules/core/src/encrypt.ts
@@ -1,0 +1,48 @@
+import * as sjcl from './vendor/sjcl.min.js';
+import { randomBytes } from 'crypto';
+
+/**
+ * convert a 4 element Uint8Array to a 4 byte Number
+ *
+ * @param bytes
+ * @return 4 byte number
+ */
+export function bytesToWord(bytes?: Uint8Array | number[]): number {
+  if (!(bytes instanceof Uint8Array) || bytes.length !== 4) {
+    throw new Error('bytes must be a Uint8Array with length 4');
+  }
+
+  return bytes.reduce((num, byte) => num * 0x100 + byte, 0);
+}
+
+export function encrypt(password: string, plaintext: string, {
+  salt = randomBytes(8),
+  iv = randomBytes(16),
+} = {}): string {
+  if (salt.length !== 8) {
+    throw new Error(`salt must be 8 bytes`);
+  }
+  if (iv.length !== 16) {
+    throw new Error(`iv must be 16 bytes`);
+  }
+  const encryptOptions = {
+    iter: 10000,
+    ks: 256,
+    salt: [
+      bytesToWord(salt.slice(0, 4)),
+      bytesToWord(salt.slice(4)),
+    ],
+    iv: [
+      bytesToWord(iv.slice(0, 4)),
+      bytesToWord(iv.slice(4, 8)),
+      bytesToWord(iv.slice(8, 12)),
+      bytesToWord(iv.slice(12, 16)),
+    ],
+  };
+
+  return sjcl.encrypt(password, plaintext, encryptOptions);
+}
+
+export function decrypt(password: string, ciphertext: string): string {
+  return sjcl.decrypt(password, ciphertext);
+}

--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -664,7 +664,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
     let userPrv = userKeychain.prv;
     if (_.isEmpty(userPrv)) {
       const encryptedPrv = userKeychain.encryptedPrv;
-      if (!_.isEmpty(encryptedPrv)) {
+      if (encryptedPrv && !_.isEmpty(encryptedPrv)) {
         // if the decryption fails, it will throw an error
         userPrv = this.bitgo.decrypt({
           input: encryptedPrv,

--- a/modules/core/src/v2/internal/internal.ts
+++ b/modules/core/src/v2/internal/internal.ts
@@ -39,17 +39,3 @@ export function getFirstPendingTransaction(
     return bitgo.get(baseCoin.url('/tx/pending/first')).query(params).result();
   }).call(this);
 }
-
-/**
- * convert a 4 element Uint8Array to a 4 byte Number
- *
- * @param bytes
- * @return 4 byte number
- */
-export function bytesToWord(bytes?: Uint8Array): number {
-  if (!(bytes instanceof Uint8Array) || bytes.length !== 4) {
-    throw new Error('bytes must be a Uint8Array with length 4');
-  }
-
-  return bytes.reduce((num, byte) => num * 0x100 + byte, 0);
-}

--- a/modules/core/test/encrypt.ts
+++ b/modules/core/test/encrypt.ts
@@ -1,0 +1,106 @@
+/**
+ * @prettier
+ */
+import * as should from 'should';
+
+import { randomBytes } from 'crypto';
+import { decrypt, encrypt, bytesToWord } from '../src/encrypt';
+import { getSeed } from './lib/keys';
+
+describe('bytesToWord', () => {
+  it('should fail if input is not a Uint8Array', () => {
+    let inputArr: any = [0, 0, 0, 0];
+    (() => bytesToWord(inputArr)).should.throw();
+
+    inputArr = {};
+    (() => bytesToWord(inputArr)).should.throw();
+
+    inputArr = 'abc';
+    (() => bytesToWord(inputArr)).should.throw();
+  });
+
+  it('should fail if input is not exactly 4 elements', () => {
+    let inputArr = Uint8Array.of(0xff, 0xff, 0xff);
+    (() => bytesToWord(inputArr)).should.throw();
+
+    inputArr = Uint8Array.of(0xff, 0xff, 0xff, 0xff, 0xff);
+    (() => bytesToWord(inputArr)).should.throw();
+  });
+
+  it('should convert to 0', () => {
+    const inputArr = Uint8Array.of(0, 0, 0, 0);
+
+    const res = bytesToWord(inputArr);
+    res.should.equal(0);
+  });
+
+  it('should convert to 2 ^ 32 - 1', () => {
+    const inputArr = Uint8Array.of(0xff, 0xff, 0xff, 0xff);
+
+    const res = bytesToWord(inputArr);
+    res.should.equal(Math.pow(2, 32) - 1);
+  });
+
+  it('should convert to 2 ^ 16', () => {
+    const inputArr = Uint8Array.of(0x00, 0x01, 0x00, 0x00);
+
+    const res = bytesToWord(inputArr);
+    res.should.equal(Math.pow(2, 16));
+  });
+
+  it('should convert 1000 random numbers', () => {
+    for (let i = 0; i < 1000; i++) {
+      const inputArr = randomBytes(4);
+      const resStr = bytesToWord(inputArr).toString(16);
+      const arrStr = inputArr.toString('hex');
+      parseInt(resStr, 16).should.equal(parseInt(arrStr, 16));
+    }
+  });
+});
+
+describe('encrypt, decrypt', function () {
+  const passwords = Array.from({ length: 2 }).map((_, i) => `key/${i}`);
+  const plaintexts = Array.from({ length: 2 }).map((_, i) => `plaintext/${i}`);
+
+  it('matches fixture', function () {
+    const ciphertext = encrypt(passwords[0], plaintexts[0], {
+      salt: getSeed(`randomSalt`).slice(0, 8),
+      iv: getSeed(`randomIV`).slice(0, 16),
+    });
+    ciphertext.should.eql(
+      '{"iv":"BVDN1IpOeJ6E5kSV88MsHA==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"aJjlH+mKW1E=","ct":"loJEsFuypKZMZ+igqCUmbwQfMw=="}'
+    );
+    JSON.parse(ciphertext).should.eql({
+      adata: '',
+      cipher: 'aes',
+      ct: 'loJEsFuypKZMZ+igqCUmbwQfMw==',
+      iter: 10000,
+      iv: 'BVDN1IpOeJ6E5kSV88MsHA==',
+      ks: 256,
+      mode: 'ccm',
+      salt: 'aJjlH+mKW1E=',
+      ts: 64,
+      v: 1,
+    });
+  });
+
+  it('encrypts and decrypts', function () {
+    passwords.forEach((password) => {
+      plaintexts.forEach((plaintext) => {
+        const ciphertext1 = encrypt(password, plaintext);
+        const ciphertext2 = encrypt(password, plaintext);
+        (ciphertext1 === ciphertext2).should.eql(false);
+
+        [ciphertext1, ciphertext2].forEach((ct) => {
+          passwords.forEach((otherPassword) => {
+            if (password === otherPassword) {
+              decrypt(otherPassword, ct).should.eql(plaintext);
+            } else {
+              should.throws(() => decrypt(otherPassword, ct), /ccm: tag doesn't match/);
+            }
+          });
+        });
+      });
+    });
+  });
+});

--- a/modules/core/test/v2/unit/internal.ts
+++ b/modules/core/test/v2/unit/internal.ts
@@ -1,61 +1,9 @@
 import 'should';
 
-import { randomBytes } from 'crypto';
-import { bytesToWord } from '../../../src/v2/internal/internal';
 import * as bip32 from 'bip32';
 import { Util } from '../../../src/v2/internal/util';
 
 describe('Internal:', () => {
-  describe('bytesToWord', () => {
-    it('should fail if input is not a Uint8Array', () => {
-      let inputArr: any = [0, 0, 0, 0];
-      (() => bytesToWord(inputArr)).should.throw();
-
-      inputArr = {};
-      (() => bytesToWord(inputArr)).should.throw();
-
-      inputArr = 'abc';
-      (() => bytesToWord(inputArr)).should.throw();
-    });
-
-    it('should fail if input is not exactly 4 elements', () => {
-      let inputArr = Uint8Array.of(0xff, 0xff, 0xff);
-      (() => bytesToWord(inputArr)).should.throw();
-
-      inputArr = Uint8Array.of(0xff, 0xff, 0xff, 0xff, 0xff);
-      (() => bytesToWord(inputArr)).should.throw();
-    });
-
-    it('should convert to 0', () => {
-      const inputArr = Uint8Array.of(0, 0, 0, 0);
-
-      const res = bytesToWord(inputArr);
-      res.should.equal(0);
-    });
-
-    it('should convert to 2 ^ 32 - 1', () => {
-      const inputArr = Uint8Array.of(0xff, 0xff, 0xff, 0xff);
-
-      const res = bytesToWord(inputArr);
-      res.should.equal(Math.pow(2, 32) - 1);
-    });
-
-    it('should convert to 2 ^ 16', () => {
-      const inputArr = Uint8Array.of(0x00, 0x01, 0x00, 0x00);
-
-      const res = bytesToWord(inputArr);
-      res.should.equal(Math.pow(2, 16));
-    });
-
-    it('should convert 1000 random numbers', () => {
-      for (let i = 0; i < 1000; i++) {
-        const inputArr = randomBytes(4);
-        const resStr = bytesToWord(inputArr).toString(16);
-        const arrStr = inputArr.toString('hex');
-        parseInt(resStr, 16).should.equal(parseInt(arrStr, 16));
-      }
-    });
-  });
 
   describe('Util', function () {
     it('has working xpubToEthAddress', function () {


### PR DESCRIPTION
Accessing `encrypt`/`decrypt` via BitGo instance is annoying and
unintuitive.

The vendored sjcl library needs to be replaced with a regular
dependency. Add test fixtures to allow that.

Issue: BG-38773