### PR TITLE
feat: update params to post /signatureshares

### DIFF
--- a/modules/core/src/v2/internal/tssUtils.ts
+++ b/modules/core/src/v2/internal/tssUtils.ts
@@ -396,12 +396,21 @@ export class TssUtils extends MpcUtils {
    *
    * @param {String} txRequestId - the txRequest Id
    * @param {SignatureShareRecord} signatureShare - a Signature Share
+   * @returns {string} path - a bip32 path, required when signing for a derived address.
+   * When the path is not provided, signing will happen with the root wallet address.
    * @returns {Promise<SignatureShareRecord>} - a Signature Share
    */
-  async sendSignatureShare(txRequestId: string, signatureShare: SignatureShareRecord): Promise<SignatureShareRecord> {
+  async sendSignatureShare(
+    txRequestId: string,
+    signatureShare: SignatureShareRecord,
+    path?: string
+  ): Promise<SignatureShareRecord> {
     return this.bitgo
       .post(this.bitgo.url('/wallet/' + this.wallet.id() + '/txrequests/' + txRequestId + '/signatureshares', 2))
-      .send(signatureShare)
+      .send({
+        signatureShare,
+        path,
+      })
       .result();
   }
 

--- a/modules/core/test/v2/unit/internal/tssUtils.ts
+++ b/modules/core/test/v2/unit/internal/tssUtils.ts
@@ -699,7 +699,7 @@ describe('TSS Utils:', async function () {
 
   async function nockSendSignatureShare(params: { walletId: string, txRequestId: string, signatureShare: any}, status = 200): Promise<nock.Scope> {
     return nock('https://bitgo.fakeurl')
-      .post(`/api/v2/wallet/${params.walletId}/txrequests/${params.txRequestId}/signatureshares`, params.signatureShare )
+      .post(`/api/v2/wallet/${params.walletId}/txrequests/${params.txRequestId}/signatureshares`, { signatureShare: params.signatureShare } )
       .reply(status, (status === 200 ? params.signatureShare : { error: 'some error' }));
   }
 


### PR DESCRIPTION
In preparation for TSS HD Wallets, we now need an optional `path` parameter when signing transactions with signature shares.