### PR TITLE
fix(core): support password reset and enterprise with MPC

### DIFF
--- a/modules/core/src/v2/internal/mpcUtils.ts
+++ b/modules/core/src/v2/internal/mpcUtils.ts
@@ -1,3 +1,7 @@
+/**
+ * @prettier
+ */
+
 import { BitGo } from '../../bitgo';
 import { BaseCoin, KeychainsTriplet } from '../baseCoin';
 
@@ -14,6 +18,12 @@ export abstract class MpcUtils {
    * Creates User, Backup, and BitGo MPC Keychains.
    *
    * @param params.passphrase - passphrase used to encrypt signing materials created for User and Backup
+   * @param params.enterprise - optional enterprise id that will be attached to the BitGo Keychain
+   * @param params.originalPasscodeEncryptionCode - optional encryption code used to reset the user's password, if absent, password recovery will not work
    */
-  abstract createKeychains(params: { passphrase: string }): Promise<KeychainsTriplet>;
+  abstract createKeychains(params: {
+    passphrase: string;
+    enterprise?: string;
+    originalPasscodeEncryptionCode?: string;
+  }): Promise<KeychainsTriplet>;
 }

--- a/modules/core/src/v2/keychains.ts
+++ b/modules/core/src/v2/keychains.ts
@@ -106,6 +106,8 @@ interface CreateBitGoOptions {
 interface CreateMpcOptions {
   multisigType: 'onchain' | 'tss' | 'blsdkg';
   passphrase: string;
+  originalPasscodeEncryptionCode?: string;
+  enterprise?: string;
 }
 
 interface GetKeysForSigningOptions {


### PR DESCRIPTION
Create Keychains with originalPasscodeEncryptionCode and enterprise
populated if client provides as input.

`originalPasscodeEncryptionCode` is sent when creating the User key.
`enterprise` is sent when creating  the BitGo Key and Wallet

Ticket: STLX-14231