### PR TITLE
chore: define explain transaction in account-lib

### DIFF
--- a/modules/account-lib/src/coin/baseCoin/baseTransaction.ts
+++ b/modules/account-lib/src/coin/baseCoin/baseTransaction.ts
@@ -1,5 +1,5 @@
 import { BaseCoin as CoinConfig } from '@bitgo/statics';
-import { BaseKey, Entry } from './iface';
+import { BaseKey, Entry, TransactionExplanation } from './iface';
 import { TransactionType } from './enum';
 
 /**
@@ -81,4 +81,14 @@ export abstract class BaseTransaction {
    * Return the transaction in a format it can be broadcasted to the blockchain.
    */
   abstract toBroadcastFormat(): any;
+
+  /**
+   * Explain/parse a given coin transaction.
+   *
+   * TODO: Move all previous explainTransactions from 'core' to 'account-lib' for other coins,
+   * TODO: convert to abstract
+   */
+  explainTransaction(): TransactionExplanation {
+    throw new Error('explainTransaction is not implemented');
+  }
 }

--- a/modules/account-lib/src/coin/baseCoin/iface.ts
+++ b/modules/account-lib/src/coin/baseCoin/iface.ts
@@ -87,3 +87,26 @@ export interface Entry extends BaseAddress {
 export interface BaseFee {
   fee: string;
 }
+
+export interface TransactionRecipient {
+  address: string;
+  amount: string | number;
+  memo?: string;
+}
+
+export interface TransactionFee {
+  fee: string;
+  feeRate?: number;
+  size?: number;
+  type?: string;
+}
+
+export interface TransactionExplanation {
+  displayOrder: string[];
+  id: string;
+  outputs: TransactionRecipient[];
+  outputAmount: string;
+  changeOutputs: TransactionRecipient[];
+  changeAmount: string;
+  fee: TransactionFee;
+}


### PR DESCRIPTION
part of standardization effort, we want to move explainTransaction
implementation from core to account-lib.

this adds the interfaces and function to baseCoin.

Ticket: BG-00000