### PR TITLE
fix(statics): update base factor for dot and tdot

### DIFF
--- a/modules/bitgo/src/v2/coins/dot.ts
+++ b/modules/bitgo/src/v2/coins/dot.ts
@@ -12,6 +12,7 @@ import {
   VerifyAddressOptions,
   VerifyTransactionOptions,
 } from '../baseCoin';
+import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 
 export interface SignTransactionOptions extends BaseSignTransactionOptions {
   txPrebuild: TransactionPrebuild;
@@ -39,13 +40,21 @@ export interface VerifiedTransactionParameters {
 const dotUtils = accountLib.Dot.Utils.default;
 
 export class Dot extends BaseCoin {
+  protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
   readonly MAX_VALIDITY_DURATION = 2400;
-  constructor(bitgo: BitGo) {
+
+  constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo);
+
+    if (!staticsCoin) {
+      throw new Error('missing required constructor parameter staticsCoin');
+    }
+
+    this._staticsCoin = staticsCoin;
   }
 
-  static createInstance(bitgo: BitGo): BaseCoin {
-    return new Dot(bitgo);
+  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+    return new Dot(bitgo, staticsCoin);
   }
 
   getChain(): string {
@@ -65,7 +74,7 @@ export class Dot extends BaseCoin {
   }
 
   getBaseFactor(): number {
-    return 1e12;
+    return Math.pow(10, this._staticsCoin.decimalPlaces);
   }
 
   /**

--- a/modules/bitgo/src/v2/coins/tdot.ts
+++ b/modules/bitgo/src/v2/coins/tdot.ts
@@ -1,14 +1,22 @@
 import { BitGo } from '../../bitgo';
 import { BaseCoin } from '../baseCoin';
 import { Dot } from './dot';
+import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 
 export class Tdot extends Dot {
-  constructor(bitgo: BitGo) {
-    super(bitgo);
+  protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
+  constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+    super(bitgo, staticsCoin);
+
+    if (!staticsCoin) {
+      throw new Error('missing required constructor parameter staticsCoin');
+    }
+
+    this._staticsCoin = staticsCoin;
   }
 
-  static createInstance(bitgo: BitGo): BaseCoin {
-    return new Tdot(bitgo);
+  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+    return new Tdot(bitgo, staticsCoin);
   }
 
   getChain(): string {
@@ -17,5 +25,9 @@ export class Tdot extends Dot {
 
   getFullName(): string {
     return 'Testnet Polkadot';
+  }
+
+  getBaseFactor(): number {
+    return Math.pow(10, this._staticsCoin.decimalPlaces);
   }
 }

--- a/modules/bitgo/test/v2/unit/coins/dot.ts
+++ b/modules/bitgo/test/v2/unit/coins/dot.ts
@@ -7,11 +7,14 @@ import { randomBytes } from 'crypto';
 describe('DOT:', function () {
   let bitgo;
   let basecoin;
+  let prodCoin;
+
 
   before(function () {
     bitgo = new TestBitGo({ env: 'mock' });
     bitgo.initializeTestVars();
     basecoin = bitgo.coin('tdot');
+    prodCoin = bitgo.coin('dot');
   });
 
   describe('Sign Message', () => {
@@ -106,6 +109,40 @@ describe('DOT:', function () {
       const kp = basecoin.generateKeyPair(seed);
       basecoin.isValidPub(kp.pub).should.equal(true);
       basecoin.isValidPrv(kp.prv).should.equal(true);
+    });
+  });
+
+  describe('Balance Conversion', () => {
+    it('should return 10000000000 as tdot base factor', () => {
+      // mainnet uses 10 decimal places
+      const baseFactor = prodCoin.getBaseFactor();
+      baseFactor.should.equal(10000000000);
+    });
+
+    it('should return 1000000000000 as dot base factor', () => {
+      // westend (test polkadot) uses 12 decimal places
+      const baseFactor = basecoin.getBaseFactor();
+      baseFactor.should.equal(1000000000000);
+    });
+
+    it('should return 4 Dot when base unit is 40000000000 for dot', () => {
+      const bigUnit = prodCoin.baseUnitsToBigUnits('40000000000');
+      bigUnit.should.equal('4');
+    });
+
+    it('should return 0.04 Dot when base unit is 400000000 for dot', () => {
+      const bigUnit = prodCoin.baseUnitsToBigUnits('400000000');
+      bigUnit.should.equal('0.04');
+    });
+
+    it('should return 4 test Dot when base unit is 4000000000000 for tdot', () => {
+      const bigUnit = basecoin.baseUnitsToBigUnits('4000000000000');
+      bigUnit.should.equal('4');
+    });
+
+    it('should return 0.04 test Dot when base unit is 400000000 for tdot', () => {
+      const bigUnit = basecoin.baseUnitsToBigUnits('40000000000');
+      bigUnit.should.equal('0.04');
     });
   });
 });


### PR DESCRIPTION
The base factor defaults to 1e12 which is only valid for
Westend transaction since 12 decimal places is used vs 10
decimal places in mainnet.

TICKET: BG-0000