### PR TITLE
feat(bitgo): support chaincodes on BLS-DKG keychains creation

### DIFF
--- a/modules/sdk-coin-eth2/src/eth2.ts
+++ b/modules/sdk-coin-eth2/src/eth2.ts
@@ -302,16 +302,19 @@ export class Eth2 extends BaseCoin {
   generateKeyPair(seed?: Buffer): IBlsKeyPair {
     let keyPair = new Eth2KeyPair();
     if (seed && Eth2KeyPair.isValidPrv(seed)) {
-      const seedStr = '0x' + Buffer.from(seed).toString('hex');
+      const seedStr = Buffer.from(seed).toString('hex');
       keyPair = new Eth2KeyPair({ prv: seedStr });
     } else if (seed) {
       throw new Error('trying to generate keypair from invalid seed');
     }
 
+    const keys = keyPair.getKeys();
     return {
-      pub: keyPair.getKeys().publicShare,
-      prv: keyPair.getKeys().prv || '',
-      secretShares: keyPair.getKeys().secretShares || [],
+      pub: keys.publicShare,
+      prv: keys.prv || '',
+      secretShares: keys.secretShares || [],
+      seed: keys.seed,
+      chaincode: keys.chaincode || '',
     };
   }
 
@@ -348,14 +351,16 @@ export class Eth2 extends BaseCoin {
     return ethUtil.toBuffer(signedMessage);
   }
 
-  aggregateShares(shares: { pubShares: string[]; prvShares: string[] }): IBlsKeyPair {
+  aggregateShares(shares: { pubShares: string[]; prvShares: string[]; chaincodes: string[] }): IBlsKeyPair {
     const commonPub = Eth2KeyPair.aggregatePubkeys(shares.pubShares);
     const prv = Eth2KeyPair.aggregatePrvkeys(shares.prvShares);
+    const commonChaincode = Eth2KeyPair.aggregateChaincodes(shares.chaincodes);
 
     return {
       pub: commonPub,
       prv,
       secretShares: shares.prvShares,
+      chaincode: commonChaincode,
     };
   }
 }

--- a/modules/sdk-coin-eth2/src/lib/keyPair.ts
+++ b/modules/sdk-coin-eth2/src/lib/keyPair.ts
@@ -61,8 +61,7 @@ export class KeyPair extends BlsKeyPair {
           return '0'.slice(0, hex.length % 2) + hex;
         })
         .join('');
-      const privateKey = '0x' + hexPrv;
-      return isValidBLSPrivateKey(privateKey);
+      return isValidBLSPrivateKey(hexPrv);
     } catch (e) {
       return false;
     }

--- a/modules/sdk-coin-eth2/test/resources/eth2.ts
+++ b/modules/sdk-coin-eth2/test/resources/eth2.ts
@@ -1,9 +1,9 @@
 import { KeyPair } from '../../src';
 
-// ACCOUNT_1 has public and private keys with prefix
+// ACCOUNT_1 has public and private keys
 export const ACCOUNT_1 = {
-  privateKey: '0x8fa1aa4aaa6c54aa2aacaafaaa23aCaa8fa1aa4aaa6c54aa2aacaafaaa23aCaa',
-  publicKey: '0x8fa1aa4aaa6c54aa2aacaafaaa23aCaa8fa1aa4aaa6c54aa2aacaafaaa23aCaa',
+  privateKey: '8fa1aa4aaa6c54aa2aacaafaaa23aCaa8fa1aa4aaa6c54aa2aacaafaaa23aCaa',
+  publicKey: '8fa1aa4aaa6c54aa2aacaafaaa23aCaa8fa1aa4aaa6c54aa2aacaafaaa23aCaa',
   privateKeyBytes: Uint8Array.from(
     Buffer.from('4fd90ae1b8f724a4902615c09145ae134617c325b98c6970dcf62ab9cc5e12f3', 'hex')
   ),

--- a/modules/sdk-coin-eth2/test/unit/eth2.ts
+++ b/modules/sdk-coin-eth2/test/unit/eth2.ts
@@ -37,30 +37,27 @@ describe('Ethereum 2.0', function () {
   });
 
   it('should generate keypair from prv', function () {
-    const prv = Uint8Array.from(Buffer.from('4fd90ae1b8f724a4902615c09145ae134617c325b98c6970dcf62ab9cc5e12f3', 'hex'));
+    const prv = Buffer.from('4fd90ae1b8f724a4902615c09145ae134617c325b98c6970dcf62ab9cc5e12f3', 'hex');
     const localBaseCoin = bitgo.coin('teth2');
-    const keyPair = localBaseCoin.generateKeyPair(prv as any);
-    keyPair.prv.should.equal('0x4fd90ae1b8f724a4902615c09145ae134617c325b98c6970dcf62ab9cc5e12f3');
+    const keyPair = localBaseCoin.generateKeyPair(prv);
+    keyPair.prv.should.equal('4fd90ae1b8f724a4902615c09145ae134617c325b98c6970dcf62ab9cc5e12f3');
   });
 
   it('should generate keypair without seed', function () {
-    // FIXME(BG-47812): this test is flaky
-    // @ts-expect-error - no implicit this
-    this.skip();
-    const localBaseCoin: Teth2 = bitgo.coin('teth2') as Teth2;
+    const localBaseCoin = bitgo.coin('teth2') as Teth2;
     const keyPair = localBaseCoin.generateKeyPair();
-    keyPair.pub?.length.should.equal(98);
-    keyPair.secretShares?.every((secretShare) => secretShare.length.should.equal(66));
-    keyPair.pub?.startsWith('0x').should.be.true();
-    keyPair.secretShares?.every((secretShare) => secretShare.startsWith('0x').should.be.true());
+    keyPair.pub?.length.should.equal(96);
     localBaseCoin.isValidPub(keyPair.pub as string).should.be.true();
+    keyPair.secretShares?.every((secretShare) => secretShare.length.should.equal(64));
+    keyPair.seed?.length.should.equal(64);
+    keyPair.chaincode.length.should.equal(64);
   });
 
   it('should reject keypair generation from an invalid prv', function () {
-    const prv = Uint8Array.from(Buffer.from('', 'hex'));
+    const prv = Buffer.from('', 'hex');
     const localBaseCoin = bitgo.coin('teth2');
     (function () {
-      localBaseCoin.generateKeyPair(prv as any);
+      localBaseCoin.generateKeyPair(prv);
     }.should.throw());
   });
 
@@ -74,12 +71,14 @@ describe('Ethereum 2.0', function () {
       const userKey = basecoin.aggregateShares({
         pubShares: [userKeyPair.pub, backupKeyPair.pub, walletKeyPair.pub],
         prvShares: [userKeyPair.secretShares[0], backupKeyPair.secretShares[0], walletKeyPair.secretShares[0]],
+        chaincodes: [userKeyPair.chaincode, backupKeyPair.chaincode, walletKeyPair.chaincode],
       });
       const userSignatureBuffer = await basecoin.signMessage({ prv: userKey.prv }, message);
       const userSignature = bufferToHex(userSignatureBuffer);
       const walletKey = basecoin.aggregateShares({
         pubShares: [userKeyPair.pub, backupKeyPair.pub, walletKeyPair.pub],
         prvShares: [userKeyPair.secretShares[2], backupKeyPair.secretShares[2], walletKeyPair.secretShares[2]],
+        chaincodes: [userKeyPair.chaincode, backupKeyPair.chaincode, walletKeyPair.chaincode],
       });
       const walletSignatureBuffer = await basecoin.signMessage({ prv: walletKey.prv }, message);
       const walletSignature = bufferToHex(walletSignatureBuffer);
@@ -92,6 +91,43 @@ describe('Ethereum 2.0', function () {
       (await KeyPair.verifySignature(userKey.pub, Buffer.from(message), signature)).should.be.true();
     });
 
+    it('should sign with child key and validate a string message', async function () {
+      const userKeyPair = basecoin.generateKeyPair();
+      const backupKeyPair = basecoin.generateKeyPair();
+      const walletKeyPair = basecoin.generateKeyPair();
+
+      const message = 'hello world';
+      const userKey = basecoin.aggregateShares({
+        pubShares: [userKeyPair.pub, backupKeyPair.pub, walletKeyPair.pub],
+        prvShares: [userKeyPair.secretShares[0], backupKeyPair.secretShares[0], walletKeyPair.secretShares[0]],
+        chaincodes: [userKeyPair.chaincode, backupKeyPair.chaincode, walletKeyPair.chaincode],
+      });
+      const childUserKeypair = KeyPair.keyDerive(
+        userKeyPair.seed,
+        userKey.pub,
+        userKey.chaincode,
+        'm/12381/3600/0/0/0'
+      );
+      const childUserKey = basecoin.aggregateShares({
+        pubShares: [childUserKeypair.publicShare, backupKeyPair.pub, walletKeyPair.pub],
+        prvShares: [childUserKeypair.secretShares[0], backupKeyPair.secretShares[0], walletKeyPair.secretShares[0]],
+        chaincodes: [childUserKeypair.chaincode, backupKeyPair.chaincode, walletKeyPair.chaincode],
+      });
+      const userSignatureBuffer = await basecoin.signMessage({ prv: childUserKey.prv }, message);
+      const userSignature = bufferToHex(userSignatureBuffer);
+      const walletKey = basecoin.aggregateShares({
+        pubShares: [childUserKeypair.publicShare, backupKeyPair.pub, walletKeyPair.pub],
+        prvShares: [childUserKeypair.secretShares[2], backupKeyPair.secretShares[2], walletKeyPair.secretShares[2]],
+        chaincodes: [childUserKeypair.chaincode, backupKeyPair.chaincode, walletKeyPair.chaincode],
+      });
+      const walletSignatureBuffer = await basecoin.signMessage({ prv: walletKey.prv }, message);
+      const walletSignature = bufferToHex(walletSignatureBuffer);
+      const signature = KeyPair.aggregateSignatures({ 1: BigInt(userSignature), 3: BigInt(walletSignature) });
+
+      childUserKey.pub.should.equal(walletKey.pub);
+      (await KeyPair.verifySignature(childUserKey.pub, Buffer.from(message), signature)).should.be.true();
+    });
+
     it('should fail to validate a string message with wrong public key', async function () {
       const userKeyPair = basecoin.generateKeyPair();
       const backupKeyPair = basecoin.generateKeyPair();
@@ -102,12 +138,14 @@ describe('Ethereum 2.0', function () {
       const userKey = basecoin.aggregateShares({
         pubShares: [userKeyPair.pub, backupKeyPair.pub, otherKeyPair.pub],
         prvShares: [userKeyPair.secretShares[0], backupKeyPair.secretShares[0], walletKeyPair.secretShares[0]],
+        chaincodes: [userKeyPair.chaincode, backupKeyPair.chaincode, walletKeyPair.chaincode],
       });
       const userSignatureBuffer = await basecoin.signMessage({ prv: userKey.prv }, message);
       const userSignature = bufferToHex(userSignatureBuffer);
       const walletKey = basecoin.aggregateShares({
         pubShares: [userKeyPair.pub, backupKeyPair.pub, otherKeyPair.pub],
         prvShares: [userKeyPair.secretShares[2], backupKeyPair.secretShares[2], walletKeyPair.secretShares[2]],
+        chaincodes: [userKeyPair.chaincode, backupKeyPair.chaincode, walletKeyPair.chaincode],
       });
       const walletSignatureBuffer = await basecoin.signMessage({ prv: walletKey.prv }, message);
       const walletSignature = bufferToHex(walletSignatureBuffer);

--- a/modules/sdk-core/src/account-lib/baseCoin/iface.ts
+++ b/modules/sdk-core/src/account-lib/baseCoin/iface.ts
@@ -114,6 +114,8 @@ export type BlsKeys = {
   prv?: string;
   secretShares: string[];
   publicShare: string;
+  seed: string;
+  chaincode: string;
 };
 
 export interface BaseAddress {

--- a/modules/sdk-core/src/account-lib/util/crypto.ts
+++ b/modules/sdk-core/src/account-lib/util/crypto.ts
@@ -167,7 +167,7 @@ export function isValidEd25519PublicKey(pub: string): boolean {
  */
 export function isValidBLSPrivateKey(prv: string): boolean {
   try {
-    return bls.Fr.isValid(BigInt(prv));
+    return bls.Fr.isValid(BigInt('0x' + prv));
   } catch (e) {
     return false;
   }
@@ -204,9 +204,13 @@ export function toHex(buffer: Buffer | Uint8Array): string {
  * @param {bigint} bigint - the bigint to be converted to hex
  * @returns {string} - the hex value
  */
-export function bigIntToHex(bigint: bigint): string {
-  const hex = bigint.toString(16);
-  return '0x' + '0'.slice(0, hex.length % 2) + hex;
+export function bigIntToHex(bigint: bigint, hexLength?: number): string {
+  let hex = bigint.toString(16);
+  hex = '0'.slice(0, hex.length % 2) + hex;
+  if (hexLength) {
+    hex = hex.padStart(hexLength, '0');
+  }
+  return hex;
 }
 
 /**

--- a/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
@@ -94,6 +94,8 @@ export interface KeyPair {
 
 export interface IBlsKeyPair extends KeyPair {
   secretShares?: string[];
+  chaincode: string;
+  seed?: string;
 }
 
 export interface VerifyAddressOptions {


### PR DESCRIPTION
As part of the BLS-DKG HS implementation, chaincodes needs to be supported at the time of keychain
creation so then it is possible to derive the subkeys when signing tx. Each participant contributes
with its own chaincode and those are added up to the common keychain.

Also fixes BG-47812. Add padding to the secret shares hex so it always
is 64. It sometimes was 62.

BG-46184