### PR TITLE
fix(statics): use `utxolibName` instead of redefining constants

### DIFF
--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -42,6 +42,7 @@ export const coins = CoinMap.fromCoins([
   utxo('btc', 'Bitcoin', Networks.main.bitcoin, UnderlyingAsset.BTC),
   utxo('tbtc', 'Testnet Bitcoin', Networks.test.bitcoin, UnderlyingAsset.BTC),
   utxo('btg', 'Bitcoin Gold', Networks.main.bitcoinGold, UnderlyingAsset.BTG),
+  utxo('tbtg', 'Testnet Bitcoin Gold', Networks.test.bitcoinGold, UnderlyingAsset.BTG),
   utxo('ltc', 'Litecoin', Networks.main.litecoin, UnderlyingAsset.LTC),
   utxo('tltc', 'Testnet Litecoin', Networks.test.litecoin, UnderlyingAsset.LTC),
   utxo('dash', 'Dash', Networks.main.dash, UnderlyingAsset.DASH),

--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -157,11 +157,11 @@ class BitcoinGold extends Mainnet implements UtxoNetwork {
   explorerUrl = 'https://btgexplorer.com/tx/';
 }
 
-class BitcoinGoldTestnet extends Mainnet implements UtxoNetwork {
+class BitcoinGoldTestnet extends Testnet implements UtxoNetwork {
   name = 'BitcoinGoldTestnet';
   family = CoinFamily.BTG;
   utxolibName = 'bitcoingoldTestnet';
-  explorerUrl = 'https://btgexplorer.com/tx/';
+  explorerUrl = undefined;
 }
 
 class Dash extends Mainnet implements UtxoNetwork {

--- a/modules/statics/test/unit/coins.ts
+++ b/modules/statics/test/unit/coins.ts
@@ -1,13 +1,10 @@
 import 'should';
 import { CoinFamily, coins, Erc20Coin, EthereumNetwork, BaseNetwork } from '../../src';
-import { BitGo } from '../../../core';
 
 interface DuplicateCoinObject {
   name: string;
   network: BaseNetwork;
 }
-
-const bitGo = new BitGo({ env: 'test' });
 
 describe('ERC20 Coins', () => {
   it('should have no duplicate contract addresses', () => {
@@ -36,29 +33,5 @@ describe('ERC20 Coins', () => {
         acc[address] = { name: token.name, network: token.network };
         return acc;
       }, {});
-  });
-});
-
-describe('All Coins', () => {
-  it('should initialize all coins in statics', () => {
-    // will throw exception if we fail to init
-    coins.filter(coin => !coin.isToken && !['dot', 'tdot'].includes(coin.name)).forEach(coin => bitGo.coin(coin.name));
-  });
-  describe('Polkadot Mainnet', () => {
-    const dot = coins.get('dot');
-    dot.network.name.should.equal('Polkadot');
-    dot.network.type.should.equal('mainnet');
-    dot.network.family.should.equal('dot');
-    dot.decimalPlaces.should.equal(10);
-    dot.primaryKeyCurve.should.equal('ed25519');
-  });
-
-  describe('Polkadot Westend', () => {
-    const dot = coins.get('tdot');
-    dot.network.name.should.equal('Westend');
-    dot.network.type.should.equal('testnet');
-    dot.network.family.should.equal('dot');
-    dot.decimalPlaces.should.equal(12);
-    dot.primaryKeyCurve.should.equal('ed25519');
   });
 });


### PR DESCRIPTION
The network constants are already defined in utxolib, there is no need
to repeat them in `statics`.

Also add `BitcoinGoldTestnet`.

Sanity check:

```
» yarn ts-node -e '
import * as utxolib from "@bitgo/utxo-lib";
import { coins, UtxoCoin } from "./src";

for (const name in utxolib.networks) {
  console.log(
    name,
    coins
      .filter((coin => (coin as UtxoCoin).network.utxolibName === name))
      .map(coin => coin.name)
  );
}
'

bitcoin [ 'btc' ]
testnet [ 'tbtc' ]
bitcoincash [ 'bch', 'bcha' ]
bitcoincashTestnet [ 'tbch', 'tbcha' ]
bitcoingold [ 'btg' ]
bitcoingoldTestnet [ 'tbtg' ]
bitcoinsv [ 'bsv' ]
bitcoinsvTestnet [ 'tbsv' ]
dash [ 'dash' ]
dashTest [ 'tdash' ]
litecoin [ 'ltc' ]
litecoinTest [ 'tltc' ]
zcash [ 'zec' ]
zcashTest [ 'tzec' ]
```

Issue: BG-39753