### PR TITLE
add light copyedit to account-lib docs

### DIFF
--- a/modules/account-lib/DEVELOPER.md
+++ b/modules/account-lib/DEVELOPER.md
@@ -1,6 +1,7 @@
 # Developer Guide
 
-Thanks for contributing to this library. Below are some tips to help you understand:
+Thanks for contributing to this library. Below are some tips to help you
+understand:
 
 - the structure of the project
 - the important classes and how they are used
@@ -11,12 +12,15 @@ Thanks for contributing to this library. Below are some tips to help you underst
 
 ### Base Classes
 
-As specified in [the project README](README.md), there are two main classes that users will interact with:
+As specified in [the project README](README.md), there are two main classes that
+users will interact with:
 
-- `TransactionBuilder`: A class that implements coin specific logic to handle the construction, validation, and signing of blockchain transactions.
+- `TransactionBuilder`: A class that implements coin specific logic to handle
+  the construction, validation, and signing of blockchain transactions.
 - `Transaction`: JavaScript representations of blockchain transactions.
 
-The `TransactionBuilder`'s job is to build and sign `transactions` for a specific blockchain.
+The `TransactionBuilder`'s job is to build and sign `transactions` for a
+specific blockchain.
 
 The flow typically looks something like:
 
@@ -42,19 +46,31 @@ const signedTxJson = tx.toJson();
 
 ### Coin Specific Implementations
 
-If you have spent time poking around the project, you likely noticed that we have base `TransactionBuilder` and base `Transaction` classes - they live in `src/coin/baseCoin`. These classes define the core interfaces that all subclasses will extend and implement.
+If you have spent time poking around the project, you likely noticed that we
+have base `TransactionBuilder` and base `Transaction` classes - they live in
+`src/coin/baseCoin`. These classes define the core interfaces that all
+subclasses will extend and implement.
 
-Coin specific implementations of the `TransactionBuilder` and `Transaction` classes live under the coin's ticker symbol in `src/coin` (ie: `src/coin/trx` for Tron). This is where the meat of the signing, validation, and encoding logic lives for each blockchain supported by the library.
+Coin specific implementations of the `TransactionBuilder` and `Transaction`
+classes live under the coin's ticker symbol in `src/coin` (ie: `src/coin/trx`
+for Tron). This is where the meat of the signing, validation, and encoding logic
+lives for each blockchain supported by the library.
 
 We recommend that you follow this pattern when adding a new coin to the library:
 
 ### Test Structure
 
-Accoutn Lib comes with unit tests and it is expected that all changes introduced to the library increase test coverage. Tests live in `test`. Coin specific tests live in `test/unit/coin/<coin-ticker>/<coin-ticker.js>`.
+Account Lib comes with unit tests and it is expected that all changes introduced
+to the library increase test coverage. Tests live in `test`. Coin specific tests
+live in `test/unit/coin/<coin-ticker>/<coin-ticker.js>`.
 
 ## (External) Resources
 
-There are situations in which this library requires upstream dependencies, but you might not want to pull in the entire library only to use the tiny slice of functionality that we require. Rather, you can take snippets of the external code and stick them in `resources/`. See [the README in that directory for more information](resources/README.md).
+There are situations in which this library requires upstream dependencies, but
+you might not want to pull in the entire library only to use the tiny slice of
+functionality that we require. Rather, you can take snippets of the external
+code and stick them in `resources/`. See
+[the README in that directory for more information](resources/README.md).
 
 ## Running Tests
 
@@ -66,8 +82,12 @@ npm test
 
 ## Coding Norms & Expectations
 
-When contributing, we recommend that you follow the existing patterns defined in the project. Pull requests that break these norms will likely be rejected or require a round of feedback.
+When contributing, we recommend that you follow the existing patterns defined in
+the project. Pull requests that break these norms will likely be rejected or
+require a round of feedback.
 
 Take note:
 
-> Do not specify default accessors. In Typescript, the default accessor for a class attribute is `public`, so specifying it for functions and attributes is redundant.
+> Do not specify default accessors. In Typescript, the default accessor for a
+> class attribute is `public`, so specifying it for functions and attributes is
+> redundant.

--- a/modules/account-lib/DEVELOPER.md
+++ b/modules/account-lib/DEVELOPER.md
@@ -1,20 +1,22 @@
 # Developer Guide
+
 Thanks for contributing to this library. Below are some tips to help you understand:
-* the structure of the project
-* the important classes and how they are used
-* how to run the test suite
-* how to contribute to the project
+
+- the structure of the project
+- the important classes and how they are used
+- how to run the test suite
+- how to contribute to the project
 
 ## Project Architecture
 
-
 ### Base Classes
+
 As specified in [the project README](README.md), there are two main classes that users will interact with:
 
-* `TransactionBuilder`: A class that implements coin specific logic to handle the construction, validation, and signing of blockchain transactions.
-* `Transaction`: Javascript representations of blockchain transactions.
+- `TransactionBuilder`: A class that implements coin specific logic to handle the construction, validation, and signing of blockchain transactions.
+- `Transaction`: JavaScript representations of blockchain transactions.
 
-The `TransactionBuilder`'s job is to build + sign `transactions` for a specific blockchain.
+The `TransactionBuilder`'s job is to build and sign `transactions` for a specific blockchain.
 
 The flow typically looks something like:
 
@@ -39,20 +41,23 @@ const signedTxJson = tx.toJson();
 ```
 
 ### Coin Specific Implementations
+
 If you have spent time poking around the project, you likely noticed that we have base `TransactionBuilder` and base `Transaction` classes - they live in `src/coin/baseCoin`. These classes define the core interfaces that all subclasses will extend and implement.
 
 Coin specific implementations of the `TransactionBuilder` and `Transaction` classes live under the coin's ticker symbol in `src/coin` (ie: `src/coin/trx` for Tron). This is where the meat of the signing, validation, and encoding logic lives for each blockchain supported by the library.
 
-It is recommended to follow this pattern when adding a new coin to the library.
+We recommend that you follow this pattern when adding a new coin to the library:
 
 ### Test Structure
-This library comes with unit tests and it is expected that all changes introduced to the library increase test coverage. Tests live in `test`. Coin specific tests live in `test/unit/coin/<coin-ticker>/<coin-ticker.js>`.
 
+Accoutn Lib comes with unit tests and it is expected that all changes introduced to the library increase test coverage. Tests live in `test`. Coin specific tests live in `test/unit/coin/<coin-ticker>/<coin-ticker.js>`.
 
 ## (External) Resources
-There are situations in which this library requires upstream dependencies, but we don't want to pull in the entire library in order to use the tiny slice of functionality that we require. In these cases, we take snippets of that external code and stick them in `resources/`. See [the README in that directory for more information](resources/README.md).
+
+There are situations in which this library requires upstream dependencies, but you might not want to pull in the entire library only to use the tiny slice of functionality that we require. Rather, you can take snippets of the external code and stick them in `resources/`. See [the README in that directory for more information](resources/README.md).
 
 ## Running Tests
+
 To run the test suite locally:
 
 ```
@@ -60,7 +65,9 @@ npm test
 ```
 
 ## Coding Norms & Expectations
-When contributing, it is recommended that you follow the existing patterns defined in the project. Pull requests that break these norms will likely be rejected or require a round of feedback. A few specific notes:
 
-- Do not specify default accessors. In Typescript, the default accessor for a class attribute is
-`public`, so specifying it for functions and attributes is redundant.
+When contributing, we recommend that you follow the existing patterns defined in the project. Pull requests that break these norms will likely be rejected or require a round of feedback.
+
+Take note:
+
+> Do not specify default accessors. In Typescript, the default accessor for a class attribute is `public`, so specifying it for functions and attributes is redundant.

--- a/modules/account-lib/README.md
+++ b/modules/account-lib/README.md
@@ -5,8 +5,7 @@ account-based coins (for example, Ethereum, Algorand, EOS, Tron, etc.). Account
 Lib was developed for BitGo and BitGo's multi-sig wallets, but it can also be
 used independently, outside of our wallet ecosystem.
 
-> Account Lib was intended to be used in an offline environment, for offline
-> signings.
+> Account Lib can be used in an offline environment.
 
 ## Supported Coins
 
@@ -43,31 +42,23 @@ network.
 
 #### Transaction Types
 
-The `TransactionBuilder` supports the following transaction types:
+`TransactionBuilder` supports the following transaction types:
 
-- [Send](#send)
-- [Wallet Initialization](#wallet-initialization)
-- [Address Initialization](#address-initialization)
-- [Account Update](#account-update)
+- **Send**: Transfers funds from a wallet.
 
-##### Send
+- **Wallet Initialization**: Initializes a wallet's account on the network
+  (e.g., multi-sig contract deployment).
 
-Transfers funds from a wallet.
+- **Address Initialization**: Initializes a wallet's address on the network
+  (e.g., forwarder contract deployment).
 
-##### Wallet Initialization
+- **Account Update**: Updates an account on the network (e.g., public key
+  revelation operation for Tezos).
 
-Initializes a wallet's account on the network (e.g., multi-sig contract
-deployment).
+### Offline Availability
 
-##### Address Initialization
-
-Initializes a wallet's address on the network (e.g., forwarder contract
-deployment).
-
-##### Account Update
-
-Updates an account on the network (e.g., public key revelation operation for
-Tezos).
+Account Lib was designed to be used for offline signings in an offline
+environment.
 
 ---
 

--- a/modules/account-lib/README.md
+++ b/modules/account-lib/README.md
@@ -1,12 +1,17 @@
 # BitGo Account Lib
 
-This library is responsible for building and signing transactions for account-based coins (for example, Ethereum, Algorand, EOS, Tron, etc.). Account Lib was developed for BitGo and BitGo's multi-sig wallets, but it can also be used independently, outside of our wallet ecosystem.
+This library is responsible for building and signing transactions for
+account-based coins (for example, Ethereum, Algorand, EOS, Tron, etc.). Account
+Lib was developed for BitGo and BitGo's multi-sig wallets, but it can also be
+used independently, outside of our wallet ecosystem.
 
-> Account lib was intended to be used in an offline environment, for offline signings.
+> Account Lib was intended to be used in an offline environment, for offline
+> signings.
 
 ## Supported Coins
 
-Below is the list of coins supported by this library -- as well as those that are on the roadmap.
+Below is the list of coins supported by this library -- as well as those that
+are on the roadmap.
 
 | Coin             | Mainnet Ticker | Testnet Ticker | Supported In Library |
 | :--------------- | :------------- | :------------- | :------------------- |
@@ -25,11 +30,16 @@ Below is the list of coins supported by this library -- as well as those that ar
 
 ### TransactionBuilder
 
-The `TranssactionBuilder` class guides a user through the construction of a transaction. The purpose of the `TransactionBuilder` is to yield a `Transaction` object that can broadcast to the network.
+The `TranssactionBuilder` class guides a user through the construction of a
+transaction. The purpose of the `TransactionBuilder` is to yield a `Transaction`
+object that can broadcast to the network.
 
 ### Transaction
 
-`Transaction` objects are JavaScript representations of blockchain transactions that implement protocol specific validation rules. `Transactions` provide encoding mechanisms that allow them to be validly broadcast to their respective network.
+`Transaction` objects are JavaScript representations of blockchain transactions
+that implement protocol specific validation rules. `Transactions` provide
+encoding mechanisms that allow them to be validly broadcast to their respective
+network.
 
 #### Transaction Types
 
@@ -46,21 +56,26 @@ Transfers funds from a wallet.
 
 ##### Wallet Initialization
 
-Initializes a wallet's account on the network (e.g., multi-sig contract deployment).
+Initializes a wallet's account on the network (e.g., multi-sig contract
+deployment).
 
 ##### Address Initialization
 
-Initializes a wallet's address on the network (e.g., forwarder contract deployment).
+Initializes a wallet's address on the network (e.g., forwarder contract
+deployment).
 
 ##### Account Update
 
-Updates an account on the network (e.g., public key revelation operation for Tezos).
+Updates an account on the network (e.g., public key revelation operation for
+Tezos).
 
 ---
 
 ## Installation
 
-Install the library with npm. If you plan on contributing to the project, you may wish to follow different installation instructions [outlined in this doc](DEVELOPER.md).
+Install the library with npm. If you plan on contributing to the project, you
+may wish to follow different installation instructions
+[outlined in this doc](DEVELOPER.md).
 
 ```
 $ cd <your_project>
@@ -69,7 +84,8 @@ $ npm install @bitgo/account-lib
 
 ## Usage
 
-Below is an example that demonstrates how the library can be used to build and sign a Tron testnet transaction.
+Below is an example that demonstrates how the library can be used to build and
+sign a Tron testnet transaction.
 
 ### Instantiation
 
@@ -87,7 +103,8 @@ const txBuilder = accountLib.getBuilder('ttrx');
 
 ### Transaction Construction and Signing
 
-Use the transaction builder instance (created in the previous step) to sign a transaction:
+Use the transaction builder instance (created in the previous step) to sign a
+transaction:
 
 ```javascript
 // Define an unsigned Tron transaction object
@@ -132,6 +149,9 @@ More examples:
 
 ## Developers
 
-If you'd like to contribute to this project, see the [developer guide](DEVELOPER.md) for contribution norms and expectations.
+If you'd like to contribute to this project, see the
+[developer guide](DEVELOPER.md) for contribution norms and expectations.
 
-There is a near-term goal to move this library toward a plugin-based architecture for coin registration. Until then, PRs adding support for new coins will be put on hold.
+There is a near-term goal to move this library toward a plugin-based
+architecture for coin registration. Until then, PRs adding support for new coins
+will be put on hold.

--- a/modules/account-lib/README.md
+++ b/modules/account-lib/README.md
@@ -1,50 +1,66 @@
 # BitGo Account Lib
 
-This library is responsible for building and signing transactions for account-based coins (ie: coins such as Ethereum, Algorand, EOS, Tron, etc.). This library is used by BitGo and our multi-sig wallets, however, it can be used independently, outside of our wallet ecosystem.
+This library is responsible for building and signing transactions for account-based coins (for example, Ethereum, Algorand, EOS, Tron, etc.). Account Lib was developed for BitGo and BitGo's multi-sig wallets, but it can also be used independently, outside of our wallet ecosystem.
+
+> Account lib was intended to be used in an offline environment, for offline signings.
 
 ## Supported Coins
+
 Below is the list of coins supported by this library -- as well as those that are on the roadmap.
 
-|Coin|Mainnet Ticker|Testnet Ticker|Supported In Library|
-|---|---|---|---|
-|Tron|trx|ttrx|Yes|
-|Tezos|xtz|txtz|Yes|
-|Ethereum|eth|teth|Yes|
-|CELO|celo|tcelo|Yes|
-|Ethereum Classic|etc|tetc|Yes|
-|RSK|rbtc|trbtc|Yes|
-|EOS|eos|teos|Not yet...|
-|Alogrand|algo|talgo|Not yet...|
-|Ripple|xrp|txrp|Not yet...|
-|Stellar|xlm|txlm|Not yet...|
+| Coin             | Mainnet Ticker | Testnet Ticker | Supported In Library |
+| :--------------- | :------------- | :------------- | :------------------- |
+| Tron             | trx            | ttrx           | Yes                  |
+| Tezos            | xtz            | txtz           | Yes                  |
+| Ethereum         | eth            | teth           | Yes                  |
+| CELO             | celo           | tcelo          | Yes                  |
+| Ethereum Classic | etc            | tetc           | Yes                  |
+| RSK              | rbtc           | trbtc          | Yes                  |
+| EOS              | eos            | teos           | Not yet...           |
+| Alogrand         | algo           | talgo          | Not yet...           |
+| Ripple           | xrp            | txrp           | Not yet...           |
+| Stellar          | xlm            | txlm           | Not yet...           |
 
 ## Core Concepts
 
 ### TransactionBuilder
-The `TranssactionBuilder` class guides a user through the construction of a transaction. The purpose of the `TransactionBuilder` is to yield `Transaction` object that is able to be broadcast to the network.
+
+The `TranssactionBuilder` class guides a user through the construction of a transaction. The purpose of the `TransactionBuilder` is to yield a `Transaction` object that can broadcast to the network.
 
 ### Transaction
-`Transaction` objects are javascript representations of blockchain transactions that implement protocol specific validation rules. `Transactions` provide encoding mechanisms that allow them to be validly broadcast to their respective network.
+
+`Transaction` objects are JavaScript representations of blockchain transactions that implement protocol specific validation rules. `Transactions` provide encoding mechanisms that allow them to be validly broadcast to their respective network.
 
 #### Transaction Types
-The `TransactionBuilder` supports 3 types types of transactions
-##### Send
-Transfers funds from a wallet
-##### Wallet Initialization
-Initializes a wallet's account on the network (e.g. Multi-sig contract deployment)
-##### Address Initialization
-Initializes a wallet's address on the network (e.g. Forwarder contract deployment)
-##### Account Update
-Updates an account on the network (e.g. Public key revelation operation for Tezos)
 
-### Offline Availability
-The intention is that this library can be used in an offline environment, for offline signings.
+The `TransactionBuilder` supports the following transaction types:
+
+- [Send](#send)
+- [Wallet Initialization](#wallet-initialization)
+- [Address Initialization](#address-initialization)
+- [Account Update](#account-update)
+
+##### Send
+
+Transfers funds from a wallet.
+
+##### Wallet Initialization
+
+Initializes a wallet's account on the network (e.g., multi-sig contract deployment).
+
+##### Address Initialization
+
+Initializes a wallet's address on the network (e.g., forwarder contract deployment).
+
+##### Account Update
+
+Updates an account on the network (e.g., public key revelation operation for Tezos).
 
 ---
 
 ## Installation
 
-Install the library via npm. If you plan on contributing to the project, you may wish to follow different installation instructions [outlined in this doc](DEVELOPER.md).
+Install the library with npm. If you plan on contributing to the project, you may wish to follow different installation instructions [outlined in this doc](DEVELOPER.md).
 
 ```
 $ cd <your_project>
@@ -52,10 +68,12 @@ $ npm install @bitgo/account-lib
 ```
 
 ## Usage
+
 Below is an example that demonstrates how the library can be used to build and sign a Tron testnet transaction.
 
 ### Instantiation
-Instantiate the `TransactionBuilder` for the coin you want to work sign with:
+
+Instantiate the `TransactionBuilder` for the coin you want to work with:
 
 ```javascript
 // Import the package (javascript import)
@@ -67,8 +85,9 @@ import * as accountLib from '@bitgo/account-lib';
 const txBuilder = accountLib.getBuilder('ttrx');
 ```
 
-### Transaction Construction + Signing
-Use that transaction builder instance to sign a transaction:
+### Transaction Construction and Signing
+
+Use the transaction builder instance (created in the previous step) to sign a transaction:
 
 ```javascript
 // Define an unsigned Tron transaction object
@@ -76,38 +95,43 @@ const unsignedBuildTransaction = {
   visible: false,
   txID: '80b8b9eaed51c8bba3b49f7f0e7cc5f21ac99a6f3e2893c663b544bf2c695b1d',
   raw_data: {
-    contract: [ {
-      parameter: {
-        value: {
-          amount: 1718,
-          owner_address: '41c4530f6bfa902b7398ac773da56106a15af15f92',
-          to_address: '4189ffaf9da8c6fae32189b2e6dce228249b1129aa'
+    contract: [
+      {
+        parameter: {
+          value: {
+            amount: 1718,
+            owner_address: '41c4530f6bfa902b7398ac773da56106a15af15f92',
+            to_address: '4189ffaf9da8c6fae32189b2e6dce228249b1129aa',
+          },
+          type_url: 'type.googleapis.com/protocol.TransferContract',
         },
-        type_url: 'type.googleapis.com/protocol.TransferContract'
+        type: 'TransferContract',
       },
-      type: 'TransferContract'
-    } ],
+    ],
     ref_block_bytes: '90e4',
     ref_block_hash: 'a018bf9892ddb138',
     expiration: 1571811468000,
-    timestamp: 1571811410819
+    timestamp: 1571811410819,
   },
-  raw_data_hex: '0a0290e42208a018bf9892ddb13840e0c58ebadf2d5a66080112620a2d747970652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e5472616e73666572436f6e747261637412310a1541c4530f6bfa902b7398ac773da56106a15af15f9212154189ffaf9da8c6fae32189b2e6dce228249b1129aa18b60d7083878bbadf2d',
+  raw_data_hex:
+    '0a0290e42208a018bf9892ddb13840e0c58ebadf2d5a66080112620a2d747970652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e5472616e73666572436f6e747261637412310a1541c4530f6bfa902b7398ac773da56106a15af15f9212154189ffaf9da8c6fae32189b2e6dce228249b1129aa18b60d7083878bbadf2d',
 };
 
 // Use that object to build and sign a transaction
 txBuilder.from(unsignedBuildTransaction);
 txBuilder.sign({
-  key: 'A81B2E0C55A7E2B2E837ZZC437A6397B316536196989A6F09EE49C19AD33590W'
+  key: 'A81B2E0C55A7E2B2E837ZZC437A6397B316536196989A6F09EE49C19AD33590W',
 });
 const tx = await txBuilder.build();
 ```
 
 More examples:
-* [Tron transaction building examples](https://github.com/BitGo/bitgo-account-lib/blob/master/test/unit/coin/trx/transactionBuilder.ts)
-* [Tezos transaction building examples](https://github.com/BitGo/bitgo-account-lib/blob/master/test/unit/coin/xtz/transactionBuilder.ts)
+
+- [Tron transaction building examples](https://github.com/BitGo/bitgo-account-lib/blob/master/test/unit/coin/trx/transactionBuilder.ts)
+- [Tezos transaction building examples](https://github.com/BitGo/bitgo-account-lib/blob/master/test/unit/coin/xtz/transactionBuilder.ts)
 
 ## Developers
+
 If you'd like to contribute to this project, see the [developer guide](DEVELOPER.md) for contribution norms and expectations.
 
-Note that there is a near-term goal to move this library towards a plugin-based architecture for coin registration. Until this library gets there (and this note is removed), PRs adding support for new coins will be put on hold.
+There is a near-term goal to move this library toward a plugin-based architecture for coin registration. Until then, PRs adding support for new coins will be put on hold.


### PR DESCRIPTION
Did a light copyedit to familiarize myself with the account-lib docs. This is step 1 in creating a suite of coin onboarding tutorials. 

