### PR TITLE
refactor(account-lib): implement singleton for registry

### DIFF
--- a/modules/account-lib/src/coin/dot/singletonRegistry.ts
+++ b/modules/account-lib/src/coin/dot/singletonRegistry.ts
@@ -1,0 +1,27 @@
+import { TypeRegistry } from '@substrate/txwrapper-core/lib/types';
+import { getRegistry } from '@substrate/txwrapper-polkadot';
+import { PolkadotSpecNameType } from '@bitgo/statics';
+import { Metadata } from '@polkadot/types/metadata/Metadata';
+
+export class SingletonRegistry {
+  private static instance: TypeRegistry;
+  private static material: any;
+  private static metadata: Metadata;
+
+  static getInstance(material) {
+    if (material !== SingletonRegistry.material) {
+      SingletonRegistry.material = material;
+      SingletonRegistry.instance = getRegistry({
+        chainName: material.chainName,
+        specName: material.specName as PolkadotSpecNameType,
+        specVersion: material.specVersion,
+        metadataRpc: material.metadata as `0x${string}`,
+      });
+    }
+    return SingletonRegistry.instance;
+  }
+
+  static setMetadata(metadata) {
+    this.metadata = metadata;
+  }
+}

--- a/modules/account-lib/src/coin/dot/transaction.ts
+++ b/modules/account-lib/src/coin/dot/transaction.ts
@@ -17,8 +17,6 @@ import {
   TransactionExplanation,
   TxData,
   UnstakeArgs,
-  AddAnonymousProxyArgs,
-  BatchArgs,
   WithdrawUnstakedArgs,
   HexString,
 } from './iface';

--- a/modules/account-lib/src/coin/dot/transactionBuilder.ts
+++ b/modules/account-lib/src/coin/dot/transactionBuilder.ts
@@ -1,8 +1,8 @@
 import { BaseCoin as CoinConfig, PolkadotSpecNameType } from '@bitgo/statics';
 import { UnsignedTransaction } from '@substrate/txwrapper-core';
 import { DecodedSignedTx, DecodedSigningPayload, TypeRegistry } from '@substrate/txwrapper-core/lib/types';
-import { decode, getRegistry } from '@substrate/txwrapper-polkadot';
-import _ from 'lodash';
+import { decode } from '@substrate/txwrapper-polkadot';
+import * as _ from 'lodash';
 import BigNumber from 'bignumber.js';
 import { isValidEd25519Seed } from '../../utils/crypto';
 import { BaseTransactionBuilder, TransactionType, Interface } from '../baseCoin';
@@ -21,6 +21,7 @@ import { KeyPair } from './keyPair';
 import { Transaction } from './transaction';
 import { BaseTransactionSchema, SignedTransactionSchema, SigningPayloadTransactionSchema } from './txnSchema';
 import { default as utils } from './utils';
+import { SingletonRegistry } from './singletonRegistry';
 
 export abstract class TransactionBuilder extends BaseTransactionBuilder {
   protected _transaction: Transaction;
@@ -158,12 +159,8 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
    */
   material(material: Material): this {
     this.__material = material;
-    this._registry = getRegistry({
-      chainName: material.chainName,
-      specName: material.specName,
-      specVersion: material.specVersion,
-      metadataRpc: material.metadata,
-    });
+    // const SingletonRegistry = require('./singletonRegistry');
+    this._registry = SingletonRegistry.getInstance(material);
     return this;
   }
 
@@ -221,8 +218,6 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
     this.transaction.chainName(this._material.chainName);
     if (this._keyPair) {
       this.transaction.sign(this._keyPair);
-    } else if (this._signature) {
-      this.transaction.addSignature(this._signature);
     }
     if (this._signatures?.length > 0) {
       // if we have a signature, apply that and update this._signedTransaction

--- a/modules/account-lib/src/coin/dot/transactionBuilder.ts
+++ b/modules/account-lib/src/coin/dot/transactionBuilder.ts
@@ -25,6 +25,7 @@ import { default as utils } from './utils';
 export abstract class TransactionBuilder extends BaseTransactionBuilder {
   protected _transaction: Transaction;
   protected _keyPair: KeyPair;
+  protected _signature?: string;
   protected _sender: string;
 
   protected _blockNumber: number;
@@ -197,6 +198,7 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
       this.sender({ address: utils.decodeDotAddress(decodedTxn.address) });
       const edSignature = utils.recoverSignatureFromRawTx(rawTransaction, { registry: this._registry });
       this._transaction.signature.push(edSignature);
+      this._signature = utils.recoverSignatureFromRawTx(rawTransaction, { registry: this._registry });
     }
     this.validity({ maxDuration: decodedTxn.eraPeriod });
     this.sequenceId({
@@ -219,6 +221,8 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
     this.transaction.chainName(this._material.chainName);
     if (this._keyPair) {
       this.transaction.sign(this._keyPair);
+    } else if (this._signature) {
+      this.transaction.addSignature(this._signature);
     }
     if (this._signatures?.length > 0) {
       // if we have a signature, apply that and update this._signedTransaction

--- a/modules/account-lib/src/coin/dot/transactionBuilderFactory.ts
+++ b/modules/account-lib/src/coin/dot/transactionBuilderFactory.ts
@@ -1,7 +1,7 @@
 import { BaseCoin as CoinConfig } from '@bitgo/statics';
 import { BaseTransactionBuilderFactory } from '../baseCoin';
 import { NotImplementedError, NotSupported } from '../baseCoin/errors';
-import { decode, getRegistry } from '@substrate/txwrapper-polkadot';
+import { decode } from '@substrate/txwrapper-polkadot';
 import { TransactionBuilder } from './transactionBuilder';
 import { TransferBuilder } from './transferBuilder';
 import { AddressInitializationBuilder } from './addressInitializationBuilder';
@@ -10,6 +10,7 @@ import { Material, MethodNames } from './iface';
 import utils from './utils';
 import { BatchTransactionBuilder, UnstakeBuilder, WithdrawUnstakedBuilder } from '.';
 import { UnnominateBuilder } from './unnominateBuilder';
+import { SingletonRegistry } from './singletonRegistry';
 
 export class TransactionBuilderFactory extends BaseTransactionBuilderFactory {
   protected _material: Material;
@@ -63,13 +64,7 @@ export class TransactionBuilderFactory extends BaseTransactionBuilderFactory {
   }
 
   private getBuilder(rawTxn: string): TransactionBuilder {
-    const registry = getRegistry({
-      chainName: this._material.chainName,
-      specName: this._material.specName,
-      specVersion: this._material.specVersion,
-      metadataRpc: this._material.metadata,
-    });
-
+    const registry = SingletonRegistry.getInstance(this._material);
     const decodedTxn = decode(rawTxn, {
       metadataRpc: this._material.metadata,
       registry: registry,

--- a/modules/account-lib/src/coin/dot/transferBuilder.ts
+++ b/modules/account-lib/src/coin/dot/transferBuilder.ts
@@ -10,6 +10,7 @@ import { MethodNames, ProxyArgs, ProxyType, TransferArgs } from './iface';
 import { ProxyTransactionSchema, TransferTransactionSchema } from './txnSchema';
 import utils from './utils';
 import { BaseAddress } from '../baseCoin/iface';
+import { SingletonRegistry } from './singletonRegistry';
 
 export class TransferBuilder extends TransactionBuilder {
   protected _amount: string;
@@ -131,7 +132,7 @@ export class TransferBuilder extends TransactionBuilder {
       const real = txMethod.real;
       const forceProxyType = txMethod.forceProxyType;
       const decodedCall = utils.decodeCallMethod(rawTransaction, {
-        registry: this._registry,
+        registry: SingletonRegistry.getInstance(this._material),
         metadataRpc: this._material.metadata,
       });
       const amount = `${decodedCall.value}`;
@@ -155,7 +156,7 @@ export class TransferBuilder extends TransactionBuilder {
       this.owner({ address: utils.decodeDotAddress(txMethod.real) });
       this.forceProxyType(txMethod.forceProxyType);
       const decodedCall = utils.decodeCallMethod(rawTransaction, {
-        registry: this._registry,
+        registry: SingletonRegistry.getInstance(this._material),
         metadataRpc: this._material.metadata,
       });
       if (!decodedCall.value || !decodedCall.dest) {

--- a/modules/account-lib/src/coin/dot/utils.ts
+++ b/modules/account-lib/src/coin/dot/utils.ts
@@ -172,6 +172,19 @@ export class Utils implements BaseUtils {
       .sign(pair);
 
     // Serialize a signed transaction.
+    return this.serializeSignedTransaction(transaction, signature, metadataRpc, registry);
+  }
+
+  /**
+   * Serializes the signed transaction
+   *
+   * @param transaction Transaction to serialize
+   * @param signature Signature of the message
+   * @param metadataRpc Network metadata
+   * @param registry Transaction registry
+   * @returns string Serialized transaction
+   */
+  serializeSignedTransaction(transaction, signature, metadataRpc, registry) {
     return construct.signedTx(transaction, signature, {
       metadataRpc,
       registry,

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/base.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/base.ts
@@ -79,7 +79,7 @@ class StubTransactionBuilder extends TransactionBuilder {
 }
 
 // TODO: BG-43197
-xdescribe('Dot Transfer Builder', () => {
+describe('Dot Transfer Builder', () => {
   let builder: StubTransactionBuilder;
 
   const sender = accounts.account1;

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/batchTransactionBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/batchTransactionBuilder.ts
@@ -33,7 +33,7 @@ describe('Dot Batch Transaction Builder', () => {
   });
 
   // TODO: BG-43197
-  xdescribe('build batch transaction', () => {
+  describe('build batch transaction', () => {
     it('should build a batch transaction', async () => {
       builder
         .calls(rawTx.anonymous.batch)

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/stakingBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/stakingBuilder.ts
@@ -54,7 +54,7 @@ describe('Dot Stake Builder', () => {
   });
 
   // TODO: BG-43197
-  xdescribe('build stake transaction', () => {
+  describe('build stake transaction', () => {
     it('should build a stake transaction', async () => {
       builder
         .amount('90034235235322')

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/transactionBuilderFactory.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/transactionBuilderFactory.ts
@@ -23,6 +23,8 @@ class StubTransactionBuilderFactory extends TransactionBuilderFactory {
 // TODO: BG-43197
 xdescribe('dot Transaction Builder Factory', () => {
   const factory = register('tdot', StubTransactionBuilderFactory).material(materialData as Material);
+  const { rawTx } = dotResources;
+  const sender = dotResources.accounts.account1;
   const sender = accounts.account1;
   const sender2 = accounts.account3;
 
@@ -52,9 +54,7 @@ xdescribe('dot Transaction Builder Factory', () => {
 
       builder
         .validity({ firstValid: 3933 })
-        .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
-        .sender({ address: sender.address })
-        .sign({ key: sender.secretKey });
+        .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
       const tx = await builder.build();
       should.equal(tx.toBroadcastFormat(), rawTx[txn.type].signed);
     });
@@ -76,9 +76,7 @@ xdescribe('dot Transaction Builder Factory', () => {
     should(builder).instanceOf(TransferBuilder);
     builder
       .validity({ firstValid: 3933, maxDuration: 64 })
-      .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
-      .sender({ address: sender2.address })
-      .sign({ key: sender2.secretKey });
+      .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
     const tx = await builder.build();
     should.equal(tx.toBroadcastFormat(), rawTx.proxy.signed);
   });

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/transactionBuilderFactory.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/transactionBuilderFactory.ts
@@ -23,10 +23,7 @@ class StubTransactionBuilderFactory extends TransactionBuilderFactory {
 // TODO: BG-43197
 xdescribe('dot Transaction Builder Factory', () => {
   const factory = register('tdot', StubTransactionBuilderFactory).material(materialData as Material);
-  const { rawTx } = dotResources;
-  const sender = dotResources.accounts.account1;
   const sender = accounts.account1;
-  const sender2 = accounts.account3;
 
   [
     { type: 'transfer', builder: TransferBuilder },

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/transferBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/transferBuilder.ts
@@ -51,7 +51,7 @@ describe('Dot Transfer Builder', () => {
   });
 
   // TODO: BG-43197
-  xdescribe('build transfer transaction', () => {
+  describe('build transfer transaction', () => {
     it('should build a transfer transaction', async () => {
       builder
         .amount('90034235235322')

--- a/modules/account-lib/test/unit/coin/dot/utils.ts
+++ b/modules/account-lib/test/unit/coin/dot/utils.ts
@@ -1,8 +1,18 @@
 import should from 'should';
 import utils from '../../../../src/coin/dot/utils';
-import { accounts, blockHash, signatures, txIds } from '../../../resources/dot';
+import { accounts, blockHash, signatures, txIds, rawTx } from '../../../resources/dot';
+import { TypeRegistry } from '@substrate/txwrapper-core/lib/types';
+import { getRegistry } from '@substrate/txwrapper-polkadot';
+import * as material from '../../../resources/dot/materialData.json';
+import { PolkadotSpecNameType } from '@bitgo/statics';
 
 describe('utils', () => {
+  const registry: TypeRegistry = getRegistry({
+    chainName: material.chainName,
+    specName: material.specName as PolkadotSpecNameType,
+    specVersion: material.specVersion,
+    metadataRpc: material.metadata as `0x${string}`,
+  });
   it('should validate addresses correctly', () => {
     should.equal(utils.isValidAddress(accounts.account1.address), true);
     should.equal(utils.isValidAddress(accounts.account2.address), true);
@@ -74,5 +84,26 @@ describe('utils', () => {
 
   it('should encode DOT address correctly', () => {
     should.equal(utils.encodeDotAddress(accounts.account1.address), '5EGoFA95omzemRssELLDjVenNZ68aXyUeqtKQScXSEBvVJkr');
+  });
+
+  it('should recover signature from raw tx correctly', () => {
+    should.equal(
+      utils.recoverSignatureFromRawTx(rawTx.transfer.signed, { registry: registry }),
+      '0x00b6d868a11d202b56df1959f5d5f81f44ce1f95c8e70424b17080ea869d1c39d453f16c38fbef600a636c9a62a49ede5ee695a1822faf2f94fcfbb184a4254009',
+    );
+  });
+
+  it('should serialize signed transaction successfully', () => {
+    const signature = utils.recoverSignatureFromRawTx(rawTx.transfer.signed, { registry: registry });
+    const txHex = utils.serializeSignedTransaction(
+      rawTx.transfer.unsigned,
+      signature,
+      material.metadata as `0x${string}`,
+      registry,
+    );
+    should.equal(
+      txHex,
+      '0xb9018400000000000000000000000000000000000000000000000000000000000000000000b6d868a11d202b56df1959f5d5f81f44ce1f95c8e70424b17080ea869d1c39d453f16c38fbef600a636c9a62a49ede5ee695a1822faf2f94fcfbb184a4254009d501210300000000000000',
+    );
   });
 });

--- a/modules/account-lib/test/unit/coin/dot/utils.ts
+++ b/modules/account-lib/test/unit/coin/dot/utils.ts
@@ -1,18 +1,11 @@
 import should from 'should';
 import utils from '../../../../src/coin/dot/utils';
 import { accounts, blockHash, signatures, txIds, rawTx } from '../../../resources/dot';
-import { TypeRegistry } from '@substrate/txwrapper-core/lib/types';
-import { getRegistry } from '@substrate/txwrapper-polkadot';
 import * as material from '../../../resources/dot/materialData.json';
-import { PolkadotSpecNameType } from '@bitgo/statics';
-
+import { SingletonRegistry } from '../../../../src/coin/dot/singletonRegistry';
 describe('utils', () => {
-  const registry: TypeRegistry = getRegistry({
-    chainName: material.chainName,
-    specName: material.specName as PolkadotSpecNameType,
-    specVersion: material.specVersion,
-    metadataRpc: material.metadata as `0x${string}`,
-  });
+  const registry = SingletonRegistry.getInstance(material);
+
   it('should validate addresses correctly', () => {
     should.equal(utils.isValidAddress(accounts.account1.address), true);
     should.equal(utils.isValidAddress(accounts.account2.address), true);
@@ -89,7 +82,7 @@ describe('utils', () => {
   it('should recover signature from raw tx correctly', () => {
     should.equal(
       utils.recoverSignatureFromRawTx(rawTx.transfer.signed, { registry: registry }),
-      '0x00b6d868a11d202b56df1959f5d5f81f44ce1f95c8e70424b17080ea869d1c39d453f16c38fbef600a636c9a62a49ede5ee695a1822faf2f94fcfbb184a4254009',
+      'b6d868a11d202b56df1959f5d5f81f44ce1f95c8e70424b17080ea869d1c39d453f16c38fbef600a636c9a62a49ede5ee695a1822faf2f94fcfbb184a4254009',
     );
   });
 
@@ -97,7 +90,7 @@ describe('utils', () => {
     const signature = utils.recoverSignatureFromRawTx(rawTx.transfer.signed, { registry: registry });
     const txHex = utils.serializeSignedTransaction(
       rawTx.transfer.unsigned,
-      signature,
+      signature.replace(/^/, '0x00'),
       material.metadata as `0x${string}`,
       registry,
     );


### PR DESCRIPTION
STLX-13615
Although this is a good practice and should be implemented, we have only seen a small decrease in memory usage. All the tests have been run on my local machine and the results are:

- Memory usage with the implementation of the Singleton Pattern for registry: 1392 MB
- Memory usage without the implementation of the Singleton Pattern for registry: 1457 MB