### PR TITLE
fix: v1 wallet cross chain recovery

### DIFF
--- a/modules/bitgo/src/v2/coins/utxo/recovery/crossChainRecovery.ts
+++ b/modules/bitgo/src/v2/coins/utxo/recovery/crossChainRecovery.ts
@@ -95,7 +95,7 @@ async function getWallet(bitgo: BitGo, coin: AbstractUtxoCoin, walletId: string)
   try {
     return await coin.wallets().get({ id: walletId });
   } catch (e) {
-    if (e.status !== 404) {
+    if (e.status >= 400 && e.status < 500) {
       throw e;
     }
   }


### PR DESCRIPTION
Currently, bitgo throws a 400 error for v1 wallet Ids that are not found in the `api/v2/:coin/wallets/:walletId` route, causing cross chain recovery for v1 wallets to fail. This commit expands the range of error responses to prevent similar errors occurring in the future.

A test for this will be created in another ticket (BG-46179)

Ticket: BG-44440