### PR TITLE
fix(core): token transactions does build correctly

### DIFF
--- a/modules/core/src/v2/coins/avaxcToken.ts
+++ b/modules/core/src/v2/coins/avaxcToken.ts
@@ -75,6 +75,10 @@ export class AvaxCToken extends AvaxC {
     return this.tokenConfig.type;
   }
 
+  getBaseChain() {
+    return this.coin;
+  }
+
   getFullName(): string {
     return 'Avaxc Token';
   }

--- a/modules/core/test/v2/unit/coins/avaxcToken.ts
+++ b/modules/core/test/v2/unit/coins/avaxcToken.ts
@@ -17,7 +17,7 @@ describe('Avaxc Token:', function () {
 
     it('should return constants', function () {
       avaxcTokenCoin.getChain().should.equal('tavaxc:LINK');
-      avaxcTokenCoin.getBaseChain().should.equal('tavaxc:LINK');
+      avaxcTokenCoin.getBaseChain().should.equal('tavaxc');
       avaxcTokenCoin.getFullName().should.equal('Avaxc Token');
       avaxcTokenCoin.getBaseFactor().should.equal(1e18);
       avaxcTokenCoin.type.should.equal(tokenName);
@@ -44,7 +44,7 @@ describe('Avaxc Token:', function () {
 
     it('should return constants', function () {
       avaxcTokenCoin.getChain().should.equal('avaxc:PNG');
-      avaxcTokenCoin.getBaseChain().should.equal('avaxc:PNG');
+      avaxcTokenCoin.getBaseChain().should.equal('avaxc');
       avaxcTokenCoin.getFullName().should.equal('Avaxc Token');
       avaxcTokenCoin.getBaseFactor().should.equal(1e18);
       avaxcTokenCoin.type.should.equal(tokenName);


### PR DESCRIPTION
Fixed avaxcToken class to get base chain and build correctly the transaction. Fixed respectly
unit-test

STLX-12548

Signed-off-by: evalenti-simtlix <evalenti@simtlix.com>