### PR TITLE
fix(core): rename verifyAddress and remove invalid implementations

### DIFF
--- a/modules/core/src/v2/baseCoin.ts
+++ b/modules/core/src/v2/baseCoin.ts
@@ -386,10 +386,17 @@ export abstract class BaseCoin {
   abstract verifyTransaction(params: VerifyTransactionOptions): Promise<boolean>;
 
   /**
-   * Verify that an address belongs to a wallet
-   * @returns {boolean}
+   * @deprecated use {@see isWalletAddress} instead
    */
-  abstract verifyAddress(params: VerifyAddressOptions): boolean;
+  verifyAddress(params: VerifyAddressOptions): boolean {
+    return this.isWalletAddress(params);
+  }
+
+  /**
+   * @param params
+   * @return true iff address is a wallet address. Must return false if address is outside wallet.
+   */
+  abstract isWalletAddress(params: VerifyAddressOptions): boolean;
 
   /**
    * convert address into desired address format.

--- a/modules/core/src/v2/coins/abstractEthLikeCoin.ts
+++ b/modules/core/src/v2/coins/abstractEthLikeCoin.ts
@@ -14,7 +14,6 @@ import {
   ParsedTransaction,
   ParseTransactionOptions,
   SignTransactionOptions,
-  VerifyAddressOptions,
   VerifyTransactionOptions,
   TransactionFee,
   TransactionRecipient as Recipient,
@@ -23,7 +22,7 @@ import {
 } from '../baseCoin';
 
 import { BitGo } from '../../bitgo';
-import { InvalidAddressError, MethodNotImplementedError } from '../../errors';
+import { MethodNotImplementedError } from '../../errors';
 import BigNumber from 'bignumber.js';
 
 export interface EthSignTransactionOptions extends SignTransactionOptions {
@@ -131,11 +130,8 @@ export abstract class AbstractEthLikeCoin extends BaseCoin {
     return {};
   }
 
-  verifyAddress({ address }: VerifyAddressOptions): boolean {
-    if (!this.isValidAddress(address)) {
-      throw new InvalidAddressError(`invalid address: ${address}`);
-    }
-    return true;
+  isWalletAddress(): boolean {
+    throw new MethodNotImplementedError();
   }
 
   async verifyTransaction(params: VerifyTransactionOptions): Promise<boolean> {

--- a/modules/core/src/v2/coins/abstractUtxoCoin.ts
+++ b/modules/core/src/v2/coins/abstractUtxoCoin.ts
@@ -876,7 +876,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
    * @throws {InvalidAddressDerivationPropertyError}
    * @throws {UnexpectedAddressError}
    */
-  verifyAddress(params: VerifyAddressOptions): boolean {
+  isWalletAddress(params: VerifyAddressOptions): boolean {
     const { address, addressType, keychains, coinSpecific, chain, index } = params;
 
     if (!this.isValidAddress(address)) {

--- a/modules/core/src/v2/coins/algo.ts
+++ b/modules/core/src/v2/coins/algo.ts
@@ -13,7 +13,6 @@ import {
   KeyPair,
   ParseTransactionOptions,
   ParsedTransaction,
-  VerifyAddressOptions,
   VerifyTransactionOptions,
   SignedTransaction,
   TransactionRecipient,
@@ -21,6 +20,7 @@ import {
 } from '../baseCoin';
 import { KeyIndices } from '../keychains';
 import { TokenManagementType } from '../types';
+import { MethodNotImplementedError } from '../../errors';
 
 export interface AlgoTransactionExplanation extends TransactionExplanation {
   memo?: string;
@@ -441,8 +441,8 @@ export class Algo extends BaseCoin {
     return {};
   }
 
-  verifyAddress(params: VerifyAddressOptions): boolean {
-    return true;
+  isWalletAddress(): boolean {
+    throw new MethodNotImplementedError();
   }
 
   async verifyTransaction(params: VerifyTransactionOptions): Promise<boolean> {

--- a/modules/core/src/v2/coins/cspr.ts
+++ b/modules/core/src/v2/coins/cspr.ts
@@ -105,7 +105,7 @@ export class Cspr extends BaseCoin {
    *
    * @param {VerifyAddressOptions} params address and rootAddress to verify
    */
-  verifyAddress(params: VerifyAddressOptions): boolean {
+  isWalletAddress(params: VerifyAddressOptions): boolean {
     const { address, rootAddress } = params;
     if (!this.isValidAddress(address)) {
       throw new InvalidAddressError(`invalid address: ${address}`);

--- a/modules/core/src/v2/coins/dot.ts
+++ b/modules/core/src/v2/coins/dot.ts
@@ -271,8 +271,8 @@ export class Dot extends BaseCoin {
     return {};
   }
 
-  verifyAddress(params: VerifyAddressOptions): boolean {
-    return this.isValidAddress(params.address);
+  isWalletAddress(params: VerifyAddressOptions): boolean {
+    throw new MethodNotImplementedError();
   }
 
   async verifyTransaction(params: VerifyTransactionOptions): Promise<boolean> {

--- a/modules/core/src/v2/coins/eos.ts
+++ b/modules/core/src/v2/coins/eos.ts
@@ -392,12 +392,11 @@ export class Eos extends BaseCoin {
   }
 
   /**
-   * Check if address is a valid EOS address, then verify it matches the root address.
-   *
    * @param address - the address to verify
    * @param rootAddress - the wallet's root address
+   * @return true iff address is a wallet address (based on rootAddress)
    */
-  verifyAddress({ address, rootAddress }: VerifyAddressOptions): boolean {
+  isWalletAddress({ address, rootAddress }: VerifyAddressOptions): boolean {
     if (!rootAddress || !_.isString(rootAddress)) {
       throw new Error('missing required string rootAddress');
     }

--- a/modules/core/src/v2/coins/eth.ts
+++ b/modules/core/src/v2/coins/eth.ts
@@ -1516,7 +1516,7 @@ export class Eth extends BaseCoin {
   }
 
   /**
-   * Make sure an address is valid and throw an error if it's not.
+   * Make sure an address is a wallet address and throw an error if it's not.
    * @param {Object} params
    * @param {String} params.address The derived address string on the network
    * @param {Object} params.coinSpecific Coin-specific details for the address such as a forwarderVersion
@@ -1524,9 +1524,9 @@ export class Eth extends BaseCoin {
    * @throws {InvalidAddressError}
    * @throws {InvalidAddressVerificationObjectPropertyError}
    * @throws {UnexpectedAddressError}
-   * @returns {Boolean} True if address is valid
+   * @returns {Boolean} True iff address is a wallet address
    */
-  verifyAddress(params: VerifyEthAddressOptions): boolean {
+  isWalletAddress(params: VerifyEthAddressOptions): boolean {
     let expectedAddress;
     let actualAddress;
 

--- a/modules/core/src/v2/coins/eth2.ts
+++ b/modules/core/src/v2/coins/eth2.ts
@@ -19,6 +19,7 @@ import {
 } from '../baseCoin';
 import { BitGo } from '../../bitgo';
 import * as common from '../../common';
+import { MethodNotImplementedError } from '../../errors';
 
 interface Recipient {
   address: string;
@@ -304,8 +305,8 @@ export class Eth2 extends BaseCoin {
     return {};
   }
 
-  verifyAddress(params: VerifyAddressOptions): boolean {
-    return true;
+  isWalletAddress(params: VerifyAddressOptions): boolean {
+    throw new MethodNotImplementedError();
   }
 
   async verifyTransaction(params: VerifyTransactionOptions): Promise<boolean> {

--- a/modules/core/src/v2/coins/hbar.ts
+++ b/modules/core/src/v2/coins/hbar.ts
@@ -145,8 +145,8 @@ export class Hbar extends BaseCoin {
     return {};
   }
 
-  verifyAddress(params: VerifyAddressOptions): boolean {
-    return true;
+  isWalletAddress(params: VerifyAddressOptions): boolean {
+    throw new MethodNotImplementedError();
   }
 
   async verifyTransaction(params: VerifyTransactionOptions): Promise<boolean> {

--- a/modules/core/src/v2/coins/near.ts
+++ b/modules/core/src/v2/coins/near.ts
@@ -207,8 +207,8 @@ export class Near extends BaseCoin {
     throw new MethodNotImplementedError('Near parse transaction not implemented');
   }
 
-  verifyAddress(params: VerifyAddressOptions): boolean {
-    return true;
+  isWalletAddress(params: VerifyAddressOptions): boolean {
+    throw new MethodNotImplementedError();
   }
 
   async verifyTransaction(params: VerifyTransactionOptions): Promise<boolean> {

--- a/modules/core/src/v2/coins/ofc.ts
+++ b/modules/core/src/v2/coins/ofc.ts
@@ -87,8 +87,8 @@ export class Ofc extends BaseCoin {
     return {};
   }
 
-  verifyAddress(params: VerifyAddressOptions): boolean {
-    return true;
+  isWalletAddress(params: VerifyAddressOptions): boolean {
+    throw new MethodNotImplementedError();
   }
 
   async verifyTransaction(params: VerifyTransactionOptions): Promise<boolean> {

--- a/modules/core/src/v2/coins/sol.ts
+++ b/modules/core/src/v2/coins/sol.ts
@@ -24,6 +24,7 @@ import { BitGo } from '../../bitgo';
 import { Memo } from '../wallet';
 import * as _ from 'lodash';
 import { DerivedKeyPair, DeriveKeypairOptions } from '..';
+import { MethodNotImplementedError } from '../../errors';
 
 export interface TransactionFee {
   fee: string;
@@ -169,8 +170,8 @@ export class Sol extends BaseCoin {
     return true;
   }
 
-  verifyAddress(params: VerifyAddressOptions): boolean {
-    return this.isValidAddress(params.address);
+  isWalletAddress(params: VerifyAddressOptions): boolean {
+    throw new MethodNotImplementedError();
   }
 
   /**

--- a/modules/core/src/v2/coins/stx.ts
+++ b/modules/core/src/v2/coins/stx.ts
@@ -3,7 +3,6 @@
  */
 import * as accountLib from '@bitgo/account-lib';
 import { BaseCoin as StaticsBaseCoin, CoinFamily } from '@bitgo/statics';
-import { c32addressDecode } from 'c32check';
 
 import {
   BaseCoin,
@@ -17,7 +16,7 @@ import {
   TransactionPrebuild as BaseTransactionPrebuild,
 } from '../baseCoin';
 import { BitGo } from '../../bitgo';
-import { InvalidAddressError } from '../../errors';
+import { MethodNotImplementedError } from '../../errors';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 interface SupplementGenerateWalletOptions {
@@ -91,20 +90,8 @@ export class Stx extends BaseCoin {
     return true;
   }
 
-  verifyAddress(params: VerifyAddressOptions): boolean {
-    const { address } = params;
-    if (!this.isValidAddress(address)) throw new InvalidAddressError(`invalid address: ${address}`);
-
-    const addressDetails = accountLib.Stx.Utils.getAddressDetails(address);
-    try {
-      const [version] = c32addressDecode(addressDetails.address);
-      const versionString = accountLib.Stx.AddressVersion[version];
-      if (versionString === undefined) throw new InvalidAddressError(`invalid address version: ${address}`);
-    } catch (e) {
-      throw new InvalidAddressError(`invalid address: ${address}`);
-    }
-
-    return true;
+  isWalletAddress(params: VerifyAddressOptions): boolean {
+    throw new MethodNotImplementedError();
   }
 
   /**

--- a/modules/core/src/v2/coins/susd.ts
+++ b/modules/core/src/v2/coins/susd.ts
@@ -62,8 +62,8 @@ export class Susd extends BaseCoin {
     return {};
   }
 
-  verifyAddress(params: VerifyAddressOptions): boolean {
-    return true;
+  isWalletAddress(params: VerifyAddressOptions): boolean {
+    throw new MethodNotImplementedError();
   }
 
   async verifyTransaction(params: VerifyTransactionOptions): Promise<boolean> {

--- a/modules/core/src/v2/coins/trx.ts
+++ b/modules/core/src/v2/coins/trx.ts
@@ -27,6 +27,7 @@ import {
 
 import { BitGo } from '../../bitgo';
 import { getBip32Keys, getIsKrsRecovery, getIsUnsignedSweep } from '../recovery/initiate';
+import { MethodNotImplementedError } from '../../errors';
 
 export const MINIMUM_TRON_MSIG_TRANSACTION_FEE = 1e6;
 
@@ -196,8 +197,8 @@ export class Trx extends BaseCoin {
     return {};
   }
 
-  verifyAddress(params: VerifyAddressOptions): boolean {
-    return true;
+  isWalletAddress(params: VerifyAddressOptions): boolean {
+    throw new MethodNotImplementedError();
   }
 
   async verifyTransaction(params: VerifyTransactionOptions): Promise<boolean> {

--- a/modules/core/src/v2/coins/xlm.ts
+++ b/modules/core/src/v2/coins/xlm.ts
@@ -576,7 +576,7 @@ export class Xlm extends BaseCoin {
    * @param address {String} the address to verify
    * @param rootAddress {String} the wallet's root address
    */
-  verifyAddress({ address, rootAddress }: VerifyAddressOptions): boolean {
+  isWalletAddress({ address, rootAddress }: VerifyAddressOptions): boolean {
     if (!this.isValidAddress(address)) {
       throw new InvalidAddressError(`invalid address: ${address}`);
     }

--- a/modules/core/src/v2/coins/xrp.ts
+++ b/modules/core/src/v2/coins/xrp.ts
@@ -383,8 +383,9 @@ export class Xrp extends BaseCoin {
    * This prevents attacks where an attack may switch out the new address for one of their own
    * @param address {String} the address to verify
    * @param rootAddress {String} the wallet's root address
+   * @return true iff address is a wallet address (based on rootAddress)
    */
-  public verifyAddress({ address, rootAddress }: VerifyAddressOptions): boolean {
+  public isWalletAddress({ address, rootAddress }: VerifyAddressOptions): boolean {
     if (!this.isValidAddress(address)) {
       throw new InvalidAddressError(`address verification failure: address "${address}" is not valid`);
     }

--- a/modules/core/src/v2/coins/xtz.ts
+++ b/modules/core/src/v2/coins/xtz.ts
@@ -147,8 +147,8 @@ export class Xtz extends BaseCoin {
     return {};
   }
 
-  verifyAddress(params: VerifyAddressOptions): boolean {
-    return true;
+  isWalletAddress(params: VerifyAddressOptions): boolean {
+    throw new MethodNotImplementedError();
   }
 
   async verifyTransaction(params: VerifyTransactionOptions): Promise<boolean> {

--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -9,7 +9,7 @@ import * as debugLib from 'debug';
 import { makeRandomKey } from '../bitcoin';
 import { BitGo } from '../bitgo';
 import * as common from '../common';
-import { AddressGenerationError } from '../errors';
+import { AddressGenerationError, MethodNotImplementedError } from '../errors';
 import {
   BaseCoin,
   SignedTransaction,
@@ -1521,7 +1521,19 @@ export class Wallet {
         (!verificationData.coinSpecific.pendingChainInitialization || verificationData.impliedForwarderVersion === 1)
       ) {
         // can't verify addresses which are pending chain initialization, as the address is hidden
-        this.baseCoin.verifyAddress(verificationData);
+        let isWalletAddress = false;
+        try {
+          isWalletAddress = this.baseCoin.isWalletAddress(verificationData);
+        } catch (e) {
+          if (!(e instanceof MethodNotImplementedError)) {
+            throw e;
+          }
+          // FIXME(BG-43225): implement this correctly
+          isWalletAddress = true;
+        }
+        if (!isWalletAddress) {
+          throw new Error(`not a wallet address`);
+        }
       } else if (!allowSkipVerifyAddress) {
         throw new Error(`address verification skipped for count = ${count}`);
       }

--- a/modules/core/test/v2/unit/coins/abstractEthCoin.ts
+++ b/modules/core/test/v2/unit/coins/abstractEthCoin.ts
@@ -155,18 +155,14 @@ describe('ETH-like coins', () => {
           basecoin.isValidAddress('3KgL6DTUb6gEoqSwMMJzyf96ekH8oZtWtZ').should.equal(false);
         });
 
-        it('Should not throw when verifying valid addresses', () => {
-          basecoin.verifyAddress({ address: '0x2af9152fc4afd89a8124731bdfb8710c8751f3ed' }).should.equal(true);
-          basecoin.verifyAddress({ address: '0x2af9152FC4afd89A8124731BdFb8710c8751f3eD' }).should.equal(true);
+        it('Should not throw when verifying valid addresses', function () {
+          // FIXME(BG-43225): not implemented
+          this.skip();
         });
 
-        it('Should throw when verifying invalid addresses', () => {
-          should.throws(() => basecoin.verifyAddress({ address: '0x2af9152fc4afd89a8124731bdfb8710c8751f3edd' }));
-          should.throws(() => basecoin.verifyAddress({ address: '0x2af9152fc4afd89a8124731bdfb8710c8751f3e' }));
-          should.throws(() => basecoin.verifyAddress({ address: '2af9152fc4afd89a8124731bdfb8710c8751f3ed' }));
-          should.throws(() => basecoin.verifyAddress({ address: 'notanaddress' }));
-          should.throws(() => basecoin.verifyAddress({ address: 'not an address' }));
-          should.throws(() => basecoin.verifyAddress({ address: '3KgL6DTUb6gEoqSwMMJzyf96ekH8oZtWtZ' }));
+        it('Should throw when verifying invalid addresses', function () {
+          // FIXME(BG-43225): not implemented
+          this.skip();
         });
       });
 

--- a/modules/core/test/v2/unit/coins/sol.ts
+++ b/modules/core/test/v2/unit/coins/sol.ts
@@ -15,7 +15,6 @@ describe('SOL:', function () {
   let newTxParamsWithError;
   let newTxParamsWithExtraData;
   const badAddresses = resources.addresses.invalidAddresses;
-  const goodAddresses = resources.addresses.validAddresses;
 
   const keypair = {
     pub: resources.accountWithSeed.publicKey,
@@ -254,9 +253,9 @@ describe('SOL:', function () {
   });
 
 
-  it('should verify valid address', (function () {
-    const params = { address: goodAddresses[0] };
-    basecoin.verifyAddress(params).should.equal(true);
+  it('should verify wallet address', (function () {
+    // FIXME(BG-43225): not implemented
+    this.skip();
   }));
 
   it('should check invalid address', (function () {

--- a/modules/core/test/v2/unit/coins/sol.ts
+++ b/modules/core/test/v2/unit/coins/sol.ts
@@ -15,6 +15,7 @@ describe('SOL:', function () {
   let newTxParamsWithError;
   let newTxParamsWithExtraData;
   const badAddresses = resources.addresses.invalidAddresses;
+  const goodAddresses = resources.addresses.validAddresses;
 
   const keypair = {
     pub: resources.accountWithSeed.publicKey,
@@ -253,13 +254,16 @@ describe('SOL:', function () {
   });
 
 
-  it('should verify wallet address', (function () {
-    // FIXME(BG-43225): not implemented
-    this.skip();
+  it('should accept valid address', (function () {
+    goodAddresses.forEach(addr => {
+      basecoin.isValidAddress(addr).should.equal(true);
+    });
   }));
 
-  it('should check invalid address', (function () {
-    badAddresses.map(addr => { basecoin.isValidAddress(addr).should.equal(false); });
+  it('should reject invalid address', (function () {
+    badAddresses.forEach(addr => {
+      basecoin.isValidAddress(addr).should.equal(false);
+    });
   }));
 
   it('should check valid pub keys', (function () {

--- a/modules/core/test/v2/unit/coins/stx.ts
+++ b/modules/core/test/v2/unit/coins/stx.ts
@@ -14,14 +14,6 @@ describe('STX:', function () {
     'SP244HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
     'ST1T758K6T2YRKG9Q0TJ16B6FP5QQREWZSESRS0PY',
   ];
-  const badVerifyAddresses = [
-    ...badValidAddresses,
-    'SB1DP9Q0QPPKB07FK79MQE0CDJAYEFSGFVXE1KZ8X',
-    'SYB44HYPYAT2BB2QE513NSP81HTMYWBJP2Q9N4TN',
-    'S32T758K6T2YRKG9Q0TJ16B6FP5QQREWZSE461MK8',
-    'SM3W5QFWGPG1JC8R25EVZDEP3BESJZ831JPNNQFTZ?memoId=',
-    'SM3W5QFWGPG1JC8R25EVZDEP3BESJZ831JPNNQFTZ?memoId=null',
-  ];
 
   const goodAddresses = [
     'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
@@ -102,10 +94,10 @@ describe('STX:', function () {
     goodAddresses.map(addr => { basecoin.isValidAddress(addr).should.equal(true); });
   }));
 
-  it('should verify addresses', (function () {
-    goodAddresses.map(address => { basecoin.verifyAddress({ address }).should.equal(true); });
-    badVerifyAddresses.map(address => (() => basecoin.verifyAddress({ address })).should.throw());
-  }));
+  it('should verify addresses', function () {
+    // FIXME(BG-43225): not implemented
+    this.skip();
+  });
 
   it('should explain a transfer transaction', async function () {
     const explain = await basecoin.explainTransaction({

--- a/modules/core/test/v2/unit/wallet.ts
+++ b/modules/core/test/v2/unit/wallet.ts
@@ -214,7 +214,7 @@ describe('V2 Wallet:', function () {
     });
   });
 
-  describe('Wallet Transactions', function () {
+  describe('TETH Wallet Transactions', function () {
     let ethWallet;
 
     before(async function () {
@@ -365,7 +365,7 @@ describe('V2 Wallet:', function () {
     });
   });
 
-  describe('Create Address', () => {
+  describe('TETH Create Address', () => {
     let ethWallet, nocks;
     const walletData = {
       id: '598f606cd8fc24710d2ebadb1d9459bb',


### PR DESCRIPTION
Rename to `isWalletAddress()` and throw exceptions where it is not
implemented correctly.

Issue: BG-43225