### PR TITLE
chore: update dot tests to use tss way of signing

### DIFF
--- a/modules/account-lib/test/resources/dot/index.ts
+++ b/modules/account-lib/test/resources/dot/index.ts
@@ -1,6 +1,9 @@
 export { testnetMetadataRpc } from './testnet';
 import { Networks } from '@bitgo/statics';
 
+export const mockTssSignature =
+  'aadae7fa1f53e7a5c900b330ff71bee6782cf3c29a2c6f9599162381cd021ad581c74ded89f49ec79adefed64af8ff16649553523dda9cb4f017cbf15681e50e';
+
 export const accounts = {
   account1: {
     secretKey: '874578010603af8e93b44bfc1d13b32830d0dbca6c89f28ccdc662afd3cdc824',

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/addressInitializationBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/addressInitializationBuilder.ts
@@ -1,7 +1,15 @@
 import should from 'should';
 import sinon from 'sinon';
 import { AddressInitializationBuilder } from '../../../../../src/coin/dot';
-import { rawTx, accounts, txVersion, specVersion, genesisHash, chainName } from '../../../../resources/dot';
+import {
+  rawTx,
+  accounts,
+  txVersion,
+  specVersion,
+  genesisHash,
+  chainName,
+  mockTssSignature,
+} from '../../../../resources/dot';
 import { buildTestConfig } from './base';
 import { ProxyType } from '../../../../../src/coin/dot/iface';
 import utils from '../../../../../src/coin/dot/utils';
@@ -60,7 +68,7 @@ describe('Dot Address Initialization Builder', () => {
         .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
         .sequenceId({ name: 'Nonce', keyword: 'nonce', value: 200 })
         .fee({ amount: 0, type: 'tip' });
-      builder.sign({ key: sender.secretKey });
+      builder.addSignature({ pub: sender.publicKey }, Buffer.from(mockTssSignature, 'hex'));
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.owner, receiver.address);
@@ -133,7 +141,7 @@ describe('Dot Address Initialization Builder', () => {
         .validity({ firstValid: 3933, maxDuration: 64 })
         .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
         .sender({ address: sender.address })
-        .sign({ key: sender.secretKey });
+        .addSignature({ pub: sender.publicKey }, Buffer.from(mockTssSignature, 'hex'));
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.owner, receiver.address);
@@ -163,7 +171,7 @@ describe('Dot Address Initialization Builder', () => {
         .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
         .sequenceId({ name: 'Nonce', keyword: 'nonce', value: 200 })
         .fee({ amount: 0, type: 'tip' });
-      builder.sign({ key: sender.secretKey });
+      builder.addSignature({ pub: sender.publicKey }, Buffer.from(mockTssSignature, 'hex'));
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.proxyType, ProxyType.ANY);
@@ -217,7 +225,7 @@ describe('Dot Address Initialization Builder', () => {
         .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
         .sequenceId({ name: 'Nonce', keyword: 'nonce', value: 200 })
         .fee({ amount: 0, type: 'tip' });
-      builder.sign({ key: sender.secretKey });
+      builder.addSignature({ pub: sender.publicKey }, Buffer.from(mockTssSignature, 'hex'));
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.proxyType, ProxyType.ANY);
@@ -262,7 +270,7 @@ describe('Dot Address Initialization Builder', () => {
         .validity({ firstValid: 8975007, maxDuration: 64 })
         .referenceBlock('0x9ed0c8ee5fdc375ee57f79591d7d0db4d7cd2aa0e5403a2ed84edf0f859e3f05')
         .sender({ address: sender.address })
-        .sign({ key: sender.secretKey });
+        .addSignature({ pub: sender.publicKey }, Buffer.from(mockTssSignature, 'hex'));
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.proxyType, ProxyType.ANY);

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/base.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/base.ts
@@ -176,56 +176,6 @@ describe('Dot Transfer Builder', () => {
     });
   });
 
-  describe('add signature', () => {
-    it('should add a signature to transaction', async () => {
-      const factory = register('tdot', TransactionBuilderFactory);
-      const transferBuilder = factory
-        .getTransferBuilder()
-        .amount('90034235235322')
-        .sender({ address: sender.address })
-        .to({ address: receiver.address })
-        .validity({ firstValid: 3933, maxDuration: 64 })
-        .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
-        .sequenceId({ name: 'Nonce', keyword: 'nonce', value: 200 })
-        .fee({ amount: 0, type: 'tip' });
-
-      transferBuilder.sign({ key: accounts.account1.secretKey });
-      const signedTx = await transferBuilder.build();
-      const signature = signedTx.signature[0];
-
-      // verify rebuilt transaction contains signature
-      const rawTransaction = signedTx.toBroadcastFormat() as string;
-      const rebuiltSignedTransaction = await factory
-        .from(rawTransaction)
-        .validity({ firstValid: 3933, maxDuration: 64 })
-        .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
-        .build();
-      rebuiltSignedTransaction.signature.should.deepEqual(signedTx.signature);
-
-      const transferBuilder2 = factory
-        .getTransferBuilder()
-        .amount('90034235235322')
-        .sender({ address: sender.address })
-        .to({ address: receiver.address })
-        .validity({ firstValid: 3933, maxDuration: 64 })
-        .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
-        .sequenceId({ name: 'Nonce', keyword: 'nonce', value: 200 })
-        .fee({ amount: 0, type: 'tip' });
-      transferBuilder2.addSignature({ pub: accounts.account1.publicKey }, Buffer.from(signature, 'hex'));
-      const signedTransaction2 = await transferBuilder2.build();
-
-      // verify signatures are correct
-      signedTx.signature.should.deepEqual(signedTransaction2.signature);
-      const rawTransaction2 = signedTransaction2.toBroadcastFormat() as string;
-      const rebuiltTransaction2 = await factory
-        .from(rawTransaction2)
-        .validity({ firstValid: 3933, maxDuration: 64 })
-        .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
-        .build();
-      rebuiltTransaction2.signature.should.deepEqual(signedTransaction2.signature);
-    });
-  });
-
   describe('add TSS signature', function () {
     before('initialize mpc module', async () => {
       await Eddsa.initialize();

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/batchTransactionBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/batchTransactionBuilder.ts
@@ -1,7 +1,7 @@
 import should from 'should';
 import { spy, assert } from 'sinon';
 import { BatchTransactionBuilder } from '../../../../../src/coin/dot';
-import { accounts, rawTx, specVersion, txVersion } from '../../../../resources/dot';
+import { accounts, mockTssSignature, rawTx, specVersion, txVersion } from '../../../../resources/dot';
 import { buildTestConfig } from './base';
 import { ProxyType } from '../../../../../src/coin/dot/iface';
 import utils from '../../../../../src/coin/dot/utils';
@@ -42,8 +42,9 @@ describe('Dot Batch Transaction Builder', () => {
         .validity({ firstValid: 9279281, maxDuration: 64 })
         .referenceBlock(referenceBlock)
         .sequenceId({ name: 'Nonce', keyword: 'nonce', value: 0 })
-        .fee({ amount: 0, type: 'tip' });
-      builder.sign({ key: sender.secretKey });
+        .fee({ amount: 0, type: 'tip' })
+        .addSignature({ pub: sender.publicKey }, Buffer.from(mockTssSignature, 'hex'));
+
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.batchCalls.length, rawTx.anonymous.batch.length);
@@ -129,7 +130,7 @@ describe('Dot Batch Transaction Builder', () => {
         .validity({ firstValid: 9266787, maxDuration: 64 })
         .referenceBlock(referenceBlock)
         .sender({ address: sender.address })
-        .sign({ key: sender.secretKey });
+        .addSignature({ pub: sender.publicKey }, Buffer.from(mockTssSignature, 'hex'));
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.sender, sender.address);

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/claimBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/claimBuilder.ts
@@ -2,7 +2,15 @@ import should from 'should';
 import { spy, assert } from 'sinon';
 import { ClaimBuilder } from '../../../../../src/coin/dot';
 import utils from '../../../../../src/coin/dot/utils';
-import { accounts, rawTx, specVersion, txVersion, chainName, genesisHash } from '../../../../resources/dot';
+import {
+  accounts,
+  rawTx,
+  specVersion,
+  txVersion,
+  chainName,
+  genesisHash,
+  mockTssSignature,
+} from '../../../../resources/dot';
 import { buildTestConfig } from './base';
 
 describe('Dot Claim Builder', () => {
@@ -47,8 +55,9 @@ describe('Dot Claim Builder', () => {
         .validity({ firstValid: 3933, maxDuration: 64 })
         .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
         .sequenceId({ name: 'Nonce', keyword: 'nonce', value: 200 })
-        .fee({ amount: 0, type: 'tip' });
-      builder.sign({ key: sender.secretKey });
+        .fee({ amount: 0, type: 'tip' })
+        .addSignature({ pub: sender.publicKey }, Buffer.from(mockTssSignature, 'hex'));
+
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.validatorStash, validatorStash.address);
@@ -117,7 +126,8 @@ describe('Dot Claim Builder', () => {
         .validity({ firstValid: 3933 })
         .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
         .sender({ address: sender.address })
-        .sign({ key: sender.secretKey });
+        .addSignature({ pub: sender.publicKey }, Buffer.from(mockTssSignature, 'hex'));
+
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.validatorStash, validatorStash.address);

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/stakingBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/stakingBuilder.ts
@@ -2,7 +2,15 @@ import should from 'should';
 import { spy, assert } from 'sinon';
 import { StakingBuilder } from '../../../../../src/coin/dot';
 import utils from '../../../../../src/coin/dot/utils';
-import { accounts, rawTx, specVersion, txVersion, chainName, genesisHash } from '../../../../resources/dot';
+import {
+  accounts,
+  rawTx,
+  specVersion,
+  txVersion,
+  chainName,
+  genesisHash,
+  mockTssSignature,
+} from '../../../../resources/dot';
 import { buildTestConfig } from './base';
 
 describe('Dot Stake Builder', () => {
@@ -61,8 +69,9 @@ describe('Dot Stake Builder', () => {
         .validity({ firstValid: 3933, maxDuration: 64 })
         .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
         .sequenceId({ name: 'Nonce', keyword: 'nonce', value: 200 })
-        .fee({ amount: 0, type: 'tip' });
-      builder.sign({ key: sender.secretKey });
+        .fee({ amount: 0, type: 'tip' })
+        .addSignature({ pub: sender.publicKey }, Buffer.from(mockTssSignature, 'hex'));
+
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.amount, '90034235235322');
@@ -135,7 +144,7 @@ describe('Dot Stake Builder', () => {
         .validity({ firstValid: 3933 })
         .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
         .sender({ address: sender.address })
-        .sign({ key: sender.secretKey });
+        .addSignature({ pub: sender.publicKey }, Buffer.from(mockTssSignature, 'hex'));
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.amount, '90034235235322');
@@ -181,7 +190,7 @@ describe('Dot Stake Builder', () => {
         .validity({ firstValid: 3933 })
         .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
         .sender({ address: sender.address })
-        .sign({ key: sender.secretKey });
+        .addSignature({ pub: sender.publicKey }, Buffer.from(mockTssSignature, 'hex'));
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.amount, '90034235235322');

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/transactionBuilderFactory.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/transactionBuilderFactory.ts
@@ -7,7 +7,7 @@ import {
   StakingBuilder,
   UnstakeBuilder,
 } from '../../../../../src/coin/dot';
-import { rawTx, accounts } from '../../../../resources/dot';
+import { rawTx, accounts, mockTssSignature } from '../../../../resources/dot';
 import * as materialData from '../../../../resources/dot/materialData.json';
 import { Material } from '../../../../../src/coin/dot/iface';
 
@@ -78,7 +78,7 @@ describe('dot Transaction Builder Factory', function () {
         .validity({ firstValid: 3933, maxDuration: 64 })
         .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
         .sender({ address: sender2.address })
-        .sign({ key: sender2.secretKey });
+        .addSignature({ pub: sender.publicKey }, Buffer.from(mockTssSignature, 'hex'));
       const tx = await builder.build();
       should.equal(tx.toBroadcastFormat(), rawTx.proxy.signed);
     });

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/transferBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/transferBuilder.ts
@@ -1,7 +1,15 @@
 import should from 'should';
 import sinon from 'sinon';
 import { TransferBuilder } from '../../../../../src/coin/dot';
-import { accounts, rawTx, chainName, txVersion, genesisHash, specVersion } from '../../../../resources/dot';
+import {
+  accounts,
+  rawTx,
+  chainName,
+  txVersion,
+  genesisHash,
+  specVersion,
+  mockTssSignature,
+} from '../../../../resources/dot';
 import { buildTestConfig } from './base';
 import { ProxyType } from '../../../../../src/coin/dot/iface';
 import utils from '../../../../../src/coin/dot/utils';
@@ -58,7 +66,7 @@ describe('Dot Transfer Builder', () => {
         .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
         .sequenceId({ name: 'Nonce', keyword: 'nonce', value: 200 })
         .fee({ amount: 0, type: 'tip' });
-      builder.sign({ key: sender.secretKey });
+      builder.addSignature({ pub: sender.publicKey }, Buffer.from(mockTssSignature, 'hex'));
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.amount, '90034235235322');
@@ -92,7 +100,7 @@ describe('Dot Transfer Builder', () => {
         .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
         .sequenceId({ name: 'Nonce', keyword: 'nonce', value: 200 })
         .fee({ amount: 0, type: 'tip' });
-      builder.sign({ key: sender.secretKey });
+      builder.addSignature({ pub: sender.publicKey }, Buffer.from(mockTssSignature, 'hex'));
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.amount, '90034235235322');
@@ -169,7 +177,8 @@ describe('Dot Transfer Builder', () => {
         .validity({ firstValid: 3933, maxDuration: 64 })
         .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
         .sender({ address: sender.address })
-        .sign({ key: sender.secretKey });
+        .addSignature({ pub: sender.publicKey }, Buffer.from(mockTssSignature, 'hex'));
+
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.amount, '90034235235322');
@@ -217,8 +226,8 @@ describe('Dot Transfer Builder', () => {
         .validity({ firstValid: 3933, maxDuration: 64 })
         .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
         .sequenceId({ name: 'Nonce', keyword: 'nonce', value: 200 })
-        .fee({ amount: 0, type: 'tip' });
-      builder.sign({ key: proxySender.secretKey });
+        .fee({ amount: 0, type: 'tip' })
+        .addSignature({ pub: sender.publicKey }, Buffer.from(mockTssSignature, 'hex'));
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.owner, sender.address);
@@ -297,7 +306,7 @@ describe('Dot Transfer Builder', () => {
         .validity({ firstValid: 3933, maxDuration: 64 })
         .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
         .sender({ address: proxySender.address })
-        .sign({ key: proxySender.secretKey });
+        .addSignature({ pub: sender.publicKey }, Buffer.from(mockTssSignature, 'hex'));
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.owner, sender.address);

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/unnominateBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/unnominateBuilder.ts
@@ -1,6 +1,6 @@
 import should from 'should';
 import { UnnominateBuilder } from '../../../../../src/coin/dot';
-import { accounts, rawTx, genesisHash, specVersion, txVersion } from '../../../../resources/dot';
+import { accounts, rawTx, genesisHash, specVersion, txVersion, mockTssSignature } from '../../../../resources/dot';
 import { buildTestConfig } from './base';
 
 describe('Dot Unnominate Builder', () => {
@@ -20,7 +20,7 @@ describe('Dot Unnominate Builder', () => {
         .referenceBlock(refBlock)
         .sequenceId({ name: 'Nonce', keyword: 'nonce', value: 200 })
         .fee({ amount: 0, type: 'tip' });
-      builder.sign({ key: sender.secretKey });
+      builder.addSignature({ pub: sender.publicKey }, Buffer.from(mockTssSignature, 'hex'));
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.sender, sender.address);
@@ -79,7 +79,7 @@ describe('Dot Unnominate Builder', () => {
         .validity({ firstValid: 3933 })
         .referenceBlock(refBlock)
         .sender({ address: sender.address })
-        .sign({ key: sender.secretKey });
+        .addSignature({ pub: sender.publicKey }, Buffer.from(mockTssSignature, 'hex'));
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.sender, sender.address);

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/unstakeBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/unstakeBuilder.ts
@@ -2,7 +2,15 @@ import should from 'should';
 import { spy, assert } from 'sinon';
 import { UnstakeBuilder } from '../../../../../src/coin/dot';
 import utils from '../../../../../src/coin/dot/utils';
-import { rawTx, accounts, specVersion, txVersion, chainName, genesisHash } from '../../../../resources/dot';
+import {
+  rawTx,
+  accounts,
+  specVersion,
+  txVersion,
+  chainName,
+  genesisHash,
+  mockTssSignature,
+} from '../../../../resources/dot';
 import { buildTestConfig } from './base';
 
 describe('Dot Unstake Builder', () => {
@@ -36,7 +44,7 @@ describe('Dot Unstake Builder', () => {
         .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
         .sequenceId({ name: 'Nonce', keyword: 'nonce', value: 200 })
         .fee({ amount: 0, type: 'tip' });
-      builder.sign({ key: sender.secretKey });
+      builder.addSignature({ pub: sender.publicKey }, Buffer.from(mockTssSignature, 'hex'));
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.amount, '50000000000000');
@@ -101,7 +109,7 @@ describe('Dot Unstake Builder', () => {
         .validity({ firstValid: 3933 })
         .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
         .sender({ address: sender.address })
-        .sign({ key: sender.secretKey });
+        .addSignature({ pub: sender.publicKey }, Buffer.from(mockTssSignature, 'hex'));
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.amount, '50000000000000');

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/withdrawUnstakedBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/withdrawUnstakedBuilder.ts
@@ -2,7 +2,15 @@ import should from 'should';
 import { assert, spy } from 'sinon';
 import { WithdrawUnstakedBuilder } from '../../../../../src/coin/dot';
 import { buildTestConfig } from './base';
-import { accounts, rawTx, specVersion, txVersion, chainName, genesisHash } from '../../../../resources/dot';
+import {
+  accounts,
+  rawTx,
+  specVersion,
+  txVersion,
+  chainName,
+  genesisHash,
+  mockTssSignature,
+} from '../../../../resources/dot';
 import utils from '../../../../../src/coin/dot/utils';
 
 describe('Dot WithdrawUnstaked Builder', () => {
@@ -37,7 +45,7 @@ describe('Dot WithdrawUnstaked Builder', () => {
         .referenceBlock(refBlock)
         .sequenceId({ name: 'Nonce', keyword: 'nonce', value: 200 })
         .fee({ amount: 0, type: 'tip' });
-      builder.sign({ key: sender.secretKey });
+      builder.addSignature({ pub: sender.publicKey }, Buffer.from(mockTssSignature, 'hex'));
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.numSlashingSpans, '0');
@@ -100,7 +108,7 @@ describe('Dot WithdrawUnstaked Builder', () => {
         .validity({ firstValid: 3933 })
         .referenceBlock(refBlock)
         .sender({ address: sender.address })
-        .sign({ key: sender.secretKey });
+        .addSignature({ pub: sender.publicKey }, Buffer.from(mockTssSignature, 'hex'));
       const tx = await builder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.numSlashingSpans, '0');


### PR DESCRIPTION
Updates dot tss tests to use `addSignature` instead of `.sign` since we're now using TSS to add a signature to a dot transaction.

TICKET: BG-45942