### PR TITLE
feat: add external signing functionality for v2 wallet

### DIFF
--- a/modules/express/src/errors.ts
+++ b/modules/express/src/errors.ts
@@ -40,3 +40,10 @@ export class IpcError extends Errors.BitGoJsError {
     Object.setPrototypeOf(this, IpcError.prototype);
   }
 }
+
+export class ExternalSignerConfigError extends Errors.BitGoJsError {
+  public constructor(message?: string) {
+    super(message || 'External signer configuration is invalid');
+    Object.setPrototypeOf(this, ExternalSignerConfigError.prototype);
+  }
+}

--- a/modules/express/src/expressApp.ts
+++ b/modules/express/src/expressApp.ts
@@ -220,6 +220,10 @@ function checkPreconditions(config: Config) {
     config.env = 'custom';
   }
 
+  if (env !== 'test' && (externalSignerUrl !== undefined || signerMode !== undefined)) {
+    throw new ExternalSignerConfigError('external signer feature is only enabled for test mode.');
+  }
+
   if (externalSignerUrl !== undefined && (signerMode !== undefined || signerFileSystemPath !== undefined)) {
     throw new ExternalSignerConfigError(
       'signerMode or signerFileSystemPath is set, but externalSignerUrl is also set.'

--- a/modules/express/src/expressApp.ts
+++ b/modules/express/src/expressApp.ts
@@ -156,6 +156,22 @@ export function createBaseUri(config: Config): string {
 }
 
 /**
+ * Check the that the json file containing the external signer private key exists
+ * @param path
+ */
+function checkSignerPrvPath(path: string) {
+  try {
+    const privKeyFile = fs.readFileSync(path, { encoding: 'utf8' });
+    const privKey = JSON.parse(privKeyFile);
+    if (privKey.prv === undefined) {
+      throw new Error(`required field "prv" is missing`);
+    }
+  } catch (e) {
+    throw new Error(`Failed to parse ${path} - ${e.message}`);
+  }
+}
+
+/**
  * Check environment and other preconditions to ensure bitgo-express can start safely
  * @param config
  */
@@ -214,6 +230,14 @@ function checkPreconditions(config: Config) {
     throw new ExternalSignerConfigError(
       'signerMode and signerFileSystemPath must both be set in order to run in external signing mode.'
     );
+  }
+
+  if (signerFileSystemPath !== undefined) {
+    try {
+      checkSignerPrvPath(signerFileSystemPath);
+    } catch (e) {
+      throw e;
+    }
   }
 }
 

--- a/modules/express/test/unit/bitgoExpress.ts
+++ b/modules/express/test/unit/bitgoExpress.ts
@@ -31,6 +31,8 @@ import * as clientRoutes from '../../src/clientRoutes';
 describe('Bitgo Express', function () {
 
   describe('server initialization', function () {
+    const validPrvJSON =
+      '{"prv":"xprv9s21ZrQH143K3EuPWCBuqnWxydaQV6et9htQige4EswvcHKEzNmkVmwTwKoadyHzJYppuADB7Us7AbaNLToNvoFoSxuWqndQRYtnNy5DUY2"}';
 
     it('should require NODE_ENV to be production when running against prod env', function () {
       const envStub = sinon.stub(process, 'env').value({ NODE_ENV: 'production' });
@@ -372,7 +374,7 @@ describe('Bitgo Express', function () {
     it('should only call setupAPIRoutes when running in regular mode', () => {
       const args: any = {
         env: 'test',
-        signerMode: '',
+        signerMode: undefined,
       };
 
       const apiStub = sinon.stub(clientRoutes, 'setupAPIRoutes');
@@ -389,23 +391,28 @@ describe('Bitgo Express', function () {
       const args: any = {
         env: 'test',
         signerMode: 'signerMode',
+        signerFileSystemPath: 'signerFileSystemPath',
       };
 
       const apiStub = sinon.stub(clientRoutes, 'setupAPIRoutes');
       const signerStub = sinon.stub(clientRoutes, 'setupSigningRoutes');
+      const readFileStub = sinon.stub(fs, 'readFileSync').returns(validPrvJSON);
 
       expressApp(args);
       signerStub.should.have.been.calledOnce();
       apiStub.called.should.be.false();
       apiStub.restore();
       signerStub.restore();
+      readFileStub.restore();
     });
 
     it('should require a signerFileSystemPath and signerMode are both set when running in signer mode', function () {
       const args: any = {
         env: 'test',
         signerMode: 'signerMode',
+        signerFileSystemPath: undefined,
       };
+
       (() => expressApp(args)).should.throw({
         name: 'ExternalSignerConfigError',
         message: 'signerMode and signerFileSystemPath must both be set in order to run in external signing mode.'
@@ -418,8 +425,11 @@ describe('Bitgo Express', function () {
         message: 'signerMode and signerFileSystemPath must both be set in order to run in external signing mode.'
       });
 
+      const readFileStub = sinon.stub(fs, 'readFileSync').returns(validPrvJSON);
       args.signerMode = 'signerMode';
       (() => expressApp(args)).should.not.throw();
+
+      readFileStub.restore();
     });
 
     it('should require that an externalSignerUrl and signerMode are not both set', function () {
@@ -437,5 +447,23 @@ describe('Bitgo Express', function () {
       (() => expressApp(args)).should.not.throw();
     });
 
+    it('should require that an signerFileSystemPath contains a json with a prv field', function () {
+      const args: any = {
+        env: 'test',
+        signerMode: 'signerMode',
+        signerFileSystemPath: 'invalidSignerFileSystemPath',
+      };
+      (() => expressApp(args)).should.throw();
+
+      const invalidPrv =
+        '{"invalidField":"invalidPrivKey"}';
+      const readInvalidStub = sinon.stub(fs, 'readFileSync').returns(invalidPrv);
+      (() => expressApp(args)).should.throw(`Failed to parse ${args.signerFileSystemPath} - required field "prv" is missing`);
+      readInvalidStub.restore();
+
+      const readValidStub = sinon.stub(fs, 'readFileSync').returns(validPrvJSON);
+      (() => expressApp(args)).should.not.throw();
+      readValidStub.restore();
+    });
   });
 });

--- a/modules/express/test/unit/bitgoExpress.ts
+++ b/modules/express/test/unit/bitgoExpress.ts
@@ -400,5 +400,42 @@ describe('Bitgo Express', function () {
       apiStub.restore();
       signerStub.restore();
     });
+
+    it('should require a signerFileSystemPath and signerMode are both set when running in signer mode', function () {
+      const args: any = {
+        env: 'test',
+        signerMode: 'signerMode',
+      };
+      (() => expressApp(args)).should.throw({
+        name: 'ExternalSignerConfigError',
+        message: 'signerMode and signerFileSystemPath must both be set in order to run in external signing mode.'
+      });
+
+      args.signerMode = undefined;
+      args.signerFileSystemPath = 'signerFileSystemPath';
+      (() => expressApp(args)).should.throw({
+        name: 'ExternalSignerConfigError',
+        message: 'signerMode and signerFileSystemPath must both be set in order to run in external signing mode.'
+      });
+
+      args.signerMode = 'signerMode';
+      (() => expressApp(args)).should.not.throw();
+    });
+
+    it('should require that an externalSignerUrl and signerMode are not both set', function () {
+      const args: any = {
+        env: 'test',
+        signerMode: 'signerMode',
+        externalSignerUrl: 'externalSignerUrl',
+      };
+      (() => expressApp(args)).should.throw({
+        name: 'ExternalSignerConfigError',
+        message: 'signerMode or signerFileSystemPath is set, but externalSignerUrl is also set.'
+      });
+
+      args.signerMode = undefined;
+      (() => expressApp(args)).should.not.throw();
+    });
+
   });
 });

--- a/modules/express/test/unit/bitgoExpress.ts
+++ b/modules/express/test/unit/bitgoExpress.ts
@@ -465,5 +465,32 @@ describe('Bitgo Express', function () {
       (() => expressApp(args)).should.not.throw();
       readValidStub.restore();
     });
+
+    it('should require express to be in test mode when using the external signer feature', function () {
+      const readValidStub = sinon.stub(fs, 'readFileSync').returns(validPrvJSON);
+
+      const args: any = {
+        env: 'notTestMode',
+        signerMode: 'signerMode',
+        signerFileSystemPath: 'signerFileSystemPath',
+      };
+      (() => expressApp(args)).should.throw({
+        name: 'ExternalSignerConfigError',
+        message: 'external signer feature is only enabled for test mode.'
+      });
+
+      args.signerMode = undefined;
+      args.signerFileSystemPath = undefined;
+      args.externalSignerUrl = 'externalSignerUrl';
+      (() => expressApp(args)).should.throw({
+        name: 'ExternalSignerConfigError',
+        message: 'external signer feature is only enabled for test mode.'
+      });
+
+      args.env = 'test';
+      (() => expressApp(args)).should.not.throw();
+
+      readValidStub.restore();
+    });
   });
 });

--- a/modules/express/test/unit/clientRoutes/externalSign.ts
+++ b/modules/express/test/unit/clientRoutes/externalSign.ts
@@ -1,0 +1,44 @@
+/**
+ * @prettier
+ */
+import * as sinon from 'sinon';
+
+import 'should-http';
+import 'should-sinon';
+import '../../lib/asserts';
+
+import * as express from 'express';
+import { handleV2Sign } from '../../../src/clientRoutes';
+import * as fs from 'fs';
+import { Btc } from 'bitgo/dist/src/v2/coins/btc';
+import { BitGo } from 'bitgo';
+
+describe('External signer', () => {
+  it('should read prv from signerFileSystemPath and pass it to coin.signTransaction', async () => {
+    const validPrv =
+      '{"prv":"xprv9s21ZrQH143K3EuPWCBuqnWxydaQV6et9htQige4EswvcHKEzNmkVmwTwKoadyHzJYppuADB7Us7AbaNLToNvoFoSxuWqndQRYtnNy5DUY2"}';
+    const readFileStub = sinon.stub(fs.promises, 'readFile').resolves(validPrv);
+    const signTransactionStub = sinon.stub(Btc.prototype, 'signTransaction').resolves('signedTx');
+
+    const req = {
+      bitgo: new BitGo({ env: 'test' }),
+      params: {
+        coin: 'tbtc',
+      },
+      config: {
+        signerFileSystemPath: 'signerFileSystemPath',
+      },
+    } as unknown as express.Request;
+
+    await handleV2Sign(req);
+
+    readFileStub.should.be.calledOnceWith('signerFileSystemPath');
+    signTransactionStub.should.be.calledOnceWith(
+      sinon.match({
+        prv: 'xprv9s21ZrQH143K3EuPWCBuqnWxydaQV6et9htQige4EswvcHKEzNmkVmwTwKoadyHzJYppuADB7Us7AbaNLToNvoFoSxuWqndQRYtnNy5DUY2',
+      })
+    );
+    readFileStub.restore();
+    signTransactionStub.restore();
+  });
+});


### PR DESCRIPTION
- Add signing functionality for v2 wallet in `handleV2Sign`
- Check config arguments to prevent a user from running as a normal BG Express instance and an external signer instance at the same time
- Check the `signerFileSystemPath` argument on startup to make sure it contains a JSON file with a "prv" field
- Only allow external signer mode to run in test mode