### PR TITLE
fix(core): change etherscan url to default goerli

### DIFF
--- a/modules/core/src/v2/environments.ts
+++ b/modules/core/src/v2/environments.ts
@@ -102,7 +102,7 @@ const testnetBase: EnvironmentTemplate = {
   serverXpub: hardcodedPublicKeys.serverXpub.test,
   hsmXpub: hardcodedPublicKeys.hsmXpub.test,
   btcExplorerBaseUrl: 'https://blockstream.info/testnet/api',
-  etherscanBaseUrl: 'https://api-kovan.etherscan.io',
+  etherscanBaseUrl: 'https://api-goerli.etherscan.io',
   etherscanApiToken: process.env.ETHERSCAN_API_TOKEN,
   eth2ExplorerBaseUrl: 'https://beaconscan.com/api',
   // https://monitor.jungletestnet.io/#apiendpoints for more endpoints
@@ -156,7 +156,7 @@ export const Environments: Environments = {
   mock: Object.assign({}, devBase, {
     uri: 'https://bitgo.fakeurl',
     stellarFederationServerUrl: 'https://bitgo.fakeurl/api/v2/txlm/federation',
-    etherscanBaseUrl: 'https://api-kovan.etherscan.fakeurl',
+    etherscanBaseUrl: 'https://api-goerli.etherscan.fakeurl',
     etherscanApiToken: process.env.ETHERSCAN_API_TOKEN,
     eth2ExplorerBaseUrl: 'https://beaconscan.com/api',
   }),
@@ -191,7 +191,7 @@ export const Environments: Environments = {
         : 'https://blockstream.info/api',
     etherscanBaseUrl:
       process.env.BITGO_CUSTOM_ETHEREUM_NETWORK !== 'ethereum'
-        ? 'https://api-kovan.etherscan.io'
+        ? 'https://api-goerli.etherscan.io'
         : 'https://api.etherscan.io',
     stellarFederationServerUrl:
       process.env.BITGO_CUSTOM_STELLAR_NETWORK !== 'stellar'

--- a/modules/core/test/lib/test_bitgo.ts
+++ b/modules/core/test/lib/test_bitgo.ts
@@ -269,24 +269,24 @@ BitGo.prototype.checkFunded = async function () {
   const testWalletId = BitGo.V2.TEST_ETH_WALLET_ID;
 
   const {
-    tethWallet,
+    gtethWallet,
     tbtcWallet,
     unspentWallet,
     sweep1Wallet,
   }: any = await promiseProps({
-    tethWallet: this.coin('teth').wallets().get({ id: testWalletId }),
+    gtethWallet: this.coin('gteth').wallets().get({ id: testWalletId }),
     tbtcWallet: this.coin('tbtc').wallets().getWallet({ id: BitGo.V2.TEST_WALLET1_ID }),
     unspentWallet: this.coin('tbtc').wallets().getWallet({ id: BitGo.V2.TEST_WALLET2_UNSPENTS_ID }),
     sweep1Wallet: this.coin('tbtc').wallets().getWallet({ id: BitGo.V2.TEST_SWEEP1_ID }),
   });
 
-  const spendableBalance = tethWallet.spendableBalanceString;
+  const spendableBalance = gtethWallet.spendableBalanceString;
 
   let balance = new BigNumber(spendableBalance);
 
   // Check our balance is over 60000 (we spend 50000, add some cushion)
   if (balance.lt(60000)) {
-    throw new Error(`The TETH wallet ${testWalletId} does not have enough funds to run the test suite. The current balance is ${balance}. Please fund this wallet!`);
+    throw new Error(`The GTETH wallet ${testWalletId} does not have enough funds to run the test suite. The current balance is ${balance}. Please fund this wallet!`);
   }
 
   // Check we have enough in the wallet to run test suite
@@ -330,7 +330,7 @@ BitGo.prototype.nockEthWallet = function () {
         permissions: [Object],
       },
     ],
-    coin: 'teth',
+    coin: 'gteth',
     label: 'my test ether wallet',
     m: 2,
     n: 3,
@@ -371,7 +371,7 @@ BitGo.prototype.nockEthWallet = function () {
       address: '0xa7f9ca5c1268b0082db1833d30f33d3cfd4286d8',
       chain: 0,
       index: 701,
-      coin: 'teth',
+      coin: 'gteth',
       lastNonce: 0,
       wallet: '598f606cd8fc24710d2ebadb1d9459bb',
       coinSpecific: {
@@ -385,20 +385,20 @@ BitGo.prototype.nockEthWallet = function () {
     pendingApprovals: [],
   };
 
-  const wallet = new Wallet(this, this.coin('teth'), walletData);
+  const wallet = new Wallet(this, this.coin('gteth'), walletData);
 
   // Nock calls to platform for building transactions and getting user key
   // Should be OK to persist these since they are wallet specific data reads
   nock(this._baseUrl)
     .persist()
     .filteringRequestBody(() => '*')
-    .post(`/api/v2/teth/wallet/${wallet.id()}/tx/build`, '*')
+    .post(`/api/v2/gteth/wallet/${wallet.id()}/tx/build`, '*')
     .reply(200, {
       gasLimit: 500000,
       gasPrice: 20000000000,
       nextContractSequenceId: 101,
     })
-    .get(`/api/v2/teth/key/${wallet.keyIds()[KeyIndices.USER]}`)
+    .get(`/api/v2/gteth/key/${wallet.keyIds()[KeyIndices.USER]}`)
     .reply(200, {
       id: '598f606cd8fc24710d2ebad89dce86c2',
       users: ['543c11ed356d00cb7600000b98794503'],
@@ -419,7 +419,7 @@ BitGo.prototype.nockEthWallet = function () {
   }
 
   // Nock tokens stuck on the wallet
-  nock('https://api-kovan.etherscan.io')
+  nock('https://api-goerli.etherscan.io')
     .get('/api')
     .query(params)
     .reply(200, { status: '1', message: 'OK', result: '2400' });

--- a/modules/core/test/v2/lib/recovery-nocks.ts
+++ b/modules/core/test/v2/lib/recovery-nocks.ts
@@ -389,7 +389,7 @@ module.exports.nockEthRecovery = function (bitgo, nockData = nockEthData) {
     if (apiKey) {
       data.params.apiKey = apiKey;
     }
-    nock('https://api-kovan.etherscan.io').get('/api').query(data.params).reply(200, data.response);
+    nock('https://api-goerli.etherscan.io').get('/api').query(data.params).reply(200, data.response);
   });
 };
 
@@ -406,7 +406,7 @@ module.exports.nockEtherscanRateLimitError = function () {
     address: '0x74c2137d54b0fc9f907e13f14e0dd18485fee924',
   };
 
-  nock('https://api-kovan.etherscan.io').get('/api').query(params).reply(200, response);
+  nock('https://api-goerli.etherscan.io').get('/api').query(params).reply(200, response);
 };
 
 module.exports.nockXlmRecovery = function () {


### PR DESCRIPTION
The recover function calls etherscan internally to get some details regarding the address but seems like it defaults to kovan even if we initialise the sdk with goerli. Since kovan is already retiring, reverting the default to goerli instead of kovan.

Ticket: [BG-42778](https://bitgoinc.atlassian.net/browse/BG-42778)