### PR TITLE
feat(utxo-bin): add support for odd transactions

### DIFF
--- a/modules/utxo-bin/src/commands.ts
+++ b/modules/utxo-bin/src/commands.ts
@@ -49,6 +49,7 @@ export const cmdParse = {
       .option('parseScriptAsm', { alias: 'scriptasm', type: 'boolean', default: false })
       .option('parseScriptData', { alias: 'scriptdata', type: 'boolean', default: false })
       .option('parseSignatureData', { alias: 'sigdata', type: 'boolean', default: false })
+      .option('maxOutputs', { type: 'number' })
       .option('all', { type: 'boolean', default: false })
       .option('format', { choices: ['tree', 'json'], default: 'tree' } as const);
   },


### PR DESCRIPTION
The command now works with odd transactions

```
$ utxo-bin parse -n testnet --txid \
   2d0a64a14faa9dc707dc84647a4e0dd1d4f31753e8a85574128bc8110e312e10
fetching txHex via blockapi...
transaction: 2d0a64a14faa9dc707dc84647a4e0dd1d4f31753e8a85574128bc8110e312e10
├── parsedAs: bitcoin testnet
├── version: 2
├── hasWitnesses: true
├── status: unknown
├── vsize: 900105vbytes (3600417wu)
├─┬ inputs: 1
│ └─┬ 0: e162a29a77f0b12adf70051a1135c48c691f44f0371f635b9f6a435dcba6ebb9:0
│   └── sigScript: unknown
└─┬ outputs: 100000 sum=0.03034297
  └── (omitted)
```

```
$ utxo-bin parse -n bitcoin --txid \
   905ecdf95a84804b192f4dc221cfed4d77959b81ed66013a7e41a
fetching txHex via blockapi...
transaction: 905ecdf95a84804b192f4dc221cfed4d77959b81ed66013a7e41a6e61e7ed530
├── parsedAs: bitcoin mainnet
├── version: 2
├── hasWitnesses: true
├── status: unknown
├── vsize: 188vbytes (749wu)
├─┬ inputs: 1
│ └─┬ 0: 5b79f5d6039c188613342eb13961dd7d1e1a0f90023d3eaed25fc85a29201bb4:0
│   └─┬ sigScript: p2tr
│     └── signatures: [65byte] [64byte]
└─┬ outputs: 1 sum=0.00000000
  └─┬ 0: OP_RETURN
    ├─┬ 0: 58 bytes
    │ ├── hex: 546878205361746f7368692120e2889e2f32316d696c20466972737420546170726f6f74206d756c7469736967
207370656e64202d426974476f
    │ └── utf8: Thx Satoshi! ∞/21mil First Taproot multisig spend -BitGo
    └── value: 0
```

Issue: BG-00000
