### PR TITLE
chore: remove header check from eos verifyTransaction

### DIFF
--- a/modules/bitgo/src/v2/coins/eos.ts
+++ b/modules/bitgo/src/v2/coins/eos.ts
@@ -1075,29 +1075,6 @@ export class Eos extends BaseCoin {
       throw new Error('unpacked packed_trx and unpacked txHex are not equal');
     }
 
-    // check the headers
-    const eosTransactionHeaderFields = ['expiration', 'ref_block_num', 'ref_block_prefix'];
-    const txJsonFromHexHeaders = _.pick(txJsonFromHex, eosTransactionHeaderFields);
-    const txJsonFromPackedTrxHeaders = _.pick(txJsonFromPackedTrx, eosTransactionHeaderFields);
-
-    // dates are rounded to the nearest second in packed_trx and txHex
-    _.map([txJsonFromPackedTrxHeaders, txJsonFromHexHeaders, txPrebuild.headers], (headers) => {
-      const date = moment(headers.expiration as string);
-
-      headers.expiration = date
-        .seconds(date.seconds() + Math.round(date.milliseconds() / 1000))
-        .milliseconds(0)
-        .toISOString();
-      return headers;
-    });
-
-    if (
-      !_.isEqual(txJsonFromPackedTrxHeaders, txJsonFromHexHeaders) ||
-      !_.isEqual(txJsonFromHexHeaders, txPrebuild.headers)
-    ) {
-      throw new Error('the transaction headers are inconsistent');
-    }
-
     if (txParams.recipients.length > 1) {
       throw new Error('only 0 or 1 recipients are supported');
     }

--- a/modules/bitgo/test/v2/unit/coins/eos.ts
+++ b/modules/bitgo/test/v2/unit/coins/eos.ts
@@ -456,16 +456,6 @@ describe('EOS:', function () {
         .should.be.rejectedWith('unpacked packed_trx and unpacked txHex are not equal');
     });
 
-    it('should throw if the transaction headers are inconsistent', async function () {
-      const txPrebuild = newTxPrebuild();
-      const txParams = newTxParams();
-      txParams.txPrebuild = txPrebuild;
-      txParams.txPrebuild.headers.ref_block_prefix = 5;
-      await basecoin
-        .verifyTransaction({ txParams, txPrebuild, wallet, verification })
-        .should.be.rejectedWith('the transaction headers are inconsistent');
-    });
-
     it('should throw if the expected amount is different than actual amount', async function () {
       const txPrebuild = newTxPrebuild();
       const txParams = newTxParams();


### PR DESCRIPTION
Hedaers are set from the server and not the client, therfore removing
this check which has caused client issues due to time rounding.

TICKET: BG-46365