### PR TITLE
chore(core): improve support for tss wallets

### DIFF
--- a/modules/core/src/v2/baseCoin.ts
+++ b/modules/core/src/v2/baseCoin.ts
@@ -188,6 +188,7 @@ export interface TransactionPrebuild {
   wallet?: Wallet;
   buildParams?: any;
   consolidateId?: string;
+  txRequestId?: string;
 }
 
 export interface AddressCoinSpecific {
@@ -215,7 +216,15 @@ export interface HalfSignedAccountTransaction {
   };
 }
 
-export type SignedTransaction = HalfSignedAccountTransaction | HalfSignedUtxoTransaction | FullySignedTransaction;
+export interface SignedTransactionRequest {
+  txRequestId: string;
+}
+
+export type SignedTransaction =
+  | HalfSignedAccountTransaction
+  | HalfSignedUtxoTransaction
+  | FullySignedTransaction
+  | SignedTransactionRequest;
 
 export abstract class BaseCoin {
   protected readonly bitgo: BitGo;

--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -13,6 +13,7 @@ import { AddressGenerationError } from '../errors';
 import {
   BaseCoin,
   SignedTransaction,
+  SignedTransactionRequest,
   TransactionPrebuild,
   VerificationOptions,
   VerifyAddressOptions,
@@ -20,12 +21,11 @@ import {
 import { Eth } from './coins';
 import * as internal from './internal/internal';
 import { drawKeycard } from './internal/keycard';
-import { Keychain } from './keychains';
+import { Keychain, KeyIndices } from './keychains';
 import { TradingAccount } from './trading/tradingAccount';
 import { PendingApproval, PendingApprovalData } from './pendingApproval';
 import { RequestTracer } from './internal/util';
 import { getSharedSecret } from '../ecdh';
-import { KeyIndices } from '.';
 import { TssUtils } from './internal/tssUtils';
 
 const debug = debugLib('bitgo:v2:wallet');
@@ -134,6 +134,7 @@ export interface CustomSigningFunction {
 }
 
 export interface WalletSignTransactionOptions {
+  reqId?: RequestTracer;
   txPrebuild?: TransactionPrebuild;
   prv?: string;
   pubs?: string[];
@@ -381,6 +382,7 @@ export interface SubmitTransactionOptions {
     txBase64?: string;
   };
   comment?: string;
+  txRequestId?: string;
 }
 
 export interface SendOptions {
@@ -503,36 +505,25 @@ export interface DownloadKeycardOptions {
   backupKeyID?: string;
 }
 
-// #region TSS interfaces
-
-interface TSSSendManyOptions extends SendManyOptions {
-  reqId: RequestTracer;
-  intentType: string;
-  recipients: {
-    address: string;
-    amount: string | number;
-  }[];
-}
-
 // #endregion
 
 export class Wallet {
   public readonly bitgo: BitGo;
   public readonly baseCoin: BaseCoin;
   private _wallet: WalletData;
+  private readonly tssUtils: TssUtils;
   private readonly _permissions?: string[];
-  private tssUtils: TssUtils;
 
   constructor(bitgo: BitGo, baseCoin: BaseCoin, walletData: any) {
     this.bitgo = bitgo;
     this.baseCoin = baseCoin;
     this._wallet = walletData;
-    this.tssUtils = new TssUtils(this.bitgo, this.baseCoin, this);
     const userId = _.get(bitgo, '_user.id');
     if (_.isString(userId)) {
       const userDetails = _.find(walletData.users, { user: userId });
       this._permissions = _.get(userDetails, 'permissions');
     }
+    this.tssUtils = new TssUtils(bitgo, baseCoin, this);
   }
 
   /**
@@ -1866,6 +1857,10 @@ export class Wallet {
    * @returns {*}
    */
   async prebuildTransaction(params: PrebuildTransactionOptions = {}): Promise<PrebuildTransactionResult> {
+    if (this._wallet.multisigType === 'tss') {
+      return this.prebuildTransactionTss(params);
+    }
+
     // Whitelist params to build tx
     const whitelistedParams = _.pick(params, this.prebuildWhitelistedParams());
     debug('prebuilding transaction: %O', whitelistedParams);
@@ -1920,7 +1915,13 @@ export class Wallet {
     if (!txPrebuild || typeof txPrebuild !== 'object') {
       throw new Error('txPrebuild must be an object');
     }
+
     const presign = await this.baseCoin.presignTransaction(params);
+
+    if (txPrebuild.consolidateId === undefined && this._wallet.multisigType === 'tss') {
+      // consolidation will continue with single sig signing
+      return this.signTransactionTss({ ...params, prv: this.getUserPrv(presign) });
+    }
 
     let { pubs } = params;
     if (!pubs && this.baseCoin.keyIdsForSigning().length > 1) {
@@ -2030,14 +2031,19 @@ export class Wallet {
         reqId: params.reqId,
       });
     } catch (e) {
-      console.error('transaction prebuild failed local validation:', e.message);
-      console.error(
-        'transaction params:',
-        _.omit(params, ['keychain', 'prv', 'passphrase', 'walletPassphrase', 'key', 'wallet'])
-      );
-      console.error('transaction prebuild:', txPrebuild);
-      console.trace(e);
-      throw e;
+      if (this._wallet.multisigType === 'tss') {
+        // TODO: STLX-13411 - implement verify tx for tss wallets
+        console.warn('transaction prebuild failed local validation:', e.message);
+      } else {
+        console.error('transaction prebuild failed local validation:', e.message);
+        console.error(
+          'transaction params:',
+          _.omit(params, ['keychain', 'prv', 'passphrase', 'walletPassphrase', 'key', 'wallet'])
+        );
+        console.error('transaction prebuild:', txPrebuild);
+        console.trace(e);
+        throw e;
+      }
     }
     // pass our three keys
     const signingParams = {
@@ -2049,6 +2055,7 @@ export class Wallet {
       },
       keychain: keychains[0],
       pubs: keychains.map((k) => k.pub),
+      reqId: params.reqId,
     };
 
     if (txPrebuild.consolidationDetails && this.baseCoin.supportsDerivationKeypair()) {
@@ -2161,13 +2168,16 @@ export class Wallet {
    * - halfSigned: object containing transaction (txHex or txBase64) to submit
    */
   async submitTransaction(params: SubmitTransactionOptions = {}): Promise<any> {
-    common.validateParams(params, [], ['otp', 'txHex']);
+    common.validateParams(params, [], ['otp', 'txHex', 'txRequestId']);
     const hasTxHex = !!params.txHex;
     const hasHalfSigned = !!params.halfSigned;
 
-    if ((hasTxHex && hasHalfSigned) || (!hasTxHex && !hasHalfSigned)) {
+    if (params.txRequestId && (hasTxHex || hasHalfSigned)) {
+      throw new Error('must supply exactly one of txRequestId, txHex, or halfSigned');
+    } else if (!params.txRequestId && ((hasTxHex && hasHalfSigned) || (!hasTxHex && !hasHalfSigned))) {
       throw new Error('must supply either txHex or halfSigned, but not both');
     }
+
     return this.bitgo
       .post(this.baseCoin.url('/wallet/' + this.id() + '/tx/send'))
       .send(params)
@@ -2275,42 +2285,42 @@ export class Wallet {
         }
       });
     }
-    if (this._wallet.multisigType !== 'tss') {
-      const halfSignedTransaction = await this.prebuildAndSignTransaction(params);
-      const selectParams = _.pick(params, [
-        'recipients',
-        'numBlocks',
-        'feeRate',
-        'maxFeeRate',
-        'minConfirms',
-        'enforceMinConfirmsForChange',
-        'targetWalletUnspents',
-        'message',
-        'minValue',
-        'maxValue',
-        'sequenceId',
-        'lastLedgerSequence',
-        'ledgerSequenceDelta',
-        'gasPrice',
-        'noSplitChange',
-        'unspents',
-        'comment',
-        'otp',
-        'changeAddress',
-        'instant',
-        'memo',
-        'type',
-        'trustlines',
-        'transferId',
-        'stakingOptions',
-      ]);
-      const finalTxParams = _.extend({}, halfSignedTransaction, selectParams);
 
-      return this.bitgo.post(this.url('/tx/send')).send(finalTxParams).result();
-    } else {
-      const tssParams = _.assign(params, { intentType: 'payment' }) as TSSSendManyOptions;
-      return this.sendManyTSS(tssParams);
+    if (this._wallet.multisigType === 'tss') {
+      return this.sendManyTss(params);
     }
+
+    const halfSignedTransaction = await this.prebuildAndSignTransaction(params);
+    const selectParams = _.pick(params, [
+      'recipients',
+      'numBlocks',
+      'feeRate',
+      'maxFeeRate',
+      'minConfirms',
+      'enforceMinConfirmsForChange',
+      'targetWalletUnspents',
+      'message',
+      'minValue',
+      'maxValue',
+      'sequenceId',
+      'lastLedgerSequence',
+      'ledgerSequenceDelta',
+      'gasPrice',
+      'noSplitChange',
+      'unspents',
+      'comment',
+      'otp',
+      'changeAddress',
+      'instant',
+      'memo',
+      'type',
+      'trustlines',
+      'transferId',
+      'stakingOptions',
+    ]);
+    const finalTxParams = _.extend({}, halfSignedTransaction, selectParams);
+
+    return this.bitgo.post(this.url('/tx/send')).send(finalTxParams).result();
   }
 
   /**
@@ -2680,23 +2690,90 @@ export class Wallet {
     }
   }
 
-  // #region TSS
+  /* MARK: TSS Helpers */
 
   /**
-   * Builds, sign and send a transaction using TSS keys
+   * Prebuilds a transaction for a TSS wallet.
    *
-   * @param {TSSSendManyOptions} params - parameters to build and sign the tx
-   * @returns {Promise<any>}
+   * @param params prebuild transaction options
    */
-  private async sendManyTSS(params: TSSSendManyOptions): Promise<any> {
-    // improve validations
-    if (_.isNil(params.walletPassphrase)) {
-      throw new Error('Missing wallet passphrase');
+  private async prebuildTransactionTss(params: PrebuildTransactionOptions = {}): Promise<PrebuildTransactionResult> {
+    if (params.type !== 'transfer') {
+      throw new Error(`transaction type not supported: ${params.type}`);
     }
 
-    const unsignedTx = await this.tssUtils.prebuildTxWithIntent(params);
+    const reqId = params.reqId || new RequestTracer();
+    this.bitgo.setRequestTracer(reqId);
 
-    return this.tssUtils.signAndSendTxRequest(unsignedTx, params.walletPassphrase, params.reqId);
+    const unsignedTxRequest = await this.tssUtils.prebuildTxWithIntent({
+      reqId,
+      intentType: 'payment',
+      sequenceId: params.sequenceId,
+      comment: params.comment,
+      recipients: params.recipients || [],
+      memo: params.memo,
+    });
+
+    const unsignedTxs = unsignedTxRequest.unsignedTxs;
+    if (unsignedTxs.length !== 1) {
+      throw new Error(`Expected a single unsigned tx for tx request with id: ${unsignedTxRequest.txRequestId}`);
+    }
+
+    return {
+      walletId: this.id(),
+      wallet: this,
+      txRequestId: unsignedTxRequest.txRequestId,
+      txHex: unsignedTxs[0].serializedTx,
+    };
   }
-  // #endregion
+
+  /**
+   * Signs a transaction from a TSS wallet.
+   *
+   * @param params signing options
+   */
+  private async signTransactionTss(params: WalletSignTransactionOptions = {}): Promise<SignedTransaction> {
+    if (!params.txPrebuild) {
+      throw new Error('txPrebuild required to sign transactions with TSS');
+    }
+
+    if (params.txPrebuild.consolidateId !== undefined) {
+      throw new Error('should not sign consolidation transactions with TSS');
+    }
+
+    if (!params.txPrebuild.txRequestId) {
+      throw new Error('txRequestId required to sign transactions with TSS');
+    }
+
+    if (!params.prv) {
+      throw new Error('prv required to sign transactions with TSS');
+    }
+
+    try {
+      const signedTxRequest = await this.tssUtils.signTxRequest(
+        params.txPrebuild.txRequestId,
+        params.prv,
+        params.reqId || new RequestTracer()
+      );
+      return {
+        txRequestId: signedTxRequest.txRequestId,
+      };
+    } catch (e) {
+      throw new Error('failed to sign transaction');
+    }
+  }
+
+  /**
+   * Builds, signs, and sends a transaction from a TSS wallet.
+   *
+   * @param params send options
+   */
+  private async sendManyTss(params: SendManyOptions = {}): Promise<any> {
+    const signedTransaction = (await this.prebuildAndSignTransaction(params)) as SignedTransactionRequest;
+    if (!signedTransaction.txRequestId) {
+      throw new Error('txRequestId missing from signed transaction');
+    }
+
+    return this.tssUtils.sendTxRequest(signedTransaction.txRequestId);
+  }
 }

--- a/modules/core/test/v2/unit/internal/tssUtils.ts
+++ b/modules/core/test/v2/unit/internal/tssUtils.ts
@@ -7,7 +7,7 @@ import * as sinon from 'sinon';
 
 import Eddsa, { GShare, KeyShare, SignShare } from '../../../../../account-lib/dist/src/mpc/tss';
 import { Keychain, Wallet } from '../../../../src';
-import { SignatureShareRecord, SignatureShareType, TssUtils } from '../../../../src/v2/internal/tssUtils';
+import { SignatureShareRecord, SignatureShareType, TssUtils, TxRequest } from '../../../../src/v2/internal/tssUtils';
 import { TestBitGo } from '../../../lib/test_bitgo';
 import * as common from '../../../../src/common';
 import { RequestTracer } from '../../../../src/v2/internal/util';
@@ -20,7 +20,6 @@ describe('TSS Utils:', async function () {
   let wallet: Wallet;
   let bitgoKeyShare;
   const reqId = new RequestTracer;
-  const walletPassphrase = 'MyTssWall3t!';
   const coinName = 'tsol';
   const validUserPShare = '{"i":"1","y":"c4f36234dbcb78ba7efee44771692a71f1d366c70b99656922168590a63c96c2","x":"5d462225ce32327c1ad0c9b1c2263bdbdb154236fb4b3445f199f05b135d010b","prefix":"77e5611f781363b4e303bbe20bed8c62028d88ba22b47af9e77e6b134c373009"}';
   const txRequest = {
@@ -208,10 +207,20 @@ describe('TSS Utils:', async function () {
     });
   });
 
-  describe('signAndSendTxRequest:', function() {
-    it('should succeed', async function () {
-      // each function used here is individually tested, so here we mock everything and verify inputs / outputs
-      const userPShare = 'userPShare';
+  describe('signTxRequest:', function() {
+    const txRequestId = 'txRequestId';
+    const userPShare = 'userPShare';
+    const txRequest: TxRequest = {
+      txRequestId,
+      unsignedTxs: [
+        {
+          serializedTx: 'ababfefe',
+          signableHex: 'deadbeef',
+        }
+      ]
+    };
+
+    beforeEach(function () {
       const userSignShare: SignShare = {
         xShare: {
           i: 'i',
@@ -234,10 +243,6 @@ describe('TSS Utils:', async function () {
         gamma: 'gamma',
       };
 
-      const getUserPShare = sandbox.stub(tssUtils, 'getUserPShare');
-      getUserPShare.calledOnceWithExactly(reqId, 'walletPassphrase');
-      getUserPShare.resolves(userPShare);
-
       const createUserSignShare = sandbox.stub(tssUtils, 'createUserSignShare');
       createUserSignShare.calledOnceWithExactly(Buffer.from('deadbeef', 'hex'), userPShare);
       createUserSignShare.resolves(userSignShare);
@@ -257,21 +262,30 @@ describe('TSS Utils:', async function () {
       const sendUserToBitgoGShare = sandbox.stub(tssUtils, 'sendUserToBitgoGShare');
       sendUserToBitgoGShare.calledOnceWithExactly('txRequestId', userToBitGoGShare);
       sendUserToBitgoGShare.resolves(undefined);
+    });
 
-      const sendTxRequest = sandbox.stub(tssUtils, 'sendTxRequest');
-      sendTxRequest.calledOnceWithExactly('txRequestId');
-      sendTxRequest.resolves('sendTxResponse');
+    it('signTxRequest should succeed with txRequest object as input', async function () {
+      const getTxRequest = sandbox.stub(tssUtils, 'getTxRequest');
+      getTxRequest.resolves(txRequest);
+      getTxRequest.calledWith('txRequestId');
 
-      const result = await tssUtils.signAndSendTxRequest({
-        txRequestId: 'txRequestId',
-        unsignedTxs: [{
-          serializedTx: 'unsignedSerializedTx',
-          signableHex: 'deadbeef',
-        }],
-      }, 'walletPassphrase', reqId);
-      result.should.equal('sendTxResponse');
+      const signedTxRequest = await tssUtils.signTxRequest(txRequest, userPShare, reqId);
+      signedTxRequest.should.deepEqual(txRequest);
+      sinon.assert.calledOnce(getTxRequest);
 
-      sandbox.verify();
+      sandbox.verifyAndRestore();
+    });
+
+    it('signTxRequest should succeed with txRequest id as input', async function () {
+      const getTxRequest = sandbox.stub(tssUtils, 'getTxRequest');
+      getTxRequest.resolves(txRequest);
+      getTxRequest.calledWith(txRequestId);
+
+      const signedTxRequest = await tssUtils.signTxRequest(txRequestId, userPShare, reqId);
+      signedTxRequest.should.deepEqual(txRequest);
+      sinon.assert.calledTwice(getTxRequest);
+
+      sandbox.verifyAndRestore();
     });
   });
 
@@ -356,22 +370,6 @@ describe('TSS Utils:', async function () {
       });
 
       nockedCreateTx.isDone().should.be.true();
-    });
-  });
-
-  describe('getUserPShare:', async function() {
-    it('should succeed to get the user P Share', async function() {
-      const nock = await nockUserKey({ coin: coinName });
-      const userPShare = await tssUtils.getUserPShare(reqId, walletPassphrase);
-      userPShare.should.equal(validUserPShare);
-      nock.isDone().should.equal(true);
-    });
-
-    it('should fail if the password is wrong', async function() {
-      const nock = await nockUserKey({ coin: coinName });
-      const wrongPassword = 'randompass';
-      await tssUtils.getUserPShare(reqId, wrongPassword ).should.be.rejectedWith('password error - ccm: tag doesn\'t match');
-      nock.isDone().should.equal(true);
     });
   });
 
@@ -468,21 +466,21 @@ describe('TSS Utils:', async function () {
       await tssUtils.getBitgoToUserRShare(txRequest.txRequestId).should.be.rejectedWith('No signatures shares found for id: ' + txRequest.txRequestId);
       nock.isDone().should.equal(true);
     });
-
-    it('should fail if there is no txRequest', async function() {
-      const response = { txRequests: [] };
-      const nock = await nockGetTxRequest({ walletId: wallet.id(), txRequestId: txRequest.txRequestId, response });
-      await tssUtils.getBitgoToUserRShare(txRequest.txRequestId).should.be.rejectedWith('No txRequest found for id: ' + txRequest.txRequestId);
-      nock.isDone().should.equal(true);
-    });
   });
 
   describe('getTxRequest:', async function() {
-    it('should succeed to get txRequest by id', async function() {
+    it('should succeed to get txRequest by id', async function () {
       const response = { txRequests: [txRequest] };
       const nock = await nockGetTxRequest({ walletId: wallet.id(), txRequestId: txRequest.txRequestId, response });
       const txReq = await tssUtils.getTxRequest(txRequest.txRequestId);
-      txReq.should.deepEqual(response);
+      txReq.should.deepEqual(txRequest);
+      nock.isDone().should.equal(true);
+    });
+
+    it('should fail if there are no txRequests', async function () {
+      const response = { txRequests: [] };
+      const nock = await nockGetTxRequest({ walletId: wallet.id(), txRequestId: txRequest.txRequestId, response });
+      await tssUtils.getTxRequest(txRequest.txRequestId).should.be.rejectedWith('Unable to find TxRequest with id randomId');
       nock.isDone().should.equal(true);
     });
   });
@@ -624,27 +622,6 @@ describe('TSS Utils:', async function () {
       .reply(200, backupKeychain);
 
     return backupKeychain;
-  }
-
-  async function nockUserKey(params: {
-    coin: string,
-  }): Promise<nock.Scope> {
-    const userKeychain: Keychain = {
-      id: '1',
-      pub: '',
-      // source: 'user',
-      // type: 'tss',
-      addressDerivationKeypair: {
-        pub: '62d29SxqRcvQgt3se81mpCtaY7DmF7ikqYkxqX8MkZQ7',
-        encryptedPrv: '{"iv":"006X48Gm8u13yR7vg//gIA==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"NmbmXejhE6s=","ct":"WCDi17IA1NEWCeMUQhajelWceueXdHMgpIbt8EftIQW44mi+Komxa33xDW8DJVTR7RPjp5MEC38NeSw5McLc+vit1FvrHg/VGyhFsoMZgILIORZK/LrC617Wvc16dyyE"}',
-      },
-      commonPub: 'EFpAC5x8eP3L9a4YSXSiuf8NZfXchU6yWJREWvvpNBhs',
-      encryptedPrv: '{"iv":"W6QRXzBSkeCD8dFyO0FnBg==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"fsJ5Oz3vcr4=","ct":"99J8zy0i8berN7/qLFiyItD8esL1b4o741YlDwy4SWOo9oJ4SuBjjGV/NODgYNg+z/a9Er9QqH5h1KFsuakcWt+Hd3fcZd6h384CDwtHKGWLCJueHXffcyaTlMnMQOVdKZct/T3gm5zhy6+9uE27cBUz3C6wr9SxUf55I4xo8XXppWDlt307+Y7W1orf4/luL4MIoadlVaRE22znz6FUT5KgkNTaVcgVZ2wqUoAJZE6ElHeJ05akiOAziu0E4lzMIfueHTkFBVOdljSCVTuIUVgmoN6QEj44ZyxRhcwzDEcUgYoY0W1lwMsv4w=="}',
-    };
-
-    return nock('https://bitgo.fakeurl')
-      .get(`/api/v2/${params.coin}/key/5b3424f91bf349930e34017500000000`, )
-      .reply(200, userKeychain);
   }
 
   async function nockSendTxRequest(params: {coin:string, walletId: string, txRequestId: string}): Promise<nock.Scope> {

--- a/modules/core/test/v2/unit/wallet.ts
+++ b/modules/core/test/v2/unit/wallet.ts
@@ -13,10 +13,13 @@ import { CustomSigningFunction, Wallet } from '../../../src/';
 import * as common from '../../../src/common';
 
 import { TestBitGo } from '../../lib/test_bitgo';
+import { TssUtils, TxRequest } from '../../../src/v2/internal/tssUtils';
+import { RequestTracer } from '../../../src/v2/internal/util';
 
 nock.disableNetConnect();
 
 describe('V2 Wallet:', function () {
+  const reqId = new RequestTracer();
   const bitgo = new TestBitGo({ env: 'test' });
   bitgo.initializeTestVars();
   const basecoin = bitgo.coin('tbtc');
@@ -1427,6 +1430,232 @@ describe('V2 Wallet:', function () {
           .reply(200, {});
       await wallet.freeze(params);
       scope.isDone().should.be.True();
+    });
+  });
+
+  describe('TSS Wallets', function () {
+    const sandbox = sinon.createSandbox();
+    const tsol = bitgo.coin('tsol');
+    const walletData = {
+      id: '5b34252f1bf349930e34020a00000000',
+      coin: 'tsol',
+      keys: [
+        '5b3424f91bf349930e34017500000000',
+        '5b3424f91bf349930e34017600000000',
+        '5b3424f91bf349930e34017700000000',
+      ],
+      coinSpecific: {},
+      multisigType: 'tss',
+    };
+    const tssWallet = new Wallet(bitgo, tsol, walletData);
+
+    const txRequest: TxRequest = {
+      txRequestId: 'id',
+      unsignedTxs: [
+        {
+          serializedTx: 'ababcdcd',
+          signableHex: 'deadbeef',
+        },
+      ],
+    };
+
+    afterEach(function () {
+      sandbox.verifyAndRestore();
+    });
+
+    describe('Transaction prebuilds', function () {
+      it('should build a single recipient transfer transaction', async function () {
+        const recipients = [{
+          address: '6DadkZcx9JZgeQUDbHh12cmqCpaqehmVxv6sGy49jrah',
+          amount: '1000',
+        }];
+
+        const prebuildTxWithIntent = sandbox.stub(TssUtils.prototype, 'prebuildTxWithIntent');
+        prebuildTxWithIntent.resolves(txRequest);
+        prebuildTxWithIntent.calledOnceWithExactly({
+          reqId,
+          recipients,
+          intentType: 'payment',
+        });
+
+        const txPrebuild = await tssWallet.prebuildTransaction({
+          reqId,
+          recipients,
+          type: 'transfer',
+        });
+
+        txPrebuild.should.deepEqual({
+          walletId: tssWallet.id(),
+          wallet: tssWallet,
+          txRequestId: 'id',
+          txHex: 'ababcdcd',
+        });
+      });
+
+      it('should build a multiple recipient transfer transaction with memo', async function () {
+        const recipients = [{
+          address: '6DadkZcx9JZgeQUDbHh12cmqCpaqehmVxv6sGy49jrah',
+          amount: '1000',
+        }, {
+          address: '6DadkZcx9JZgeQUDbHh12cmqCpaqehmVxv6sGy49jrah',
+          amount: '2000',
+        }];
+
+        const prebuildTxWithIntent = sandbox.stub(TssUtils.prototype, 'prebuildTxWithIntent');
+        prebuildTxWithIntent.resolves(txRequest);
+        prebuildTxWithIntent.calledOnceWithExactly({
+          reqId,
+          recipients,
+          intentType: 'payment',
+          memo: {
+            type: 'type',
+            value: 'test memo'
+          },
+        });
+
+        const txPrebuild = await tssWallet.prebuildTransaction({
+          reqId,
+          recipients,
+          type: 'transfer',
+          memo: {
+            type: 'type',
+            value: 'test memo'
+          }
+        });
+
+        txPrebuild.should.deepEqual({
+          walletId: tssWallet.id(),
+          wallet: tssWallet,
+          txRequestId: 'id',
+          txHex: 'ababcdcd',
+        });
+      });
+
+      it('should fail for non-transfer transaction types', async function () {
+        await tssWallet.prebuildTransaction({
+          reqId,
+          recipients: [{
+            address: '6DadkZcx9JZgeQUDbHh12cmqCpaqehmVxv6sGy49jrah',
+            amount: '1000',
+          }],
+          type: 'stake',
+        }).should.be.rejectedWith('transaction type not supported: stake');
+      });
+    });
+
+    describe('Transaction signing', function () {
+      it('should sign transaction', async function () {
+        const signTxRequest = sandbox.stub(TssUtils.prototype, 'signTxRequest');
+        signTxRequest.resolves(txRequest);
+        signTxRequest.calledOnceWithExactly(txRequest, 'secretKey', reqId);
+
+        const txPrebuild = {
+          walletId: tssWallet.id(),
+          wallet: tssWallet,
+          txRequestId: 'id',
+          txHex: 'ababcdcd',
+        };
+        const signedTransaction = await tssWallet.signTransaction({
+          reqId,
+          txPrebuild,
+          prv: 'sercretKey',
+        });
+        signedTransaction.should.deepEqual({
+          txRequestId: txRequest.txRequestId,
+        });
+      });
+
+      it('should fail to sign transaction without txRequestId', async function () {
+        const txPrebuild = {
+          walletId: tssWallet.id(),
+          wallet: tssWallet,
+          txHex: 'ababcdcd',
+        };
+        await tssWallet.signTransaction({
+          reqId,
+          txPrebuild,
+          prv: 'sercretKey',
+        }).should.be.rejectedWith('txRequestId required to sign transactions with TSS');
+      });
+    });
+
+    describe('Send Many', function () {
+      const sendManyInput = {
+        type: 'transfer',
+        recipients: [{
+          address: 'address',
+          amount: '1000'
+        }],
+      };
+
+      it('should send many', async function () {
+        const signedTransaction = {
+          txRequestId: 'txRequestId',
+        };
+
+        const prebuildAndSignTransaction = sandbox.stub(tssWallet, 'prebuildAndSignTransaction');
+        prebuildAndSignTransaction.resolves(signedTransaction);
+        prebuildAndSignTransaction.calledOnceWithExactly(sendManyInput);
+
+        const sendTxRequest = sandbox.stub(TssUtils.prototype, 'sendTxRequest');
+        sendTxRequest.resolves('sendTxResponse');
+        sendTxRequest.calledOnceWithExactly(signedTransaction.txRequestId);
+
+        const sendMany = await tssWallet.sendMany(sendManyInput);
+        sendMany.should.deepEqual('sendTxResponse');
+      });
+
+      it('should fail if txRequestId is missing from prebuild', async function () {
+        const signedTransaction = {
+          txHex: 'deadbeef',
+        };
+
+        const prebuildAndSignTransaction = sandbox.stub(tssWallet, 'prebuildAndSignTransaction');
+        prebuildAndSignTransaction.resolves(signedTransaction);
+        prebuildAndSignTransaction.calledOnceWithExactly(sendManyInput);
+
+        await tssWallet.sendMany(sendManyInput).should.be.rejectedWith('txRequestId missing from signed transaction');
+      });
+    });
+
+    describe('Submit transaction', function () {
+      it('should submit transaction with txRequestId', async function () {
+        const nockSendTx = nock(bgUrl)
+          .persist(false)
+          .post(tssWallet.url('/tx/send').replace(bgUrl, ''))
+          .reply(200, { message: 'success' });
+
+        const submittedTx = await tssWallet.submitTransaction({
+          txRequestId: 'id',
+        });
+        submittedTx.should.deepEqual({ message: 'success' });
+        nockSendTx.isDone().should.be.true();
+      });
+
+      it('should fail when txRequestId and txHex are both provided', async function () {
+        await tssWallet.submitTransaction({
+          txRequestId: 'id',
+          txHex: 'beef',
+        }).should.be.rejectedWith('must supply exactly one of txRequestId, txHex, or halfSigned');
+      });
+
+      it('should fail when txRequestId and halfSigned are both provided', async function () {
+        await tssWallet.submitTransaction({
+          txRequestId: 'id',
+          halfSigned: {
+            txHex: 'beef',
+          },
+        }).should.be.rejectedWith('must supply exactly one of txRequestId, txHex, or halfSigned');
+      });
+
+      it('should fail when txHex and halfSigned are both provided', async function () {
+        await tssWallet.submitTransaction({
+          txHex: 'beef',
+          halfSigned: {
+            txHex: 'beef',
+          },
+        }).should.be.rejectedWith('must supply either txHex or halfSigned, but not both');
+      });
     });
   });
 });


### PR DESCRIPTION
adds functionality to build, sign, and send transactions from a
tss wallets. previously, sendMany would handle this, but we want to be
able to build, sign, and send independently.

Ticket: STLX-13780

this change is needed to support UI clients, where the build, sign, and send operations are performed separately. this is typically:
1. User builds transaction
2. Client displays details for user to review
3. User inputs password
4. Client signs and sends transaction

sample script that mimics the above:
```
async function prebuildTransaction() {
  const wallet = await bitgo.coin('tsol').wallets().get({ id: walletId });
  console.log(wallet);
  const builtTx = await wallet.prebuildTransaction({
    recipients: [{
      address: '6DadkZcx9JZgeQUDbHh12cmqCpaqehmVxv6sGy49jrah',
      amount: '1000'
    }],
    type: 'transfer',
  });

  return builtTx;
}

async function prebuildAndSignTx(prebuiltTransaction) {
  const wallet = await bitgo.coin('tsol').wallets().get({ id: walletId });
  const prebuildAndSignTx = await wallet.prebuildAndSignTransaction({ prebuildTx: prebuiltTransaction, walletPassphrase: 'Ghghjkg!455544llll' });

  return prebuildAndSignTx;
}

async function submitTx(signedTx) {
  const wallet = await bitgo.coin('tsol').wallets().get({ id: walletId });
  const sentTx = await wallet.submitTransaction(signedTx);

  console.log('sentTx', JSON.stringify(sentTx, undefined, 2));
}

prebuildTransaction()
  .then(prebuildAndSignTx)
  .then(submitTx)
  .catch(console.error);
```