### PR TITLE
fix(core): correct type of `allTokens` property on `TransfersOptions`

### DIFF
--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -159,7 +159,7 @@ export interface GetTransactionOptions extends PaginationOptions {
 
 export interface TransfersOptions extends PaginationOptions {
   txHash?: string;
-  allTokens?: string;
+  allTokens?: boolean;
   searchLabel?: string;
   address?: string[] | string;
   dateGte?: string;


### PR DESCRIPTION
This is a boolean parameter and typing as a `string` is incorrect.

Ticket: BG-41942