### PR TITLE
feat(statics): create Fiat and Tfiat coins

### DIFF
--- a/modules/bitgo/src/v2/coinFactory.ts
+++ b/modules/bitgo/src/v2/coinFactory.ts
@@ -18,6 +18,7 @@ import {
   Etc,
   Eth,
   Eth2,
+  Fiat,
   Hbar,
   Ltc,
   Ofc,
@@ -37,6 +38,7 @@ import {
   Tetc,
   Teth,
   Teth2,
+  Tfiat,
   Gteth,
   Thbar,
   Tltc,
@@ -175,6 +177,8 @@ GlobalCoinFactory.registerCoinConstructor('thbar', Thbar.createInstance);
 GlobalCoinFactory.registerCoinConstructor('ofc', Ofc.createInstance);
 GlobalCoinFactory.registerCoinConstructor('susd', Susd.createInstance);
 GlobalCoinFactory.registerCoinConstructor('tsusd', Tsusd.createInstance);
+GlobalCoinFactory.registerCoinConstructor('fiat', Fiat.createInstance);
+GlobalCoinFactory.registerCoinConstructor('tfiat', Tfiat.createInstance);
 GlobalCoinFactory.registerCoinConstructor('cspr', Cspr.createInstance);
 GlobalCoinFactory.registerCoinConstructor('tcspr', Tcspr.createInstance);
 GlobalCoinFactory.registerCoinConstructor('stx', Stx.createInstance);

--- a/modules/bitgo/src/v2/coins/fiat.ts
+++ b/modules/bitgo/src/v2/coins/fiat.ts
@@ -1,6 +1,7 @@
 /**
  * @prettier
  */
+import { BitGo } from '../../bitgo';
 import {
   BaseCoin,
   KeyPair,
@@ -13,7 +14,14 @@ import {
 } from '../baseCoin';
 import { MethodNotImplementedError } from '../../errors';
 
-export abstract class Fiat extends BaseCoin {
+export class Fiat extends BaseCoin {
+  constructor(bitgo: BitGo) {
+    super(bitgo);
+  }
+
+  static createInstance(bitgo: BitGo): BaseCoin {
+    return new Fiat(bitgo);
+  }
   /**
    * Returns the factor between the base unit and its smallest subdivison
    * @return {number}

--- a/modules/bitgo/src/v2/coins/index.ts
+++ b/modules/bitgo/src/v2/coins/index.ts
@@ -15,6 +15,7 @@ export { Erc20Token } from './erc20Token';
 export { Etc } from './etc';
 export { Eth } from './eth';
 export { Eth2 } from './eth2';
+export { Fiat } from './fiat';
 export { Ltc } from './ltc';
 export { Ofc } from './ofc'; // TODO: SDKT-15: make abstract and remove from exported list
 export { OfcToken } from './ofcToken';
@@ -36,6 +37,7 @@ export { Tltc } from './tltc';
 export { Trbtc } from './trbtc';
 export { Trx } from './trx';
 export { Tsusd } from './tsusd';
+export { Tfiat } from './tfiat';
 export { FiatToken } from './fiatToken'; 
 export { Ttrx } from './ttrx';
 export { Hbar } from './hbar';

--- a/modules/bitgo/src/v2/coins/tfiat.ts
+++ b/modules/bitgo/src/v2/coins/tfiat.ts
@@ -1,0 +1,24 @@
+/**
+ * @prettier
+ */
+import { BitGo } from '../../bitgo';
+import { BaseCoin } from '../baseCoin';
+import { Fiat } from './fiat';
+
+export class Tfiat extends Fiat {
+  constructor(bitgo: BitGo) {
+    super(bitgo);
+  }
+
+  static createInstance(bitgo: BitGo): BaseCoin {
+    return new Tfiat(bitgo);
+  }
+
+  getChain() {
+    return 'tfiat';
+  }
+
+  getFullName() {
+    return 'Test Fiat';
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/fiat.ts
+++ b/modules/bitgo/test/v2/unit/coins/fiat.ts
@@ -1,6 +1,25 @@
 import 'should';
 import { TestBitGo } from '../../../lib/test_bitgo';
 
+describe('FIAT', function () {
+  let bitgo;
+  let fiat;
+
+  before(function () {
+    bitgo = new TestBitGo({ env: 'test' });
+    bitgo.initializeTestVars();
+    fiat = bitgo.coin('fiat');
+  });
+
+  it('functions that return constants', function () {
+    fiat.getChain().should.equal('fiat');
+    fiat.type.should.equal('fiat');
+    fiat.getFullName().should.equal('Fiat');
+    fiat.getFamily().should.equal('fiat');
+    fiat.getBaseFactor().should.equal(100);
+  });
+});
+
 describe('FIAT:USD', function () {
   let bitgo;
   let fiatUSD;

--- a/modules/bitgo/test/v2/unit/coins/tfiat.ts
+++ b/modules/bitgo/test/v2/unit/coins/tfiat.ts
@@ -1,6 +1,25 @@
 import 'should';
 import { TestBitGo } from '../../../lib/test_bitgo';
 
+describe('FIAT', function () {
+  let bitgo;
+  let fiat;
+
+  before(function () {
+    bitgo = new TestBitGo({ env: 'test' });
+    bitgo.initializeTestVars();
+    fiat = bitgo.coin('tfiat');
+  });
+
+  it('functions that return constants', function () {
+    fiat.getChain().should.equal('tfiat');
+    fiat.type.should.equal('tfiat');
+    fiat.getFullName().should.equal('Test Fiat');
+    fiat.getFamily().should.equal('fiat');
+    fiat.getBaseFactor().should.equal(100);
+  });
+});
+
 describe('FIAT:USD', function () {
   let bitgo;
   let fiatUSD;

--- a/modules/statics/src/account.ts
+++ b/modules/statics/src/account.ts
@@ -281,6 +281,38 @@ export class AvaxERC20Token extends ContractAddressDefinedToken {
 }
 
 /**
+ * FIAT base coin
+ */
+export class FiatCoin extends BaseCoin {
+  public static readonly DEFAULT_FEATURES = [
+    CoinFeature.ACCOUNT_MODEL,
+    CoinFeature.REQUIRES_BIG_NUMBER,
+    CoinFeature.VALUELESS_TRANSFER,
+    CoinFeature.TRANSACTION_DATA,
+    CoinFeature.CUSTODY,
+  ];
+
+  public readonly network: BaseNetwork;
+
+  constructor(options: AccountConstructorOptions) {
+    super({
+      ...options,
+      kind: CoinKind.FIAT,
+    });
+
+    this.network = options.network;
+  }
+
+  protected requiredFeatures(): Set<CoinFeature> {
+    return new Set<CoinFeature>([CoinFeature.ACCOUNT_MODEL]);
+  }
+
+  protected disallowedFeatures(): Set<CoinFeature> {
+    return new Set<CoinFeature>([CoinFeature.UNSPENT_MODEL]);
+  }
+}
+
+/**
  * FIAT based tokens, such as USD, EUR, or YEN.
  */
 export class FiatToken extends BaseCoin {
@@ -1162,6 +1194,48 @@ export function tavaxErc20(
     suffix,
     network,
     primaryKeyCurve
+  );
+}
+
+/**
+ * Factory function for FIAT coin instance.
+ *
+ * @param name unique identifier of the currency
+ * @param fullName Complete human-readable name of the currency
+ * @param asset Asset which this coin represents. This is the same for both mainnet and testnet variants of a coin.
+ * @param decimalPlaces Number of decimal places this coin supports (divisibility exponent)
+ * @param network Network object for this coin
+ * @param prefix? Optional coin prefix. Defaults to empty string
+ * @param suffix? Optional coin suffix. Defaults to coin name.
+ * @param features? Features of this coin. Defaults to the DEFAULT_FEATURES defined in `AccountCoin`
+ * @param isToken? Whether or not this account coin is a token of another coin
+ * @param primaryKeyCurve The elliptic curve for this chain/token
+ */
+export function fiat(
+  name: string,
+  fullName: string,
+  asset: UnderlyingAsset,
+  decimalPlaces: number,
+  network: BaseNetwork = Networks.main.fiat,
+  prefix = '',
+  suffix: string = name.toUpperCase(),
+  features: CoinFeature[] = FiatCoin.DEFAULT_FEATURES,
+  isToken = false,
+  primaryKeyCurve: KeyCurve = KeyCurve.Secp256k1
+) {
+  return Object.freeze(
+    new FiatCoin({
+      name,
+      fullName,
+      network,
+      prefix,
+      suffix,
+      features,
+      decimalPlaces,
+      isToken,
+      asset,
+      primaryKeyCurve,
+    })
   );
 }
 

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -22,6 +22,7 @@ import {
   tfiatToken,
   terc721,
   erc721,
+  fiat,
   fiatToken,
 } from './account';
 import { CoinFeature, CoinKind, KeyCurve, UnderlyingAsset } from './base';
@@ -1361,6 +1362,8 @@ export const coins = CoinMap.fromCoins([
     UnderlyingAsset.SLND,
     AccountCoin.DEFAULT_FEATURES
   ),
+  fiat('fiat', 'Fiat', UnderlyingAsset.FIAT, 2, Networks.main.fiat),
+  fiat('tfiat', 'Testnet Fiat', UnderlyingAsset.FIAT, 2, Networks.test.fiat),
   tfiatToken('tfiat:USD', 'FIAT US Dollar', UnderlyingAsset.USD, 2),
   fiatToken('fiat:USD', 'FIAT US Dollar', UnderlyingAsset.USD, 2),
 ]);


### PR DESCRIPTION
create Fiat and Tfiat coins to be used as backingCoin for `ofctusd` and `ofcusd`

We had added 'fiat tokens' (fiat:USD) but decided that we should also add the 'fiat coins' as they will support the creation of wallets.

STLX-13382