### PR TITLE
fix(core): change loop to POST /address

### DIFF
--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -1470,7 +1470,9 @@ export class Wallet {
     const addressDerivationKeypair = _.get(keychains[KeyIndices.USER], 'addressDerivationKeypair');
     const lastChainIndex = _.get(this.coinSpecific(), `lastChainIndex.${chain || 0}`, 0);
 
-    const newAddresses = _.times(count, async (index) => {
+    const newAddresses: Record<string, any>[] = [];
+    for (let index = 0; index < count; index++) {
+      // synchronously make requests to keep order of derivation index when POSTing derived addresses
       if (addressDerivationKeypair && passphrase) {
         const addressDerivationPrv = this.bitgo.decrypt({
           password: passphrase,
@@ -1524,8 +1526,8 @@ export class Wallet {
         throw new Error(`address verification skipped for count = ${count}`);
       }
 
-      return newAddress;
-    });
+      newAddresses.push(newAddress);
+    }
 
     if (newAddresses.length === 1) {
       return newAddresses[0];


### PR DESCRIPTION
When SDK-core is used to create multiple receive addresses (call createAddress on wallet and pass in param count > 2), using `_.times` to loop `count` # of times led to making count # of async calls which means that the requests were getting handled by WP in an order different from the index on the loop. This behavior break derived address creation because WP checks the index used to create the address against the next available index on the wallet. If the incoming index is not 1 greater than the index on the wallet, WP throws. 
WP index verification: https://github.com/BitGo/bitgo-microservices/blob/58318068c355baee01345e84819d3db4cef1c289/packages/wallet-platform/app/controllers/api/v2/coins/base/utils.ts#L119

This PR changes createAddress from using an async loop to using a sync loop so that the order of the requests are kept in the order of index used to derive the address. 

JIRA ticket: https://bitgoinc.atlassian.net/browse/STLX-13639