### PR TITLE
feat(core): add method to aggregate ETH2 BLS shares

### DIFF
--- a/modules/core/src/v2/coins/eth2.ts
+++ b/modules/core/src/v2/coins/eth2.ts
@@ -332,4 +332,15 @@ export class Eth2 extends BaseCoin {
     const signedMessage = await keyPair.sign(messageToSign);
     return ethUtil.toBuffer(signedMessage);
   }
+
+  aggregateShares(shares: { pubShares: string[]; prvShares: string[] }): BlsKeyPair {
+    const commonPub = Eth2AccountLib.KeyPair.aggregatePubkeys(shares.pubShares);
+    const prv = Eth2AccountLib.KeyPair.aggregatePrvkeys(shares.prvShares);
+
+    return {
+      pub: commonPub,
+      prv,
+      secretShares: shares.prvShares,
+    };
+  }
 }


### PR DESCRIPTION
ETH2 BLS shares needs to be aggregated in client side in order to post the new user and backup keys
to platform.

BG-36122