### PR TITLE
Avax hop transaction

### DIFF
--- a/modules/core/example/ts/send-hop-transaction.ts
+++ b/modules/core/example/ts/send-hop-transaction.ts
@@ -1,0 +1,27 @@
+import { BitGo } from 'bitgo';
+const bitgo = new BitGo({
+  env: 'test',
+});
+const coin = '';
+const accessToken = '';
+const walletId = '';
+const walletPassphrase = '';
+
+async function sendTxWithHop() {
+  bitgo.authenticateWithAccessToken({ accessToken });
+
+  const wallet = await bitgo.coin(coin).wallets().getWallet({ id: walletId });
+
+  const res = await wallet.sendMany({
+    recipients: [{
+      amount: '',
+      address: '',
+    }],
+    walletPassphrase: walletPassphrase,
+    hop: true,
+  });
+
+  console.log(res);
+}
+
+sendTxWithHop().catch((e) => console.error(e));

--- a/modules/core/src/v2/coins/avaxc.ts
+++ b/modules/core/src/v2/coins/avaxc.ts
@@ -1,19 +1,132 @@
 /**
  * @prettier
  */
-import { BaseCoin, KeyPair } from '../baseCoin';
-import { BitGo } from '../../bitgo';
-import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
-import { AbstractEthLikeCoin, EthSignTransactionOptions, SignedEthLikeTransaction } from './abstractEthLikeCoin';
-import { AvaxC as AvaxCAccountLib } from '@bitgo/account-lib';
+import { BigNumber } from 'bignumber.js';
+// import * as debugLib from 'debug';
 
-export class AvaxC extends AbstractEthLikeCoin {
+import {
+  BaseCoin,
+  FullySignedTransaction,
+  HalfSignedAccountTransaction,
+  KeyPair,
+  ParsedTransaction,
+  ParseTransactionOptions,
+  SignTransactionOptions as BaseSignTransactionOptions,
+  VerifyAddressOptions,
+  VerifyTransactionOptions,
+  TransactionFee,
+  TransactionRecipient as Recipient,
+  TransactionPrebuild as BaseTransactionPrebuild,
+  TransactionExplanation,
+} from '../baseCoin';
+
+import { BitGo } from '../../bitgo';
+import { InvalidAddressError, MethodNotImplementedError } from '../../errors';
+import { BaseCoin as StaticsBaseCoin, CoinFamily } from '@bitgo/statics';
+import { getBuilder, Eth, AvaxC as AvaxCAccountLib } from '@bitgo/account-lib';
+
+// const debug = debugLib('bitgo:v2:avaxc');
+
+// For explainTransaction
+export interface ExplainTransactionOptions {
+  txHex?: string;
+  halfSigned?: {
+    txHex: string;
+  };
+  feeInfo: TransactionFee;
+}
+
+// For txPreBuild
+export interface TxInfo {
+  recipients: Recipient[];
+  from: string;
+  txid: string;
+}
+
+export interface EthTransactionFee {
+  fee: string;
+  gasLimit?: string;
+}
+
+export interface TransactionPrebuild extends BaseTransactionPrebuild {
+  txHex: string;
+  txInfo: TxInfo;
+  feeInfo: EthTransactionFee;
+  source: string;
+  dataToSign: string;
+  nextContractSequenceId?: string;
+  expireTime?: number;
+}
+
+// For signTransaction
+export interface SignTransactionOptions extends BaseSignTransactionOptions {
+  txPrebuild: TransactionPrebuild;
+  prv: string;
+}
+
+export interface HalfSignedTransaction extends HalfSignedAccountTransaction {
+  halfSigned: {
+    txHex?: never;
+    recipients: Recipient[];
+    expiration?: number;
+  };
+}
+
+export type SignedTransaction = HalfSignedTransaction | FullySignedTransaction;
+
+export class AvaxC extends BaseCoin {
+  static hopTransactionSalt = 'bitgoHopAddressRequestSalt';
+
+  protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
+
   protected constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
-    super(bitgo, staticsCoin);
+    super(bitgo);
+
+    if (!staticsCoin) {
+      throw new Error('missing required constructor parameter staticsCoin');
+    }
+
+    this._staticsCoin = staticsCoin;
   }
 
   static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new AvaxC(bitgo, staticsCoin);
+  }
+
+  // static buildTransaction() : {
+  //
+  //
+  // }
+  //
+  getBaseFactor(): number {
+    return Math.pow(10, this._staticsCoin.decimalPlaces);
+  }
+
+  getChain() {
+    return this._staticsCoin.name;
+  }
+
+  /**
+   * Get the base chain that the coin exists on.
+   */
+  getBaseChain() {
+    return this.getChain();
+  }
+
+  getFamily(): CoinFamily {
+    return this._staticsCoin.family;
+  }
+
+  getFullName() {
+    return this._staticsCoin.fullName;
+  }
+
+  valuelessTransferAllowed(): boolean {
+    return true;
+  }
+
+  isValidAddress(address: string): boolean {
+    return !!address && AvaxCAccountLib.Utils.isValidEthAddress(address);
   }
 
   generateKeyPair(seed?: Buffer): KeyPair {
@@ -23,6 +136,21 @@ export class AvaxC extends AbstractEthLikeCoin {
       pub: extendedKeys.xpub,
       prv: extendedKeys.xprv!,
     };
+  }
+
+  async parseTransaction(params: ParseTransactionOptions): Promise<ParsedTransaction> {
+    return {};
+  }
+
+  verifyAddress({ address }: VerifyAddressOptions): boolean {
+    if (!this.isValidAddress(address)) {
+      throw new InvalidAddressError(`invalid address: ${address}`);
+    }
+    return true;
+  }
+
+  async verifyTransaction(params: VerifyTransactionOptions): Promise<boolean> {
+    return true;
   }
 
   isValidPub(pub: string): boolean {
@@ -35,11 +163,65 @@ export class AvaxC extends AbstractEthLikeCoin {
     return valid;
   }
 
-  isValidAddress(address: string): boolean {
-    return !!address && AvaxCAccountLib.Utils.isValidEthAddress(address);
+  /**
+   * Builds a funds recovery transaction without BitGo.
+   * We need to do three queries during this:
+   * 1) Node query - how much money is in the account
+   * 2) Build transaction - build our transaction for the amount
+   * 3) Send signed build - send our signed build to a public node
+   * @param params The options with which to recover
+   */
+  async recover(params: any): Promise<any> {
+    throw new MethodNotImplementedError();
   }
 
-  async signTransaction(params: EthSignTransactionOptions): Promise<SignedEthLikeTransaction> {
+  /**
+   * Create a new transaction builder for the current chain
+   * @return a new transaction builder
+   */
+  protected getTransactionBuilder(): Eth.TransactionBuilder {
+    return getBuilder(this.getBaseChain()) as Eth.TransactionBuilder;
+  }
+
+  /**
+   * Explain a transaction from txHex, overriding BaseCoins
+   * @param params The options with which to explain the transaction
+   */
+  async explainTransaction(params: ExplainTransactionOptions): Promise<TransactionExplanation> {
+    const txHex = params.txHex || (params.halfSigned && params.halfSigned.txHex);
+    if (!txHex || !params.feeInfo) {
+      throw new Error('missing explain tx parameters');
+    }
+    const txBuilder = this.getTransactionBuilder();
+    txBuilder.from(txHex);
+    const tx = await txBuilder.build();
+    const outputs = tx.outputs.map((output) => {
+      return {
+        address: output.address,
+        amount: output.value,
+      };
+    });
+
+    const displayOrder = ['id', 'outputAmount', 'changeAmount', 'outputs', 'changeOutputs', 'fee'];
+
+    return {
+      displayOrder,
+      id: tx.id,
+      outputs: outputs,
+      outputAmount: outputs
+        .reduce((accumulator, output) => accumulator.plus(output.amount), new BigNumber('0'))
+        .toFixed(0),
+      changeOutputs: [], // account based does not use change outputs
+      changeAmount: '0', // account base does not make change
+      fee: params.feeInfo,
+    };
+  }
+
+  /**
+   * Assemble half-sign prebuilt transaction
+   * @param params
+   */
+  async signTransaction(params: SignTransactionOptions): Promise<SignedTransaction> {
     const txBuilder = this.getTransactionBuilder();
     txBuilder.from(params.txPrebuild.txHex);
     txBuilder.transfer().key(new AvaxCAccountLib.KeyPair({ prv: params.prv }).getKeys().prv!);
@@ -55,4 +237,6 @@ export class AvaxC extends AbstractEthLikeCoin {
       },
     };
   }
+
+  // async getExtraPreBuildParams(buildParams: )
 }

--- a/modules/core/src/v2/coins/avaxc.ts
+++ b/modules/core/src/v2/coins/avaxc.ts
@@ -2,10 +2,15 @@
  * @prettier
  */
 import { BigNumber } from 'bignumber.js';
+import * as bip32 from 'bip32';
+import * as Keccak from 'keccak';
+import * as secp256k1 from 'secp256k1';
+import * as _ from 'lodash';
 // import * as debugLib from 'debug';
 
 import {
   BaseCoin,
+  FeeEstimateOptions,
   FullySignedTransaction,
   HalfSignedAccountTransaction,
   KeyPair,
@@ -15,7 +20,7 @@ import {
   VerifyAddressOptions,
   VerifyTransactionOptions,
   TransactionFee,
-  TransactionRecipient as Recipient,
+  // TransactionRecipient,
   TransactionPrebuild as BaseTransactionPrebuild,
   TransactionExplanation,
 } from '../baseCoin';
@@ -24,6 +29,11 @@ import { BitGo } from '../../bitgo';
 import { InvalidAddressError, MethodNotImplementedError } from '../../errors';
 import { BaseCoin as StaticsBaseCoin, CoinFamily } from '@bitgo/statics';
 import { getBuilder, Eth, AvaxC as AvaxCAccountLib } from '@bitgo/account-lib';
+import * as common from '../../common';
+
+import { optionalDeps } from './eth';
+import { Erc20Token } from './erc20Token';
+import { Wallet } from '../wallet';
 
 // const debug = debugLib('bitgo:v2:avaxc');
 
@@ -34,6 +44,63 @@ export interface ExplainTransactionOptions {
     txHex: string;
   };
   feeInfo: TransactionFee;
+}
+
+// For createHopTransactionParams
+interface HopTransactionBuildOptions {
+  wallet: Wallet;
+  recipients: Recipient[];
+  walletPassphrase: string;
+}
+
+interface Recipient {
+  address: string;
+  amount: string;
+  data?: string;
+}
+
+// For getExtraPrebuildParams
+interface BuildOptions {
+  hop?: boolean;
+  wallet?: Wallet;
+  recipients?: Recipient[];
+  walletPassphrase?: string;
+  [index: string]: unknown;
+}
+
+// For FeeEstimate
+interface FeeEstimate {
+  gasLimitEstimate: number;
+  feeEstimate: number;
+}
+
+/**
+ * The extra parameters to send to platform build route for hop transactions
+ */
+interface HopParams {
+  hopParams: {
+    gasPriceMax: number;
+    userReqSig: string;
+    paymentId: string;
+  };
+  gasLimit: number;
+}
+
+/**
+ * The prebuilt hop transaction returned from the HSM
+ */
+interface HopPrebuild {
+  tx: string;
+  id: string;
+  signature: string;
+  paymentId: string;
+  gasPrice: number;
+  gasLimit: number;
+  amount: number;
+  recipient: string;
+  nonce: number;
+  userReqSig: string;
+  gasPriceMax: number;
 }
 
 // For txPreBuild
@@ -218,6 +285,71 @@ export class AvaxC extends BaseCoin {
   }
 
   /**
+   * Above is standard BaseCoins functions
+   * ================================================================================================================
+   * ================================================================================================================
+   * Below is transaction functions
+   */
+
+  /**
+   * Validates that the hop prebuild from the HSM is valid and correct
+   * @param wallet The wallet that the prebuild is for
+   * @param hopPrebuild The prebuild to validate
+   * @param originalParams The original parameters passed to prebuildTransaction
+   * @returns void
+   * @throws Error if The prebuild is invalid
+   */
+  async validateHopPrebuild(
+    wallet: Wallet,
+    hopPrebuild: HopPrebuild,
+    originalParams?: { recipients: Recipient[] }
+  ): Promise<void> {
+    const { tx, id, signature } = hopPrebuild;
+
+    // first, validate the HSM signature
+    const serverXpub = common.Environments[this.bitgo.getEnv()].hsmXpub;
+    const serverPubkeyBuffer: Buffer = bip32.fromBase58(serverXpub).publicKey;
+    const signatureBuffer: Buffer = Buffer.from(optionalDeps.ethUtil.stripHexPrefix(signature), 'hex');
+    const messageBuffer: Buffer = Buffer.from(optionalDeps.ethUtil.stripHexPrefix(id), 'hex');
+
+    const sig = new Uint8Array(signatureBuffer.slice(1));
+    const isValidSignature: boolean = secp256k1.ecdsaVerify(sig, messageBuffer, serverPubkeyBuffer);
+    if (!isValidSignature) {
+      throw new Error(`Hop txid signature invalid`);
+    }
+
+    const builtHopTx = optionalDeps.EthTx.TransactionFactory.fromSerializedData(optionalDeps.ethUtil.toBuffer(tx));
+    // If original params are given, we can check them against the transaction prebuild params
+    if (!_.isNil(originalParams)) {
+      const { recipients } = originalParams;
+
+      // Then validate that the tx params actually equal the requested params
+      const originalAmount = new BigNumber(recipients[0].amount);
+      const originalDestination: string = recipients[0].address;
+
+      const hopAmount = new BigNumber(optionalDeps.ethUtil.bufferToHex(builtHopTx.value));
+      if (!builtHopTx.to) {
+        throw new Error(`Transaction does not have a destination address`);
+      }
+      const hopDestination = builtHopTx.to.toString();
+      if (!hopAmount.eq(originalAmount)) {
+        throw new Error(`Hop amount: ${hopAmount} does not equal original amount: ${originalAmount}`);
+      }
+      if (hopDestination.toLowerCase() !== originalDestination.toLowerCase()) {
+        throw new Error(`Hop destination: ${hopDestination} does not equal original recipient: ${hopDestination}`);
+      }
+    }
+
+    if (!builtHopTx.verifySignature()) {
+      // We dont want to continue at all in this case, at risk of ETH being stuck on the hop address
+      throw new Error(`Invalid hop transaction signature, txid: ${id}`);
+    }
+    if (optionalDeps.ethUtil.addHexPrefix(builtHopTx.hash().toString('hex')) !== id) {
+      throw new Error(`Signed hop txid does not equal actual txid`);
+    }
+  }
+
+  /**
    * Assemble half-sign prebuilt transaction
    * @param params
    */
@@ -236,6 +368,132 @@ export class AvaxC extends BaseCoin {
         expiration: params.txPrebuild.expireTime,
       },
     };
+  }
+
+  /**
+   * Modify prebuild before sending it to the server. Add things like hop transaction params
+   * @param buildParams The whitelisted parameters for this prebuild
+   * @param buildParams.hop True if this should prebuild a hop tx, else false
+   * @param buildParams.recipients The recipients array of this transaction
+   * @param buildParams.wallet The wallet sending this tx
+   * @param buildParams.walletPassphrase the passphrase for this wallet
+   */
+  async getExtraPrebuildParams(buildParams: BuildOptions): Promise<BuildOptions> {
+    if (
+      !_.isUndefined(buildParams.hop) &&
+      buildParams.hop &&
+      !_.isUndefined(buildParams.wallet) &&
+      !_.isUndefined(buildParams.recipients) &&
+      !_.isUndefined(buildParams.walletPassphrase)
+    ) {
+      if (this instanceof Erc20Token) {
+        throw new Error(
+          `Hop transactions are not enabled for ERC-20 tokens, nor are they necessary. Please remove the 'hop' parameter and try again.`
+        );
+      }
+      return (await this.createHopTransactionParams({
+        wallet: buildParams.wallet,
+        recipients: buildParams.recipients,
+        walletPassphrase: buildParams.walletPassphrase,
+      })) as any;
+    }
+    return {};
+  }
+
+  /**
+   * Creates the extra parameters needed to build a hop transaction
+   * @param buildParams The original build parameters
+   * @returns extra parameters object to merge with the original build parameters object and send to the platform
+   */
+  async createHopTransactionParams(buildParams: HopTransactionBuildOptions): Promise<HopParams> {
+    const wallet = buildParams.wallet;
+    const recipients = buildParams.recipients;
+    const walletPassphrase = buildParams.walletPassphrase;
+
+    const userKeychain = await this.keychains().get({ id: wallet.keyIds()[0] });
+    const userPrv = wallet.getUserPrv({ keychain: userKeychain, walletPassphrase });
+    const userPrvBuffer = bip32.fromBase58(userPrv).privateKey;
+    if (!userPrvBuffer) {
+      throw new Error('invalid userPrv');
+    }
+    if (!recipients || !Array.isArray(recipients)) {
+      throw new Error('expecting array of recipients');
+    }
+
+    // Right now we only support 1 recipient
+    if (recipients.length !== 1) {
+      throw new Error('must send to exactly 1 recipient');
+    }
+    const recipientAddress = recipients[0].address;
+    const recipientAmount = recipients[0].amount;
+    const feeEstimateParams = {
+      recipient: recipientAddress,
+      amount: recipientAmount,
+      hop: true,
+    };
+    const feeEstimate: FeeEstimate = await this.feeEstimate(feeEstimateParams);
+
+    const gasLimit = feeEstimate.gasLimitEstimate;
+    const gasPrice = Math.round(feeEstimate.feeEstimate / gasLimit);
+    const gasPriceMax = gasPrice * 5;
+    // Payment id a random number so its different for every tx
+    const paymentId = Math.floor(Math.random() * 10000000000).toString();
+    const hopDigest: Buffer = AvaxC.getHopDigest([
+      recipientAddress,
+      recipientAmount,
+      gasPriceMax.toString(),
+      gasLimit.toString(),
+      paymentId,
+    ]);
+
+    const userReqSig = optionalDeps.ethUtil.addHexPrefix(
+      Buffer.from(secp256k1.ecdsaSign(hopDigest, userPrvBuffer).signature).toString('hex')
+    );
+
+    return {
+      hopParams: {
+        gasPriceMax,
+        userReqSig,
+        paymentId,
+      },
+      gasLimit,
+    };
+  }
+
+  /**
+   * Fetch fee estimate information from the server
+   * @param {Object} params The params passed into the function
+   * @param {Boolean} [params.hop] True if we should estimate fee for a hop transaction
+   * @param {String} [params.recipient] The recipient of the transaction to estimate a send to
+   * @param {String} [params.data] The ETH tx data to estimate a send for
+   * @returns {Object} The fee info returned from the server
+   */
+  async feeEstimate(params: FeeEstimateOptions): Promise<FeeEstimate> {
+    const query: FeeEstimateOptions = {};
+    if (params && params.hop) {
+      query.hop = params.hop;
+    }
+    if (params && params.recipient) {
+      query.recipient = params.recipient;
+    }
+    if (params && params.data) {
+      query.data = params.data;
+    }
+    if (params && params.amount) {
+      query.amount = params.amount;
+    }
+
+    return await this.bitgo.get(this.url('/tx/fee')).query(query).result();
+  }
+
+  /**
+   * Gets the hop digest for the user to sign. This is validated in the HSM to prove that the user requested this tx
+   * @param paramsArr The parameters to hash together for the digest
+   */
+  private static getHopDigest(paramsArr: string[]): Buffer {
+    const hash = new Keccak('keccak256');
+    hash.update([AvaxC.hopTransactionSalt, ...paramsArr].join('$'));
+    return hash.digest();
   }
 
   // async getExtraPreBuildParams(buildParams: )

--- a/modules/core/src/v2/coins/avaxcToken.ts
+++ b/modules/core/src/v2/coins/avaxcToken.ts
@@ -102,4 +102,8 @@ export class AvaxCToken extends AvaxC {
   transactionDataAllowed(): boolean {
     return false;
   }
+
+  isToken(): boolean {
+    return true;
+  }
 }

--- a/modules/core/test/v2/unit/coins/avaxc.ts
+++ b/modules/core/test/v2/unit/coins/avaxc.ts
@@ -1,20 +1,51 @@
 import { TestBitGo } from '../../../lib/test_bitgo';
 import { AvaxC, TavaxC } from '../../../../src/v2/coins';
 import { getBuilder, AvaxC as AvaxCAccountLib, BaseCoin } from '@bitgo/account-lib';
+import * as secp256k1 from 'secp256k1';
+import * as bip32 from 'bip32';
+import { Wallet } from '../../../../src';
+import * as nock from 'nock';
+import * as common from '../../../../src/common';
+
+nock.enableNetConnect();
 
 describe('Avalanche C-Chain', function () {
   let bitgo;
   let tavaxCoin;
   let avaxCoin;
+  let hopTxBitgoSignature;
+
+  const address1 = '0x174cfd823af8ce27ed0afee3fcf3c3ba259116be';
+  const address2 = '0x7e85bdc27c050e3905ebf4b8e634d9ad6edd0de6';
+  const hopContractAddress = '0x47ce7cc86efefef19f8fb516b11735d183da8635';
+  const hopDestinationAddress = '0x9c7e8ce6825bD48278B3Ab59228EE26f8BE7925b';
+  const hopTx = '0xf86b808504a817c8ff8252ff949c7e8ce6825bd48278b3ab59228ee26f8be7925b87038d7ea4c68000801ca011bc22c664570133dfca4f08a0b8d02339cf467046d6a4152f04f368d0eaf99ea01d6dc5cf0c897c8d4c3e1df53d0d042784c424536a4cc5b802552b7d64fee8b5';
+  const hopTxid = '0x4af65143bc77da2b50f35b3d13cacb4db18f026bf84bc0743550bc57b9b53351';
+  const userReqSig = '0x404db307f6147f0d8cd338c34c13906ef46a6faa7e0e119d5194ef05aec16e6f3d710f9b7901460f97e924066b62efd74443bd34402c6d40b49c203a559ff2c8';
+
 
   before(function () {
-    bitgo = new TestBitGo({ env: 'mock' });
+    const bitgoKeyXprv = 'xprv9s21ZrQH143K3tpWBHWe31sLoXNRQ9AvRYJgitkKxQ4ATFQMwvr7hHNqYRUnS7PsjzB7aK1VxqHLuNQjj1sckJ2Jwo2qxmsvejwECSpFMfC';
+    const bitgoKey = bip32.fromBase58(bitgoKeyXprv);
+    if (!bitgoKey.privateKey) {
+      throw new Error('no privateKey');
+    }
+    const bitgoXpub = bitgoKey.neutered().toBase58();
+    hopTxBitgoSignature = '0xaa' + Buffer.from(secp256k1.ecdsaSign(Buffer.from(hopTxid.slice(2), 'hex'), bitgoKey.privateKey).signature).toString('hex');
+
+    const env = 'test';
+    bitgo = new TestBitGo({ env: 'test' });
+    common.Environments[env].hsmXpub = bitgoXpub;
     bitgo.initializeTestVars();
   });
 
   beforeEach(() => {
     tavaxCoin = bitgo.coin('tavaxc') as TavaxC;
     avaxCoin = bitgo.coin('avaxc') as AvaxC;
+  });
+
+  after(function () {
+    nock.cleanAll();
   });
 
   describe('Instantiate', () => {
@@ -238,6 +269,282 @@ describe('Avalanche C-Chain', function () {
       halfSignedRawTx.halfSigned.recipients.length.should.equals(1);
       halfSignedRawTx.halfSigned.recipients[0].address.toLowerCase().should.equals(account_2.address.toLowerCase());
       halfSignedRawTx.halfSigned.recipients[0].amount.toLowerCase().should.equals('1');
+    });
+  });
+
+  describe('Transaction Verification', () => {
+    it('should verify a hop txPrebuild from the bitgo server that matches the client txParams', async function () {
+      const wallet = new Wallet(bitgo, tavaxCoin, {});
+
+      const txParams = {
+        recipients: [{ amount: 1000000000000000, address: hopDestinationAddress }],
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+        hop: true,
+      };
+
+      const txPrebuild = {
+        recipients: [{ amount: '5000000000000000', address: hopContractAddress }],
+        nextContractSequenceId: 0,
+        gasPrice: 20000000000,
+        gasLimit: 500000,
+        isBatch: false,
+        coin: 'tavaxc',
+        walletId: 'fakeWalletId',
+        walletContractAddress: 'fakeWalletContractAddress',
+        hopTransaction: {
+          tx: hopTx,
+          id: hopTxid,
+          signature: hopTxBitgoSignature,
+          paymentId: '2773928196',
+          gasPrice: 20000000000,
+          gasLimit: 500000,
+          amount: '1000000000000000',
+          recipient: hopDestinationAddress,
+          nonce: 0,
+          userReqSig: userReqSig,
+          gasPriceMax: 500000000000,
+        },
+      };
+
+      const verification = {};
+
+      const isTransactionVerified = await tavaxCoin.verifyTransaction({ txParams, txPrebuild, wallet, verification });
+      isTransactionVerified.should.equal(true);
+    });
+
+    it('should reject when client txParams are missing', async function () {
+      const coin = bitgo.coin('teth');
+      const wallet = new Wallet(bitgo, coin, {});
+
+      const txParams = null;
+
+      const txPrebuild = {
+        recipients: [{ amount: '1000000000000', address: address1 }],
+        nextContractSequenceId: 0,
+        gasPrice: 20000000000,
+        gasLimit: 500000,
+        isBatch: false,
+        coin: 'tavaxc',
+        walletId: 'fakeWalletId',
+        walletContractAddress: 'fakeWalletContractAddress',
+      };
+
+      const verification = {};
+
+      await coin.verifyTransaction({ txParams, txPrebuild, wallet, verification })
+        .should.be.rejectedWith('missing params');
+    });
+
+    it('should reject txPrebuild that is both batch and hop', async function () {
+      const wallet = new Wallet(bitgo, tavaxCoin, {});
+
+      const txParams = {
+        recipients: [{ amount: '1000000000000', address: address1 }, { amount: '2500000000000', address: address2 }],
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+        hop: true,
+      };
+
+      const txPrebuild = {
+        recipients: [{ amount: '3500000000000', address: address1 }],
+        nextContractSequenceId: 0,
+        gasPrice: 20000000000,
+        gasLimit: 500000,
+        isBatch: true,
+        coin: 'tavaxc',
+        walletId: 'fakeWalletId',
+        walletContractAddress: 'fakeWalletContractAddress',
+        hopTransaction: {
+          tx: hopTx,
+          id: hopTxid,
+          signature: hopTxBitgoSignature,
+          paymentId: '2773928196',
+          gasPrice: 20000000000,
+          gasLimit: 500000,
+          amount: '1000000000000000',
+          recipient: hopDestinationAddress,
+          nonce: 0,
+          userReqSig: userReqSig,
+          gasPriceMax: 500000000000,
+        },
+      };
+
+      const verification = {};
+
+      await tavaxCoin.verifyTransaction({ txParams, txPrebuild, wallet, verification })
+        .should.be.rejectedWith('tx cannot be both a batch and hop transaction');
+    });
+
+    it('should reject a txPrebuild with more than one recipient', async function () {
+      const wallet = new Wallet(bitgo, tavaxCoin, {});
+
+      const txParams = {
+        recipients: [{ amount: '1000000000000', address: address1 }, { amount: '2500000000000', address: address2 }],
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+      };
+
+      const txPrebuild = {
+        recipients: [{ amount: '1000000000000', address: address1 }, { amount: '2500000000000', address: address2 }],
+        nextContractSequenceId: 0,
+        gasPrice: 20000000000,
+        gasLimit: 500000,
+        isBatch: true,
+        coin: 'tavaxc',
+        walletId: 'fakeWalletId',
+        walletContractAddress: 'fakeWalletContractAddress',
+      };
+
+      const verification = {};
+
+      await tavaxCoin.verifyTransaction({ txParams, txPrebuild, wallet, verification })
+        .should.be.rejectedWith('txPrebuild should only have 1 recipient but 2 found');
+    });
+
+    it('should reject a hop txPrebuild that does not send to its hop address', async function () {
+      const wallet = new Wallet(bitgo, tavaxCoin, {});
+
+      const txParams = {
+        recipients: [{ amount: '1000000000000000', address: hopDestinationAddress }],
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+        hop: true,
+      };
+
+      const txPrebuild = {
+        recipients: [{ amount: '5000000000000000', address: address1 }],
+        nextContractSequenceId: 0,
+        gasPrice: 20000000000,
+        gasLimit: 500000,
+        isBatch: false,
+        coin: 'tavaxc',
+        walletId: 'fakeWalletId',
+        walletContractAddress: 'fakeWalletContractAddress',
+        hopTransaction: {
+          tx: hopTx,
+          id: hopTxid,
+          signature: hopTxBitgoSignature,
+          paymentId: '0',
+          gasPrice: 20000000000,
+          gasLimit: 500000,
+          amount: '1000000000000000',
+          recipient: hopDestinationAddress,
+          nonce: 0,
+          userReqSig: userReqSig,
+          gasPriceMax: 500000000000,
+        },
+      };
+
+      const verification = {};
+
+      await tavaxCoin.verifyTransaction({ txParams, txPrebuild, wallet, verification })
+        .should.be.rejectedWith('recipient address of txPrebuild does not match hop address');
+    });
+
+    it('should reject a normal txPrebuild from the bitgo server with the wrong amount', async function () {
+      const wallet = new Wallet(bitgo, tavaxCoin, {});
+
+      const txParams = {
+        recipients: [{ amount: '1000000000000', address: address1 }],
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+      };
+
+      const txPrebuild = {
+        recipients: [{ amount: '2000000000000', address: address1 }],
+        nextContractSequenceId: 0,
+        gasPrice: 20000000000,
+        gasLimit: 500000,
+        isBatch: false,
+        coin: 'tavaxc',
+        walletId: 'fakeWalletId',
+        walletContractAddress: 'fakeWalletContractAddress',
+      };
+
+      const verification = {};
+
+      await tavaxCoin.verifyTransaction({ txParams, txPrebuild, wallet, verification })
+        .should.be.rejectedWith('normal transaction amount in txPrebuild received from BitGo servers does not match txParams supplied by client');
+    });
+
+    it('should reject a normal txPrebuild from the bitgo server with the wrong recipient', async function () {
+      const wallet = new Wallet(bitgo, tavaxCoin, {});
+
+      const txParams = {
+        recipients: [{ amount: '1000000000000', address: address1 }],
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+      };
+
+      const txPrebuild = {
+        recipients: [{ amount: '1000000000000', address: address2 }],
+        nextContractSequenceId: 0,
+        gasPrice: 20000000000,
+        gasLimit: 500000,
+        isBatch: false,
+        coin: 'tavaxc',
+        walletId: 'fakeWalletId',
+        walletContractAddress: 'fakeWalletContractAddress',
+      };
+
+      const verification = {};
+
+      await tavaxCoin.verifyTransaction({ txParams, txPrebuild, wallet, verification })
+        .should.be.rejectedWith('destination address in normal txPrebuild does not match that in txParams supplied by client');
+    });
+
+    it('should verify a token txPrebuild from the bitgo server that matches the client txParams', async function () {
+      const wallet = new Wallet(bitgo, tavaxCoin, {});
+
+      const txParams = {
+        recipients: [{ amount: '1000000000000', address: address1 }],
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+      };
+
+      const txPrebuild = {
+        recipients: [{ amount: '1000000000000', address: address1 }],
+        nextContractSequenceId: 0,
+        gasPrice: 20000000000,
+        gasLimit: 500000,
+        isBatch: false,
+        coin: 'tavaxc',
+        token: 'test',
+        walletId: 'fakeWalletId',
+        walletContractAddress: 'fakeWalletContractAddress',
+      };
+
+      const verification = {};
+
+      const isTransactionVerified = await tavaxCoin.verifyTransaction({ txParams, txPrebuild, wallet, verification });
+      isTransactionVerified.should.equal(true);
+    });
+
+    it('should reject a txPrebuild from the bitgo server with the wrong coin', async function () {
+      const wallet = new Wallet(bitgo, tavaxCoin, {});
+
+      const txParams = {
+        recipients: [{ amount: '1000000000000', address: address1 }],
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+      };
+
+      const txPrebuild = {
+        recipients: [{ amount: '1000000000000', address: address1 }],
+        nextContractSequenceId: 0,
+        gasPrice: 20000000000,
+        gasLimit: 500000,
+        isBatch: false,
+        coin: 'btc',
+        walletId: 'fakeWalletId',
+        walletContractAddress: 'fakeWalletContractAddress',
+      };
+
+      const verification = {};
+
+      await tavaxCoin.verifyTransaction({ txParams, txPrebuild, wallet, verification })
+        .should.be.rejectedWith('coin in txPrebuild did not match that in txParams supplied by client');
     });
   });
 });


### PR DESCRIPTION
Enable hop transaction for AVAXC

When it comes to the choice of design, the options were

1. modify ethlike to add hop + 1559
2. extend from eth by typescriptifying
3. copy paste and keep redundant code to decouple development and move fast

we picked option 3 due to time and complexity reason. And also to avoid modifying and breaking another eth-like coin.

<img width="798" alt="Screen Shot 2022-02-02 at 2 16 04 PM (1)" src="https://user-images.githubusercontent.com/95242722/157994368-9aaa62f7-f99f-46b7-a15e-3d2879589f07.png">

