### PR TITLE
fix: change keyname from asset to symbol in amount

### DIFF
--- a/modules/bitgo/src/v2/internal/tssUtils.ts
+++ b/modules/bitgo/src/v2/internal/tssUtils.ts
@@ -352,7 +352,7 @@ export class TssUtils extends MpcUtils {
     const chain = this.baseCoin.getChain();
     const intentRecipients = params.recipients.map((recipient) => ({
       address: { address: recipient.address },
-      amount: { value: `${recipient.amount}`, asset: chain },
+      amount: { value: `${recipient.amount}`, symbol: chain },
     }));
 
     const whitelistedParams = {

--- a/modules/bitgo/test/v2/unit/internal/tssUtils.ts
+++ b/modules/bitgo/test/v2/unit/internal/tssUtils.ts
@@ -352,7 +352,7 @@ describe('TSS Utils:', async function () {
               },
               amount: {
                 value: '10000',
-                asset: 'tsol',
+                symbol: 'tsol',
               },
             }],
           },
@@ -385,7 +385,7 @@ describe('TSS Utils:', async function () {
               },
               amount: {
                 value: '10000',
-                asset: 'tsol',
+                symbol: 'tsol',
               },
             }, {
               address: {
@@ -393,7 +393,7 @@ describe('TSS Utils:', async function () {
               },
               amount: {
                 value: '20000',
-                asset: 'tsol',
+                symbol: 'tsol',
               },
             }],
             memo: 'memo',


### PR DESCRIPTION
The api docs expect keyname of symbol rather than asset
in the amount object. amount: {value: string; symbol: string}

TICKET: STLX-15129