### PR TITLE
Fix publishConfig property for public packages

### DIFF
--- a/modules/account-lib/package.json
+++ b/modules/account-lib/package.json
@@ -124,6 +124,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "ef15427ab86ecf83431e8474bfff445cf5b2774b"
+  }
 }

--- a/modules/account-lib/package.json
+++ b/modules/account-lib/package.json
@@ -121,5 +121,9 @@
       "eslint --fix",
       "git add"
     ]
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "gitHead": "ef15427ab86ecf83431e8474bfff445cf5b2774b"
 }

--- a/modules/blockapis/package.json
+++ b/modules/blockapis/package.json
@@ -36,6 +36,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "license": "MIT",
-  "gitHead": "ef15427ab86ecf83431e8474bfff445cf5b2774b"
+  "license": "MIT"
 }

--- a/modules/blockapis/package.json
+++ b/modules/blockapis/package.json
@@ -33,5 +33,9 @@
     "ts-node": "^10.4.0",
     "typescript": "^4.5.4"
   },
-  "license": "MIT"
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT",
+  "gitHead": "ef15427ab86ecf83431e8474bfff445cf5b2774b"
 }

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -136,6 +136,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "ef15427ab86ecf83431e8474bfff445cf5b2774b"
+  }
 }

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -133,5 +133,9 @@
     "extension": [
       ".ts"
     ]
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "gitHead": "ef15427ab86ecf83431e8474bfff445cf5b2774b"
 }

--- a/modules/statics/package.json
+++ b/modules/statics/package.json
@@ -47,5 +47,6 @@
     "extension": [
       ".ts"
     ]
-  }
+  },
+  "gitHead": "ef15427ab86ecf83431e8474bfff445cf5b2774b"
 }

--- a/modules/statics/package.json
+++ b/modules/statics/package.json
@@ -47,6 +47,5 @@
     "extension": [
       ".ts"
     ]
-  },
-  "gitHead": "ef15427ab86ecf83431e8474bfff445cf5b2774b"
+  }
 }

--- a/modules/unspents/package.json
+++ b/modules/unspents/package.json
@@ -42,5 +42,9 @@
     "@bitgo/utxo-lib": "^2.2.0",
     "lodash": "~4.17.21",
     "tcomb": "~3.2.29"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "gitHead": "ef15427ab86ecf83431e8474bfff445cf5b2774b"
 }

--- a/modules/unspents/package.json
+++ b/modules/unspents/package.json
@@ -45,6 +45,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "ef15427ab86ecf83431e8474bfff445cf5b2774b"
+  }
 }

--- a/modules/utxo-bin/package.json
+++ b/modules/utxo-bin/package.json
@@ -36,5 +36,9 @@
     "ts-node": "^10.4.0",
     "typescript": "^4.5.4"
   },
-  "license": "MIT"
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT",
+  "gitHead": "ef15427ab86ecf83431e8474bfff445cf5b2774b"
 }

--- a/modules/utxo-bin/package.json
+++ b/modules/utxo-bin/package.json
@@ -39,6 +39,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "license": "MIT",
-  "gitHead": "ef15427ab86ecf83431e8474bfff445cf5b2774b"
+  "license": "MIT"
 }

--- a/modules/utxo-lib/package.json
+++ b/modules/utxo-lib/package.json
@@ -62,5 +62,9 @@
     "nyc": "^15.1.0",
     "ts-node": "^9.1.1"
   },
-  "license": "MIT"
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT",
+  "gitHead": "ef15427ab86ecf83431e8474bfff445cf5b2774b"
 }

--- a/modules/utxo-lib/package.json
+++ b/modules/utxo-lib/package.json
@@ -65,6 +65,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "license": "MIT",
-  "gitHead": "ef15427ab86ecf83431e8474bfff445cf5b2774b"
+  "license": "MIT"
 }


### PR DESCRIPTION
This needs to be set to `"access": "public"` or else publishing to npm fails. 