### PR TITLE
fix: v1 get wallet

### DIFF
--- a/modules/bitgo/src/v2/coins/utxo/recovery/crossChainRecovery.ts
+++ b/modules/bitgo/src/v2/coins/utxo/recovery/crossChainRecovery.ts
@@ -91,7 +91,7 @@ type WalletV1 = {
   getEncryptedUserKeychain(): Promise<{ encryptedXprv: string }>;
 };
 
-async function getWallet(bitgo: BitGo, coin: AbstractUtxoCoin, walletId: string): Promise<Wallet | WalletV1> {
+export async function getWallet(bitgo: BitGo, coin: AbstractUtxoCoin, walletId: string): Promise<Wallet | WalletV1> {
   try {
     return await coin.wallets().get({ id: walletId });
   } catch (e) {

--- a/modules/bitgo/src/v2/coins/utxo/recovery/crossChainRecovery.ts
+++ b/modules/bitgo/src/v2/coins/utxo/recovery/crossChainRecovery.ts
@@ -95,7 +95,9 @@ async function getWallet(bitgo: BitGo, coin: AbstractUtxoCoin, walletId: string)
   try {
     return await coin.wallets().get({ id: walletId });
   } catch (e) {
-    if (e.status >= 400 && e.status < 500) {
+    // TODO: BG-46364 handle errors more gracefully
+    // The v2 endpoint coin.wallets().get() may throw 404 or 400 errors, but this should not prevent us from searching for the walletId in v1 wallets.
+    if (e.status >= 500) {
       throw e;
     }
   }


### PR DESCRIPTION
A bad fix was introduced in #2180, this is now the correct version. 

When `getWallet` is called, if `coin.wallets().get({ id: walletId })` returns a 4xx error, the correct behavior is to search for the wallet using the v1 endpoint.

Originally the condition was just `if (e.status !== 404) {` so that if the wallet wasn't found, it would search v1 wallets. The problem was the v1 endpoint was returning a 400 error. It's not necessarily incorrect because if v1 wallets are a different format to v2 wallets, that would be an appropriate response. So that's why the range of errors was expanded to any 4xx error

Ticket: BG-44440