### PR TITLE
feat(root): add unit-test-all to ci

### DIFF
--- a/.github/workflows/test_package_updates.yml
+++ b/.github/workflows/test_package_updates.yml
@@ -1,0 +1,52 @@
+name: Package updates
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "*/**/package.json"
+      - "!*/**/node_modules/package.json"
+      - "package.json"
+      - "!node_modules/package.json"
+  pull_request:
+    branches:
+      - master
+      - rel/**
+    paths:
+      - "*/**/package.json"
+      - "!*/**/node_modules/package.json"
+      - "package.json"
+      - "!node_modules/package.json"
+
+jobs:
+  unit-test-all:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup node:${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Fetch Base Ref
+        run: git fetch origin $GITHUB_BASE_REF
+
+      - name: Remove yarn.lock to simulate downstream installs
+        run: rm yarn.lock
+
+      - name: Install Packages
+        run: yarn install
+
+      - name: Unit test all
+        run: yarn unit-test
+        env:
+          BITGOJS_TEST_PASSWORD: ${{ secrets.BITGOJS_TEST_PASSWORD }}


### PR DESCRIPTION
## Motivation
On package updates, the current CI won't prevent breaking changes with running all unit tests but instead relies on running unit test diff. This is what we encountered in the Solana and Dot tests updates, where it broke some tests. With package updates, most likely there will not be new test cases introduced and it may risk breaking the code. 

## What is included
- A new workflow that runs all unit tests if there are changes involved in any of the `package.json`

## Testing
An additional commit was introduced to purposedly trigger the workflow in the PR, and will be borked before merging

## Q&A
### Why not run integration tests too?
I was going to add `integration` tests into the run options too but seems like they are mostly obsolete.

### Why not just add a new job?
There isn't really a quick native way to run jobs on file changes without relying on 3rd party actions. Reference: https://github.community/t/is-it-possible-to-run-the-job-only-when-a-specific-file-changes/115484/10

## Misc
The test drive `package.json` update commit will need to be borked before merging

NEW TICKET: BG-43414