### PR TITLE
feat(sol): initial implementation of explain transaction

### DIFF
--- a/modules/account-lib/src/coin/baseCoin/baseTransaction.ts
+++ b/modules/account-lib/src/coin/baseCoin/baseTransaction.ts
@@ -1,5 +1,5 @@
 import { BaseCoin as CoinConfig } from '@bitgo/statics';
-import { BaseKey, Entry } from './iface';
+import { BaseKey, Entry, TransactionExplanation } from './iface';
 import { TransactionType } from './enum';
 
 /**
@@ -81,4 +81,14 @@ export abstract class BaseTransaction {
    * Return the transaction in a format it can be broadcasted to the blockchain.
    */
   abstract toBroadcastFormat(): any;
+
+  /**
+   * Explain/parse a given coin transaction.
+   *
+   * TODO: Move all previous explainTransactions from 'core' to 'account-lib' for other coins,
+   * TODO: convert to abstract
+   */
+  explainTransaction(): TransactionExplanation {
+    throw new Error('explainTransaction is not implemented');
+  }
 }

--- a/modules/account-lib/src/coin/baseCoin/iface.ts
+++ b/modules/account-lib/src/coin/baseCoin/iface.ts
@@ -87,3 +87,36 @@ export interface Entry extends BaseAddress {
 export interface BaseFee {
   fee: string;
 }
+
+export interface TransactionRecipient {
+  address: string;
+  amount: string | number;
+  memo?: string;
+}
+
+export interface TransactionFee {
+  fee: string;
+  feeRate?: number;
+  size?: number;
+  type?: string;
+}
+
+export interface TransactionOutputs {
+  outputs: TransactionRecipient[];
+  outputAmount: string;
+}
+
+export interface TransactionChanges {
+  changeOutputs: TransactionRecipient[];
+  changeAmount: string;
+}
+
+export interface TransactionExplanation {
+  displayOrder: string[];
+  id: string;
+  outputs: TransactionRecipient[];
+  outputAmount: string;
+  changeOutputs: TransactionRecipient[];
+  changeAmount: string;
+  fee: TransactionFee;
+}

--- a/modules/account-lib/src/coin/sol/iface.ts
+++ b/modules/account-lib/src/coin/sol/iface.ts
@@ -1,5 +1,6 @@
 import { Blockhash, SystemInstructionType, TransactionSignature } from '@solana/web3.js';
 import { InstructionBuilderTypes } from './constants';
+import { TransactionExplanation as BaseTransactionExplanation } from '../baseCoin/iface';
 
 // TODO(STLX-9890): Add the interfaces for validityWindow, feeOptions and SequenceId
 export interface SolanaKeys {
@@ -43,3 +44,11 @@ export interface Transfer {
 }
 
 export type ValidInstructionTypes = SystemInstructionType | 'Memo';
+
+export interface TransactionExplanation extends BaseTransactionExplanation {
+  type: string;
+  blockhash: Blockhash;
+  // only populated if blockhash is from a nonce account
+  durableNonce?: DurableNonceParams;
+  memo?: string;
+}


### PR DESCRIPTION
partially implements explain transaction for solana.
does not handle fees or transaction ids correctly.

Ticket: STLX-8791

Note: follows new standardized pattern, where implementation is in account-lib.
See Dot PR for reference: https://github.com/BitGo/BitGoJS/pull/1723/files