### PR TITLE
fix(core): use wallet keys in explainTransaction

### DIFF
--- a/modules/core/src/v2/coins/utxo/sign.ts
+++ b/modules/core/src/v2/coins/utxo/sign.ts
@@ -107,17 +107,16 @@ export function verifyWalletTransactionWithUnspents(
   if (tx.ins.length !== unspents.length) {
     throw new Error(`input length must match unspents length`);
   }
-  const prevOutputs = unspents.map((u) => toOutput(u, tx.network));
   const unspent = unspents[inputIndex];
   if (!isWalletUnspent(unspent)) {
     return [false, false, false];
   }
-  const verifications = utxolib.bitgo.getSignatureVerifications(tx, inputIndex, unspent.value, {}, prevOutputs);
-  return walletKeys
-    .deriveForChainAndIndex(unspent.chain, unspent.index)
-    .publicKeys.map(
-      (publicKey) => !!verifications.find((s) => s.signedBy && s.signedBy.equals(publicKey))
-    ) as Triple<boolean>;
+  return utxolib.bitgo.verifySignatureWithPublicKeys(
+    tx,
+    inputIndex,
+    unspents.map((u) => toOutput(u, tx.network)),
+    walletKeys.deriveForChainAndIndex(unspent.chain, unspent.index).publicKeys
+  ) as Triple<boolean>;
 }
 
 export class InputSigningError extends Error {

--- a/modules/core/src/v2/coins/utxo/sign.ts
+++ b/modules/core/src/v2/coins/utxo/sign.ts
@@ -96,7 +96,7 @@ export function signWalletTransactionWithUnspent(
  * @param inputIndex
  * @param unspents
  * @param walletKeys
- * @return signature verification result for each key
+ * @return triple of booleans indicating a valid signature for each pubkey
  */
 export function verifyWalletTransactionWithUnspents(
   tx: utxolib.bitgo.UtxoTransaction,

--- a/modules/core/test/v2/unit/coins/utxo/transaction.ts
+++ b/modules/core/test/v2/unit/coins/utxo/transaction.ts
@@ -24,7 +24,12 @@ import {
   getDefaultWalletKeys,
 } from './util';
 
-import { FullySignedTransaction, HalfSignedUtxoTransaction, WalletSignTransactionOptions } from '../../../../../src';
+import {
+  FullySignedTransaction,
+  HalfSignedUtxoTransaction,
+  Triple,
+  WalletSignTransactionOptions,
+} from '../../../../../src';
 
 function run(coin: AbstractUtxoCoin, inputScripts: InputScriptType[]) {
   describe(`Transaction Stages ${coin.getChain()} scripts=${inputScripts.join(',')}`, function () {
@@ -207,6 +212,7 @@ function run(coin: AbstractUtxoCoin, inputScripts: InputScriptType[]) {
           txInfo: {
             unspents: getUnspents(),
           },
+          pubs: walletKeys.triple.map((k) => k.neutered().toBase58()) as Triple<string>,
         });
 
         explanation.should.have.properties(

--- a/modules/utxo-lib/src/bitgo/signature.ts
+++ b/modules/utxo-lib/src/bitgo/signature.ts
@@ -581,7 +581,7 @@ function isSignatureByPublicKey(v: SignatureVerification, publicKey: Buffer): bo
  * @param inputIndex
  * @param prevOutputs - transaction outputs for inputs
  * @param publicKeys - public keys to check signatures for
- * @return array with signature verification result for each public key in publicKeys
+ * @return array of booleans indicating a valid signature for every pubkey in _publicKeys_
  */
 export function verifySignatureWithPublicKeys(
   transaction: UtxoTransaction,
@@ -610,6 +610,7 @@ export function verifySignatureWithPublicKeys(
  * @param inputIndex
  * @param prevOutputs
  * @param publicKey
+ * @return true iff signature is valid
  */
 export function verifySignatureWithPublicKey(
   transaction: UtxoTransaction,

--- a/modules/utxo-lib/src/bitgo/signature.ts
+++ b/modules/utxo-lib/src/bitgo/signature.ts
@@ -399,7 +399,7 @@ export type VerificationSettings = {
    */
   signatureIndex?: number;
   /**
-   * The hex of the public key to verify.
+   * The public key to verify.
    */
   publicKey?: Buffer;
 };
@@ -413,6 +413,7 @@ export type SignatureVerification = {
 };
 
 /**
+ * @deprecated - use {@see verifySignaturesWithPublicKeys} instead
  * Get signature verifications for multsig transaction
  * @param transaction
  * @param inputIndex
@@ -528,6 +529,7 @@ export function getSignatureVerifications(
 }
 
 /**
+ * @deprecated use {@see verifySignatureWithPublicKeys} instead
  * @param transaction
  * @param inputIndex
  * @param amount
@@ -558,6 +560,64 @@ export function verifySignature(
   );
 
   return signatureVerifications.length > 0 && signatureVerifications.every((v) => v.signedBy !== undefined);
+}
+
+/**
+ * @param v
+ * @param publicKey
+ * @return true iff signature is by publicKey (or xonly variant of publicKey)
+ */
+function isSignatureByPublicKey(v: SignatureVerification, publicKey: Buffer): boolean {
+  return (
+    !!v.signedBy &&
+    (v.signedBy.equals(publicKey) ||
+      /* for p2tr signatures, we pass the pubkey in 33-byte format recover it from the signature in 32-byte format */
+      (publicKey.length === 33 && isSignatureByPublicKey(v, publicKey.slice(1))))
+  );
+}
+
+/**
+ * @param transaction
+ * @param inputIndex
+ * @param prevOutputs - transaction outputs for inputs
+ * @param publicKeys - public keys to check signatures for
+ * @return array with signature verification result for each public key in publicKeys
+ */
+export function verifySignatureWithPublicKeys(
+  transaction: UtxoTransaction,
+  inputIndex: number,
+  prevOutputs: TxOutput[],
+  publicKeys: Buffer[]
+): boolean[] {
+  if (transaction.ins.length !== prevOutputs.length) {
+    throw new Error(`input length must match prevOutputs length`);
+  }
+
+  const signatureVerifications = getSignatureVerifications(
+    transaction,
+    inputIndex,
+    prevOutputs[inputIndex].value,
+    {},
+    prevOutputs
+  );
+
+  return publicKeys.map((publicKey) => !!signatureVerifications.find((v) => isSignatureByPublicKey(v, publicKey)));
+}
+
+/**
+ * Wrapper for {@see verifySignatureWithPublicKeys} for single pubkey
+ * @param transaction
+ * @param inputIndex
+ * @param prevOutputs
+ * @param publicKey
+ */
+export function verifySignatureWithPublicKey(
+  transaction: UtxoTransaction,
+  inputIndex: number,
+  prevOutputs: TxOutput[],
+  publicKey: Buffer
+): boolean {
+  return verifySignatureWithPublicKeys(transaction, inputIndex, prevOutputs, [publicKey])[0];
 }
 
 export function signInputP2shP2pk(txBuilder: UtxoTransactionBuilder, vin: number, keyPair: bip32.BIP32Interface): void {


### PR DESCRIPTION
We want to know that a transaction was signed by the wallet keys.

Issue: BG-38773