### PR TITLE
feat(core): support creating algo wallets with seed

### DIFF
--- a/modules/core/test/v2/unit/coins/algo.ts
+++ b/modules/core/test/v2/unit/coins/algo.ts
@@ -649,6 +649,17 @@ describe('ALGO:', function () {
       basecoin.isValidPub(kp.pub).should.equal(true);
       basecoin.isValidPrv(kp.prv).should.equal(true);
     });
+
+    it('should deterministically derive keypair with seed', () => {
+      const derivedKeypair = basecoin.deriveKeyWithSeed({ key: 'UBI2KNGT742KGIPHMZDJHHSADIT56HRDPVOOCCRYIETD4BAJLCBMQNSCNE', seed: 'cold derivation seed' });
+      console.log(JSON.stringify(derivedKeypair));
+
+      basecoin.isValidPub(derivedKeypair.key).should.be.true();
+      derivedKeypair.should.deepEqual({
+        key: 'NAYUBR4HQKJBBTNNKXQIY7GMHUCHVAUH5DQ4ZVHVL67CUQLGHRWDKQAHYU',
+        derivationPath: "m/999999'/25725073'/5121434'",
+      });
+    });
   });
 
   describe('Enable, disable and transfer Token ', () => {


### PR DESCRIPTION
support creating algo wallets when client provides coldDerivationSeed

Ticket: BG-43801

Note: This is nearly identical to XLM's solution. We should generalize the solution for all ed25519 keys when we have the bandwidth: https://bitgoinc.atlassian.net/browse/BG-43801

verified wallet creation working as expected:
```
async function createTalgoWallet() {
  const newWallet = await bitgo.coin('talgo').wallets().generateWallet({
    label: 'joey test algo 3/9',
    userKey: 'UBI2KNGT742KGIPHMZDJHHSADIT56HRDPVOOCCRYIETD4BAJLCBMQNSCNE',
    coldDerivationSeed: 'this is my seed',
    backupXpub: '7M5KGULVPK3VKIMANQMEP3EN2EL5DMN4WGQJ3SM7ELYU4IEZ52UDDTOORA',
  });

  console.log(JSON.stringify(newWallet, undefined, 2));
}
```