### PR TITLE
chore: use keyType instead of type for tss + bls keys

### DIFF
--- a/modules/bitgo/src/v2/internal/blsUtils.ts
+++ b/modules/bitgo/src/v2/internal/blsUtils.ts
@@ -72,7 +72,7 @@ export class BlsUtils extends MpcUtils {
 
     const userKeychainParams: any = {
       source: 'user',
-      type: 'blsdkg',
+      keyType: 'blsdkg',
       commonPub: commonPub,
       encryptedPrv: this.bitgo.encrypt({ input: userPrivateKey, password: passphrase }),
       originalPasscodeEncryptionCode: originalPasscodeEncryptionCode,
@@ -132,7 +132,7 @@ export class BlsUtils extends MpcUtils {
 
     return await this.baseCoin.keychains().createBackup({
       source: 'backup',
-      type: 'blsdkg',
+      keyType: 'blsdkg',
       commonPub: commonPub,
       prv: backupPrivateKey,
       encryptedPrv: this.bitgo.encrypt({ input: backupPrivateKey, password: passphrase }),

--- a/modules/bitgo/src/v2/internal/mpcUtils.ts
+++ b/modules/bitgo/src/v2/internal/mpcUtils.ts
@@ -5,7 +5,7 @@
 import { SerializedKeyPair, readPrivateKey, decrypt, readMessage } from 'openpgp';
 import { BitGo } from '../../bitgo';
 import { BaseCoin, KeychainsTriplet } from '../baseCoin';
-import { Keychain } from '../keychains';
+import { Keychain, KeyType } from '../keychains';
 import { encryptText, getBitgoGpgPubKey } from './opengpgUtils';
 
 export interface MpcKeyShare {
@@ -43,7 +43,7 @@ export abstract class MpcUtils {
     userGpgKey: SerializedKeyPair<string>,
     userKeyShare: MpcKeyShare,
     backupKeyShare: MpcKeyShare,
-    keyType: string,
+    keyType: KeyType,
     enterprise?: string
   ): Promise<Keychain> {
     const bitgoKey = await getBitgoGpgPubKey(this.bitgo);
@@ -51,7 +51,7 @@ export abstract class MpcUtils {
     const encBackupToBitGoMessage = await encryptText(backupKeyShare.privateShare, bitgoKey);
 
     const createBitGoMPCParams = {
-      type: keyType,
+      keyType,
       source: 'bitgo',
       keyShares: [
         {

--- a/modules/bitgo/src/v2/internal/tssUtils.ts
+++ b/modules/bitgo/src/v2/internal/tssUtils.ts
@@ -18,7 +18,7 @@ import Eddsa, {
 } from '@bitgo/account-lib/dist/src/mpc/tss';
 
 import { BaseCoin, KeychainsTriplet } from '../baseCoin';
-import { Keychain } from '../keychains';
+import { Keychain, KeyType } from '../keychains';
 import { BitGo } from '../../bitgo';
 import { encryptText, getBitgoGpgPubKey } from './opengpgUtils';
 import { MpcUtils } from './mpcUtils';
@@ -151,7 +151,7 @@ export class TssUtils extends MpcUtils {
 
     const userKeychainParams = {
       source: 'user',
-      type: 'tss',
+      keyType: 'tss' as KeyType,
       commonKeychain: bitgoKeychain.commonKeychain,
       encryptedPrv: this.bitgo.encrypt({ input: JSON.stringify(userSigningMaterial), password: passphrase }),
       originalPasscodeEncryptionCode,
@@ -213,7 +213,7 @@ export class TssUtils extends MpcUtils {
 
     return await this.baseCoin.keychains().createBackup({
       source: 'backup',
-      type: 'tss',
+      keyType: 'tss',
       commonKeychain: bitgoKeychain.commonKeychain,
       prv: prv,
       encryptedPrv: this.bitgo.encrypt({ input: prv, password: passphrase }),

--- a/modules/bitgo/src/v2/keychains.ts
+++ b/modules/bitgo/src/v2/keychains.ts
@@ -9,6 +9,9 @@ import { TssUtils } from './internal/tssUtils';
 import { BlsUtils } from './internal/blsUtils';
 
 const { validateParams } = common;
+
+export type KeyType = 'tss' | 'independent' | 'blsdkg';
+
 export interface Keychain {
   id: string;
   pub: string;
@@ -60,6 +63,7 @@ interface AddKeychainOptions {
   commonKeychain?: string;
   encryptedPrv?: string;
   type?: string;
+  keyType?: KeyType;
   source?: string;
   originalPasscodeEncryptionCode?: string;
   enterprise?: string;
@@ -86,6 +90,7 @@ export interface CreateBackupOptions {
   disableKRSEmail?: boolean;
   krsSpecific?: any;
   type?: string;
+  keyType?: KeyType;
   reqId?: RequestTracer;
   commonPub?: string;
   commonKeychain?: string;
@@ -97,6 +102,7 @@ interface CreateBitGoOptions {
   source?: 'bitgo';
   enterprise?: string;
   reqId?: RequestTracer;
+  keyType?: KeyType;
 }
 
 interface CreateMpcOptions {
@@ -276,7 +282,7 @@ export class Keychains {
    */
   async add(params: AddKeychainOptions = {}): Promise<Keychain> {
     params = params || {};
-    validateParams(params, [], ['pub', 'encryptedPrv', 'type', 'source', 'originalPasscodeEncryptionCode', 'enterprise', 'derivedFromParentWithSeed']);
+    validateParams(params, [], ['pub', 'encryptedPrv', 'keyType', 'type', 'source', 'originalPasscodeEncryptionCode', 'enterprise', 'derivedFromParentWithSeed']);
 
     if (!_.isUndefined(params.disableKRSEmail)) {
       if (!_.isBoolean(params.disableKRSEmail)) {
@@ -294,6 +300,7 @@ export class Keychains {
         commonKeychain: params.commonKeychain,
         encryptedPrv: params.encryptedPrv,
         type: params.type,
+        keyType: params.keyType,
         source: params.source,
         provider: params.provider,
         originalPasscodeEncryptionCode: params.originalPasscodeEncryptionCode,

--- a/modules/bitgo/test/v2/unit/internal/blsUtils.ts
+++ b/modules/bitgo/test/v2/unit/internal/blsUtils.ts
@@ -252,7 +252,7 @@ describe('BLS Utils:', async function () {
     };
 
     nock(bgUrl)
-      .post(`/api/v2/${params.coin}/key`, _.matches({ type: 'blsdkg', source: 'bitgo' }))
+      .post(`/api/v2/${params.coin}/key`, _.matches({ keyType: 'blsdkg', source: 'bitgo' }))
       .reply(200, bitgoKeychain);
 
     return bitgoKeychain;
@@ -267,7 +267,7 @@ describe('BLS Utils:', async function () {
     };
 
     nock('https://bitgo.fakeurl')
-      .post(`/api/v2/${params.coin}/key`, _.matches({ type: 'blsdkg', source: 'user' }))
+      .post(`/api/v2/${params.coin}/key`, _.matches({ keyType: 'blsdkg', source: 'user' }))
       .reply(200, userKeychain);
 
     return userKeychain;
@@ -282,7 +282,7 @@ describe('BLS Utils:', async function () {
     };
 
     nock('https://bitgo.fakeurl')
-      .post(`/api/v2/${params.coin}/key`, _.matches({ type: 'blsdkg', source: 'backup' }))
+      .post(`/api/v2/${params.coin}/key`, _.matches({ keyType: 'blsdkg', source: 'backup' }))
       .reply(200, backupKeychain);
 
     return backupKeychain;

--- a/modules/bitgo/test/v2/unit/internal/tssUtils.ts
+++ b/modules/bitgo/test/v2/unit/internal/tssUtils.ts
@@ -750,7 +750,7 @@ describe('TSS Utils:', async function () {
     };
 
     nock(bgUrl)
-      .post(`/api/v2/${params.coin}/key`, _.matches({ type: 'tss', source: 'bitgo' }))
+      .post(`/api/v2/${params.coin}/key`, _.matches({ keyType: 'tss', source: 'bitgo' }))
       .reply(200, bitgoKeychain);
 
     return bitgoKeychain;
@@ -765,7 +765,7 @@ describe('TSS Utils:', async function () {
     };
 
     nock('https://bitgo.fakeurl')
-      .post(`/api/v2/${params.coin}/key`, _.matches({ type: 'tss', source: 'user' }))
+      .post(`/api/v2/${params.coin}/key`, _.matches({ keyType: 'tss', source: 'user' }))
       .reply(200, userKeychain);
 
     return userKeychain;
@@ -780,7 +780,7 @@ describe('TSS Utils:', async function () {
     };
 
     nock('https://bitgo.fakeurl')
-      .post(`/api/v2/${params.coin}/key`, _.matches({ type: 'tss', source: 'backup' }))
+      .post(`/api/v2/${params.coin}/key`, _.matches({ keyType: 'tss', source: 'backup' }))
       .reply(200, backupKeychain);
 
     return backupKeychain;


### PR DESCRIPTION
type was originally used to differentiate different types of backup keys
(i.e. using an external key provider or holding on to your own).

this was overloaded with the introduction of TSS and BLS.

this change refactors to use keyType to determine multisig type (tss,
bls, or independent/onchain).

Ticket: BG-43890