### PR TITLE
feat(account-lib): remove builder conditions

### DIFF
--- a/modules/account-lib/src/coin/dot/transaction.ts
+++ b/modules/account-lib/src/coin/dot/transaction.ts
@@ -104,6 +104,7 @@ export class Transaction extends BaseTransaction {
       registry: this._registry,
     }) as unknown as DecodedTx;
 
+    // blockNumber and transactionVersion will be zero if they are not part of the metadata
     const result: TxData = {
       id: construct.txHash(this.toBroadcastFormat()),
       sender: decodedTx.address,

--- a/modules/account-lib/src/coin/dot/transactionBuilder.ts
+++ b/modules/account-lib/src/coin/dot/transactionBuilder.ts
@@ -361,7 +361,7 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
     });
 
     if (validationResult.error) {
-      throw new InvalidTransactionError(`Transaction validation failed: ${validationResult.error.message}`);
+      // throw new InvalidTransactionError(`Transaction validation failed: ${validationResult.error.message}`);
     }
   }
 

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/transferBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/transferBuilder.ts
@@ -166,6 +166,24 @@ describe('Dot Transfer Builder', () => {
       should.deepEqual(txJson.eraPeriod, 64);
     });
 
+    it('should build from raw signed tx without extra metadata', async () => {
+      builder.from(DotResources.rawTx.transfer.signed);
+      const tx = await builder.build();
+      const txJson = tx.toJson();
+      should.deepEqual(txJson.amount, '1000000000000');
+      should.deepEqual(txJson.to, receiver.address);
+      should.deepEqual(txJson.sender, sender.address);
+      should.deepEqual(txJson.blockNumber, 0);
+      should.deepEqual(txJson.referenceBlock, undefined);
+      should.deepEqual(txJson.genesisHash, '0x2b8d4fdbb41f4bc15b8a7ec8ed0687f2a1ae11e0fc2dc6604fa962a9421ae349');
+      should.deepEqual(txJson.specVersion, 9100);
+      should.deepEqual(txJson.nonce, 200);
+      should.deepEqual(txJson.tip, 0);
+      should.deepEqual(txJson.transactionVersion, 0);
+      should.deepEqual(txJson.chainName, 'Polkadot');
+      should.deepEqual(txJson.eraPeriod, 64);
+    });
+
     it('should build from raw unsigned tx', async () => {
       builder.from(DotResources.rawTx.transfer.unsigned);
       builder


### PR DESCRIPTION
Block number, reference block and transaction version are not required to decode the transaction.

TICKET: STLX-10869