### PR TITLE
feat(account-lib): add support for offline keyreg txn

### DIFF
--- a/modules/account-lib/src/coin/algo/transaction.ts
+++ b/modules/account-lib/src/coin/algo/transaction.ts
@@ -220,11 +220,19 @@ export class Transaction extends BaseTransaction {
     }
     if (this.type === TransactionType.WalletInitialization) {
       if (!this._algoTransaction.nonParticipation) {
-        result.voteKey = this._algoTransaction.voteKey.toString('base64');
-        result.selectionKey = this._algoTransaction.selectionKey.toString('base64');
-        result.voteFirst = this._algoTransaction.voteFirst;
-        result.voteLast = this._algoTransaction.voteLast;
-        result.voteKeyDilution = this._algoTransaction.voteKeyDilution;
+        if (
+          this._algoTransaction.voteKey &&
+          this._algoTransaction.selectionKey &&
+          this._algoTransaction.voteFirst &&
+          this._algoTransaction.voteLast &&
+          this._algoTransaction.voteKeyDilution
+        ) {
+          result.voteKey = this._algoTransaction.voteKey.toString('base64');
+          result.selectionKey = this._algoTransaction.selectionKey.toString('base64');
+          result.voteFirst = this._algoTransaction.voteFirst;
+          result.voteLast = this._algoTransaction.voteLast;
+          result.voteKeyDilution = this._algoTransaction.voteKeyDilution;
+        }
       } else {
         result.nonParticipation = this._algoTransaction.nonParticipation;
       }

--- a/modules/account-lib/test/unit/coin/algo/transactionBuilder/keyRegistrationBuilder.ts
+++ b/modules/account-lib/test/unit/coin/algo/transactionBuilder/keyRegistrationBuilder.ts
@@ -70,14 +70,17 @@ describe('Algo KeyRegistration Builder', () => {
     beforeEach(() => {
       builder.sender({ address: sender.address }).fee({ fee: '1000' }).firstRound(1).lastRound(100).testnet();
     });
-    it('should validate a normal transaction', () => {
+    it('should validate an online transaction', () => {
       builder.voteKey(sender.voteKey).selectionKey(sender.selectionKey).voteFirst(1).voteLast(100).voteKeyDilution(9);
       should.doesNotThrow(() => builder.validateTransaction(builder.getTransaction()));
     });
   });
 
   describe('build key registration transaction', () => {
-    it('should build a key registration transaction', async () => {
+    const requiredFieldErrorRegEx =
+      /Transaction validation failed: "(voteLast|voteKey|voteFirst|voteKeyDilution|selectionKey)" is required/;
+
+    it('should build an online key registration transaction', async () => {
       builder
         .sender({ address: sender.address })
         .fee({ fee: '1000' })
@@ -107,17 +110,37 @@ describe('Algo KeyRegistration Builder', () => {
       should.deepEqual(txJson.genesisHash.toString('base64'), genesisHash);
     });
 
+    it('should build an offline key registration transaction', async () => {
+      builder
+        .sender({ address: sender.address })
+        .fee({ fee: '1000' })
+        .firstRound(1)
+        .lastRound(100)
+        .testnet()
+        .numberOfSigners(1)
+        .nonParticipation(false);
+      builder.sign({ key: sender.prvKey });
+      const tx = await builder.build();
+      const txJson = tx.toJson();
+      should.deepEqual(txJson.voteKey, undefined);
+      should.deepEqual(txJson.selectionKey, undefined);
+      should.deepEqual(txJson.from, sender.address);
+      should.deepEqual(txJson.firstRound, 1);
+      should.deepEqual(txJson.lastRound, 100);
+      should.deepEqual(txJson.voteFirst, undefined);
+      should.deepEqual(txJson.voteLast, undefined);
+      should.deepEqual(txJson.voteKeyDilution, undefined);
+      should.deepEqual(txJson.nonParticipation, undefined);
+      should.deepEqual(txJson.genesisID, genesisID.toString());
+      should.deepEqual(txJson.genesisHash.toString('base64'), genesisHash);
+    });
+
     it('should build a key registration transaction with non participation', async () => {
       builder
         .sender({ address: sender.address })
         .fee({ fee: '1000' })
         .firstRound(1)
         .lastRound(100)
-        .voteKey(sender.voteKey)
-        .selectionKey(sender.selectionKey)
-        .voteFirst(1)
-        .voteLast(100)
-        .voteKeyDilution(9)
         .testnet()
         .numberOfSigners(1)
         .nonParticipation(true);
@@ -137,16 +160,129 @@ describe('Algo KeyRegistration Builder', () => {
       should.deepEqual(txJson.genesisHash.toString('base64'), genesisHash);
     });
 
-    it('build a key registration transaction with non participation should thrown an error when does not have fee', async () => {
+    it('build an offline key registration transaction should thrown an error when it hasfee', async () => {
+      builder.sender({ address: sender.address }).firstRound(1).lastRound(100).testnet().numberOfSigners(1);
+      builder.sign({ key: sender.prvKey });
+      await builder.build().should.be.rejectedWith('Transaction validation failed: "fee" is required');
+    });
+
+    it('build an offline key registration transaction should thrown an error when it has voteLast', async () => {
+      builder
+        .sender({ address: sender.address })
+        .fee({ fee: '1000' })
+        .firstRound(1)
+        .lastRound(100)
+        .voteLast(100)
+        .testnet()
+        .numberOfSigners(1);
+      builder.sign({ key: sender.prvKey });
+      await builder.build().should.be.rejectedWith(requiredFieldErrorRegEx);
+    });
+
+    it('build an offline key registration transaction should thrown an error when it has selectionKey', async () => {
+      builder
+        .sender({ address: sender.address })
+        .fee({ fee: '1000' })
+        .firstRound(1)
+        .lastRound(100)
+        .selectionKey(sender.selectionKey)
+        .testnet()
+        .numberOfSigners(1);
+      builder.sign({ key: sender.prvKey });
+      await builder.build().should.be.rejectedWith(requiredFieldErrorRegEx);
+    });
+
+    it('build an offline key registration transaction should thrown an error when it has voteKeyDilution', async () => {
+      builder
+        .sender({ address: sender.address })
+        .fee({ fee: '1000' })
+        .firstRound(1)
+        .lastRound(100)
+        .voteKeyDilution(9)
+        .testnet()
+        .numberOfSigners(1);
+      builder.sign({ key: sender.prvKey });
+      await builder.build().should.be.rejectedWith(requiredFieldErrorRegEx);
+    });
+
+    it('build an offline key registration transaction should thrown an error when it has voteFirst', async () => {
+      builder
+        .sender({ address: sender.address })
+        .fee({ fee: '1000' })
+        .firstRound(1)
+        .lastRound(100)
+        .voteFirst(1)
+        .testnet()
+        .numberOfSigners(1);
+      builder.sign({ key: sender.prvKey });
+      await builder.build().should.be.rejectedWith(requiredFieldErrorRegEx);
+    });
+
+    it('build an offline key registration transaction should thrown an error when it has voteKey', async () => {
+      builder
+        .sender({ address: sender.address })
+        .fee({ fee: '1000' })
+        .firstRound(1)
+        .lastRound(100)
+        .voteKey(sender.voteKey)
+        .testnet()
+        .numberOfSigners(1);
+      builder.sign({ key: sender.prvKey });
+      await builder.build().should.be.rejectedWith(requiredFieldErrorRegEx);
+    });
+
+    it('build an offline key registration transaction without non participation should thrown an error when it has not first round', async () => {
+      builder
+        .sender({ address: sender.address })
+        .fee({ fee: '1000' })
+        .lastRound(100)
+        .testnet()
+        .numberOfSigners(1)
+        .nonParticipation(false);
+      builder.sign({ key: sender.prvKey });
+      await builder.build().should.be.rejectedWith('Transaction validation failed: "firstRound" is required');
+    });
+
+    it('build an offline key registration transaction without non participation should thrown an error when it has not last round', async () => {
+      builder
+        .sender({ address: sender.address })
+        .fee({ fee: '1000' })
+        .firstRound(1)
+        .testnet()
+        .numberOfSigners(1)
+        .nonParticipation(false);
+      builder.sign({ key: sender.prvKey });
+      await builder.build().should.be.rejectedWith('Transaction validation failed: "lastRound" is required');
+    });
+
+    it('build an offline key registration transaction without non participation should thrown an error when it has not testnet set', async () => {
+      builder
+        .sender({ address: sender.address })
+        .fee({ fee: '1000' })
+        .firstRound(1)
+        .lastRound(100)
+        .numberOfSigners(1)
+        .nonParticipation(false);
+      builder.sign({ key: sender.prvKey });
+      await builder.build().should.be.rejectedWith('Transaction validation failed: "genesisHash" is required');
+    });
+
+    it('should build an unsigned offline key registration transaction', async () => {
+      builder.sender({ address: sender.address }).fee({ fee: '1000' }).firstRound(1).lastRound(100).testnet();
+      const tx = await builder.build();
+      const txJson = tx.toJson();
+      should.deepEqual(txJson.from, sender.address);
+      should.deepEqual(txJson.firstRound, 1);
+      should.deepEqual(txJson.lastRound, 100);
+      should.deepEqual(txJson.genesisID, genesisID.toString());
+      should.deepEqual(txJson.genesisHash.toString('base64'), genesisHash);
+    });
+
+    it('build a key registration transaction with non participation should thrown an error when it has not fee', async () => {
       builder
         .sender({ address: sender.address })
         .firstRound(1)
         .lastRound(100)
-        .voteKey(sender.voteKey)
-        .selectionKey(sender.selectionKey)
-        .voteFirst(1)
-        .voteLast(100)
-        .voteKeyDilution(9)
         .testnet()
         .numberOfSigners(1)
         .nonParticipation(true);
@@ -154,16 +290,11 @@ describe('Algo KeyRegistration Builder', () => {
       await builder.build().should.be.rejectedWith('Transaction validation failed: "fee" is required');
     });
 
-    it('build a key registration transaction with non participation should thrown an error when does not have first round', async () => {
+    it('build a key registration transaction with non participation should thrown an error when it has not first round', async () => {
       builder
         .sender({ address: sender.address })
         .fee({ fee: '1000' })
         .lastRound(100)
-        .voteKey(sender.voteKey)
-        .selectionKey(sender.selectionKey)
-        .voteFirst(1)
-        .voteLast(100)
-        .voteKeyDilution(9)
         .testnet()
         .numberOfSigners(1)
         .nonParticipation(true);
@@ -171,16 +302,11 @@ describe('Algo KeyRegistration Builder', () => {
       await builder.build().should.be.rejectedWith('Transaction validation failed: "firstRound" is required');
     });
 
-    it('build a key registration transaction with non participation should thrown an error when does not have last round', async () => {
+    it('build a key registration transaction with non participation should thrown an error when it has not last round', async () => {
       builder
         .sender({ address: sender.address })
         .fee({ fee: '1000' })
         .firstRound(1)
-        .voteKey(sender.voteKey)
-        .selectionKey(sender.selectionKey)
-        .voteFirst(1)
-        .voteLast(100)
-        .voteKeyDilution(9)
         .testnet()
         .numberOfSigners(1)
         .nonParticipation(true);
@@ -188,46 +314,16 @@ describe('Algo KeyRegistration Builder', () => {
       await builder.build().should.be.rejectedWith('Transaction validation failed: "lastRound" is required');
     });
 
-    it('build a key registration transaction with non participation should thrown an error when does not have testnet set', async () => {
+    it('build a key registration transaction with non participation should thrown an error when it has not testnet set', async () => {
       builder
         .sender({ address: sender.address })
         .fee({ fee: '1000' })
         .firstRound(1)
         .lastRound(100)
-        .voteKey(sender.voteKey)
-        .selectionKey(sender.selectionKey)
-        .voteFirst(1)
-        .voteLast(100)
-        .voteKeyDilution(9)
         .numberOfSigners(1)
         .nonParticipation(true);
       builder.sign({ key: sender.prvKey });
       await builder.build().should.be.rejectedWith('Transaction validation failed: "genesisHash" is required');
-    });
-
-    it('should build a key registration transaction with non participation without vote parameters', async () => {
-      builder
-        .sender({ address: sender.address })
-        .fee({ fee: '1000' })
-        .firstRound(1)
-        .lastRound(100)
-        .testnet()
-        .numberOfSigners(1)
-        .nonParticipation(true);
-      builder.sign({ key: sender.prvKey });
-      const tx = await builder.build();
-      const txJson = tx.toJson();
-      should.deepEqual(txJson.voteKey, undefined);
-      should.deepEqual(txJson.selectionKey, undefined);
-      should.deepEqual(txJson.from, sender.address);
-      should.deepEqual(txJson.firstRound, 1);
-      should.deepEqual(txJson.lastRound, 100);
-      should.deepEqual(txJson.voteFirst, undefined);
-      should.deepEqual(txJson.voteLast, undefined);
-      should.deepEqual(txJson.voteKeyDilution, undefined);
-      should.deepEqual(txJson.nonParticipation, true);
-      should.deepEqual(txJson.genesisID, genesisID.toString());
-      should.deepEqual(txJson.genesisHash.toString('base64'), genesisHash);
     });
 
     it('should build an unsigned key registration transaction', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3297,7 +3297,12 @@ acorn-walk@^7.0.0:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
-acorn-walk@^8.0.2, acorn-walk@^8.1.1, acorn-walk@^8.2.0:
+acorn-walk@^8.0.2:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.1.0.tgz#d3c6a9faf00987a5e2b9bdb506c2aa76cd707f83"
+  integrity sha512-mjmzmv12YIG/G8JQdQuz2MUDShEJ6teYpT5bmWA4q7iwoGen8xtt3twF3OvzIUl+Q06aWIjvnwQUKvQ6TtMRjg==
+
+acorn-walk@^8.1.1, acorn-walk@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
@@ -3317,7 +3322,12 @@ acorn@^7.0.0, acorn@^7.4.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.1.0, acorn@^8.4.1, acorn@^8.7.0:
+acorn@^8.1.0:
+  version "8.2.4"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.2.4.tgz#caba24b08185c3b56e3168e97d15ed17f4d31fd0"
+  integrity sha512-Ibt84YwBDDA890eDiDCEqcbwvHlBvzzDkU2cGBBDDI1QWT12jTiXIOn2CIw5KK4i6N5Z2HUxwYjzriDyqaqqZg==
+
+acorn@^8.4.1, acorn@^8.7.0:
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
   integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==


### PR DESCRIPTION
add support for offline key registration transactions on accountLib.
This transaction is pretty similar to non-participation keyreg, but it doesn't need "keyregTo" and "nonParticipation" params.

[STLX-13389](https://bitgoinc.atlassian.net/browse/STLX-13389)