### PR TITLE
feat(account-lib): add solana util functions for use in wp, refactor

### DIFF
--- a/modules/account-lib/test/unit/coin/sol/transactionBuilder/ataInitBuilder.ts
+++ b/modules/account-lib/test/unit/coin/sol/transactionBuilder/ataInitBuilder.ts
@@ -88,7 +88,7 @@ describe('Sol Associated Token Account Builder', () => {
     describe('Fail', () => {
       it('build an associated token account init tx when mint is invalid', () => {
         const txBuilder = ataInitBuilder();
-        should(() => txBuilder.mint('invalidToken')).throwError("coin 'invalidToken' is not defined");
+        should(() => txBuilder.mint('invalidToken')).throwError('Invalid transaction: invalid mint, got: invalidToken');
       });
 
       it('build a wallet init tx and sign with an incorrect account', async () => {
@@ -124,7 +124,9 @@ describe('Sol Associated Token Account Builder', () => {
 
       it('build when mint is invalid', async () => {
         const txBuilder = factory.getAtaInitializationBuilder();
-        should(() => txBuilder.mint('sol:invalid mint')).throwError("coin 'sol:invalid mint' is not defined");
+        should(() => txBuilder.mint('sol:invalid mint')).throwError(
+          'Invalid transaction: invalid mint, got: sol:invalid mint',
+        );
       });
 
       it('build when rentExemptAmount is invalid', async () => {

--- a/modules/account-lib/test/unit/coin/sol/utils.ts
+++ b/modules/account-lib/test/unit/coin/sol/utils.ts
@@ -280,4 +280,16 @@ describe('SOL util library', function () {
       should(() => Utils.validateRawTransaction()).throwError('Invalid raw transaction: Undefined');
     });
   });
+
+  describe('getSolTokenFromTokenName', function () {
+    it('should succeed for sol token', function () {
+      should.notEqual(Utils.getSolTokenFromTokenName('tsol:usdc'), undefined);
+    });
+    it('should fail for non tokens', function () {
+      should.equal(Utils.getSolTokenFromTokenName('tsol'), undefined);
+    });
+    it('should fail if tokenName is not in coins', function () {
+      should.equal(Utils.getSolTokenFromTokenName('something random'), undefined);
+    });
+  });
 });


### PR DESCRIPTION
STLX-14417

Add `getAssociatedTokenAccountAddress` to be used in wp, this avoids adding a dependency on spl-token in wp. 

Also refactor token builders to use new util methods