### PR TITLE
chore: improve robustness of Sol transactions

### DIFF
--- a/modules/bitgo/src/v2/baseCoin.ts
+++ b/modules/bitgo/src/v2/baseCoin.ts
@@ -9,7 +9,7 @@ import * as utxolib from '@bitgo/utxo-lib';
 
 import { BitGo } from '../bitgo';
 import { RequestTracer } from './internal/util';
-import { Wallet } from './wallet';
+import { Wallet, WalletData } from './wallet';
 import { Wallets } from './wallets';
 import { Markets } from './markets';
 import { Webhooks } from './webhooks';
@@ -19,6 +19,7 @@ import { Enterprises } from './enterprises';
 
 import { InitiateRecoveryOptions } from './recovery/initiate';
 import { signMessage } from '../bip32util';
+import { TssUtils } from './internal/tssUtils';
 
 // re-export account lib transaction types
 export type TransactionType = AccountLibBasecoin.TransactionType;
@@ -137,6 +138,9 @@ export interface ExtraPrebuildParamsOptions {
 
 // TODO (SDKT-9): reverse engineer and add options
 export interface PresignTransactionOptions {
+  txPrebuild?: TransactionPrebuild;
+  walletData: WalletData;
+  tssUtils: TssUtils;
   [index: string]: unknown;
 }
 

--- a/modules/bitgo/test/v2/unit/wallets.ts
+++ b/modules/bitgo/test/v2/unit/wallets.ts
@@ -347,6 +347,7 @@ describe('V2 Wallets:', function () {
     const tsol = bitgo.coin('tsol');
 
     it('should create a new TSS wallet', async function () {
+      const sandbox = sinon.createSandbox();
       const stubbedKeychainsTriplet = {
         userKeychain: {
           id: '1',
@@ -361,7 +362,7 @@ describe('V2 Wallets:', function () {
           pub: 'userPub',
         },
       };
-      sinon.stub(TssUtils.prototype, 'createKeychains').resolves(stubbedKeychainsTriplet);
+      sandbox.stub(TssUtils.prototype, 'createKeychains').resolves(stubbedKeychainsTriplet);
 
       const walletNock = nock('https://bitgo.fakeurl')
         .post('/api/v2/tsol/wallet')
@@ -378,7 +379,7 @@ describe('V2 Wallets:', function () {
       });
 
       walletNock.isDone().should.be.true();
-      sinon.verify();
+      sandbox.verifyAndRestore();
     });
 
     it('should fail to create TSS wallet with invalid inputs', async function () {


### PR DESCRIPTION
rebuild solana hot wallet transactions right before signing to reduce
chances of tx becoming expired.

Ticket: BG-00000

Verified manually:
```
async function sendMany() {
  const wallet = await bitgo.coin('sol').wallets().get({ id: '62507b4ede430a000806cd722da9ebe3' });
  const sent = await wallet.sendMany({
    recipients: [{
      address: 'GQQpr6bV4Vbro7iKDtTdCuPFzUetFa3U68RkYED43Z1o',
      amount: '10000',
    }],
    type: 'transfer',
    walletPassphrase: PASSPHRASE,
  });

  console.log(JSON.stringify(sent, undefined, 2));
}
```