### PR TITLE
feat: add nft tokens to statics

### DIFF
--- a/modules/statics/src/account.ts
+++ b/modules/statics/src/account.ts
@@ -134,6 +134,20 @@ export class Base58ContractAddressDefinedToken extends AccountCoinToken {
 export class Erc20Coin extends ContractAddressDefinedToken {}
 
 /**
+ * ERC 721 is the non fungible token standard for the Ethereum blockchain.
+ *
+ * {@link https://eips.ethereum.org/EIPS/eip-721 EIP721}
+ */
+export class Erc721Coin extends ContractAddressDefinedToken {}
+
+/**
+ * ERC 1155 is the multi token standard for the Ethereum blockchain.
+ *
+ * {@link https://eips.ethereum.org/EIPS/eip-1155 EIP1155}
+ */
+export class Erc1155Coin extends ContractAddressDefinedToken {}
+
+/**
  * The TRON blockchain supports tokens of the ERC20 standard similar to ETH ERC20 tokens.
  */
 export class TronErc20Coin extends Base58ContractAddressDefinedToken {}
@@ -407,6 +421,136 @@ export function terc20(
   network: EthereumNetwork = Networks.test.kovan
 ) {
   return erc20(name, fullName, decimalPlaces, contractAddress, asset, features, prefix, suffix, network);
+}
+
+/**
+ * Factory function for erc721 token instances.
+ *
+ * @param name unique identifier of the token
+ * @param fullName Complete human-readable name of the token
+ * @param contractAddress Contract address of this token
+ * @param features? Features of this coin. Defaults to the DEFAULT_FEATURES defined in `AccountCoin`
+ * @param prefix? Optional token prefix. Defaults to empty string
+ * @param suffix? Optional token suffix. Defaults to token name.
+ * @param network? Optional token network. Defaults to Ethereum main network.
+ * @param features? Features of this coin. Defaults to the DEFAULT_FEATURES defined in `AccountCoin`
+ * @param primaryKeyCurve The elliptic curve for this chain/token
+ */
+export function erc721(
+  name: string,
+  fullName: string,
+  contractAddress: string,
+  features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
+  prefix = '',
+  suffix: string = name.toUpperCase(),
+  network: EthereumNetwork = Networks.main.ethereum,
+  primaryKeyCurve: KeyCurve = KeyCurve.Secp256k1
+) {
+  return Object.freeze(
+    new Erc721Coin({
+      name,
+      fullName,
+      network,
+      contractAddress,
+      prefix,
+      suffix,
+      features,
+      decimalPlaces: 0,
+      asset: UnderlyingAsset.ERC721,
+      isToken: true,
+      primaryKeyCurve,
+    })
+  );
+}
+
+/**
+ * Factory function for testnet erc721 token instances.
+ *
+ * @param name unique identifier of the token
+ * @param fullName Complete human-readable name of the token
+ * @param contractAddress Contract address of this token
+ * @param features? Features of this coin. Defaults to the DEFAULT_FEATURES defined in `AccountCoin`
+ * @param prefix? Optional token prefix. Defaults to empty string
+ * @param suffix? Optional token suffix. Defaults to token name.
+ * @param network? Optional token network. Defaults to Goerli test network.
+ * @param primaryKeyCurve The elliptic curve for this chain/token
+ */
+export function terc721(
+  name: string,
+  fullName: string,
+  contractAddress: string,
+  features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
+  prefix = '',
+  suffix: string = name.toUpperCase(),
+  network: EthereumNetwork = Networks.test.goerli,
+  primaryKeyCurve: KeyCurve = KeyCurve.Secp256k1
+) {
+  return erc721(name, fullName, contractAddress, features, prefix, suffix, network, primaryKeyCurve);
+}
+
+/**
+ * Factory function for erc1155 token instances.
+ *
+ * @param name unique identifier of the token
+ * @param fullName Complete human-readable name of the token
+ * @param contractAddress Contract address of this token
+ * @param features? Features of this coin. Defaults to the DEFAULT_FEATURES defined in `AccountCoin`
+ * @param prefix? Optional token prefix. Defaults to empty string
+ * @param suffix? Optional token suffix. Defaults to token name.
+ * @param network? Optional token network. Defaults to Ethereum main network.
+ * @param features? Features of this coin. Defaults to the DEFAULT_FEATURES defined in `AccountCoin`
+ * @param primaryKeyCurve The elliptic curve for this chain/token
+ */
+export function erc1155(
+  name: string,
+  fullName: string,
+  contractAddress: string,
+  features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
+  prefix = '',
+  suffix: string = name.toUpperCase(),
+  network: EthereumNetwork = Networks.main.ethereum,
+  primaryKeyCurve: KeyCurve = KeyCurve.Secp256k1
+) {
+  return Object.freeze(
+    new Erc1155Coin({
+      name,
+      fullName,
+      network,
+      contractAddress,
+      prefix,
+      suffix,
+      features,
+      decimalPlaces: 0,
+      asset: UnderlyingAsset.ERC1155,
+      isToken: true,
+      primaryKeyCurve,
+    })
+  );
+}
+
+/**
+ * Factory function for testnet erc1155 token instances.
+ *
+ * @param name unique identifier of the token
+ * @param fullName Complete human-readable name of the token
+ * @param contractAddress Contract address of this token
+ * @param features? Features of this coin. Defaults to the DEFAULT_FEATURES defined in `AccountCoin`
+ * @param prefix? Optional token prefix. Defaults to empty string
+ * @param suffix? Optional token suffix. Defaults to token name.
+ * @param network? Optional token network. Defaults to Goerli test network.
+ * @param primaryKeyCurve The elliptic curve for this chain/token
+ */
+export function terc1155(
+  name: string,
+  fullName: string,
+  contractAddress: string,
+  features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
+  prefix = '',
+  suffix: string = name.toUpperCase(),
+  network: EthereumNetwork = Networks.test.goerli,
+  primaryKeyCurve: KeyCurve = KeyCurve.Secp256k1
+) {
+  return erc1155(name, fullName, contractAddress, features, prefix, suffix, network, primaryKeyCurve);
 }
 
 /**

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -764,6 +764,9 @@ export enum UnderlyingAsset {
   'avaxc:usdt' = 'avaxc:usdt',
   'avaxc:usdc' = 'avaxc:usdc',
   'avaxc:link' = 'avaxc:link',
+
+  ERC721 = 'erc721',
+  ERC1155 = 'erc1155',
 }
 
 /**

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -20,6 +20,8 @@ import {
   solToken,
   tsolToken,
   tfiatToken,
+  terc721,
+  erc721,
 } from './account';
 import { CoinFeature, CoinKind, KeyCurve, UnderlyingAsset } from './base';
 import { CoinMap } from './map';
@@ -1123,6 +1125,9 @@ export const coins = CoinMap.fromCoins([
   terc20('tdai', 'Test DAI', 18, '0x4f96fe3b7a6cf9725f59d353f723c1bdb64ca6aa', UnderlyingAsset.TERC20),
   terc20('trif', 'Test RIF Token', 18, '0x19f64674d8a5b4e652319f5e239efd3bc969a1fe', UnderlyingAsset.RIF),
   tceloToken('tcusd', 'Test Celo USD Token', 18, '0x874069fa1eb16d44d622f2e0ca25eea172369bc1', UnderlyingAsset.CUSD),
+  erc721('erc721:witch', 'Crypto Coven', '0x5180db8f5c931aae63c74266b211f580155ecac8'),
+  terc721('terc721:bitgoerc721', 'Test BITGO ERC 721 Token', '0x8397b091514c1f7bebb9dea6ac267ea23b570605'),
+  terc721('terc1155:bitgoerc1155', 'Test BITGO ERC 1155 Token', '0x87cd6a40640befdd96e563b788a6b1fb3e07a186'),
   tofcerc20('ofcterc', 'Test ERC Token', 0, UnderlyingAsset.TERC),
   tofcerc20('ofctest', 'Test Mintable ERC20 Token', 18, UnderlyingAsset.TEST),
   tstellarToken(


### PR DESCRIPTION
Add supports for nft tokens to statics.

We add two testnet tokens: a test ERC721 and a test ERC1155 and we add a ERC721 token in mainnet: Crypto Covens which will be using for testing.

https://opensea.io/collection/cryptocoven

ticket: BG-44467