### PR TITLE
feat: support validation of  base58 dot public keys

### DIFF
--- a/modules/account-lib/src/coin/dot/keyPair.ts
+++ b/modules/account-lib/src/coin/dot/keyPair.ts
@@ -5,7 +5,7 @@ import { Ed25519KeyPair } from '../baseCoin';
 import { AddressFormat } from '../baseCoin/enum';
 import { DefaultKeys, KeyPairOptions } from '../baseCoin/iface';
 import utils from './utils';
-import { toHex } from '../../utils/crypto';
+import { toHex, isBase58 } from '../../utils/crypto';
 import bs58 from 'bs58';
 
 const TYPE = 'ed25519';
@@ -58,19 +58,10 @@ export class KeyPair extends Ed25519KeyPair {
   /** @inheritdoc */
   recordKeysFromPublicKeyInProtocolFormat(pub: string): DefaultKeys {
     const publicKey = keyring.addFromPair({
-      publicKey: this.isBase58(pub) ? new Uint8Array(bs58.decode(pub)) : new Uint8Array(Buffer.from(pub, 'hex')),
+      // tss common pub is in base58 format and decodes to length of 32
+      publicKey: isBase58(pub, 32) ? new Uint8Array(bs58.decode(pub)) : new Uint8Array(Buffer.from(pub, 'hex')),
       secretKey: new Uint8Array(),
     }).publicKey;
     return { pub: toHex(publicKey) };
-  }
-
-  private isBase58(pub: string): boolean {
-    try {
-      bs58.decode(pub);
-    } catch (e) {
-      return false;
-    }
-
-    return true;
   }
 }

--- a/modules/account-lib/src/coin/dot/utils.ts
+++ b/modules/account-lib/src/coin/dot/utils.ts
@@ -16,6 +16,8 @@ import { HexString, Material, ProxyArgs, ProxyCallArgs, TransferArgs, TxMethod }
 import nacl from 'tweetnacl';
 import { BaseCoin as CoinConfig, DotNetwork } from '@bitgo/statics';
 import { createTypeUnsafe, GenericCall, GenericExtrinsic, GenericExtrinsicPayload } from '@polkadot/types';
+import bs58 from 'bs58';
+import { isBase58 } from './../../utils/crypto';
 
 const PROXY_METHOD_ARG = 2;
 export class Utils implements BaseUtils {
@@ -46,7 +48,16 @@ export class Utils implements BaseUtils {
 
   /** @inheritdoc */
   isValidPublicKey(key: string): boolean {
-    return isValidEd25519PublicKey(key);
+    let pubKey = key;
+
+    // convert base58 pub key to hex format
+    // tss common pub is in base58 format and decodes to length of 32
+    if (isBase58(pubKey, 32)) {
+      const base58Decode = bs58.decode(pubKey);
+      pubKey = base58Decode.toString('hex');
+    }
+
+    return isValidEd25519PublicKey(pubKey);
   }
 
   /** @inheritdoc */

--- a/modules/account-lib/src/coin/near/utils.ts
+++ b/modules/account-lib/src/coin/near/utils.ts
@@ -1,5 +1,6 @@
 import { BaseUtils } from '../baseCoin';
 import { KeyPair } from './keyPair';
+import { isBase58 } from './../../utils/crypto';
 import bs58 from 'bs58';
 
 export class Utils implements BaseUtils {
@@ -10,7 +11,7 @@ export class Utils implements BaseUtils {
 
   /** @inheritdoc */
   isValidBlockId(hash: string): boolean {
-    return this.isBase58(hash, 32);
+    return isBase58(hash, 32);
   }
 
   /** @inheritdoc */
@@ -37,28 +38,12 @@ export class Utils implements BaseUtils {
 
   /** @inheritdoc */
   isValidSignature(signature: string): boolean {
-    return this.isBase58(signature, 64);
+    return isBase58(signature, 64);
   }
 
   /** @inheritdoc */
   isValidTransactionId(txId: string): boolean {
-    return this.isBase58(txId, 32);
-  }
-
-  /**
-   * Check if base58 decoded string is equale to length
-   *
-   * @param {string} value - string to be checked
-   * @param {number} length - expected decoded length
-   * @return {boolean} if the string can decoded as base58 and match the expected length
-   */
-
-  isBase58(value: string, length: number): boolean {
-    try {
-      return !!value && bs58.decode(value).length === length;
-    } catch (e) {
-      return false;
-    }
+    return isBase58(txId, 32);
   }
 
   base58Encode(value: Uint8Array): string {

--- a/modules/account-lib/src/utils/crypto.ts
+++ b/modules/account-lib/src/utils/crypto.ts
@@ -6,6 +6,7 @@ import * as bls from 'noble-bls12-381';
 import { stripHexPrefix } from 'ethereumjs-utils-old';
 import { ExtendedKeys } from '../coin/baseCoin/iface';
 import { toUint8Array } from '../coin/hbar/utils';
+import bs58 from 'bs58';
 
 /**
  * @param {string} xpub - a base-58 encoded extended public key (BIP32)
@@ -207,4 +208,20 @@ export function toHex(buffer: Buffer | Uint8Array): string {
 export function bigIntToHex(bigint: bigint): string {
   const hex = bigint.toString(16);
   return '0x' + '0'.slice(0, hex.length % 2) + hex;
+}
+
+/**
+ * Check if base58 decoded string is equale to length
+ *
+ * @param {string} value - string to be checked
+ * @param {number} length - expected decoded length
+ * @return {boolean} if the string can decoded as base58 and match the expected length
+ */
+
+export function isBase58(value: string, length: number): boolean {
+  try {
+    return !!value && bs58.decode(value).length === length;
+  } catch (e) {
+    return false;
+  }
 }

--- a/modules/account-lib/test/unit/coin/dot/utils.ts
+++ b/modules/account-lib/test/unit/coin/dot/utils.ts
@@ -30,6 +30,10 @@ describe('utils', () => {
     should.equal(utils.isValidPublicKey(accounts.account4.publicKey), true);
   });
 
+  it('should validate base58 key correctly', () => {
+    should.equal(utils.isValidPublicKey(accounts.bs58Account.publicKey), true);
+  });
+
   it('should validate private key correctly', () => {
     should.equal(utils.isValidPrivateKey(accounts.account1.secretKey), true);
     should.equal(utils.isValidPrivateKey(accounts.account2.secretKey), true);

--- a/yarn.lock
+++ b/yarn.lock
@@ -14528,9 +14528,9 @@ uri-js@^4.2.2:
     punycode "^2.1.0"
 
 urijs@^1.19.1:
-  version "1.19.9"
-  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.9.tgz#3b15844835de3732866d420768c16f24be7d3e65"
-  integrity sha512-v0V+v5F3NQFt6TX0GpA2NKyrpythDJI+PHRo66sUIDP/U6cXbm6NqLVcXylQGwiwW5VYNj+OAei3EU0ALj9AWg==
+  version "1.19.10"
+  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.10.tgz#8e2fe70a8192845c180f75074884278f1eea26cb"
+  integrity sha512-EzauQlgKuJgsXOqoMrCiePBf4At5jVqRhXykF3Wfb8ZsOBMxPcfiVBcsHXug4Aepb/ICm2PIgqAUGMelgdrWEg==
 
 urix@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
This PR includes changes to support validating base58 public keys. During TSS wallet creation, base58 keys are generated and should be valid. Dot needs to validate hex keys therefore there is check added to determine whether a key is in base58 format and decodes to length of 32. If so, it should convert that to hex before validating. 

Closes TICKET: STLX-14315