### PR TITLE
fix(core): expose feeInfo when building txns from tx requests

### DIFF
--- a/modules/core/src/v2/internal/tssUtils.ts
+++ b/modules/core/src/v2/internal/tssUtils.ts
@@ -49,6 +49,10 @@ export interface TxRequest {
   unsignedTxs: {
     serializedTxHex: string;
     signableHex: string;
+    feeInfo?: {
+      fee: number;
+      feeString: string;
+    };
   }[];
   signatureShares?: SignatureShareRecord[];
 }

--- a/modules/core/src/v2/wallet.ts
+++ b/modules/core/src/v2/wallet.ts
@@ -128,6 +128,10 @@ export interface PrebuildTransactionResult extends TransactionPrebuild {
   consolidationDetails?: {
     senderAddressIndex: number;
   };
+  feeInfo?: {
+    fee?: number;
+    feeString?: string;
+  };
 }
 
 export interface CustomSigningFunction {
@@ -2749,6 +2753,7 @@ export class Wallet {
       txRequestId: unsignedTxRequest.txRequestId,
       txHex: unsignedTxs[0].serializedTxHex,
       buildParams: whitelistedParams,
+      feeInfo: unsignedTxs[0].feeInfo,
     };
   }
 

--- a/modules/core/test/v2/unit/wallet.ts
+++ b/modules/core/test/v2/unit/wallet.ts
@@ -1433,7 +1433,7 @@ describe('V2 Wallet:', function () {
       const getSharingKeyNock = nock(bgUrl)
         .post('/api/v1/user/sharingkey', { email })
         .reply(200, { userId, pubkey, path });
-      
+
       const getKeyNock = nock(bgUrl)
         .get(`/api/v2/tbtc/key/${wallet.keyIds()[0]}`)
         .reply(200, {
@@ -1456,7 +1456,7 @@ describe('V2 Wallet:', function () {
         }
       );
       await wallet.shareWallet({ email, permissions, walletPassphrase });
-      
+
       stub.calledOnce.should.be.true();
       getSharingKeyNock.isDone().should.be.True();
       getKeyNock.isDone().should.be.True();
@@ -1497,6 +1497,10 @@ describe('V2 Wallet:', function () {
         {
           serializedTxHex: 'ababcdcd',
           signableHex: 'deadbeef',
+          feeInfo: {
+            fee: 5000,
+            feeString: '5000',
+          }
         },
       ],
     };
@@ -1534,7 +1538,11 @@ describe('V2 Wallet:', function () {
           buildParams: {
             recipients,
             type: 'transfer',
-          }
+          },
+          feeInfo: {
+            fee: 5000,
+            feeString: '5000',
+          },
         });
       });
 
@@ -1581,7 +1589,11 @@ describe('V2 Wallet:', function () {
               value: 'test memo',
             },
             type: 'transfer',
-          }
+          },
+          feeInfo: {
+            fee: 5000,
+            feeString: '5000',
+          },
         });
       });
 
@@ -1625,6 +1637,10 @@ describe('V2 Wallet:', function () {
             },
             type: 'enabletoken',
             token,
+          },
+          feeInfo: {
+            fee: 5000,
+            feeString: '5000',
           },
         });
       });
@@ -1769,7 +1785,7 @@ describe('V2 Wallet:', function () {
         const getSharingKeyNock = nock(bgUrl)
           .post('/api/v1/user/sharingkey', { email })
           .reply(200, { userId, pubkey, path });
-        
+
         const getKeyNock = nock(bgUrl)
           .get(`/api/v2/tsol/key/${tssWallet.keyIds()[0]}`)
           .reply(200, {
@@ -1792,7 +1808,7 @@ describe('V2 Wallet:', function () {
           }
         );
         await tssWallet.shareWallet({ email, permissions, walletPassphrase });
-        
+
         stub.calledOnce.should.be.true();
         getSharingKeyNock.isDone().should.be.True();
         getKeyNock.isDone().should.be.True();


### PR DESCRIPTION
surface feeInfo in PrebuildTransactionResult when building transactions
with Tx Requests.

Ticket: STLX-14462