### PR TITLE
fix(utxo-lib): always verify ECDSA in strict mode

### DIFF
--- a/modules/utxo-lib/test/bitgo/signatureModify.ts
+++ b/modules/utxo-lib/test/bitgo/signatureModify.ts
@@ -1,0 +1,78 @@
+/* eslint-disable no-redeclare */
+import { script, ScriptSignature } from 'bitcoinjs-lib';
+import { isPlaceholderSignature, parseSignatureScript, UtxoTransaction } from '../../src/bitgo';
+
+const BN = require('bn.js');
+const EC = require('elliptic').ec;
+const secp256k1 = new EC('secp256k1');
+const n = secp256k1.curve.n;
+const nDiv2 = n.shrn(1);
+
+function changeSignatureToHighS(signatureBuffer: Buffer): Buffer {
+  if (!script.isCanonicalScriptSignature(signatureBuffer)) {
+    throw new Error(`not canonical`);
+  }
+  const { signature, hashType } = ScriptSignature.decode(signatureBuffer);
+
+  const r = signature.slice(0, 32);
+  const s = signature.slice(32);
+
+  if (r.length !== 32 || s.length !== 32) {
+    throw new Error(`invalid scalar length`);
+  }
+
+  let ss = new BN(s);
+
+  if (ss.cmp(nDiv2) > 0) {
+    throw new Error(`signature already has high s value`);
+  }
+
+  // convert to high-S
+  ss = n.sub(ss);
+
+  const newSig = ScriptSignature.encode(Buffer.concat([r, ss.toArrayLike(Buffer, 'be', 32)]), hashType);
+  if (!script.isCanonicalScriptSignature(newSig)) {
+    throw new Error(`newSig not canonical`);
+  }
+  return newSig;
+}
+
+function changeSignatureScriptToHighS(script: Buffer, signature: Buffer): Buffer;
+function changeSignatureScriptToHighS(witness: Buffer[], signature: Buffer): Buffer[];
+function changeSignatureScriptToHighS(v: Buffer | Buffer[], signature: Buffer): Buffer | Buffer[] {
+  const parts = Buffer.isBuffer(v) ? script.decompile(v) : v;
+  if (!parts) {
+    throw new Error(`could not decompile input`);
+  }
+  const newParts = parts.map((p) => {
+    if (typeof p === 'number') {
+      return p;
+    }
+    return p.equals(signature) ? changeSignatureToHighS(p) : Buffer.from(p);
+  });
+  return Buffer.isBuffer(v) ? script.compile(newParts) : (newParts as Buffer[]);
+}
+
+export function getTransactionWithHighS(tx: UtxoTransaction, inputIndex: number): UtxoTransaction[] {
+  const parsed = parseSignatureScript(tx.ins[inputIndex]);
+  switch (parsed.scriptType) {
+    case 'p2sh':
+    case 'p2shP2wsh':
+    case 'p2wsh':
+      break;
+    default:
+      return [];
+  }
+  return parsed.signatures.flatMap((signature) => {
+    if (isPlaceholderSignature(signature)) {
+      return [];
+    }
+    const cloned = tx.clone();
+    cloned.ins[inputIndex].script = changeSignatureScriptToHighS(cloned.ins[inputIndex].script, signature);
+    cloned.ins[inputIndex].witness = changeSignatureScriptToHighS(cloned.ins[inputIndex].witness, signature);
+    if (parseSignatureScript(cloned.ins[inputIndex]).scriptType !== parsed.scriptType) {
+      throw new Error(`could not parsed modified input`);
+    }
+    return [cloned];
+  });
+}


### PR DESCRIPTION
Per consensus rules, signatures must have a lower-S value

See https://github.com/bitcoin/bips/blob/master/bip-0146.mediawiki for 
details.

This change replaces the indirect call to `ecc.verify()` inside
`ECPair.verify()`[^1] with a direct call that sets the last argument
`strict` to `true`.

Note that this strict (low-S) verification is the default in the
`noble-secp256k1` library[^2], which is the prospective secp256k1 library going
forward.

Issue: BG-44787

----

adba1c287

test(utxo-lib): add test  for high-S ECDSA signatures

Add `verifySignature()` test where we take an existing signature and tweak
the signature `S` value to `n - S` (high-S).

The resulting signature is valid according to old consensus rules, but 
invalid according BIP-0146 which requires a low-S value.

https://github.com/bitcoin/bips/blob/master/bip-0146.mediawiki

Note that the test will fail in this commit, showing that we currently do
not reject high-S signatures. The fix is included in the next commit.

Issue: BG-44787

----

[^1]: https://github.com/bitcoinjs/ecpair/blob/d35a64c/ts_src/ecpair.ts#L215
[^2]: https://github.com/paulmillr/noble-secp256k1/blob/97aa518/index.ts#L1212