### PR TITLE
chore(statics): remove package level prettier

### DIFF
--- a/modules/statics/package.json
+++ b/modules/statics/package.json
@@ -27,7 +27,6 @@
     "mocha": "^6.2.1",
     "mochawesome": "^3.1.2",
     "nyc": "^15.0.0",
-    "prettier": "^1.16.4",
     "should": "^13.2.3"
   },
   "husky": {

--- a/modules/statics/src/account.ts
+++ b/modules/statics/src/account.ts
@@ -104,7 +104,7 @@ export class ContractAddressDefinedToken extends AccountCoinToken {
       throw new InvalidContractAddressError(options.name, options.contractAddress);
     }
 
-    this.contractAddress = (options.contractAddress as unknown) as ContractAddress;
+    this.contractAddress = options.contractAddress as unknown as ContractAddress;
   }
 }
 
@@ -123,7 +123,7 @@ export class Base58ContractAddressDefinedToken extends AccountCoinToken {
       throw new InvalidContractAddressError(options.name, options.contractAddress);
     }
 
-    this.contractAddress = (options.contractAddress as unknown) as ContractAddress;
+    this.contractAddress = options.contractAddress as unknown as ContractAddress;
   }
 }
 
@@ -287,9 +287,9 @@ export function account(
   asset: UnderlyingAsset,
   features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
   primaryKeyCurve: KeyCurve = KeyCurve.Secp256k1,
-  prefix: string = '',
+  prefix = '',
   suffix: string = name.toUpperCase(),
-  isToken: boolean = false
+  isToken = false
 ) {
   return Object.freeze(
     new AccountCoin({
@@ -328,7 +328,7 @@ export function erc20(
   contractAddress: string,
   asset: UnderlyingAsset,
   features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
-  prefix: string = '',
+  prefix = '',
   suffix: string = name.toUpperCase(),
   network: EthereumNetwork = Networks.main.ethereum,
   primaryKeyCurve: KeyCurve = KeyCurve.Secp256k1
@@ -370,7 +370,7 @@ export function terc20(
   contractAddress: string,
   asset: UnderlyingAsset,
   features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
-  prefix: string = '',
+  prefix = '',
   suffix: string = name.toUpperCase(),
   network: EthereumNetwork = Networks.test.kovan
 ) {
@@ -399,7 +399,7 @@ export function erc20CompatibleAccountCoin(
   contractAddress: string,
   asset: UnderlyingAsset,
   features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
-  prefix: string = '',
+  prefix = '',
   suffix: string = name.toUpperCase(),
   primaryKeyCurve: KeyCurve = KeyCurve.Secp256k1
 ) {
@@ -441,7 +441,7 @@ export function celoToken(
   contractAddress: string,
   asset: UnderlyingAsset,
   features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
-  prefix: string = '',
+  prefix = '',
   suffix: string = name.toUpperCase(),
   network: EthereumNetwork = Networks.main.celo,
   primaryKeyCurve: KeyCurve = KeyCurve.Secp256k1
@@ -483,7 +483,7 @@ export function tceloToken(
   contractAddress: string,
   asset: UnderlyingAsset,
   features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
-  prefix: string = '',
+  prefix = '',
   suffix: string = name.toUpperCase(),
   network: EthereumNetwork = Networks.test.celo
 ) {
@@ -510,9 +510,9 @@ export function stellarToken(
   fullName: string,
   decimalPlaces: number,
   asset: UnderlyingAsset,
-  domain: string = '',
+  domain = '',
   features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
-  prefix: string = '',
+  prefix = '',
   suffix: string = name.toUpperCase(),
   network: AccountNetwork = Networks.main.stellar,
   primaryKeyCurve: KeyCurve = KeyCurve.Ed25519
@@ -553,9 +553,9 @@ export function tstellarToken(
   fullName: string,
   decimalPlaces: number,
   asset: UnderlyingAsset,
-  domain: string = '',
+  domain = '',
   features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
-  prefix: string = '',
+  prefix = '',
   suffix: string = name.toUpperCase(),
   network: AccountNetwork = Networks.test.stellar
 ) {
@@ -583,7 +583,7 @@ export function tronToken(
   contractAddress: string,
   asset: UnderlyingAsset,
   features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
-  prefix: string = '',
+  prefix = '',
   suffix: string = name.toUpperCase(),
   network: TronNetwork = Networks.main.trx,
   primaryKeyCurve: KeyCurve = KeyCurve.Secp256k1
@@ -626,7 +626,7 @@ export function ttronToken(
   contractAddress: string,
   asset: UnderlyingAsset,
   features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
-  prefix: string = '',
+  prefix = '',
   suffix: string = name.toUpperCase(),
   network: TronNetwork = Networks.test.trx,
   primaryKeyCurve: KeyCurve = KeyCurve.Secp256k1
@@ -665,9 +665,9 @@ export function hederaCoin(
   network: AccountNetwork,
   decimalPlaces: number,
   asset: UnderlyingAsset,
-  nodeAccountId: string = '0.0.3',
+  nodeAccountId = '0.0.3',
   features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
-  prefix: string = '',
+  prefix = '',
   suffix: string = name.toUpperCase(),
   primaryKeyCurve: KeyCurve = KeyCurve.Ed25519
 ) {
@@ -708,9 +708,9 @@ export function algoToken(
   fullName: string,
   decimalPlaces: number,
   asset: UnderlyingAsset,
-  tokenURL: string = '',
+  tokenURL = '',
   features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
-  prefix: string = '',
+  prefix = '',
   suffix: string = name.toUpperCase(),
   network: AccountNetwork = Networks.main.algorand,
   primaryKeyCurve: KeyCurve = KeyCurve.Ed25519
@@ -751,9 +751,9 @@ export function talgoToken(
   fullName: string,
   decimalPlaces: number,
   asset: UnderlyingAsset,
-  tokenURL: string = '',
+  tokenURL = '',
   features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
-  prefix: string = '',
+  prefix = '',
   suffix: string = name.toUpperCase(),
   network: AccountNetwork = Networks.test.algorand
 ) {
@@ -781,7 +781,7 @@ export function eosToken(
   contractName: string,
   asset: UnderlyingAsset,
   features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
-  prefix: string = '',
+  prefix = '',
   suffix: string = name.toUpperCase(),
   network: AccountNetwork = Networks.main.eos,
   primaryKeyCurve: KeyCurve = KeyCurve.Secp256k1
@@ -823,7 +823,7 @@ export function teosToken(
   contractName: string,
   asset: UnderlyingAsset,
   features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
-  prefix: string = '',
+  prefix = '',
   suffix: string = name.toUpperCase(),
   network: AccountNetwork = Networks.test.eos
 ) {
@@ -851,7 +851,7 @@ export function solToken(
   tokenAddress: string,
   asset: UnderlyingAsset,
   features: CoinFeature[] = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.REQUIRES_RESERVE],
-  prefix: string = '',
+  prefix = '',
   suffix: string = name.toUpperCase(),
   network: AccountNetwork = Networks.main.sol,
   primaryKeyCurve: KeyCurve = KeyCurve.Ed25519
@@ -893,7 +893,7 @@ export function tsolToken(
   tokenAddress: string,
   asset: UnderlyingAsset,
   features: CoinFeature[] = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.REQUIRES_RESERVE],
-  prefix: string = '',
+  prefix = '',
   suffix: string = name.toUpperCase(),
   network: AccountNetwork = Networks.test.sol
 ) {
@@ -921,7 +921,7 @@ export function avaxErc20(
   contractAddress: string,
   asset: UnderlyingAsset,
   features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
-  prefix: string = '',
+  prefix = '',
   suffix: string = name.toUpperCase(),
   network: AccountNetwork = Networks.main.avalancheC,
   primaryKeyCurve: KeyCurve = KeyCurve.Secp256k1
@@ -964,7 +964,7 @@ export function tavaxErc20(
   contractAddress: string,
   asset: UnderlyingAsset,
   features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
-  prefix: string = '',
+  prefix = '',
   suffix: string = name.toUpperCase(),
   network: AccountNetwork = Networks.test.avalancheC,
   primaryKeyCurve: KeyCurve = KeyCurve.Secp256k1

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -828,7 +828,7 @@ export abstract class BaseCoin {
     const requiredFeatures = this.requiredFeatures();
     const disallowedFeatures = this.disallowedFeatures();
 
-    const intersectionFeatures = Array.from(requiredFeatures).filter(feat => disallowedFeatures.has(feat));
+    const intersectionFeatures = Array.from(requiredFeatures).filter((feat) => disallowedFeatures.has(feat));
 
     if (intersectionFeatures.length > 0) {
       throw new ConflictingCoinFeaturesError(options.name, intersectionFeatures);

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -28,7 +28,7 @@ const ETH_FEATURES = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.SUPPORTS_TOKE
 const ETH2_FEATURES = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.SUPPORTS_TOKENS];
 const XLM_FEATURES = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.SUPPORTS_TOKENS];
 const XTZ_FEATURES = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.ENTERPRISE_PAYS_FEES].filter(
-  feature => feature !== CoinFeature.CUSTODY
+  (feature) => feature !== CoinFeature.CUSTODY
 );
 const CSPR_FEATURES = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.REQUIRES_RESERVE];
 const ALGO_FEATURES = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.SUPPORTS_TOKENS];

--- a/yarn.lock
+++ b/yarn.lock
@@ -9898,6 +9898,18 @@ libnpmpublish@^4.0.0:
     semver "^7.1.3"
     ssri "^8.0.1"
 
+libsodium-sumo@^0.7.0:
+  version "0.7.9"
+  resolved "https://registry.yarnpkg.com/libsodium-sumo/-/libsodium-sumo-0.7.9.tgz#dff3d6144849e30d9b9a7bf628d28243f1c49102"
+  integrity sha512-DcfJ57zlSlcmQU4s8KOX78pT0zKx5S9RLi0oyDuoIgm4K95+VNSaOidK/y9lUK4lxft14PtTPjoBy8tmLk1TDQ==
+
+libsodium-wrappers-sumo@^0.7.9:
+  version "0.7.9"
+  resolved "https://registry.yarnpkg.com/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.7.9.tgz#d15a346870c8e339baf1518f06b0ddccfa1e1046"
+  integrity sha512-XLgLkqY973PngrRElbjOH0y7bJKYEfMWVpWPmW5iuhBjO6zXvHYQWtN52MVEeie/h98ZXN1Aw9BE+GzxQVAfLg==
+  dependencies:
+    libsodium-sumo "^0.7.0"
+
 libsodium-wrappers@^0.7.6:
   version "0.7.9"
   resolved "https://registry.yarnpkg.com/libsodium-wrappers/-/libsodium-wrappers-0.7.9.tgz#4ffc2b69b8f7c7c7c5594a93a4803f80f6d0f346"
@@ -12499,7 +12511,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.16.4, prettier@^1.19.1:
+prettier@^1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==


### PR DESCRIPTION
The package level prettier version is behind, which is causing compilation errors when running precommit hooks on typescript packages that have string literal types. Given the amount of format changes, this will be a standalone PR.

Ticket: STLX-12051