### PR TITLE
fix: update signer share in tss signing flow

### DIFF
--- a/modules/bitgo/src/v2/internal/tssUtils.ts
+++ b/modules/bitgo/src/v2/internal/tssUtils.ts
@@ -376,7 +376,8 @@ export class TssUtils extends MpcUtils {
 
     const userSignShare = await this.createUserSignShare({ signablePayload, pShare: signingKey.pShare });
 
-    const signerShare = signingKey.yShares[3].u + signingKey.yShares[3].chaincode;
+    const signerShare =
+      userSignShare.rShares[ShareKeyPosition.BITGO].u + signingKey.yShares[ShareKeyPosition.BITGO].chaincode;
     const bitgoGpgKey = await getBitgoGpgPubKey(this.bitgo);
     const encryptedSignerShare = await encryptText(signerShare, bitgoGpgKey);
 

--- a/modules/bitgo/src/v2/wallet.ts
+++ b/modules/bitgo/src/v2/wallet.ts
@@ -2607,6 +2607,10 @@ export class Wallet {
       throw new Error('Failed to find consolidation id on consolidation transaction.');
     }
 
+    if (this._wallet.multisigType === 'tss') {
+      return await this.sendManyTss(params);
+    }
+
     const signedPrebuild = (await this.prebuildAndSignTransaction(params)) as any;
 
     // decorate with our consolidation id

--- a/modules/bitgo/test/v2/unit/internal/tssUtils.ts
+++ b/modules/bitgo/test/v2/unit/internal/tssUtils.ts
@@ -26,26 +26,26 @@ describe('TSS Utils:', async function () {
       i: 1,
       t: 2,
       n: 3,
-      y: '9e69e3e92978896e872d71ff7a9e63a963ab0f59583d4fcbe79f82cde9ea6bf9',
-      seed: '1bd73e7a4592405bfd297a85a7d28bacc676f3f5a89d84023f0e4e0be2a0b526',
-      chaincode: 'bda980c34aa06916f25c4c7934ea09a928bff7730a100902f4d53bb9236771a7',
+      y: 'ac7863c8880d5236b21703fe6a1151651eeabad7518a5fee2c2fc3bb6bbef56b',
+      seed: 'cb5734412298c808cccb81d00f5319befb607353a2f3a47acb05e90ab618e882',
+      chaincode: '3a9b4b61368770067696a8470c664d02fe3584119442bc7576c32e382c76324d',
     },
-    commonChaincode: '99dd8f3e26f906a66ff0ee5d586afd403fd4cc8a6378a00347f90aa8983164b9',
     bitgoYShare: {
       i: 1,
       j: 3,
-      y: '141fd5cbb901d46b8c2c783f3d4ee968ae91c38f71aba05146b3ba8bd4309596',
-      u: 'd9d21c0a0a4434ddc17d386d47b022487169408429bd544e9d98b1cc9a73a508',
-      chaincode: '67d33063052606f341cae40877709de725abda41f2df7f4765e3f58ce5030e1a',
+      y: '68698ed707fba9bc6f927fff6447ba424faa5176ee92174db44e8327d277c0b6',
+      u: 'de35071c8ae162f51d47fb4e7b8c2e778c630ab237040e460d48eb1476ae9205',
+      chaincode: '51491f212fc6e4cd294b9810ca9c05ee021989dc9a1805d4815be19bc0d2a1c0',
     },
     backupYShare: {
       i: 1,
       j: 2,
-      y: 'e2b844934b56f278b4a8a3665d43d14de80732241622ec7a8bd6cffc0f74452a',
-      u: '971b424cea4c978cfe4669272c2fde01ef46b49a2823e4281a244bf877f1430b',
-      chaincode: '7460de17d732969c3bc9bddbac1055aff168fad5668917b8ed3fd9628fc6e4f8',
+      y: '954342b73735255488f1ab99383a4bae86adfe819983115a36a5af62f5742838',
+      u: '2e27243e5ad2d47c41223113647ebfae740ba06d544c66ddbdd705cb93554909',
+      chaincode: 'bc4ee6a483fbaba3800c3c4603f7856361e66622f0c0337a46825c9851d5347c',
     },
   };
+
   const txRequest = {
     txRequestId: 'randomId',
     unsignedTxs: [{ signableHex: 'randomhex', serializedTxHex: 'randomhex2' }],
@@ -76,7 +76,7 @@ describe('TSS Utils:', async function () {
   const validUserToBitgoGShare = {
     i: 1,
     y: 'c4f36234dbcb78ba7efee44771692a71f1d366c70b99656922168590a63c96c2',
-    gamma: 'a1fb6fa4206d47202f215ab15c23597f4fa663e42ae74e01e38232f05d97ce0d',
+    gamma: '4cf29f3ce88a34f4ce9d62431f5b3c0b53e58e0347b3a3fc2633bb3302be6c0f',
     R: 'f6546d5a44f9dd5b594f0de0c1bf80db45f15f432ccf498e651e6160a7710a83',
   };
 
@@ -298,7 +298,7 @@ describe('TSS Utils:', async function () {
         {
           serializedTxHex: 'ababfefe',
           signableHex: 'deadbeef',
-          derivationPath: 'm/0/1/2',
+          derivationPath: 'm/0',
         },
       ],
     };
@@ -312,7 +312,15 @@ describe('TSS Utils:', async function () {
           R: 'R',
           r: 'r',
         },
-        rShares: {},
+        rShares: {
+          3: {
+            i: 1,
+            j: 3,
+            u: 'a',
+            r: 'b',
+            R: 'c',
+          }
+        },
       };
       const bitGoToUserShare: SignatureShareRecord = {
         from: SignatureShareType.BITGO,
@@ -506,7 +514,7 @@ describe('TSS Utils:', async function () {
       rShares[3].should.have.property('R').and.be.a.String();
     });
 
-    it('should fail if the Pshare doesnt belong to the User', async function() {
+    it('should fail if the secret material doesnt belong to the User', async function() {
       const invalidUserSigningMaterial = JSON.parse('{"uShare":{"i":2,"t":2,"n":3,"y":"e2b844934b56f278b4a8a3665d43d14de80732241622ec7a8bd6cffc0f74452a","seed":"5259ee23a364429919f969247323eee2f4af5786457b4af67d423f8944d3a691","chaincode":"7460de17d732969c3bc9bddbac1055aff168fad5668917b8ed3fd9628fc6e4f8"},"bitgoYShare":{"i":2,"j":3,"y":"141fd5cbb901d46b8c2c783f3d4ee968ae91c38f71aba05146b3ba8bd4309596","u":"581cfacb3de956cc434a35a3ac927f7d0a4daaef48a95c162cadb7878ef2270b","chaincode":"67d33063052606f341cae40877709de725abda41f2df7f4765e3f58ce5030e1a"},"backupYShare":{"i":2,"j":1,"y":"9e69e3e92978896e872d71ff7a9e63a963ab0f59583d4fcbe79f82cde9ea6bf9","u":"52a539f79df448a2f5108a5e410377cbd1574b7c3d9864bb310ebf7beb13460d","chaincode":"bda980c34aa06916f25c4c7934ea09a928bff7730a100902f4d53bb9236771a7"}}');
       const signingKey = MPC.keyDerive(
         invalidUserSigningMaterial.uShare,


### PR DESCRIPTION
signerShare prefix should use the R share
also, signing consolidate txns should use TSS flow for TSS wallets.

Ticket: BG-00000

Reference from HSM-API test: https://github.com/BitGo/hsm-api/blob/v3/test/api.js#L2890-L2893
```
              u: await pgp.encrypt({
                message: await pgp.createMessage({text: A_sign_share.rShares[3].u + A_subkey.yShares[3].chaincode}),
                encryptionKeys: [bitgoPublicKey],
              }),
```