### PR TITLE
chore(account-lib): add getter to factory for batch transaction builder

### DIFF
--- a/modules/account-lib/src/coin/dot/iface.ts
+++ b/modules/account-lib/src/coin/dot/iface.ts
@@ -30,6 +30,7 @@ export interface TxData {
   specVersion: number;
   transactionVersion: number;
   chainName: string;
+  method?: string;
   specName?: string;
   amount?: string;
   to?: string;

--- a/modules/account-lib/src/coin/dot/transaction.ts
+++ b/modules/account-lib/src/coin/dot/transaction.ts
@@ -181,6 +181,7 @@ export class Transaction extends BaseTransaction {
         txMethod = decodedTx.method.args as AddAnonymousProxyArgs;
         result.index = txMethod.index;
       }
+      result.method = this._dotTransaction.method;
       result.proxyType = txMethod.proxyType;
       result.delay = txMethod.delay;
     }

--- a/modules/account-lib/src/coin/dot/transactionBuilderFactory.ts
+++ b/modules/account-lib/src/coin/dot/transactionBuilderFactory.ts
@@ -8,7 +8,7 @@ import { AddressInitializationBuilder } from './addressInitializationBuilder';
 import { StakingBuilder } from './stakingBuilder';
 import { Material, MethodNames } from './iface';
 import utils from './utils';
-import { UnstakeBuilder } from '.';
+import { BatchTransactionBuilder, UnstakeBuilder } from '.';
 import { UnnominateBuilder } from './unnominateBuilder';
 
 export class TransactionBuilderFactory extends BaseTransactionBuilderFactory {
@@ -29,6 +29,10 @@ export class TransactionBuilderFactory extends BaseTransactionBuilderFactory {
 
   getAddressInitializationBuilder(): AddressInitializationBuilder {
     return new AddressInitializationBuilder(this._coinConfig).material(this._material);
+  }
+
+  getBatchTransactionBuilder(): BatchTransactionBuilder {
+    return new BatchTransactionBuilder(this._coinConfig).material(this._material);
   }
 
   getWalletInitializationBuilder(): void {


### PR DESCRIPTION
Add getter so that it can be used in WP after `register` is invoked.

WP PR that needs this: https://github.com/BitGo/bitgo-microservices/pull/15379

JIRA ticket: https://bitgoinc.atlassian.net/browse/STLX-12458