### PR TITLE
chore(account-lib): export polkadot interface

### DIFF
--- a/modules/account-lib/src/coin/dot/index.ts
+++ b/modules/account-lib/src/coin/dot/index.ts
@@ -1,4 +1,5 @@
 import * as Utils from './utils';
+import * as Interface from './iface';
 
 export { KeyPair } from './keyPair';
 export { Transaction } from './transaction';
@@ -8,4 +9,4 @@ export { TransferBuilder } from './transferBuilder';
 export { AddressInitializationBuilder } from './addressInitializationBuilder';
 export { UnstakeBuilder } from './unstakeBuilder';
 export { TransactionBuilderFactory } from './transactionBuilderFactory';
-export { Utils };
+export { Interface, Utils };


### PR DESCRIPTION
In order to use the type def outside of account-lib, we will need to export the type like eth or celo do.

Ticket: STLX-8335