### PR TITLE
chore(avaxc): depcrecate some avaxc tokens

### DIFF
--- a/modules/account-lib/test/unit/coin/avaxc/transferBuilder.ts
+++ b/modules/account-lib/test/unit/coin/avaxc/transferBuilder.ts
@@ -18,13 +18,6 @@ const tokensNames = [
   'avaxc:usdt',
   'avaxc:usdc',
   'avaxc:link',
-  'tavaxc:png',
-  'tavaxc:xava',
-  'tavaxc:klo',
-  'tavaxc:joe',
-  'tavaxc:qi',
-  'tavaxc:usdt',
-  'tavaxc:usdc',
   'tavaxc:link',
 ];
 
@@ -62,11 +55,12 @@ describe('AVAXERC20 Tokens', () => {
 
   it('a send token transaction', async () => {
     const amount = '100';
+
     initTxBuilder();
     txBuilder.contract(contractAddress);
     txBuilder
       .transfer()
-      .coin('tavaxc:png')
+      .coin('tavaxc:link')
       .amount(amount)
       .to(testData.TEST_ACCOUNT_2.ethAddress)
       .expirationTime(1590066728)
@@ -80,11 +74,11 @@ describe('AVAXERC20 Tokens', () => {
     should.equal(tx.inputs.length, 1);
     should.equal(tx.inputs[0].address.toLowerCase(), contractAddress.toLowerCase());
     should.equal(tx.inputs[0].value, amount);
-    should.equal(tx.inputs[0].coin, 'tavaxc:png');
+    should.equal(tx.inputs[0].coin, 'tavaxc:link');
 
     should.equal(tx.outputs.length, 1);
     should.equal(tx.outputs[0].address.toLowerCase(), testData.TEST_ACCOUNT_2.ethAddress.toLowerCase());
     should.equal(tx.outputs[0].value, amount);
-    should.equal(tx.outputs[0].coin, 'tavaxc:png');
+    should.equal(tx.outputs[0].coin, 'tavaxc:link');
   });
 });

--- a/modules/bitgo/src/v2/coinFactory.ts
+++ b/modules/bitgo/src/v2/coinFactory.ts
@@ -72,8 +72,6 @@ import { Tdot } from './coins/tdot';
 import { Near } from './coins/near';
 import { TNear } from './coins/tnear';
 
-import { AvaxcTokenConfigEnvDependent } from './coins/avaxcToken';
-
 export type CoinConstructor = (bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) => BaseCoin;
 
 export class CoinFactory {
@@ -222,32 +220,10 @@ for (const token of [...tokens.bitcoin.algo.tokens, ...tokens.testnet.algo.token
   }
 }
 
-const zipAvaxToken: Record<string, AvaxcTokenConfigEnvDependent> = {};
-
-for (const token of [...tokens.bitcoin.avaxc.tokens]) {
+for (const token of [...tokens.bitcoin.avaxc.tokens, ...tokens.testnet.avaxc.tokens]) {
   const tokenConstructor = AvaxCToken.createTokenConstructor(token);
   GlobalCoinFactory.registerCoinConstructor(token.type, tokenConstructor);
-  zipAvaxToken[token.tokenContractAddress] = { mainnet: token };
-}
-
-for (const token of [...tokens.testnet.avaxc.tokens]) {
-  const tokenConstructor = AvaxCToken.createTokenConstructor(token);
-  GlobalCoinFactory.registerCoinConstructor(token.type, tokenConstructor);
-  if (!!zipAvaxToken[token.tokenContractAddress]) {
-    zipAvaxToken[token.tokenContractAddress].testnet = token;
-  } else {
-    GlobalCoinFactory.registerCoinConstructor(token.tokenContractAddress, tokenConstructor);
-  }
-}
-
-for (const [tokenContractAddress, tokenConfig] of Object.entries(zipAvaxToken)) {
-  if (!!tokenConfig.testnet) {
-    const tokenConstructor = AvaxCToken.createTokenConstructorEnvDependent(tokenConfig);
-    GlobalCoinFactory.registerCoinConstructor(tokenContractAddress, tokenConstructor);
-  } else {
-    const tokenConstructor = AvaxCToken.createTokenConstructor(tokenConfig.mainnet);
-    GlobalCoinFactory.registerCoinConstructor(tokenContractAddress, tokenConstructor);
-  }
+  GlobalCoinFactory.registerCoinConstructor(token.tokenContractAddress, tokenConstructor);
 }
 
 for (const token of [...tokens.bitcoin.fiat.tokens, ...tokens.testnet.fiat.tokens]) {

--- a/modules/bitgo/src/v2/coins/avaxcToken.ts
+++ b/modules/bitgo/src/v2/coins/avaxcToken.ts
@@ -5,7 +5,6 @@ import { BitGo } from '../../bitgo';
 
 import { AvaxC, TransactionPrebuild } from './avaxc';
 import { CoinConstructor } from '../coinFactory';
-import { Environments } from '../environments';
 import { coins } from '@bitgo/statics';
 
 export interface AvaxcTokenConfig {
@@ -15,11 +14,6 @@ export interface AvaxcTokenConfig {
   network: string;
   tokenContractAddress: string;
   decimalPlaces: number;
-}
-
-export interface AvaxcTokenConfigEnvDependent {
-  mainnet: AvaxcTokenConfig;
-  testnet?: AvaxcTokenConfig;
 }
 
 export class AvaxCToken extends AvaxC {
@@ -33,18 +27,6 @@ export class AvaxCToken extends AvaxC {
 
   static createTokenConstructor(config: AvaxcTokenConfig): CoinConstructor {
     return (bitgo: BitGo) => new AvaxCToken(bitgo, config);
-  }
-
-  /**
-   * It creates a constructor according to the network env.
-   * Avalanche network has the same contract address for both Mainnet and Testnet.
-   * The goal is to select the right one when a particular network is used.
-   */
-  static createTokenConstructorEnvDependent(config: AvaxcTokenConfigEnvDependent): CoinConstructor {
-    return (bitgo: BitGo) =>
-      Environments[bitgo.getEnv()].network !== 'testnet'
-        ? new AvaxCToken(bitgo, config.mainnet)
-        : new AvaxCToken(bitgo, config.testnet!);
   }
 
   get type(): string {

--- a/modules/bitgo/test/v2/unit/coins/avaxcToken.ts
+++ b/modules/bitgo/test/v2/unit/coins/avaxcToken.ts
@@ -35,11 +35,11 @@ describe('Avaxc Token:', function () {
   });
 
   describe('In env prod:', function () {
-    const tokenName = 'avaxc:png';
+    const prodTokenName = 'avaxc:png';
     before(function () {
       bitgo = new TestBitGo({ env: 'prod' });
       bitgo.initializeTestVars();
-      avaxcTokenCoin = bitgo.coin(tokenName);
+      avaxcTokenCoin = bitgo.coin(prodTokenName);
     });
 
     it('should return constants', function () {
@@ -47,7 +47,7 @@ describe('Avaxc Token:', function () {
       avaxcTokenCoin.getBaseChain().should.equal('avaxc');
       avaxcTokenCoin.getFullName().should.equal('Avaxc Token');
       avaxcTokenCoin.getBaseFactor().should.equal(1e18);
-      avaxcTokenCoin.type.should.equal(tokenName);
+      avaxcTokenCoin.type.should.equal(prodTokenName);
       avaxcTokenCoin.name.should.equal('Pangolin');
       avaxcTokenCoin.coin.should.equal('avaxc');
       avaxcTokenCoin.network.should.equal('Mainnet');
@@ -56,11 +56,6 @@ describe('Avaxc Token:', function () {
 
     it('should return same token by contract address', function () {
       const tokencoinBycontractAddress = bitgo.coin(avaxcTokenCoin.tokenContractAddress);
-      avaxcTokenCoin.should.deepEqual(tokencoinBycontractAddress);
-    });
-
-    it('should return mainnet token, however it uses a testnet contract address', function () {
-      const tokencoinBycontractAddress = bitgo.coin(bitgo.coin('t' + tokenName).tokenContractAddress);
       avaxcTokenCoin.should.deepEqual(tokencoinBycontractAddress);
     });
 

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -1237,55 +1237,12 @@ export const coins = CoinMap.fromCoins([
   avaxErc20('avaxc:link', 'Chainlink', 18, '0x5947bb275c521040051d82396192181b413227a3', UnderlyingAsset['avaxc:link']),
   avaxErc20('avaxc:usdt', 'Tether USD', 6, '0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7', UnderlyingAsset['avaxc:usdt']),
   avaxErc20('avaxc:usdc', 'USD Coin', 6, '0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e', UnderlyingAsset['avaxc:usdc']),
-  tavaxErc20('tavaxc:qi', 'Test BenQi', 18, '0x8729438eb15e2c8b576fcc6aecda6a148776c0f5', UnderlyingAsset['avaxc:qi']),
-  tavaxErc20(
-    'tavaxc:xava',
-    'Test Avalaunch',
-    18,
-    '0xd1c3f94de7e5b45fa4edbba472491a9f4b166fc4',
-    UnderlyingAsset['avaxc:xava']
-  ),
-  tavaxErc20(
-    'tavaxc:klo',
-    'Test Kalao',
-    18,
-    '0xb27c8941a7df8958a1778c0259f76d1f8b711c35',
-    UnderlyingAsset['avaxc:klo']
-  ),
-  tavaxErc20(
-    'tavaxc:joe',
-    'Test Trader Joe',
-    18,
-    '0x6e84a6216ea6dacc71ee8e6b0a5b7322eebc0fdd',
-    UnderlyingAsset['avaxc:joe']
-  ),
-  tavaxErc20(
-    'tavaxc:png',
-    'Test Pangolin',
-    18,
-    '0x60781c2586d68229fde47564546784ab3faca982',
-    UnderlyingAsset['avaxc:png']
-  ),
   tavaxErc20(
     'tavaxc:link',
     'Test Chainlink',
     18,
     '0x0b9d5d9136855f6fec3c0993fee6e9ce8a297846',
     UnderlyingAsset['avaxc:link']
-  ),
-  tavaxErc20(
-    'tavaxc:usdt',
-    'Test Tether USD',
-    6,
-    '0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7',
-    UnderlyingAsset['avaxc:usdt']
-  ),
-  tavaxErc20(
-    'tavaxc:usdc',
-    'Test USD Coin',
-    6,
-    '0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e',
-    UnderlyingAsset['avaxc:usdc']
   ),
   solToken(
     'sol:srm',


### PR DESCRIPTION
we are deprececating all avaxc tokens that do not have a faucet and thus
cannot be tested