### PR TITLE
fix(core): add multisig type param on add wallet

### DIFF
--- a/modules/core/src/v2/wallets.ts
+++ b/modules/core/src/v2/wallets.ts
@@ -91,6 +91,7 @@ export interface AddWalletOptions {
   disableTransactionNotifications?: boolean;
   gasPrice?: number;
   walletVersion?: number;
+  multisigType?: 'onchain' | 'tss' | 'blsdkg';
 }
 
 export interface ListWalletOptions extends PaginationOptions {
@@ -246,6 +247,10 @@ export class Wallets {
 
     if (params.disableTransactionNotifications) {
       walletParams.disableTransactionNotifications = params.disableTransactionNotifications;
+    }
+
+    if (params.multisigType) {
+      walletParams.multisigType = params.multisigType;
     }
 
     const newWallet = await this.bitgo.post(this.baseCoin.url('/wallet')).send(walletParams).result();


### PR DESCRIPTION
Wallet Platform supports a new multisig type param when adding a wallet

BG-36122