### PR TITLE
fix(statics): fix send many memo contract address for prod

### DIFF
--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -399,7 +399,7 @@ class Stx extends Mainnet implements StacksNetwork {
   name = 'Stx';
   family = CoinFamily.STX;
   explorerUrl = 'https://explorer.stacks.co/';
-  sendmanymemoContractAddress = 'SP3HVG0704NNCN0DHYJ0SFHE87XPJWMVTXG4B30BD';
+  sendmanymemoContractAddress = 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE';
   stakingContractAddress = 'SP000000000000000000002Q6VF78';
 }
 


### PR DESCRIPTION
Changed send-many-memo contract address in the stx mainnet config

[STLX-11908](https://bitgoinc.atlassian.net/browse/STLX-11908)