### PR TITLE
feat(utxo-lib): add isSupportedScriptType(network, scriptType)

### DIFF
--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -321,7 +321,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       return version;
     } catch (e) {
       // if that fails, and we aren't supporting p2wsh, then we are done and did not find a version
-      if (!this.supportsP2wsh()) {
+      if (!this.supportsAddressType('p2wsh') && !this.supportsAddressType('p2tr')) {
         return;
       }
     }
@@ -367,7 +367,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
     const addressVersionValid = _.isNumber(addressVersion) && validVersions.includes(addressVersion);
     const addressPrefix = this.getAddressPrefix(address);
 
-    if (!this.supportsP2wsh() || _.isUndefined(addressPrefix)) {
+    if (!this.supportsAddressType('p2wsh') || _.isUndefined(addressPrefix)) {
       return addressVersionValid;
     }
 
@@ -971,45 +971,11 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
   }
 
   /**
-   * Indicates whether a coin supports spending from wrapped segwit outputs
-   * @returns {boolean}
-   */
-  supportsP2shP2wsh() {
-    return false;
-  }
-
-  /**
-   * Indicates whether a coin supports spending from native segwit outputs
-   * @returns {boolean}
-   */
-  supportsP2wsh() {
-    return false;
-  }
-
-  /**
-   * Indicates whether a coin supports spending from segwit v1 taproot outputs
-   * @returns {boolean}
-   */
-  supportsP2tr() {
-    return false;
-  }
-
-  /**
    * @param addressType
    * @returns true iff coin supports spending from unspentType
    */
   supportsAddressType(addressType: ScriptType2Of3): boolean {
-    switch (addressType) {
-      case 'p2sh':
-        return true;
-      case 'p2shP2wsh':
-        return this.supportsP2shP2wsh();
-      case 'p2wsh':
-        return this.supportsP2wsh();
-      case 'p2tr':
-        return this.supportsP2tr();
-    }
-    throw new errors.UnsupportedAddressTypeError();
+    return utxolib.bitgo.outputScripts.isSupportedScriptType(this.network, addressType);
   }
 
   /**

--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -320,10 +320,12 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       const { version } = utxolib.address.fromBase58Check(address, this.network);
       return version;
     } catch (e) {
-      // if that fails, and we aren't supporting p2wsh, then we are done and did not find a version
-      if (!this.supportsAddressType('p2wsh') && !this.supportsAddressType('p2tr')) {
-        return;
-      }
+      // try next format
+    }
+
+    // if coin does not support script types with bech32 encoding, do not attempt to parse
+    if (!this.supportsAddressType('p2wsh') && !this.supportsAddressType('p2tr')) {
+      return;
     }
 
     // otherwise, try decoding as bech32

--- a/modules/core/src/v2/coins/btc.ts
+++ b/modules/core/src/v2/coins/btc.ts
@@ -32,16 +32,4 @@ export class Btc extends AbstractUtxoCoin {
   supportsBlockTarget(): boolean {
     return true;
   }
-
-  supportsP2shP2wsh(): boolean {
-    return true;
-  }
-
-  supportsP2wsh(): boolean {
-    return true;
-  }
-
-  supportsP2tr(): boolean {
-    return true;
-  }
 }

--- a/modules/core/src/v2/coins/btg.ts
+++ b/modules/core/src/v2/coins/btg.ts
@@ -28,16 +28,4 @@ export class Btg extends Btc {
   supportsBlockTarget(): boolean {
     return false;
   }
-
-  supportsP2shP2wsh(): boolean {
-    return true;
-  }
-
-  supportsP2wsh(): boolean {
-    return true;
-  }
-
-  supportsP2tr(): boolean {
-    return false;
-  }
 }

--- a/modules/core/src/v2/coins/ltc.ts
+++ b/modules/core/src/v2/coins/ltc.ts
@@ -37,14 +37,6 @@ export class Ltc extends AbstractUtxoCoin {
     return false;
   }
 
-  supportsP2shP2wsh(): boolean {
-    return true;
-  }
-
-  supportsP2wsh(): boolean {
-    return true;
-  }
-
   /**
    * Canonicalize a Litecoin address for a specific scriptHash version
    * @param address

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -105,18 +105,6 @@ export enum CoinFeature {
    */
   CHILD_PAYS_FOR_PARENT = 'cpfp',
   /*
-   * Does this coin support pay-to-script-hash wrapped segregated witness transactions.
-   *
-   * These are upgraded transaction types which can only apply to UTXO coins such as Bitcoin.
-   */
-  WRAPPED_SEGWIT = 'wrapped-segwit',
-  /*
-   * Does this coin support segregated witness transactions natively? (eg, not wrapped in a P2SH indirection layer)
-   *
-   * These are upgraded transaction types which can only apply to UTXO coins such as Bitcoin.
-   */
-  NATIVE_SEGWIT = 'native-segwit',
-  /*
    * Does this coin support tokens? These are distinct assets from the underlying coin, but run on the same network.
    *
    * For example, Ethereum's ERC 20 token standard means that it supports tokens, so it shall have this feature.

--- a/modules/statics/src/ofc.ts
+++ b/modules/statics/src/ofc.ts
@@ -39,9 +39,7 @@ export class OfcCoin extends BaseCoin {
     return new Set<CoinFeature>([
       CoinFeature.UNSPENT_MODEL,
       CoinFeature.CHILD_PAYS_FOR_PARENT,
-      CoinFeature.NATIVE_SEGWIT,
       CoinFeature.PAYGO,
-      CoinFeature.WRAPPED_SEGWIT,
       CoinFeature.SUPPORTS_TOKENS,
     ]);
   }

--- a/modules/statics/src/utxo.ts
+++ b/modules/statics/src/utxo.ts
@@ -13,12 +13,7 @@ export interface UtxoConstructorOptions {
 }
 
 export class UtxoCoin extends BaseCoin {
-  public static readonly DEFAULT_FEATURES = [
-    CoinFeature.UNSPENT_MODEL,
-    CoinFeature.CHILD_PAYS_FOR_PARENT,
-    CoinFeature.WRAPPED_SEGWIT,
-    CoinFeature.NATIVE_SEGWIT,
-  ];
+  public static readonly DEFAULT_FEATURES = [CoinFeature.UNSPENT_MODEL, CoinFeature.CHILD_PAYS_FOR_PARENT];
 
   /**
    * Additional fields for utxo coins

--- a/modules/utxo-lib/src/bitgo/nonStandardHalfSigned.ts
+++ b/modules/utxo-lib/src/bitgo/nonStandardHalfSigned.ts
@@ -8,6 +8,7 @@ import { classify, script as bscript, TxInput } from '../';
  */
 export function padInputScript(input: TxInput, signatureIndex: number): void {
   if (![0, 1, 2].includes(signatureIndex)) {
+    /* istanbul ignore next */
     throw new Error(`invalid signature index: must be one of [0, 1, 2]`);
   }
 
@@ -21,19 +22,23 @@ export function padInputScript(input: TxInput, signatureIndex: number): void {
   // The shape of a non-standard half-signed input is
   //   OP_0 <signature> <p2ms>
   if (!decompiledSigScript || decompiledSigScript.length !== 3) {
+    /* istanbul ignore next */
     return;
   }
 
   const [op0, signatureBuffer, sigScript] = decompiledSigScript;
   if (op0 !== opcodes.OP_0 && !(Buffer.isBuffer(op0) && op0.length === 0)) {
+    /* istanbul ignore next */
     return;
   }
 
   if (!Buffer.isBuffer(sigScript)) {
+    /* istanbul ignore next */
     return;
   }
 
   if (classify.output(sigScript) !== classify.types.P2MS) {
+    /* istanbul ignore next */
     return;
   }
 

--- a/modules/utxo-lib/src/bitgo/outputScripts.ts
+++ b/modules/utxo-lib/src/bitgo/outputScripts.ts
@@ -1,6 +1,11 @@
 import * as assert from 'assert';
 import * as bitcoinjs from 'bitcoinjs-lib';
+
+import { Network, supportsSegwit, supportsTaproot } from '..';
+
 import { isTriple, Triple, Tuple } from './types';
+
+export { scriptTypeForChain } from './wallet/chains';
 
 export const scriptTypeP2shP2pk = 'p2shP2pk';
 export type ScriptTypeP2shP2pk = typeof scriptTypeP2shP2pk;
@@ -14,7 +19,26 @@ export function isScriptType2Of3(t: string): t is ScriptType2Of3 {
 
 export type ScriptType = ScriptTypeP2shP2pk | ScriptType2Of3;
 
-export { scriptTypeForChain } from './wallet/chains';
+/**
+ * @param network
+ * @param scriptType
+ * @return true iff script type is supported for network
+ */
+export function isSupportedScriptType(network: Network, scriptType: ScriptType): boolean {
+  switch (scriptType) {
+    case 'p2sh':
+    case 'p2shP2pk':
+      return true;
+    case 'p2shP2wsh':
+    case 'p2wsh':
+      return supportsSegwit(network);
+    case 'p2tr':
+      return supportsTaproot(network);
+  }
+
+  /* istanbul ignore next */
+  throw new Error(`unexpected script type ${scriptType}`);
+}
 
 /**
  * @param t
@@ -30,9 +54,10 @@ export function scriptType2Of3AsPrevOutType(t: ScriptType2Of3): string {
       return 'p2wsh-p2ms';
     case 'p2tr':
       return 'p2tr-p2ns';
-    default:
-      throw new Error(`unsupported script type ${t}`);
   }
+
+  /* istanbul ignore next */
+  throw new Error(`unsupported script type ${t}`);
 }
 
 export type SpendableScript = {
@@ -68,9 +93,20 @@ export function createOutputScriptP2shP2pk(pubkey: Buffer): SpendableScript {
  * Return scripts for 2-of-3 multisig output
  * @param pubkeys - the key triple for multisig
  * @param scriptType
+ * @param network - if set, performs sanity check for scriptType support
  * @returns {{redeemScript, witnessScript, scriptPubKey}}
  */
-export function createOutputScript2of3(pubkeys: Buffer[], scriptType: ScriptType2Of3): SpendableScript {
+export function createOutputScript2of3(
+  pubkeys: Buffer[],
+  scriptType: ScriptType2Of3,
+  network?: Network
+): SpendableScript {
+  if (network) {
+    if (!isSupportedScriptType(network, scriptType)) {
+      throw new Error(`unsupported script type ${scriptType} for network`);
+    }
+  }
+
   if (!isTriple(pubkeys)) {
     throw new Error(`must provide pubkey triple`);
   }

--- a/modules/utxo-lib/src/coins.ts
+++ b/modules/utxo-lib/src/coins.ts
@@ -175,6 +175,14 @@ export function isValidNetwork(network: unknown): network is Network {
   return getNetworkList().includes(network as Network);
 }
 
+export function supportsSegwit(network: Network): boolean {
+  return [networks.bitcoin, networks.litecoin, networks.bitcoingold].includes(getMainnet(network));
+}
+
+export function supportsTaproot(network: Network): boolean {
+  return getMainnet(network) === networks.bitcoin;
+}
+
 /** @deprecated */
 export const BCH = coins.BCH;
 /** @deprecated */

--- a/modules/utxo-lib/src/index.ts
+++ b/modules/utxo-lib/src/index.ts
@@ -3,6 +3,8 @@ export * from 'bitcoinjs-lib';
 export * as bitgo from './bitgo';
 export * as coins from './coins';
 
+export { getMainnet, getTestnet, isMainnet, isTestnet, supportsSegwit, supportsTaproot } from './coins';
+
 export * as address from './address';
 
 export const networks = require('./networks');

--- a/modules/utxo-lib/test/address/address.ts
+++ b/modules/utxo-lib/test/address/address.ts
@@ -50,6 +50,11 @@ describe('Address', function () {
           assert.deepStrictEqual(v, refVectors[i]);
           const [, scriptPubKeyHex, address] = v;
           assert.strictEqual(utxolib.address.toOutputScript(address, network).toString('hex'), scriptPubKeyHex);
+
+          if (network.bech32 && !address.startsWith(network.bech32)) {
+            const { hash, version } = utxolib.address.fromBase58Check(address, network);
+            assert.deepStrictEqual(utxolib.address.toBase58Check(hash, version, network), address);
+          }
         });
       });
     });

--- a/modules/utxo-lib/test/bitgo/outputScripts.ts
+++ b/modules/utxo-lib/test/bitgo/outputScripts.ts
@@ -5,14 +5,54 @@ import {
   createOutputScript2of3,
   createOutputScriptP2shP2pk,
   createPaymentP2tr,
+  isSupportedScriptType,
   scriptTypes2Of3,
 } from '../../src/bitgo/outputScripts';
 
 import { getKeyTriple } from '../testutil';
+import { getNetworkList, getNetworkName } from '../../src/coins';
+
+const keys = getKeyTriple('utxo');
+const pubkeys = keys.map((k) => k.publicKey) as [Buffer, Buffer, Buffer];
+
+describe('output script support', function () {
+  it('has expected values for each network', function () {
+    assert.deepStrictEqual(
+      getNetworkList().map((n) => [getNetworkName(n), scriptTypes2Of3.filter((t) => isSupportedScriptType(n, t))]),
+      [
+        ['bitcoin', ['p2sh', 'p2shP2wsh', 'p2wsh', 'p2tr']],
+        ['testnet', ['p2sh', 'p2shP2wsh', 'p2wsh', 'p2tr']],
+        ['bitcoincash', ['p2sh']],
+        ['bitcoincashTestnet', ['p2sh']],
+        ['bitcoingold', ['p2sh', 'p2shP2wsh', 'p2wsh']],
+        ['bitcoingoldTestnet', ['p2sh', 'p2shP2wsh', 'p2wsh']],
+        ['bitcoinsv', ['p2sh']],
+        ['bitcoinsvTestnet', ['p2sh']],
+        ['dash', ['p2sh']],
+        ['dashTest', ['p2sh']],
+        ['litecoin', ['p2sh', 'p2shP2wsh', 'p2wsh']],
+        ['litecoinTest', ['p2sh', 'p2shP2wsh', 'p2wsh']],
+        ['zcash', ['p2sh']],
+        ['zcashTest', ['p2sh']],
+      ]
+    );
+  });
+
+  it('does not allow unsupported scripts when network parameter is provided', function () {
+    getNetworkList().forEach((n) => {
+      scriptTypes2Of3
+        .filter((t) => !isSupportedScriptType(n, t))
+        .forEach((t) =>
+          assert.throws(
+            () => createOutputScript2of3(pubkeys, t, n),
+            (err) => !!(err instanceof Error && err.message.match(/^unsupported script type/))
+          )
+        );
+    });
+  });
+});
 
 describe('createOutputScript2of3()', function () {
-  const keys = getKeyTriple('utxo');
-  const pubkeys = keys.map((k) => k.publicKey) as [Buffer, Buffer, Buffer];
   const p2ms =
     '522103f1667be6e8b8eb0c980155dfcda742affeeb0b0ca10969c54152713185' +
     '6d65c9210305902cf20a0bbc9274e62414aa4afea8c96e3e83abb5233d72355c' +
@@ -66,9 +106,6 @@ describe('createOutputScriptP2shP2pk', function () {
 });
 
 describe('createPaymentP2tr', () => {
-  const keys = getKeyTriple('utxo');
-  const pubkeys = keys.map((k) => k.publicKey) as [Buffer, Buffer, Buffer];
-
   const controlBlocks = [
     'c1aa3303d48847f4d54aa02a4ff97448f1f430b07eecd632c41f390e3f8431a166487df024a0eb38aeb56b5263cf22c84a2c9c7daad9a8e55cce2e3cac87c52a0a',
     'c1aa3303d48847f4d54aa02a4ff97448f1f430b07eecd632c41f390e3f8431a1660a75f62db677b9c1974741735aa4b0c2c8718796c82578b960e1fa0986d4f25cf0b2127669c12ad75a079c25502a5456764de23f30df1fcdb88418fe970834d7',

--- a/modules/utxo-lib/test/integration_local_rpc/generate/main.ts
+++ b/modules/utxo-lib/test/integration_local_rpc/generate/main.ts
@@ -10,13 +10,12 @@ import {
   createScriptPubKey,
   createSpendTransaction,
   isSupportedDepositType,
-  isSupportedSpendType,
   ScriptType,
   scriptTypes,
 } from './outputScripts.util';
 import { RpcClient } from './RpcClient';
 import { fixtureKeys, wipeFixtures, writeTransactionFixtureWithInputs } from './fixtures';
-import { isScriptType2Of3 } from '../../../src/bitgo/outputScripts';
+import { isScriptType2Of3, isSupportedScriptType } from '../../../src/bitgo/outputScripts';
 import { sendFromFaucet, generateToFaucet } from './faucet';
 
 async function initBlockchain(rpc: RpcClient, network: Network): Promise<void> {
@@ -72,7 +71,7 @@ async function createTransactionsForScriptType(
   const deposit1Txid = await sendFromFaucet(rpc, address, 1);
   const deposit1Tx = await rpc.getRawTransaction(deposit1Txid);
   await writeTransactionFixtureWithInputs(rpc, network, `deposit_${scriptType}.json`, deposit1Txid);
-  if (!isScriptType2Of3(scriptType) || !isSupportedSpendType(network, scriptType)) {
+  if (!isScriptType2Of3(scriptType) || !isSupportedScriptType(network, scriptType)) {
     console.log(logTag + ': spend not supported, skipping spend');
     return;
   }

--- a/modules/utxo-lib/test/networks.ts
+++ b/modules/utxo-lib/test/networks.ts
@@ -1,6 +1,5 @@
 import * as assert from 'assert';
-import { coins, networks } from '../src';
-import { Network } from '../src/networkTypes';
+import { coins, Network, networks, supportsSegwit, supportsTaproot } from '../src';
 
 describe('networks', function () {
   // Ideally, all properties for all coins should be distinct.
@@ -63,6 +62,30 @@ describe('networks', function () {
           list.shift();
         }
       }
+    });
+  });
+
+  describe('Features', function () {
+    it('have expected values for networks', function () {
+      assert.deepStrictEqual(
+        coins.getNetworkList().map((n) => [coins.getNetworkName(n), supportsSegwit(n), supportsTaproot(n)]),
+        [
+          ['bitcoin', true, true],
+          ['testnet', true, true],
+          ['bitcoincash', false, false],
+          ['bitcoincashTestnet', false, false],
+          ['bitcoingold', true, false],
+          ['bitcoingoldTestnet', true, false],
+          ['bitcoinsv', false, false],
+          ['bitcoinsvTestnet', false, false],
+          ['dash', false, false],
+          ['dashTest', false, false],
+          ['litecoin', true, false],
+          ['litecoinTest', true, false],
+          ['zcash', false, false],
+          ['zcashTest', false, false],
+        ]
+      );
     });
   });
 


### PR DESCRIPTION
Provide canonical place for this information.

BREAKING CHANGE: Removes these methods from AbstractUtxoCoin:

* `supportsP2sh()`
* `supportsP2shP2wsh()`
* `supportsP2wsh()`
* `supportsP2tr()`

Use `supportsAddressType(ScriptType2Of3)` instead.

Issue: BG-38773