### PR TITLE
fix(root): resolve `follow-redirects` to version ^1.14.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "resolutions": {
     "axios": "^0.21.2",
     "elliptic": "^6.5.4",
+    "follow-redirects": "^1.14.7",
     "normalize-url": "^6.0.1",
     "trim-newlines": "^3.0.0",
     "underscore": "^1.12.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7602,15 +7602,10 @@ fn-name@~2.0.1:
   resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
   integrity sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=
 
-follow-redirects@^1.0.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.1.tgz#d9114ded0a1cfdd334e164e6662ad02bfd91ff43"
-  integrity sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
-
-follow-redirects@^1.14.0:
-  version "1.14.4"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.4.tgz#838fdf48a8bbdd79e52ee51fb1c94e3ed98b9379"
-  integrity sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==
+follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.14.7:
+  version "1.14.7"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
+  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
 
 for-each@~0.3.3:
   version "0.3.3"


### PR DESCRIPTION
```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ high          │ Exposure of sensitive information in follow-redirects        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ follow-redirects                                             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.14.7                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @bitgo/account-lib                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @bitgo/account-lib > casper-client-sdk > axios >             │
│               │ follow-redirects                                             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1006865                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ high          │ Exposure of sensitive information in follow-redirects        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ follow-redirects                                             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.14.7                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ bitgo                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ bitgo > @bitgo/account-lib > casper-client-sdk > axios >     │
│               │ follow-redirects                                             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1006865                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ high          │ Exposure of sensitive information in follow-redirects        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ follow-redirects                                             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.14.7                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @bitgo/express                                               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @bitgo/express > bitgo > @bitgo/account-lib >                │
│               │ casper-client-sdk > axios > follow-redirects                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1006865                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
```

Ticket: BG-41675