### PR TITLE
refactor(statics): change batcher addr for gteth

### DIFF
--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -285,7 +285,7 @@ class Goerli extends Testnet implements EthereumNetwork {
   accountExplorerUrl = 'https://goerli.etherscan.io/address/';
   // from https://github.com/ethereumjs/ethereumjs-common/blob/a978f630858f6843176bb20b277569785914e899/src/chains/index.ts
   chainId = 5;
-  batcherContractAddress = '0xc0aaf2649e7b0f3950164681eca2b1a8f654a478';
+  batcherContractAddress = '0xe8e847cf573fc8ed75621660a36affd18c543d7e';
   forwarderFactoryAddress = '0xf5caa5e3e93afbc21bd19ef4f2691a37121f7917';
   forwarderImplementationAddress = '0x80d5c91e8cc21df69fc4d64f21dc2d83121c3999';
 }


### PR DESCRIPTION
Ticket: BG-0000
For GTETH Coin the batcher contract address in BitGoJS and wallet-platform are different.
So changed in BitGoJS to use the one in wallet-platform