### PR TITLE
feat(core): generate receive addresses on client

### DIFF
--- a/modules/core/src/v2/baseCoin.ts
+++ b/modules/core/src/v2/baseCoin.ts
@@ -115,6 +115,15 @@ export interface SupplementGenerateWalletOptions {
   };
   rootPrivateKey?: string;
   disableKRSEmail?: boolean;
+  addressDerivationKeypair?: {
+    encryptedPrv: string;
+    pub: string;
+  };
+}
+
+export interface DeriveKeypairOptions {
+  addressDerivationPrv: string;
+  index: number;
 }
 
 export interface FeeEstimateOptions {
@@ -485,6 +494,14 @@ export abstract class BaseCoin {
    */
   initiateRecovery(params: InitiateRecoveryOptions): never {
     throw new Error('deprecated method');
+  }
+
+  /**
+   *
+   * @param params
+   */
+  deriveKeypair(params: DeriveKeypairOptions): KeyPair | undefined {
+    return undefined;
   }
 
   abstract parseTransaction(params: ParseTransactionOptions): Promise<ParsedTransaction>;

--- a/modules/core/src/v2/coins/sol.ts
+++ b/modules/core/src/v2/coins/sol.ts
@@ -19,6 +19,7 @@ import {
   VerifyTransactionOptions,
   SignTransactionOptions,
   TransactionPrebuild as BaseTransactionPrebuild,
+  DeriveKeypairOptions,
 } from '../baseCoin';
 import { BitGo } from '../../bitgo';
 import { Memo } from '../wallet';
@@ -200,6 +201,17 @@ export class Sol extends BaseCoin {
     }
 
     return Buffer.from(solKeypair.signMessage(message));
+  }
+
+  /** @inheritDoc */
+  deriveKeypair(params: DeriveKeypairOptions): KeyPair | undefined {
+    const rootKeypair = new accountLib.Sol.KeyPair({ prv: params.addressDerivationPrv });
+
+    const derivedKeys = rootKeypair.deriveHardened(`m/0'/0'/0'/${params.index}'`);
+    return {
+      prv: derivedKeys.prv || '',
+      pub: derivedKeys.pub,
+    };
   }
 
   /**

--- a/modules/core/src/v2/wallets.ts
+++ b/modules/core/src/v2/wallets.ts
@@ -46,6 +46,10 @@ export interface GenerateWalletOptions {
   };
   coldDerivationSeed?: string;
   rootPrivateKey?: string;
+  addressDerivationKeypair?: {
+    pub: string;
+    encryptedPrv: string;
+  };
 }
 
 export interface GetWalletByAddressOptions {
@@ -453,6 +457,20 @@ export class Wallets {
 
     if (_.includes(['xrp', 'xlm', 'cspr'], this.baseCoin.getFamily()) && !_.isUndefined(params.rootPrivateKey)) {
       walletParams.rootPrivateKey = params.rootPrivateKey;
+    }
+
+    // TODO: only generate if coin supports?
+    if (canEncrypt) {
+      const addressDerivationKeypair = this.baseCoin.keychains().create();
+      if (!addressDerivationKeypair.pub) {
+        throw new Error('Expected address derivation keypair to contain a public key.');
+      }
+
+      const encryptedPrv = this.bitgo.encrypt({ password: passphrase, input: addressDerivationKeypair.prv });
+      walletParams.addressDerivationKeypair = {
+        pub: addressDerivationKeypair.pub,
+        encryptedPrv: encryptedPrv,
+      };
     }
 
     const keychains = {


### PR DESCRIPTION
during wallet creation, we'll generate a secret that's used solely for
address derivation. secret will be encrypted with wallet's passphrase.

currently, only supports hardened derivation, so will need to provide
passphrase when deriving new addresses.

Ticket: BG-00000