### PR TITLE
test(core): move bespoke btc tests to utxo/custom

### DIFF
--- a/modules/core/test/v2/unit/coins/utxo/custom/btc.ts
+++ b/modules/core/test/v2/unit/coins/utxo/custom/btc.ts
@@ -1,7 +1,7 @@
 import 'should';
 
-import { TestBitGo } from '../../../lib/test_bitgo';
-import { Btc } from '../../../../src/v2/coins';
+import { TestBitGo } from '../../../../../lib/test_bitgo';
+import { Btc } from '../../../../../../src/v2/coins';
 
 describe('BTC:', function () {
   let bitgo;


### PR DESCRIPTION
There are now no custom one-off utxo tests in `unit/coins`.

Issue: BG-35154