### PR TITLE
fix(bitgo): fix non native decimalPlaces

### DIFF
--- a/modules/bitgo/src/v2/coins/algoToken.ts
+++ b/modules/bitgo/src/v2/coins/algoToken.ts
@@ -83,6 +83,10 @@ export class AlgoToken extends Algo {
     return 'Algo Token';
   }
 
+  getBaseFactor(): number {
+    return Math.pow(10, this.tokenConfig.decimalPlaces);
+  }
+
   /**
    * Flag for sending value of 0
    * @returns {boolean} True if okay to send 0 value, false otherwise

--- a/modules/bitgo/test/v2/unit/coins/algoToken.ts
+++ b/modules/bitgo/test/v2/unit/coins/algoToken.ts
@@ -17,6 +17,7 @@ describe('Algo Unison Token:', function () {
     algoTokenCoin.getChain().should.equal('talgo:16026728');
     algoTokenCoin.getBaseChain().should.equal('talgo');
     algoTokenCoin.getFullName().should.equal('Algo Token');
+    algoTokenCoin.getBaseFactor().should.equal(1e2);
     algoTokenCoin.type.should.equal(tokenName);
     algoTokenCoin.name.should.equal('Unison');
     algoTokenCoin.coin.should.equal('talgo');
@@ -40,6 +41,7 @@ describe('Algo USDC Token:', function () {
     algoTokenCoin.getChain().should.equal(USDCtokenName);
     algoTokenCoin.getBaseChain().should.equal('talgo');
     algoTokenCoin.getFullName().should.equal('Algo Token');
+    algoTokenCoin.getBaseFactor().should.equal(1e6);
     algoTokenCoin.type.should.equal(USDCtokenName);
     algoTokenCoin.name.should.equal('USDC');
     algoTokenCoin.coin.should.equal('talgo');
@@ -63,6 +65,7 @@ describe('Algo USDt Token:', function () {
     algoTokenCoin.getChain().should.equal(USDTtokenName);
     algoTokenCoin.getBaseChain().should.equal('talgo');
     algoTokenCoin.getFullName().should.equal('Algo Token');
+    algoTokenCoin.getBaseFactor().should.equal(1e6);
     algoTokenCoin.type.should.equal(USDTtokenName);
     algoTokenCoin.name.should.equal('USDt');
     algoTokenCoin.coin.should.equal('talgo');


### PR DESCRIPTION
Do not merge  ####
Fix decimalPlaces for algorand tokens in order to get the right maxSpendable balance
The AlgoToken class extends from Algo class. And the getBaseFactor method was declarated only in Algo class returning the value from its own decimalPlaces. Now getBaseFactor method is overwriting on AlgoToken class taking the right decimalPlaces.

STLX-15317