### PR TITLE
fix(core): fix avaxctoken cannot withdraw

### DIFF
--- a/modules/bitgo/src/v2/coins/avaxcToken.ts
+++ b/modules/bitgo/src/v2/coins/avaxcToken.ts
@@ -3,7 +3,7 @@
  */
 import { BitGo } from '../../bitgo';
 
-import { AvaxC } from './avaxc';
+import { AvaxC, TransactionPrebuild } from './avaxc';
 import { CoinConstructor } from '../coinFactory';
 import { Environments } from '../environments';
 import { coins } from '@bitgo/statics';
@@ -105,5 +105,9 @@ export class AvaxCToken extends AvaxC {
 
   isToken(): boolean {
     return true;
+  }
+
+  verifyCoin(txPrebuild: TransactionPrebuild): boolean {
+    return txPrebuild.coin === this.tokenConfig.coin && txPrebuild.token === this.tokenConfig.type;
   }
 }

--- a/modules/bitgo/test/v2/unit/coins/avaxc.ts
+++ b/modules/bitgo/test/v2/unit/coins/avaxc.ts
@@ -273,6 +273,7 @@ describe('Avalanche C-Chain', function () {
   });
 
   describe('Transaction Verification', () => {
+
     it('should verify a hop txPrebuild from the bitgo server that matches the client txParams', async function () {
       const wallet = new Wallet(bitgo, tavaxCoin, {});
 

--- a/modules/bitgo/test/v2/unit/coins/avaxcToken.ts
+++ b/modules/bitgo/test/v2/unit/coins/avaxcToken.ts
@@ -64,5 +64,14 @@ describe('Avaxc Token:', function () {
       avaxcTokenCoin.should.deepEqual(tokencoinBycontractAddress);
     });
 
+    it('should successfully verify coin', function() {
+      const txPrebuild = { coin: 'avaxc', token: 'avaxc:png' };
+      avaxcTokenCoin.verifyCoin(txPrebuild).should.equal(true);
+    });
+
+    it('should fail verify coin', function() {
+      const txPrebuild = { coin: 'eth', token: 'eth:png' };
+      avaxcTokenCoin.verifyCoin(txPrebuild).should.equal(false);
+    });
   });
 });


### PR DESCRIPTION
Becasuse missing this method, it uses AVAXC verifyCoin
Ticket: BG-0