### PR TITLE
chore(account-lib): troubleshoot dot test OOM

### DIFF
--- a/modules/account-lib/test/unit/coin/dot/transaction.ts
+++ b/modules/account-lib/test/unit/coin/dot/transaction.ts
@@ -24,11 +24,9 @@ class StubTransaction extends Transaction {
 
 describe('Dot Transaction', () => {
   let tx: StubTransaction;
-  const config = buildTestConfig();
-  const material = utils.getMaterial(config);
 
   beforeEach(() => {
-    tx = new StubTransaction(config);
+    tx = new StubTransaction(buildTestConfig());
   });
 
   describe('empty transaction', () => {
@@ -68,7 +66,7 @@ describe('Dot Transaction', () => {
 
   describe('should build from raw unsigned tx', async () => {
     it('Transaction size validation', async () => {
-      const builder = new TransferBuilder(coins.get('tdot')).material(material);
+      const builder = new TransferBuilder(coins.get('tdot')).material(utils.getMaterial(buildTestConfig()));
       builder.from(DotResources.rawTx.transfer.unsigned);
       builder
         .validity({ firstValid: 3933 })

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/addressInitializationBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/addressInitializationBuilder.ts
@@ -1,21 +1,22 @@
 import should from 'should';
-import sinon, { assert } from 'sinon';
+import sinon from 'sinon';
 import { AddressInitializationBuilder } from '../../../../../src/coin/dot';
 import * as DotResources from '../../../../resources/dot';
 import { buildTestConfig } from './base';
 import { ProxyType } from '../../../../../src/coin/dot/iface';
 import utils from '../../../../../src/coin/dot/utils';
+import { Networks } from '@bitgo/statics';
 
 describe('Dot Address Initialization Builder', () => {
   let builder: AddressInitializationBuilder;
 
   const sender = DotResources.accounts.account1;
   const receiver = DotResources.accounts.account3;
-  const config = buildTestConfig();
-  const materialData = utils.getMaterial(config);
+  const { txVersion, specVersion, genesisHash, chainName } = Networks.test.dot;
 
   beforeEach(() => {
-    builder = new AddressInitializationBuilder(config).material(materialData);
+    const config = buildTestConfig();
+    builder = new AddressInitializationBuilder(config).material(utils.getMaterial(config));
   });
 
   describe('setter validation', () => {
@@ -26,7 +27,7 @@ describe('Dot Address Initialization Builder', () => {
         (e: Error) => e.message === 'Value cannot be less than zero',
       );
       should.doesNotThrow(() => builder.delay('0'));
-      assert.calledTwice(spy);
+      sinon.assert.calledTwice(spy);
     });
 
     it('should validate owner address', () => {
@@ -36,7 +37,7 @@ describe('Dot Address Initialization Builder', () => {
         (e: Error) => e.message === `The address 'asd' is not a well-formed dot address`,
       );
       should.doesNotThrow(() => builder.owner({ address: sender.address }));
-      assert.calledTwice(spy);
+      sinon.assert.calledTwice(spy);
     });
 
     it('should validate index', () => {
@@ -46,7 +47,7 @@ describe('Dot Address Initialization Builder', () => {
         (e: Error) => e.message === 'Value cannot be less than zero',
       );
       should.doesNotThrow(() => builder.index(0));
-      assert.calledTwice(spy);
+      sinon.assert.calledTwice(spy);
     });
   });
 
@@ -70,12 +71,12 @@ describe('Dot Address Initialization Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
       should.deepEqual(txJson.eraPeriod, 64);
     });
 
@@ -97,12 +98,12 @@ describe('Dot Address Initialization Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
       should.deepEqual(txJson.eraPeriod, 64);
     });
 
@@ -119,12 +120,12 @@ describe('Dot Address Initialization Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
       should.deepEqual(txJson.eraPeriod, 64);
     });
 
@@ -143,13 +144,13 @@ describe('Dot Address Initialization Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.eraPeriod, 64);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
     });
   });
 
@@ -173,12 +174,12 @@ describe('Dot Address Initialization Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
       should.deepEqual(txJson.eraPeriod, 64);
     });
 
@@ -200,12 +201,12 @@ describe('Dot Address Initialization Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
       should.deepEqual(txJson.eraPeriod, 64);
     });
 
@@ -227,12 +228,12 @@ describe('Dot Address Initialization Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
       should.deepEqual(txJson.eraPeriod, 64);
     });
 
@@ -252,8 +253,8 @@ describe('Dot Address Initialization Builder', () => {
       should.deepEqual(txJson.genesisHash, '0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e');
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
       should.deepEqual(txJson.eraPeriod, 64);
     });
 
@@ -275,8 +276,8 @@ describe('Dot Address Initialization Builder', () => {
       should.deepEqual(txJson.genesisHash, '0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e');
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
       should.deepEqual(txJson.eraPeriod, 64);
     });
   });

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/base.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/base.ts
@@ -1,7 +1,7 @@
 import { BaseCoin as CoinConfig, coins, DotNetwork, Networks } from '@bitgo/statics';
 import { DecodedSignedTx, DecodedSigningPayload, UnsignedTransaction } from '@substrate/txwrapper-core';
 import should from 'should';
-import sinon, { assert } from 'sinon';
+import sinon from 'sinon';
 import { TransactionType } from '../../../../../src/coin/baseCoin';
 import { BaseKey } from '../../../../../src/coin/baseCoin/iface';
 import { TransactionBuilder, Transaction } from '../../../../../src/coin/dot';
@@ -80,12 +80,11 @@ describe('Dot Transfer Builder', () => {
   let builder: StubTransactionBuilder;
 
   const sender = DotResources.accounts.account1;
-  const materialData = Networks.test.dot;
+  const { specName, specVersion, genesisHash, chainName } = Networks.test.dot;
 
   beforeEach(() => {
     const config = buildTestConfig();
-    const material = utils.getMaterial(config);
-    builder = new StubTransactionBuilder(config).material(material);
+    builder = new StubTransactionBuilder(config).material(utils.getMaterial(config));
   });
 
   describe('setter validation', () => {
@@ -96,7 +95,7 @@ describe('Dot Transfer Builder', () => {
         (e: Error) => e.message === `The address 'asd' is not a well-formed dot address`,
       );
       should.doesNotThrow(() => builder.sender({ address: sender.address }));
-      assert.calledTwice(spy);
+      sinon.assert.calledTwice(spy);
     });
 
     it('should validate eraPeriod', () => {
@@ -106,7 +105,7 @@ describe('Dot Transfer Builder', () => {
         (e: Error) => e.message === 'Value cannot be less than zero',
       );
       should.doesNotThrow(() => builder.validity({ maxDuration: 64 }));
-      assert.calledTwice(spy);
+      sinon.assert.calledTwice(spy);
     });
 
     it('should validate nonce', () => {
@@ -116,7 +115,7 @@ describe('Dot Transfer Builder', () => {
         (e: Error) => e.message === 'Value cannot be less than zero',
       );
       should.doesNotThrow(() => builder.sequenceId({ name: 'Nonce', keyword: 'nonce', value: 10 }));
-      assert.calledTwice(spy);
+      sinon.assert.calledTwice(spy);
     });
 
     it('should validate tip', () => {
@@ -126,7 +125,7 @@ describe('Dot Transfer Builder', () => {
         (e: Error) => e.message === 'Value cannot be less than zero',
       );
       should.doesNotThrow(() => builder.fee({ amount: 10, type: 'tip' }));
-      assert.calledTwice(spy);
+      sinon.assert.calledTwice(spy);
     });
 
     it('should validate blockNumber', () => {
@@ -136,7 +135,7 @@ describe('Dot Transfer Builder', () => {
         (e: Error) => e.message === 'Value cannot be less than zero',
       );
       should.doesNotThrow(() => builder.validity({ firstValid: 10 }));
-      assert.calledTwice(spy);
+      sinon.assert.calledTwice(spy);
     });
   });
 
@@ -153,10 +152,10 @@ describe('Dot Transfer Builder', () => {
 
     it('should build a base transaction on testnet', async () => {
       const material = builder.getMaterial();
-      should.deepEqual(material.specName, materialData.specName);
-      should.deepEqual(material.genesisHash, materialData.genesisHash);
-      should.deepEqual(material.specVersion, materialData.specVersion);
-      should.deepEqual(material.chainName, materialData.chainName);
+      should.deepEqual(material.specName, specName);
+      should.deepEqual(material.genesisHash, genesisHash);
+      should.deepEqual(material.specVersion, specVersion);
+      should.deepEqual(material.chainName, chainName);
     });
 
     it('should build from raw signed tx', async () => {

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/batchTransactionBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/batchTransactionBuilder.ts
@@ -1,22 +1,22 @@
 import should from 'should';
-import sinon, { assert } from 'sinon';
+import sinon from 'sinon';
 import { BatchTransactionBuilder } from '../../../../../src/coin/dot';
 import * as DotResources from '../../../../resources/dot';
 import { buildTestConfig } from './base';
 import { ProxyType } from '../../../../../src/coin/dot/iface';
 import utils from '../../../../../src/coin/dot/utils';
+import { Networks } from '@bitgo/statics';
 
 describe('Dot Batch Transaction Builder', () => {
   let builder: BatchTransactionBuilder;
 
-  const config = buildTestConfig();
-  const materialData = utils.getMaterial(config);
+  const { specVersion, txVersion } = Networks.test.dot;
   const referenceBlock = '0x462ab5246361febb9294ffa41dd099edddec30a205ea15fbd247abb0ddbabd51';
   const sender = DotResources.accounts.account1;
 
   beforeEach(() => {
     const config = buildTestConfig();
-    builder = new BatchTransactionBuilder(config).material(materialData);
+    builder = new BatchTransactionBuilder(config).material(utils.getMaterial(config));
   });
 
   describe('setter validation', () => {
@@ -28,7 +28,7 @@ describe('Dot Batch Transaction Builder', () => {
         (e: Error) => e.message === `call in string format must be hex format of a method and its arguments`,
       );
       should.doesNotThrow(() => builder.calls(DotResources.rawTx.anonymous.batch));
-      assert.calledTwice(spy);
+      sinon.assert.calledTwice(spy);
     });
   });
 
@@ -40,8 +40,7 @@ describe('Dot Batch Transaction Builder', () => {
         .validity({ firstValid: 9279281, maxDuration: 64 })
         .referenceBlock(referenceBlock)
         .sequenceId({ name: 'Nonce', keyword: 'nonce', value: 0 })
-        .fee({ amount: 0, type: 'tip' })
-        .version(8);
+        .fee({ amount: 0, type: 'tip' });
       builder.sign({ key: sender.secretKey });
       const tx = await builder.build();
       const txJson = tx.toJson();
@@ -58,10 +57,10 @@ describe('Dot Batch Transaction Builder', () => {
       should.deepEqual(txJson.blockNumber, 9279281);
       should.deepEqual(txJson.referenceBlock, referenceBlock);
       should.deepEqual(txJson.genesisHash, '0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e');
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 0);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
+      should.deepEqual(txJson.transactionVersion, txVersion);
       should.deepEqual(txJson.chainName, 'Westend');
       should.deepEqual(txJson.eraPeriod, 64);
     });
@@ -72,8 +71,7 @@ describe('Dot Batch Transaction Builder', () => {
         .validity({ firstValid: 9266787, maxDuration: 64 })
         .referenceBlock(referenceBlock)
         .sequenceId({ name: 'Nonce', keyword: 'nonce', value: 200 })
-        .fee({ amount: 0, type: 'tip' })
-        .version(8);
+        .fee({ amount: 0, type: 'tip' });
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.batchCalls.length, DotResources.rawTx.anonymous.batch.length);
@@ -89,16 +87,16 @@ describe('Dot Batch Transaction Builder', () => {
       should.deepEqual(txJson.blockNumber, 9266787);
       should.deepEqual(txJson.referenceBlock, referenceBlock);
       should.deepEqual(txJson.genesisHash, '0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e');
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
+      should.deepEqual(txJson.transactionVersion, txVersion);
       should.deepEqual(txJson.chainName, 'Westend');
       should.deepEqual(txJson.eraPeriod, 64);
     });
     it('should build from raw signed tx', async () => {
       builder.from(DotResources.rawTx.batch.signed);
-      builder.validity({ firstValid: 9266787, maxDuration: 64 }).referenceBlock(referenceBlock).version(8);
+      builder.validity({ firstValid: 9266787, maxDuration: 64 }).referenceBlock(referenceBlock);
       const tx = await builder.build();
       const txJson = tx.toJson();
       // test the call items
@@ -116,10 +114,10 @@ describe('Dot Batch Transaction Builder', () => {
       should.deepEqual(txJson.blockNumber, 9266787);
       should.deepEqual(txJson.referenceBlock, referenceBlock);
       should.deepEqual(txJson.genesisHash, '0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e');
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 0);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
+      should.deepEqual(txJson.transactionVersion, txVersion);
       should.deepEqual(txJson.chainName, 'Westend');
       should.deepEqual(txJson.eraPeriod, 64);
     });
@@ -146,10 +144,10 @@ describe('Dot Batch Transaction Builder', () => {
       should.deepEqual(txJson.blockNumber, 9266787);
       should.deepEqual(txJson.referenceBlock, referenceBlock);
       should.deepEqual(txJson.genesisHash, '0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e');
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 0);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
+      should.deepEqual(txJson.transactionVersion, txVersion);
       should.deepEqual(txJson.chainName, 'Westend');
       should.deepEqual(txJson.eraPeriod, 64);
     });

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/stakingBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/stakingBuilder.ts
@@ -1,21 +1,23 @@
 import should from 'should';
-import sinon, { assert } from 'sinon';
+import sinon from 'sinon';
 import { StakingBuilder } from '../../../../../src/coin/dot';
 import utils from '../../../../../src/coin/dot/utils';
 import * as DotResources from '../../../../resources/dot';
 import { buildTestConfig } from './base';
+import { Networks } from '@bitgo/statics';
 
 describe('Dot Stake Builder', () => {
   let builder: StakingBuilder;
 
   const sender = DotResources.accounts.account1;
   const receiver = DotResources.accounts.account2;
-  const config = buildTestConfig();
-  const materialData = utils.getMaterial(config);
+  const { specVersion, txVersion, chainName, genesisHash } = Networks.test.dot;
 
   beforeEach(() => {
-    builder = new StakingBuilder(config).material(materialData);
+    const config = buildTestConfig();
+    builder = new StakingBuilder(config).material(utils.getMaterial(config));
   });
+
   describe('setter validation', () => {
     it('should validate stake amount', () => {
       const spy = sinon.spy(builder, 'validateValue');
@@ -24,7 +26,7 @@ describe('Dot Stake Builder', () => {
         (e: Error) => e.message === 'Value cannot be less than zero',
       );
       should.doesNotThrow(() => builder.amount('1000'));
-      assert.calledTwice(spy);
+      sinon.assert.calledTwice(spy);
     });
 
     it('should validate controller address', () => {
@@ -34,7 +36,7 @@ describe('Dot Stake Builder', () => {
         (e: Error) => e.message === `The address 'asd' is not a well-formed dot address`,
       );
       should.doesNotThrow(() => builder.owner({ address: sender.address }));
-      assert.calledTwice(spy);
+      sinon.assert.calledTwice(spy);
     });
 
     it('should validate payee', () => {
@@ -47,7 +49,7 @@ describe('Dot Stake Builder', () => {
       should.doesNotThrow(() => builder.payee('Staked'));
       should.doesNotThrow(() => builder.payee('Controller'));
       should.doesNotThrow(() => builder.payee('Stash'));
-      assert.calledTwice(spy);
+      sinon.assert.calledTwice(spy);
     });
   });
 
@@ -71,12 +73,12 @@ describe('Dot Stake Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
       should.deepEqual(txJson.eraPeriod, 64);
     });
 
@@ -98,12 +100,12 @@ describe('Dot Stake Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
       should.deepEqual(txJson.eraPeriod, 64);
     });
 
@@ -120,12 +122,12 @@ describe('Dot Stake Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
       should.deepEqual(txJson.eraPeriod, 64);
     });
 
@@ -144,13 +146,13 @@ describe('Dot Stake Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.eraPeriod, 64);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
     });
 
     it('should build from raw signed tx with receiver account', async () => {
@@ -166,12 +168,12 @@ describe('Dot Stake Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
       should.deepEqual(txJson.eraPeriod, 64);
     });
 
@@ -190,13 +192,13 @@ describe('Dot Stake Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.eraPeriod, 64);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
     });
   });
 });

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/transferBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/transferBuilder.ts
@@ -1,6 +1,6 @@
 import { coins, Networks } from '@bitgo/statics';
 import should from 'should';
-import sinon, { assert } from 'sinon';
+import sinon from 'sinon';
 import { TransferBuilder } from '../../../../../src/coin/dot';
 import * as DotResources from '../../../../resources/dot';
 import { buildTestConfig } from './base';
@@ -13,13 +13,13 @@ describe('Dot Transfer Builder', () => {
   const proxySender = DotResources.accounts.account3;
   const sender = DotResources.accounts.account1;
   const receiver = DotResources.accounts.account2;
-  const materialData = Networks.test.dot;
-  const config = buildTestConfig();
-  const material = utils.getMaterial(config);
+  const { chainName, txVersion, genesisHash, specVersion } = Networks.test.dot;
 
   beforeEach(() => {
-    builder = new TransferBuilder(config).material(material);
+    const config = buildTestConfig();
+    builder = new TransferBuilder(config).material(utils.getMaterial(config));
   });
+
   describe('setter validation', () => {
     it('should validate real address', () => {
       const spy = sinon.spy(builder, 'validateAddress');
@@ -28,7 +28,7 @@ describe('Dot Transfer Builder', () => {
         (e: Error) => e.message === `The address 'asd' is not a well-formed dot address`,
       );
       should.doesNotThrow(() => builder.owner({ address: sender.address }));
-      assert.calledTwice(spy);
+      sinon.assert.calledTwice(spy);
     });
     it('should validate to address', () => {
       const spy = sinon.spy(builder, 'validateAddress');
@@ -37,7 +37,7 @@ describe('Dot Transfer Builder', () => {
         (e: Error) => e.message === `The address 'asd' is not a well-formed dot address`,
       );
       should.doesNotThrow(() => builder.to({ address: sender.address }));
-      assert.calledTwice(spy);
+      sinon.assert.calledTwice(spy);
     });
     it('should validate transfer amount', () => {
       const spy = sinon.spy(builder, 'validateValue');
@@ -46,7 +46,7 @@ describe('Dot Transfer Builder', () => {
         (e: Error) => e.message === 'Value cannot be less than zero',
       );
       should.doesNotThrow(() => builder.amount('1000'));
-      assert.calledTwice(spy);
+      sinon.assert.calledTwice(spy);
     });
   });
 
@@ -68,12 +68,12 @@ describe('Dot Transfer Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
       should.deepEqual(txJson.eraPeriod, 64);
 
       const inputs = tx.inputs[0];
@@ -102,12 +102,12 @@ describe('Dot Transfer Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
       should.deepEqual(txJson.eraPeriod, 64);
 
       const inputs = tx.inputs[0];
@@ -135,12 +135,12 @@ describe('Dot Transfer Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
       should.deepEqual(txJson.eraPeriod, 64);
     });
 
@@ -156,12 +156,12 @@ describe('Dot Transfer Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
       should.deepEqual(txJson.eraPeriod, 64);
     });
 
@@ -179,13 +179,13 @@ describe('Dot Transfer Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.eraPeriod, 64);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
     });
 
     it('should build from raw signed westend tx', async () => {
@@ -202,10 +202,10 @@ describe('Dot Transfer Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
+      should.deepEqual(txJson.genesisHash, genesisHash);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
+      should.deepEqual(txJson.transactionVersion, txVersion);
       should.deepEqual(txJson.eraPeriod, 64);
     });
   });
@@ -230,12 +230,12 @@ describe('Dot Transfer Builder', () => {
       should.deepEqual(txJson.sender, proxySender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
       should.deepEqual(txJson.eraPeriod, 64);
 
       const inputs = tx.inputs[0];
@@ -265,12 +265,12 @@ describe('Dot Transfer Builder', () => {
       should.deepEqual(txJson.sender, proxySender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
       should.deepEqual(txJson.eraPeriod, 64);
     });
 
@@ -286,12 +286,12 @@ describe('Dot Transfer Builder', () => {
       should.deepEqual(txJson.sender, proxySender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
       should.deepEqual(txJson.eraPeriod, 64);
     });
 
@@ -309,13 +309,13 @@ describe('Dot Transfer Builder', () => {
       should.deepEqual(txJson.sender, proxySender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.eraPeriod, 64);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
     });
   });
 });

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/unnominateBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/unnominateBuilder.ts
@@ -7,13 +7,12 @@ import { Networks } from '@bitgo/statics';
 describe('Dot Unnominate Builder', () => {
   let builder: UnnominateBuilder;
 
-  const materialData = Networks.test.dot;
+  const { genesisHash, specVersion, txVersion } = Networks.test.dot;
   const sender = DotResources.accounts.account1;
   const refBlock = '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d';
 
   beforeEach(() => {
-    const config = buildTestConfig();
-    builder = new UnnominateBuilder(config);
+    builder = new UnnominateBuilder(buildTestConfig());
   });
 
   describe('build unnominate transaction', () => {
@@ -31,11 +30,11 @@ describe('Dot Unnominate Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, refBlock);
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
+      should.deepEqual(txJson.transactionVersion, txVersion);
       should.deepEqual(txJson.chainName, 'Westend');
       should.deepEqual(txJson.eraPeriod, 64);
     });
@@ -53,11 +52,11 @@ describe('Dot Unnominate Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, refBlock);
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
+      should.deepEqual(txJson.transactionVersion, txVersion);
       should.deepEqual(txJson.chainName, 'Westend');
       should.deepEqual(txJson.eraPeriod, 64);
     });
@@ -70,11 +69,11 @@ describe('Dot Unnominate Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, refBlock);
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
+      should.deepEqual(txJson.transactionVersion, txVersion);
       should.deepEqual(txJson.chainName, 'Westend');
       should.deepEqual(txJson.eraPeriod, 64);
     });
@@ -91,12 +90,12 @@ describe('Dot Unnominate Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, refBlock);
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.eraPeriod, 64);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
+      should.deepEqual(txJson.transactionVersion, txVersion);
       should.deepEqual(txJson.chainName, 'Westend');
     });
   });

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/unstakeBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/unstakeBuilder.ts
@@ -10,12 +10,11 @@ describe('Dot Unstake Builder', () => {
   let builder: UnstakeBuilder;
 
   const sender = DotResources.accounts.account1;
-  const materialData = Networks.test.dot;
-  const config = buildTestConfig();
-  const material = utils.getMaterial(config);
+  const { specVersion, txVersion, chainName, genesisHash } = Networks.test.dot;
 
   beforeEach(() => {
-    builder = new UnstakeBuilder(config).material(material);
+    const config = buildTestConfig();
+    builder = new UnstakeBuilder(config).material(utils.getMaterial(config));
   });
 
   describe('setter validation', () => {
@@ -46,12 +45,12 @@ describe('Dot Unstake Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
       should.deepEqual(txJson.eraPeriod, 64);
     });
 
@@ -69,12 +68,12 @@ describe('Dot Unstake Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
       should.deepEqual(txJson.eraPeriod, 64);
     });
 
@@ -89,12 +88,12 @@ describe('Dot Unstake Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
       should.deepEqual(txJson.eraPeriod, 64);
     });
 
@@ -111,13 +110,13 @@ describe('Dot Unstake Builder', () => {
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
-      should.deepEqual(txJson.genesisHash, materialData.genesisHash);
-      should.deepEqual(txJson.specVersion, materialData.specVersion);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
       should.deepEqual(txJson.nonce, 200);
       should.deepEqual(txJson.eraPeriod, 64);
       should.deepEqual(txJson.tip, 0);
-      should.deepEqual(txJson.transactionVersion, materialData.txVersion);
-      should.deepEqual(txJson.chainName, materialData.chainName);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
     });
   });
 });


### PR DESCRIPTION
## Motivation
Given that the SDK tests are run in parallel, all tests share the same memory resource. In dot tests, the metadata rpc variable has very heavy usage of memory resources given its size, but we seem to duplicate it too much in the unit tests in dot.

In this PR, all unnecessary usage that involves the metadata rpc is refactored through:
* Only use the required variables through deconstructing objects instead of copying the whole
* Making the config variable ephemeral so that this huge variable is eligible for garbage collection

Comparing to:
* In the previous tests, all duplicated metadata was persisted at the top level in the test suites for easy use of its value.

Ticket: BG-43065