### PR TITLE
chore(account-lib/dot): rename walletInitialization to

### DIFF
--- a/modules/account-lib/src/coin/dot/addressInitializationBuilder.ts
+++ b/modules/account-lib/src/coin/dot/addressInitializationBuilder.ts
@@ -7,10 +7,10 @@ import { Transaction } from './transaction';
 import { DecodedSignedTx, DecodedSigningPayload, UnsignedTransaction } from '@substrate/txwrapper-core';
 import { TransactionType } from '../baseCoin';
 import { AddProxyArgs, MethodNames, proxyType } from './iface';
-import { WalletInitializationSchema } from './txnSchema';
+import { AddressInitializationSchema } from './txnSchema';
 import { BaseAddress } from '../baseCoin/iface';
 
-export class WalletInitializationBuilder extends TransactionBuilder {
+export class AddressInitializationBuilder extends TransactionBuilder {
   protected _delegate: string;
   protected _proxyType: proxyType;
   protected _delay: string;
@@ -40,14 +40,14 @@ export class WalletInitializationBuilder extends TransactionBuilder {
   }
 
   protected get transactionType(): TransactionType {
-    return TransactionType.WalletInitialization;
+    return TransactionType.AddressInitialization;
   }
 
   /**
    * The account to delegate auth to.
    *
    * @param {BaseAddress} owner
-   * @returns {WalletInitializationBuilder} This builder.
+   * @returns {AddressInitializationBuilder} This builder.
    *
    * @see https://wiki.polkadot.network/docs/learn-proxies#why-use-a-proxy
    */
@@ -61,7 +61,7 @@ export class WalletInitializationBuilder extends TransactionBuilder {
    * The proxy type to add.
    *
    * @param {proxyType} proxyType
-   * @returns {WalletInitializationBuilder} This builder.
+   * @returns {AddressInitializationBuilder} This builder.
    *
    * @see https://wiki.polkadot.network/docs/learn-proxies#proxy-types
    */
@@ -77,7 +77,7 @@ export class WalletInitializationBuilder extends TransactionBuilder {
    * TODO: move to the validity window method once it has been standardized
    *
    * @param {string} delay
-   * @returns {WalletInitializationBuilder} This transfer builder.
+   * @returns {AddressInitializationBuilder} This transfer builder.
    *
    * @see https://wiki.polkadot.network/docs/learn-proxies#time-delayed-proxies
    */
@@ -94,7 +94,7 @@ export class WalletInitializationBuilder extends TransactionBuilder {
       const delegate = txMethod.delegate;
       const proxyType = txMethod.proxyType;
       const delay = txMethod.delay;
-      const validationResult = WalletInitializationSchema.validate({ delegate, proxyType, delay });
+      const validationResult = AddressInitializationSchema.validate({ delegate, proxyType, delay });
       if (validationResult.error) {
         throw new InvalidTransactionError(`Transaction validation failed: ${validationResult.error.message}`);
       }
@@ -124,7 +124,7 @@ export class WalletInitializationBuilder extends TransactionBuilder {
   }
 
   private validateFields(delegate: string, proxyType: string, delay: string): void {
-    const validationResult = WalletInitializationSchema.validate({
+    const validationResult = AddressInitializationSchema.validate({
       delegate,
       proxyType,
       delay,
@@ -132,7 +132,7 @@ export class WalletInitializationBuilder extends TransactionBuilder {
 
     if (validationResult.error) {
       throw new InvalidTransactionError(
-        `WalletInitialization Transaction validation failed: ${validationResult.error.message}`,
+        `AddressInitialization Transaction validation failed: ${validationResult.error.message}`,
       );
     }
   }

--- a/modules/account-lib/src/coin/dot/index.ts
+++ b/modules/account-lib/src/coin/dot/index.ts
@@ -5,7 +5,7 @@ export { Transaction } from './transaction';
 export { TransactionBuilder } from './transactionBuilder';
 export { StakingBuilder } from './stakingBuilder';
 export { TransferBuilder } from './transferBuilder';
-export { WalletInitializationBuilder } from './walletInitializationBuilder';
+export { AddressInitializationBuilder } from './addressInitializationBuilder';
 export { UnstakeBuilder } from './unstakeBuilder';
 export { TransactionBuilderFactory } from './transactionBuilderFactory';
 export { Utils };

--- a/modules/account-lib/src/coin/dot/transaction.ts
+++ b/modules/account-lib/src/coin/dot/transaction.ts
@@ -165,7 +165,7 @@ export class Transaction extends BaseTransaction {
       }
     }
 
-    if (this.type === TransactionType.WalletInitialization) {
+    if (this.type === TransactionType.AddressInitialization) {
       const txMethod = decodedTx.method.args as AddProxyArgs;
       const keypair = new KeyPair({
         pub: Buffer.from(decodeAddress(txMethod.delegate, false, this._registry.chainSS58)).toString('hex'),
@@ -213,7 +213,7 @@ export class Transaction extends BaseTransaction {
     };
   }
 
-  explainWalletInitializationTransaction(
+  explainAddressInitializationTransaction(
     json: TxData,
     explanationResult: TransactionExplanation,
   ): TransactionExplanation {
@@ -262,8 +262,8 @@ export class Transaction extends BaseTransaction {
         return this.explainTransferTransaction(result, explanationResult);
       case TransactionType.StakingActivate:
         return this.explainStakingActivateTransaction(result, explanationResult);
-      case TransactionType.WalletInitialization:
-        return this.explainWalletInitializationTransaction(result, explanationResult);
+      case TransactionType.AddressInitialization:
+        return this.explainAddressInitializationTransaction(result, explanationResult);
       case TransactionType.StakingUnlock:
         return this.explainStakingUnlockTransaction(result, explanationResult);
       default:

--- a/modules/account-lib/src/coin/dot/transactionBuilderFactory.ts
+++ b/modules/account-lib/src/coin/dot/transactionBuilderFactory.ts
@@ -1,11 +1,11 @@
 import { BaseCoin as CoinConfig, DotNetwork } from '@bitgo/statics';
 import { BaseTransactionBuilderFactory } from '../baseCoin';
-import { BuildTransactionError, NotSupported } from '../baseCoin/errors';
+import { BuildTransactionError, NotImplementedError, NotSupported } from '../baseCoin/errors';
 import { decode, getRegistry } from '@substrate/txwrapper-polkadot';
 import { TypeRegistry } from '@substrate/txwrapper-core/lib/types';
 import { TransactionBuilder } from './transactionBuilder';
 import { TransferBuilder } from './transferBuilder';
-import { WalletInitializationBuilder } from './walletInitializationBuilder';
+import { AddressInitializationBuilder } from './addressInitializationBuilder';
 import { StakingBuilder } from './stakingBuilder';
 import { MethodNames } from './iface';
 import { UnstakeBuilder } from '.';
@@ -26,8 +26,12 @@ export class TransactionBuilderFactory extends BaseTransactionBuilderFactory {
     return new StakingBuilder(this._coinConfig);
   }
 
-  getWalletInitializationBuilder(): WalletInitializationBuilder {
-    return new WalletInitializationBuilder(this._coinConfig);
+  getAddressInitializationBuilder(): AddressInitializationBuilder {
+    return new AddressInitializationBuilder(this._coinConfig);
+  }
+
+  getWalletInitializationBuilder(): void {
+    throw new NotImplementedError(`walletInitialization for ${this._coinConfig.name} not implemented`);
   }
 
   getUnstakeBuilder(): UnstakeBuilder {
@@ -66,7 +70,7 @@ export class TransactionBuilderFactory extends BaseTransactionBuilderFactory {
     } else if (methodName === MethodNames.Bond) {
       return this.getStakingBuilder();
     } else if (methodName === MethodNames.AddProxy) {
-      return this.getWalletInitializationBuilder();
+      return this.getAddressInitializationBuilder();
     } else if (methodName === MethodNames.Unbond) {
       return this.getUnstakeBuilder();
     } else {

--- a/modules/account-lib/src/coin/dot/txnSchema.ts
+++ b/modules/account-lib/src/coin/dot/txnSchema.ts
@@ -63,7 +63,7 @@ export const StakeTransactionSchema = joi.object({
   ],
 });
 
-export const WalletInitializationSchema = joi.object({
+export const AddressInitializationSchema = joi.object({
   proxyType: joi
     .string()
     .valid(...proxyTypes)

--- a/modules/account-lib/test/unit/coin/dot/transaction.ts
+++ b/modules/account-lib/test/unit/coin/dot/transaction.ts
@@ -103,15 +103,15 @@ describe('Dot Transaction', () => {
       explain.forceProxyType?.should.equal('Any');
     });
 
-    it('should explain a wallet initialization transaction', async () => {
+    it('should explain a address initialization transaction', async () => {
       const json = JSON.parse(DotResources.jsonTransactions.walletInitialization) as TxData;
       tx.setTxJson(json);
-      tx.transactionType(TransactionType.WalletInitialization);
+      tx.transactionType(TransactionType.AddressInitialization);
       const explain = tx.explainTransaction();
       explain.outputAmount.should.equal('0');
       explain.fee.fee.should.equal('0');
       explain.changeAmount.should.equal('0');
-      explain.type.should.equal(TransactionType.WalletInitialization);
+      explain.type.should.equal(TransactionType.AddressInitialization);
       explain.owner?.should.equal(receiver.address);
       explain.proxyType?.should.equal('Any');
       explain.delay?.should.equal('0');

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/transactionBuilderFactory.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/transactionBuilderFactory.ts
@@ -4,7 +4,7 @@ import { register } from '../../../../../src/index';
 import {
   TransactionBuilderFactory,
   TransferBuilder,
-  WalletInitializationBuilder,
+  AddressInitializationBuilder,
   StakingBuilder,
   UnstakeBuilder,
 } from '../../../../../src/coin/dot';
@@ -50,7 +50,7 @@ describe('dot Transaction Builder Factory', () => {
 
   it('should parse an unsigned add proxy txn and return an Add Proxy builder', async () => {
     const builder = factory.from(rawTx.addProxy.unsigned);
-    should(builder).instanceOf(WalletInitializationBuilder);
+    should(builder).instanceOf(AddressInitializationBuilder);
     builder
       .validity({ firstValid: 3933 })
       .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
@@ -62,7 +62,7 @@ describe('dot Transaction Builder Factory', () => {
 
   it('should parse an signed add proxy txn and return an Add Proxy builder', async () => {
     const builder = factory.from(rawTx.addProxy.signed);
-    should(builder).instanceOf(WalletInitializationBuilder);
+    should(builder).instanceOf(AddressInitializationBuilder);
     builder
       .validity({ firstValid: 3933 })
       .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/walletInitializationBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/walletInitializationBuilder.ts
@@ -1,18 +1,18 @@
 import should from 'should';
 import sinon, { assert } from 'sinon';
-import { WalletInitializationBuilder } from '../../../../../src/coin/dot';
+import { AddressInitializationBuilder } from '../../../../../src/coin/dot';
 import * as DotResources from '../../../../resources/dot';
 import { buildTestConfig } from './base';
 
 describe('Dot Add Proxy Builder', () => {
-  let builder: WalletInitializationBuilder;
+  let builder: AddressInitializationBuilder;
 
   const sender = DotResources.accounts.account1;
   const receiver = DotResources.accounts.account3;
 
   beforeEach(() => {
     const config = buildTestConfig();
-    builder = new WalletInitializationBuilder(config);
+    builder = new AddressInitializationBuilder(config);
   });
   describe('setter validation', () => {
     it('should validate delay', () => {


### PR DESCRIPTION
The transaction type for create of a Proxy Account (receive address) should be labelled as `addressInitialization`.
This PR renames the types/schema and the transaction builder for adding a proxy account on the DOT network.

JIRA ticket: https://bitgoinc.atlassian.net/browse/STLX-10457