### PR TITLE
fix(core): tss backup keychain output prv

### DIFF
--- a/modules/core/src/v2/internal/tssUtils.ts
+++ b/modules/core/src/v2/internal/tssUtils.ts
@@ -149,11 +149,14 @@ export class TssUtils {
       throw new Error('Failed to create backup keychain - commonPubs do not match.');
     }
 
-    return await this.baseCoin.keychains().add({
+    const prv = JSON.stringify(backupCombined.pShare);
+
+    return await this.baseCoin.keychains().createBackup({
       source: 'backup',
       type: 'tss',
       commonPub,
-      encryptedPrv: this.bitgo.encrypt({ input: JSON.stringify(backupCombined.pShare), password: passphrase }),
+      prv: prv,
+      encryptedPrv: this.bitgo.encrypt({ input: prv, password: passphrase }),
     });
   }
 

--- a/modules/core/src/v2/keychains.ts
+++ b/modules/core/src/v2/keychains.ts
@@ -90,6 +90,9 @@ export interface CreateBackupOptions {
   krsSpecific?: any;
   type?: string;
   reqId?: RequestTracer;
+  commonPub?: string;
+  prv?: string;
+  encryptedPrv?: string;
 }
 
 interface CreateBitGoOptions {
@@ -321,7 +324,9 @@ export class Keychains {
   async createBackup(params: CreateBackupOptions = {}): Promise<Keychain> {
     params.source = 'backup';
 
-    if (_.isUndefined(params.provider)) {
+    const isTssBackupKey = params.prv && params.encryptedPrv && params.commonPub;
+
+    if (_.isUndefined(params.provider) && !isTssBackupKey) {
       // if the provider is undefined, we generate a local key and add the source details
       const key = this.create();
       _.extend(params, key);


### PR DESCRIPTION
backup keychain should output the unencrypted prv share.
this is needed since we do not support KRS w/ TSS yet.

Ticket: BG-00000

**Before**
```
  "backupKeychain": {
    "id": "6202d633335cd700089ee54475f4a5f5",
    "source": "backup",
    "type": "tss",
    "addressDerivationKeypair": {},
    "commonPub": "45qD39LXNrG8LihJBwRHZD9Dpgxjj4p4fLa142cbbjKN"
  },
```

**After**
```
  "backupKeychain": {
    "id": "6203e72b7c3669000786ad2c98f82ba0",
    "source": "backup",
    "type": "tss",
    "addressDerivationKeypair": {},
    "commonPub": "GR69h5Q9Egs7P1CHHdPdE9Xsmo7cbeWghTNocFYX5WAg",
    "prv": "{\"i\":\"2\",\"y\":\"e50b10f67243042f16a2842bd307b161d2a25f47f333887dab096735ff383d25\",\"x\":\"f0934db45e7bf984b93d6b7477dbe91f64f00eed1b05bb6ecc8a0883c384940b\",\"prefix\":\"9ab729fbcb16f554522b263435d625ebc6719c881845b279b54138b3a120e306\"}",
    "encryptedPrv": "{\"iv\":\"Ck+iPGUpqyxcCWYZFyk7/Q==\",\"v\":1,\"iter\":10000,\"ks\":256,\"ts\":64,\"mode\":\"ccm\",\"adata\":\"\",\"cipher\":\"aes\",\"salt\":\"XUSitlC5BPs=\",\"ct\":\"eEyM076yDDv0VekSjjbPo96k1QUMbm9irG+UggA11TT43F2wyE4HdPfL5yotJ1YU2xUOGsom3fQZAIH2qJM2r6x3ts/ldupoAByd8nUm3zi1GLMin9tVYg52/jlMjV+ObuLHgQACQC2atrxXGpuP5eGEd1LgMRIXdcqn4UrQ6/ZzuE8fKdNFeOVHxSljnjD/a6FzigEAmjrUqUqtBRUywC7xgcWH+lUxrmcPARSGBQPGJkH1Qvq7w8JskDQJeKYBf/k0GAu6Yam4irlXQVF/JZ9GA9pWv9QV0l4zKmqAi7UBvnKoQcgPkU7iHQ==\"}"
  },
```