### PR TITLE
feat(sol): implement parse transaction

### DIFF
--- a/modules/account-lib/src/coin/sol/transaction.ts
+++ b/modules/account-lib/src/coin/sol/transaction.ts
@@ -30,6 +30,10 @@ export class Transaction extends BaseTransaction {
     this._solTransaction = tx;
   }
 
+  private get numberOfRequiredSignatures(): number {
+    return this._solTransaction.compileMessage().header.numRequiredSignatures;
+  }
+
   /** @inheritDoc **/
   get id(): string {
     // Solana transaction ID === first signature: https://docs.solana.com/terminology#transaction-id
@@ -268,7 +272,7 @@ export class Transaction extends BaseTransaction {
     }
 
     const feeString = this.lamportsPerSignature
-      ? new BigNumber(this.lamportsPerSignature).multipliedBy(this._solTransaction.signatures.length).toFixed(0)
+      ? new BigNumber(this.lamportsPerSignature).multipliedBy(this.numberOfRequiredSignatures).toFixed(0)
       : UNAVAILABLE_TEXT;
 
     const explainedTransaction = {

--- a/modules/account-lib/test/unit/coin/sol/transaction.ts
+++ b/modules/account-lib/test/unit/coin/sol/transaction.ts
@@ -256,7 +256,7 @@ describe('Sol Transaction', () => {
           },
         ],
         fee: {
-          fee: '0',
+          fee: '5000',
           feeRate: 5000,
         },
         memo: undefined,
@@ -443,7 +443,7 @@ describe('Sol Transaction', () => {
           },
         ],
         fee: {
-          fee: '0',
+          fee: '10000',
           feeRate: 5000,
         },
         memo: undefined,

--- a/modules/core/test/v2/unit/coins/sol.ts
+++ b/modules/core/test/v2/unit/coins/sol.ts
@@ -72,8 +72,92 @@ describe('SOL:', function () {
   }));
 
   describe('Parse Transactions:', () => {
-    it('should parse a transfer transaction', async function () {
-      await should.throws(() => basecoin.parseTransaction('placeholder'), 'parseTransaction method not implemented');
+    it('should parse an unsigned transfer transaction', async function () {
+      const parsedTransaction = await basecoin.parseTransaction({
+        txBase64: testData.rawTransactions.transfer.unsigned,
+        feeInfo: {
+          fee: '5000',
+        },
+      });
+
+      parsedTransaction.should.deepEqual({
+        inputs: {
+          address: 'CP5Dpaa42RtJmMuKqCQsLwma5Yh3knuvKsYDFX85F41S',
+          amount: 305000,
+        },
+        outputs: [
+          {
+            address: 'CP5Dpaa42RtJmMuKqCQsLwma5Yh3knuvKsYDFX85F41S',
+            amount: '300000',
+          },
+        ],
+      });
+    });
+
+    it('should parse an signed transfer transaction', async function () {
+      const parsedTransaction = await basecoin.parseTransaction({
+        txBase64: testData.rawTransactions.transfer.signed,
+        feeInfo: {
+          fee: '5000',
+        },
+      });
+
+      parsedTransaction.should.deepEqual({
+        inputs: {
+          address: 'CP5Dpaa42RtJmMuKqCQsLwma5Yh3knuvKsYDFX85F41S',
+          amount: 305000,
+        },
+        outputs: [
+          {
+            address: 'CP5Dpaa42RtJmMuKqCQsLwma5Yh3knuvKsYDFX85F41S',
+            amount: '300000',
+          },
+        ],
+      });
+    });
+
+    it('should parse an unsigned transfer transaction', async function () {
+      const parsedTransaction = await basecoin.parseTransaction({
+        txBase64: testData.rawTransactions.walletInit.unsigned,
+        feeInfo: {
+          fee: '5000',
+        },
+      });
+
+      parsedTransaction.should.deepEqual({
+        inputs: {
+          address: '8Y7RM6JfcX4ASSNBkrkrmSbRu431YVi9Y3oLFnzC2dCh',
+          amount: 310000,
+        },
+        outputs: [
+          {
+            address: '8Y7RM6JfcX4ASSNBkrkrmSbRu431YVi9Y3oLFnzC2dCh',
+            amount: '300000',
+          },
+        ],
+      });
+    });
+
+    it('should parse an signed transfer transaction', async function () {
+      const parsedTransaction = await basecoin.parseTransaction({
+        txBase64: testData.rawTransactions.walletInit.unsigned,
+        feeInfo: {
+          fee: '5000',
+        },
+      });
+
+      parsedTransaction.should.deepEqual({
+        inputs: {
+          address: '8Y7RM6JfcX4ASSNBkrkrmSbRu431YVi9Y3oLFnzC2dCh',
+          amount: 310000,
+        },
+        outputs: [
+          {
+            address: '8Y7RM6JfcX4ASSNBkrkrmSbRu431YVi9Y3oLFnzC2dCh',
+            amount: '300000',
+          },
+        ],
+      });
     });
   });
 


### PR DESCRIPTION
implements parse transaction for Solana

also sneaks in a fix to calculate `fee` correctly by using the transaction's `numSignaturesRequired` instead of current number of signatures.

Ticket: STLX-10400