### PR TITLE
chore: update express API link in readme

### DIFF
--- a/modules/express/README.md
+++ b/modules/express/README.md
@@ -8,7 +8,7 @@ This ensures your keys never leave your network, and are not seen by BitGo. BitG
 
 # Documentation
 
-Comprehensive documentation on the APIs provided by BitGo Express can be found at our [Platform API Reference](https://www.bitgo.com/api/v2/#tag/Express).
+Comprehensive documentation on the APIs provided by BitGo Express can be found at our [Platform API Reference](https://app.bitgo.com/docs/#tag/Express).
 
 # Running BitGo Express
 


### PR DESCRIPTION
Was exploring SDK and Express, and found the current README link we have for express API is broken. 
I'm guessing this is the new one? - https://api.bitgo.com/docs/#tag/Express
