### PR TITLE
fix(core): fix sol send tx

### DIFF
--- a/modules/core/test/v2/unit/coins/sol.ts
+++ b/modules/core/test/v2/unit/coins/sol.ts
@@ -106,6 +106,14 @@ describe('SOL:', function () {
       const validTransaction = await basecoin.verifyTransaction({ txParams, txPrebuild, memo, feePayer, blockhash, durableNonce });
       validTransaction.should.equal(true);
     });
+    it('should handle txBase64 and txHex interchangeably', async function () {
+      const txParams = newTxParams();
+      const txPrebuild = newTxPrebuild();
+      txPrebuild.txHex = txPrebuild.txBase64;
+      txPrebuild.txBase64 = undefined;
+      const validTransaction = await basecoin.verifyTransaction({ txParams, txPrebuild, memo, feePayer, blockhash, durableNonce });
+      validTransaction.should.equal(true);
+    });
     it('should fail verify transactions when have different memo', async function () {
       const txParams = newTxParams();
       const txPrebuild = newTxPrebuild();
@@ -440,7 +448,18 @@ describe('SOL:', function () {
         },
         prv: resources.accountWithSeed.privateKey.base58,
       });
-      signed.txBase64.should.equal(resources.RAW_TX_SIGNED);
+      signed.txHex.should.equal(resources.RAW_TX_SIGNED);
+    });
+
+    it('should handle txHex and txBase64 interchangeably', async function () {
+      const signed = await basecoin.signTransaction({
+        txPrebuild: {
+          txHex: resources.RAW_TX_UNSIGNED,
+          keys: [resources.accountWithSeed.publicKey.toString()],
+        },
+        prv: resources.accountWithSeed.privateKey.base58,
+      });
+      signed.txHex.should.equal(resources.RAW_TX_SIGNED);
     });
 
     it('should throw invalid transaction when sign with public key', async function () {


### PR DESCRIPTION
addresses mismatches between usages of txHex and txBase64

Ticket: STLX-12389

verified in testnet-06:
```
  const wallet = await bitgo.coin('tsol').wallets().get({ id: '61e8dfa754e0f10007750aaf8c11640e' });
  const sendTx = await wallet.send({
    address: 'DHjfEwHhPaK4cmAu7Y77DLArgFz7g9HcoaK9YQvLJVwi',
    amount: '1000',
    walletPassphrase: 'Ghghjkg!455544llll',
    type: 'transfer',
  });
  console.log(JSON.stringify(sendTx, undefined, 2));
```