### PR TITLE
chore: update support and owner references

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,12 +2,12 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners and first officers will be the default owners for everything in the repo.
-*   tyler@bitgo.com
+*   @BitGo/sdk-team
 
 # Order is important. The last matching pattern has the most precedence.
 
 # Recovery
-modules/bitgo/src/v2/recovery.ts tyler@bitgo.com
+modules/bitgo/src/v2/recovery.ts @BitGo/sdk-team
 
 # Coin Support
 modules/bitgo/src/v2/coins/*btc.ts @BitGo/btc-team
@@ -37,20 +37,20 @@ modules/bitgo/test/v2/unit/coins/*eth2.ts @BitGo/eth-team
 modules/bitgo/test/v2/unit/coins/*rbtc.ts @BitGo/eth-team
 modules/bitgo/test/v2/unit/coins/token.ts @BitGo/eth-team
 
-modules/bitgo/src/v2/coins/*xlm.ts luis@bitgo.com jorge@bitgo.com tyler@bitgo.com
-modules/bitgo/src/v2/coins/*xrp.ts luis@bitgo.com jorge@bitgo.com tyler@bitgo.com
+modules/bitgo/src/v2/coins/*xlm.ts @lcovar @argjv @BitGo/sdk-team
+modules/bitgo/src/v2/coins/*xrp.ts @lcovar @argjv @BitGo/sdk-team
 
 # Trading accounts
-modules/bitgo/src/v2/trading/*.ts tyler@bitgo.com
+modules/bitgo/src/v2/trading/*.ts @BitGo/sdk-team
 
 # Express
-modules/express/* tyler@bitgo.com
+modules/express/* @BitGo/sdk-team
 
 # Statics
-modules/statics/* tyler@bitgo.com
+modules/statics/* @BitGo/sdk-team
 
 # Package Configuration Files
-modules/*/package*.json tyler@bitgo.com
+modules/*/package*.json @BitGo/sdk-team
 
 # ACCOUNT LIB
 modules/account-lib/* @argjv @CapnMigraine
@@ -70,9 +70,9 @@ modules/account-lib/test/coin/eth2/* @BitGo/eth-team
 modules/account-lib/test/coin/rbtc/* @BitGo/eth-team
 
 # Lock files
-yarn.lock tyler@bitgo.com
-modules/express/package-lock.json tyler@bitgo.com
+yarn.lock @BitGo/sdk-team
+modules/express/package-lock.json @BitGo/sdk-team
 
 # NOTHING BELOW THIS LINE
-CODEOWNERS @BitGo/git-admins @argjv @CapnMigraine @tylerlevine
+CODEOWNERS @BitGo/git-admins @argjv @CapnMigraine @BitGo/sdk-team
 

--- a/modules/account-lib/package.json
+++ b/modules/account-lib/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/BitGo/BitGoJS.git",
     "directory": "modules/account-lib"
   },
-  "author": "",
+  "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "ISC",
   "engines": {
     "node": ">=14 <17"

--- a/modules/bitgo/test/lib/test_bitgo.ts
+++ b/modules/bitgo/test/lib/test_bitgo.ts
@@ -24,7 +24,7 @@ if (process.env.BITGOJS_TEST_PASSWORD) {
   BitGo.TEST_PASSWORD = process.env.BITGOJS_TEST_PASSWORD;
 } else {
   // Test accounts are locked internally to prevent tampering
-  // Contact bencxr@fragnetics.com benchan for further help on how to fix this
+  // Contact support@bitgo.com for further help on how to fix this
   throw new Error('Need to set BITGOJS_TEST_PASSWORD env variable - please see the developer setup docs.');
 }
 

--- a/modules/bls-dkg/package.json
+++ b/modules/bls-dkg/package.json
@@ -7,7 +7,7 @@
     "unit-test": "mocha",
     "test": "npm run unit-test"
   },
-  "author": "John Driscoll <john@bitgo.com>",
+  "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "ISC",
   "dependencies": {
     "noble-bls12-381": "^0.7.2"

--- a/modules/express/package.json
+++ b/modules/express/package.json
@@ -11,7 +11,7 @@
   "keywords": [
     "bitgo"
   ],
-  "author": "Tyler Levine <tyler@bitgo.com>",
+  "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/modules/express/test/lib/test_bitgo.ts
+++ b/modules/express/test/lib/test_bitgo.ts
@@ -37,7 +37,7 @@ if (process.env.BITGOJS_TEST_PASSWORD) {
   BitGo.TEST_PASSWORD = process.env.BITGOJS_TEST_PASSWORD;
 } else {
   // Test accounts are locked internally to prevent tampering
-  // Contact bencxr@fragnetics.com benchan for further help on how to fix this
+  // Contact support@bitgo.com for further help on how to fix this
   throw new Error('Need to set BITGOJS_TEST_PASSWORD env variable - please see the developer setup docs.');
 }
 

--- a/modules/sjcl/package.json
+++ b/modules/sjcl/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "fork of Stanford Javascript Crypto Library",
   "main": "sjcl.min.js",
-  "author": "BitGo Inc.",
+  "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "(BSD-2-Clause OR GPL-2.0-only)",
   "repository": {
     "type": "git",

--- a/modules/statics/CODEOWNERS
+++ b/modules/statics/CODEOWNERS
@@ -1,5 +1,0 @@
-# @bito/statics code owners and first officers will automatically be requested for review whenever a pull request touches the files they own.
-# Each line is a file pattern followed by one or more owners.
-
-# These owners and first officers will be the default owners for everything in the repo.
-*   tyler@bitgo.com

--- a/modules/statics/package.json
+++ b/modules/statics/package.json
@@ -14,7 +14,7 @@
     "precommit": "lint-staged",
     "prepare": "npm run build"
   },
-  "author": "Tyler Levine <tyler@bitgo.com>",
+  "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/modules/unspents/package.json
+++ b/modules/unspents/package.json
@@ -23,7 +23,7 @@
     "bitcoin",
     "utxo"
   ],
-  "author": "BitGo Inc.",
+  "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/BitGo/BitGoJS/issues"


### PR DESCRIPTION
Update support and codeowner references for SDK code ownership and contact points.

Looks like @BitGo/sdk-team needs to be fixed for assigned repositories. Same with eth-team? @BitGo/git-admins 

BG-000000