### PR TITLE
chore: add api versioning to tx requests

### DIFF
--- a/modules/bitgo/src/v2/internal/tssUtils.ts
+++ b/modules/bitgo/src/v2/internal/tssUtils.ts
@@ -61,6 +61,7 @@ export interface TxRequest {
     derivationPath: string;
   }[];
   signatureShares?: SignatureShareRecord[];
+  apiVersion?: string;
 }
 
 export enum SignatureShareType {
@@ -407,9 +408,10 @@ export class TssUtils extends MpcUtils {
    * Builds a tx request from params and verify it
    *
    * @param {PrebuildTransactionWithIntentOptions} params - parameters to build the tx
+   * @param apiVersion
    * @returns {Promise<TxRequest>} - a built tx request
    */
-  async prebuildTxWithIntent(params: PrebuildTransactionWithIntentOptions): Promise<TxRequest> {
+  async prebuildTxWithIntent(params: PrebuildTransactionWithIntentOptions, apiVersion = 'lite'): Promise<TxRequest> {
     const chain = this.baseCoin.getChain();
     const intentRecipients = params.recipients.map((recipient) => ({
       address: { address: recipient.address },
@@ -426,6 +428,7 @@ export class TssUtils extends MpcUtils {
         token: params.tokenName,
         nonce: params.nonce,
       },
+      apiVersion: apiVersion,
     };
 
     const unsignedTx = (await this.bitgo
@@ -461,6 +464,7 @@ export class TssUtils extends MpcUtils {
    *
    * @param {String} txRequestId - the txRequest Id
    * @param {SignatureShareRecord} signatureShare - a Signature Share
+   * @param apiVersion
    * @returns {Promise<SignatureShareRecord>} - a Signature Share
    */
   async sendSignatureShare(params: {

--- a/modules/bitgo/test/v2/unit/internal/tssUtils.ts
+++ b/modules/bitgo/test/v2/unit/internal/tssUtils.ts
@@ -402,6 +402,7 @@ describe('TSS Utils:', async function () {
       const nockedCreateTx = await nockCreateTxRequest({
         walletId: wallet.id(),
         requestBody: {
+          apiVersion: 'lite',
           intent: {
             intentType: 'payment',
             recipients: [{
@@ -435,6 +436,7 @@ describe('TSS Utils:', async function () {
       const nockedCreateTx = await nockCreateTxRequest({
         walletId: wallet.id(),
         requestBody: {
+          apiVersion: 'lite',
           intent: {
             intentType: 'payment',
             recipients: [{


### PR DESCRIPTION
Add api versioning for tx requests to differentiate light v full