### PR TITLE
fix(express): pass POST body for proxy requests

### DIFF
--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -993,7 +993,7 @@ export function setupAPIRoutes(app: express.Application, config: Config): void {
 
   // everything else should use the proxy handler
   if (!config.disableProxy) {
-    app.use(prepareBitGo(config), promiseWrapper(handleProxyReq));
+    app.use(parseBody, prepareBitGo(config), promiseWrapper(handleProxyReq));
   }
 }
 

--- a/modules/express/test/integration/bitgoExpress.ts
+++ b/modules/express/test/integration/bitgoExpress.ts
@@ -220,6 +220,24 @@ describe('Bitgo Express', function () {
     res.body.marketData[0].should.have.property('coin', 'tbtc');
   });
 
+  it('should pass POST body data to the proxy target url', async function () {
+    const path = '/api/v2/post';
+    const body = { some: 'data' };
+    const serverResponse = { testResponse: 'server response' };
+
+    // client constants are retrieved upon BitGo
+    // object creation so they need to be nocked
+    const scopes = [
+      nock(Environments.test.uri).get('/api/v1/client/constants').reply(200, {}),
+      nock(Environments.test.uri).post(path, body).reply(200, serverResponse),
+    ];
+
+    const postRes = await agent.post(path).send(body);
+    postRes.should.have.status(200);
+    postRes.should.have.property('body', serverResponse);
+    scopes.forEach((s) => s.done());
+  });
+
   describe('proxy error handling', () => {
     let agent;
     before(() => {


### PR DESCRIPTION
The proxy request routes were not correctly parsing the incoming POST
body and therefore would always drop POST bodies when forwarding
requests to the proxy target.

Add the `parseBody` middleware to the proxy handler route, and add a
test for this case to prevent regression.

Ticket: BG-40647