### PR TITLE
feat: allow external signer to sign for multiple wallet ids

### DIFF
--- a/modules/express/src/expressApp.ts
+++ b/modules/express/src/expressApp.ts
@@ -162,10 +162,7 @@ export function createBaseUri(config: Config): string {
 function checkSignerPrvPath(path: string) {
   try {
     const privKeyFile = fs.readFileSync(path, { encoding: 'utf8' });
-    const privKey = JSON.parse(privKeyFile);
-    if (privKey.prv === undefined) {
-      throw new Error(`required field "prv" is missing`);
-    }
+    JSON.parse(privKeyFile);
   } catch (e) {
     throw new Error(`Failed to parse ${path} - ${e.message}`);
   }

--- a/modules/express/test/unit/bitgoExpress.ts
+++ b/modules/express/test/unit/bitgoExpress.ts
@@ -32,7 +32,7 @@ describe('Bitgo Express', function () {
 
   describe('server initialization', function () {
     const validPrvJSON =
-      '{"prv":"xprv9s21ZrQH143K3EuPWCBuqnWxydaQV6et9htQige4EswvcHKEzNmkVmwTwKoadyHzJYppuADB7Us7AbaNLToNvoFoSxuWqndQRYtnNy5DUY2"}';
+      '{"61f039aad587c2000745c687373e0fa9":"xprv9s21ZrQH143K3EuPWCBuqnWxydaQV6et9htQige4EswvcHKEzNmkVmwTwKoadyHzJYppuADB7Us7AbaNLToNvoFoSxuWqndQRYtnNy5DUY2"}';
 
     it('should require NODE_ENV to be production when running against prod env', function () {
       const envStub = sinon.stub(process, 'env').value({ NODE_ENV: 'production' });
@@ -447,7 +447,7 @@ describe('Bitgo Express', function () {
       (() => expressApp(args)).should.not.throw();
     });
 
-    it('should require that an signerFileSystemPath contains a json with a prv field', function () {
+    it('should require that an signerFileSystemPath contains a parsable json', function () {
       const args: any = {
         env: 'test',
         signerMode: 'signerMode',
@@ -455,10 +455,9 @@ describe('Bitgo Express', function () {
       };
       (() => expressApp(args)).should.throw();
 
-      const invalidPrv =
-        '{"invalidField":"invalidPrivKey"}';
+      const invalidPrv = '{"invalid json"}';
       const readInvalidStub = sinon.stub(fs, 'readFileSync').returns(invalidPrv);
-      (() => expressApp(args)).should.throw(`Failed to parse ${args.signerFileSystemPath} - required field "prv" is missing`);
+      (() => expressApp(args)).should.throw();
       readInvalidStub.restore();
 
       const readValidStub = sinon.stub(fs, 'readFileSync').returns(validPrvJSON);

--- a/modules/express/test/unit/clientRoutes/externalSign.ts
+++ b/modules/express/test/unit/clientRoutes/externalSign.ts
@@ -16,12 +16,17 @@ import { BitGo } from 'bitgo';
 describe('External signer', () => {
   it('should read prv from signerFileSystemPath and pass it to coin.signTransaction', async () => {
     const validPrv =
-      '{"prv":"xprv9s21ZrQH143K3EuPWCBuqnWxydaQV6et9htQige4EswvcHKEzNmkVmwTwKoadyHzJYppuADB7Us7AbaNLToNvoFoSxuWqndQRYtnNy5DUY2"}';
+      '{"61f039aad587c2000745c687373e0fa9":"xprv9s21ZrQH143K3EuPWCBuqnWxydaQV6et9htQige4EswvcHKEzNmkVmwTwKoadyHzJYppuADB7Us7AbaNLToNvoFoSxuWqndQRYtnNy5DUY2"}';
     const readFileStub = sinon.stub(fs.promises, 'readFile').resolves(validPrv);
     const signTransactionStub = sinon.stub(Btc.prototype, 'signTransaction').resolves('signedTx');
 
     const req = {
       bitgo: new BitGo({ env: 'test' }),
+      body: {
+        txPrebuild: {
+          walletId: '61f039aad587c2000745c687373e0fa9',
+        },
+      },
       params: {
         coin: 'tbtc',
       },


### PR DESCRIPTION
Previously the external signer would produce signatures using the single private key provided in the json file (specified by the config arg `signerFileSystemPath`). Now, it'll find the appropriate private key corresponding to the `walletId` for the transaction being signed and use that private key. 

Note: Only the last commit corresponds to this PR. The previous commits are from #1944 waiting to be merged