### PR TITLE
feat: support tss hd signing

### DIFF
--- a/modules/account-lib/test/unit/mpc/tss.ts
+++ b/modules/account-lib/test/unit/mpc/tss.ts
@@ -4,7 +4,7 @@
 import 'should';
 import * as bs58 from 'bs58';
 import * as sol from '@solana/web3.js';
-import { Dot } from '../../../src';
+import { Dot, Sol } from '../../../src';
 
 import Eddsa from '../../../src/mpc/tss';
 import { Ed25519BIP32 } from '../../../src/mpc/hdTree';
@@ -135,9 +135,14 @@ describe('TSS EDDSA key generation and signing', function () {
     for (let index = 0; index < 10; index++) {
       const path = `m/0/0/${index}`;
       const derive1 = MPC.deriveUnhardened(commonKeychain, path);
+      const subkey = MPC.keyDerive(A.uShare, [B.yShares[1], C.yShares[1]], path);
       const derive2 = MPC.deriveUnhardened(commonKeychain, path);
 
+      subkey.pShare.y.should.equal(derive1);
       derive1.should.equal(derive2, 'derivation should be deterministic');
+
+      const solAddress = bs58.encode(Buffer.from(derive1, 'hex'));
+      Sol.Utils.isValidPublicKey(solAddress).should.be.true();
 
       const solPk = new sol.PublicKey(bs58.encode(Buffer.from(derive1, 'hex')));
       solPk.toBuffer().toString('hex').should.equal(derive1);

--- a/modules/bitgo/src/v2/internal/opengpgUtils.ts
+++ b/modules/bitgo/src/v2/internal/opengpgUtils.ts
@@ -1,0 +1,39 @@
+import { createMessage, encrypt, Key, readKey } from 'openpgp';
+import { BitGo } from '../../bitgo';
+
+/**
+ * Fetches BitGo's pubic gpg key used in MPC flows
+ * @param {BitGo} bitgo BitGo object
+ * @return {Key} public gpg key
+ */
+export async function getBitgoGpgPubKey(bitgo: BitGo): Promise<Key> {
+  const constants = await bitgo.fetchConstants();
+  if (!constants.mpc || !constants.mpc.bitgoPublicKey) {
+    throw new Error('Unable to create MPC keys - bitgoPublicKey is missing from constants');
+  }
+
+  const bitgoPublicKeyStr = constants.mpc.bitgoPublicKey as string;
+  return await readKey({ armoredKey: bitgoPublicKeyStr });
+}
+
+/**
+ * Encrypts string using gpg key
+ * @param text string to encrypt
+ * @param key encryption key
+ * @return {string} encrypted string
+ */
+export async function encryptText(text: string, key: Key): Promise<string> {
+  const messageToEncrypt = await createMessage({
+    text,
+  });
+  return await encrypt({
+    message: messageToEncrypt,
+    encryptionKeys: [key],
+    format: 'armored',
+    config: {
+      rejectCurves: new Set(),
+      showVersion: false,
+      showComment: false,
+    },
+  });
+}

--- a/modules/bitgo/src/v2/internal/tssUtils.ts
+++ b/modules/bitgo/src/v2/internal/tssUtils.ts
@@ -11,7 +11,6 @@ import Eddsa, {
   KeyShare,
   JShare,
   SignShare,
-  XShare,
   YShare,
   RShare,
   GShare,
@@ -22,6 +21,7 @@ import Eddsa, {
 import { BaseCoin, KeychainsTriplet } from '../baseCoin';
 import { Keychain } from '../keychains';
 import { BitGo } from '../../bitgo';
+import { encryptText, getBitgoGpgPubKey } from './opengpgUtils';
 import { MpcUtils } from './mpcUtils';
 import { Memo, Wallet } from '..';
 import { RequestTracer } from '../internal/util';
@@ -56,6 +56,7 @@ export interface TxRequest {
       fee: number;
       feeString: string;
     };
+    derivationPath: string;
   }[];
   signatureShares?: SignatureShareRecord[];
 }
@@ -74,7 +75,6 @@ export interface SignatureShareRecord {
 
 interface SigningMaterial {
   uShare: UShare;
-  commonChaincode: string;
   bitgoYShare: YShare;
 }
 
@@ -147,38 +147,24 @@ export class TssUtils extends MpcUtils {
     };
 
     const userCombined = MPC.keyCombine(userKeyShare.uShare, [backupKeyShare.yShares[1], bitgoToUser]);
-    const commonChaincode = userCombined.pShare.chaincode;
-    if (commonChaincode !== bitgoKeychain.commonKeychain?.slice(64)) {
-      throw new Error('Failed to create user keychain - commonChaincodes do not match.');
+    const commonKeychain = userCombined.pShare.y + userCombined.pShare.chaincode;
+    if (commonKeychain !== bitgoKeychain.commonKeychain) {
+      throw new Error('Failed to create user keychain - commonKeychains do not match.');
     }
 
     const userSigningMaterial: UserSigningMaterial = {
       uShare: userKeyShare.uShare,
-      commonChaincode: commonChaincode,
       bitgoYShare: bitgoToUser,
       backupYShare: backupKeyShare.yShares[1],
     };
 
-    const userKeychainParams: any = {
+    const userKeychainParams = {
       source: 'user',
       type: 'tss',
       commonKeychain: bitgoKeychain.commonKeychain,
       encryptedPrv: this.bitgo.encrypt({ input: JSON.stringify(userSigningMaterial), password: passphrase }),
+      originalPasscodeEncryptionCode,
     };
-
-    if (this.baseCoin.supportsDerivationKeypair()) {
-      const addressDerivationKeypair = this.baseCoin.keychains().create();
-      if (!addressDerivationKeypair.pub) {
-        throw new Error('Expected address derivation keypair to contain a public key.');
-      }
-
-      const encryptedPrv = this.bitgo.encrypt({ password: passphrase, input: addressDerivationKeypair.prv });
-      userKeychainParams.addressDerivationKeypair = {
-        pub: addressDerivationKeypair.pub,
-        encryptedPrv: encryptedPrv,
-        originalPasscodeEncryptionCode: originalPasscodeEncryptionCode,
-      };
-    }
 
     return await this.baseCoin.keychains().add(userKeychainParams);
   }
@@ -222,14 +208,13 @@ export class TssUtils extends MpcUtils {
     };
 
     const backupCombined = MPC.keyCombine(backupKeyShare.uShare, [userKeyShare.yShares[2], bitgoToBackup]);
-    const commonChaincode = backupCombined.pShare.chaincode;
-    if (commonChaincode !== bitgoKeychain.commonKeychain?.slice(64)) {
-      throw new Error('Failed to create backup keychain - commonChaincodes do not match.');
+    const commonKeychain = backupCombined.pShare.y + backupCombined.pShare.chaincode;
+    if (commonKeychain !== bitgoKeychain.commonKeychain) {
+      throw new Error('Failed to create backup keychain - commonKeychains do not match.');
     }
 
     const backupSigningMaterial: BackupSigningMaterial = {
       uShare: backupKeyShare.uShare,
-      commonChaincode,
       bitgoYShare: bitgoToBackup,
       userYShare: userKeyShare.yShares[2],
     };
@@ -360,13 +345,12 @@ export class TssUtils extends MpcUtils {
   async signTxRequest(params: {
     txRequest: string | TxRequest;
     prv: string;
-    path: string;
     reqId: RequestTracer;
   }): Promise<TxRequest> {
     let txRequestResolved: TxRequest;
     let txRequestId: string;
 
-    const { txRequest, prv, path } = params;
+    const { txRequest, prv } = params;
 
     if (typeof txRequest === 'string') {
       txRequestResolved = await this.getTxRequest(txRequest);
@@ -384,16 +368,22 @@ export class TssUtils extends MpcUtils {
     const signingKey = MPC.keyDerive(
       userSigningMaterial.uShare,
       [userSigningMaterial.bitgoYShare, userSigningMaterial.backupYShare],
-      path
+      txRequestResolved.unsignedTxs[0].derivationPath
     );
-    const signerShare =
-      signingKey.yShares[ShareKeyPosition.BITGO].u + signingKey.yShares[ShareKeyPosition.BITGO].chaincode;
 
     const signablePayload = Buffer.from(txRequestResolved.unsignedTxs[0].signableHex, 'hex');
 
     const userSignShare = await this.createUserSignShare({ signablePayload, pShare: signingKey.pShare });
 
-    await this.offerUserToBitgoRShare({ txRequestId, userSignShare, signerShare });
+    const signerShare = signingKey.yShares[3].u + signingKey.yShares[3].chaincode;
+    const bitgoGpgKey = await getBitgoGpgPubKey(this.bitgo);
+    const encryptedSignerShare = await encryptText(signerShare, bitgoGpgKey);
+
+    await this.offerUserToBitgoRShare({
+      txRequestId,
+      userSignShare,
+      encryptedSignerShare,
+    });
 
     const bitgoToUserRShare = await this.getBitgoToUserRShare(txRequestId);
 
@@ -401,6 +391,7 @@ export class TssUtils extends MpcUtils {
       userSignShare,
       bitgoToUserRShare,
       userSigningMaterial.backupYShare,
+      userSigningMaterial.bitgoYShare,
       signablePayload
     );
 
@@ -488,14 +479,15 @@ export class TssUtils extends MpcUtils {
    *
    * @param {String} txRequestId - the txRequest Id
    * @param {SignShare} userSignShare - the user Sign Share
+   * @param {String} encryptedSignerShare - signer share encrypted to bitgo key
    * @returns {Promise<void>}
    */
   async offerUserToBitgoRShare(params: {
     txRequestId: string;
     userSignShare: SignShare;
-    signerShare: string;
+    encryptedSignerShare: string;
   }): Promise<void> {
-    const { txRequestId, userSignShare, signerShare } = params;
+    const { txRequestId, userSignShare, encryptedSignerShare } = params;
     const rShare: RShare = userSignShare.rShares[ShareKeyPosition.BITGO];
     if (_.isNil(rShare)) {
       throw new Error('userToBitgo RShare not found');
@@ -508,7 +500,8 @@ export class TssUtils extends MpcUtils {
       to: SignatureShareType.BITGO,
       share: rShare.r + rShare.R,
     };
-    await this.sendSignatureShare({ txRequestId, signatureShare, signerShare });
+
+    await this.sendSignatureShare({ txRequestId, signatureShare, signerShare: encryptedSignerShare });
   }
 
   /**
@@ -579,6 +572,7 @@ export class TssUtils extends MpcUtils {
     userSignShare: SignShare,
     bitgoToUserRShare: SignatureShareRecord,
     backupToUserYShare: YShare,
+    bitgoToUserYShare: YShare,
     signablePayload: Buffer
   ): Promise<GShare> {
     if (userSignShare.xShare.i !== ShareKeyPosition.USER) {
@@ -594,17 +588,16 @@ export class TssUtils extends MpcUtils {
       throw new Error('Invalid YShare, is not backup key');
     }
 
-    const userXShare: XShare = userSignShare.xShare;
     const RShare: RShare = {
       i: ShareKeyPosition.USER,
       j: ShareKeyPosition.BITGO,
-      u: userXShare.u,
+      u: bitgoToUserYShare.u,
       r: bitgoToUserRShare.share.substring(0, 64),
       R: bitgoToUserRShare.share.substring(64, 128),
     };
     await Eddsa.initialize();
     const MPC = new Eddsa();
-    return MPC.sign(signablePayload, userXShare, [RShare], [backupToUserYShare]);
+    return MPC.sign(signablePayload, userSignShare.xShare, [RShare], [backupToUserYShare]);
   }
 
   /**
@@ -650,15 +643,10 @@ export class TssUtils extends MpcUtils {
    * @param {RequestTracer} reqId id tracer.
    * @returns {Promise<any>}
    */
-  async recreateTxRequest(
-    txRequestId: string,
-    decryptedPrv: string,
-    path: string,
-    reqId: RequestTracer
-  ): Promise<TxRequest> {
+  async recreateTxRequest(txRequestId: string, decryptedPrv: string, reqId: RequestTracer): Promise<TxRequest> {
     await this.deleteSignatureShares(txRequestId);
     // after delete signatures shares get the tx without them
     const txRequest = await this.getTxRequest(txRequestId);
-    return await this.signTxRequest({ txRequest, prv: decryptedPrv, path, reqId });
+    return await this.signTxRequest({ txRequest, prv: decryptedPrv, reqId });
   }
 }

--- a/modules/bitgo/src/v2/pendingApproval.ts
+++ b/modules/bitgo/src/v2/pendingApproval.ts
@@ -337,8 +337,7 @@ export class PendingApproval {
     }
 
     const decryptedPrv = await this.wallet.getPrv({ walletPassphrase });
-    // TODO (STLX-14667): avoid hard coding derivation path to support consolidation
-    const txRequest = await this.tssUtils.recreateTxRequest(txRequestId, decryptedPrv, 'm/0', reqId);
+    const txRequest = await this.tssUtils.recreateTxRequest(txRequestId, decryptedPrv, reqId);
     return {
       txHex: txRequest.unsignedTxs[0].serializedTxHex,
     };

--- a/modules/bitgo/src/v2/wallet.ts
+++ b/modules/bitgo/src/v2/wallet.ts
@@ -2789,8 +2789,6 @@ export class Wallet {
       const signedTxRequest = await this.tssUtils.signTxRequest({
         txRequest: params.txPrebuild.txRequestId,
         prv: params.prv,
-        // TODO (STLX-14667): avoid hard coding derivation path to support consolidation
-        path: 'm/0',
         reqId: params.reqId || new RequestTracer(),
       });
       return {

--- a/modules/bitgo/test/v2/unit/pendingApproval.ts
+++ b/modules/bitgo/test/v2/unit/pendingApproval.ts
@@ -114,7 +114,7 @@ describe('Pending Approvals:', () => {
     const params = { txRequestId, walletPassphrase };
     const txRequest = {
       txRequestId: txRequestId,
-      unsignedTxs: [{ signableHex: 'randomhex', serializedTxHex: 'randomhex2' }],
+      unsignedTxs: [{ signableHex: 'randomhex', serializedTxHex: 'randomhex2', derivationPath: 'm/0' }],
       signatureShares: [
         {
           from: SignatureShareType.BITGO,
@@ -129,7 +129,7 @@ describe('Pending Approvals:', () => {
     decryptedPrv.resolves(decryptedPrvResponse);
 
     const recreateTxRequest = sandbox.stub(TssUtils.prototype, 'recreateTxRequest');
-    recreateTxRequest.calledOnceWithExactly(txRequest.txRequestId, decryptedPrvResponse, 'm/0', reqId);
+    recreateTxRequest.calledOnceWithExactly(txRequest.txRequestId, decryptedPrvResponse, reqId);
     recreateTxRequest.resolves(txRequest);
 
     const recreatedTx = await pendingApproval.recreateAndSignTSSTransaction(params, reqId);

--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -1500,7 +1500,8 @@ describe('V2 Wallet:', function () {
           feeInfo: {
             fee: 5000,
             feeString: '5000',
-          }
+          },
+          derivationPath: 'm/0',
         },
       ],
     };
@@ -1661,7 +1662,7 @@ describe('V2 Wallet:', function () {
       it('should sign transaction', async function () {
         const signTxRequest = sandbox.stub(TssUtils.prototype, 'signTxRequest');
         signTxRequest.resolves(txRequest);
-        signTxRequest.calledOnceWithExactly({ txRequest, prv: 'secretKey', path: 'm/0', reqId });
+        signTxRequest.calledOnceWithExactly({ txRequest, prv: 'secretKey', reqId });
 
         const txPrebuild = {
           walletId: tssWallet.id(),


### PR DESCRIPTION
server will determine derivationPath based on the transaction that is
being built. this is will be used to derive the signing key in tss
flows.

Ticket: STLX-14667

`derivationPath` is being added in this PR: https://github.com/BitGo/bitgo-microservices/pull/17332