### PR TITLE
feat(account-lib): migrate BLS key pair from @bitgo/bls to @bitgo/bls-dkg lib

### DIFF
--- a/modules/account-lib/package.json
+++ b/modules/account-lib/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@bitgo/blake2b": "^3.0.1",
     "@bitgo/bls": "^0.1.0",
+    "@bitgo/bls-dkg": "^1.0.1",
     "@bitgo/statics": "^6.15.0",
     "@celo/contractkit": "^1.2.4",
     "@ethereumjs/common": "^2.4.0",
@@ -73,6 +74,7 @@
     "lodash": "^4.17.15",
     "long": "^4.0.0",
     "near-api-js": "^0.44.2",
+    "noble-bls12-381": "0.7.2",
     "protobufjs": "^6.8.9",
     "secp256k1": "4.0.2",
     "stellar-sdk": "^9.0.1",

--- a/modules/account-lib/src/coin/baseCoin/blsKeyPair.ts
+++ b/modules/account-lib/src/coin/baseCoin/blsKeyPair.ts
@@ -1,51 +1,65 @@
 import assert from 'assert';
-import * as BLS from '@bitgo/bls';
-import { stripHexPrefix } from 'ethereumjs-utils-old';
+import * as BLS from '@bitgo/bls-dkg';
 import { BaseKeyPair } from './baseKeyPair';
 import { AddressFormat } from './enum';
 import { NotImplementedError } from './errors';
+import { BlsKeys, KeyPairOptions, isDkg, isBlsKey, isPrivateKey } from './iface';
+import { isValidBLSPublicKey, isValidBLSPrivateKey } from '../../utils/crypto';
 
-let initialized = false;
-const initialize = async () => {
-  await BLS.initBLS();
-  initialized = true;
-};
-
-initialize();
-
-function ensureInitialized() {
-  if (!initialized) {
-    throw new Error('BLS lib not yet initialized, please retry');
-  }
-}
+const DEFAULT_SIGNATURE_THRESHOLD = 2;
+const DEFAULT_SIGNATURE_PARTICIPANTS = 3;
 
 /**
  * Base class for BLS keypairs.
  */
 export abstract class BlsKeyPair implements BaseKeyPair {
-  protected keyPair: BLS.Keypair;
+  protected keyPair: BlsKeys;
 
   /**
-   * Public constructor. By default, creates a key pair with a random master seed.
+   * Public constructor. By default, creates a key pair with a random polynomial.
    *
+   * @param {KeyPairOptions} source Either a dkg options, a public and secret shares, or a private key
    */
-  protected constructor() {
-    ensureInitialized();
-    this.keyPair = BLS.generateKeyPair();
+  protected constructor(source?: KeyPairOptions) {
+    if (!source) {
+      this.createShares(DEFAULT_SIGNATURE_THRESHOLD, DEFAULT_SIGNATURE_PARTICIPANTS);
+    } else if (isDkg(source)) {
+      this.createShares(source.threshold, source.participants);
+    } else if (isBlsKey(source)) {
+      assert(source.secretShares.every(isValidBLSPrivateKey), 'Invalid private keys');
+      assert(isValidBLSPublicKey(source.publicShare), 'Invalid public key');
+      this.keyPair = source;
+    } else if (isPrivateKey(source)) {
+      this.keyPair = {
+        prv: source.prv,
+        publicShare: '',
+        secretShares: [],
+      };
+    } else {
+      throw new Error('Invalid key pair options');
+    }
+  }
+
+  createShares(threshold: number, participants: number): void {
+    if (participants < threshold) {
+      throw new Error('Participants should be greater than threshold');
+    }
+    const polynomial = BLS.generatePolynomial(threshold);
+    const keySecretShares = BLS.secretShares(polynomial, participants);
+    const keyPublicShare = BLS.publicShare(polynomial);
+    this.keyPair = {
+      secretShares: keySecretShares.map((secretShare) => '0x' + secretShare.toString(16)),
+      publicShare: '0x' + keyPublicShare.toString(16),
+    };
   }
 
   /**
-   * Build a keyPair from private key.
+   * Note - this is not possible using BLS. BLS does not support prvkey derived key gen
    *
-   * @param {string} prv a hexadecimal private key
+   * @param {string[]} prv a hexadecimal private key
    */
-  recordKeysFromPrivateKey(prv: string) {
-    if (BlsKeyPair.isValidBLSPrv(prv)) {
-      const privateKey = BLS.PrivateKey.fromHexString(prv);
-      this.keyPair = new BLS.Keypair(privateKey);
-    } else {
-      throw new Error('Invalid private key');
-    }
+  recordKeysFromPrivateKey(prv: string): void {
+    throw new NotImplementedError('Private key derivation is not supported in bls');
   }
 
   /**
@@ -67,51 +81,68 @@ export abstract class BlsKeyPair implements BaseKeyPair {
 
   /**
    * Signs bytes using the key pair
+   *
    * @param msg The message bytes to sign
    * @return signature of the bytes using this keypair
    */
-  sign(msg: Buffer): Buffer {
-    return BLS.sign(this.keyPair.privateKey.toBytes(), msg);
+  async sign(msg: Buffer): Promise<string> {
+    if (this.keyPair.prv) {
+      const signedMessage = await BLS.sign(msg, BigInt(this.keyPair.prv));
+      return '0x' + signedMessage.toString(16);
+    }
+    throw new Error('Missing private key');
   }
 
   /**
-   * Whether the input is a valid BLS private key
+   * Aggregates the secret shares of different key pairs into one private key
    *
-   * @param {string} prv A hexadecimal public key to validate
-   * @returns {boolean} Whether the input is a valid private key or not
+   * @param prvKeys an array of secret shares
+   * @returns a private key
    */
-  public static isValidBLSPrv(prv: string): boolean {
-    ensureInitialized();
+  public static aggregatePrvkeys(prvKeys: string[]): string {
+    assert(prvKeys.every(isValidBLSPrivateKey), 'Invalid private keys');
     try {
-      BLS.PrivateKey.fromHexString(prv);
-      return true;
+      const secretShares = prvKeys.map((secretShare) => BigInt(secretShare));
+      const prv = BLS.mergeSecretShares(secretShares);
+      return '0x' + prv.toString(16);
     } catch (e) {
-      return false;
+      throw new Error('Error aggregating prvkeys: ' + e);
     }
   }
 
   /**
-   * Return boolean indicating whether input is valid public key for the coin.
+   * Aggregates the public shares of different key pairs into a common public key
    *
-   * @param {string} pub the pub to be checked
-   * @returns {boolean} is it valid?
+   * @param pubKeys an array of public shares
+   * @returns a common public key
    */
-  public static isValidBLSPub(pub: string): boolean {
-    ensureInitialized();
+  public static aggregatePubkeys(pubKeys: string[]): string {
     try {
-      BLS.PublicKey.fromHex(pub);
-      return true;
-    } catch (e) {
-      return false;
-    }
-  }
-
-  public static aggregatePubkeys(pubKeys: Uint8Array[]): Buffer {
-    ensureInitialized();
-    try {
-      return BLS.aggregatePubkeys(pubKeys);
+      const secretShares = pubKeys.map((secretShare) => BigInt(secretShare));
+      const commonPubKey = BLS.mergePublicShares(secretShares);
+      return '0x' + commonPubKey.toString(16);
     } catch (e) {
       throw new Error('Error aggregating pubkeys: ' + e);
+    }
+  }
+
+  /**
+   * Aggregates the message signed by different key pairs into one sign
+   *
+   * @param signatures the message signed by different key pairs. The signer id is relevant to ensure a valid signature.
+   * @example <caption> E.g., the message is signed by user and wallet, then signatures would be:</caption>
+   * {
+   *   1: BigInt(messageSignedWithUserPrv),
+   *   3: BigInt(messageSignedWithWalletPrv),
+   * }
+   * @returns a signature combining all the provided signed messages
+   */
+  public static aggregateSignatures(signatures: { [n: number]: bigint }): string {
+    try {
+      const signature = BLS.mergeSignatures(signatures);
+      return '0x' + signature.toString(16);
+    } catch (e) {
+      throw new Error('Error aggregating signatures: ' + e);
     }
   }
 
@@ -122,9 +153,8 @@ export abstract class BlsKeyPair implements BaseKeyPair {
    * @param signature the signature to verify
    * @return true if the signature is valid, else false
    */
-  public static verifySignature(pub: string, msg: Buffer, signature: Buffer): boolean {
-    ensureInitialized();
-    assert(BlsKeyPair.isValidBLSPub(pub), `Invalid public key: ${pub}`);
-    return BLS.verify(Buffer.from(stripHexPrefix(pub), 'hex'), msg, signature);
+  public static async verifySignature(pub: string, msg: Buffer, signature: string): Promise<boolean> {
+    assert(isValidBLSPublicKey(pub), `Invalid public key: ${pub}`);
+    return await BLS.verify(BigInt(signature), msg, BigInt(pub));
   }
 }

--- a/modules/account-lib/src/coin/baseCoin/iface.ts
+++ b/modules/account-lib/src/coin/baseCoin/iface.ts
@@ -26,7 +26,17 @@ export type Seed = {
   seed: Buffer;
 };
 
-export type KeyPairOptions = Seed | PrivateKey | PublicKey;
+/**
+ * The number of participants for which to generate shares and a threshold of those that would be required when signing
+ */
+export type DkgOptions = {
+  threshold: number;
+  participants: number;
+};
+
+export type BlsKeyPairOptions = DkgOptions | BlsKeys;
+
+export type KeyPairOptions = Seed | PrivateKey | PublicKey | BlsKeyPairOptions;
 
 export type BaseBuilder = BaseTransactionBuilder | BaseTransactionBuilderFactory;
 
@@ -52,6 +62,19 @@ export function isPublicKey(source: KeyPairOptions): source is PublicKey {
 }
 
 /**
+ * @param source
+ */
+export function isDkg(source: KeyPairOptions): source is DkgOptions {
+  const dkg = source as DkgOptions;
+  return dkg.threshold !== undefined && dkg.participants !== undefined;
+}
+
+export function isBlsKey(source: KeyPairOptions): source is BlsKeys {
+  const bls = source as BlsKeys;
+  return bls.publicShare !== undefined && bls.secretShares !== undefined;
+}
+
+/**
  * Key pair in the protocol default format.
  */
 export type DefaultKeys = {
@@ -73,6 +96,15 @@ export type ByteKeys = {
 export type ExtendedKeys = {
   xprv?: string;
   xpub: string;
+};
+
+/**
+ * BLS signature keys.
+ */
+export type BlsKeys = {
+  prv?: string;
+  secretShares: string[];
+  publicShare: string;
 };
 
 export interface BaseAddress {

--- a/modules/account-lib/src/utils/crypto.ts
+++ b/modules/account-lib/src/utils/crypto.ts
@@ -2,6 +2,8 @@ import * as bip32 from 'bip32';
 import { ECPair, networks } from 'bitcoinjs-lib';
 import * as nacl from 'tweetnacl';
 import * as hex from '@stablelib/hex';
+import * as bls from 'noble-bls12-381';
+import { stripHexPrefix } from 'ethereumjs-utils-old';
 import { ExtendedKeys } from '../coin/baseCoin/iface';
 import { toUint8Array } from '../coin/hbar/utils';
 
@@ -152,6 +154,35 @@ export function isValidEd25519PublicKey(pub: string): boolean {
   try {
     const decodedPub = new Uint8Array(Buffer.from(pub, 'hex'));
     return decodedPub.length === nacl.sign.publicKeyLength;
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
+ * Whether the input is a valid BLS private key
+ *
+ * @param {string} prv a private key to validate
+ * @returns {boolean} Whether the input is a valid private key or not
+ */
+export function isValidBLSPrivateKey(prv: string): boolean {
+  try {
+    return bls.Fr.isValid(BigInt(prv));
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
+ * Whether input is a valid BLS public key
+ *
+ * @param {string} pub the public key to validate
+ * @returns {boolean} Whether input is a valid public key or not
+ */
+export function isValidBLSPublicKey(pub: string): boolean {
+  try {
+    bls.PointG1.fromCompressedHex(stripHexPrefix(pub)).assertValidity();
+    return true;
   } catch (e) {
     return false;
   }

--- a/modules/account-lib/test/resources/eth2/eth2.ts
+++ b/modules/account-lib/test/resources/eth2/eth2.ts
@@ -9,7 +9,7 @@ export const ACCOUNT_1 = {
   ),
 };
 
-export const errorMessageInvalidPrivateKey = 'Invalid private key';
+export const errorMessageInvalidPrivateKey = 'Private key derivation is not supported in bls';
 
 export const errorMessageInvalidPublicKey = 'Public key derivation is not supported in bls';
 

--- a/modules/core/src/v2/baseCoin.ts
+++ b/modules/core/src/v2/baseCoin.ts
@@ -52,6 +52,10 @@ export interface KeyPair {
   prv: string;
 }
 
+export interface BlsKeyPair extends KeyPair {
+  secretShares?: string[];
+}
+
 export interface VerifyAddressOptions {
   address: string;
   addressType?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11326,7 +11326,7 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
-noble-bls12-381@^0.7.2:
+noble-bls12-381@0.7.2, noble-bls12-381@^0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/noble-bls12-381/-/noble-bls12-381-0.7.2.tgz#9a9384891569ba32785d6e4ff8588b783487eae4"
   integrity sha512-Z5isbU6opuWPL3dxsGqO5BdOE8WP1XUM7HFIn/xeE5pATTnml/PEIy4MFQQrktHiitkuJdsCDtzEOnS9eIpC3Q==


### PR DESCRIPTION
With bls-dkg lib it is possible to verify a signature of a meessage signed by 2 of the 3 key pairs

BREAKING CHANGE: BlsKeyPair is not just a default prv and pub object, instead it has an array of
secretShares and a publicShare which should be merged with the other BLS key pairs to get the common
public key and the private key of each keypair.

BG-35989