### PR TITLE
fix: whitelist nonce as an intent param

### DIFF
--- a/modules/bitgo/src/v2/internal/tssUtils.ts
+++ b/modules/bitgo/src/v2/internal/tssUtils.ts
@@ -39,6 +39,7 @@ interface PrebuildTransactionWithIntentOptions {
   comment?: string;
   memo?: Memo;
   tokenName?: string;
+  nonce?: string;
 }
 
 enum ShareKeyPosition {
@@ -423,6 +424,7 @@ export class TssUtils extends MpcUtils {
         recipients: intentRecipients,
         memo: params.memo?.value,
         token: params.tokenName,
+        nonce: params.nonce,
       },
     };
 

--- a/modules/bitgo/src/v2/wallet.ts
+++ b/modules/bitgo/src/v2/wallet.ts
@@ -113,6 +113,7 @@ export interface PrebuildTransactionOptions {
   comment?: string;
   [index: string]: unknown;
   tokenName?: string;
+  nonce?: string;
 }
 
 export interface PrebuildAndSignTransactionOptions extends PrebuildTransactionOptions, WalletSignTransactionOptions {
@@ -2683,6 +2684,7 @@ export class Wallet {
           comment: params.comment,
           recipients: params.recipients || [],
           memo: params.memo,
+          nonce: params.nonce,
         });
         break;
       case 'enabletoken':


### PR DESCRIPTION
If nonce is passed as part of a transfer request then send that nonce value to wallet-platform to build the transaction accordingly. Tested in testnet-05 for dot successfully. 