### PR TITLE
feat(core): allow alphanumeric memoid for eos

### DIFF
--- a/modules/core/src/v2/coins/eos.ts
+++ b/modules/core/src/v2/coins/eos.ts
@@ -300,18 +300,7 @@ export class Eos extends BaseCoin {
    * @param memoId - the memo id to be checked
    */
   isValidMemoId(memoId: string): boolean {
-    if (!this.isValidMemo({ value: memoId })) {
-      return false;
-    }
-
-    let memoIdNumber;
-    try {
-      memoIdNumber = new BigNumber(memoId);
-    } catch (e) {
-      return false;
-    }
-
-    return memoIdNumber.gte(0);
+    return this.isValidMemo({ value: memoId });
   }
 
   /**

--- a/modules/core/test/v2/fixtures/coins/eos.ts
+++ b/modules/core/test/v2/fixtures/coins/eos.ts
@@ -430,11 +430,15 @@ export const EosResponses = {
   explainRefundOutput,
 } as const;
 
+const string257CharsLong =
+  '4WMNlu0fFU8N94AwukfpfPPQn2Myo80JdmLNF5rgeKAab9XLD93KUQipcT6US0LRwWWIGbUt89fjmdwpg3CBklNi8QIeBI2i8UDJCEuQKYobR5m4ismm1RooTXUnw5OPjmfLuuajYV4e5cS1jpC6hez5X43PZ5SsGaHNYX2YYXY03ir54cWWx5QW5VCPKPKUzfq2UYK5fjAG2Fe3xCUOzqgoR6KaAiuOOnDSyhZygLJyaoJpOXZM9olblNtAW75Ed';
+
 export const EosInputs = {
   explainTransactionInputChex,
   explainTransactionInputNative,
   explainUnstakeInput1,
   explainUnstakeInput2,
   explainRefundInput,
-  unsignedTransaction
+  unsignedTransaction,
+  string257CharsLong,
 } as const;

--- a/modules/core/test/v2/unit/coins/eos.ts
+++ b/modules/core/test/v2/unit/coins/eos.ts
@@ -1,3 +1,6 @@
+/**
+ * @prettier
+ */
 import * as should from 'should';
 import * as ecc from 'eosjs-ecc';
 import * as bip32 from 'bip32';
@@ -29,7 +32,9 @@ describe('EOS:', function () {
     addressDetails.address.should.equal('ks13k3hdui24');
     addressDetails.memoId.should.equal('1');
 
-    (() => { basecoin.getAddressDetails('ks13k3hdui24?memoId=1&memoId=2'); }).should.throw();
+    (() => {
+      basecoin.getAddressDetails('ks13k3hdui24?memoId=1&memoId=2');
+    }).should.throw();
   });
 
   it('should get address details with alphanumeric memoid', function () {
@@ -87,15 +92,13 @@ describe('EOS:', function () {
   it('isValidMemo should work', function () {
     basecoin.isValidMemo({ value: '1' }).should.equal(true);
     basecoin.isValidMemo({ value: 'uno' }).should.equal(true);
-    const string257CharsLong = '4WMNlu0fFU8N94AwukfpfPPQn2Myo80JdmLNF5rgeKAab9XLD93KUQipcT6US0LRwWWIGbUt89fjmdwpg3CBklNi8QIeBI2i8UDJCEuQKYobR5m4ismm1RooTXUnw5OPjmfLuuajYV4e5cS1jpC6hez5X43PZ5SsGaHNYX2YYXY03ir54cWWx5QW5VCPKPKUzfq2UYK5fjAG2Fe3xCUOzqgoR6KaAiuOOnDSyhZygLJyaoJpOXZM9olblNtAW75Ed';
-    basecoin.isValidMemo({ value: string257CharsLong }).should.equal(false);
+    basecoin.isValidMemo({ value: EosInputs.string257CharsLong }).should.equal(false);
   });
 
   it('isValidMemoId should work', function () {
     basecoin.isValidMemoId('1').should.equal(true);
     basecoin.isValidMemoId('123abc').should.equal(true);
-    const string257CharsLong = '4WMNlu0fFU8N94AwukfpfPPQn2Myo80JdmLNF5rgeKAab9XLD93KUQipcT6US0LRwWWIGbUt89fjmdwpg3CBklNi8QIeBI2i8UDJCEuQKYobR5m4ismm1RooTXUnw5OPjmfLuuajYV4e5cS1jpC6hez5X43PZ5SsGaHNYX2YYXY03ir54cWWx5QW5VCPKPKUzfq2UYK5fjAG2Fe3xCUOzqgoR6KaAiuOOnDSyhZygLJyaoJpOXZM9olblNtAW75Ed';
-    basecoin.isValidMemoId( string257CharsLong).should.equal(false);
+    basecoin.isValidMemoId(EosInputs.string257CharsLong).should.equal(false);
   });
 
   it('should validate pub key', () => {
@@ -117,35 +120,49 @@ describe('EOS:', function () {
       const seed = Buffer.from('c3b09c24731be2851b641d9d5b3f60fa129695c24071768d15654bea207b7bb6', 'hex');
       const keyPair = basecoin.generateKeyPair(seed);
 
-      keyPair.pub.should.equal('xpub661MyMwAqRbcF2SUqUMiqxWGwaVX6sH4okTtX8jxJ1A14wfL8W7jZEoNE537JqSESXFpTcXCZahPz7RKQLpAEGsVp233dc5CffLSecpU13X');
-      keyPair.prv.should.equal('xprv9s21ZrQH143K2YN1jSpiUpZYPYf2hQZDSXYHikLLjfd2C9LBaxoV1SUtNnZGnXeyJ6uFWMbQTfjXqVfgNqRBw5yyaCtBK1AM8PF3XZtKjQp');
+      keyPair.pub.should.equal(
+        'xpub661MyMwAqRbcF2SUqUMiqxWGwaVX6sH4okTtX8jxJ1A14wfL8W7jZEoNE537JqSESXFpTcXCZahPz7RKQLpAEGsVp233dc5CffLSecpU13X'
+      );
+      keyPair.prv.should.equal(
+        'xprv9s21ZrQH143K2YN1jSpiUpZYPYf2hQZDSXYHikLLjfd2C9LBaxoV1SUtNnZGnXeyJ6uFWMbQTfjXqVfgNqRBw5yyaCtBK1AM8PF3XZtKjQp'
+      );
     });
   });
 
   it('should create unsigned recovery transaction without Bitgo', async function () {
-    const userKey = 'xpub661MyMwAqRbcH1oUADxatLuKkVjaDB2zTNJoZQsGVQEvoogpbXJw24QMokNwFKj9Qhci6KWaCcQKrzpL4LCQXXX3YpTQxgD9KLBjhDrUWo4';
-    const backupKey = 'xpub661MyMwAqRbcH1n6sgY29G7dAxL7twS8rt1jyuuQb1kfnA7s3FJPGoVqb9JenXkeJmC4jZ8iVscn3AH6MkYAVc61FTYCHpxv5cxWar5Jw3C';
+    const userKey =
+      'xpub661MyMwAqRbcH1oUADxatLuKkVjaDB2zTNJoZQsGVQEvoogpbXJw24QMokNwFKj9Qhci6KWaCcQKrzpL4LCQXXX3YpTQxgD9KLBjhDrUWo4';
+    const backupKey =
+      'xpub661MyMwAqRbcH1n6sgY29G7dAxL7twS8rt1jyuuQb1kfnA7s3FJPGoVqb9JenXkeJmC4jZ8iVscn3AH6MkYAVc61FTYCHpxv5cxWar5Jw3C';
     const rootAddress = 'i1skda3kso43';
     const destinationAddress = 'ks13kdh245ls';
 
     // mock responses to the block chain
     const sandBox = sinon.createSandbox();
     const callBack = sandBox.stub(Eos.prototype, <any>'getDataFromNode');
-    callBack.withArgs({
-      endpoint: '/v1/chain/get_account',
-      payload: { account_name: rootAddress },
-    }).resolves(EosResponses.getAccountResponseSuccess1);
-    callBack.withArgs({
-      endpoint: '/v1/chain/get_account',
-      payload: { account_name: destinationAddress },
-    }).resolves(EosResponses.getAccountResponseSuccess2);
-    callBack.withArgs({
-      endpoint: '/v1/chain/get_info',
-    }).resolves(EosResponses.getInfoResponseSuccess1);
-    callBack.withArgs({
-      endpoint: '/v1/chain/get_block',
-      payload: { block_num_or_id: 191839472 },
-    }).resolves(EosResponses.getBlockResponseSuccess1);
+    callBack
+      .withArgs({
+        endpoint: '/v1/chain/get_account',
+        payload: { account_name: rootAddress },
+      })
+      .resolves(EosResponses.getAccountResponseSuccess1);
+    callBack
+      .withArgs({
+        endpoint: '/v1/chain/get_account',
+        payload: { account_name: destinationAddress },
+      })
+      .resolves(EosResponses.getAccountResponseSuccess2);
+    callBack
+      .withArgs({
+        endpoint: '/v1/chain/get_info',
+      })
+      .resolves(EosResponses.getInfoResponseSuccess1);
+    callBack
+      .withArgs({
+        endpoint: '/v1/chain/get_block',
+        payload: { block_num_or_id: 191839472 },
+      })
+      .resolves(EosResponses.getBlockResponseSuccess1);
 
     // can create unsigned recovery transaction
     const unsignedRecoveryTransaction = await basecoin.recover({
@@ -160,7 +177,9 @@ describe('EOS:', function () {
 
     // coin and txHex fields are expected during recovery of unsigned transaction using OVC
     unsignedRecoveryTransaction.coin.should.equal('teos');
-    unsignedRecoveryTransaction.txHex.should.equal('2a02a0053e5a8cf73a56ba0fda11e4d92e0238a4a2aa74fccf46d5a9107468408cdcdb60f03cf4a9e53c000000000100a6823403ea3055000000572d3ccdcd013008c5709804717000000000a8ed3232213008c57098047170806321a22538028650c300000000000004454f530000000000000000000000000000000000000000000000000000000000000000000000000000');
+    unsignedRecoveryTransaction.txHex.should.equal(
+      '2a02a0053e5a8cf73a56ba0fda11e4d92e0238a4a2aa74fccf46d5a9107468408cdcdb60f03cf4a9e53c000000000100a6823403ea3055000000572d3ccdcd013008c5709804717000000000a8ed3232213008c57098047170806321a22538028650c300000000000004454f530000000000000000000000000000000000000000000000000000000000000000000000000000'
+    );
 
     // destination address and root address can include memoId
     const unsignedRecoveryTransaction2 = await basecoin.recover({
@@ -175,17 +194,20 @@ describe('EOS:', function () {
 
     // coin and txHex fields are expected during recovery of unsigned transaction using OVC
     unsignedRecoveryTransaction.coin.should.equal('teos');
-    unsignedRecoveryTransaction.txHex.should.equal('2a02a0053e5a8cf73a56ba0fda11e4d92e0238a4a2aa74fccf46d5a9107468408cdcdb60f03cf4a9e53c000000000100a6823403ea3055000000572d3ccdcd013008c5709804717000000000a8ed3232213008c57098047170806321a22538028650c300000000000004454f530000000000000000000000000000000000000000000000000000000000000000000000000000');
+    unsignedRecoveryTransaction.txHex.should.equal(
+      '2a02a0053e5a8cf73a56ba0fda11e4d92e0238a4a2aa74fccf46d5a9107468408cdcdb60f03cf4a9e53c000000000100a6823403ea3055000000572d3ccdcd013008c5709804717000000000a8ed3232213008c57098047170806321a22538028650c300000000000004454f530000000000000000000000000000000000000000000000000000000000000000000000000000'
+    );
 
     sandBox.restore();
   });
 
   describe('Transactions:', function () {
-    const testExplainTransaction = (input, expectedOutput) => async function() {
-      const explainedTransaction = await basecoin.explainTransaction(input);
-      should.exist(explainedTransaction);
-      explainedTransaction.should.deepEqual(expectedOutput);
-    };
+    const testExplainTransaction = (input, expectedOutput) =>
+      async function () {
+        const explainedTransaction = await basecoin.explainTransaction(input);
+        should.exist(explainedTransaction);
+        explainedTransaction.should.deepEqual(expectedOutput);
+      };
     it('should generate a valid transaction signature', async function () {
       const signatureData = 'abcd';
       const tx = {
@@ -199,7 +221,7 @@ describe('EOS:', function () {
           packed_trx: signatureData,
           compression: 'none',
         },
-        recipients: [{ }],
+        recipients: [{}],
       };
 
       const seed = Buffer.from('c3b09c24731be2851b624d9d5b3f60fa129695c24071768d15654bea207b7bb6', 'hex');
@@ -220,7 +242,8 @@ describe('EOS:', function () {
           expiration: '2018-04-27T18:40:34.000Z',
         },
         transaction: {
-          packed_trx: 'a26ee35ae30364000000000000000100a6823403ea3055000000572d3ccdcd019013e48c8ce5eed400000000a8ed3232229013e48c8ce5eed4b012362b61b31236640000000000000004454f5300000000013100',
+          packed_trx:
+            'a26ee35ae30364000000000000000100a6823403ea3055000000572d3ccdcd019013e48c8ce5eed400000000a8ed3232229013e48c8ce5eed4b012362b61b31236640000000000000004454f5300000000013100',
         },
       };
 
@@ -232,16 +255,26 @@ describe('EOS:', function () {
       explainedTx.id.should.equal('6132f3bf4a746e6ecad8a31df67d71b4741fc5b7c868ae36dde18309a91df8a6');
       explainedTx.memo.should.equal('1');
     });
-    it('explains EOS native transfer transaction', testExplainTransaction(
-      EosInputs.explainTransactionInputNative, EosResponses.explainTransactionOutputNative));
-    it('explains CHEX token transfer transaction', testExplainTransaction(
-      EosInputs.explainTransactionInputChex, EosResponses.explainTransactionOutputChex));
-    it('explain EOS Unstake1 transaction', testExplainTransaction(
-      EosInputs.explainUnstakeInput1, EosResponses.explainUnstakeOutput1));
-    it('explain EOS Unstake2 transaction', testExplainTransaction(
-      EosInputs.explainUnstakeInput2, EosResponses.explainUnstakeOutput2));
-    it('explain EOS Refund transaction', testExplainTransaction(
-      EosInputs.explainRefundInput, EosResponses.explainRefundOutput));
+    it(
+      'explains EOS native transfer transaction',
+      testExplainTransaction(EosInputs.explainTransactionInputNative, EosResponses.explainTransactionOutputNative)
+    );
+    it(
+      'explains CHEX token transfer transaction',
+      testExplainTransaction(EosInputs.explainTransactionInputChex, EosResponses.explainTransactionOutputChex)
+    );
+    it(
+      'explain EOS Unstake1 transaction',
+      testExplainTransaction(EosInputs.explainUnstakeInput1, EosResponses.explainUnstakeOutput1)
+    );
+    it(
+      'explain EOS Unstake2 transaction',
+      testExplainTransaction(EosInputs.explainUnstakeInput2, EosResponses.explainUnstakeOutput2)
+    );
+    it(
+      'explain EOS Refund transaction',
+      testExplainTransaction(EosInputs.explainRefundInput, EosResponses.explainRefundOutput)
+    );
   });
 
   describe('Transaction Verification', function () {
@@ -259,11 +292,7 @@ describe('EOS:', function () {
         users: [
           {
             user: '543c11ed356d00cb7600000b98794503',
-            permissions: [
-              'admin',
-              'view',
-              'spend',
-            ],
+            permissions: ['admin', 'view', 'spend'],
           },
         ],
         coin: 'teos',
@@ -275,9 +304,7 @@ describe('EOS:', function () {
           '5a78dd5674a70eb4079f58797dfe2f5e',
           '5a78dd561c6258a907f1eea9f1d079e2',
         ],
-        tags: [
-          '5a78dd561c6258a907f1eeaee132f796',
-        ],
+        tags: ['5a78dd561c6258a907f1eeaee132f796'],
         disableTransactionNotifications: false,
         freeze: {},
         deleted: false,
@@ -323,10 +350,12 @@ describe('EOS:', function () {
           ref_block_num: 42915,
           ref_block_prefix: 1204086709,
         },
-        txHex: '2a02a0053e5a8cf73a56ba0fda11e4d92e0238a4a2aa74fccf46d5a9107468401e0c7a61a3a7b5e7c4470000000100408c7a02ea3055000000000085269d00030233330100a6823403ea3055000000572d3ccdcd0120ceb8437333427c00000000a8ed32322220ceb8437333427c20825019ab3ca98be80300000000000004454f53000000000131000000000000000000000000000000000000000000000000000000000000000000',
+        txHex:
+          '2a02a0053e5a8cf73a56ba0fda11e4d92e0238a4a2aa74fccf46d5a9107468401e0c7a61a3a7b5e7c4470000000100408c7a02ea3055000000000085269d00030233330100a6823403ea3055000000572d3ccdcd0120ceb8437333427c00000000a8ed32322220ceb8437333427c20825019ab3ca98be80300000000000004454f53000000000131000000000000000000000000000000000000000000000000000000000000000000',
         transaction: {
           compression: 'none',
-          packed_trx: '1e0c7a61a3a7b5e7c4470000000100408c7a02ea3055000000000085269d00030233330100a6823403ea3055000000572d3ccdcd0120ceb8437333427c00000000a8ed32322220ceb8437333427c20825019ab3ca98be80300000000000004454f5300000000013100',
+          packed_trx:
+            '1e0c7a61a3a7b5e7c4470000000100408c7a02ea3055000000000085269d00030233330100a6823403ea3055000000572d3ccdcd0120ceb8437333427c00000000a8ed32322220ceb8437333427c20825019ab3ca98be80300000000000004454f5300000000013100',
           signatures: [],
         },
         txid: '586c5b59b10b134d04c16ac1b273fe3c5529f34aef75db4456cd469c5cdac7e2',
@@ -353,21 +382,29 @@ describe('EOS:', function () {
         ],
       };
 
-      newTxPrebuild = () => { return _.cloneDeep(txPrebuild); };
-      newTxParams = () => { return _.cloneDeep(txParams); };
+      newTxPrebuild = () => {
+        return _.cloneDeep(txPrebuild);
+      };
+      newTxParams = () => {
+        return _.cloneDeep(txParams);
+      };
     });
 
     beforeEach(async () => {
       // mock responses to the block chain
       sandBox = sinon.createSandbox();
       const callBack = sandBox.stub(Eos.prototype, <any>'getDataFromNode');
-      callBack.withArgs({
-        endpoint: '/v1/chain/get_info',
-      }).resolves(EosResponses.getInfoResponseSuccess1);
-      callBack.withArgs({
-        endpoint: '/v1/chain/get_block',
-        payload: { block_num_or_id: 191839472 },
-      }).resolves(EosResponses.getBlockResponseSuccess1);
+      callBack
+        .withArgs({
+          endpoint: '/v1/chain/get_info',
+        })
+        .resolves(EosResponses.getInfoResponseSuccess1);
+      callBack
+        .withArgs({
+          endpoint: '/v1/chain/get_block',
+          payload: { block_num_or_id: 191839472 },
+        })
+        .resolves(EosResponses.getBlockResponseSuccess1);
     });
 
     afterEach(async () => {
@@ -381,7 +418,7 @@ describe('EOS:', function () {
       validTransaction.should.equal(true);
     });
 
-    it('should verify a transaction without a memoId', async function() {
+    it('should verify a transaction without a memoId', async function () {
       const txPrebuild = newTxPrebuild();
 
       // txParams with different txPrebuild
@@ -394,7 +431,7 @@ describe('EOS:', function () {
       validTransaction.should.equal(true);
     });
 
-    it('should throw if different prebuilds are provided in txParams and txPrebuild', async function() {
+    it('should throw if different prebuilds are provided in txParams and txPrebuild', async function () {
       const txPrebuild = newTxPrebuild();
 
       // txParams with different txPrebuild
@@ -403,47 +440,60 @@ describe('EOS:', function () {
       const txParams = newTxParams();
       txParams.txPrebuild = txPrebuild2;
 
-      await basecoin.verifyTransaction({ txParams, txPrebuild, wallet, verification }).should.be.rejectedWith('inputs txParams.txPrebuild and txPrebuild expected to be equal but were not');
+      await basecoin
+        .verifyTransaction({ txParams, txPrebuild, wallet, verification })
+        .should.be.rejectedWith('inputs txParams.txPrebuild and txPrebuild expected to be equal but were not');
     });
 
-    it('should throw if unpacked txHex is not the same as the unpacked packed_trx', async function() {
+    it('should throw if unpacked txHex is not the same as the unpacked packed_trx', async function () {
       const txPrebuild = newTxPrebuild();
-      txPrebuild.txHex = 'e70aaab8997e1dfce58fbfac80cbbb8fecec7b99cf9111111111111111111111111111111111640000000000000100408c7a02ea3055000000000085269d000201310100a6823403ea3055000000572d3ccdcd01d0f9ce64f437f7cf00000000a8ed323222d0f9ce64f437f7cfb012362b61b31236640000000000000004454f53000000000131000000000000000000000000000000000000000000000000000000000000000000';
+      txPrebuild.txHex =
+        'e70aaab8997e1dfce58fbfac80cbbb8fecec7b99cf9111111111111111111111111111111111640000000000000100408c7a02ea3055000000000085269d000201310100a6823403ea3055000000572d3ccdcd01d0f9ce64f437f7cf00000000a8ed323222d0f9ce64f437f7cfb012362b61b31236640000000000000004454f53000000000131000000000000000000000000000000000000000000000000000000000000000000';
       const txParams = newTxParams();
       txParams.txPrebuild = txPrebuild;
-      await basecoin.verifyTransaction({ txParams, txPrebuild, wallet, verification }).should.be.rejectedWith('unpacked packed_trx and unpacked txHex are not equal');
+      await basecoin
+        .verifyTransaction({ txParams, txPrebuild, wallet, verification })
+        .should.be.rejectedWith('unpacked packed_trx and unpacked txHex are not equal');
     });
 
-    it('should throw if the transaction headers are inconsistent', async function() {
+    it('should throw if the transaction headers are inconsistent', async function () {
       const txPrebuild = newTxPrebuild();
       const txParams = newTxParams();
       txParams.txPrebuild = txPrebuild;
       txParams.txPrebuild.headers.ref_block_prefix = 5;
-      await basecoin.verifyTransaction({ txParams, txPrebuild, wallet, verification }).should.be.rejectedWith('the transaction headers are inconsistent');
+      await basecoin
+        .verifyTransaction({ txParams, txPrebuild, wallet, verification })
+        .should.be.rejectedWith('the transaction headers are inconsistent');
     });
 
-    it('should throw if the expected amount is different than actual amount', async function() {
+    it('should throw if the expected amount is different than actual amount', async function () {
       const txPrebuild = newTxPrebuild();
       const txParams = newTxParams();
       txParams.recipients[0].amount = 10000;
-      await basecoin.verifyTransaction({ txParams, txPrebuild, wallet, verification }).should.be.rejectedWith('txHex receive amount does not match expected recipient amount');
+      await basecoin
+        .verifyTransaction({ txParams, txPrebuild, wallet, verification })
+        .should.be.rejectedWith('txHex receive amount does not match expected recipient amount');
     });
 
-    it('should throw if the expected recipient is different than actual recipient', async function() {
+    it('should throw if the expected recipient is different than actual recipient', async function () {
       const txPrebuild = newTxPrebuild();
       const txParams = newTxParams();
       txParams.recipients[0].address = 'aaaaaaaaaaaa';
-      await basecoin.verifyTransaction({ txParams, txPrebuild, wallet, verification }).should.be.rejectedWith('txHex receive address does not match expected recipient address');
+      await basecoin
+        .verifyTransaction({ txParams, txPrebuild, wallet, verification })
+        .should.be.rejectedWith('txHex receive address does not match expected recipient address');
     });
 
-    it('should throw if the expected memo is different than actual memo', async function() {
+    it('should throw if the expected memo is different than actual memo', async function () {
       const txPrebuild = newTxPrebuild();
       const txParams = newTxParams();
       txParams.recipients[0].address = 'lionteste212?memoId=10';
-      await basecoin.verifyTransaction({ txParams, txPrebuild, wallet, verification }).should.be.rejectedWith('txHex receive memoId does not match expected recipient memoId');
+      await basecoin
+        .verifyTransaction({ txParams, txPrebuild, wallet, verification })
+        .should.be.rejectedWith('txHex receive memoId does not match expected recipient memoId');
     });
 
-    it('should verify transaction with memo id in params only', async function() {
+    it('should verify transaction with memo id in params only', async function () {
       const txPrebuild = newTxPrebuild();
 
       txPrebuild.headers = {
@@ -452,18 +502,19 @@ describe('EOS:', function () {
         ref_block_prefix: 100,
       };
       // has memoid in the txaction with value of '1'
-      txPrebuild.txHex = 'e70aaab8997e1dfce58fbfac80cbbb8fecec7b99cf982a9444273cbc64c41473605d89610100640000000000000100408c7a02ea3055000000000085269d000201300100a6823403ea3055000000572d3ccdcd01001dd9f9a000a53d00000000a8ed323222001dd9f9a000a53d20825019ab3ca98be80300000000000004454f53000000000131000000000000000000000000000000000000000000000000000000000000000000';
-      txPrebuild.transaction.packed_trx = '605d89610100640000000000000100408c7a02ea3055000000000085269d000201300100a6823403ea3055000000572d3ccdcd01001dd9f9a000a53d00000000a8ed323222001dd9f9a000a53d20825019ab3ca98be80300000000000004454f5300000000013100';
+      txPrebuild.txHex =
+        'e70aaab8997e1dfce58fbfac80cbbb8fecec7b99cf982a9444273cbc64c41473605d89610100640000000000000100408c7a02ea3055000000000085269d000201300100a6823403ea3055000000572d3ccdcd01001dd9f9a000a53d00000000a8ed323222001dd9f9a000a53d20825019ab3ca98be80300000000000004454f53000000000131000000000000000000000000000000000000000000000000000000000000000000';
+      txPrebuild.transaction.packed_trx =
+        '605d89610100640000000000000100408c7a02ea3055000000000085269d000201300100a6823403ea3055000000572d3ccdcd01001dd9f9a000a53d00000000a8ed323222001dd9f9a000a53d20825019ab3ca98be80300000000000004454f5300000000013100';
       const txParams = newTxParams();
       txParams.recipients[0].address = 'lionteste212';
       txParams.txPrebuild = txPrebuild;
-
 
       const validTransaction = await basecoin.verifyTransaction({ txParams, txPrebuild, wallet, verification });
       validTransaction.should.equal(true);
     });
 
-    it('should verify transaction with alpha numeric memo id params', async function() {
+    it('should verify transaction with alpha numeric memo id params', async function () {
       const txPrebuild = newTxPrebuild();
 
       txPrebuild.headers = {
@@ -472,12 +523,13 @@ describe('EOS:', function () {
         ref_block_prefix: 100,
       };
       // has memoid in the txaction with value of 'QG73WAXXG'
-      txPrebuild.txHex = 'e70aaab8997e1dfce58fbfac80cbbb8fecec7b99cf982a9444273cbc64c41473866489610100640000000000000100408c7a02ea3055000000000085269d000201300100a6823403ea3055000000572d3ccdcd013085b943b1b54ed700000000a8ed32322a3085b943b1b54ed720825019ab3ca98be80300000000000004454f530000000009514737335741585847000000000000000000000000000000000000000000000000000000000000000000';
-      txPrebuild.transaction.packed_trx = '866489610100640000000000000100408c7a02ea3055000000000085269d000201300100a6823403ea3055000000572d3ccdcd013085b943b1b54ed700000000a8ed32322a3085b943b1b54ed720825019ab3ca98be80300000000000004454f53000000000951473733574158584700';
+      txPrebuild.txHex =
+        'e70aaab8997e1dfce58fbfac80cbbb8fecec7b99cf982a9444273cbc64c41473866489610100640000000000000100408c7a02ea3055000000000085269d000201300100a6823403ea3055000000572d3ccdcd013085b943b1b54ed700000000a8ed32322a3085b943b1b54ed720825019ab3ca98be80300000000000004454f530000000009514737335741585847000000000000000000000000000000000000000000000000000000000000000000';
+      txPrebuild.transaction.packed_trx =
+        '866489610100640000000000000100408c7a02ea3055000000000085269d000201300100a6823403ea3055000000572d3ccdcd013085b943b1b54ed700000000a8ed32322a3085b943b1b54ed720825019ab3ca98be80300000000000004454f53000000000951473733574158584700';
       const txParams = newTxParams();
       txParams.recipients[0].address = 'lionteste212';
       txParams.txPrebuild = txPrebuild;
-
 
       const validTransaction = await basecoin.verifyTransaction({ txParams, txPrebuild, wallet, verification });
       validTransaction.should.equal(true);

--- a/modules/core/test/v2/unit/coins/eos.ts
+++ b/modules/core/test/v2/unit/coins/eos.ts
@@ -29,15 +29,21 @@ describe('EOS:', function () {
     addressDetails.address.should.equal('ks13k3hdui24');
     addressDetails.memoId.should.equal('1');
 
-    (() => { basecoin.getAddressDetails('ks13k3hdui24?memoId=x'); }).should.throw();
     (() => { basecoin.getAddressDetails('ks13k3hdui24?memoId=1&memoId=2'); }).should.throw();
+  });
+
+  it('should get address details with alphanumeric memoid', function () {
+    const addressDetails = basecoin.getAddressDetails('i1skda3kso43?memoId=123abc');
+
+    addressDetails.address.should.equal('i1skda3kso43');
+    addressDetails.memoId.should.equal('123abc');
   });
 
   it('should validate address', function () {
     basecoin.isValidAddress('i1skda3kso43').should.equal(true);
     basecoin.isValidAddress('ks13kdh245ls').should.equal(true);
     basecoin.isValidAddress('ks13k3hdui24?memoId=1').should.equal(true);
-    basecoin.isValidAddress('ks13k3hdui24?memoId=x').should.equal(false);
+    basecoin.isValidAddress('ks13k3hdui24?memoId=x').should.equal(true);
   });
 
   it('verifyAddress should work', function () {
@@ -78,11 +84,18 @@ describe('EOS:', function () {
     }
   });
 
-  it('isValidMemoId should work', function () {
+  it('isValidMemo should work', function () {
     basecoin.isValidMemo({ value: '1' }).should.equal(true);
     basecoin.isValidMemo({ value: 'uno' }).should.equal(true);
     const string257CharsLong = '4WMNlu0fFU8N94AwukfpfPPQn2Myo80JdmLNF5rgeKAab9XLD93KUQipcT6US0LRwWWIGbUt89fjmdwpg3CBklNi8QIeBI2i8UDJCEuQKYobR5m4ismm1RooTXUnw5OPjmfLuuajYV4e5cS1jpC6hez5X43PZ5SsGaHNYX2YYXY03ir54cWWx5QW5VCPKPKUzfq2UYK5fjAG2Fe3xCUOzqgoR6KaAiuOOnDSyhZygLJyaoJpOXZM9olblNtAW75Ed';
     basecoin.isValidMemo({ value: string257CharsLong }).should.equal(false);
+  });
+
+  it('isValidMemoId should work', function () {
+    basecoin.isValidMemoId('1').should.equal(true);
+    basecoin.isValidMemoId('123abc').should.equal(true);
+    const string257CharsLong = '4WMNlu0fFU8N94AwukfpfPPQn2Myo80JdmLNF5rgeKAab9XLD93KUQipcT6US0LRwWWIGbUt89fjmdwpg3CBklNi8QIeBI2i8UDJCEuQKYobR5m4ismm1RooTXUnw5OPjmfLuuajYV4e5cS1jpC6hez5X43PZ5SsGaHNYX2YYXY03ir54cWWx5QW5VCPKPKUzfq2UYK5fjAG2Fe3xCUOzqgoR6KaAiuOOnDSyhZygLJyaoJpOXZM9olblNtAW75Ed';
+    basecoin.isValidMemoId( string257CharsLong).should.equal(false);
   });
 
   it('should validate pub key', () => {


### PR DESCRIPTION
There is a current use case where a custodial wallet
wants to send to an alphanumeric memoid for eos.

TICKET: BG-39825