### PR TITLE
test(bitgo): integration test for ETH2 BLS keychains message signing

### DIFF
--- a/modules/bitgo/src/v2/coins/eth2.ts
+++ b/modules/bitgo/src/v2/coins/eth2.ts
@@ -20,6 +20,7 @@ import {
 import { BitGo } from '../../bitgo';
 import * as common from '../../common';
 import { MethodNotImplementedError } from '../../errors';
+import { KeyIndices } from '../keychains';
 
 interface Recipient {
   address: string;
@@ -186,6 +187,13 @@ export class Eth2 extends BaseCoin {
    */
   getRecoveryGasLimit(): any {
     throw new Error('Method not yet implemented');
+  }
+
+  /**
+   * Specifies what key we will need for signing - ETH2 needs the backup, bitgo pubs.
+   */
+  keyIdsForSigning(): number[] {
+    return [KeyIndices.USER, KeyIndices.BACKUP, KeyIndices.BITGO];
   }
 
   /**

--- a/modules/bitgo/test/lib/test_bitgo.ts
+++ b/modules/bitgo/test/lib/test_bitgo.ts
@@ -164,6 +164,9 @@ BitGo.prototype.initializeTestVars = function () {
     BitGo.V2.TEST_ETH_WALLET_PASSPHRASE = 'moon';
     BitGo.V2.TEST_ETH_WALLET_FIRST_ADDRESS = '0xdf07117705a9f8dc4c2a78de66b7f1797dba9d4e';
 
+    BitGo.V2.TEST_ETH2_WALLET_ID = '6245df06b0c50d0008e0b2acea0b1f0e';
+    BitGo.V2.TEST_ETH2_WALLET_PASSPHRASE = 'Eth2OnMoon!';
+
     BitGo.V2.TEST_BCH_WALLET_ID = '6148987267660d00069dd844af297a2b';
     BitGo.V2.TEST_BCH_WALLET_PASSPHRASE = 'BchOnMoon4';
     BitGo.V2.TEST_BCH_WALLET_CASH_ADDRESS = 'bchtest:pr3zp43qxu8ztudephsvyafxj2zfznw5v5wh85sg54';

--- a/modules/bitgo/test/v2/integration/coins/eth2.ts
+++ b/modules/bitgo/test/v2/integration/coins/eth2.ts
@@ -1,0 +1,52 @@
+import { bufferToHex } from 'ethereumjs-util';
+import { Eth2 as Eth2AccountLib } from '@bitgo/account-lib';
+import * as Bluebird from 'bluebird';
+const co = Bluebird.coroutine;
+
+import { TestBitGo } from '../../../lib/test_bitgo';
+import * as nock from 'nock';
+nock.restore();
+
+describe('ETH2:', function () {
+  let bitgo;
+  let wallet;
+
+  before(co(function *() {
+    bitgo = new TestBitGo({ env: 'test' });
+    bitgo.initializeTestVars();
+
+    yield bitgo.authenticateTestUser(bitgo.testUserOTP());
+    wallet = yield bitgo.coin('teth2').wallets().getWallet({ id: TestBitGo.V2.TEST_ETH2_WALLET_ID });
+  }));
+
+  describe('Sign message', function () {
+    it('should sign and verify a message', async function () {
+      const basecoin = bitgo.coin('teth2');
+      await bitgo.unlock( { otp: '0000000' });
+
+      const ethKeychains = bitgo.coin('teth2').keychains();
+      const keychains = await ethKeychains.getKeysForSigning({ wallet });
+      keychains.length.should.equal(3);
+      
+      const message = 'hello world';
+      const userKeyPrv = bitgo.decrypt({
+        input: keychains[0].encryptedPrv,
+        password: TestBitGo.V2.TEST_ETH2_WALLET_PASSPHRASE,
+      });
+      const userSignatureBuffer = await basecoin.signMessage({ prv: userKeyPrv }, message);
+      const userSignature = bufferToHex(userSignatureBuffer);
+
+      const backupKeyPrv = bitgo.decrypt({
+        input: keychains[1].encryptedPrv,
+        password: TestBitGo.V2.TEST_ETH2_WALLET_PASSPHRASE,
+      });
+      const backupSignatureBuffer = await basecoin.signMessage({ prv: backupKeyPrv }, message);
+      const backupSignature = bufferToHex(backupSignatureBuffer);
+
+      const signature = Eth2AccountLib.KeyPair.aggregateSignatures({ 1: BigInt(userSignature), 2: BigInt(backupSignature) });
+      
+      keychains[0].commonPub.should.equal(keychains[1].commonPub);
+      (await Eth2AccountLib.KeyPair.verifySignature(keychains[0].commonPub, Buffer.from(message), signature)).should.be.true();
+    });
+  });
+});


### PR DESCRIPTION
Integration test for ETH2 BLS keychains signing methods. We should be able to sign a message and
verify its signature.

BG-36125