### PR TITLE
fix(account-lib): remove proxy type from constants STLX-12064

### DIFF
--- a/modules/account-lib/src/coin/dot/iface.ts
+++ b/modules/account-lib/src/coin/dot/iface.ts
@@ -85,7 +85,6 @@ export interface UnstakeArgs {
 export enum ProxyType {
   ANY = 'Any',
   NON_TRANSFER = 'NonTransfer',
-  GOVERNANCE = 'Governance',
   STAKING = 'Staking',
   IDENTTITY_JUDGEMENT = 'IdentityJudgement',
   CANCEL_PROXY = 'CancelProxy',


### PR DESCRIPTION
the proxy type of “Governance” is no longer supported by the substrate package used for transaction building - removing the type from account-lib will help remove testing for the type which could cause failures.

JIRA ticket: https://bitgoinc.atlassian.net/browse/STLX-12064