### PR TITLE
refactor(account-lib): refactor mpc folder to easily add more curves

### DIFF
--- a/modules/account-lib/src/mpc/curves/baseCurve.ts
+++ b/modules/account-lib/src/mpc/curves/baseCurve.ts
@@ -1,0 +1,34 @@
+/**
+ * Base Interface for supporting elliptic curve parameters
+ */
+
+interface BaseCurve {
+  // Function that reduces a scalar modulo the order of the
+  // curve.
+  scalarReduce(s: bigint): bigint;
+  // Function that returns the negated field element modulo
+  // the order of the curve.
+  scalarNegate(s: bigint): bigint;
+  // Function that returns the modular multiplicative inverse
+  // of a field element.
+  scalarInvert(s: bigint): bigint;
+  // Function that returns a random field element.
+  scalarRandom(): bigint;
+  //  Function that returns the sum of two field elements modulo
+  //  the order of the curve.
+  scalarAdd(x: bigint, y: bigint): bigint;
+  // Function that returns the difference of two field elements
+  // modulo the order of the curve.
+  scalarSub(x: bigint, y: bigint): bigint;
+  // Function that returns the product of two field elements
+  // modulo the order of the curve.
+  scalarMult(x: bigint, y: bigint): bigint;
+  // Function that multiplies a group element by a field element.
+  basePointMult(n: bigint): bigint;
+  // Function that adds two group elements.
+  pointAdd(p: bigint, q: bigint): bigint;
+  // Function that verifies a signature.
+  verify(y: bigint, signedMessage: Buffer): Buffer;
+}
+
+export default BaseCurve;

--- a/modules/account-lib/src/mpc/curves/ed25519.ts
+++ b/modules/account-lib/src/mpc/curves/ed25519.ts
@@ -1,23 +1,9 @@
 const sodium = require('libsodium-wrappers-sumo');
 import { randomBytes } from 'crypto';
-import { bigIntFromBufferLE, bigIntToBufferLE } from './util';
+import { bigIntFromBufferLE, bigIntToBufferLE } from '../util';
+import BaseCurve from './baseCurve';
 
-interface Curve {
-  scalarRandom(): bigint;
-  scalarReduce(s: bigint): bigint;
-  scalarNegate(s: bigint): bigint;
-  scalarInvert(s: bigint): bigint;
-  scalarAdd(x: bigint, y: bigint): bigint;
-  scalarSub(x: bigint, y: bigint): bigint;
-  scalarMult(x: bigint, y: bigint): bigint;
-  basePointMult(n: bigint): bigint;
-  pointAdd(p: bigint, q: bigint): bigint;
-  verify(y: bigint, signedMessage: Buffer): Buffer;
-}
-
-export default Curve;
-
-export class Ed25519Curve {
+export class Ed25519Curve implements BaseCurve {
   static initialized = false;
 
   static async initialize(): Promise<Ed25519Curve> {

--- a/modules/account-lib/src/mpc/curves/index.ts
+++ b/modules/account-lib/src/mpc/curves/index.ts
@@ -1,0 +1,5 @@
+import curve from './baseCurve';
+import { Ed25519Curve } from './ed25519';
+
+export default curve;
+export { Ed25519Curve };


### PR DESCRIPTION
This commit refactors the mpc folder to easily add more curves by defining base interfaces and dedicated files specific to each implementation rather than having everything defined in a single file

TICKET: BG-47401