### PR TITLE
chore: refactor TSS lib

### DIFF
--- a/modules/account-lib/src/mpc/curves.ts
+++ b/modules/account-lib/src/mpc/curves.ts
@@ -20,11 +20,13 @@ export default Curve;
 export class Ed25519Curve {
   static initialized = false;
 
-  static async initialize(): Promise<void> {
+  static async initialize(): Promise<Ed25519Curve> {
     if (!Ed25519Curve.initialized) {
       await sodium.ready;
       Ed25519Curve.initialized = true;
     }
+
+    return new Ed25519Curve();
   }
 
   scalarRandom(): bigint {

--- a/modules/account-lib/src/mpc/hdTree.ts
+++ b/modules/account-lib/src/mpc/hdTree.ts
@@ -64,11 +64,13 @@ export class Ed25519BIP32 {
   static curve: Ed25519Curve = new Ed25519Curve();
   static initialized = false;
 
-  static async initialize(): Promise<void> {
+  static async initialize(): Promise<Ed25519BIP32> {
     if (!Ed25519BIP32.initialized) {
       await Ed25519Curve.initialize();
       Ed25519BIP32.initialized = true;
     }
+
+    return new Ed25519BIP32();
   }
 
   publicDerive(keychain: PublicKeychain, path: string): PublicKeychain {

--- a/modules/account-lib/src/mpc/tss.ts
+++ b/modules/account-lib/src/mpc/tss.ts
@@ -125,11 +125,13 @@ export default class Eddsa {
   static shamir: Shamir = new Shamir(Eddsa.curve);
   static initialized = false;
 
-  static async initialize(): Promise<void> {
+  static async initialize(hdTree?: HDTree): Promise<Eddsa> {
     if (!Eddsa.initialized) {
       await Ed25519Curve.initialize();
       Eddsa.initialized = true;
     }
+
+    return new Eddsa(hdTree);
   }
 
   hdTree?: HDTree;
@@ -214,11 +216,11 @@ export default class Eddsa {
   }
 
   /**
-   * Derives a child public key from common keychain
+   * Derives a child common keychain from common keychain
    *
    * @param commonKeychain - common keychain as a hex string
    * @param path - bip32 path
-   * @return {string} public key as a hex string
+   * @return {string} derived common keychain as a hex string
    */
   deriveUnhardened(commonKeychain: string, path: string): string {
     if (this.hdTree === undefined) {
@@ -235,7 +237,10 @@ export default class Eddsa {
       path,
     );
 
-    return bigIntToBufferLE(derivedPublicKeychain.pk, 32).toString('hex');
+    const derivedPk = bigIntToBufferLE(derivedPublicKeychain.pk, 32).toString('hex');
+    const derivedChaincode = bigIntToBufferBE(derivedPublicKeychain.chaincode, 32).toString('hex');
+
+    return derivedPk + derivedChaincode;
   }
 
   keyDerive(uShare: UShare, yShares: YShare[], path: string): SubkeyShare {

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/base.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/base.ts
@@ -177,12 +177,13 @@ describe('Dot Transfer Builder', () => {
   });
 
   describe('add TSS signature', function () {
+    let MPC: Eddsa;
     before('initialize mpc module', async () => {
-      await Eddsa.initialize();
+      MPC = await Eddsa.initialize();
     });
     it('should add TSS signature', async () => {
       const factory = register('tdot', TransactionBuilderFactory);
-      const MPC = new Eddsa();
+
       const A = MPC.keyShare(1, 2, 3);
       const B = MPC.keyShare(2, 2, 3);
       const C = MPC.keyShare(3, 2, 3);

--- a/modules/account-lib/test/unit/coin/near/transactionBuilder/transferBuilder.ts
+++ b/modules/account-lib/test/unit/coin/near/transactionBuilder/transferBuilder.ts
@@ -65,12 +65,13 @@ describe('Near Transfer Builder', () => {
   });
 
   describe('add TSS signature', function () {
+    let MPC: Eddsa;
+
     before('initialize mpc module', async () => {
-      await Eddsa.initialize();
+      MPC = await Eddsa.initialize();
     });
     it('should add TSS signature', async () => {
       const factory = register('tnear', TransactionBuilderFactory);
-      const MPC = new Eddsa();
       const A = MPC.keyShare(1, 2, 3);
       const B = MPC.keyShare(2, 2, 3);
       const C = MPC.keyShare(3, 2, 3);

--- a/modules/account-lib/test/unit/coin/sol/transactionBuilder/transactionBuilder.ts
+++ b/modules/account-lib/test/unit/coin/sol/transactionBuilder/transactionBuilder.ts
@@ -335,6 +335,8 @@ describe('Sol Transaction Builder', async () => {
   });
 
   describe('add signature', () => {
+    let MPC: Eddsa;
+
     it('should add signature to transaction', async () => {
       const transferBuilder = factory
         .getTransferBuilder()
@@ -372,12 +374,11 @@ describe('Sol Transaction Builder', async () => {
     });
 
     before('initialize mpc module', async () => {
-      await Eddsa.initialize();
-      await Ed25519BIP32.initialize();
+      const hdTree = await Ed25519BIP32.initialize();
+      MPC = await Eddsa.initialize(hdTree);
     });
 
     it('should add TSS signature', async () => {
-      const MPC = new Eddsa();
       const A = MPC.keyShare(1, 2, 3);
       const B = MPC.keyShare(2, 2, 3);
       const C = MPC.keyShare(3, 2, 3);
@@ -489,7 +490,6 @@ describe('Sol Transaction Builder', async () => {
     });
 
     it('should add TSS HD signature', async () => {
-      const MPC = new Eddsa(new Ed25519BIP32());
       const A = MPC.keyShare(1, 2, 3);
       const B = MPC.keyShare(2, 2, 3);
       const C = MPC.keyShare(3, 2, 3);

--- a/modules/bitgo/src/v2/internal/tssUtils.ts
+++ b/modules/bitgo/src/v2/internal/tssUtils.ts
@@ -128,8 +128,7 @@ export class TssUtils extends MpcUtils {
     passphrase: string,
     originalPasscodeEncryptionCode?: string
   ): Promise<Keychain> {
-    await Eddsa.initialize();
-    const MPC = new Eddsa();
+    const MPC = await Eddsa.initialize();
     const bitgoKeyShares = bitgoKeychain.keyShares;
     if (!bitgoKeyShares) {
       throw new Error('Missing BitGo key shares');
@@ -189,8 +188,7 @@ export class TssUtils extends MpcUtils {
     bitgoKeychain: Keychain,
     passphrase: string
   ): Promise<Keychain> {
-    await Eddsa.initialize();
-    const MPC = new Eddsa();
+    const MPC = await Eddsa.initialize();
     const bitgoKeyShares = bitgoKeychain.keyShares;
     if (!bitgoKeyShares) {
       throw new Error('Invalid bitgo keyshares');
@@ -291,8 +289,7 @@ export class TssUtils extends MpcUtils {
     enterprise?: string;
     originalPasscodeEncryptionCode?: string;
   }): Promise<KeychainsTriplet> {
-    await Eddsa.initialize();
-    const MPC = new Eddsa();
+    const MPC = await Eddsa.initialize();
     const m = 2;
     const n = 3;
 
@@ -364,9 +361,8 @@ export class TssUtils extends MpcUtils {
       txRequestId = txRequest.txRequestId;
     }
 
-    await Eddsa.initialize();
-    await Ed25519BIP32.initialize();
-    const MPC = new Eddsa(new Ed25519BIP32());
+    const hdTree = await Ed25519BIP32.initialize();
+    const MPC = await Eddsa.initialize(hdTree);
 
     const userSigningMaterial: UserSigningMaterial = JSON.parse(prv);
     const signingKey = MPC.keyDerive(
@@ -449,8 +445,7 @@ export class TssUtils extends MpcUtils {
   async createUserSignShare(params: { signablePayload: Buffer; pShare: PShare }): Promise<SignShare> {
     const { signablePayload, pShare } = params;
 
-    await Eddsa.initialize();
-    const MPC = new Eddsa();
+    const MPC = await Eddsa.initialize();
 
     if (pShare.i !== ShareKeyPosition.USER) {
       throw new Error('Invalid PShare, PShare doesnt belong to the User');
@@ -603,8 +598,8 @@ export class TssUtils extends MpcUtils {
       r: bitgoToUserRShare.share.substring(0, 64),
       R: bitgoToUserRShare.share.substring(64, 128),
     };
-    await Eddsa.initialize();
-    const MPC = new Eddsa();
+
+    const MPC = await Eddsa.initialize();
     return MPC.sign(signablePayload, userSignShare.xShare, [RShare], [backupToUserYShare]);
   }
 

--- a/modules/bitgo/test/v2/unit/internal/tssUtils.ts
+++ b/modules/bitgo/test/v2/unit/internal/tssUtils.ts
@@ -14,7 +14,7 @@ import { RequestTracer } from '../../../../src/v2/internal/util';
 
 describe('TSS Utils:', async function () {
   let sandbox: sinon.SinonSandbox;
-  let MPC;
+  let MPC: Eddsa;
   let bgUrl: string;
   let tssUtils: TssUtils;
   let wallet: Wallet;
@@ -89,12 +89,12 @@ describe('TSS Utils:', async function () {
   });
 
   before('initializes mpc', async function() {
-    await Eddsa.initialize();
-    await Ed25519BIP32.initialize();
+    const hdTree = await Ed25519BIP32.initialize();
+    MPC = await Eddsa.initialize(hdTree);
+
   });
 
   before(async function () {
-    MPC = new Eddsa(new Ed25519BIP32());
     bitgoKeyShare = await MPC.keyShare(3, 2, 3);
 
     const bitGoGPGKey = await openpgp.generateKey({


### PR DESCRIPTION
- deriveUnhardened returns full keychain; clients will need to take the
first 32 bytes if they wish to use it as a public key
- initialize functions will also return a newly instantiated object

Ticket: BG-00000