### PR TITLE
BG-44315: Support MPC HD keys

### DIFF
--- a/modules/account-lib/src/mpc/hdTree.ts
+++ b/modules/account-lib/src/mpc/hdTree.ts
@@ -1,0 +1,116 @@
+/**
+ * An interface for calculating a subkey in an HD key scheme.
+ */
+import { createHmac } from 'crypto';
+import { Ed25519Curve } from './curves';
+import { bigIntFromBufferBE, bigIntToBufferBE, bigIntFromBufferLE, bigIntToBufferLE } from './util';
+
+// 2^256
+const base = BigInt('0x010000000000000000000000000000000000000000000000000000000000000000');
+
+interface PrivateKeychain {
+  pk: bigint;
+  sk: bigint;
+  prefix: bigint;
+  chaincode: bigint;
+}
+
+export interface PublicKeychain {
+  pk: bigint;
+  chaincode: bigint;
+}
+
+interface HDTree {
+  publicDerive(keychain: PublicKeychain, path: string): PublicKeychain;
+
+  privateDerive(keychain: PrivateKeychain, path: string): PrivateKeychain;
+}
+
+export default HDTree;
+
+function deriveEd25519Helper(index: number | undefined = 0, chaincode: bigint, pk: bigint, sk?: bigint): Buffer[] {
+  const zmac = createHmac('sha512', bigIntToBufferBE(chaincode, 32).toString('latin1'));
+  const imac = createHmac('sha512', bigIntToBufferBE(chaincode, 32).toString('latin1'));
+  const seri = Buffer.alloc(4);
+  seri.writeUInt32LE(index, 0);
+  if (((index >>> 0) & 0x80000000) === 0) {
+    // Normal derivation:
+    // Z = HMAC-SHA512(Key = cpar, Data = 0x02 || serP(point(kpar)) || ser32(i)).
+    // I = HMAC-SHA512(Key = cpar, Data = 0x03 || serP(point(kpar)) || ser32(i)).
+    zmac.update('\x02');
+    zmac.update(bigIntToBufferLE(pk, 32));
+    zmac.update(seri);
+    imac.update('\x03');
+    imac.update(bigIntToBufferLE(pk, 32));
+    imac.update(seri);
+  } else {
+    if (sk === undefined) {
+      throw new Error("Can't performed hardened derivation without private key");
+    }
+    // Hardened derivation:
+    // Z = HMAC-SHA512(Key = cpar, Data = 0x00 || ser256(left(kpar)) || ser32(i)).
+    // I = HMAC-SHA512(Key = cpar, Data = 0x01 || ser256(left(kpar)) || ser32(i)).
+    zmac.update('\x00');
+    zmac.update(bigIntToBufferLE(sk, 32));
+    zmac.update(seri);
+    imac.update('\x01');
+    imac.update(bigIntToBufferLE(sk, 32));
+    imac.update(seri);
+  }
+  return [zmac.digest(), imac.digest()];
+}
+
+export class Ed25519BIP32 {
+  static curve: Ed25519Curve = new Ed25519Curve();
+  static initialized = false;
+
+  static async initialize(): Promise<void> {
+    if (!Ed25519BIP32.initialized) {
+      await Ed25519Curve.initialize();
+      Ed25519BIP32.initialized = true;
+    }
+  }
+
+  publicDerive(keychain: PublicKeychain, path: string): PublicKeychain {
+    const indices = path
+      .replace(/^m\//, '')
+      .split('/')
+      .map((index) => parseInt(index, 10));
+    function deriveIndex(acc: bigint[], index: number | undefined): bigint[] {
+      const [pk, chaincode] = acc;
+      const [zout, iout] = deriveEd25519Helper(index, chaincode, pk);
+      const zl = zout.slice(0, 32);
+      // left = kl + 8 * trunc28(zl)
+      const t = BigInt(8) * bigIntFromBufferLE(zl.slice(0, 28));
+      const left = Ed25519BIP32.curve.pointAdd(pk, Ed25519BIP32.curve.basePointMult(t));
+      return [left, bigIntFromBufferBE(iout.slice(32))];
+    }
+    const subkey = indices.reduce(deriveIndex, deriveIndex([keychain.pk, keychain.chaincode], indices.shift()));
+    return { pk: subkey[0], chaincode: subkey[1] };
+  }
+
+  privateDerive(keychain: PrivateKeychain, path: string): PrivateKeychain {
+    const indices = path
+      .replace(/^m\//, '')
+      .split('/')
+      .map((index) => parseInt(index, 10));
+    function deriveIndex(acc: bigint[], index: number | undefined): bigint[] {
+      const [pk, sk, prefix, chaincode] = acc;
+      const [zout, iout] = deriveEd25519Helper(index, chaincode, pk, sk);
+      const zl = zout.slice(0, 32);
+      const zr = zout.slice(32);
+      // left = kl + 8 * trunc28(zl)
+      const t = BigInt(8) * bigIntFromBufferLE(zl.slice(0, 28));
+      const left_pk = Ed25519BIP32.curve.pointAdd(pk, Ed25519BIP32.curve.basePointMult(t));
+      const left_sk = Ed25519BIP32.curve.scalarAdd(sk, t);
+      // right = zr + kr
+      const right = (prefix + bigIntFromBufferBE(zr)) % base;
+      return [left_pk, left_sk, right, bigIntFromBufferBE(iout.slice(32))];
+    }
+    const [pk, sk, prefix, chaincode] = indices.reduce(
+      deriveIndex,
+      deriveIndex([keychain.pk, keychain.sk, keychain.prefix, keychain.chaincode], indices.shift()),
+    );
+    return { pk, sk, prefix, chaincode };
+  }
+}

--- a/modules/account-lib/src/mpc/shamir.ts
+++ b/modules/account-lib/src/mpc/shamir.ts
@@ -1,6 +1,15 @@
 const assert = require('assert');
+const crypto = require('crypto');
+import Curve from './curves';
+import { bigIntFromBufferLE, bigIntToBufferLE, clamp } from './util';
 
-const Shamir = (curve: any) => {
+export default class Shamir {
+  curve: Curve;
+
+  constructor(curve: Curve) {
+    this.curve = curve;
+  }
+
   /**
    * Perform Shamir sharing on the secret `secret` to the degree `threshold - 1` split `numShares`
    * ways. The split secret requires `threshold` shares to be reconstructed.
@@ -12,41 +21,38 @@ const Shamir = (curve: any) => {
    * @returns Dictionary of shares. Each key is an int in the range 1<=x<=numShares
    * representing that share's free term.
    */
-  const split = (
-    secret: Buffer,
-    threshold: number,
-    numShares: number,
-    indices?: Array<number>,
-  ): Record<number, Buffer> => {
-    if (indices === undefined) {
+  split(secret: bigint, threshold: number, numShares: number, indices?: Array<number>): Record<number, bigint> {
+    let bigIndices: Array<bigint>;
+    if (indices) {
+      bigIndices = indices.map((i) => BigInt(i));
+    } else {
       // make range(1, n + 1)
-      indices = Array.from({ length: numShares }, (_, i) => i + 1);
+      bigIndices = Array(numShares)
+        .fill(null)
+        .map((_, i) => BigInt(i + 1));
     }
     assert(threshold > 1);
     assert(threshold <= numShares);
-    const coefs: Buffer[] = [];
+    const coefs: bigint[] = [];
     for (let ind = 0; ind < threshold - 1; ind++) {
-      const random_value = curve.scalarRandom();
-      coefs.push(random_value);
+      const coeff = clamp(
+        bigIntFromBufferLE(crypto.createHmac('sha256', ind.toString(10)).update(bigIntToBufferLE(secret, 32)).digest()),
+      );
+      coefs.push(coeff);
     }
     coefs.push(secret);
 
-    const shares: Record<number, Buffer> = {};
-    for (let ind = 0; ind < indices.length; ind++) {
-      const x = indices[ind];
-      const x_buffer = Buffer.alloc(32);
-      // TODO BG-40908 : converting internal representation to buffers
-      x_buffer.writeUInt32LE(x, 0);
+    const shares: Record<number, bigint> = {};
+    for (let ind = 0; ind < bigIndices.length; ind++) {
+      const x = bigIndices[ind];
       let partial = coefs[0];
       for (let other = 1; other < coefs.length; other++) {
-        const scalarMult = curve.scalarMult(partial, x_buffer);
-        const newAdd = curve.scalarAdd(coefs[other], scalarMult);
-        partial = newAdd;
+        partial = this.curve.scalarAdd(coefs[other], this.curve.scalarMult(partial, x));
       }
-      shares[x] = Buffer.from(partial);
+      shares[parseInt(x.toString(), 10)] = partial;
     }
     return shares;
-  };
+  }
 
   /**
    * Reconstitute a secret from a dictionary of shares. The number of shares must
@@ -55,45 +61,31 @@ const Shamir = (curve: any) => {
    * @param shares dictionary of shares. each key is the free term of the share
    * @returns secret
    */
-  const combine = (shares: Record<number, Buffer>): Buffer => {
-    let s = Buffer.alloc(32);
-    for (const xi in shares) {
-      const yi = shares[xi];
-      const xi_buffer = Buffer.alloc(32);
-      let num_buffer = Buffer.alloc(32);
-      let denum_buffer = Buffer.alloc(32);
-      xi_buffer.writeUInt32LE(parseInt(xi, 10), 0);
-      num_buffer.writeUInt32LE(1, 0);
-      denum_buffer.writeUInt32LE(1, 0);
+  combine(shares: Record<number, bigint>): bigint {
+    let s = BigInt(0);
+    for (const i in shares) {
+      const yi = shares[i];
+      const xi = BigInt(i);
+      let num = BigInt(1);
+      let denum = BigInt(1);
 
-      for (const xj in shares) {
-        const xj_buffer = Buffer.alloc(32);
-        xj_buffer.writeUInt32LE(parseInt(xj, 10), 0);
+      for (const j in shares) {
+        const xj = BigInt(j);
         if (xi !== xj) {
-          num_buffer = curve.scalarMult(num_buffer, xj_buffer);
+          num = this.curve.scalarMult(num, xj);
         }
       }
-      num_buffer = Buffer.from(num_buffer);
-      for (const xj in shares) {
-        const xj_buffer = Buffer.alloc(32);
-        xj_buffer.writeUInt32LE(parseInt(xj, 10), 0);
+      for (const j in shares) {
+        const xj = BigInt(j);
         if (xi !== xj) {
-          denum_buffer = curve.scalarMult(denum_buffer, curve.scalarSub(xj_buffer, xi_buffer));
+          denum = this.curve.scalarMult(denum, this.curve.scalarSub(xj, xi));
         }
       }
-      denum_buffer = Buffer.from(denum_buffer);
-      const inverted = curve.scalarInvert(denum_buffer);
-      const innerMultiplied = curve.scalarMult(num_buffer, inverted);
-      const multiplied = curve.scalarMult(innerMultiplied, yi);
-      s = curve.scalarAdd(multiplied, s);
+      const inverted = this.curve.scalarInvert(denum);
+      const innerMultiplied = this.curve.scalarMult(num, inverted);
+      const multiplied = this.curve.scalarMult(innerMultiplied, yi);
+      s = this.curve.scalarAdd(multiplied, s);
     }
     return s;
-  };
-
-  return {
-    split,
-    combine,
-  };
-};
-
-export default Shamir;
+  }
+}

--- a/modules/account-lib/src/mpc/tss.ts
+++ b/modules/account-lib/src/mpc/tss.ts
@@ -30,78 +30,85 @@
  * 5. After the signers broadcast their g-shares, the final signature can be re-constructed independently.
  */
 const assert = require('assert');
-import Ed25519Curve from './curves';
-import { sha512 } from 'js-sha512';
+import { randomBytes, createHash } from 'crypto';
+import { Ed25519Curve } from './curves';
 import Shamir from './shamir';
-import { randomBytes as cryptoRandomBytes } from 'crypto';
-import _ from 'lodash';
+import HDTree from './hdTree';
+import { bigIntFromBufferLE, bigIntToBufferLE, bigIntFromBufferBE, bigIntToBufferBE, clamp } from './util';
 
-const convertObjectHexToBuffer = (object: Record<string, any>, keys: string[]) => {
-  const result: any = _.cloneDeep(object);
-  keys.forEach((key) => {
-    result[key] = Buffer.from(object[key], 'hex');
-  });
-  return result;
-};
+// 2^256
+const base = BigInt('0x010000000000000000000000000000000000000000000000000000000000000000');
 
 interface UShare {
-  i: string;
+  i: number;
+  t: number;
+  n: number;
   y: string;
-  u: string;
-  prefix: string;
+  seed: string;
+  chaincode: string;
 }
 
-interface YShare {
-  i: string;
-  j: string;
+export interface YShare {
+  i: number;
+  j: number;
   y: string;
   u: string;
+  chaincode: string;
 }
 
 export interface KeyShare {
   uShare: UShare;
-  yShares: Record<string, YShare>;
+  yShares: Record<number, YShare>;
 }
 
 export interface PShare {
-  i: string;
-  x: string;
+  i: number;
+  t: number;
+  n: number;
   y: string;
+  u: string;
   prefix: string;
+  chaincode: string;
 }
 
 export interface JShare {
-  i: string;
-  j: string;
+  i: number;
+  j: number;
 }
 
 interface KeyCombine {
   pShare: PShare;
-  jShares: Record<string, JShare>;
+  jShares: Record<number, JShare>;
+}
+
+interface SubkeyShare {
+  pShare: PShare;
+  yShares: Record<number, YShare>;
 }
 
 export interface XShare {
-  i: string;
+  i: number;
   y: string;
-  x: string;
+  u: string;
   r: string;
   R: string;
 }
 
 export interface RShare {
-  i: string;
-  j: string;
+  i: number;
+  j: number;
+  u: string;
   r: string;
   R: string;
 }
 
 export interface SignShare {
   xShare: XShare;
-  rShares: Record<string, RShare>;
+  rShares: Record<number, RShare>;
 }
 
 export interface GShare {
-  i: string;
+  i: number;
   y: string;
   gamma: string;
   R: string;
@@ -113,37 +120,41 @@ interface Signature {
   sigma: string;
 }
 
-const Eddsa = async () => {
-  const ed25519 = await Ed25519Curve();
-  const shamir = Shamir(ed25519);
+export default class Eddsa {
+  static curve: Ed25519Curve = new Ed25519Curve();
+  static shamir: Shamir = new Shamir(Eddsa.curve);
+  static initialized = false;
 
-  const keyShare = (index: number, threshold: number, numShares: number): KeyShare => {
+  static async initialize(): Promise<void> {
+    if (!Eddsa.initialized) {
+      await Ed25519Curve.initialize();
+      Eddsa.initialized = true;
+    }
+  }
+
+  hdTree?: HDTree;
+
+  constructor(hdTree?: HDTree) {
+    this.hdTree = hdTree;
+  }
+
+  keyShare(index: number, threshold: number, numShares: number): KeyShare {
     assert(index > 0 && index <= numShares);
-    const sk = cryptoRandomBytes(32);
-    const h = Buffer.from(sha512.digest(sk));
-    const zeroBuffer = Buffer.alloc(64 - h.length);
-    const combinedBuffer = Buffer.concat([zeroBuffer, h]);
-
-    let uBuffer = combinedBuffer.slice(0, 32);
-    uBuffer[0] &= 248;
-    uBuffer[31] &= 63;
-    uBuffer[31] |= 64;
-
-    const zeroBuffer32 = Buffer.alloc(32);
-    uBuffer = Buffer.concat([uBuffer, zeroBuffer32]);
-    const u = Buffer.from(ed25519.scalarReduce(uBuffer));
-    const y = Buffer.from(ed25519.basePointMult(u));
-    const split_u = shamir.split(u, threshold, numShares);
-
-    let prefixBuffer = combinedBuffer.subarray(32, combinedBuffer.length);
-    prefixBuffer = Buffer.concat([zeroBuffer32, prefixBuffer]);
-    const prefix = Buffer.from(ed25519.scalarReduce(prefixBuffer));
+    const seedchain = randomBytes(64);
+    const seed = seedchain.slice(0, 32);
+    const chaincode = seedchain.slice(32);
+    const h = createHash('sha512').update(seed).digest();
+    const u = clamp(bigIntFromBufferLE(h.slice(0, 32)));
+    const y = Eddsa.curve.basePointMult(u);
+    const split_u = Eddsa.shamir.split(u, threshold, numShares);
 
     const P_i: UShare = {
-      i: index.toString(),
-      y: y.toString('hex'),
-      u: split_u[index.toString()].toString('hex'),
-      prefix: prefix.toString('hex'),
+      i: index,
+      t: threshold,
+      n: numShares,
+      y: bigIntToBufferLE(y, 32).toString('hex'),
+      seed: seed.toString('hex'),
+      chaincode: chaincode.toString('hex'),
     };
     const shares: KeyShare = {
       uShare: P_i,
@@ -151,72 +162,132 @@ const Eddsa = async () => {
     };
 
     for (const ind in split_u) {
-      if (ind === index.toString()) {
+      const i = parseInt(ind, 10);
+      if (i === index) {
         continue;
       }
-      shares.yShares[ind] = {
-        i: ind,
-        j: P_i['i'],
-        y: y.toString('hex'),
-        u: split_u[ind].toString('hex'),
+      shares.yShares[i] = {
+        i,
+        j: P_i.i,
+        y: bigIntToBufferLE(y, 32).toString('hex'),
+        u: bigIntToBufferLE(split_u[ind], 32).toString('hex'),
+        chaincode: chaincode.toString('hex'),
       };
     }
     return shares;
-  };
-  const keyCombine = (uShare: UShare, distributedShares: YShare[]): KeyCombine => {
-    // u-shares and y-shares required buffer format for curve functions
-    const shares = [uShare, ...distributedShares].map((share) => convertObjectHexToBuffer(share, ['y', 'u']));
-    const yShares = shares.map((share) => share['y']);
-    const uShares = shares.map((share) => share['u']);
-    const y = Buffer.from(yShares.reduce((partial, share) => ed25519.pointAdd(partial, share)));
-    const x = Buffer.from(uShares.reduce((partial, share) => ed25519.scalarAdd(partial, share)));
+  }
+
+  keyCombine(uShare: UShare, yShares: YShare[]): KeyCombine {
+    const h = createHash('sha512').update(Buffer.from(uShare.seed, 'hex')).digest();
+    const u = clamp(bigIntFromBufferLE(h.slice(0, 32)));
+    const yValues = [uShare, ...yShares].map((share) => bigIntFromBufferLE(Buffer.from(share.y, 'hex')));
+    const y = yValues.reduce((partial, share) => Eddsa.curve.pointAdd(partial, share));
+    const chaincodes = [uShare, ...yShares].map(({ chaincode }) => bigIntFromBufferBE(Buffer.from(chaincode, 'hex')));
+    const chaincode = chaincodes.reduce((acc, chaincode) => (acc + chaincode) % base);
 
     const P_i: PShare = {
-      i: uShare['i'],
-      y: y.toString('hex'),
-      x: x.toString('hex'),
-      prefix: uShare['prefix'],
+      i: uShare.i,
+      t: uShare.t,
+      n: uShare.n,
+      y: bigIntToBufferLE(y, 32).toString('hex'),
+      u: bigIntToBufferLE(u, 32).toString('hex'),
+      prefix: h.slice(32).toString('hex'),
+      chaincode: bigIntToBufferBE(chaincode, 32).toString('hex'),
     };
     const players: KeyCombine = {
       pShare: P_i,
       jShares: {},
     };
 
-    for (let ind = 0; ind < distributedShares.length; ind++) {
-      const P_j = distributedShares[ind];
-      players.jShares[P_j['j']] = {
-        i: P_j['j'],
-        j: P_i['i'],
+    for (let ind = 0; ind < yShares.length; ind++) {
+      const P_j = yShares[ind];
+      players.jShares[P_j.j] = {
+        i: P_j.j,
+        j: P_i.i,
       };
     }
     return players;
-  };
+  }
 
-  const signShare = (message: Buffer, pShare: PShare, jShares: JShare[]): SignShare => {
-    // x-shares and y-shares required buffer format for curve functions
-    const shares = [convertObjectHexToBuffer(pShare, ['x', 'y']), ...jShares];
-    const indices = shares.map((share) => share['i']);
+  keyDerive(uShare: UShare, yShares: YShare[], path: string): SubkeyShare {
+    if (this.hdTree === undefined) {
+      throw new Error("Can't derive key without HDTree implementation");
+    }
+    const h = createHash('sha512').update(Buffer.from(uShare.seed, 'hex')).digest();
+    const yValues = [uShare, ...yShares].map((share) => bigIntFromBufferLE(Buffer.from(share.y, 'hex')));
+    const y = yValues.reduce((partial, share) => Eddsa.curve.pointAdd(partial, share));
+    const u = clamp(bigIntFromBufferLE(h.slice(0, 32)));
+    const prefix = bigIntFromBufferBE(h.slice(32));
+    let contribChaincode = bigIntFromBufferBE(Buffer.from(uShare.chaincode, 'hex'));
+    const chaincodes = [
+      contribChaincode,
+      ...yShares.map(({ chaincode }) => bigIntFromBufferBE(Buffer.from(chaincode, 'hex'))),
+    ];
+    const chaincode = chaincodes.reduce((acc, chaincode) => (acc + chaincode) % base);
 
-    // use big endian for prefix
-    const randomBuffer = cryptoRandomBytes(32);
-    const prefix_reference = Buffer.from(pShare['prefix'], 'hex');
-    prefix_reference.reverse();
-    const combinedBuffer = Buffer.concat([prefix_reference, message, randomBuffer]);
+    // Derive subkey.
+    const subkey = this.hdTree.privateDerive({ pk: y, sk: u, prefix, chaincode }, path);
 
-    // using big endian
-    const digest = Buffer.from(sha512.digest(combinedBuffer));
-    digest.reverse();
+    // Calculate new public key contribution.
+    const contribY = Eddsa.curve.basePointMult(subkey.sk);
 
-    const r = Buffer.from(ed25519.scalarReduce(digest));
-    const R = Buffer.from(ed25519.basePointMult(r));
-    const split_r = shamir.split(r, shares.length, shares.length, indices);
+    // Calculate new chaincode contribution.
+    const chaincodeDelta = (base + subkey.chaincode - chaincode) % base;
+    contribChaincode = (contribChaincode + chaincodeDelta) % base;
+
+    // Calculate new u values.
+    const split_u = Eddsa.shamir.split(subkey.sk, uShare.t, uShare.n);
+
+    const P_i: PShare = {
+      i: uShare.i,
+      t: uShare.t,
+      n: uShare.n,
+      y: bigIntToBufferLE(subkey.pk, 32).toString('hex'),
+      u: bigIntToBufferLE(subkey.sk, 32).toString('hex'),
+      prefix: bigIntToBufferBE(subkey.prefix, 32).toString('hex'),
+      chaincode: bigIntToBufferBE(subkey.chaincode, 32).toString('hex'),
+    };
+
+    const shares: SubkeyShare = {
+      pShare: P_i,
+      yShares: {},
+    };
+
+    for (let ind = 0; ind < yShares.length; ind++) {
+      const P_j = yShares[ind];
+      shares.yShares[P_j.j] = {
+        i: P_j.j,
+        j: P_i.i,
+        y: bigIntToBufferLE(contribY, 32).toString('hex'),
+        u: bigIntToBufferLE(split_u[P_j.i], 32).toString('hex'),
+        chaincode: bigIntToBufferBE(contribChaincode, 32).toString('hex'),
+      };
+    }
+
+    return shares;
+  }
+
+  signShare(message: Buffer, pShare: PShare, jShares: JShare[]): SignShare {
+    const indices = [pShare, ...jShares].map(({ i }) => i);
+    const split_u = Eddsa.shamir.split(bigIntFromBufferLE(Buffer.from(pShare.u, 'hex')), pShare.t, pShare.n);
+
+    // Generate nonce contribution.
+    const prefix = Buffer.from(pShare.prefix, 'hex');
+    const randomBuffer = randomBytes(32);
+    const digest = createHash('sha512')
+      .update(Buffer.concat([prefix, message, randomBuffer]))
+      .digest();
+
+    const r = Eddsa.curve.scalarReduce(bigIntFromBufferLE(digest));
+    const R = Eddsa.curve.basePointMult(r);
+    const split_r = Eddsa.shamir.split(r, indices.length, indices.length, indices);
 
     const P_i: XShare = {
-      i: pShare['i'],
-      y: pShare['y'],
-      x: pShare['x'],
-      r: split_r[pShare['i']].toString('hex'),
-      R: R.toString('hex'),
+      i: pShare.i,
+      y: pShare.y,
+      u: bigIntToBufferLE(split_u[pShare.i], 32).toString('hex'),
+      r: bigIntToBufferLE(split_r[pShare.i], 32).toString('hex'),
+      R: bigIntToBufferLE(R, 32).toString('hex'),
     };
 
     const resultShares: SignShare = {
@@ -226,73 +297,68 @@ const Eddsa = async () => {
 
     for (let ind = 0; ind < jShares.length; ind++) {
       const S_j = jShares[ind];
-      resultShares.rShares[S_j['i']] = {
-        i: S_j['i'],
-        j: pShare['i'],
-        r: split_r[S_j['i']].toString('hex'),
-        R: R.toString('hex'),
+      resultShares.rShares[S_j.i] = {
+        i: S_j.i,
+        j: pShare.i,
+        u: bigIntToBufferLE(split_u[S_j.i], 32).toString('hex'),
+        r: bigIntToBufferLE(split_r[S_j.i], 32).toString('hex'),
+        R: bigIntToBufferLE(R, 32).toString('hex'),
       };
     }
     return resultShares;
-  };
+  }
 
-  const sign = (message: Buffer, playerShare: XShare, distributedShares: RShare[]): GShare => {
-    // x, y, r, R required buffer format for curve functions
-    const shares = [playerShare, ...distributedShares].map((share) => convertObjectHexToBuffer(share, ['R', 'r']));
+  sign(message: Buffer, playerShare: XShare, rShares: RShare[], yShares: YShare[] = []): GShare {
     const S_i = playerShare;
 
-    const rShares = shares.map((share) => share['R']);
-    const littleRShares = shares.map((share) => share['r']);
+    const uValues = [playerShare, ...rShares, ...yShares].map(({ u }) => bigIntFromBufferLE(Buffer.from(u, 'hex')));
+    const x = uValues.reduce((acc, u) => Eddsa.curve.scalarAdd(acc, u));
 
-    const R = Buffer.from(rShares.reduce((partial, share) => ed25519.pointAdd(partial, share)));
-    const r = Buffer.from(littleRShares.reduce((partial, share) => ed25519.scalarAdd(partial, share)));
+    const RValues = [playerShare, ...rShares].map(({ R }) => bigIntFromBufferLE(Buffer.from(R, 'hex')));
+    const R = RValues.reduce((partial, share) => Eddsa.curve.pointAdd(partial, share));
 
-    const combinedBuffer = Buffer.concat([R, Buffer.from(S_i['y'], 'hex'), message]);
-    const digest = Buffer.from(sha512.digest(combinedBuffer));
-    const k = Buffer.from(ed25519.scalarReduce(digest));
+    const rValues = [playerShare, ...rShares].map(({ r }) => bigIntFromBufferLE(Buffer.from(r, 'hex')));
+    const r = rValues.reduce((partial, share) => Eddsa.curve.scalarAdd(partial, share));
 
-    const gamma = Buffer.from(ed25519.scalarAdd(r, ed25519.scalarMult(k, Buffer.from(S_i['x'], 'hex'))));
+    const combinedBuffer = Buffer.concat([bigIntToBufferLE(R, 32), Buffer.from(S_i.y, 'hex'), message]);
+    const digest = createHash('sha512').update(combinedBuffer).digest();
+    const k = Eddsa.curve.scalarReduce(bigIntFromBufferLE(digest));
+
+    const gamma = Eddsa.curve.scalarAdd(r, Eddsa.curve.scalarMult(k, x));
     const result = {
-      i: playerShare['i'],
-      y: playerShare['y'],
-      gamma: gamma.toString('hex'),
-      R: R.toString('hex'),
+      i: playerShare.i,
+      y: playerShare.y,
+      gamma: bigIntToBufferLE(gamma, 32).toString('hex'),
+      R: bigIntToBufferLE(R, 32).toString('hex'),
     };
     return result;
-  };
+  }
 
-  const signCombine = (shares: GShare[]): Signature => {
-    shares = shares.map((share) => convertObjectHexToBuffer(share, ['y', 'gamma', 'R']));
-    const keys = Object.keys(shares);
-    const y = shares[keys[0]]['y'];
-    const R = shares[keys[0]]['R'];
+  signCombine(shares: GShare[]): Signature {
+    const y = shares[0].y;
+    const R = shares[0].R;
 
     const resultShares = {};
     for (const ind in shares) {
       const S_i = shares[ind];
-      resultShares[S_i['i']] = S_i['gamma'];
+      resultShares[S_i.i] = bigIntFromBufferLE(Buffer.from(S_i.gamma, 'hex'));
     }
-    let sigma: Buffer = shamir.combine(resultShares);
-    sigma = Buffer.from(sigma);
+    const sigma: bigint = Eddsa.shamir.combine(resultShares);
     const result = {
-      y: y.toString('hex'),
-      R: R.toString('hex'),
-      sigma: sigma.toString('hex'),
+      y,
+      R,
+      sigma: bigIntToBufferLE(sigma, 32).toString('hex'),
     };
     return result;
-  };
+  }
 
-  const verify = (message: Buffer, signature: Signature): Buffer => {
-    const publicKey = Buffer.from(signature['y'], 'hex');
+  verify(message: Buffer, signature: Signature): Buffer {
+    const publicKey = bigIntFromBufferLE(Buffer.from(signature.y, 'hex'));
     const signedMessage = Buffer.concat([
-      Buffer.from(signature['R'], 'hex'),
-      Buffer.from(signature['sigma'], 'hex'),
+      Buffer.from(signature.R, 'hex'),
+      Buffer.from(signature.sigma, 'hex'),
       message,
     ]);
-    return Buffer.from(ed25519.verify(publicKey, signedMessage));
-  };
-
-  return { keyShare, keyCombine, signShare, sign, signCombine, verify };
-};
-
-export default Eddsa;
+    return Eddsa.curve.verify(publicKey, signedMessage);
+  }
+}

--- a/modules/account-lib/src/mpc/util.ts
+++ b/modules/account-lib/src/mpc/util.ts
@@ -1,0 +1,33 @@
+export function bigIntFromBufferLE(buf: Buffer): bigint {
+  return BigInt('0x' + Buffer.from(buf).reverse().toString('hex'));
+}
+
+export function bigIntToBufferLE(n: bigint, bytes?: number): Buffer {
+  let v = n.toString(16);
+  v = '0'.slice(0, v.length % 2) + v;
+  const buf = Buffer.from(v, 'hex').reverse();
+  if (bytes && buf.length < bytes) {
+    return Buffer.concat([buf, Buffer.alloc(bytes - buf.length)]);
+  }
+  return buf;
+}
+
+export function bigIntFromBufferBE(buf: Buffer): bigint {
+  return BigInt('0x' + buf.toString('hex'));
+}
+
+export function bigIntToBufferBE(n: bigint, bytes?: number): Buffer {
+  let v = n.toString(16);
+  v = '0'.slice(0, v.length % 2) + v;
+  const buf = Buffer.from(v, 'hex');
+  if (bytes && buf.length < bytes) {
+    return Buffer.concat([Buffer.alloc(bytes - buf.length), buf]);
+  }
+  return buf;
+}
+
+export function clamp(u: bigint): bigint {
+  u &= BigInt('0x7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8');
+  u |= BigInt('0x4000000000000000000000000000000000000000000000000000000000000000');
+  return u;
+}

--- a/modules/account-lib/test/tsconfig.json
+++ b/modules/account-lib/test/tsconfig.json
@@ -3,7 +3,5 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "include": [
-    "./**/*"
-  ]
+  "include": ["./**/*"]
 }

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/base.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/base.ts
@@ -227,9 +227,12 @@ describe('Dot Transfer Builder', () => {
   });
 
   describe('add TSS signature', function () {
+    before('initialize mpc module', async () => {
+      await Eddsa.initialize();
+    });
     it('should add TSS signature', async () => {
       const factory = register('tdot', TransactionBuilderFactory);
-      const MPC = await Eddsa();
+      const MPC = new Eddsa();
       const A = MPC.keyShare(1, 2, 3);
       const B = MPC.keyShare(2, 2, 3);
       const C = MPC.keyShare(3, 2, 3);
@@ -283,8 +286,8 @@ describe('Dot Transfer Builder', () => {
       // signing with A and B
       A_sign_share = MPC.signShare(signablePayload, A_combine.pShare, [A_combine.jShares[2]]);
       B_sign_share = MPC.signShare(signablePayload, B_combine.pShare, [B_combine.jShares[1]]);
-      A_sign = MPC.sign(signablePayload, A_sign_share.xShare, [B_sign_share.rShares[1]]);
-      B_sign = MPC.sign(signablePayload, B_sign_share.xShare, [A_sign_share.rShares[2]]);
+      A_sign = MPC.sign(signablePayload, A_sign_share.xShare, [B_sign_share.rShares[1]], [C.yShares[1]]);
+      B_sign = MPC.sign(signablePayload, B_sign_share.xShare, [A_sign_share.rShares[2]], [C.yShares[2]]);
       // sign the message_buffer (unsigned txHex)
       signature = MPC.signCombine([A_sign, B_sign]);
       rawSignature = Buffer.concat([Buffer.from(signature.R, 'hex'), Buffer.from(signature.sigma, 'hex')]);
@@ -306,8 +309,8 @@ describe('Dot Transfer Builder', () => {
       // signing with A and C
       A_sign_share = MPC.signShare(signablePayload, A_combine.pShare, [A_combine.jShares[3]]);
       C_sign_share = MPC.signShare(signablePayload, C_combine.pShare, [C_combine.jShares[1]]);
-      A_sign = MPC.sign(signablePayload, A_sign_share.xShare, [C_sign_share.rShares[1]]);
-      C_sign = MPC.sign(signablePayload, C_sign_share.xShare, [A_sign_share.rShares[3]]);
+      A_sign = MPC.sign(signablePayload, A_sign_share.xShare, [C_sign_share.rShares[1]], [B.yShares[1]]);
+      C_sign = MPC.sign(signablePayload, C_sign_share.xShare, [A_sign_share.rShares[3]], [B.yShares[3]]);
       signature = MPC.signCombine([A_sign, C_sign]);
       rawSignature = Buffer.concat([Buffer.from(signature.R, 'hex'), Buffer.from(signature.sigma, 'hex')]);
       transferBuilder = factory
@@ -328,8 +331,8 @@ describe('Dot Transfer Builder', () => {
       // signing with B and C
       B_sign_share = MPC.signShare(signablePayload, B_combine.pShare, [B_combine.jShares[3]]);
       C_sign_share = MPC.signShare(signablePayload, C_combine.pShare, [C_combine.jShares[2]]);
-      B_sign = MPC.sign(signablePayload, B_sign_share.xShare, [C_sign_share.rShares[2]]);
-      C_sign = MPC.sign(signablePayload, C_sign_share.xShare, [B_sign_share.rShares[3]]);
+      B_sign = MPC.sign(signablePayload, B_sign_share.xShare, [C_sign_share.rShares[2]], [A.yShares[2]]);
+      C_sign = MPC.sign(signablePayload, C_sign_share.xShare, [B_sign_share.rShares[3]], [A.yShares[3]]);
       signature = MPC.signCombine([B_sign, C_sign]);
       rawSignature = Buffer.concat([Buffer.from(signature.R, 'hex'), Buffer.from(signature.sigma, 'hex')]);
       transferBuilder = factory

--- a/modules/account-lib/test/unit/coin/near/transactionBuilder/transferBuilder.ts
+++ b/modules/account-lib/test/unit/coin/near/transactionBuilder/transferBuilder.ts
@@ -65,9 +65,12 @@ describe('Near Transfer Builder', () => {
   });
 
   describe('add TSS signature', function () {
+    before('initialize mpc module', async () => {
+      await Eddsa.initialize();
+    });
     it('should add TSS signature', async () => {
       const factory = register('tnear', TransactionBuilderFactory);
-      const MPC = await Eddsa();
+      const MPC = new Eddsa();
       const A = MPC.keyShare(1, 2, 3);
       const B = MPC.keyShare(2, 2, 3);
       const C = MPC.keyShare(3, 2, 3);
@@ -113,8 +116,8 @@ describe('Near Transfer Builder', () => {
       // signing with A and B
       A_sign_share = MPC.signShare(signablePayload, A_combine.pShare, [A_combine.jShares[2]]);
       B_sign_share = MPC.signShare(signablePayload, B_combine.pShare, [B_combine.jShares[1]]);
-      A_sign = MPC.sign(signablePayload, A_sign_share.xShare, [B_sign_share.rShares[1]]);
-      B_sign = MPC.sign(signablePayload, B_sign_share.xShare, [A_sign_share.rShares[2]]);
+      A_sign = MPC.sign(signablePayload, A_sign_share.xShare, [B_sign_share.rShares[1]], [C.yShares[1]]);
+      B_sign = MPC.sign(signablePayload, B_sign_share.xShare, [A_sign_share.rShares[2]], [C.yShares[2]]);
       // sign the message_buffer (unsigned txHex)
       signature = MPC.signCombine([A_sign, B_sign]);
       rawSignature = Buffer.concat([Buffer.from(signature.R, 'hex'), Buffer.from(signature.sigma, 'hex')]);
@@ -132,8 +135,8 @@ describe('Near Transfer Builder', () => {
       // signing with A and C
       A_sign_share = MPC.signShare(signablePayload, A_combine.pShare, [A_combine.jShares[3]]);
       C_sign_share = MPC.signShare(signablePayload, C_combine.pShare, [C_combine.jShares[1]]);
-      A_sign = MPC.sign(signablePayload, A_sign_share.xShare, [C_sign_share.rShares[1]]);
-      C_sign = MPC.sign(signablePayload, C_sign_share.xShare, [A_sign_share.rShares[3]]);
+      A_sign = MPC.sign(signablePayload, A_sign_share.xShare, [C_sign_share.rShares[1]], [B.yShares[1]]);
+      C_sign = MPC.sign(signablePayload, C_sign_share.xShare, [A_sign_share.rShares[3]], [B.yShares[3]]);
       signature = MPC.signCombine([A_sign, C_sign]);
       rawSignature = Buffer.concat([Buffer.from(signature.R, 'hex'), Buffer.from(signature.sigma, 'hex')]);
       txBuilder = factory.getTransferBuilder();
@@ -150,8 +153,8 @@ describe('Near Transfer Builder', () => {
       // signing with B and C
       B_sign_share = MPC.signShare(signablePayload, B_combine.pShare, [B_combine.jShares[3]]);
       C_sign_share = MPC.signShare(signablePayload, C_combine.pShare, [C_combine.jShares[2]]);
-      B_sign = MPC.sign(signablePayload, B_sign_share.xShare, [C_sign_share.rShares[2]]);
-      C_sign = MPC.sign(signablePayload, C_sign_share.xShare, [B_sign_share.rShares[3]]);
+      B_sign = MPC.sign(signablePayload, B_sign_share.xShare, [C_sign_share.rShares[2]], [A.yShares[2]]);
+      C_sign = MPC.sign(signablePayload, C_sign_share.xShare, [B_sign_share.rShares[3]], [A.yShares[3]]);
       signature = MPC.signCombine([B_sign, C_sign]);
       rawSignature = Buffer.concat([Buffer.from(signature.R, 'hex'), Buffer.from(signature.sigma, 'hex')]);
       txBuilder = factory.getTransferBuilder();

--- a/modules/account-lib/test/unit/coin/sol/transactionBuilder/transactionBuilder.ts
+++ b/modules/account-lib/test/unit/coin/sol/transactionBuilder/transactionBuilder.ts
@@ -370,8 +370,12 @@ describe('Sol Transaction Builder', async () => {
       rebuiltTransaction2.signature.should.deepEqual(signedTransaction2.signature);
     });
 
+    before('initialize mpc module', async () => {
+      await Eddsa.initialize();
+    });
+
     it('should add TSS signature', async () => {
-      const MPC = await Eddsa();
+      const MPC = new Eddsa();
       const A = MPC.keyShare(1, 2, 3);
       const B = MPC.keyShare(2, 2, 3);
       const C = MPC.keyShare(3, 2, 3);
@@ -419,8 +423,8 @@ describe('Sol Transaction Builder', async () => {
       // signing with A and B
       A_sign_share = MPC.signShare(signablePayload, A_combine.pShare, [A_combine.jShares[2]]);
       B_sign_share = MPC.signShare(signablePayload, B_combine.pShare, [B_combine.jShares[1]]);
-      A_sign = MPC.sign(signablePayload, A_sign_share.xShare, [B_sign_share.rShares[1]]);
-      B_sign = MPC.sign(signablePayload, B_sign_share.xShare, [A_sign_share.rShares[2]]);
+      A_sign = MPC.sign(signablePayload, A_sign_share.xShare, [B_sign_share.rShares[1]], [C.yShares[1]]);
+      B_sign = MPC.sign(signablePayload, B_sign_share.xShare, [A_sign_share.rShares[2]], [C.yShares[2]]);
       signature = MPC.signCombine([A_sign, B_sign]);
       rawSignature = Buffer.concat([Buffer.from(signature.R, 'hex'), Buffer.from(signature.sigma, 'hex')]);
 
@@ -439,8 +443,8 @@ describe('Sol Transaction Builder', async () => {
       // signing with A and C
       A_sign_share = MPC.signShare(signablePayload, A_combine.pShare, [A_combine.jShares[3]]);
       C_sign_share = MPC.signShare(signablePayload, C_combine.pShare, [C_combine.jShares[1]]);
-      A_sign = MPC.sign(signablePayload, A_sign_share.xShare, [C_sign_share.rShares[1]]);
-      C_sign = MPC.sign(signablePayload, C_sign_share.xShare, [A_sign_share.rShares[3]]);
+      A_sign = MPC.sign(signablePayload, A_sign_share.xShare, [C_sign_share.rShares[1]], [B.yShares[1]]);
+      C_sign = MPC.sign(signablePayload, C_sign_share.xShare, [A_sign_share.rShares[3]], [B.yShares[3]]);
       signature = MPC.signCombine([A_sign, C_sign]);
       rawSignature = Buffer.concat([Buffer.from(signature.R, 'hex'), Buffer.from(signature.sigma, 'hex')]);
 
@@ -459,8 +463,8 @@ describe('Sol Transaction Builder', async () => {
       // signing with B and C
       B_sign_share = MPC.signShare(signablePayload, B_combine.pShare, [B_combine.jShares[3]]);
       C_sign_share = MPC.signShare(signablePayload, C_combine.pShare, [C_combine.jShares[2]]);
-      B_sign = MPC.sign(signablePayload, B_sign_share.xShare, [C_sign_share.rShares[2]]);
-      C_sign = MPC.sign(signablePayload, C_sign_share.xShare, [B_sign_share.rShares[3]]);
+      B_sign = MPC.sign(signablePayload, B_sign_share.xShare, [C_sign_share.rShares[2]], [A.yShares[2]]);
+      C_sign = MPC.sign(signablePayload, C_sign_share.xShare, [B_sign_share.rShares[3]], [A.yShares[3]]);
       signature = MPC.signCombine([B_sign, C_sign]);
       rawSignature = Buffer.concat([Buffer.from(signature.R, 'hex'), Buffer.from(signature.sigma, 'hex')]);
 

--- a/modules/account-lib/test/unit/mpc/tss.ts
+++ b/modules/account-lib/test/unit/mpc/tss.ts
@@ -4,10 +4,18 @@
 import 'should';
 
 import Eddsa from '../../../src/mpc/tss';
+import { Ed25519BIP32 } from '../../../src/mpc/hdTree';
 
-describe('TSS EDDSA key generation and signing', () => {
-  it('should generate keys and sign message', async () => {
-    const MPC = await Eddsa();
+import { bigIntFromBufferLE, bigIntToBufferLE, bigIntFromBufferBE, bigIntToBufferBE } from '../../../src/mpc/util';
+
+describe('TSS EDDSA key generation and signing', function () {
+  before('initialize modules', async function () {
+    await Eddsa.initialize();
+    await Ed25519BIP32.initialize();
+  });
+
+  it('should generate keys and sign message', function () {
+    const MPC = new Eddsa();
     const A = MPC.keyShare(1, 2, 3);
     const B = MPC.keyShare(2, 2, 3);
     const C = MPC.keyShare(3, 2, 3);
@@ -17,7 +25,7 @@ describe('TSS EDDSA key generation and signing', () => {
     const C_combine = MPC.keyCombine(C.uShare, [A.yShares[3], B.yShares[3]]);
 
     const message = 'MPC on a Friday night';
-    const message_buffer = Buffer.from(message, 'utf-8');
+    const message_buffer = Buffer.from(message);
 
     // signing with 3-3 signatures
     let A_sign_share = MPC.signShare(message_buffer, A_combine.pShare, [A_combine.jShares[2], A_combine.jShares[3]]);
@@ -33,8 +41,8 @@ describe('TSS EDDSA key generation and signing', () => {
     // signing with A and B
     A_sign_share = MPC.signShare(message_buffer, A_combine.pShare, [A_combine.jShares[2]]);
     B_sign_share = MPC.signShare(message_buffer, B_combine.pShare, [B_combine.jShares[1]]);
-    A_sign = MPC.sign(message_buffer, A_sign_share.xShare, [B_sign_share.rShares[1]]);
-    B_sign = MPC.sign(message_buffer, B_sign_share.xShare, [A_sign_share.rShares[2]]);
+    A_sign = MPC.sign(message_buffer, A_sign_share.xShare, [B_sign_share.rShares[1]], [C.yShares[1]]);
+    B_sign = MPC.sign(message_buffer, B_sign_share.xShare, [A_sign_share.rShares[2]], [C.yShares[2]]);
     signature = MPC.signCombine([A_sign, B_sign]);
     result = MPC.verify(message_buffer, signature).toString();
     result.should.equal(message);
@@ -42,8 +50,8 @@ describe('TSS EDDSA key generation and signing', () => {
     // signing with A and C
     A_sign_share = MPC.signShare(message_buffer, A_combine.pShare, [A_combine.jShares[3]]);
     C_sign_share = MPC.signShare(message_buffer, C_combine.pShare, [C_combine.jShares[1]]);
-    A_sign = MPC.sign(message_buffer, A_sign_share.xShare, [C_sign_share.rShares[1]]);
-    C_sign = MPC.sign(message_buffer, C_sign_share.xShare, [A_sign_share.rShares[3]]);
+    A_sign = MPC.sign(message_buffer, A_sign_share.xShare, [C_sign_share.rShares[1]], [B.yShares[1]]);
+    C_sign = MPC.sign(message_buffer, C_sign_share.xShare, [A_sign_share.rShares[3]], [B.yShares[3]]);
     signature = MPC.signCombine([A_sign, C_sign]);
     result = MPC.verify(message_buffer, signature).toString();
     result.should.equal(message);
@@ -51,14 +59,66 @@ describe('TSS EDDSA key generation and signing', () => {
     // signing with B and C
     B_sign_share = MPC.signShare(message_buffer, B_combine.pShare, [B_combine.jShares[3]]);
     C_sign_share = MPC.signShare(message_buffer, C_combine.pShare, [C_combine.jShares[2]]);
-    B_sign = MPC.sign(message_buffer, B_sign_share.xShare, [C_sign_share.rShares[2]]);
-    C_sign = MPC.sign(message_buffer, C_sign_share.xShare, [B_sign_share.rShares[3]]);
+    B_sign = MPC.sign(message_buffer, B_sign_share.xShare, [C_sign_share.rShares[2]], [A.yShares[2]]);
+    C_sign = MPC.sign(message_buffer, C_sign_share.xShare, [B_sign_share.rShares[3]], [A.yShares[3]]);
     signature = MPC.signCombine([B_sign, C_sign]);
     result = MPC.verify(message_buffer, signature).toString();
     result.should.equal(message);
   });
-  it('should fail signing without meeting threshold', async () => {
-    const MPC = await Eddsa();
+
+  it('should verify BIP32 subkey signature', function () {
+    const path = 'm/0/1/2';
+    const hdTree = new Ed25519BIP32();
+    const MPC = new Eddsa(hdTree);
+    const A = MPC.keyShare(1, 2, 3);
+    const B = MPC.keyShare(2, 2, 3);
+    const C = MPC.keyShare(3, 2, 3);
+
+    // Combine shares to common base address.
+    const A_combine = MPC.keyCombine(A.uShare, [B.yShares[1], C.yShares[1]]);
+    const B_combine = MPC.keyCombine(B.uShare, [A.yShares[2], C.yShares[2]]);
+
+    // Party A derives subkey P share and new Y shares.
+    const A_subkey = MPC.keyDerive(A.uShare, [B.yShares[1], C.yShares[1]], path);
+
+    // Party B calculates new P share using party A's subkey Y shares.
+    const B_subkey = MPC.keyCombine(B.uShare, [A_subkey.yShares[2], C.yShares[2]]);
+
+    // Derive the public subkeychain separately using the common keychain.
+    const subkey = hdTree.publicDerive(
+      {
+        pk: bigIntFromBufferLE(Buffer.from(A_combine.pShare.y, 'hex')),
+        chaincode: bigIntFromBufferBE(Buffer.from(A_combine.pShare.chaincode, 'hex')),
+      },
+      path,
+    );
+    const y = bigIntToBufferLE(subkey.pk, 32).toString('hex');
+    const chaincode = bigIntToBufferBE(subkey.chaincode, 32).toString('hex');
+
+    // Verify the keychain in the subkey P shares equals the separately derived public subkeychain.
+    A_subkey.pShare.y.should.equal(y);
+    A_subkey.pShare.chaincode.should.equal(chaincode);
+    B_subkey.pShare.y.should.equal(y);
+    B_subkey.pShare.chaincode.should.equal(chaincode);
+
+    const message = 'MPC on a Friday night';
+    const message_buffer = Buffer.from(message);
+
+    // Signing with A and B using subkey P shares.
+    const A_sign_share = MPC.signShare(message_buffer, A_subkey.pShare, [A_combine.jShares[2]]);
+    const B_sign_share = MPC.signShare(message_buffer, B_subkey.pShare, [B_combine.jShares[1]]);
+    const A_sign = MPC.sign(message_buffer, A_sign_share.xShare, [B_sign_share.rShares[1]], [C.yShares[1]]);
+    const B_sign = MPC.sign(message_buffer, B_sign_share.xShare, [A_sign_share.rShares[2]], [C.yShares[2]]);
+    const signature = MPC.signCombine([A_sign, B_sign]);
+    const result = MPC.verify(message_buffer, signature).toString();
+    result.should.equal(message);
+
+    // Verify the public key in the signature equals the separately derived public subkey.
+    signature.y.should.equal(y);
+  });
+
+  it('should fail signing without meeting threshold', function () {
+    const MPC = new Eddsa();
     const A = MPC.keyShare(1, 2, 3);
     const B = MPC.keyShare(2, 2, 3);
     const C = MPC.keyShare(3, 2, 3);
@@ -73,9 +133,6 @@ describe('TSS EDDSA key generation and signing', () => {
 
     const A_sign = MPC.sign(message_buffer, A_sign_share.xShare, [B_sign_share.rShares[1]]);
     const signature = MPC.signCombine([A_sign]);
-    const result = () => {
-      MPC.verify(message_buffer, signature).toString();
-    };
-    result.should.throw();
+    MPC.verify.bind(MPC, message_buffer, signature).should.throw();
   });
 });


### PR DESCRIPTION
General quality of life improvements to MPC module.
Changes MPC module's internal format from Buffer to BigInt.
Adds deterministic coefficient generation for Shamir splitting.
Adds chaincode generation and combination.
Adds HDTree interface and Ed25519BIP32 implementation.
Adds keyDerive method to Ed25519 TSS implementation.
TSS signing key combination moved from `keyCombine` to `sign`.
TSS `sign` method now requires Y shares of non-signers to facilitate key combination.

Note that integration work between core and account-lib needs some work (see TODO).