### PR TITLE
chore(account-lib): change proxyType to an enum

### DIFF
--- a/modules/account-lib/src/coin/dot/addressInitializationBuilder.ts
+++ b/modules/account-lib/src/coin/dot/addressInitializationBuilder.ts
@@ -6,13 +6,13 @@ import { TransactionBuilder } from './transactionBuilder';
 import { Transaction } from './transaction';
 import { DecodedSignedTx, DecodedSigningPayload, UnsignedTransaction } from '@substrate/txwrapper-core';
 import { TransactionType } from '../baseCoin';
-import { AddProxyArgs, MethodNames, proxyType } from './iface';
+import { AddProxyArgs, MethodNames, ProxyType } from './iface';
 import { AddressInitializationSchema } from './txnSchema';
 import { BaseAddress } from '../baseCoin/iface';
 
 export class AddressInitializationBuilder extends TransactionBuilder {
   protected _delegate: string;
-  protected _proxyType: proxyType;
+  protected _proxyType: ProxyType;
   protected _delay: string;
 
   constructor(_coinConfig: Readonly<CoinConfig>) {
@@ -65,7 +65,7 @@ export class AddressInitializationBuilder extends TransactionBuilder {
    *
    * @see https://wiki.polkadot.network/docs/learn-proxies#proxy-types
    */
-  type(proxyType: proxyType): this {
+  type(proxyType: ProxyType): this {
     this._proxyType = proxyType;
     return this;
   }

--- a/modules/account-lib/src/coin/dot/iface.ts
+++ b/modules/account-lib/src/coin/dot/iface.ts
@@ -36,7 +36,7 @@ export interface TxData {
   owner?: string;
   proxyType?: string;
   delay?: string;
-  forceProxyType?: proxyType;
+  forceProxyType?: ProxyType;
 }
 
 /**
@@ -80,14 +80,14 @@ export interface UnstakeArgs {
  * The types of proxies that can be setup and used
  * https://wiki.polkadot.network/docs/learn-proxies#proxy-types
  */
-export type proxyType =
-  | 'Any'
-  | 'NonTransfer'
-  | 'Governance'
-  | 'Staking'
-  | 'UnusedSudoBalances'
-  | 'IdentityJudgement'
-  | 'CancelProxy';
+export enum ProxyType {
+  ANY = 'Any',
+  NON_TRANSFER = 'NonTransfer',
+  GOVERNANCE = 'Governance',
+  STAKING = 'Staking',
+  IDENTTITY_JUDGEMENT = 'IdentityJudgement',
+  CANCEL_PROXY = 'CancelProxy',
+}
 
 /**
  * Transaction method specific args
@@ -95,7 +95,7 @@ export type proxyType =
 export interface AddProxyArgs {
   delegate: string;
   delay: string;
-  proxyType: proxyType;
+  proxyType: ProxyType;
 }
 
 /**
@@ -111,7 +111,7 @@ export type ProxyCallArgs = {
  */
 export interface ProxyArgs {
   real: string;
-  forceProxyType: proxyType;
+  forceProxyType: ProxyType;
 }
 
 /**
@@ -163,7 +163,7 @@ export interface ValidityWindow {
 
 export interface TransactionExplanation extends BaseTransactionExplanation {
   type: TransactionType;
-  forceProxyType?: proxyType;
+  forceProxyType?: ProxyType;
   controller?: string;
   payee?: string;
   owner?: string;

--- a/modules/account-lib/src/coin/dot/transferBuilder.ts
+++ b/modules/account-lib/src/coin/dot/transferBuilder.ts
@@ -6,7 +6,7 @@ import { TransactionBuilder } from './transactionBuilder';
 import { Transaction } from './transaction';
 import { DecodedSignedTx, DecodedSigningPayload, UnsignedTransaction } from '@substrate/txwrapper-core';
 import { TransactionType } from '../baseCoin';
-import { MethodNames, ProxyArgs, proxyType, TransferArgs } from './iface';
+import { MethodNames, ProxyArgs, ProxyType, TransferArgs } from './iface';
 import { ProxyTransactionSchema, TransferTransactionSchema } from './txnSchema';
 import utils from './utils';
 import { BaseAddress } from '../baseCoin/iface';
@@ -15,7 +15,7 @@ export class TransferBuilder extends TransactionBuilder {
   protected _amount: string;
   protected _to: string;
   protected _owner: string;
-  protected _forceProxyType: proxyType;
+  protected _forceProxyType: ProxyType;
 
   constructor(_coinConfig: Readonly<CoinConfig>) {
     super(_coinConfig);
@@ -111,7 +111,7 @@ export class TransferBuilder extends TransactionBuilder {
    *
    * @see https://wiki.polkadot.network/docs/learn-proxies#proxy-types
    */
-  forceProxyType(forceProxyType: proxyType): this {
+  forceProxyType(forceProxyType: ProxyType): this {
     this._forceProxyType = forceProxyType;
     return this;
   }

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/addressInitializationBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/addressInitializationBuilder.ts
@@ -3,6 +3,7 @@ import sinon, { assert } from 'sinon';
 import { AddressInitializationBuilder } from '../../../../../src/coin/dot';
 import * as DotResources from '../../../../resources/dot';
 import { buildTestConfig } from './base';
+import { ProxyType } from '../../../../../src/coin/dot/iface';
 
 describe('Dot Add Proxy Builder', () => {
   let builder: AddressInitializationBuilder;
@@ -40,7 +41,7 @@ describe('Dot Add Proxy Builder', () => {
     it('should build a addProxy transaction', async () => {
       builder
         .owner({ address: receiver.address })
-        .type('Any')
+        .type(ProxyType.ANY)
         .delay('0')
         .sender({ address: sender.address })
         .validity({ firstValid: 3933, maxDuration: 64 })
@@ -52,7 +53,7 @@ describe('Dot Add Proxy Builder', () => {
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.owner, receiver.address);
-      should.deepEqual(txJson.proxyType, 'Any');
+      should.deepEqual(txJson.proxyType, ProxyType.ANY);
       should.deepEqual(txJson.delay, '0');
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
@@ -69,7 +70,7 @@ describe('Dot Add Proxy Builder', () => {
     it('should build an unsigned addProxy transaction', async () => {
       builder
         .owner({ address: receiver.address })
-        .type('Any')
+        .type(ProxyType.ANY)
         .delay('0')
         .sender({ address: sender.address })
         .validity({ firstValid: 3933, maxDuration: 64 })
@@ -80,7 +81,7 @@ describe('Dot Add Proxy Builder', () => {
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.owner, receiver.address);
-      should.deepEqual(txJson.proxyType, 'Any');
+      should.deepEqual(txJson.proxyType, ProxyType.ANY);
       should.deepEqual(txJson.delay, '0');
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
@@ -103,7 +104,7 @@ describe('Dot Add Proxy Builder', () => {
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.owner, receiver.address);
-      should.deepEqual(txJson.proxyType, 'Any');
+      should.deepEqual(txJson.proxyType, ProxyType.ANY);
       should.deepEqual(txJson.delay, '0');
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
@@ -127,7 +128,7 @@ describe('Dot Add Proxy Builder', () => {
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.owner, receiver.address);
-      should.deepEqual(txJson.proxyType, 'Any');
+      should.deepEqual(txJson.proxyType, ProxyType.ANY);
       should.deepEqual(txJson.delay, '0');
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/transferBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/transferBuilder.ts
@@ -4,6 +4,7 @@ import sinon, { assert } from 'sinon';
 import { TransferBuilder } from '../../../../../src/coin/dot';
 import * as DotResources from '../../../../resources/dot';
 import { buildTestConfig } from './base';
+import { ProxyType } from '../../../../../src/coin/dot/iface';
 
 describe('Dot Transfer Builder', () => {
   let builder: TransferBuilder;
@@ -215,7 +216,7 @@ describe('Dot Transfer Builder', () => {
     it('should build a proxy transaction', async () => {
       builder
         .owner({ address: sender.address })
-        .forceProxyType('Any')
+        .forceProxyType(ProxyType.ANY)
         .to({ address: receiver.address })
         .amount('90034235235322')
         .sender({ address: proxySender.address })
@@ -228,7 +229,7 @@ describe('Dot Transfer Builder', () => {
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.owner, sender.address);
-      should.deepEqual(txJson.forceProxyType, 'Any');
+      should.deepEqual(txJson.forceProxyType, ProxyType.ANY);
       should.deepEqual(txJson.sender, proxySender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
@@ -252,7 +253,7 @@ describe('Dot Transfer Builder', () => {
     it('should build an unsigned proxy transaction', async () => {
       builder
         .owner({ address: sender.address })
-        .forceProxyType('Any')
+        .forceProxyType(ProxyType.ANY)
         .to({ address: receiver.address })
         .amount('90034235235322')
         .sender({ address: proxySender.address })
@@ -264,7 +265,7 @@ describe('Dot Transfer Builder', () => {
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.owner, sender.address);
-      should.deepEqual(txJson.forceProxyType, 'Any');
+      should.deepEqual(txJson.forceProxyType, ProxyType.ANY);
       should.deepEqual(txJson.sender, proxySender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
@@ -286,7 +287,7 @@ describe('Dot Transfer Builder', () => {
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.owner, sender.address);
-      should.deepEqual(txJson.forceProxyType, 'Any');
+      should.deepEqual(txJson.forceProxyType, ProxyType.ANY);
       should.deepEqual(txJson.sender, proxySender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
@@ -309,7 +310,7 @@ describe('Dot Transfer Builder', () => {
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.owner, sender.address);
-      should.deepEqual(txJson.forceProxyType, 'Any');
+      should.deepEqual(txJson.forceProxyType, ProxyType.ANY);
       should.deepEqual(txJson.sender, proxySender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');


### PR DESCRIPTION
Changing `proxyType` to an enum will allow WP to access the values inside instead of just using `proxyType` as a `type`

JIRA ticket: https://bitgoinc.atlassian.net/browse/STLX-8351