### PR TITLE
remove tss support for dot tss

### DIFF
--- a/modules/core/src/v2/coins/dot.ts
+++ b/modules/core/src/v2/coins/dot.ts
@@ -85,7 +85,8 @@ export class Dot extends BaseCoin {
 
   /** @inheritDoc */
   supportsTss(): boolean {
-    return true;
+    // return true once TSS integration is supported
+    return false;
   }
 
   allowsAccountConsolidations(): boolean {


### PR DESCRIPTION
DOT TSS is not ready to be integrated. Changing dot to not support TSS so we don't see errors when creating a wallet.