### PR TITLE
fix(core): add base `explainTransaction` method

### DIFF
--- a/modules/core/src/v2/baseCoin.ts
+++ b/modules/core/src/v2/baseCoin.ts
@@ -1,12 +1,14 @@
 /**
  * @prettier
  */
-import { BigNumber } from 'bignumber.js';
-import * as utxolib from '@bitgo/utxo-lib';
+import * as crypto from 'crypto';
 import * as bip32 from 'bip32';
+import { BigNumber } from 'bignumber.js';
+import { BaseCoin as AccountLibBasecoin } from '@bitgo/account-lib';
+import * as utxolib from '@bitgo/utxo-lib';
+
 import { BitGo } from '../bitgo';
 import { RequestTracer } from './internal/util';
-
 import { Wallet } from './wallet';
 import { Wallets } from './wallets';
 import { Markets } from './markets';
@@ -15,11 +17,10 @@ import { PendingApprovals } from './pendingApprovals';
 import { Keychain, Keychains, KeyIndices } from './keychains';
 import { Enterprises } from './enterprises';
 
-// re-export account lib transaction types
-import { BaseCoin as AccountLibBasecoin } from '@bitgo/account-lib';
-import { signMessage } from '../bip32util';
-import * as crypto from 'crypto';
 import { InitiateRecoveryOptions } from './recovery/initiate';
+import { signMessage } from '../bip32util';
+
+// re-export account lib transaction types
 export type TransactionType = AccountLibBasecoin.TransactionType;
 
 export interface TransactionRecipient {
@@ -28,20 +29,20 @@ export interface TransactionRecipient {
   memo?: string;
 }
 
-export interface TransactionFee {
-  fee: string;
+export interface TransactionFee<TAmount = string> {
+  fee: TAmount;
   feeRate?: number;
   size?: number;
 }
 
-export interface TransactionExplanation {
+export interface TransactionExplanation<TFee = any, TAmount = any> {
   displayOrder: string[];
   id: string;
   outputs: TransactionRecipient[];
-  outputAmount: string;
+  outputAmount: TAmount;
   changeOutputs: TransactionRecipient[];
-  changeAmount: string;
-  fee: TransactionFee;
+  changeAmount: TAmount;
+  fee: TFee;
   proxy?: string;
   producers?: string[];
 }
@@ -345,6 +346,14 @@ export abstract class BaseCoin {
    */
   async signMessage(key: { prv: string }, message: string): Promise<Buffer> {
     return signMessage(message, bip32.fromBase58(key.prv), utxolib.networks.bitcoin);
+  }
+
+  /**
+   * Decompose a raw transaction into useful information.
+   * @param options - coin-specific
+   */
+  explainTransaction(options: Record<string, any>): Promise<TransactionExplanation<any, string | number> | undefined> {
+    throw new Error(`not implemented`);
   }
 
   /**

--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -42,6 +42,7 @@ import {
   SignedTransaction,
   SignTransactionOptions as BaseSignTransactionOptions,
   SupplementGenerateWalletOptions,
+  TransactionExplanation as BaseTransactionExplanation,
   TransactionParams as BaseTransactionParams,
   TransactionPrebuild as BaseTransactionPrebuild,
   TransactionRecipient,
@@ -76,21 +77,10 @@ export interface Output {
   needsCustomChangeKeySignatureVerification?: boolean;
 }
 
-export interface TransactionFee {
-  fee: number;
-  feeRate?: number;
-  size: number;
-}
-
-export interface TransactionExplanation {
-  displayOrder: string[];
-  id: string;
+export interface TransactionExplanation extends BaseTransactionExplanation<string, number> {
   locktime: number;
   outputs: Output[];
   changeOutputs: Output[];
-  outputAmount: number;
-  changeAmount: number;
-  fee: TransactionFee | string;
 
   /**
    * Number of input signatures per input.


### PR DESCRIPTION
The method, while optional, is part of the generic coin interface.

Unfortunately it is very difficult to have very strong types here so
we have to add a bunch of type parameters.

The `options` argument in fact is so heterogeneous between coin
implementations that it cannot be narrowed to anything meaningful
besides `any` (see implementation for EOS).

Issue: BG-40467