### PR TITLE
fix(utxo-lib): do not throw on unsigned inputs

### DIFF
--- a/modules/utxo-lib/src/bitgo/signature.ts
+++ b/modules/utxo-lib/src/bitgo/signature.ts
@@ -439,6 +439,11 @@ export function getSignatureVerifications(
     throw new Error(`no input at index ${inputIndex}`);
   }
 
+  if ((!input.script || input.script.length === 0) && input.witness.length === 0) {
+    // Unsigned input: no signatures.
+    return [];
+  }
+
   const parsedScript = parseSignatureScript2Of3(input);
 
   const signatures = parsedScript.signatures

--- a/modules/utxo-lib/test/transaction_util.ts
+++ b/modules/utxo-lib/test/transaction_util.ts
@@ -123,6 +123,14 @@ export function getTransactionBuilder(
   return txBuilder;
 }
 
+export function getUnsignedTransaction2Of3(
+  keys: KeyTriple,
+  scriptType: ScriptType2Of3 | 'p2shP2pk',
+  network: Network
+): UtxoTransaction {
+  return getTransactionBuilder(keys, [], scriptType, network).buildIncomplete();
+}
+
 export function getHalfSignedTransaction2Of3(
   keys: KeyTriple,
   signer1: bip32.BIP32Interface,


### PR DESCRIPTION
Correctly handle unsigned inputs and return empty signature array.

Issue: BG-38773