### PR TITLE
fix(statics): update deprecated bch explorer url

### DIFF
--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -117,14 +117,14 @@ class BitcoinCash extends Mainnet implements UtxoNetwork {
   name = 'BitcoinCash';
   family = CoinFamily.BCH;
   utxolibName = 'bitcoincash';
-  explorerUrl = 'http://blockdozer.com/tx/';
+  explorerUrl = 'https://www.blockchain.com/bch/tx/';
 }
 
 class BitcoinCashTestnet extends Testnet implements UtxoNetwork {
   name = 'BitcoinCashTestnet';
   family = CoinFamily.BCH;
   utxolibName = 'bitcoincashTestnet';
-  explorerUrl = 'https://tbch.blockdozer.com/tx/';
+  explorerUrl = 'https://www.blockchain.com/bch-testnet/tx/';
 }
 
 class BitcoinABC extends Mainnet implements UtxoNetwork {


### PR DESCRIPTION
This PR updates the explorer url for BCH to use https://www.blockchain.com/ over the deprecated url

Fixes: https://bitgoinc.atlassian.net/browse/BG-40963