### PR TITLE
fix: slice secret key array from 0 to 64 instead 0 to 32

### DIFF
--- a/modules/account-lib/src/coin/baseCoin/ed25519KeyPair.ts
+++ b/modules/account-lib/src/coin/baseCoin/ed25519KeyPair.ts
@@ -37,7 +37,7 @@ export abstract class Ed25519KeyPair implements BaseKeyPair {
 
   private getKeyPair(naclKeyPair: nacl.SignKeyPair): DefaultKeys {
     return {
-      prv: toHex(naclKeyPair.secretKey.slice(0, 32)),
+      prv: toHex(naclKeyPair.secretKey.slice(0, 64)),
       pub: toHex(naclKeyPair.publicKey),
     };
   }


### PR DESCRIPTION
TICKET: BG-0000