### PR TITLE
chore(core): add deriveKeypair method to DOT

### DIFF
--- a/modules/core/src/v2/baseCoin.ts
+++ b/modules/core/src/v2/baseCoin.ts
@@ -49,6 +49,7 @@ export interface TransactionExplanation<TFee = any, TAmount = any> {
 
 export interface KeyPair {
   pub?: string;
+  address?: string;
   prv: string;
 }
 

--- a/modules/core/src/v2/baseCoin.ts
+++ b/modules/core/src/v2/baseCoin.ts
@@ -49,7 +49,6 @@ export interface TransactionExplanation<TFee = any, TAmount = any> {
 
 export interface KeyPair {
   pub?: string;
-  address?: string;
   prv: string;
 }
 

--- a/modules/core/src/v2/coins/dot.ts
+++ b/modules/core/src/v2/coins/dot.ts
@@ -4,6 +4,7 @@ import { BitGo } from '../../bitgo';
 import { MethodNotImplementedError } from '../../errors';
 import {
   BaseCoin,
+  DerivedKeyPair,
   DeriveKeypairOptions,
   KeyPair,
   ParsedTransaction,
@@ -103,7 +104,7 @@ export class Dot extends BaseCoin {
   }
 
   /** @inheritDoc */
-  deriveKeypair(params: DeriveKeypairOptions): KeyPair | undefined {
+  deriveKeypair(params: DeriveKeypairOptions): DerivedKeyPair | undefined {
     try {
       if (_.isNil(params.addressDerivationPrv)) {
         throw new Error('addressDerivationPrv is missing');

--- a/modules/core/src/v2/coins/dot.ts
+++ b/modules/core/src/v2/coins/dot.ts
@@ -4,6 +4,7 @@ import { BitGo } from '../../bitgo';
 import { MethodNotImplementedError } from '../../errors';
 import {
   BaseCoin,
+  DeriveKeypairOptions,
   KeyPair,
   ParsedTransaction,
   ParseTransactionOptions,
@@ -76,6 +77,11 @@ export class Dot extends BaseCoin {
     return true;
   }
 
+  /** @inheritDoc */
+  supportsDerivationKeypair(): boolean {
+    return true;
+  }
+
   /**
    * Generate ed25519 key pair
    *
@@ -94,6 +100,40 @@ export class Dot extends BaseCoin {
       pub: keys.pub,
       prv: keys.prv,
     };
+  }
+
+  /** @inheritDoc */
+  deriveKeypair(params: DeriveKeypairOptions): KeyPair | undefined {
+    try {
+      if (_.isNil(params.addressDerivationPrv)) {
+        throw new Error('addressDerivationPrv is missing');
+      }
+      const rootKeyPair = new accountLib.Dot.KeyPair({ prv: params.addressDerivationPrv });
+      const derivationPath = `m/0'/0'/0'/${params.index}'`;
+      const derivedKeys = rootKeyPair.deriveHardened(derivationPath);
+      if (_.isNil(derivedKeys?.prv)) {
+        throw new Error('Key derivation failed - missing derived prv key');
+      }
+      const derivedBase58KeyPair = new accountLib.Dot.KeyPair({ prv: derivedKeys.prv });
+      const { prv, pub } = derivedBase58KeyPair.getKeys();
+      const derivedAddress = derivedBase58KeyPair.getAddress();
+      if (!_.isString(prv) || !accountLib.Dot.Utils.default.isValidPrivateKey(prv)) {
+        throw new Error('failed to create valid derived base58 prv key');
+      }
+      if (!_.isString(pub) || !accountLib.Dot.Utils.default.isValidPublicKey(pub)) {
+        throw new Error('failed to create valid derived base58 pub key');
+      }
+      if (!accountLib.Dot.Utils.default.isValidAddress(derivedAddress)) {
+        throw new Error('failed to create valid DOT address from derived base58 keys');
+      }
+      return {
+        prv,
+        pub,
+        address: derivedAddress,
+      };
+    } catch (e) {
+      throw new Error(`failed to derive key pair with: ${e}`);
+    }
   }
 
   /**

--- a/modules/core/test/v2/unit/coins/dot.ts
+++ b/modules/core/test/v2/unit/coins/dot.ts
@@ -106,4 +106,35 @@ describe('DOT:', function () {
       basecoin.isValidPrv(kp.prv).should.equal(true);
     });
   });
+
+  describe('Derive Keypair', () => {
+    const params = {
+      addressDerivationPrv: DotResources.accounts.account1.secretKey,
+      addressDerivationPub: DotResources.accounts.account1.publicKey,
+      index: 0,
+    };
+    it('should derive valid key pairs', async () => {
+      Array.from({ length: 10 }).forEach((val, idx) => {
+        params.index = idx + 1;
+        const derivedKeypair = basecoin.deriveKeypair(params);
+        basecoin.isValidPub(derivedKeypair.pub).should.be.true();
+        basecoin.isValidAddress(derivedKeypair.address).should.be.true();
+      });
+    });
+    it('should throw if prv is missing from deriveKeypair params', async () => {
+      // @ts-ignore allow invalid type for testing
+      params.addressDerivationPrv = undefined;
+      should(() => basecoin.deriveKeypair(params)).throw();
+    });
+    it('should throw if prv is invalid in deriveKeypair params', async () => {
+      // @ts-ignore allow invalid type for testing
+      params.addressDerivationPrv = 'fakeprvkey';
+      should(() => basecoin.deriveKeypair(params)).throw();
+    });
+    it('should throw if index is invalid', async () => {
+      params.addressDerivationPrv = DotResources.accounts.account1.secretKey;
+      params.index = -1;
+      should(() => basecoin.deriveKeypair(params)).throw();
+    });
+  });
 });

--- a/modules/core/test/v2/unit/coins/dot.ts
+++ b/modules/core/test/v2/unit/coins/dot.ts
@@ -117,6 +117,7 @@ describe('DOT:', function () {
       Array.from({ length: 10 }).forEach((val, idx) => {
         params.index = idx + 1;
         const derivedKeypair = basecoin.deriveKeypair(params);
+        basecoin.isValidPrv(derivedKeypair.prv).should.be.true();
         basecoin.isValidPub(derivedKeypair.pub).should.be.true();
         basecoin.isValidAddress(derivedKeypair.address).should.be.true();
       });

--- a/modules/core/test/v2/unit/coins/dot.ts
+++ b/modules/core/test/v2/unit/coins/dot.ts
@@ -122,12 +122,11 @@ describe('DOT:', function () {
       });
     });
     it('should throw if prv is missing from deriveKeypair params', async () => {
-      // @ts-ignore allow invalid type for testing
+      // @ts-expect-error allow invalid type for testing
       params.addressDerivationPrv = undefined;
       should(() => basecoin.deriveKeypair(params)).throw();
     });
     it('should throw if prv is invalid in deriveKeypair params', async () => {
-      // @ts-ignore allow invalid type for testing
       params.addressDerivationPrv = 'fakeprvkey';
       should(() => basecoin.deriveKeypair(params)).throw();
     });

--- a/modules/core/test/v2/unit/wallet.ts
+++ b/modules/core/test/v2/unit/wallet.ts
@@ -801,9 +801,7 @@ describe('V2 Wallet:', function () {
     const walletData = {
       id: '598f606cd8fc24710d2ebadb1d9459bb',
       coinSpecific: {
-        baseAddress: '5f8WmC2uW9SAk7LMX2r4G1Bx8MMwx8sdgpotyHGodiZo',
-        pendingChainInitialization: false,
-        minimumFunding: 2447136,
+        rootAddress: '5f8WmC2uW9SAk7LMX2r4G1Bx8MMwx8sdgpotyHGodiZo',
         lastChainIndex: { 0: 0 },
       },
       coin: 'tdot',
@@ -880,8 +878,6 @@ describe('V2 Wallet:', function () {
             lastNonce: 0,
             wallet: '598f606cd8fc24710d2ebadb1d9459bb',
             coinSpecific: {
-              pendingChainInitialization: true,
-              minimumFunding: 2447136,
               rootAddress: parsedBody.derivedAddress,
             },
           };
@@ -912,8 +908,6 @@ describe('V2 Wallet:', function () {
             lastNonce: 0,
             wallet: '598f606cd8fc24710d2ebadb1d9459bb',
             coinSpecific: {
-              pendingChainInitialization: true,
-              minimumFunding: 2447136,
               rootAddress: parsedBody.derivedAddress,
             },
           };

--- a/modules/core/test/v2/unit/wallet.ts
+++ b/modules/core/test/v2/unit/wallet.ts
@@ -792,6 +792,141 @@ describe('V2 Wallet:', function () {
     });
   });
 
+  describe('Create Address for Polkadot', () => {
+    let dotWallet, coinNocks;
+    const passphrase = 'Passphrase1234';
+    const coinBitgo = new TestBitGo({ env: 'mock' });
+    coinBitgo.initializeTestVars();
+    const tdot = coinBitgo.coin('tdot');
+    const walletData = {
+      id: '598f606cd8fc24710d2ebadb1d9459bb',
+      coinSpecific: {
+        baseAddress: '5f8WmC2uW9SAk7LMX2r4G1Bx8MMwx8sdgpotyHGodiZo',
+        pendingChainInitialization: false,
+        minimumFunding: 2447136,
+        lastChainIndex: { 0: 0 },
+      },
+      coin: 'tdot',
+      keys: [
+        '598f606cd8fc24710d2ebad89dce86c2',
+        '598f606cc8e43aef09fcb785221d9dd2',
+        '5935d59cf660764331bafcade1855fd7',
+      ],
+    };
+
+    beforeEach(async function () {
+      dotWallet = new Wallet(bitgo, bitgo.coin('tdot'), walletData);
+      coinNocks = [
+        nock(bgUrl)
+          .get(`/api/v2/${dotWallet.coin()}/key/${dotWallet.keyIds()[0]}`)
+          .times(2)
+          .reply(200, {
+            id: '598f606cd8fc24710d2ebad89dce86c2',
+            pub: '61b18c6dc02ddcabdeac56cb4f21a971cc41cc97640f6f85b073480008c53a0d',
+            source: 'user',
+            encryptedPrv: '{"iv":"8yOcLDpWe5wZnqJyftjrqQ==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"YDBv4nR/hu8=","ct":"m4CKUWNGTNXMJahCrYG2+6M+YmhegZTk0S3SP3BEOoNunc4dvg7ZT3EdryXeKoFG77W8bh+uJpB38yVEnLGQv5vYNjAmMu4J"}',
+            coinSpecific: {},
+            // addressDerivationKeypair represents the single sig KP used to derive addresses from
+            addressDerivationKeypair: {
+              pub: '9f7b0675db59d19b4bd9c8c72eaabba75a9863d02b30115b8b3c3ca5c20f0254',
+              encryptedPrv: '{"iv":"qv4P1xvbBWvJ82ANzVQICA==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"xUMlfBzd6/E=","ct":"UVWWDhivmo/9DCMUOdTzLnDrDbjEX98MmVwC+TBAC+C6RYi6EKSL5wiCx5QI8PRic1CALeU2NEg6uu2akhIm7nS3bEDD4Vfe"}',
+            },
+          }),
+
+        nock(bgUrl)
+          .get(`/api/v2/${dotWallet.coin()}/key/${dotWallet.keyIds()[1]}`)
+          .times(2)
+          .reply(200, {
+            id: '598f606cc8e43aef09fcb785221d9dd2',
+            pub: 'd472bd6e0f1f92297631938e30edb682208c2cd2698d80cf678c53a69979eb9f',
+            encryptedPrv: '{"iv":"Os4sXt/AWg4GVOlzcswxhQ==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"cn7WLegr0zA=","ct":"29Aq9b+7KmCZbnpqDYBusS2qxj3JB3prNbc3Fq+TBwjv97K69NNR2h2Id2Fq36lJO9eu7neqvjG0rkI64phBRD6npdw7mtmt"}',
+            source: 'backup',
+            coinSpecific: {},
+          }),
+
+        nock(bgUrl)
+          .get(`/api/v2/${dotWallet.coin()}/key/${dotWallet.keyIds()[2]}`)
+          .times(2)
+          .reply(200, {
+            id: '5935d59cf660764331bafcade1855fd7',
+            pub: '7788327c695dca4b3e649a0db45bc3e703a2c67428fce360e61800cc4248f4f7',
+            encryptedPrv: '{"iv":"45l3KXJTWVeT24fjPAwK9g==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"NctSBGanqrc=","ct":"uquQCan0ItRHCGNnUkF1JkjxGJyAChLnx6QfkgKE5FSeoMutA77hB4GM2DTn2kMoxYhXMnnCX/nIld1RXvAjSrX99vHwdcuQ"}',
+            source: 'bitgo',
+            coinSpecific: {},
+          }),
+      ];
+    });
+
+    afterEach(async function () {
+      nock.cleanAll();
+      coinNocks.forEach(scope => scope.isDone().should.be.true());
+    });
+
+    it('should create a 2 derived addresses for dot', async function () {
+      const nock1 = nock(bgUrl)
+        .post(`/api/v2/${dotWallet.coin()}/wallet/${dotWallet.id()}/address`, _.conforms(
+          { chain: (c) => _.isNumber(c), index: (i) => _.isEqual(i, 1), derivedAddress: (a) => _.isString(a) }))
+        .reply(200, (uri, body) => {
+          const parsedBody = JSON.parse(body as string);
+          tdot.isValidAddress(parsedBody.derivedAddress).should.be.true();
+          parsedBody.chain.should.equal(0);
+          parsedBody.index.should.equal(1);
+          return {
+            id: '615c643a98a2a100068e023c639c0f74',
+            address: parsedBody.derivedAddress,
+            chain: parsedBody.chain,
+            index: parsedBody.index,
+            coin: 'tdot',
+            lastNonce: 0,
+            wallet: '598f606cd8fc24710d2ebadb1d9459bb',
+            coinSpecific: {
+              pendingChainInitialization: true,
+              minimumFunding: 2447136,
+              rootAddress: parsedBody.derivedAddress,
+            },
+          };
+        });
+      await dotWallet.createAddress({
+        chain: 0,
+        passphrase,
+      });
+      nock1.isDone().should.be.true();
+
+      // imitates the raise of the lastChainIndex after the address creation
+      walletData.coinSpecific.lastChainIndex[0]++;
+      const updatedDotWallet = new Wallet(bitgo, bitgo.coin('tdot'), walletData);
+      const nock2 = nock(bgUrl)
+        .post(`/api/v2/${updatedDotWallet.coin()}/wallet/${updatedDotWallet.id()}/address`, _.conforms(
+          { chain: (c) => _.isNumber(c), index: (i) => _.isEqual(i, 2), derivedAddress: (a) => _.isString(a) }))
+        .reply(200, (uri, body) => {
+          const parsedBody = JSON.parse(body as string);
+          tdot.isValidAddress(parsedBody.derivedAddress).should.be.true();
+          parsedBody.chain.should.equal(0);
+          parsedBody.index.should.equal(2);
+          return {
+            id: '615c643a98a2a100068e023c639c0f73',
+            address: parsedBody.derivedAddress,
+            chain: parsedBody.chain,
+            index: parsedBody.index,
+            coin: 'tdot',
+            lastNonce: 0,
+            wallet: '598f606cd8fc24710d2ebadb1d9459bb',
+            coinSpecific: {
+              pendingChainInitialization: true,
+              minimumFunding: 2447136,
+              rootAddress: parsedBody.derivedAddress,
+            },
+          };
+        });
+
+      await updatedDotWallet.createAddress({
+        chain: 0,
+        passphrase,
+      });
+      nock2.isDone().should.be.true();
+    });
+  });
+
   describe('Accelerate Transaction', function () {
     it('fails if cpfpTxIds is not passed', async function () {
       await wallet.accelerateTransaction({})

--- a/modules/core/test/v2/unit/wallets.ts
+++ b/modules/core/test/v2/unit/wallets.ts
@@ -376,6 +376,8 @@ describe('V2 Wallets:', function () {
       backupNock.isDone().should.be.true();
       walletNock.isDone().should.be.true();
     });
+
+
   });
 
   describe('Sharing', () => {


### PR DESCRIPTION
When DOT wallet object is used in core for address creation, use hardened key derivation to generate an address to POST to WP for receive addresses. 

Follows workflow implemented by Solana

JIRA ticket: https://bitgoinc.atlassian.net/browse/STLX-13001
