### PR TITLE
feat: enable external signer mode for production

### DIFF
--- a/modules/express/src/expressApp.ts
+++ b/modules/express/src/expressApp.ts
@@ -217,10 +217,6 @@ function checkPreconditions(config: Config) {
     config.env = 'custom';
   }
 
-  if (env !== 'test' && (externalSignerUrl !== undefined || signerMode !== undefined)) {
-    throw new ExternalSignerConfigError('external signer feature is only enabled for test mode.');
-  }
-
   if (externalSignerUrl !== undefined && (signerMode !== undefined || signerFileSystemPath !== undefined)) {
     throw new ExternalSignerConfigError(
       'signerMode or signerFileSystemPath is set, but externalSignerUrl is also set.'

--- a/modules/express/test/unit/bitgoExpress.ts
+++ b/modules/express/test/unit/bitgoExpress.ts
@@ -464,32 +464,5 @@ describe('Bitgo Express', function () {
       (() => expressApp(args)).should.not.throw();
       readValidStub.restore();
     });
-
-    it('should require express to be in test mode when using the external signer feature', function () {
-      const readValidStub = sinon.stub(fs, 'readFileSync').returns(validPrvJSON);
-
-      const args: any = {
-        env: 'notTestMode',
-        signerMode: 'signerMode',
-        signerFileSystemPath: 'signerFileSystemPath',
-      };
-      (() => expressApp(args)).should.throw({
-        name: 'ExternalSignerConfigError',
-        message: 'external signer feature is only enabled for test mode.'
-      });
-
-      args.signerMode = undefined;
-      args.signerFileSystemPath = undefined;
-      args.externalSignerUrl = 'externalSignerUrl';
-      (() => expressApp(args)).should.throw({
-        name: 'ExternalSignerConfigError',
-        message: 'external signer feature is only enabled for test mode.'
-      });
-
-      args.env = 'test';
-      (() => expressApp(args)).should.not.throw();
-
-      readValidStub.restore();
-    });
   });
 });


### PR DESCRIPTION
remove the restriction that allowed the external signer to be used only in a test env

Note: This should only be merged after the following PRs have been merged
- #2069
- #2080
- #2082

Ticket: BG-43925