### PR TITLE
feat: add custom signing function url to requests

### DIFF
--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -125,7 +125,7 @@ export interface PrebuildTransactionResult extends TransactionPrebuild {
 }
 
 export interface CustomSigningFunction {
-  (params: { txPrebuild: TransactionPrebuild; pubs?: string[] }): Promise<SignedTransaction>;
+  (params: { coin: BaseCoin; txPrebuild: TransactionPrebuild; pubs?: string[] }): Promise<SignedTransaction>;
 }
 
 export interface WalletSignTransactionOptions {
@@ -1842,6 +1842,7 @@ export class Wallet {
       ...presign,
       txPrebuild,
       pubs,
+      coin: this.baseCoin,
     };
 
     if (_.isFunction(params.customSigningFunction)) {

--- a/modules/express/package.json
+++ b/modules/express/package.json
@@ -58,6 +58,7 @@
     "@types/nock": "^9.3.1",
     "@types/node": "^11.11.4",
     "@types/sinon": "^7.0.6",
+    "@types/supertest": "^2.0.11",
     "bignumber.js": "^8.0.1",
     "lint-staged": "^9.2.0",
     "mocha": "^7.0.0",

--- a/modules/express/test/integration/externalSigner.ts
+++ b/modules/express/test/integration/externalSigner.ts
@@ -1,0 +1,88 @@
+/**
+ * @prettier
+ */
+import 'should';
+import 'should-http';
+import * as sinon from 'sinon';
+
+import * as request from 'supertest';
+import { app as expressApp } from '../../src/expressApp';
+import * as nock from 'nock';
+import { Environments } from 'bitgo';
+import { Btc } from 'bitgo/dist/src/v2/coins/btc';
+
+describe('Custom signing function', () => {
+  let agent: request.SuperAgentTest;
+  const externalSignerUrl = 'https://external-signer.invalid';
+  before(() => {
+    const args: any = {
+      debug: true,
+      env: 'test',
+      externalSignerUrl,
+    };
+
+    const app = expressApp(args);
+    agent = request.agent(app);
+
+    if (!nock.isActive()) {
+      nock.activate();
+    }
+    nock.disableNetConnect();
+    nock.enableNetConnect('127.0.0.1');
+  });
+
+  after(() => {
+    if (nock.isActive()) {
+      nock.restore();
+    }
+  });
+
+  it('should make a request to external signer when sending', async function () {
+    const bgUrl = Environments.test.uri;
+    // setup nock to external signer
+    const signernock = nock(externalSignerUrl)
+      .post('/api/v2/btc/sign')
+      .reply(200, { externalSigner: 'external signer response' });
+
+    // setup nock to wallet platform GET /wallet/fakeid
+    const wpWalletnock = nock(bgUrl)
+      .get('/api/v2/btc/wallet/fakeid')
+      .reply(200, { id: 'fakeid', keys: ['abc', 'def', 'ghi'], coinSpecific: {} });
+    const wpKeychainNocks = [
+      nock(bgUrl).get('/api/v2/btc/key/abc').reply(200, { pub: 'xpubabc' }),
+      nock(bgUrl).get('/api/v2/btc/key/def').reply(200, { pub: 'xpubdef' }),
+      nock(bgUrl).get('/api/v2/btc/key/ghi').reply(200, { pub: 'xpubghi' }),
+    ];
+    const wpLatestBlockNock = nock(bgUrl).get('/api/v2/btc/public/block/latest').reply(200);
+
+    const wpBuildnock = nock(bgUrl)
+      .post('/api/v2/btc/wallet/fakeid/tx/build')
+      .reply(200, { wpBuild: 'WP build response' });
+    const wpSendnock = nock(bgUrl).post('/api/v2/btc/wallet/fakeid/tx/send').reply(200, { wpSend: 'WP send response' });
+
+    const postProcessPrebuildStub = sinon.stub(Btc.prototype, 'postProcessPrebuild').resolvesArg(0);
+    const verifyTransactionStub = sinon.stub(Btc.prototype, 'verifyTransaction').resolves(true);
+
+    // make request to express application to initiate send
+    const result = await agent
+      .post('/api/v2/btc/wallet/fakeid/sendcoins')
+      .type('json')
+      .send({ address: 'abc', amount: 123 });
+
+    // check to make sure request to external signer was successful
+    result.ok.should.be.true();
+
+    // make sure wallet platform request contained response from external signer
+    result.body.should.have.property('wpSend', 'WP send response');
+
+    signernock.done();
+    wpKeychainNocks.forEach((s) => s.done());
+    wpLatestBlockNock.done();
+    wpWalletnock.done();
+    wpBuildnock.done();
+    wpSendnock.done();
+
+    postProcessPrebuildStub.restore();
+    verifyTransactionStub.restore();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3146,6 +3146,14 @@
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-7.5.2.tgz#5e2f1d120f07b9cda07e5dedd4f3bf8888fccdb9"
   integrity sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg==
 
+"@types/superagent@*":
+  version "4.1.15"
+  resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-4.1.15.tgz#63297de457eba5e2bc502a7609426c4cceab434a"
+  integrity sha512-mu/N4uvfDN2zVQQ5AYJI/g4qxn2bHB6521t1UuH09ShNWjebTqN0ZFuYK9uYjcgmI0dTQEs+Owi1EO6U0OkOZQ==
+  dependencies:
+    "@types/cookiejar" "*"
+    "@types/node" "*"
+
 "@types/superagent@^4.1.3":
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-4.1.11.tgz#4822bc64a82a0f579261a77097dbca276556c20e"
@@ -3153,6 +3161,13 @@
   dependencies:
     "@types/cookiejar" "*"
     "@types/node" "*"
+
+"@types/supertest@^2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@types/supertest/-/supertest-2.0.11.tgz#2e70f69f220bc77b4f660d72c2e1a4231f44a77d"
+  integrity sha512-uci4Esokrw9qGb9bvhhSVEjd6rkny/dk5PK/Qz4yxKiyppEI+dOPlNrZBahE3i+PoKFYyDxChVXZ/ysS/nrm1Q==
+  dependencies:
+    "@types/superagent" "*"
 
 "@types/urijs@^1.19.6":
   version "1.19.15"


### PR DESCRIPTION
This commit takes the external signer url passed into the express config
and uses it to create a custom signing function. The custom signing
function is then included in any calls which involve signing. Note that
this commit only covers wallet v2 endpoints.

Ticket: BG-42397