### PR TITLE
fix(account-lib): polkadot/api dependency is removed

### DIFF
--- a/modules/account-lib/package.json
+++ b/modules/account-lib/package.json
@@ -45,7 +45,6 @@
     "@ethereumjs/tx": "^3.3.0",
     "@hashgraph/sdk": "~2.3.0",
     "@solana/web3.js": "^1.30.2",
-    "@polkadot/api": "^6.11.1",
     "@stablelib/hex": "^1.0.0",
     "@stablelib/sha384": "^1.0.0",
     "@stacks/transactions": "2.0.1",


### PR DESCRIPTION
@polkadot/api has multiple versions, ensure that there is only one installed.
Either remove and explicitly install matching versions or dedupe using your package manager.
The following conflicting packages were found:
	cjs 7.3.1 	/home/node/srv/node_modules/@substrate/txwrapper-core/node_modules/@polkadot/api
	    6.12.1	/home/node/srv/node_modules/@polkadot/api
	    
[STLX-12053](https://bitgoinc.atlassian.net/browse/STLX-12053)