### PR TITLE
chore(account-lib): upgrade to es2019

### DIFF
--- a/modules/account-lib/test/tsconfig.json
+++ b/modules/account-lib/test/tsconfig.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "include": ["./**/*"]
-}

--- a/modules/account-lib/test/unit/coin/algo/keyPair.ts
+++ b/modules/account-lib/test/unit/coin/algo/keyPair.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { Algo } from '../../../../src';
 import * as AlgoResources from '../../../resources/algo';
@@ -37,21 +38,21 @@ describe('Algo KeyPair', () => {
   describe('KeyPair validation', () => {
     it('should fail to create from an invalid seed', () => {
       const seed = { seed: Buffer.alloc(8) }; //  Seed should be 512 bits (64 bytes)
-      should.throws(() => new Algo.KeyPair(seed), 'bad seed size');
+      assert.throws(() => new Algo.KeyPair(seed), /bad seed size/);
     });
 
     it('should fail to create from an invalid public key', () => {
       const source = {
         pub: '01D63D',
       };
-      should.throws(() => new Algo.KeyPair(source), 'address seems to be malformed');
+      assert.throws(() => new Algo.KeyPair(source), /address seems to be malformed/);
     });
 
     it('should fail to create from an invalid private key', () => {
       const source = {
         prv: '82A34',
       };
-      should.throws(() => new Algo.KeyPair(source), 'Invalid base32 characters');
+      assert.throws(() => new Algo.KeyPair(source), /Invalid base32 characters/);
     });
   });
 

--- a/modules/account-lib/test/unit/coin/algo/transaction.ts
+++ b/modules/account-lib/test/unit/coin/algo/transaction.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { coins } from '@bitgo/statics';
 import * as AlgoResources from '../../../resources/algo';
@@ -34,19 +35,19 @@ describe('Algo Transaction', () => {
 
   describe('empty transaction', () => {
     it('should throw empty transaction', () => {
-      should.throws(() => tx.toJson(), 'Empty transaction');
-      should.throws(() => tx.toBroadcastFormat(), 'Empty transaction');
+      assert.throws(() => tx.toJson(), /Empty transaction/);
+      assert.throws(() => tx.toBroadcastFormat(), /Empty transaction/);
     });
 
     it('should not sign', () => {
-      should.throws(
+      assert.throws(
         () => tx.sign([new KeyPair({ prv: AlgoResources.accounts.default.secretKey.toString('hex') })]),
-        'Empty transaction',
+        /Empty transaction/,
       );
       tx.setNumberOfRequiredSigners(2);
-      should.throws(
+      assert.throws(
         () => tx.sign([new KeyPair({ prv: AlgoResources.accounts.default.secretKey.toString('hex') })]),
-        'Empty transaction',
+        /Empty transaction/,
       );
     });
   });

--- a/modules/account-lib/test/unit/coin/algo/transactionBuilder/assetTransferBuilder.ts
+++ b/modules/account-lib/test/unit/coin/algo/transactionBuilder/assetTransferBuilder.ts
@@ -1,4 +1,5 @@
 import { coins } from '@bitgo/statics';
+import assert from 'assert';
 import should from 'should';
 import { test } from 'mocha';
 import { AssetTransferBuilder, TransactionBuilderFactory } from '../../../../../src/coin/algo';
@@ -20,8 +21,8 @@ describe('Algo Asset Transfer Transaction Builder', () => {
 
   describe('setter validation', () => {
     it('should validate asset id is not lte 0', () => {
-      should.throws(() => txnBuilder.tokenId(-1));
-      should.throws(() => txnBuilder.tokenId(0));
+      assert.throws(() => txnBuilder.tokenId(-1));
+      assert.throws(() => txnBuilder.tokenId(0));
       should.doesNotThrow(() => txnBuilder.tokenId(1));
     });
   });
@@ -109,27 +110,27 @@ describe('Algo Asset Transfer Transaction Builder', () => {
     it('should not build a token transaction with an invalid sender address', async function () {
       const wrongAddress = 'RIJVLDYWASZZNGOSQNOK7HN6JNFLMMZ3FFBBFG2NNROM5CE744DAJSPZJ';
       const tx = await txnBuilder.testnet();
-      should.throws(
+      assert.throws(
         () => tx.sender({ address: wrongAddress }),
-        "The address '" + wrongAddress + "' is not a well-formed algorand address",
+        new RegExp("The address '" + wrongAddress + "' is not a well-formed algorand address"),
       );
     });
 
     it('should not build a token transaction with an invalid closeRemainderTo address', async function () {
       const wrongAddress = 'RIJVLDYWASZZNGOSQNOK7HN6JNFLMMZ3FFBBFG2NNROM5CE744DAJSPZJ';
       const tx = await txnBuilder.testnet();
-      should.throws(
+      assert.throws(
         () => tx.closeRemainderTo({ address: wrongAddress }),
-        "The address '" + wrongAddress + "' is not a well-formed algorand address",
+        new RegExp("The address '" + wrongAddress + "' is not a well-formed algorand address"),
       );
     });
 
     it('should not build a token transaction with an invalid to address', async function () {
       const wrongAddress = 'RIJVLDYWASZZNGOSQNOK7HN6JNFLMMZ3FFBBFG2NNROM5CE744DAJSPZJ';
       const tx = await txnBuilder.testnet();
-      should.throws(
+      assert.throws(
         () => tx.to({ address: wrongAddress }),
-        "The address '" + wrongAddress + "' is not a well-formed algorand address",
+        new RegExp("The address '" + wrongAddress + "' is not a well-formed algorand address"),
       );
     });
 
@@ -281,10 +282,10 @@ describe('Algo Asset Transfer Transaction Builder', () => {
     });
 
     it('should fail to decode other types of transactions', () => {
-      should.throws(() => txnBuilder.from(rawTx.keyReg.unsigned), 'Invalid Transaction Type: keyreg. Expected axfer');
-      should.throws(() => txnBuilder.from(rawTx.keyReg.signed), 'Invalid Transaction Type: keyreg. Expected axfer');
-      should.throws(() => txnBuilder.from(rawTx.transfer.unsigned), 'Invalid Transaction Type: pay. Expected axfer');
-      should.throws(() => txnBuilder.from(rawTx.transfer.signed), 'Invalid Transaction Type: pay. Expected axfer');
+      assert.throws(() => txnBuilder.from(rawTx.keyReg.unsigned), /Invalid Transaction Type: keyreg. Expected axfer/);
+      assert.throws(() => txnBuilder.from(rawTx.keyReg.signed), /Invalid Transaction Type: keyreg. Expected axfer/);
+      assert.throws(() => txnBuilder.from(rawTx.transfer.unsigned), /Invalid Transaction Type: pay. Expected axfer/);
+      assert.throws(() => txnBuilder.from(rawTx.transfer.signed), /Invalid Transaction Type: pay. Expected axfer/);
     });
   });
 

--- a/modules/account-lib/test/unit/coin/algo/transactionBuilder/base.ts
+++ b/modules/account-lib/test/unit/coin/algo/transactionBuilder/base.ts
@@ -1,8 +1,9 @@
 import crypto from 'crypto';
 import { BaseCoin as CoinConfig, coins } from '@bitgo/statics';
 import algosdk from 'algosdk';
+import assert from 'assert';
 import should from 'should';
-import sinon, { assert } from 'sinon';
+import sinon, { assert as SinonAssert } from 'sinon';
 import {
   AddressValidationError,
   InsufficientFeeError,
@@ -108,7 +109,7 @@ describe('Algo Transaction Builder', () => {
     it('should validate fee is not lt 1000 microalgos if flat fee is set to true', () => {
       txnBuilder.isFlatFee(true);
 
-      should.throws(
+      assert.throws(
         () => txnBuilder.fee({ fee: '999' }),
         (e: Error) => e.name === InsufficientFeeError.name,
       );
@@ -117,16 +118,16 @@ describe('Algo Transaction Builder', () => {
 
     it('should validate sender address is a valid algo address', () => {
       const spy = sinon.spy(txnBuilder, 'validateAddress');
-      should.throws(
+      assert.throws(
         () => txnBuilder.sender({ address: 'asdf' }),
         (e: Error) => e.name === AddressValidationError.name,
       );
       should.doesNotThrow(() => txnBuilder.sender({ address: account1.address }));
-      assert.calledTwice(spy);
+      SinonAssert.calledTwice(spy);
     });
 
     it('should validate number of signers is not less than 0', () => {
-      should.throws(() => txnBuilder.numberOfRequiredSigners(-1), "Number of signers: '-1' cannot be negative");
+      assert.throws(() => txnBuilder.numberOfRequiredSigners(-1), /Number of signers: '-1' cannot be negative/);
 
       for (let i = 0; i < STANDARD_REQUIRED_NUMBER_OF_SIGNERS; i++) {
         should.doesNotThrow(() => txnBuilder.numberOfRequiredSigners(i));
@@ -272,9 +273,9 @@ describe('Algo Transaction Builder', () => {
       txn.setAlgoTransaction(algoTxn);
       txn.setNumberOfRequiredSigners(1);
 
-      should.throws(
+      assert.throws(
         () => txnBuilder.signImplementation({ key: Buffer.from(account1.prvKey).toString('hex') }),
-        'Invalid base32 characters',
+        new RegExp('Invalid base32 characters'),
       );
     });
 
@@ -313,9 +314,11 @@ describe('Algo Transaction Builder', () => {
         .genesisId(testnet.genesisID)
         .genesisHash(testnet.genesisHash);
 
-      should.throws(
+      assert.throws(
         () => txnBuilder.validateTransaction(txnBuilder.getTransaction()),
-        'Transaction validation failed: "value" failed custom validation because lastRound cannot be greater than or equal to firstRound',
+        new RegExp(
+          'Transaction validation failed: "value" failed custom validation because lastRound cannot be greater than or equal to firstRound',
+        ),
       );
     });
 

--- a/modules/account-lib/test/unit/coin/algo/transactionBuilder/keyRegistrationBuilder.ts
+++ b/modules/account-lib/test/unit/coin/algo/transactionBuilder/keyRegistrationBuilder.ts
@@ -1,7 +1,8 @@
 import { coins } from '@bitgo/statics';
 import algosdk from 'algosdk';
+import assert from 'assert';
 import should from 'should';
-import sinon, { assert } from 'sinon';
+import sinon, { assert as SinonAssert } from 'sinon';
 import { Transaction } from '../../../../../src/coin/algo';
 import { KeyRegistrationBuilder } from '../../../../../src/coin/algo/keyRegistrationBuilder';
 
@@ -39,30 +40,30 @@ describe('Algo KeyRegistration Builder', () => {
 
     it('should validate voteFirst is gt than 0', () => {
       const spy = sinon.spy(builder, 'validateValue');
-      should.throws(
+      assert.throws(
         () => builder.voteFirst(-1),
         (e: Error) => e.message === 'Value cannot be less than zero',
       );
       should.doesNotThrow(() => builder.voteFirst(15));
-      assert.calledTwice(spy);
+      SinonAssert.calledTwice(spy);
     });
 
     it('should validate voteLast is gt than 0', () => {
       const validateValueSpy = sinon.spy(builder, 'validateValue');
       builder.voteFirst(1);
-      should.throws(
+      assert.throws(
         () => builder.voteLast(-1),
         (e: Error) => e.message === 'Value cannot be less than zero',
       );
       should.doesNotThrow(() => builder.voteLast(15));
-      assert.calledThrice(validateValueSpy);
+      SinonAssert.calledThrice(validateValueSpy);
     });
 
     it('should validate vote Key Dilution', () => {
       const validateValueSpy = sinon.spy(builder, 'validateValue');
       builder.voteFirst(5).voteLast(18);
       should.doesNotThrow(() => builder.voteKeyDilution(2));
-      assert.calledThrice(validateValueSpy);
+      SinonAssert.calledThrice(validateValueSpy);
     });
   });
 
@@ -155,7 +156,7 @@ describe('Algo KeyRegistration Builder', () => {
         .voteFirst(1)
         .voteLast(100)
         .voteKeyDilution(9);
-      should.throws(() => builder.stateProofKey(malformatedStateProofKey), 'Error: Invalid base64 string');
+      assert.throws(() => builder.stateProofKey(malformatedStateProofKey), 'Error: Invalid base64 string');
     });
 
     it('should build an offline key registration transaction', async () => {

--- a/modules/account-lib/test/unit/coin/algo/transactionBuilder/transferBuilder.ts
+++ b/modules/account-lib/test/unit/coin/algo/transactionBuilder/transferBuilder.ts
@@ -1,8 +1,9 @@
 import crypto from 'crypto';
 import algosdk from 'algosdk';
 import { coins } from '@bitgo/statics';
+import assert from 'assert';
 import should from 'should';
-import sinon, { assert } from 'sinon';
+import sinon, { assert as SinonAssert } from 'sinon';
 import { AddressValidationError, TransferBuilder } from '../../../../../src/coin/algo';
 import * as AlgoResources from '../../../../resources/algo';
 
@@ -23,22 +24,22 @@ describe('Algo Transfer Builder', () => {
   describe('setter validation', () => {
     it('should validate receiver address is a valid algo address', () => {
       const spy = sinon.spy(builder, 'validateAddress');
-      should.throws(
+      assert.throws(
         () => builder.to({ address: 'wrong-addr' }),
         (e: Error) => e.name === AddressValidationError.name,
       );
       should.doesNotThrow(() => builder.to({ address: sender.address }));
-      assert.calledTwice(spy);
+      SinonAssert.calledTwice(spy);
     });
 
     it('should validate transfer amount', () => {
       const spy = sinon.spy(builder, 'validateValue');
-      should.throws(
+      assert.throws(
         () => builder.amount(-1),
         (e: Error) => e.message === 'Value cannot be less than zero',
       );
       should.doesNotThrow(() => builder.amount(1000));
-      assert.calledTwice(spy);
+      SinonAssert.calledTwice(spy);
     });
   });
 

--- a/modules/account-lib/test/unit/coin/algo/utils.ts
+++ b/modules/account-lib/test/unit/coin/algo/utils.ts
@@ -40,7 +40,7 @@ describe('utils', () => {
     const secretKeyInValid = '9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f6$';
     assert.throws(
       () => Algo.algoUtils.secretKeyToMnemonic(Buffer.from(secretKeyInValid, 'hex')),
-      /InvalidKey: The secret key: 9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f is invalid/,
+      /The secret key: 9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f is invalid/,
     );
   });
 

--- a/modules/account-lib/test/unit/coin/algo/utils.ts
+++ b/modules/account-lib/test/unit/coin/algo/utils.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import algosdk from 'algosdk';
 import utils from '../../../../src/coin/algo/utils';
@@ -37,9 +38,9 @@ describe('utils', () => {
 
   it('it should return error if the secret key is invalid', () => {
     const secretKeyInValid = '9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f6$';
-    should.throws(
+    assert.throws(
       () => Algo.algoUtils.secretKeyToMnemonic(Buffer.from(secretKeyInValid, 'hex')),
-      'The secret key: 9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f6$ is invalid',
+      /InvalidKey: The secret key: 9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f is invalid/,
     );
   });
 
@@ -54,9 +55,9 @@ describe('utils', () => {
   it('it should return error if the mnemonic is invalid', () => {
     const mnemonicInValid =
       'crisp hello solution ten remove object watch enhance future rather biology era myth image swap crash coffee scatter buffalo depart day twist advance about unfair';
-    should.throws(
+    assert.throws(
       () => Algo.algoUtils.seedFromMnemonic(mnemonicInValid),
-      'the mnemonic contains a word that is not in the wordlist',
+      new RegExp('the mnemonic contains a word that is not in the wordlist'),
     );
   });
 
@@ -75,7 +76,7 @@ describe('utils', () => {
     const seedInValid = new Uint8Array(
       Buffer.from('9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f6$', 'hex'),
     );
-    should.throws(() => Algo.algoUtils.keyPairFromSeed(seedInValid), 'seed length must be 32');
+    assert.throws(() => Algo.algoUtils.keyPairFromSeed(seedInValid), /Seed length must be 32/);
   });
 
   it('should generate the same keyPair with which it started', () => {
@@ -112,13 +113,13 @@ describe('utils', () => {
   it('stellarAddressToAlgoAddress should return error if the xlm and algoaddress are invalid', () => {
     const xlmAddress = 'GDV4ZW7UBRSQAHLORJPQF4L6OZJBKU3ZIVS2O6C7WWGSNZOV42JDHPM/';
     const algoAddress = '5PGNX5AMMUAB23UKL4BPC7TWKIKVG6KFMWTXQX5VRUTOLVPGSIZSHUA7H/';
-    should.throws(
+    assert.throws(
       () => Algo.algoUtils.stellarAddressToAlgoAddress(xlmAddress),
-      'Neither an Algorand address nor a stellar pubkey',
+      new RegExp('Neither an Algorand address nor a stellar pubkey'),
     );
-    should.throws(
+    assert.throws(
       () => Algo.algoUtils.stellarAddressToAlgoAddress(algoAddress),
-      'Neither an Algorand address nor a stellar pubkey',
+      new RegExp('Neither an Algorand address nor a stellar pubkey'),
     );
   });
 
@@ -131,8 +132,8 @@ describe('utils', () => {
   it('should returns error when invalid address', () => {
     const invalidAddress1 = '25NJQAMCWEFLPVKL73J4SZAHHIHOC4XT3KTCGJNPAINGR5YHKENMEF5QT/';
     const invalidAddress2 = '25NJQAMCWEFLPVKL73J4SZAHHIHOC4XT3KTCGJNPAINGR5YHKENMEF5QTEF';
-    should.throws(() => Algo.algoUtils.decodeAddress(invalidAddress1), 'Error: Invalid base32 characters');
-    should.throws(() => Algo.algoUtils.decodeAddress(invalidAddress2), 'Error: address seems to be malformed');
+    assert.throws(() => Algo.algoUtils.decodeAddress(invalidAddress1), /Error: Invalid base32 characters/);
+    assert.throws(() => Algo.algoUtils.decodeAddress(invalidAddress2), /Error: address seems to be malformed/);
   });
 
   it('multisigAddress should return the same string with accountLib and algosdk', () => {
@@ -151,7 +152,7 @@ describe('utils', () => {
     const threshold = 2;
     const addrs = ['X4GMYVKF6VVNKA4Q4AUSRUYXYCGQSY7DZS7QXVJC33VYQTRUKCU7DDFE2U'];
 
-    should.throws(() => Algo.algoUtils.multisigAddress(version, threshold, addrs), 'Error: bad multisig threshold');
+    assert.throws(() => Algo.algoUtils.multisigAddress(version, threshold, addrs), /Error: bad multisig threshold/);
   });
 
   it('multisigAddress should fail when  threshold is 3', () => {
@@ -159,7 +160,7 @@ describe('utils', () => {
     const threshold = 3;
     const addrs = ['X4GMYVKF6VVNKA4Q4AUSRUYXYCGQSY7DZS7QXVJC33VYQTRUKCU7DDFE2U'];
 
-    should.throws(() => Algo.algoUtils.multisigAddress(version, threshold, addrs), 'Error: bad multisig threshold');
+    assert.throws(() => Algo.algoUtils.multisigAddress(version, threshold, addrs), /Error: bad multisig threshold/);
   });
 
   it('multisigAddress should fail when  version is 2', () => {
@@ -167,7 +168,7 @@ describe('utils', () => {
     const threshold = 1;
     const addrs = ['25NJQAMCWEFLPVKL73J4SZAHHIHOC4XT3KTCGJNPAINGR5YHKENMEF5QTE'];
 
-    should.throws(() => Algo.algoUtils.multisigAddress(version, threshold, addrs), 'Error: invalid multisig version');
+    assert.throws(() => Algo.algoUtils.multisigAddress(version, threshold, addrs), /Error: invalid multisig version/);
   });
 
   it('multisigAddress should fail when  address is not valid', () => {
@@ -175,7 +176,7 @@ describe('utils', () => {
     const threshold = 1;
     const addrs = ['25NJQAMCWEFLPVKL73J4SZAHHIHOC4XT3KTCGJNPAINGR5YHKENMEF5QT-'];
 
-    should.throws(() => Algo.algoUtils.multisigAddress(version, threshold, addrs), 'Error: Invalid base32 characters');
+    assert.throws(() => Algo.algoUtils.multisigAddress(version, threshold, addrs), /Error: Invalid base32 characters/);
   });
 
   it('generateAccount should of create a valid addres and valid secretKey', () => {
@@ -287,7 +288,7 @@ describe('utils', () => {
   it('Should not be able to get a txID from an incomplete multising Tx', () => {
     const rawTxn = invalidTxn.txn;
 
-    should.throws(() => {
+    assert.throws(() => {
       Algo.algoUtils.getMultisigTxID(rawTxn);
     }, 'RangeError: Insufficient data');
   });
@@ -295,7 +296,7 @@ describe('utils', () => {
   it('Should not be able to get a txID from a simple Tx', () => {
     const rawTxn = invalidTxn2.txn;
 
-    should.throws(() => {
+    assert.throws(() => {
       Algo.algoUtils.getMultisigTxID(rawTxn);
     }, 'Error: The object contains empty or 0 values. First empty or 0 value encountered during encoding: msig');
   });

--- a/modules/account-lib/test/unit/coin/avaxc/keyPair.ts
+++ b/modules/account-lib/test/unit/coin/avaxc/keyPair.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { KeyPair } from '../../../../src/coin/avaxc/keyPair';
 import { TEST_ACCOUNT } from '../../../resources/avaxc/avaxc';
@@ -42,7 +43,7 @@ describe('Avax Key Pair', () => {
       should.equal(keys.prv, TEST_ACCOUNT.ethPrivateKey);
       should.equal(keys.pub, TEST_ACCOUNT.ethUncompressedPublicKey);
 
-      should.throws(() => keyPairObj.getExtendedKeys());
+      assert.throws(() => keyPairObj.getExtendedKeys());
     });
 
     it('from a compressed public key', () => {
@@ -53,7 +54,7 @@ describe('Avax Key Pair', () => {
       should.exists(keys.pub);
       should.equal(keys.pub, TEST_ACCOUNT.ethUncompressedPublicKey);
 
-      should.throws(() => keyPairObj.getExtendedKeys());
+      assert.throws(() => keyPairObj.getExtendedKeys());
     });
 
     it('from an uncompressed public key', () => {
@@ -64,7 +65,7 @@ describe('Avax Key Pair', () => {
       should.exists(keys.pub);
       should.equal(keys.pub, TEST_ACCOUNT.ethUncompressedPublicKey);
 
-      should.throws(() => keyPairObj.getExtendedKeys());
+      assert.throws(() => keyPairObj.getExtendedKeys());
     });
 
     it('from an extended private key', () => {
@@ -100,14 +101,14 @@ describe('Avax Key Pair', () => {
 
   describe('should fail to create a KeyPair', () => {
     it('from an invalid privateKey', () => {
-      should.throws(
+      assert.throws(
         () => new KeyPair({ prv: '' }),
         (e) => e.message === 'Unsupported private key',
       );
     });
 
     it('from an invalid publicKey', () => {
-      should.throws(
+      assert.throws(
         () => new KeyPair({ pub: '' }),
         (e) => e.message.startsWith('Unsupported public key'),
       );
@@ -115,7 +116,7 @@ describe('Avax Key Pair', () => {
 
     it('from an undefined seed', () => {
       const undefinedBuffer = undefined as unknown as Buffer;
-      should.throws(
+      assert.throws(
         () => new KeyPair({ seed: undefinedBuffer }),
         (e) => e.message.startsWith('Invalid key pair options'),
       );
@@ -123,7 +124,7 @@ describe('Avax Key Pair', () => {
 
     it('from an undefined private key', () => {
       const undefinedStr: string = undefined as unknown as string;
-      should.throws(
+      assert.throws(
         () => new KeyPair({ prv: undefinedStr }),
         (e) => e.message.startsWith('Invalid key pair options'),
       );
@@ -131,7 +132,7 @@ describe('Avax Key Pair', () => {
 
     it('from an undefined public key', () => {
       const undefinedStr: string = undefined as unknown as string;
-      should.throws(
+      assert.throws(
         () => new KeyPair({ pub: undefinedStr }),
         (e) => e.message.startsWith('Invalid key pair options'),
       );

--- a/modules/account-lib/test/unit/coin/avaxc/transactionBuilder/transfer.ts
+++ b/modules/account-lib/test/unit/coin/avaxc/transactionBuilder/transfer.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { AvaxC, getBuilder, BaseCoin } from '../../../../../src';
 import { TransactionBuilder } from '../../../../../src/coin/avaxc';
@@ -148,7 +149,7 @@ describe('Avax C-Chain Transfer Transaction', function () {
     builder.counter(1);
     builder.contract(testData.TEST_ACCOUNT.ethAddress);
     builder.type(TransactionType.WalletInitialization);
-    should.throws(
+    assert.throws(
       () => builder.transfer(),
       (e) => e.message === 'Transfers can only be set for send transactions',
     );

--- a/modules/account-lib/test/unit/coin/avaxc/transactionBuilder/walletInitializationBuilder.ts
+++ b/modules/account-lib/test/unit/coin/avaxc/transactionBuilder/walletInitializationBuilder.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { AvaxC, getBuilder } from '../../../../../src';
 import { TransactionType } from '../../../../../src/coin/baseCoin';
@@ -84,7 +85,7 @@ describe('AvaxC Wallet Initialization Builder', function () {
         gasLimit: '7000000',
       });
       txBuilder.counter(1);
-      should.throws(
+      assert.throws(
         () => txBuilder.owner(testData.OWNER_1.ethAddress),
         (e) => e.message === 'Multisig wallet owner can only be set for initialization transactions',
       );
@@ -98,7 +99,7 @@ describe('AvaxC Wallet Initialization Builder', function () {
       });
       txBuilder.counter(1);
       txBuilder.type(TransactionType.WalletInitialization);
-      should.throws(
+      assert.throws(
         () => txBuilder.sign({ key: testData.OWNER_1.ethKey }),
         (e) => e.message === 'Cannot sign an wallet initialization transaction without owners',
       );

--- a/modules/account-lib/test/unit/coin/avaxc/util.ts
+++ b/modules/account-lib/test/unit/coin/avaxc/util.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { NetworkType } from '@bitgo/statics';
 import { TEST_ACCOUNT, TEST_ACCOUNT_2 } from '../../../resources/avaxc/avaxc';
@@ -259,7 +260,7 @@ describe('AVAX util library', () => {
     });
 
     it('getCommon for invalid network', () => {
-      should.throws(
+      assert.throws(
         () => getCommon('invalidNetwork' as NetworkType),
         (e) => e.message === 'Missing network common configuration',
       );

--- a/modules/account-lib/test/unit/coin/baseCoin/transactionBuilder.ts
+++ b/modules/account-lib/test/unit/coin/baseCoin/transactionBuilder.ts
@@ -1,4 +1,5 @@
 import sinon from 'sinon';
+import assert from 'assert';
 import should from 'should';
 import { TestTransactionBuilder } from '../../../resources/testTransactionBuilder';
 import { TestTransaction } from '../../../resources/testTransaction';
@@ -33,7 +34,7 @@ describe('Transaction builder', () => {
     const validateKey = sinon.spy(txBuilder, 'validateKey');
 
     txBuilder.from(testTx);
-    should.throws(() => txBuilder.sign({ key: 'invalidKey' }));
+    assert.throws(() => txBuilder.sign({ key: 'invalidKey' }));
 
     sandbox.assert.calledOnce(validateKey);
   });

--- a/modules/account-lib/test/unit/coin/celo/stakingBuilder.ts
+++ b/modules/account-lib/test/unit/coin/celo/stakingBuilder.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { coins } from '@bitgo/statics';
 import { StakingBuilder } from '../../../../src/coin/celo/stakingBuilder';
@@ -47,7 +48,7 @@ describe('Celo staking operations builder', function () {
 
   it('should fail if the index is invalid', () => {
     builder.type(StakingOperationTypes.WITHDRAW);
-    should.throws(
+    assert.throws(
       () => {
         builder.index(-1);
       },
@@ -97,7 +98,7 @@ describe('Celo staking operations builder', function () {
 
   it('should fail if the unvote index is invalid', () => {
     builder.type(StakingOperationTypes.UNVOTE);
-    should.throws(
+    assert.throws(
       () => {
         builder.index(-1);
       },
@@ -111,7 +112,7 @@ describe('Celo staking operations builder', function () {
     builder.lesser(testData.LESSER_ADDRESS);
     builder.greater(testData.GREATER_ADDRESS);
     builder.amount('1');
-    should.throws(
+    assert.throws(
       () => {
         builder.build();
       },
@@ -125,7 +126,7 @@ describe('Celo staking operations builder', function () {
     builder.greater(testData.GREATER_ADDRESS);
     builder.amount('1');
     builder.index(1);
-    should.throws(
+    assert.throws(
       () => {
         builder.build();
       },
@@ -140,7 +141,7 @@ describe('Celo staking operations builder', function () {
     builder.group(testData.GROUP_ADDRESS);
     builder.greater(testData.GREATER_ADDRESS);
     builder.index(1);
-    should.throws(
+    assert.throws(
       () => {
         builder.build();
       },
@@ -150,7 +151,7 @@ describe('Celo staking operations builder', function () {
 
   it('should fail if the address to unvote for is not set', () => {
     builder.type(StakingOperationTypes.UNVOTE);
-    should.throws(
+    assert.throws(
       () => {
         builder.build();
       },
@@ -161,7 +162,7 @@ describe('Celo staking operations builder', function () {
   it('should fail if the lesser or greater unvote are not set', () => {
     builder.type(StakingOperationTypes.UNVOTE);
     builder.group(testData.GROUP_ADDRESS);
-    should.throws(
+    assert.throws(
       () => {
         builder.build();
       },
@@ -171,7 +172,7 @@ describe('Celo staking operations builder', function () {
 
   it('should fail if the group to unvote address is invalid', () => {
     builder.type(StakingOperationTypes.UNVOTE);
-    should.throws(
+    assert.throws(
       () => {
         builder.group('invalidaddress');
       },
@@ -181,7 +182,7 @@ describe('Celo staking operations builder', function () {
 
   it('should fail if the lesser unvote address is invalid', () => {
     builder.type(StakingOperationTypes.UNVOTE);
-    should.throws(
+    assert.throws(
       () => {
         builder.lesser('invalidaddress');
       },
@@ -191,7 +192,7 @@ describe('Celo staking operations builder', function () {
 
   it('should fail if the greater unvote address is invalid', () => {
     builder.type(StakingOperationTypes.UNVOTE);
-    should.throws(
+    assert.throws(
       () => {
         builder.greater('invalidaddress');
       },
@@ -209,7 +210,7 @@ describe('Celo staking operations builder', function () {
 
   it('should fail if the activate address is not set', () => {
     builder.type(StakingOperationTypes.ACTIVATE);
-    should.throws(
+    assert.throws(
       () => {
         builder.build();
       },
@@ -219,7 +220,7 @@ describe('Celo staking operations builder', function () {
 
   it('should fail if the address to vote for is not set', () => {
     builder.type(StakingOperationTypes.VOTE);
-    should.throws(
+    assert.throws(
       () => {
         builder.build();
       },
@@ -230,7 +231,7 @@ describe('Celo staking operations builder', function () {
   it('should fail if the lesser or greater are not set', () => {
     builder.type(StakingOperationTypes.VOTE);
     builder.group(testData.GROUP_ADDRESS);
-    should.throws(
+    assert.throws(
       () => {
         builder.build();
       },
@@ -240,7 +241,7 @@ describe('Celo staking operations builder', function () {
 
   it('should fail if the group to vote address is invalid', () => {
     builder.type(StakingOperationTypes.VOTE);
-    should.throws(
+    assert.throws(
       () => {
         builder.group('invalidaddress');
       },
@@ -250,7 +251,7 @@ describe('Celo staking operations builder', function () {
 
   it('should fail if the lesser address is invalid', () => {
     builder.type(StakingOperationTypes.VOTE);
-    should.throws(
+    assert.throws(
       () => {
         builder.lesser('invalidaddress');
       },
@@ -260,7 +261,7 @@ describe('Celo staking operations builder', function () {
 
   it('should fail if the greater address is invalid', () => {
     builder.type(StakingOperationTypes.VOTE);
-    should.throws(
+    assert.throws(
       () => {
         builder.greater('invalidaddress');
       },
@@ -269,7 +270,7 @@ describe('Celo staking operations builder', function () {
   });
 
   it('should fail if amount is invalid number', () => {
-    should.throws(
+    assert.throws(
       () => {
         builder.amount('asd');
       },
@@ -280,7 +281,7 @@ describe('Celo staking operations builder', function () {
   it('should fail to build if type is not supported', function () {
     const NOT_SUPPORTED = 100;
     builder.type(NOT_SUPPORTED);
-    should.throws(
+    assert.throws(
       () => {
         builder.build();
       },

--- a/modules/account-lib/test/unit/coin/celo/transaction.ts
+++ b/modules/account-lib/test/unit/coin/celo/transaction.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { coins } from '@bitgo/statics';
 import { Transaction } from '../../../../src/coin/celo';
@@ -17,10 +18,10 @@ describe('Celo Transaction', function () {
 
   it('should throw empty transaction', function () {
     const tx = getTransaction();
-    should.throws(() => {
+    assert.throws(() => {
       tx.toJson();
     });
-    should.throws(() => {
+    assert.throws(() => {
       tx.toBroadcastFormat();
     });
   });

--- a/modules/account-lib/test/unit/coin/celo/transactionBuilder/send.ts
+++ b/modules/account-lib/test/unit/coin/celo/transactionBuilder/send.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import * as ethUtil from 'ethereumjs-utils-old';
 import EthereumAbi from 'ethereumjs-abi';
@@ -221,7 +222,7 @@ describe('Send transaction', function () {
       initTxBuilder();
       txBuilder.type(TransactionType.WalletInitialization);
       txBuilder.contract('0x8f977e912ef500548a0c3be6ddde9899f1199b81');
-      should.throws(() => {
+      assert.throws(() => {
         txBuilder.transfer();
       }, 'Error: Token transfers can only be set for send token transactions');
     });

--- a/modules/account-lib/test/unit/coin/celo/transactionBuilder/staking.ts
+++ b/modules/account-lib/test/unit/coin/celo/transactionBuilder/staking.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { coins } from '@bitgo/statics';
 import { Celo, getBuilder } from '../../../../../src';
@@ -287,7 +288,7 @@ describe('Celo staking transaction builder', () => {
 
     it('should fail to call lock if it is not an staking lock type transaction', () => {
       txBuilder.type(TransactionType.AddressInitialization);
-      should.throws(
+      assert.throws(
         () => {
           txBuilder.lock();
         },
@@ -297,7 +298,7 @@ describe('Celo staking transaction builder', () => {
 
     it('should fail to call vote if it is not an staking vote type transaction', () => {
       txBuilder.type(TransactionType.AddressInitialization);
-      should.throws(
+      assert.throws(
         () => {
           txBuilder.vote();
         },
@@ -307,7 +308,7 @@ describe('Celo staking transaction builder', () => {
 
     it('should fail to call activate if it is not an staking activate type transaction', () => {
       txBuilder.type(TransactionType.AddressInitialization);
-      should.throws(
+      assert.throws(
         () => {
           txBuilder.activate();
         },
@@ -317,7 +318,7 @@ describe('Celo staking transaction builder', () => {
 
     it('should fail to call unlock if it is not an staking unlock type transaction', () => {
       txBuilder.type(TransactionType.AddressInitialization);
-      should.throws(
+      assert.throws(
         () => {
           txBuilder.unlock();
         },
@@ -327,7 +328,7 @@ describe('Celo staking transaction builder', () => {
 
     it('should fail to call unvote if it is not an staking unvote type transaction', () => {
       txBuilder.type(TransactionType.AddressInitialization);
-      should.throws(
+      assert.throws(
         () => {
           txBuilder.unvote();
         },
@@ -337,7 +338,7 @@ describe('Celo staking transaction builder', () => {
 
     it('should fail to call withdraw if it is not an staking withdraw type transaction', () => {
       txBuilder.type(TransactionType.AddressInitialization);
-      should.throws(
+      assert.throws(
         () => {
           txBuilder.withdraw();
         },

--- a/modules/account-lib/test/unit/coin/celo/transactionBuilder/walletInitialization.ts
+++ b/modules/account-lib/test/unit/coin/celo/transactionBuilder/walletInitialization.ts
@@ -106,7 +106,7 @@ describe('Celo Transaction builder for wallet initialization', () => {
       should.doesNotThrow(() => builder.from(testData.TX_BROADCAST));
       should.doesNotThrow(() => builder.from(testData.TX_JSON));
       assert.throws(() => builder.from('0x00001000'), /There was error in decoding the hex string/);
-      assert.throws(() => builder.from(''), /There was error in decoding the hex string/);
+      assert.throws(() => builder.from(''), /Raw transaction is empty/);
       assert.throws(() => builder.from('pqrs'), /There was error in parsing the JSON string/);
       assert.throws(() => builder.from(1234), /Transaction is not a hex string or stringified json/);
     });

--- a/modules/account-lib/test/unit/coin/celo/transactionBuilder/walletInitialization.ts
+++ b/modules/account-lib/test/unit/coin/celo/transactionBuilder/walletInitialization.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { TransactionType } from '../../../../../src/coin/baseCoin/';
 import { getBuilder, Celo } from '../../../../../src';
@@ -104,10 +105,10 @@ describe('Celo Transaction builder for wallet initialization', () => {
       const builder = getBuilder('tcelo') as Celo.TransactionBuilder;
       should.doesNotThrow(() => builder.from(testData.TX_BROADCAST));
       should.doesNotThrow(() => builder.from(testData.TX_JSON));
-      should.throws(() => builder.from('0x00001000'), 'There was error in decoding the hex string');
-      should.throws(() => builder.from(''), 'There was error in decoding the hex string');
-      should.throws(() => builder.from('pqrs'), 'There was error in parsing the JSON string');
-      should.throws(() => builder.from(1234), 'Transaction is not a hex string or stringified json');
+      assert.throws(() => builder.from('0x00001000'), /There was error in decoding the hex string/);
+      assert.throws(() => builder.from(''), /There was error in decoding the hex string/);
+      assert.throws(() => builder.from('pqrs'), /There was error in parsing the JSON string/);
+      assert.throws(() => builder.from(1234), /Transaction is not a hex string or stringified json/);
     });
   });
 });

--- a/modules/account-lib/test/unit/coin/cspr/keyPair.ts
+++ b/modules/account-lib/test/unit/coin/cspr/keyPair.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import * as nacl from 'tweetnacl';
 import { KeyPair } from '../../../../src/coin/cspr';
@@ -116,35 +117,35 @@ describe('Casper Key Pair', () => {
 
     it('should not be able to get keys from prv', () => {
       const keyPair = new KeyPair({ prv: prvKey });
-      should.throws(() => keyPair.getExtendedKeys());
+      assert.throws(() => keyPair.getExtendedKeys());
     });
 
     it('should get the keys in extended format from pub', () => {
       const keyPair = new KeyPair({ pub: pubKey });
-      should.throws(() => keyPair.getExtendedKeys());
+      assert.throws(() => keyPair.getExtendedKeys());
     });
   });
 
   describe('should fail to create a KeyPair', () => {
     it('from an invalid public key', () => {
-      should.throws(
+      assert.throws(
         () => new KeyPair({ pub: testData.INVALID_SHORT_KEYPAIR_KEY }),
         (e) => e.message.includes(testData.INVALID_PUBLIC_KEY_ERROR_MESSAGE),
       );
     });
 
     it('from an invalid private key', () => {
-      should.throws(
+      assert.throws(
         () => new KeyPair({ prv: testData.INVALID_SHORT_KEYPAIR_KEY }),
         (e) => e.message === testData.INVALID_PRIVATE_KEY_ERROR_MESSAGE,
       );
-      should.throws(
+      assert.throws(
         () => {
           new KeyPair({ prv: testData.INVALID_LONG_KEYPAIR_PRV });
         },
         (e) => e.message === testData.INVALID_PRIVATE_KEY_ERROR_MESSAGE,
       );
-      should.throws(
+      assert.throws(
         () => new KeyPair({ prv: prvKey + pubKey }),
         (e) => e.message === testData.INVALID_PRIVATE_KEY_ERROR_MESSAGE,
       );

--- a/modules/account-lib/test/unit/coin/cspr/signMessage.ts
+++ b/modules/account-lib/test/unit/coin/cspr/signMessage.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from 'crypto';
-import should from 'should';
+import assert from 'assert';
 import { KeyPair } from '../../../../src/coin/cspr/keyPair';
 import { isValidMessageSignature, signMessage } from '../../../../src/coin/cspr/utils';
 import * as testData from '../../../resources/cspr/cspr';
@@ -26,7 +26,7 @@ describe('Sign Message', () => {
   it('should fail with missing private key', async () => {
     const keyPair = new KeyPair({ pub: testData.ACCOUNT_1.publicKey });
     const messageToSign = Buffer.from(randomBytes(32)).toString('hex');
-    should.throws(
+    assert.throws(
       () => signMessage(keyPair, messageToSign),
       (e) => e.message === testData.ERROR_MISSING_PRIVATE_KEY,
     );
@@ -35,7 +35,7 @@ describe('Sign Message', () => {
   it('should fail with missing private key using extended key', async () => {
     const keyPair = new KeyPair({ pub: testData.ACCOUNT_1.xPublicKey });
     const messageToSign = Buffer.from(randomBytes(32)).toString('hex');
-    should.throws(
+    assert.throws(
       () => signMessage(keyPair, messageToSign),
       (e) => e.message === testData.ERROR_MISSING_PRIVATE_KEY,
     );

--- a/modules/account-lib/test/unit/coin/cspr/transaction.ts
+++ b/modules/account-lib/test/unit/coin/cspr/transaction.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { coins } from '@bitgo/statics';
 import { CLString, DeployUtil, CLPublicKey as PublicKey } from 'casper-js-sdk';
@@ -73,10 +74,10 @@ describe('Cspr Transaction', () => {
 
   it('should throw empty transaction', () => {
     const tx = getTransaction();
-    should.throws(() => {
+    assert.throws(() => {
       tx.toJson();
     });
-    should.throws(() => {
+    assert.throws(() => {
       tx.toBroadcastFormat();
     });
   });
@@ -249,13 +250,13 @@ describe('Cspr Transaction', () => {
   describe('should reject sign if transaction signer is', () => {
     it('invalid private key', function () {
       const tx = getTransaction();
-      should.throws(() => tx.sign(testData.INVALID_KEYPAIR_PRV));
+      assert.throws(() => tx.sign(testData.INVALID_KEYPAIR_PRV));
     });
 
     it('public key', function () {
       const tx = getTransaction();
       const keypair = new KeyPair({ pub: testData.ACCOUNT_1.publicKey });
-      should.throws(
+      assert.throws(
         () => tx.sign(keypair),
         (e) => e.message === testData.ERROR_MISSING_PRIVATE_KEY,
       );
@@ -264,7 +265,7 @@ describe('Cspr Transaction', () => {
     it('public extended key', function () {
       const tx = getTransaction();
       const keypair = new KeyPair({ pub: testData.ACCOUNT_1.xPublicKey });
-      should.throws(
+      assert.throws(
         () => tx.sign(keypair),
         (e) => e.message === testData.ERROR_MISSING_PRIVATE_KEY,
       );

--- a/modules/account-lib/test/unit/coin/cspr/transactionBuilder/delegateBuilder.ts
+++ b/modules/account-lib/test/unit/coin/cspr/transactionBuilder/delegateBuilder.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import * as should from 'should';
 import { register } from '../../../../../src/index';
 import { KeyPair, TransactionBuilderFactory } from '../../../../../src/coin/cspr';
@@ -145,9 +146,9 @@ describe('CSPR Delegate Builder', () => {
     it('an address', async () => {
       const txBuilder = factory.getDelegateBuilder();
       txBuilder.validateAddress({ address: testData.VALID_ADDRESS });
-      should.throws(
+      assert.throws(
         () => txBuilder.validateAddress({ address: testData.INVALID_ADDRESS }),
-        'Invalid address ' + testData.INVALID_ADDRESS,
+        new RegExp('Invalid address ' + testData.INVALID_ADDRESS),
       );
     });
 
@@ -156,24 +157,24 @@ describe('CSPR Delegate Builder', () => {
       txBuilder = addFeeToBuilder(txBuilder, testData.FEE.gasLimit, testData.FEE.gasPrice);
       txBuilder = addSourceToBuilder(txBuilder, sender);
       txBuilder = addAmountToBuilder(txBuilder, '10');
-      should.throws(() => txBuilder.validator('abc'), 'Invalid address');
+      assert.throws(() => txBuilder.validator('abc'), /Invalid address/);
     });
 
     it('fee value should not be negative', () => {
       const txBuilder = factory.getDelegateBuilder();
-      should.throws(() => txBuilder.fee({ gasLimit: '-1' }));
+      assert.throws(() => txBuilder.fee({ gasLimit: '-1' }));
       should.doesNotThrow(() => txBuilder.fee(testData.FEE));
     });
 
     it('amount value should not be negative', () => {
       const txBuilder = factory.getDelegateBuilder();
-      should.throws(() => txBuilder.amount('-1'));
+      assert.throws(() => txBuilder.amount('-1'));
       should.doesNotThrow(() => txBuilder.amount('1'));
     });
 
     it('a private key', () => {
       const txBuilder = factory.getDelegateBuilder();
-      should.throws(() => txBuilder.validateKey({ key: 'abc' }), 'Invalid key');
+      assert.throws(() => txBuilder.validateKey({ key: 'abc' }), /Invalid key/);
       should.doesNotThrow(() => txBuilder.validateKey({ key: testData.ACCOUNT_1.privateKey }));
     });
 
@@ -182,9 +183,9 @@ describe('CSPR Delegate Builder', () => {
       should.doesNotThrow(() => txBuilder.sign({ key: testData.ACCOUNT_1.privateKey }));
       should.doesNotThrow(() => txBuilder.sign({ key: testData.ACCOUNT_2.privateKey }));
       should.doesNotThrow(() => txBuilder.sign({ key: testData.ACCOUNT_3.privateKey }));
-      should.throws(
+      assert.throws(
         () => txBuilder.sign({ key: testData.ACCOUNT_4.privateKey }),
-        'A maximum of 3 can sign the transaction.',
+        new RegExp('A maximum of 3 can sign the transaction.'),
       );
     });
   });

--- a/modules/account-lib/test/unit/coin/cspr/transactionBuilder/delegateBuilder.ts
+++ b/modules/account-lib/test/unit/coin/cspr/transactionBuilder/delegateBuilder.ts
@@ -174,7 +174,7 @@ describe('CSPR Delegate Builder', () => {
 
     it('a private key', () => {
       const txBuilder = factory.getDelegateBuilder();
-      assert.throws(() => txBuilder.validateKey({ key: 'abc' }), /Invalid key/);
+      assert.throws(() => txBuilder.validateKey({ key: 'abc' }), /Unsupported private key/);
       should.doesNotThrow(() => txBuilder.validateKey({ key: testData.ACCOUNT_1.privateKey }));
     });
 

--- a/modules/account-lib/test/unit/coin/cspr/transactionBuilder/transactionBuilder.ts
+++ b/modules/account-lib/test/unit/coin/cspr/transactionBuilder/transactionBuilder.ts
@@ -1,4 +1,5 @@
 import * as _ from 'lodash';
+import assert from 'assert';
 import * as should from 'should';
 import * as testData from '../../../../resources/cspr/cspr';
 import { register } from '../../../../../src';
@@ -53,7 +54,7 @@ describe('Casper Transaction Builder', () => {
   describe('should validate', () => {
     it('an empty raw transaction', () => {
       const txBuilder = factory.getTransferBuilder();
-      should.throws(
+      assert.throws(
         () => {
           txBuilder.validateRawTransaction('');
         },
@@ -63,7 +64,7 @@ describe('Casper Transaction Builder', () => {
 
     it('an invalid raw transfer transaction', () => {
       const txBuilder = factory.getTransferBuilder();
-      should.throws(
+      assert.throws(
         () => {
           txBuilder.validateRawTransaction(testData.INVALID_RAW_TRANSACTION);
         },
@@ -73,7 +74,7 @@ describe('Casper Transaction Builder', () => {
 
     it('an invalid raw wallet init transaction', () => {
       const txBuilder = factory.getWalletInitializationBuilder();
-      should.throws(
+      assert.throws(
         () => {
           txBuilder.validateRawTransaction(testData.INVALID_RAW_TRANSACTION);
         },
@@ -125,7 +126,7 @@ describe('Casper Transaction Builder', () => {
 
     it('an invalid expiration time', async () => {
       const builder = initWalletBuilder();
-      should.throws(
+      assert.throws(
         () => builder.expiration(testData.MAX_TRANSACTION_EXPIRATION + 1),
         (e) => e.message === testData.INVALID_TRANSACTION_EXPIRATION_MESSAGE,
       );

--- a/modules/account-lib/test/unit/coin/cspr/transactionBuilder/transferBuilder.ts
+++ b/modules/account-lib/test/unit/coin/cspr/transactionBuilder/transferBuilder.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { DeployUtil, CLOption, CLString, CLU512, CLU64, CLValueBuilder } from 'casper-js-sdk';
 import BigNumber from 'bignumber.js';
@@ -480,88 +481,64 @@ describe('Casper Transfer Builder', () => {
       tx.casperTx = DeployUtil.addArgToDeploy(tx.casperTx, 'to_address', CLValueBuilder.byteArray(Uint8Array.from([])));
 
       const builder2 = factory.getTransferBuilder();
-      should.throws(() => {
+      assert.throws(() => {
         builder2.from(tx.toBroadcastFormat());
-      }, testData.ERROR_INVALID_DESTINATION_ADDRESS_ON_FROM);
+      }, new RegExp(testData.ERROR_INVALID_DESTINATION_ADDRESS_ON_FROM));
     });
   });
 
   describe('should fail', () => {
     it('a transfer transaction with an invalid source address', () => {
-      should.throws(
-        () => {
-          initTxTransferBuilder().source({ address: testData.INVALID_ADDRESS });
-        },
-        (e) => e.message.startsWith(testData.ERROR_INVALID_ADDRESS),
-      );
+      assert.throws(() => {
+        initTxTransferBuilder().source({ address: testData.INVALID_ADDRESS });
+      }, new RegExp(testData.ERROR_INVALID_ADDRESS));
     });
 
     it('a transfer transaction with an invalid destination address', () => {
-      should.throws(
-        () => {
-          initTxTransferBuilder().to(testData.INVALID_ADDRESS);
-        },
-        (e) => e.message === testData.ERROR_INVALID_ADDRESS,
-      );
+      assert.throws(() => {
+        initTxTransferBuilder().to(testData.INVALID_ADDRESS);
+      }, new RegExp(testData.ERROR_INVALID_ADDRESS));
     });
 
     it('a transfer transaction with repeated sign', async () => {
       const txBuilder = await initTxTransferBuilder().amount(testData.MIN_MOTES_AMOUNT);
-      should.throws(
-        () => {
-          txBuilder.sign({ key: testData.ACCOUNT_3.privateKey });
-          txBuilder.sign({ key: testData.ACCOUNT_3.privateKey });
-        },
-        (e) => e.message.startsWith(testData.ERROR_REPEATED_SIGNATURE),
-      );
+      assert.throws(() => {
+        txBuilder.sign({ key: testData.ACCOUNT_3.privateKey });
+        txBuilder.sign({ key: testData.ACCOUNT_3.privateKey });
+      }, new RegExp(testData.ERROR_REPEATED_SIGNATURE));
     });
 
     it('a transfer transaction with repeated sign using extended keys', async () => {
       const txBuilder = await initTxTransferBuilder().amount(testData.MIN_MOTES_AMOUNT);
-      should.throws(
-        () => {
-          txBuilder.sign({ key: testData.ACCOUNT_3.xPrivateKey });
-          txBuilder.sign({ key: testData.ACCOUNT_3.xPrivateKey });
-        },
-        (e) => e.message.startsWith(testData.ERROR_REPEATED_SIGNATURE),
-      );
+      assert.throws(() => {
+        txBuilder.sign({ key: testData.ACCOUNT_3.xPrivateKey });
+        txBuilder.sign({ key: testData.ACCOUNT_3.xPrivateKey });
+      }, new RegExp(testData.ERROR_REPEATED_SIGNATURE));
     });
 
     it('a transfer transaction with an invalid amount: text value', () => {
-      should.throws(
-        () => {
-          initTxTransferBuilder().amount('invalid_value');
-        },
-        (e) => e.message === testData.ERROR_INVALID_AMOUNT,
-      );
+      assert.throws(() => {
+        initTxTransferBuilder().amount('invalid_value');
+      }, new RegExp(testData.ERROR_INVALID_AMOUNT));
     });
 
     it('a transfer transaction with an invalid amount: negative value', () => {
-      should.throws(
-        () => {
-          initTxTransferBuilder().amount('-1');
-        },
-        (e) => e.message === testData.ERROR_INVALID_AMOUNT,
-      );
+      assert.throws(() => {
+        initTxTransferBuilder().amount('-1');
+      }, new RegExp(testData.ERROR_INVALID_AMOUNT));
     });
 
     it('a transfer transaction with an invalid amount: zero', () => {
-      should.throws(
-        () => {
-          initTxTransferBuilder().amount('0');
-        },
-        (e) => e.message === testData.ERROR_INVALID_AMOUNT,
-      );
+      assert.throws(() => {
+        initTxTransferBuilder().amount('0');
+      }, new RegExp(testData.ERROR_INVALID_AMOUNT));
     });
 
     it('a transfer transaction with an invalid amount: minAmount - 1', () => {
       const maxInvalidAmount = new BigNumber(testData.MIN_MOTES_AMOUNT).minus(1).toString();
-      should.throws(
-        () => {
-          initTxTransferBuilder().amount(maxInvalidAmount);
-        },
-        (e) => e.message === testData.ERROR_INVALID_AMOUNT,
-      );
+      assert.throws(() => {
+        initTxTransferBuilder().amount(maxInvalidAmount);
+      }, new RegExp(testData.ERROR_INVALID_AMOUNT));
     });
 
     it('a transfer transaction without destination param', () => {
@@ -574,12 +551,9 @@ describe('Casper Transfer Builder', () => {
 
     it('a transfer transaction with invalid destination param', () => {
       const txBuilder = factory.getTransferBuilder();
-      should.throws(
-        () => {
-          txBuilder.to(testData.INVALID_ADDRESS);
-        },
-        (e) => e.message === testData.ERROR_INVALID_ADDRESS,
-      );
+      assert.throws(() => {
+        txBuilder.to(testData.INVALID_ADDRESS);
+      }, new RegExp(testData.ERROR_INVALID_ADDRESS));
     });
 
     it('a transfer transaction without amount', () => {
@@ -596,22 +570,16 @@ describe('Casper Transfer Builder', () => {
       txBuilder.fee(testData.FEE);
       txBuilder.source({ address: owner1Address });
       txBuilder.to(owner2Address);
-      should.throws(
-        () => {
-          txBuilder.amount('');
-        },
-        (e) => e.message === testData.ERROR_INVALID_AMOUNT,
-      );
+      assert.throws(() => {
+        txBuilder.amount('');
+      }, new RegExp(testData.ERROR_INVALID_AMOUNT));
     });
 
     it('a transfer transaction with invalid transfer id', () => {
       const txBuilder = factory.getTransferBuilder();
-      should.throws(
-        () => {
-          txBuilder.transferId(-1);
-        },
-        (e) => e.message === testData.ERROR_INVALID_TRANSFER_ID,
-      );
+      assert.throws(() => {
+        txBuilder.transferId(-1);
+      }, new RegExp(testData.ERROR_INVALID_TRANSFER_ID));
     });
 
     it('a transfer transaction with more than 3 signatures', () => {
@@ -619,12 +587,9 @@ describe('Casper Transfer Builder', () => {
       builder.sign({ key: testData.ROOT_ACCOUNT.privateKey });
       builder.sign({ key: testData.ACCOUNT_1.privateKey });
       builder.sign({ key: testData.ACCOUNT_2.privateKey });
-      should.throws(
-        () => {
-          builder.sign({ key: testData.ACCOUNT_2.privateKey });
-        },
-        (e) => e.message === testData.ERROR_MAX_AMOUNT_OF_SIGNERS_REACHED,
-      );
+      assert.throws(() => {
+        builder.sign({ key: testData.ACCOUNT_2.privateKey });
+      }, new RegExp(testData.ERROR_MAX_AMOUNT_OF_SIGNERS_REACHED));
     });
 
     it('a transfer transaction with more than 3 signatures with extended keys', () => {
@@ -632,12 +597,9 @@ describe('Casper Transfer Builder', () => {
       builder.sign({ key: testData.ROOT_ACCOUNT.xPrivateKey });
       builder.sign({ key: testData.ACCOUNT_1.xPrivateKey });
       builder.sign({ key: testData.ACCOUNT_2.xPrivateKey });
-      should.throws(
-        () => {
-          builder.sign({ key: testData.ACCOUNT_2.xPrivateKey });
-        },
-        (e) => e.message === testData.ERROR_MAX_AMOUNT_OF_SIGNERS_REACHED,
-      );
+      assert.throws(() => {
+        builder.sign({ key: testData.ACCOUNT_2.xPrivateKey });
+      }, new RegExp(testData.ERROR_MAX_AMOUNT_OF_SIGNERS_REACHED));
     });
   });
 

--- a/modules/account-lib/test/unit/coin/cspr/transactionBuilder/undelegateBuilder.ts
+++ b/modules/account-lib/test/unit/coin/cspr/transactionBuilder/undelegateBuilder.ts
@@ -175,7 +175,7 @@ describe('CSPR Undelegate Builder', () => {
 
     it('a private key', () => {
       const txBuilder = factory.getUndelegateBuilder();
-      assert.throws(() => txBuilder.validateKey({ key: 'abc' }), /Invalid key/);
+      assert.throws(() => txBuilder.validateKey({ key: 'abc' }), /Unsupported private key/);
       should.doesNotThrow(() => txBuilder.validateKey({ key: testData.ACCOUNT_1.privateKey }));
     });
 

--- a/modules/account-lib/test/unit/coin/cspr/transactionBuilder/undelegateBuilder.ts
+++ b/modules/account-lib/test/unit/coin/cspr/transactionBuilder/undelegateBuilder.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import * as should from 'should';
 import { register } from '../../../../../src/index';
 import { KeyPair, TransactionBuilderFactory } from '../../../../../src/coin/cspr';
@@ -146,9 +147,9 @@ describe('CSPR Undelegate Builder', () => {
     it('an address', async () => {
       const txBuilder = factory.getUndelegateBuilder();
       txBuilder.validateAddress({ address: testData.VALID_ADDRESS });
-      should.throws(
+      assert.throws(
         () => txBuilder.validateAddress({ address: testData.INVALID_ADDRESS }),
-        'Invalid address ' + testData.INVALID_ADDRESS,
+        new RegExp('Invalid address ' + testData.INVALID_ADDRESS),
       );
     });
 
@@ -157,24 +158,24 @@ describe('CSPR Undelegate Builder', () => {
       txBuilder = addFeeToBuilder(txBuilder, testData.FEE.gasLimit, testData.FEE.gasPrice);
       txBuilder = addSourceToBuilder(txBuilder, sender);
       txBuilder = addAmountToBuilder(txBuilder, '10');
-      should.throws(() => txBuilder.validator('abc'), 'Invalid address');
+      assert.throws(() => txBuilder.validator('abc'), /Invalid address/);
     });
 
     it('fee value should be greater than zero', () => {
       const txBuilder = factory.getUndelegateBuilder();
-      should.throws(() => txBuilder.fee({ gasLimit: '-10' }));
+      assert.throws(() => txBuilder.fee({ gasLimit: '-10' }));
       should.doesNotThrow(() => txBuilder.fee(testData.FEE));
     });
 
     it('amount value should be greater than zero', () => {
       const txBuilder = factory.getUndelegateBuilder();
-      should.throws(() => txBuilder.amount('-1'));
+      assert.throws(() => txBuilder.amount('-1'));
       should.doesNotThrow(() => txBuilder.amount('1'));
     });
 
     it('a private key', () => {
       const txBuilder = factory.getUndelegateBuilder();
-      should.throws(() => txBuilder.validateKey({ key: 'abc' }), 'Invalid key');
+      assert.throws(() => txBuilder.validateKey({ key: 'abc' }), /Invalid key/);
       should.doesNotThrow(() => txBuilder.validateKey({ key: testData.ACCOUNT_1.privateKey }));
     });
 
@@ -183,9 +184,9 @@ describe('CSPR Undelegate Builder', () => {
       should.doesNotThrow(() => txBuilder.sign({ key: testData.ACCOUNT_1.privateKey }));
       should.doesNotThrow(() => txBuilder.sign({ key: testData.ACCOUNT_2.privateKey }));
       should.doesNotThrow(() => txBuilder.sign({ key: testData.ACCOUNT_3.privateKey }));
-      should.throws(
+      assert.throws(
         () => txBuilder.sign({ key: testData.ACCOUNT_4.privateKey }),
-        'A maximum of 3 can sign the transaction.',
+        new RegExp('A maximum of 3 can sign the transaction.'),
       );
     });
   });

--- a/modules/account-lib/test/unit/coin/cspr/transactionBuilder/walletInitialization.ts
+++ b/modules/account-lib/test/unit/coin/cspr/transactionBuilder/walletInitialization.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { register } from '../../../../../src';
 import { KeyPair, TransactionBuilderFactory } from '../../../../../src/coin/cspr';
@@ -119,10 +120,10 @@ describe('CSPR Wallet initialization', () => {
       txBuilder.source({ address: sourceAddress });
       await txBuilder.build().should.be.rejectedWith(testData.INVALID_NUMBER_OF_OWNERS_TWO_OF_THREE);
 
-      should.throws(() => txBuilder.owner(owner1Address), 'Repeated owner address: ' + owner1Address);
+      assert.throws(() => txBuilder.owner(owner1Address), 'Repeated owner address: ' + owner1Address);
 
       should.doesNotThrow(() => txBuilder.owner(owner3Address));
-      should.throws(() => txBuilder.owner(owner4Address), 'A maximum of 3 owners can be set for a multisig wallet');
+      assert.throws(() => txBuilder.owner(owner4Address), /A maximum of 3 owners can be set for a multisig wallet/);
 
       const newTxBuilder = factory.getWalletInitializationBuilder();
       newTxBuilder.fee(testData.FEE);
@@ -147,35 +148,35 @@ describe('CSPR Wallet initialization', () => {
     it('an address', async () => {
       const txBuilder = factory.getWalletInitializationBuilder();
       txBuilder.validateAddress({ address: testData.VALID_ADDRESS });
-      should.throws(
+      assert.throws(
         () => txBuilder.validateAddress({ address: testData.INVALID_ADDRESS }),
-        'Invalid address ' + testData.INVALID_ADDRESS,
+        new RegExp('Invalid address ' + testData.INVALID_ADDRESS),
       );
     });
 
     it('value should be greater than zero', () => {
       const txBuilder = factory.getWalletInitializationBuilder();
-      should.throws(() => txBuilder.fee({ gasLimit: '-10' }));
+      assert.throws(() => txBuilder.fee({ gasLimit: '-10' }));
       should.doesNotThrow(() => txBuilder.fee({ gasLimit: '10' }));
     });
 
     it('a private key', () => {
       const txBuilder = factory.getWalletInitializationBuilder();
-      should.throws(() => txBuilder.validateKey({ key: 'abc' }), 'Invalid key');
+      assert.throws(() => txBuilder.validateKey({ key: 'abc' }), /Invalid key/);
       should.doesNotThrow(() => txBuilder.validateKey({ key: testData.ACCOUNT_1.privateKey }));
     });
 
     it('a transaction to build', async () => {
       const txBuilder = factory.getWalletInitializationBuilder();
-      should.throws(() => txBuilder.validateTransaction(), 'Invalid transaction: missing fee');
+      assert.throws(() => txBuilder.validateTransaction(), /Invalid transaction: missing fee/);
       txBuilder.fee(testData.FEE);
-      should.throws(() => txBuilder.validateTransaction(), 'Invalid transaction: missing source');
+      assert.throws(() => txBuilder.validateTransaction(), /Invalid transaction: missing source/);
       txBuilder.source({ address: testData.VALID_ADDRESS });
-      should.throws(() => txBuilder.validateTransaction(), 'wrong number of owners -- required: 3, found: 0');
+      assert.throws(() => txBuilder.validateTransaction(), /wrong number of owners -- required: 3, found: 0/);
       txBuilder.owner(new KeyPair({ pub: testData.ACCOUNT_1.publicKey }).getAddress());
-      should.throws(() => txBuilder.validateTransaction(), 'wrong number of owners -- required: 3, found: 1');
+      assert.throws(() => txBuilder.validateTransaction(), /wrong number of owners -- required: 3, found: 1/);
       txBuilder.owner(new KeyPair({ pub: testData.ACCOUNT_2.publicKey }).getAddress());
-      should.throws(() => txBuilder.validateTransaction(), 'wrong number of owners -- required: 3, found: 2');
+      assert.throws(() => txBuilder.validateTransaction(), /wrong number of owners -- required: 3, found: 2/);
       txBuilder.owner(new KeyPair({ pub: testData.ACCOUNT_3.publicKey }).getAddress());
       should.doesNotThrow(() => txBuilder.validateTransaction());
     });

--- a/modules/account-lib/test/unit/coin/cspr/transactionBuilder/walletInitialization.ts
+++ b/modules/account-lib/test/unit/coin/cspr/transactionBuilder/walletInitialization.ts
@@ -162,17 +162,17 @@ describe('CSPR Wallet initialization', () => {
 
     it('a private key', () => {
       const txBuilder = factory.getWalletInitializationBuilder();
-      assert.throws(() => txBuilder.validateKey({ key: 'abc' }), /Invalid key/);
+      assert.throws(() => txBuilder.validateKey({ key: 'abc' }), /Unsupported private key/);
       should.doesNotThrow(() => txBuilder.validateKey({ key: testData.ACCOUNT_1.privateKey }));
     });
 
     it('a transaction to build', async () => {
       const txBuilder = factory.getWalletInitializationBuilder();
-      assert.throws(() => txBuilder.validateTransaction(), /Invalid transaction: missing fee/);
+      assert.throws(() => txBuilder.validateTransaction(), /Invalid transaction: missing wallet owners/);
       txBuilder.fee(testData.FEE);
-      assert.throws(() => txBuilder.validateTransaction(), /Invalid transaction: missing source/);
+      assert.throws(() => txBuilder.validateTransaction(), /Invalid transaction: missing wallet owners/);
       txBuilder.source({ address: testData.VALID_ADDRESS });
-      assert.throws(() => txBuilder.validateTransaction(), /wrong number of owners -- required: 3, found: 0/);
+      assert.throws(() => txBuilder.validateTransaction(), /Invalid transaction: missing wallet owners/);
       txBuilder.owner(new KeyPair({ pub: testData.ACCOUNT_1.publicKey }).getAddress());
       assert.throws(() => txBuilder.validateTransaction(), /wrong number of owners -- required: 3, found: 1/);
       txBuilder.owner(new KeyPair({ pub: testData.ACCOUNT_2.publicKey }).getAddress());

--- a/modules/account-lib/test/unit/coin/cspr/transactionBuilderFactory.ts
+++ b/modules/account-lib/test/unit/coin/cspr/transactionBuilderFactory.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { register } from '../../../../src/index';
 import { KeyPair, TransactionBuilderFactory } from '../../../../src/coin/cspr/';
@@ -259,7 +260,7 @@ describe('should build ', () => {
       const builder2 = factory.from(JSON.stringify(txJson));
       const tx2 = (await builder2.build()) as Transaction;
       const keypair = new KeyPair({ prv: testData.ROOT_ACCOUNT.privateKey });
-      should.throws(
+      assert.throws(
         () => tx2.sign(keypair),
         (e) => e.message === testData.ERROR_ALREADY_SIGNED_WITH_INVALID_KEY,
       );
@@ -277,7 +278,7 @@ describe('should build ', () => {
       const builder2 = factory.from(JSON.stringify(txJson));
       const tx2 = (await builder2.build()) as Transaction;
       const keypair = new KeyPair({ prv: testData.ROOT_ACCOUNT.privateKey });
-      should.throws(
+      assert.throws(
         () => tx2.sign(keypair),
         (e) => e.message === testData.ERROR_ALREADY_SIGNED_WITH_INVALID_KEY,
       );
@@ -295,7 +296,7 @@ describe('should build ', () => {
       const builder2 = factory.from(JSON.stringify(txJson));
       const tx2 = (await builder2.build()) as Transaction;
       const keypair = new KeyPair({ prv: testData.ROOT_ACCOUNT.privateKey });
-      should.throws(
+      assert.throws(
         () => tx2.sign(keypair),
         (e) => e.message === testData.ERROR_ALREADY_SIGNED_WITH_INVALID_KEY,
       );
@@ -313,7 +314,7 @@ describe('should build ', () => {
       const builder2 = factory.from(JSON.stringify(txJson));
       const tx2 = (await builder2.build()) as Transaction;
       const keypair = new KeyPair({ prv: testData.ROOT_ACCOUNT.privateKey });
-      should.throws(
+      assert.throws(
         () => tx2.sign(keypair),
         (e) => e.message === testData.ERROR_ALREADY_SIGNED_WITH_INVALID_KEY,
       );
@@ -327,7 +328,7 @@ describe('should build ', () => {
       const txJson = JSON.parse(tx.toBroadcastFormat());
       txJson['deploy']['session'] = { OtherType: '' };
 
-      should.throws(
+      assert.throws(
         () => {
           factory.from(JSON.stringify(txJson));
         },
@@ -343,7 +344,7 @@ describe('should build ', () => {
       const txJson = JSON.parse(tx.toBroadcastFormat());
       txJson['deploy']['session'] = { OtherType: '' };
 
-      should.throws(
+      assert.throws(
         () => {
           factory.from(JSON.stringify(txJson));
         },
@@ -352,7 +353,7 @@ describe('should build ', () => {
     });
 
     it('a transaction with empty raw transaction', async () => {
-      should.throws(
+      assert.throws(
         () => {
           factory.from('{}');
         },
@@ -361,7 +362,7 @@ describe('should build ', () => {
     });
 
     it('a transaction with undefined as raw transaction', async () => {
-      should.throws(
+      assert.throws(
         () => {
           factory.from(undefined as unknown as string);
         },
@@ -377,7 +378,7 @@ describe('should build ', () => {
       const txJson = JSON.parse(tx.toBroadcastFormat());
       txJson['deploy']['session']['ModuleBytes']['module_bytes'] = testData.INVALID_WALLET_INIT_CONTRACT;
 
-      should.throws(
+      assert.throws(
         () => {
           factory.from(JSON.stringify(txJson));
         },
@@ -393,7 +394,7 @@ describe('should build ', () => {
       const txJson = JSON.parse(tx.toBroadcastFormat());
       txJson['deploy']['session']['ModuleBytes']['module_bytes'] = testData.INVALID_WALLET_INIT_CONTRACT;
 
-      should.throws(
+      assert.throws(
         () => {
           factory.from(JSON.stringify(txJson));
         },
@@ -409,7 +410,7 @@ describe('should build ', () => {
       const txJson = JSON.parse(tx.toBroadcastFormat());
       txJson['deploy']['session'] = { OtherType: '' };
 
-      should.throws(
+      assert.throws(
         () => {
           factory.from(JSON.stringify(txJson));
         },
@@ -425,7 +426,7 @@ describe('should build ', () => {
       const txJson = JSON.parse(tx.toBroadcastFormat());
       txJson['deploy']['session'] = { OtherType: '' };
 
-      should.throws(
+      assert.throws(
         () => {
           factory.from(JSON.stringify(txJson));
         },

--- a/modules/account-lib/test/unit/coin/cspr/util.ts
+++ b/modules/account-lib/test/unit/coin/cspr/util.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import * as should from 'should';
 import * as Utils from '../../../../src/coin/cspr/utils';
 import { KeyPair } from '../../../../src/coin/cspr';
@@ -90,7 +91,7 @@ describe('CSPR util library', function () {
       const data = '';
       const publicKey = '018267d68f8d249b1430551ecc7b4c176d66f2ba2bf98d5547e7c3accc99375e53';
 
-      should.throws(() => Utils.verifySignature(invalidSignature, data, publicKey));
+      assert.throws(() => Utils.verifySignature(invalidSignature, data, publicKey));
     });
 
     it('should fail to verify invalid tx signature', function () {
@@ -99,7 +100,7 @@ describe('CSPR util library', function () {
       const data = '';
       const publicKey = '018267d68f8d249b1430551ecc7b4c176d66f2ba2bf98d5547e7c3accc99375e53';
 
-      should.throws(() => Utils.verifySignature(invalidSignature, data, publicKey));
+      assert.throws(() => Utils.verifySignature(invalidSignature, data, publicKey));
     });
 
     it('should verify valid message signature', function () {

--- a/modules/account-lib/test/unit/coin/dot/keypair.ts
+++ b/modules/account-lib/test/unit/coin/dot/keypair.ts
@@ -76,7 +76,7 @@ describe('Dot KeyPair', () => {
       const source = {
         pub: '01D63D',
       };
-      assert.throws(() => new Dot.KeyPair(source), /address seems to be malformed/);
+      assert.throws(() => new Dot.KeyPair(source), /Expected a valid key to convert/);
     });
 
     it('should fail to create from an invalid private key', () => {

--- a/modules/account-lib/test/unit/coin/dot/keypair.ts
+++ b/modules/account-lib/test/unit/coin/dot/keypair.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { Dot } from '../../../../src';
 import { accounts } from '../../../resources/dot';
@@ -63,7 +64,7 @@ describe('Dot KeyPair', () => {
   describe('KeyPair validation', () => {
     it('should fail to create from an invalid seed', () => {
       const seed = { seed: Buffer.alloc(8) }; //  Seed should be 512 bits (64 bytes)
-      should.throws(() => new Dot.KeyPair(seed), 'bad seed size');
+      assert.throws(() => new Dot.KeyPair(seed), /bad seed size/);
     });
 
     it('should create from a valid seed', () => {
@@ -75,14 +76,14 @@ describe('Dot KeyPair', () => {
       const source = {
         pub: '01D63D',
       };
-      should.throws(() => new Dot.KeyPair(source), 'address seems to be malformed');
+      assert.throws(() => new Dot.KeyPair(source), /address seems to be malformed/);
     });
 
     it('should fail to create from an invalid private key', () => {
       const source = {
         prv: '82A34',
       };
-      should.throws(() => new Dot.KeyPair(source), 'Invalid base32 characters');
+      assert.throws(() => new Dot.KeyPair(source), /Invalid base32 characters/);
     });
   });
 

--- a/modules/account-lib/test/unit/coin/dot/transaction.ts
+++ b/modules/account-lib/test/unit/coin/dot/transaction.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { TransactionType } from '../../../../src/coin/baseCoin';
 import { KeyPair, Transaction, TransferBuilder } from '../../../../src/coin/dot';
@@ -30,8 +31,8 @@ describe('Dot Transaction', () => {
 
   describe('empty transaction', () => {
     it('should throw empty transaction', () => {
-      should.throws(() => tx.toJson(), 'Empty transaction');
-      should.throws(() => tx.toBroadcastFormat(), 'Empty transaction');
+      assert.throws(() => tx.toJson(), /Empty transaction/);
+      assert.throws(() => tx.toBroadcastFormat(), /Empty transaction/);
     });
 
     it('should not sign', async () => {

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/addressInitializationBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/addressInitializationBuilder.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import sinon from 'sinon';
 import { AddressInitializationBuilder } from '../../../../../src/coin/dot';
@@ -28,7 +29,7 @@ describe('Dot Address Initialization Builder', () => {
   describe('setter validation', () => {
     it('should validate delay', () => {
       const spy = sinon.spy(builder, 'validateValue');
-      should.throws(
+      assert.throws(
         () => builder.delay('-1'),
         (e: Error) => e.message === 'Value cannot be less than zero',
       );
@@ -38,7 +39,7 @@ describe('Dot Address Initialization Builder', () => {
 
     it('should validate owner address', () => {
       const spy = sinon.spy(builder, 'validateAddress');
-      should.throws(
+      assert.throws(
         () => builder.owner({ address: 'asd' }),
         (e: Error) => e.message === `The address 'asd' is not a well-formed dot address`,
       );
@@ -48,7 +49,7 @@ describe('Dot Address Initialization Builder', () => {
 
     it('should validate index', () => {
       const spy = sinon.spy(builder, 'validateValue');
-      should.throws(
+      assert.throws(
         () => builder.index(-1),
         (e: Error) => e.message === 'Value cannot be less than zero',
       );

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/base.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/base.ts
@@ -1,6 +1,7 @@
 import { BaseCoin as CoinConfig, coins, DotNetwork } from '@bitgo/statics';
 import { DecodedSignedTx, DecodedSigningPayload, UnsignedTransaction } from '@substrate/txwrapper-core';
 import Eddsa from '../../../../../src/mpc/tss';
+import assert from 'assert';
 import should from 'should';
 import sinon from 'sinon';
 import { TransactionType } from '../../../../../src/coin/baseCoin';
@@ -87,7 +88,7 @@ describe('Dot Transfer Builder', () => {
   describe('setter validation', () => {
     it('should validate sender address', () => {
       const spy = sinon.spy(builder, 'validateAddress');
-      should.throws(
+      assert.throws(
         () => builder.sender({ address: 'asd' }),
         (e: Error) => e.message === `The address 'asd' is not a well-formed dot address`,
       );
@@ -97,7 +98,7 @@ describe('Dot Transfer Builder', () => {
 
     it('should validate eraPeriod', () => {
       const spy = sinon.spy(builder, 'validateValue');
-      should.throws(
+      assert.throws(
         () => builder.validity({ maxDuration: -1 }),
         (e: Error) => e.message === 'Value cannot be less than zero',
       );
@@ -107,7 +108,7 @@ describe('Dot Transfer Builder', () => {
 
     it('should validate nonce', () => {
       const spy = sinon.spy(builder, 'validateValue');
-      should.throws(
+      assert.throws(
         () => builder.sequenceId({ name: 'Nonce', keyword: 'nonce', value: -1 }),
         (e: Error) => e.message === 'Value cannot be less than zero',
       );
@@ -117,7 +118,7 @@ describe('Dot Transfer Builder', () => {
 
     it('should validate tip', () => {
       const spy = sinon.spy(builder, 'validateValue');
-      should.throws(
+      assert.throws(
         () => builder.fee({ amount: -1, type: 'tip' }),
         (e: Error) => e.message === 'Value cannot be less than zero',
       );
@@ -127,7 +128,7 @@ describe('Dot Transfer Builder', () => {
 
     it('should validate blockNumber', () => {
       const spy = sinon.spy(builder, 'validateValue');
-      should.throws(
+      assert.throws(
         () => builder.validity({ firstValid: -1 }),
         (e: Error) => e.message === 'Value cannot be less than zero',
       );

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/batchTransactionBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/batchTransactionBuilder.ts
@@ -1,5 +1,6 @@
+import assert from 'assert';
 import should from 'should';
-import { spy, assert } from 'sinon';
+import { spy, assert as SinonAssert } from 'sinon';
 import { BatchTransactionBuilder } from '../../../../../src/coin/dot';
 import { accounts, mockTssSignature, rawTx, specVersion, txVersion } from '../../../../resources/dot';
 import { buildTestConfig } from './base';
@@ -17,12 +18,12 @@ describe('Dot Batch Transaction Builder', () => {
     it('should validate list of calls', () => {
       const call = 'invalidUnsignedTransaction';
       const spyValidateCalls = spy(builder, 'validateCalls');
-      should.throws(
+      assert.throws(
         () => builder.calls([call]),
         (e: Error) => e.message === `call in string format must be hex format of a method and its arguments`,
       );
       should.doesNotThrow(() => builder.calls(rawTx.anonymous.batch));
-      assert.calledTwice(spyValidateCalls);
+      SinonAssert.calledTwice(spyValidateCalls);
     });
   });
 

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/claimBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/claimBuilder.ts
@@ -1,5 +1,6 @@
+import assert from 'assert';
 import should from 'should';
-import { spy, assert } from 'sinon';
+import { spy, assert as SinonAssert } from 'sinon';
 import { ClaimBuilder } from '../../../../../src/coin/dot';
 import utils from '../../../../../src/coin/dot/utils';
 import {
@@ -27,22 +28,22 @@ describe('Dot Claim Builder', () => {
   describe('setter validation', () => {
     it('should validate era', () => {
       const spyValidateValue = spy(builder, 'validateValue');
-      should.throws(
+      assert.throws(
         () => builder.claimEra('-1'),
         (e: Error) => e.message === 'Value cannot be less than zero',
       );
       should.doesNotThrow(() => builder.claimEra('1000'));
-      assert.calledTwice(spyValidateValue);
+      SinonAssert.calledTwice(spyValidateValue);
     });
 
     it('should validate validatorStash address', () => {
       const spyValidateAddress = spy(builder, 'validateAddress');
-      should.throws(
+      assert.throws(
         () => builder.validatorStash({ address: 'asd' }),
         (e: Error) => e.message === `The address 'asd' is not a well-formed dot address`,
       );
       should.doesNotThrow(() => builder.validatorStash({ address: validatorStash.address }));
-      assert.calledTwice(spyValidateAddress);
+      SinonAssert.calledTwice(spyValidateAddress);
     });
   });
 

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/stakingBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/stakingBuilder.ts
@@ -1,5 +1,6 @@
+import assert from 'assert';
 import should from 'should';
-import { spy, assert } from 'sinon';
+import { spy, assert as SinonAssert } from 'sinon';
 import { StakingBuilder } from '../../../../../src/coin/dot';
 import utils from '../../../../../src/coin/dot/utils';
 import {
@@ -27,27 +28,27 @@ describe('Dot Stake Builder', () => {
   describe('setter validation', () => {
     it('should validate stake amount', () => {
       const spyValidateAddress = spy(builder, 'validateValue');
-      should.throws(
+      assert.throws(
         () => builder.amount('-1'),
         (e: Error) => e.message === 'Value cannot be less than zero',
       );
       should.doesNotThrow(() => builder.amount('1000'));
-      assert.calledTwice(spyValidateAddress);
+      SinonAssert.calledTwice(spyValidateAddress);
     });
 
     it('should validate controller address', () => {
       const spyValidateAddress = spy(builder, 'validateAddress');
-      should.throws(
+      assert.throws(
         () => builder.owner({ address: 'asd' }),
         (e: Error) => e.message === `The address 'asd' is not a well-formed dot address`,
       );
       should.doesNotThrow(() => builder.owner({ address: sender.address }));
-      assert.calledTwice(spyValidateAddress);
+      SinonAssert.calledTwice(spyValidateAddress);
     });
 
     it('should validate payee', () => {
       const spyValidateAddress = spy(builder, 'validateAddress');
-      should.throws(
+      assert.throws(
         () => builder.payee({ Account: 'asd' }),
         (e: Error) => e.message === `The address 'asd' is not a well-formed dot address`,
       );
@@ -55,7 +56,7 @@ describe('Dot Stake Builder', () => {
       should.doesNotThrow(() => builder.payee('Staked'));
       should.doesNotThrow(() => builder.payee('Controller'));
       should.doesNotThrow(() => builder.payee('Stash'));
-      assert.calledTwice(spyValidateAddress);
+      SinonAssert.calledTwice(spyValidateAddress);
     });
   });
 

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/transferBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/transferBuilder.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import sinon from 'sinon';
 import { TransferBuilder } from '../../../../../src/coin/dot';
@@ -29,7 +30,7 @@ describe('Dot Transfer Builder', () => {
   describe('setter validation', () => {
     it('should validate real address', () => {
       const spy = sinon.spy(builder, 'validateAddress');
-      should.throws(
+      assert.throws(
         () => builder.owner({ address: 'asd' }),
         (e: Error) => e.message === `The address 'asd' is not a well-formed dot address`,
       );
@@ -38,7 +39,7 @@ describe('Dot Transfer Builder', () => {
     });
     it('should validate to address', () => {
       const spy = sinon.spy(builder, 'validateAddress');
-      should.throws(
+      assert.throws(
         () => builder.to({ address: 'asd' }),
         (e: Error) => e.message === `The address 'asd' is not a well-formed dot address`,
       );
@@ -47,7 +48,7 @@ describe('Dot Transfer Builder', () => {
     });
     it('should validate transfer amount', () => {
       const spy = sinon.spy(builder, 'validateValue');
-      should.throws(
+      assert.throws(
         () => builder.amount('-1'),
         (e: Error) => e.message === 'Value cannot be less than zero',
       );

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/unstakeBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/unstakeBuilder.ts
@@ -1,5 +1,6 @@
+import assert from 'assert';
 import should from 'should';
-import { spy, assert } from 'sinon';
+import { spy, assert as SinonAssert } from 'sinon';
 import { UnstakeBuilder } from '../../../../../src/coin/dot';
 import utils from '../../../../../src/coin/dot/utils';
 import {
@@ -26,12 +27,12 @@ describe('Dot Unstake Builder', () => {
   describe('setter validation', () => {
     it('should validate unstake amount', () => {
       const spyValidateValue = spy(builder, 'validateValue');
-      should.throws(
+      assert.throws(
         () => builder.amount('-1'),
         (e: Error) => e.message === 'Value cannot be less than zero',
       );
       should.doesNotThrow(() => builder.amount('1000'));
-      assert.calledTwice(spyValidateValue);
+      SinonAssert.calledTwice(spyValidateValue);
     });
   });
 

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/withdrawUnstakedBuilder.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/withdrawUnstakedBuilder.ts
@@ -1,5 +1,6 @@
+import assert from 'assert';
 import should from 'should';
-import { assert, spy } from 'sinon';
+import { assert as SinonAssert, spy } from 'sinon';
 import { WithdrawUnstakedBuilder } from '../../../../../src/coin/dot';
 import { buildTestConfig } from './base';
 import {
@@ -27,12 +28,12 @@ describe('Dot WithdrawUnstaked Builder', () => {
   describe('setter validation', () => {
     it('should validate slashing spans', () => {
       const spyValidateValue = spy(builder, 'validateValue');
-      should.throws(
+      assert.throws(
         () => builder.slashingSpans(-1),
         (e: Error) => e.message === 'Value cannot be less than zero',
       );
       should.doesNotThrow(() => builder.slashingSpans(10));
-      assert.calledTwice(spyValidateValue);
+      SinonAssert.calledTwice(spyValidateValue);
     });
   });
 

--- a/modules/account-lib/test/unit/coin/etc/transaction.ts
+++ b/modules/account-lib/test/unit/coin/etc/transaction.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { coins } from '@bitgo/statics';
 import { Transaction } from '../../../../src/coin/eth/transaction';
@@ -18,10 +19,10 @@ describe('Etc Transaction', () => {
   describe('should throw ', () => {
     it('an empty transaction', () => {
       const tx = getTransaction();
-      should.throws(() => {
+      assert.throws(() => {
         tx.toJson();
       });
-      should.throws(() => {
+      assert.throws(() => {
         tx.toBroadcastFormat();
       });
     });

--- a/modules/account-lib/test/unit/coin/eth/keyPair.ts
+++ b/modules/account-lib/test/unit/coin/eth/keyPair.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 
 import { Eth } from '../../../../src';
@@ -46,7 +47,7 @@ describe('Eth KeyPair', function () {
       should.not.exist(defaultKeys.prv);
       defaultKeys.pub.should.equal(uncompressedPub);
 
-      should.throws(() => keyPair.getExtendedKeys());
+      assert.throws(() => keyPair.getExtendedKeys());
     });
 
     it('from a compressed public key', () => {
@@ -54,7 +55,7 @@ describe('Eth KeyPair', function () {
       const defaultKeys = keyPair.getKeys();
       should.not.exist(defaultKeys.prv);
       defaultKeys.pub.should.equal(uncompressedPub);
-      should.throws(() => keyPair.getExtendedKeys());
+      assert.throws(() => keyPair.getExtendedKeys());
     });
 
     it('from a raw private key', () => {
@@ -63,7 +64,7 @@ describe('Eth KeyPair', function () {
       defaultKeys.prv!.should.equal(prv);
       defaultKeys.pub.should.equal(uncompressedPub);
 
-      should.throws(() => keyPair.getExtendedKeys());
+      assert.throws(() => keyPair.getExtendedKeys());
     });
 
     it('from an empty value', () => {
@@ -87,15 +88,15 @@ describe('Eth KeyPair', function () {
       const source = {
         pub: '01D63D',
       };
-      should.throws(() => new Eth.KeyPair(source));
+      assert.throws(() => new Eth.KeyPair(source));
     });
 
     it('from an invalid private key', () => {
       const source = {
         prv: '82A34E',
       };
-      should.throws(() => new Eth.KeyPair(source));
-      should.throws(
+      assert.throws(() => new Eth.KeyPair(source));
+      assert.throws(
         () => new KeyPair({ prv: prv + pub }),
         (e) => e.message === invalidPrivateKeyErrorMessage,
       );
@@ -152,19 +153,19 @@ describe('Eth KeyPair', function () {
     it('should not be able to get keys from prv', () => {
       const keyPair = new Eth.KeyPair({ prv });
 
-      should.throws(() => keyPair.getExtendedKeys());
+      assert.throws(() => keyPair.getExtendedKeys());
     });
 
     it('should get the keys in extended format from pub', () => {
       const keyPair = new Eth.KeyPair({ pub });
 
-      should.throws(() => keyPair.getExtendedKeys());
+      assert.throws(() => keyPair.getExtendedKeys());
     });
 
     it('should get the keys in extended format from uncompressed pub', () => {
       const keyPair = new Eth.KeyPair({ pub: uncompressedPub });
 
-      should.throws(() => keyPair.getExtendedKeys());
+      assert.throws(() => keyPair.getExtendedKeys());
     });
   });
 });

--- a/modules/account-lib/test/unit/coin/eth/transaction.ts
+++ b/modules/account-lib/test/unit/coin/eth/transaction.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { coins, EthereumNetwork } from '@bitgo/statics';
 import { Transaction } from '../../../../src/coin/eth';
@@ -19,8 +20,8 @@ describe('ETH Transaction', () => {
   describe('should throw ', () => {
     it('an empty transaction', () => {
       const tx = getTransaction();
-      should.throws(() => tx.toJson());
-      should.throws(() => tx.toBroadcastFormat());
+      assert.throws(() => tx.toJson());
+      assert.throws(() => tx.toBroadcastFormat());
     });
   });
 

--- a/modules/account-lib/test/unit/coin/eth/transactionBuilder/send.ts
+++ b/modules/account-lib/test/unit/coin/eth/transactionBuilder/send.ts
@@ -19,8 +19,8 @@ describe('Eth transaction builder send', () => {
       fee: '10',
       gasLimit: '1000',
     });
-    assert.throws(() => txBuilder.validateTransaction(tx), /Invalid transaction: missing chain id/);
-    assert.throws(() => txBuilder.validateTransaction(tx), /Invalid transaction: missing source/);
+    assert.throws(() => txBuilder.validateTransaction(tx), /Invalid transaction: missing contract address/);
+    assert.throws(() => txBuilder.validateTransaction(tx), /Invalid transaction: missing contract address/);
   });
 
   describe('should sign and build', () => {

--- a/modules/account-lib/test/unit/coin/eth/transactionBuilder/send.ts
+++ b/modules/account-lib/test/unit/coin/eth/transactionBuilder/send.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { coins, EthereumNetwork } from '@bitgo/statics';
 import { TransactionType } from '../../../../../src/coin/baseCoin';
@@ -13,13 +14,13 @@ describe('Eth transaction builder send', () => {
     const tx = new Eth.Transaction(coinConfig, common);
     txBuilder.counter(1);
     txBuilder.type(TransactionType.Send);
-    should.throws(() => txBuilder.validateTransaction(tx), 'Invalid transaction: missing fee');
+    assert.throws(() => txBuilder.validateTransaction(tx), /Invalid transaction: missing fee/);
     txBuilder.fee({
       fee: '10',
       gasLimit: '1000',
     });
-    should.throws(() => txBuilder.validateTransaction(tx), 'Invalid transaction: missing chain id');
-    should.throws(() => txBuilder.validateTransaction(tx), 'Invalid transaction: missing source');
+    assert.throws(() => txBuilder.validateTransaction(tx), /Invalid transaction: missing chain id/);
+    assert.throws(() => txBuilder.validateTransaction(tx), /Invalid transaction: missing source/);
   });
 
   describe('should sign and build', () => {

--- a/modules/account-lib/test/unit/coin/eth/transactionBuilder/walletInitialization.ts
+++ b/modules/account-lib/test/unit/coin/eth/transactionBuilder/walletInitialization.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { TransactionType } from '../../../../../src/coin/baseCoin';
 import { getBuilder, Eth } from '../../../../../src';
@@ -263,7 +264,7 @@ describe('Eth Transaction builder wallet initialization', function () {
         gasLimit: '1000',
       });
       txBuilder.counter(1);
-      should.throws(() => txBuilder.sign({ key: defaultKeyPair.getKeys().prv }));
+      assert.throws(() => txBuilder.sign({ key: defaultKeyPair.getKeys().prv }));
     });
 
     it('a signed wallet initialization transaction', () => {
@@ -278,9 +279,9 @@ describe('Eth Transaction builder wallet initialization', function () {
       txBuilder.owner(new Eth.KeyPair({ pub: pub2 }).getAddress());
       txBuilder.owner(new Eth.KeyPair({ prv: sourcePrv }).getAddress());
       txBuilder.sign({ key: defaultKeyPair.getKeys().prv });
-      should.throws(
+      assert.throws(
         () => txBuilder.sign({ key: defaultKeyPair.getKeys().prv }),
-        'Cannot sign multiple times a non send-type transaction',
+        new RegExp('Cannot sign multiple times a non send-type transaction'),
       );
     });
   });
@@ -289,22 +290,22 @@ describe('Eth Transaction builder wallet initialization', function () {
     it('an address', async () => {
       const txBuilder: any = getBuilder('eth');
       txBuilder.validateAddress(testData.VALID_ADDRESS);
-      should.throws(
+      assert.throws(
         () => txBuilder.validateAddress(testData.INVALID_ADDRESS),
-        'Invalid address ' + testData.INVALID_ADDRESS,
+        new RegExp('Invalid address ' + testData.INVALID_ADDRESS.address),
       );
     });
 
     it('value should be greater than zero', () => {
       const txBuilder: any = getBuilder('eth');
-      should.throws(() => txBuilder.fee({ fee: '-10' }));
+      assert.throws(() => txBuilder.fee({ fee: '-10' }));
       should.doesNotThrow(() => txBuilder.fee({ fee: '10' }));
     });
 
     it('a private key', () => {
       const txBuilder: any = getBuilder('eth');
-      should.throws(() => txBuilder.validateKey({ key: 'abc' }), 'Invalid key');
-      should.throws(() => txBuilder.validateKey({ key: testData.PUBLIC_KEY }), 'Invalid key');
+      assert.throws(() => txBuilder.validateKey({ key: 'abc' }), /Invalid key/);
+      assert.throws(() => txBuilder.validateKey({ key: testData.PUBLIC_KEY }), /Invalid key/);
       should.doesNotThrow(() => txBuilder.validateKey({ key: testData.PRIVATE_KEY }));
     });
 
@@ -312,34 +313,34 @@ describe('Eth Transaction builder wallet initialization', function () {
       const builder: any = getBuilder('eth');
       should.doesNotThrow(() => builder.from(testData.TX_BROADCAST));
       should.doesNotThrow(() => builder.from(testData.TX_JSON));
-      should.throws(() => builder.from('0x00001000'), 'There was error in decoding the hex string');
-      should.throws(() => builder.from(''), 'There was error in decoding the hex string');
-      should.throws(() => builder.from('pqrs'), 'There was error in parsing the JSON string');
-      should.throws(() => builder.from(1234), 'Transaction is not a hex string or stringified json');
+      assert.throws(() => builder.from('0x00001000'), /There was error in decoding the hex string/);
+      assert.throws(() => builder.from(''), /There was error in decoding the hex string/);
+      assert.throws(() => builder.from('pqrs'), /There was error in parsing the JSON string/);
+      assert.throws(() => builder.from(1234), /Transaction is not a hex string or stringified json/);
     });
 
     it('a transaction to build', async () => {
       const txBuilder: any = getBuilder('eth');
       txBuilder.counter(undefined);
       txBuilder.type(TransactionType.WalletInitialization);
-      should.throws(() => txBuilder.validateTransaction(), 'Invalid transaction: missing fee');
+      assert.throws(() => txBuilder.validateTransaction(), /Invalid transaction: missing fee/);
       txBuilder.fee({
         fee: '10',
         gasLimit: '1000',
       });
-      should.throws(() => txBuilder.validateTransaction(), 'Invalid transaction: missing chain id');
-      should.throws(() => txBuilder.validateTransaction(), 'Invalid transaction: missing source');
+      assert.throws(() => txBuilder.validateTransaction(), /Invalid transaction: missing chain id/);
+      assert.throws(() => txBuilder.validateTransaction(), /Invalid transaction: missing source/);
       const source = {
         prv: sourcePrv,
       };
       const sourceKeyPair = new Eth.KeyPair(source);
-      should.throws(() => txBuilder.validateTransaction(), 'Invalid transaction: missing address counter');
+      assert.throws(() => txBuilder.validateTransaction(), /Invalid transaction: missing address counter/);
       txBuilder.counter(1);
-      should.throws(() => txBuilder.validateTransaction(), 'wrong number of owners -- required: 3, found: 0');
+      assert.throws(() => txBuilder.validateTransaction(), /wrong number of owners -- required: 3, found: 0/);
       txBuilder.owner(sourceKeyPair.getAddress());
-      should.throws(() => txBuilder.validateTransaction(), 'wrong number of owners -- required: 3, found: 1');
+      assert.throws(() => txBuilder.validateTransaction(), /wrong number of owners -- required: 3, found: 1/);
       txBuilder.owner(new Eth.KeyPair({ pub: pub1 }).getAddress());
-      should.throws(() => txBuilder.validateTransaction(), 'wrong number of owners -- required: 3, found: 2');
+      assert.throws(() => txBuilder.validateTransaction(), /wrong number of owners -- required: 3, found: 2/);
       txBuilder.owner(new Eth.KeyPair({ pub: pub2 }).getAddress());
       should.doesNotThrow(() => txBuilder.validateTransaction());
     });
@@ -350,9 +351,9 @@ describe('Eth Transaction builder wallet initialization', function () {
       const txBuilder: any = getBuilder('eth');
       txBuilder.type(TransactionType.Send);
       const sourceKeyPair = new Eth.KeyPair({ prv: sourcePrv });
-      should.throws(
+      assert.throws(
         () => txBuilder.owner(sourceKeyPair.getAddress()),
-        'Multisig wallet owner can only be set for initialization transactions',
+        new RegExp('Multisig wallet owner can only be set for initialization transactions'),
       );
     });
 
@@ -368,9 +369,9 @@ describe('Eth Transaction builder wallet initialization', function () {
       txBuilder.owner(sourceKeyPair.getAddress());
       txBuilder.owner('0x7325A3F7d4f9E86AE62Cf742426078C3755730d5');
       txBuilder.owner('0x603e077acd3F01e81b95fB92ce42FF60dFf3D4C7');
-      should.throws(
+      assert.throws(
         () => txBuilder.owner('0x1A88Ee4Bc80BE080fC91AC472Af2F59260695060'),
-        'A maximum of 3 owners can be set for a multisig wallet',
+        new RegExp('A maximum of 3 owners can be set for a multisig wallet'),
       );
     });
 
@@ -382,7 +383,7 @@ describe('Eth Transaction builder wallet initialization', function () {
         gasLimit: '1000',
       });
       txBuilder.counter(1);
-      should.throws(() => txBuilder.owner('0x7325A3F7d4f9E86AE62C'), 'Invalid address');
+      assert.throws(() => txBuilder.owner('0x7325A3F7d4f9E86AE62C'), /Invalid address/);
     });
   });
 

--- a/modules/account-lib/test/unit/coin/eth/transactionBuilder/walletInitialization.ts
+++ b/modules/account-lib/test/unit/coin/eth/transactionBuilder/walletInitialization.ts
@@ -314,7 +314,7 @@ describe('Eth Transaction builder wallet initialization', function () {
       should.doesNotThrow(() => builder.from(testData.TX_BROADCAST));
       should.doesNotThrow(() => builder.from(testData.TX_JSON));
       assert.throws(() => builder.from('0x00001000'), /There was error in decoding the hex string/);
-      assert.throws(() => builder.from(''), /There was error in decoding the hex string/);
+      assert.throws(() => builder.from(''), /Raw transaction is empty/);
       assert.throws(() => builder.from('pqrs'), /There was error in parsing the JSON string/);
       assert.throws(() => builder.from(1234), /Transaction is not a hex string or stringified json/);
     });
@@ -328,8 +328,8 @@ describe('Eth Transaction builder wallet initialization', function () {
         fee: '10',
         gasLimit: '1000',
       });
-      assert.throws(() => txBuilder.validateTransaction(), /Invalid transaction: missing chain id/);
-      assert.throws(() => txBuilder.validateTransaction(), /Invalid transaction: missing source/);
+      assert.throws(() => txBuilder.validateTransaction(), /Invalid transaction: missing address counter/);
+      assert.throws(() => txBuilder.validateTransaction(), /Invalid transaction: missing address counter/);
       const source = {
         prv: sourcePrv,
       };

--- a/modules/account-lib/test/unit/coin/eth/transferBuilder.ts
+++ b/modules/account-lib/test/unit/coin/eth/transferBuilder.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { TransferBuilder } from '../../../../src/coin/eth';
 import { Eth } from '../../../../src';
@@ -178,17 +179,17 @@ describe('Eth send multi sig builder', function () {
 
     it('should fail if a sequenceId param is missing', () => {
       const builder = new TransferBuilder().amount(amount).to(toAddress).key(key);
-      should.throws(() => builder.signAndBuild());
+      assert.throws(() => builder.signAndBuild());
     });
 
     it('should fail if a destination param is missing', () => {
       const builder = new TransferBuilder().amount(amount).contractSequenceId(2).key(key);
-      should.throws(() => builder.signAndBuild());
+      assert.throws(() => builder.signAndBuild());
     });
 
     it('should fail if a amount param is missing', () => {
       const builder = new TransferBuilder().to(toAddress).contractSequenceId(2).key(key);
-      should.throws(() => builder.signAndBuild());
+      assert.throws(() => builder.signAndBuild());
     });
   });
 });

--- a/modules/account-lib/test/unit/coin/eth2/keyPair.ts
+++ b/modules/account-lib/test/unit/coin/eth2/keyPair.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { KeyPair } from '../../../../src/coin/eth2';
 import * as testData from '../../../resources/eth2/eth2';
@@ -22,7 +23,7 @@ describe('Eth2 Key Pair', () => {
     });
 
     it('from a bls key with a single invalid private share', () => {
-      should.throws(
+      assert.throws(
         () =>
           new KeyPair({
             secretShares: ['0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000002'],
@@ -32,7 +33,7 @@ describe('Eth2 Key Pair', () => {
     });
 
     it('from a bls key with an invalid public share', () => {
-      should.throws(
+      assert.throws(
         () =>
           new KeyPair({
             secretShares: [prv],
@@ -52,7 +53,7 @@ describe('Eth2 Key Pair', () => {
     });
 
     it('from invalid dkg options', () => {
-      should.throws(
+      assert.throws(
         () =>
           new KeyPair({
             threshold: 2,
@@ -109,14 +110,14 @@ describe('Eth2 Key Pair', () => {
 
   describe('should fail to create a KeyPair', () => {
     it('from a public key', () => {
-      should.throws(
+      assert.throws(
         () => new KeyPair().recordKeysFromPublicKey(pub),
         (e) => e.message.includes(testData.errorMessageInvalidPublicKey),
       );
     });
 
     it('from a private key', () => {
-      should.throws(
+      assert.throws(
         () => new KeyPair().recordKeysFromPrivateKey(prv),
         (e) => e.message === testData.errorMessageInvalidPrivateKey,
       );
@@ -126,12 +127,12 @@ describe('Eth2 Key Pair', () => {
   describe('should reject key aggregation', () => {
     it('from a single invalid pubkey string', () => {
       const pub = '123';
-      should.throws(() => KeyPair.aggregatePubkeys([pub]));
+      assert.throws(() => KeyPair.aggregatePubkeys([pub]));
     });
 
     it('from a single invalid pubkey buffer', () => {
       const pub = '0x' + Buffer.from('abc').toString('hex');
-      should.throws(() => KeyPair.aggregatePubkeys([pub]));
+      assert.throws(() => KeyPair.aggregatePubkeys([pub]));
     });
 
     it('from a set of invalid pubkeys', () => {
@@ -139,12 +140,12 @@ describe('Eth2 Key Pair', () => {
 
       const keyPair2 = new KeyPair();
       const pub2 = keyPair2.getKeys().publicShare;
-      should.throws(() => KeyPair.aggregatePubkeys([pub1, pub2]));
+      assert.throws(() => KeyPair.aggregatePubkeys([pub1, pub2]));
     });
 
     it('from a single invalid prvkey string', () => {
       const prv = BigInt('0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000002');
-      should.throws(() => KeyPair.aggregatePrvkeys(['0x' + prv.toString(16)]));
+      assert.throws(() => KeyPair.aggregatePrvkeys(['0x' + prv.toString(16)]));
     });
 
     it('from a set of invalid prvkeys', () => {
@@ -152,7 +153,7 @@ describe('Eth2 Key Pair', () => {
 
       const keyPair2 = new KeyPair();
       const secretShares2 = keyPair2.getKeys().secretShares;
-      should.throws(() => KeyPair.aggregatePrvkeys(['0x' + prv1.toString(16), secretShares2[1]]));
+      assert.throws(() => KeyPair.aggregatePrvkeys(['0x' + prv1.toString(16), secretShares2[1]]));
     });
   });
 

--- a/modules/account-lib/test/unit/coin/hbar/keyPair.ts
+++ b/modules/account-lib/test/unit/coin/hbar/keyPair.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import * as should from 'should';
 import * as nacl from 'tweetnacl';
 import { KeyPair } from '../../../../src/coin/hbar';
@@ -85,7 +86,7 @@ describe('Hedera Key Pair', () => {
   describe('should fail to create a KeyPair', () => {
     it('from an invalid public key', () => {
       const source = { pub: '01D63D' };
-      should.throws(
+      assert.throws(
         () => new KeyPair(source),
         (e) => e.message.includes(testData.errorMessageInvalidPublicKey),
       );
@@ -97,27 +98,27 @@ describe('Hedera Key Pair', () => {
       const prvWithPrefix = { prv: testData.ed25519PrivKeyPrefix + prv + '12' };
       const prvWithOddNumber = { prv: testData.ed25519PrivKeyPrefix + prv + '1' };
       const prvWithNonHex = { prv: testData.ed25519PrivKeyPrefix + prv + 'GG' };
-      should.throws(
+      assert.throws(
         () => new KeyPair(shorterPrv),
         (e) => e.message === testData.errorMessageInvalidPrivateKey,
       );
-      should.throws(
+      assert.throws(
         () => new KeyPair(longerPrv),
         (e) => e.message === testData.errorMessageInvalidPrivateKey,
       );
-      should.throws(
+      assert.throws(
         () => new KeyPair(prvWithPrefix),
         (e) => e.message === testData.errorMessageInvalidPrivateKey,
       );
-      should.throws(
+      assert.throws(
         () => new KeyPair({ prv: prv + pub }),
         (e) => e.message === testData.errorMessageInvalidPrivateKey,
       );
-      should.throws(
+      assert.throws(
         () => new KeyPair(prvWithOddNumber),
         (e) => e.message === testData.errorMessageOddLengthOrNonHexPrivateKey,
       );
-      should.throws(
+      assert.throws(
         () => new KeyPair(prvWithNonHex),
         (e) => e.message === testData.errorMessageOddLengthOrNonHexPrivateKey,
       );
@@ -127,7 +128,7 @@ describe('Hedera Key Pair', () => {
   describe('should fail to get address ', () => {
     it('from a private key', () => {
       const keyPair = new KeyPair({ prv: prv });
-      should.throws(
+      assert.throws(
         () => keyPair.getAddress(),
         (e) => e.message === testData.errorMessageNotPossibleToDeriveAddress,
       );
@@ -135,7 +136,7 @@ describe('Hedera Key Pair', () => {
 
     it('from a public key', () => {
       const keyPair = new KeyPair({ pub: pub });
-      should.throws(
+      assert.throws(
         () => keyPair.getAddress(),
         (e) => e.message === testData.errorMessageNotPossibleToDeriveAddress,
       );
@@ -186,7 +187,7 @@ describe('Hedera Key Pair', () => {
     it('a message without a private key', () => {
       const message = 'Hello World!';
       const keyPair = new KeyPair({ pub: pub });
-      should.throws(
+      assert.throws(
         () => keyPair.signMessage(message),
         (e) => e.message === testData.errorMessageMissingPrivateKey,
       );

--- a/modules/account-lib/test/unit/coin/hbar/transaction.ts
+++ b/modules/account-lib/test/unit/coin/hbar/transaction.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { coins } from '@bitgo/statics';
 import { Transaction } from '../../../../src/coin/hbar/transaction';
@@ -16,10 +17,10 @@ describe('Hbar Transaction', () => {
 
   it('should throw empty transaction', () => {
     const tx = getTransaction();
-    should.throws(() => {
+    assert.throws(() => {
       tx.toJson();
     });
-    should.throws(() => {
+    assert.throws(() => {
       tx.toBroadcastFormat();
     });
   });

--- a/modules/account-lib/test/unit/coin/hbar/transactionBuilder/transferBuilder.ts
+++ b/modules/account-lib/test/unit/coin/hbar/transactionBuilder/transferBuilder.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import * as should from 'should';
 import { register } from '../../../../../src';
 import { TransactionBuilderFactory } from '../../../../../src/coin/hbar';
@@ -173,7 +174,7 @@ describe('HBAR Transfer Builder', () => {
   describe('should fail', () => {
     it('a transfer transaction with an invalid key', () => {
       const builder = initTxBuilder();
-      should.throws(
+      assert.throws(
         () => builder.sign({ key: '5bb72603f237c0993f7973d37fdade32c71aa94aee686aa79d260acba1882d90AA' }),
         (e) => e.message === 'Invalid private key',
       );
@@ -184,7 +185,7 @@ describe('HBAR Transfer Builder', () => {
       builder.sign({ key: testData.ACCOUNT_2.privateKey });
       builder.sign({ key: testData.ACCOUNT_1.prvKeyWithPrefix });
       builder.sign({ key: testData.ACCOUNT_3.privateKey });
-      should.throws(
+      assert.throws(
         () => builder.sign({ key: '5bb72603f237c0993f7973d37fdade32c71aa94aee686aa79d260acba1882d90' }),
         (e) => e.message === 'A maximum of 3 can sign the transaction.',
       );
@@ -193,7 +194,7 @@ describe('HBAR Transfer Builder', () => {
     it('a transfer transaction with repeated sign', () => {
       const builder = initTxBuilder();
       builder.sign({ key: testData.ACCOUNT_1.prvKeyWithPrefix });
-      should.throws(
+      assert.throws(
         () => builder.sign({ key: testData.ACCOUNT_1.prvKeyWithPrefix }),
         (e) =>
           e.message ===
@@ -203,7 +204,7 @@ describe('HBAR Transfer Builder', () => {
 
     it('a transfer transaction with an invalid destination address', () => {
       const txBuilder = factory.getTransferBuilder();
-      should.throws(
+      assert.throws(
         () => txBuilder.to('invalidaddress'),
         (e) => e.message === 'Invalid address',
       );
@@ -211,7 +212,7 @@ describe('HBAR Transfer Builder', () => {
 
     it('a transfer transaction with an invalid amount: text value', () => {
       const txBuilder = factory.getTransferBuilder();
-      should.throws(
+      assert.throws(
         () => txBuilder.amount('invalidamount'),
         (e) => e.message === 'Invalid amount',
       );
@@ -219,7 +220,7 @@ describe('HBAR Transfer Builder', () => {
 
     it('a transfer transaction with an invalid amount: negative value', () => {
       const txBuilder = factory.getTransferBuilder();
-      should.throws(
+      assert.throws(
         () => txBuilder.amount('-5'),
         (e) => e.message === 'Invalid amount',
       );
@@ -227,7 +228,7 @@ describe('HBAR Transfer Builder', () => {
 
     it('a transfer transaction with an invalid destination memo', () => {
       const txBuilder = factory.getTransferBuilder();
-      should.throws(
+      assert.throws(
         () =>
           txBuilder.memo(
             'This sentence has more than 100 bytes allowed for the memo, this should throw error -----------------',
@@ -254,11 +255,11 @@ describe('HBAR Transfer Builder', () => {
 
     it('a transfer transaction with invalid start time', () => {
       const txBuilder = factory.getTransferBuilder();
-      should.throws(
+      assert.throws(
         () => txBuilder.startTime('invalid start time'),
         (e) => e.message === 'Invalid value for time parameter',
       );
-      should.throws(
+      assert.throws(
         () => txBuilder.startTime('-5'),
         (e) => e.message === 'Invalid value for time parameter',
       );
@@ -266,7 +267,7 @@ describe('HBAR Transfer Builder', () => {
 
     it('a transfer transaction with invalid node', () => {
       const txBuilder = factory.getTransferBuilder();
-      should.throws(
+      assert.throws(
         () => txBuilder.node({ nodeId: 'invalid node' }),
         (e) => e.message === 'Invalid Hedera node address',
       );

--- a/modules/account-lib/test/unit/coin/hbar/transactionBuilder/walletInitialization.ts
+++ b/modules/account-lib/test/unit/coin/hbar/transactionBuilder/walletInitialization.ts
@@ -180,7 +180,7 @@ describe('HBAR Wallet initialization', () => {
 
     it('a private key', () => {
       const txBuilder = factory.getWalletInitializationBuilder();
-      assert.throws(() => txBuilder.validateKey({ key: 'abc' }), /Invalid key/);
+      assert.throws(() => txBuilder.validateKey({ key: 'abc' }), /Invalid private key length/);
       should.doesNotThrow(() => txBuilder.validateKey({ key: testData.ACCOUNT_1.prvKeyWithPrefix }));
     });
 
@@ -195,9 +195,9 @@ describe('HBAR Wallet initialization', () => {
 
     it('a transaction to build', async () => {
       const txBuilder = factory.getWalletInitializationBuilder();
-      assert.throws(() => txBuilder.validateTransaction(), /Invalid transaction: missing fee/);
+      assert.throws(() => txBuilder.validateTransaction(), /Invalid transaction: wrong number of owners/);
       txBuilder.fee({ fee: '10' });
-      assert.throws(() => txBuilder.validateTransaction(), /Invalid transaction: missing source/);
+      assert.throws(() => txBuilder.validateTransaction(), /Invalid transaction: wrong number of owners/);
       txBuilder.source(testData.VALID_ADDRESS);
       assert.throws(() => txBuilder.validateTransaction(), /wrong number of owners -- required: 3, found: 0/);
       txBuilder.owner(testData.OWNER1);

--- a/modules/account-lib/test/unit/coin/hbar/transactionBuilder/walletInitialization.ts
+++ b/modules/account-lib/test/unit/coin/hbar/transactionBuilder/walletInitialization.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import * as should from 'should';
 import { register } from '../../../../../src/index';
 import { KeyPair, TransactionBuilderFactory } from '../../../../../src/coin/hbar';
@@ -140,7 +141,7 @@ describe('HBAR Wallet initialization', () => {
         .build()
         .should.be.rejectedWith('Invalid transaction: wrong number of owners -- required: 3, found: 2');
 
-      should.throws(() => txBuilder.owner(testData.OWNER1), 'Repeated owner address: ' + testData.OWNER1);
+      assert.throws(() => txBuilder.owner(testData.OWNER1), new RegExp('Repeated owner address: ' + testData.OWNER1));
 
       const newTxBuilder = factory.getWalletInitializationBuilder();
       newTxBuilder.fee({ fee: '1000000000' });
@@ -165,44 +166,44 @@ describe('HBAR Wallet initialization', () => {
     it('an address', async () => {
       const txBuilder = factory.getWalletInitializationBuilder();
       txBuilder.validateAddress(testData.VALID_ADDRESS);
-      should.throws(
+      assert.throws(
         () => txBuilder.validateAddress(testData.INVALID_ADDRESS),
-        'Invalid address ' + testData.INVALID_ADDRESS,
+        new RegExp('Invalid address ' + testData.INVALID_ADDRESS.address),
       );
     });
 
     it('value should be greater than zero', () => {
       const txBuilder = factory.getWalletInitializationBuilder();
-      should.throws(() => txBuilder.fee({ fee: '-10' }));
+      assert.throws(() => txBuilder.fee({ fee: '-10' }));
       should.doesNotThrow(() => txBuilder.fee({ fee: '10' }));
     });
 
     it('a private key', () => {
       const txBuilder = factory.getWalletInitializationBuilder();
-      should.throws(() => txBuilder.validateKey({ key: 'abc' }), 'Invalid key');
+      assert.throws(() => txBuilder.validateKey({ key: 'abc' }), /Invalid key/);
       should.doesNotThrow(() => txBuilder.validateKey({ key: testData.ACCOUNT_1.prvKeyWithPrefix }));
     });
 
     it('a raw transaction', async () => {
       const txBuilder = factory.getWalletInitializationBuilder();
       should.doesNotThrow(() => txBuilder.validateRawTransaction(testData.WALLET_INITIALIZATION));
-      should.throws(() => txBuilder.validateRawTransaction('0x00001000'));
-      should.throws(() => txBuilder.validateRawTransaction(''));
-      should.throws(() => txBuilder.validateRawTransaction('pqrs'));
-      should.throws(() => txBuilder.validateRawTransaction(1234));
+      assert.throws(() => txBuilder.validateRawTransaction('0x00001000'));
+      assert.throws(() => txBuilder.validateRawTransaction(''));
+      assert.throws(() => txBuilder.validateRawTransaction('pqrs'));
+      assert.throws(() => txBuilder.validateRawTransaction(1234));
     });
 
     it('a transaction to build', async () => {
       const txBuilder = factory.getWalletInitializationBuilder();
-      should.throws(() => txBuilder.validateTransaction(), 'Invalid transaction: missing fee');
+      assert.throws(() => txBuilder.validateTransaction(), /Invalid transaction: missing fee/);
       txBuilder.fee({ fee: '10' });
-      should.throws(() => txBuilder.validateTransaction(), 'Invalid transaction: missing source');
+      assert.throws(() => txBuilder.validateTransaction(), /Invalid transaction: missing source/);
       txBuilder.source(testData.VALID_ADDRESS);
-      should.throws(() => txBuilder.validateTransaction(), 'wrong number of owners -- required: 3, found: 0');
+      assert.throws(() => txBuilder.validateTransaction(), /wrong number of owners -- required: 3, found: 0/);
       txBuilder.owner(testData.OWNER1);
-      should.throws(() => txBuilder.validateTransaction(), 'wrong number of owners -- required: 3, found: 1');
+      assert.throws(() => txBuilder.validateTransaction(), /wrong number of owners -- required: 3, found: 1/);
       txBuilder.owner(testData.OWNER2);
-      should.throws(() => txBuilder.validateTransaction(), 'wrong number of owners -- required: 3, found: 2');
+      assert.throws(() => txBuilder.validateTransaction(), /wrong number of owners -- required: 3, found: 2/);
       txBuilder.owner(testData.OWNER3);
       should.doesNotThrow(() => txBuilder.validateTransaction());
     });

--- a/modules/account-lib/test/unit/coin/hbar/utils.ts
+++ b/modules/account-lib/test/unit/coin/hbar/utils.ts
@@ -133,7 +133,7 @@ describe('HBAR util library', function () {
 
     it('should throw when memoId=null', async function () {
       const addr = '0.0.41098?memoId=';
-      assert.throws(() => Utils.getAddressDetails(addr), new RegExp(`invalid address: '${addr}', memoId is not valid`));
+      assert.throws(() => Utils.getAddressDetails(addr), /invalid address: '0.0.41098\?memoId=', memoId is not valid/);
     });
 
     it('should get memoId and address when no memoId', async function () {

--- a/modules/account-lib/test/unit/coin/hbar/utils.ts
+++ b/modules/account-lib/test/unit/coin/hbar/utils.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import * as stellar from 'stellar-sdk';
 import * as Utils from '../../../../src/coin/hbar/utils';
@@ -132,7 +133,7 @@ describe('HBAR util library', function () {
 
     it('should throw when memoId=null', async function () {
       const addr = '0.0.41098?memoId=';
-      should.throws(() => Utils.getAddressDetails(addr), `invalid address: '${addr}', memoId is not valid`);
+      assert.throws(() => Utils.getAddressDetails(addr), new RegExp(`invalid address: '${addr}', memoId is not valid`));
     });
 
     it('should get memoId and address when no memoId', async function () {
@@ -185,9 +186,9 @@ describe('HBAR util library', function () {
 
       const address5 = '0.0.0.0';
       const baseAddress5 = '0.0.41098';
-      should.throws(
+      assert.throws(
         () => Utils.isSameBaseAddress(address5, baseAddress5).should.false(),
-        `invalid address: ${address5}`,
+        new RegExp(`invalid address: ${address5}`),
       );
     });
   });

--- a/modules/account-lib/test/unit/coin/near/keyPair.ts
+++ b/modules/account-lib/test/unit/coin/near/keyPair.ts
@@ -52,14 +52,14 @@ describe('NEAR KeyPair', () => {
       const source = {
         pub: '01D63D',
       };
-      assert.throws(() => new Near.KeyPair(source), /address seems to be malformed/);
+      assert.throws(() => new Near.KeyPair(source), /Non-base58 character/);
     });
 
     it('should fail to create from an invalid private key', () => {
       const source = {
         prv: '82A34',
       };
-      assert.throws(() => new Near.KeyPair(source), /Invalid base32 characters/);
+      assert.throws(() => new Near.KeyPair(source), /Non-base58 character/);
     });
   });
 

--- a/modules/account-lib/test/unit/coin/near/keyPair.ts
+++ b/modules/account-lib/test/unit/coin/near/keyPair.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { Near } from '../../../../src';
 import * as NearResources from '../../../resources/near';
@@ -44,21 +45,21 @@ describe('NEAR KeyPair', () => {
   describe('KeyPair validation', () => {
     it('should fail to create from an invalid seed', () => {
       const seed = { seed: Buffer.alloc(8) }; //  Seed should be 512 bits (64 bytes)
-      should.throws(() => new Near.KeyPair(seed), 'bad seed size');
+      assert.throws(() => new Near.KeyPair(seed), /bad seed size/);
     });
 
     it('should fail to create from an invalid public key', () => {
       const source = {
         pub: '01D63D',
       };
-      should.throws(() => new Near.KeyPair(source), 'address seems to be malformed');
+      assert.throws(() => new Near.KeyPair(source), /address seems to be malformed/);
     });
 
     it('should fail to create from an invalid private key', () => {
       const source = {
         prv: '82A34',
       };
-      should.throws(() => new Near.KeyPair(source), 'Invalid base32 characters');
+      assert.throws(() => new Near.KeyPair(source), /Invalid base32 characters/);
     });
   });
 

--- a/modules/account-lib/test/unit/coin/near/transaction.ts
+++ b/modules/account-lib/test/unit/coin/near/transaction.ts
@@ -1,4 +1,5 @@
 import { coins } from '@bitgo/statics';
+import assert from 'assert';
 import should from 'should';
 import { TransactionType } from '../../../../src/coin/baseCoin';
 import { Transaction } from '../../../../src/coin/near';
@@ -14,8 +15,8 @@ describe('Near Transaction', () => {
 
   describe('empty transaction', () => {
     it('should throw empty transaction', () => {
-      should.throws(() => tx.toJson(), 'Empty transaction');
-      should.throws(() => tx.toBroadcastFormat(), 'Empty transaction');
+      assert.throws(() => tx.toJson(), 'Empty transaction');
+      assert.throws(() => tx.toBroadcastFormat(), 'Empty transaction');
     });
   });
 
@@ -57,7 +58,7 @@ describe('Near Transaction', () => {
     });
 
     it('build a transfer from incorrent raw data', async () => {
-      should.throws(() => tx.fromRawTransaction('11' + NearResources.rawTx.transfer.signed), 'incorrect raw data');
+      assert.throws(() => tx.fromRawTransaction('11' + NearResources.rawTx.transfer.signed), 'incorrect raw data');
     });
   });
 

--- a/modules/account-lib/test/unit/coin/near/transactionBuilder/transactionBuilder.ts
+++ b/modules/account-lib/test/unit/coin/near/transactionBuilder/transactionBuilder.ts
@@ -120,7 +120,7 @@ describe('NEAR Transaction Builder', async () => {
     for (const txBuilder of builders) {
       assert.throws(
         () => txBuilder.sender(testData.accounts.account1.publicKey),
-        new RegExp('Invalid or missing address, got: undefined'),
+        new RegExp('Invalid or missing pubKey, got: undefined'),
       );
     }
   });

--- a/modules/account-lib/test/unit/coin/near/transactionBuilder/transactionBuilder.ts
+++ b/modules/account-lib/test/unit/coin/near/transactionBuilder/transactionBuilder.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { register } from '../../../../../src';
 import { TransactionBuilderFactory } from '../../../../../src/coin/near';
@@ -101,9 +102,9 @@ describe('NEAR Transaction Builder', async () => {
       txBuilder.sender(testData.accounts.account1.address, testData.accounts.account1.publicKey);
       txBuilder.nonce(1);
       txBuilder.receiverId(testData.accounts.account2.address);
-      should.throws(
+      assert.throws(
         () => txBuilder.recentBlockHash(testData.errorBlockHash.block1),
-        'Invalid blockHash CDEwwp7TjjahErrorriSvX3457qZ5uF3TtgEZHj7o5ssKFNs9',
+        new RegExp('Invalid blockHash CDEwwp7TjjahErrorriSvX3457qZ5uF3TtgEZHj7o5ssKFNs9'),
       );
     }
   });
@@ -111,15 +112,15 @@ describe('NEAR Transaction Builder', async () => {
   it('should fail to build if have invalid nonce', async () => {
     for (const txBuilder of builders) {
       txBuilder.sender(testData.accounts.account1.address, testData.accounts.account1.publicKey);
-      should.throws(() => txBuilder.nonce(-1), 'Invalid nonce: -1');
+      assert.throws(() => txBuilder.nonce(-1), /Invalid nonce: -1/);
     }
   });
 
   it('should fail to build if have undefined address', async () => {
     for (const txBuilder of builders) {
-      should.throws(
+      assert.throws(
         () => txBuilder.sender(testData.accounts.account1.publicKey),
-        'Invalid or missing address, got: undefined',
+        new RegExp('Invalid or missing address, got: undefined'),
       );
     }
   });

--- a/modules/account-lib/test/unit/coin/rbtc/transaction.ts
+++ b/modules/account-lib/test/unit/coin/rbtc/transaction.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { coins } from '@bitgo/statics';
 import { Transaction } from '../../../../src/coin/rbtc';
@@ -18,10 +19,10 @@ describe('Rbtc Transaction', () => {
   describe('should throw ', () => {
     it('an empty transaction', () => {
       const tx = getTransaction();
-      should.throws(() => {
+      assert.throws(() => {
         tx.toJson();
       });
-      should.throws(() => {
+      assert.throws(() => {
         tx.toBroadcastFormat();
       });
     });

--- a/modules/account-lib/test/unit/coin/sol/keyPair.ts
+++ b/modules/account-lib/test/unit/coin/sol/keyPair.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import * as testData from '../../../resources/sol/sol';
 import { Sol } from '../../../../src';
@@ -63,21 +64,21 @@ describe('Sol KeyPair', function () {
 
     it('from an invalid seed', () => {
       const seed = { seed: Buffer.alloc(8) }; //  Seed should be 512 bits (64 bytes)
-      should.throws(() => new Sol.KeyPair(seed));
+      assert.throws(() => new Sol.KeyPair(seed));
     });
 
     it('from an invalid public key', () => {
       const source = {
         pub: '01D63D',
       };
-      should.throws(() => new Sol.KeyPair(source));
+      assert.throws(() => new Sol.KeyPair(source));
     });
 
     it('from an invalid private key', () => {
       const source = {
         prv: '82A34E',
       };
-      should.throws(() => new Sol.KeyPair(source));
+      assert.throws(() => new Sol.KeyPair(source));
     });
   });
 
@@ -178,12 +179,12 @@ describe('Sol KeyPair', function () {
 
     it('should not be able to derive without private key', () => {
       const rootKeyPair = new Sol.KeyPair({ pub: testData.accountWithSeed.publicKey });
-      should.throws(() => rootKeyPair.deriveHardened("m/0'/0'/0'/0'"), 'need private key to derive hardened keypair');
+      assert.throws(() => rootKeyPair.deriveHardened("m/0'/0'/0'/0'"), /need private key to derive hardened keypair/);
     });
 
     it('should throw error for non-hardened path', () => {
       const rootKeyPair = new Sol.KeyPair();
-      should.throws(() => rootKeyPair.deriveHardened('m/0/0/0/0'), 'Invalid derivation path');
+      assert.throws(() => rootKeyPair.deriveHardened('m/0/0/0/0'), /Invalid derivation path/);
     });
   });
 });

--- a/modules/account-lib/test/unit/coin/sol/transaction.ts
+++ b/modules/account-lib/test/unit/coin/sol/transaction.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { coins } from '@bitgo/statics';
 import { KeyPair, Transaction, TransactionBuilderFactory } from '../../../../src/coin/sol';
@@ -11,8 +12,8 @@ describe('Sol Transaction', () => {
   describe('toJson should', () => {
     it('throw empty transaction', () => {
       const tx = new Transaction(coin);
-      should.throws(() => tx.toJson(), 'Empty transaction');
-      should.throws(() => tx.toBroadcastFormat(), 'Empty transaction');
+      assert.throws(() => tx.toJson(), /Empty transaction/);
+      assert.throws(() => tx.toBroadcastFormat(), /Empty transaction/);
     });
     it('throw for toJson of empty tx', () => {
       const tx = new Transaction(coin);

--- a/modules/account-lib/test/unit/coin/stx/keyPair.ts
+++ b/modules/account-lib/test/unit/coin/stx/keyPair.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import * as testData from '../../../resources/stx/stx';
 
@@ -52,21 +53,21 @@ describe('Stx KeyPair', function () {
   describe('should fail to create a KeyPair', function () {
     it('from an invalid seed', () => {
       const seed = { seed: Buffer.alloc(8) }; //  Seed should be 512 bits (64 bytes)
-      should.throws(() => new Stx.KeyPair(seed));
+      assert.throws(() => new Stx.KeyPair(seed));
     });
 
     it('from an invalid public key', () => {
       const source = {
         pub: '01D63D',
       };
-      should.throws(() => new Stx.KeyPair(source));
+      assert.throws(() => new Stx.KeyPair(source));
     });
 
     it('from an invalid private key', () => {
       const source = {
         prv: '82A34E',
       };
-      should.throws(() => new Stx.KeyPair(source));
+      assert.throws(() => new Stx.KeyPair(source));
     });
   });
 

--- a/modules/account-lib/test/unit/coin/stx/transaction.ts
+++ b/modules/account-lib/test/unit/coin/stx/transaction.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { coins } from '@bitgo/statics';
 import { Transaction } from '../../../../src/coin/stx/transaction';
@@ -9,8 +10,8 @@ describe('Stx Transaction', () => {
 
   it('should throw empty transaction', () => {
     const tx = new Transaction(coin);
-    should.throws(() => tx.toJson(), 'Empty transaction');
-    should.throws(() => tx.toBroadcastFormat(), 'Empty transaction');
+    assert.throws(() => tx.toJson(), /Empty transaction/);
+    assert.throws(() => tx.toBroadcastFormat(), /Empty transaction/);
   });
 
   describe('should sign if transaction is', () => {

--- a/modules/account-lib/test/unit/coin/stx/transactionBuilder/contractBuilder.ts
+++ b/modules/account-lib/test/unit/coin/stx/transactionBuilder/contractBuilder.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import BigNum from 'bn.js';
 import { StacksTestnet, StacksMainnet } from '@stacks/network';
@@ -248,9 +249,9 @@ describe('Stx Contract call Builder', () => {
       it('invalid type', () => {
         const builder = initTxBuilder();
 
-        should.throws(
+        assert.throws(
           () => builder.functionArgs([{ type: 'unknow', val: 'any-val' }]),
-          (e) => e.message === 'Unexpected Clarity ABI type primitive: "unknow"',
+          new RegExp('Unexpected Clarity ABI type primitive: "unknow"'),
         );
       });
     });
@@ -258,21 +259,21 @@ describe('Stx Contract call Builder', () => {
     describe('should fail', () => {
       it('a contract call with an invalid key', () => {
         const builder = initTxBuilder();
-        should.throws(() => builder.sign({ key: 'invalidKey' }), 'Unsupported private key');
+        assert.throws(() => builder.sign({ key: 'invalidKey' }), /Unsupported private key/);
       });
       it('a contract call with an invalid contract address', () => {
         const builder = initTxBuilder();
-        should.throws(() => builder.contractAddress(testData.ACCOUNT_1.address), 'Invalid contract address');
+        assert.throws(() => builder.contractAddress(testData.ACCOUNT_1.address), /Invalid contract address/);
       });
       it('a contract call with an invalid contract name', () => {
         const builder = initTxBuilder();
-        should.throws(() => builder.contractName('test'), 'Only pox and send-many-memo contracts supported');
+        assert.throws(() => builder.contractName('test'), /Only pox and send-many-memo contracts supported/);
       });
       it('a contract call with an invalid contract function name', () => {
         const builder = initTxBuilder();
-        should.throws(
+        assert.throws(
           () => builder.functionName('test-function'),
-          'test-function is not supported contract function name',
+          new RegExp('test-function is not supported contract function name'),
         );
       });
     });

--- a/modules/account-lib/test/unit/coin/stx/transactionBuilder/transferBuilder.ts
+++ b/modules/account-lib/test/unit/coin/stx/transactionBuilder/transferBuilder.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { StacksMainnet, StacksTestnet } from '@stacks/network';
 import { register } from '../../../../../src/index';
@@ -305,27 +306,27 @@ describe('Stx Transfer Builder', () => {
     describe('should fail', () => {
       it('a transfer transaction with an invalid key', () => {
         const builder = initTxBuilder();
-        should.throws(() => builder.sign({ key: 'invalidKey' }), 'Unsupported private key');
+        assert.throws(() => builder.sign({ key: 'invalidKey' }), /Unsupported private key/);
       });
 
       it('a transfer transaction with an invalid destination address', () => {
         const txBuilder = factory.getTransferBuilder();
-        should.throws(() => txBuilder.to('invalidaddress'), 'Invalid address');
+        assert.throws(() => txBuilder.to('invalidaddress'), /Invalid address/);
       });
 
       it('a transfer transaction with an invalid amount: text value', () => {
         const txBuilder = factory.getTransferBuilder();
-        should.throws(() => txBuilder.amount('invalidamount'), 'Invalid amount');
+        assert.throws(() => txBuilder.amount('invalidamount'), /Invalid amount/);
       });
 
       it('a transfer transaction with an invalid amount: negative value', () => {
         const txBuilder = factory.getTransferBuilder();
-        should.throws(() => txBuilder.amount('-5'), 'Invalid amount');
+        assert.throws(() => txBuilder.amount('-5'), /Invalid amount/);
       });
 
       it('a transfer transaction with an invalid memo', async () => {
         const txBuilder = factory.getTransferBuilder();
-        should.throws(() => txBuilder.memo('This is a memo that is too long for a transaction'), 'Memo is too long');
+        assert.throws(() => txBuilder.memo('This is a memo that is too long for a transaction'), /Memo is too long/);
       });
     });
   });

--- a/modules/account-lib/test/unit/coin/stx/util.ts
+++ b/modules/account-lib/test/unit/coin/stx/util.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { AddressVersion, ClarityType, IntCV, NoneCV, SomeCV, UIntCV, ListCV } from '@stacks/transactions';
 import * as testData from '../../../resources/stx/stx';
@@ -92,15 +93,15 @@ describe('Stx util library', function () {
     });
 
     it('should not generate multisig addresses from invalid input', function () {
-      should.throws(() => Utils.getSTXAddressFromPubKeys([]), 'Invalid number of public keys');
-      should.throws(() => Utils.getSTXAddressFromPubKeys(['badkey', 'badkey2']), 'Invalid public key');
-      should.throws(
+      assert.throws(() => Utils.getSTXAddressFromPubKeys([]), /Invalid number of public keys/);
+      assert.throws(() => Utils.getSTXAddressFromPubKeys(['badkey', 'badkey2']), /Invalid public key/);
+      assert.throws(
         () =>
           Utils.getSTXAddressFromPubKeys([
             '02f6d0597fb6d5467203d080e17f7b4f767ead59fc303b7d7261a832cb44305bb0',
             'badkey',
           ]),
-        'Invalid public key',
+        /Invalid public key/,
       );
     });
   });
@@ -247,9 +248,9 @@ describe('Stx util library', function () {
 
     it('should not verify signatures', function () {
       // empty message
-      should.throws(
+      assert.throws(
         () => Stx.Utils.verifySignature('', testData.expectedSignature1, keyPair1.getKeys().pub),
-        'Cannot verify empty messages',
+        new RegExp('Cannot verify empty messages'),
       );
 
       // wrong public key
@@ -376,9 +377,9 @@ describe('Stx util library', function () {
 
       const address5 = 'SN237KBNCA2CZZ32CWMNTF74DFAYCPNJ3MNN6ANDF';
       const baseAddress5 = 'ST1SRCA93CE1WD8TEG28BSWBFR68J24ZTAB2FAJ0';
-      should.throws(
+      assert.throws(
         () => Utils.isSameBaseAddress(address5, baseAddress5).should.false(),
-        `invalid address: ${address5}`,
+        new RegExp(`invalid address: ${address5}`),
       );
     });
   });

--- a/modules/account-lib/test/unit/coin/trx/keyPair.ts
+++ b/modules/account-lib/test/unit/coin/trx/keyPair.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 
 import { Trx } from '../../../../src';
@@ -56,7 +57,7 @@ describe('Trx KeyPair', function () {
         '04D63D9FD9FD772A989C5B90EDB37716406356E98273E5F98FE07652247A3A827503E948A2FDBF74A981D4E0054F10EDA7042C2D469F44473D3C7791E0E326E355',
       );
 
-      should.throws(() => keyPair.getExtendedKeys());
+      assert.throws(() => keyPair.getExtendedKeys());
     });
 
     it('from a compressed public key', () => {
@@ -70,7 +71,7 @@ describe('Trx KeyPair', function () {
         '04D63D9FD9FD772A989C5B90EDB37716406356E98273E5F98FE07652247A3A827503E948A2FDBF74A981D4E0054F10EDA7042C2D469F44473D3C7791E0E326E355',
       );
 
-      should.throws(() => keyPair.getExtendedKeys());
+      assert.throws(() => keyPair.getExtendedKeys());
     });
 
     it('from a raw private key', () => {
@@ -84,28 +85,28 @@ describe('Trx KeyPair', function () {
         '04D63D9FD9FD772A989C5B90EDB37716406356E98273E5F98FE07652247A3A827503E948A2FDBF74A981D4E0054F10EDA7042C2D469F44473D3C7791E0E326E355',
       );
 
-      should.throws(() => keyPair.getExtendedKeys());
+      assert.throws(() => keyPair.getExtendedKeys());
     });
   });
 
   describe('should fail to create a KeyPair', function () {
     it('from an invalid seed', () => {
       const seed = { seed: Buffer.alloc(8) }; //  Seed should be at least 128 bits (16 bytes, not 8)
-      should.throws(() => new Trx.KeyPair(seed));
+      assert.throws(() => new Trx.KeyPair(seed));
     });
 
     it('from an invalid public key', () => {
       const source = {
         pub: '01D63D',
       };
-      should.throws(() => new Trx.KeyPair(source));
+      assert.throws(() => new Trx.KeyPair(source));
     });
 
     it('from an invalid private key', () => {
       const source = {
         prv: '82A34E',
       };
-      should.throws(() => new Trx.KeyPair(source));
+      assert.throws(() => new Trx.KeyPair(source));
     });
   });
 
@@ -186,7 +187,7 @@ describe('Trx KeyPair', function () {
       };
       const keyPair = new Trx.KeyPair(source);
       const message = 'Hello world';
-      should.throws(() => keyPair.signMessage(message));
+      assert.throws(() => keyPair.signMessage(message));
     });
   });
 

--- a/modules/account-lib/test/unit/coin/trx/transaction.ts
+++ b/modules/account-lib/test/unit/coin/trx/transaction.ts
@@ -1,4 +1,4 @@
-import should from 'should';
+import assert from 'assert';
 import { coins } from '@bitgo/statics';
 import { UnsignedBuildTransaction } from '../../../resources/trx';
 import { Transaction } from '../../../../src/coin/trx';
@@ -20,17 +20,17 @@ describe('Tron transactions', function () {
   describe('should throw when', () => {
     it('transaction is empty and toJson is called', () => {
       const tx = new Transaction(coins.get('ttrx'));
-      should.throws(() => tx.toJson());
+      assert.throws(() => tx.toJson());
     });
 
     it('transaction is empty and extendExpiration is called', () => {
       const tx = new Transaction(coins.get('ttrx'));
-      should.throws(() => tx.extendExpiration(1));
+      assert.throws(() => tx.extendExpiration(1));
     });
 
     it('the extension time is negative', () => {
       const tx = new Transaction(coins.get('ttrx'));
-      should.throws(() => tx.extendExpiration(-1));
+      assert.throws(() => tx.extendExpiration(-1));
     });
   });
 });

--- a/modules/account-lib/test/unit/coin/trx/transactionBuilder.ts
+++ b/modules/account-lib/test/unit/coin/trx/transactionBuilder.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { TransactionType } from '../../../../src/coin/baseCoin/';
 import {
@@ -88,7 +89,7 @@ describe('Tron TransactionBuilder', function () {
       it('a transaction with the same key', () => {
         const txJson = JSON.stringify(FirstSigOnBuildTransaction);
         txBuilder.from(txJson);
-        should.throws(() => txBuilder.sign({ key: FirstPrivateKey }));
+        assert.throws(() => txBuilder.sign({ key: FirstPrivateKey }));
       });
     });
   });
@@ -149,7 +150,7 @@ describe('Tron TransactionBuilder', function () {
       txBuilder.from(txJson);
       txBuilder.sign({ key: FirstPrivateKey });
 
-      should.throws(() => txBuilder.extendValidTo(10000));
+      assert.throws(() => txBuilder.extendValidTo(10000));
     });
 
     it('should extend an unsigned tx', async () => {
@@ -174,32 +175,32 @@ describe('Tron TransactionBuilder', function () {
 
     it('should catch an invalid id', async () => {
       const txJson = JSON.stringify(InvalidIDTransaction);
-      should.throws(() => txBuilder.from(txJson));
+      assert.throws(() => txBuilder.from(txJson));
     });
 
     it('should throw exception of wrong id', () => {
       const txJson = JSON.stringify(UnsignedBuildInvalidIDTransaction);
-      should.throws(() => txBuilder.from(txJson));
+      assert.throws(() => txBuilder.from(txJson));
     });
 
     it('should throw exception of empty id', () => {
       const txJson = JSON.stringify(UnsignedBuildEmptyIDTransaction);
-      should.throws(() => txBuilder.from(txJson));
+      assert.throws(() => txBuilder.from(txJson));
     });
 
     it('should throw exception of invalid time stamp', () => {
       const txJson = JSON.stringify(UnsignedInvalidTimeStampBuildTransaction);
-      should.throws(() => txBuilder.from(txJson));
+      assert.throws(() => txBuilder.from(txJson));
     });
 
     it('should throw exception of invalid expiration time', () => {
       const txJson = JSON.stringify(UnsignedInvalidExpirationBuildTransaction);
-      should.throws(() => txBuilder.from(txJson));
+      assert.throws(() => txBuilder.from(txJson));
     });
 
     it('should throw exception of non-existence of contract', () => {
       const txJson = JSON.stringify(UnsignedInvalidContractBuildTransaction);
-      should.throws(() => txBuilder.from(txJson));
+      assert.throws(() => txBuilder.from(txJson));
     });
 
     it('should validate JSON transaction', () => {
@@ -221,7 +222,7 @@ describe('Tron TransactionBuilder', function () {
 
     it('should throw an error when the key is invalid', () => {
       const key = 'jiraiya';
-      should.throws(() => txBuilder.validateKey({ key }), 'The provided key is not valid');
+      assert.throws(() => txBuilder.validateKey({ key }), /The provided key is not valid/);
     });
   });
 });

--- a/modules/account-lib/test/unit/coin/trx/transactionBuilder/contractCallBuilder.ts
+++ b/modules/account-lib/test/unit/coin/trx/transactionBuilder/contractCallBuilder.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { coins, TronNetwork } from '@bitgo/statics/';
 import BigNumber from 'bignumber.js';
@@ -173,7 +174,7 @@ describe('Trx Contract call Builder', () => {
     describe('should fail to build', () => {
       it('a transaction with wrong data', async () => {
         const txBuilder = initTxBuilder();
-        should.throws(
+        assert.throws(
           () => {
             txBuilder.data('addMintRequest()');
           },
@@ -185,7 +186,7 @@ describe('Trx Contract call Builder', () => {
         const txBuilder = initTxBuilder();
         txBuilder.data(MINT_CONFIRM_DATA);
         txBuilder.sign({ key: PARTICIPANTS.custodian.pk });
-        should.throws(
+        assert.throws(
           () => {
             txBuilder.sign({ key: PARTICIPANTS.custodian.pk });
           },
@@ -199,7 +200,7 @@ describe('Trx Contract call Builder', () => {
       });
 
       it('an invalid raw transaction', () => {
-        should.throws(
+        assert.throws(
           () => {
             getBuilder('ttrx').from('an invalid raw transaction');
           },
@@ -228,7 +229,7 @@ describe('Trx Contract call Builder', () => {
       const txBuilder = initTxBuilder();
       txBuilder.data(MINT_CONFIRM_DATA);
       txBuilder.timestamp(now);
-      should.throws(
+      assert.throws(
         () => {
           txBuilder.expiration(now + 31536000001);
         },
@@ -241,7 +242,7 @@ describe('Trx Contract call Builder', () => {
       const txBuilder = initTxBuilder();
       txBuilder.timestamp(now - 2000);
       txBuilder.data(MINT_CONFIRM_DATA);
-      should.throws(
+      assert.throws(
         () => {
           txBuilder.expiration(now - 1000);
         },
@@ -254,7 +255,7 @@ describe('Trx Contract call Builder', () => {
       const txBuilder = initTxBuilder();
       txBuilder.data(MINT_CONFIRM_DATA);
       txBuilder.timestamp(now + 2000);
-      should.throws(
+      assert.throws(
         () => {
           txBuilder.expiration(now + 1000);
         },
@@ -268,7 +269,7 @@ describe('Trx Contract call Builder', () => {
       const txBuilder = initTxBuilder();
       txBuilder.data(MINT_CONFIRM_DATA);
       await txBuilder.build();
-      should.throws(
+      assert.throws(
         () => {
           txBuilder.expiration(expiration);
         },
@@ -283,7 +284,7 @@ describe('Trx Contract call Builder', () => {
       txBuilder.data(MINT_CONFIRM_DATA);
       const tx = await txBuilder.build();
       const txBuilder2 = getBuilder('ttrx').from(tx.toBroadcastFormat());
-      should.throws(
+      assert.throws(
         () => {
           txBuilder2.expiration(expiration);
         },
@@ -294,7 +295,7 @@ describe('Trx Contract call Builder', () => {
     it('an extension without a set expiration', async () => {
       const txBuilder = initTxBuilder();
       txBuilder.data(MINT_CONFIRM_DATA);
-      should.throws(
+      assert.throws(
         () => {
           txBuilder.extendValidTo(20000);
         },
@@ -310,7 +311,7 @@ describe('Trx Contract call Builder', () => {
       const tx = await txBuilder.build();
 
       const txBuilder2 = getBuilder('ttrx').from(tx.toBroadcastFormat());
-      should.throws(
+      assert.throws(
         () => {
           txBuilder2.extendValidTo(0);
         },
@@ -326,7 +327,7 @@ describe('Trx Contract call Builder', () => {
       const tx = await txBuilder.build();
 
       const txBuilder2 = getBuilder('ttrx').from(tx.toBroadcastFormat());
-      should.throws(
+      assert.throws(
         () => {
           txBuilder2.extendValidTo(31536000001);
         },
@@ -341,7 +342,7 @@ describe('Trx Contract call Builder', () => {
       const tx = await txBuilder.build();
 
       const txBuilder2 = getBuilder('ttrx').from(tx.toBroadcastFormat());
-      should.throws(
+      assert.throws(
         () => {
           txBuilder2.extendValidTo(20000);
         },
@@ -352,21 +353,21 @@ describe('Trx Contract call Builder', () => {
     it('fee limit', async () => {
       const txBuilder = initTxBuilder();
       txBuilder.data(MINT_CONFIRM_DATA);
-      should.throws(
+      assert.throws(
         () => {
           txBuilder.fee({ feeLimit: 'not a number' });
         },
         (e) => e.message === 'Invalid fee limit value',
       );
 
-      should.throws(
+      assert.throws(
         () => {
           txBuilder.fee({ feeLimit: '-15000' });
         },
         (e) => e.message === 'Invalid fee limit value',
       );
 
-      should.throws(
+      assert.throws(
         () => {
           const tronNetwork = coins.get('ttrx').network as TronNetwork;
           txBuilder.fee({ feeLimit: new BigNumber(tronNetwork.maxFeeLimit).plus(1).toString() });

--- a/modules/account-lib/test/unit/coin/trx/transactionBuilder/wrappedBuilder.ts
+++ b/modules/account-lib/test/unit/coin/trx/transactionBuilder/wrappedBuilder.ts
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js';
+import assert from 'assert';
 import should from 'should';
 import { WrappedBuilder } from '../../../../../src/coin/trx';
 import { getBuilder } from '../../../../../src/index';
@@ -13,7 +14,7 @@ describe('Trx Contract call Builder', () => {
     });
 
     it('an empty address', () => {
-      should.throws(
+      assert.throws(
         () => {
           builder.validateAddress({ address: '' });
         },
@@ -22,7 +23,7 @@ describe('Trx Contract call Builder', () => {
     });
 
     it('a hex address', () => {
-      should.throws(
+      assert.throws(
         () => {
           builder.validateAddress({ address: '4173a5993cd182ae152adad8203163f780c65a8aa5' });
         },
@@ -31,7 +32,7 @@ describe('Trx Contract call Builder', () => {
     });
 
     it('a hex address', () => {
-      should.throws(
+      assert.throws(
         () => {
           builder.validateAddress({ address: '4173a5993cd182ae152adad8203163f780c65a8aa5' });
         },
@@ -46,7 +47,7 @@ describe('Trx Contract call Builder', () => {
 
     it('a negative value', () => {
       const value = new BigNumber('-13456');
-      should.throws(
+      assert.throws(
         () => {
           builder.validateValue(value);
         },
@@ -56,7 +57,7 @@ describe('Trx Contract call Builder', () => {
 
     it('a value too big', () => {
       const value = new BigNumber('9223372036854775808');
-      should.throws(
+      assert.throws(
         () => {
           builder.validateValue(value);
         },

--- a/modules/account-lib/test/unit/coin/trx/util.ts
+++ b/modules/account-lib/test/unit/coin/trx/util.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { TransferContract, AccountPermissionUpdateContract } from '../../../../src/coin/trx/iface';
 import { Utils } from '../../../../src/coin/trx/index';
@@ -95,17 +96,17 @@ describe('Util library should', function () {
   });
 
   it('should fail to verify a signed message if the message is not in hex', () => {
-    should.throws(() => Utils.verifySignature(txt, base58, signedString, true));
+    assert.throws(() => Utils.verifySignature(txt, base58, signedString, true));
   });
 
   it('should fail to verify a signed message if the address is not in base58', () => {
     const hexEncodedString = Buffer.from(txt).toString('hex');
-    should.throws(() => Utils.verifySignature(hexEncodedString, addressHex, signedString, true));
+    assert.throws(() => Utils.verifySignature(hexEncodedString, addressHex, signedString, true));
   });
 
   it('should fail to verify a signed message if the signature is not in hex', () => {
     const hexEncodedString = Buffer.from(txt).toString('hex');
-    should.throws(() => Utils.verifySignature(hexEncodedString, base58, 'abc', true));
+    assert.throws(() => Utils.verifySignature(hexEncodedString, base58, 'abc', true));
   });
 
   it('should return transaction data', () => {

--- a/modules/account-lib/test/unit/coin/xtz/keyPair.ts
+++ b/modules/account-lib/test/unit/coin/xtz/keyPair.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 
 import { Xtz } from '../../../../src';
@@ -49,7 +50,7 @@ describe('Xtz KeyPair', function () {
       should.not.exist(defaultKeys.prv);
       defaultKeys.pub.should.equal('sppk7csjXKT4wvUNCPMfAgZMNuvSjzW4Y2ZAKZEdvyEPtYagE6pCwkw');
 
-      should.throws(() => keyPair.getExtendedKeys());
+      assert.throws(() => keyPair.getExtendedKeys());
     });
 
     it('from a compressed public key', () => {
@@ -61,7 +62,7 @@ describe('Xtz KeyPair', function () {
       should.not.exist(defaultKeys.prv);
       defaultKeys.pub.should.equal('sppk7csjXKT4wvUNCPMfAgZMNuvSjzW4Y2ZAKZEdvyEPtYagE6pCwkw');
 
-      should.throws(() => keyPair.getExtendedKeys());
+      assert.throws(() => keyPair.getExtendedKeys());
     });
 
     it('from a Tezos public key', () => {
@@ -73,7 +74,7 @@ describe('Xtz KeyPair', function () {
       should.not.exist(defaultKeys.prv);
       defaultKeys.pub.should.equal('sppk7csjXKT4wvUNCPMfAgZMNuvSjzW4Y2ZAKZEdvyEPtYagE6pCwkw');
 
-      should.throws(() => keyPair.getExtendedKeys());
+      assert.throws(() => keyPair.getExtendedKeys());
     });
 
     it('from a raw private key', () => {
@@ -85,7 +86,7 @@ describe('Xtz KeyPair', function () {
       defaultKeys.prv!.should.equal('spsk2R6ek35CtfJMt2XHPWgFcf1wUGLK2fKbU3f4hWZNABo1YrrqP7');
       defaultKeys.pub.should.equal('sppk7csjXKT4wvUNCPMfAgZMNuvSjzW4Y2ZAKZEdvyEPtYagE6pCwkw');
 
-      should.throws(() => keyPair.getExtendedKeys());
+      assert.throws(() => keyPair.getExtendedKeys());
     });
 
     it('from a Tezos private key', () => {
@@ -98,28 +99,28 @@ describe('Xtz KeyPair', function () {
       defaultKeys.pub.should.equal('sppk7ZWB8diU2TWehxdkWCV2DTFvn1hPz4qLjiD3nJQozKnoSEnSC8b');
       keyPair.getAddress().should.equal('tz2P2E8EgHaLA6A17rH3pE9T2tx6DA7D4siW');
 
-      should.throws(() => keyPair.getExtendedKeys());
+      assert.throws(() => keyPair.getExtendedKeys());
     });
   });
 
   describe('should fail to create a KeyPair', function () {
     it('from an invalid seed', () => {
       const seed = { seed: Buffer.alloc(8) }; //  Seed should be at least 128 bits (16 bytes, not 8)
-      should.throws(() => new Xtz.KeyPair(seed));
+      assert.throws(() => new Xtz.KeyPair(seed));
     });
 
     it('from an invalid public key', () => {
       const source = {
         pub: '01D63D',
       };
-      should.throws(() => new Xtz.KeyPair(source));
+      assert.throws(() => new Xtz.KeyPair(source));
     });
 
     it('from an invalid private key', () => {
       const source = {
         prv: '82A34E',
       };
-      should.throws(() => new Xtz.KeyPair(source));
+      assert.throws(() => new Xtz.KeyPair(source));
     });
   });
 

--- a/modules/account-lib/test/unit/coin/xtz/transaction.ts
+++ b/modules/account-lib/test/unit/coin/xtz/transaction.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import { coins } from '@bitgo/statics';
 import { KeyPair, Transaction } from '../../../../src/coin/xtz';
@@ -93,7 +94,7 @@ describe('Tezos transaction', function () {
 
     it('to get the transaction JSON if it is empty', async () => {
       const tx = new Transaction(coins.get('txtz'));
-      should.throws(() => tx.toJson());
+      assert.throws(() => tx.toJson());
     });
 
     it('to sign if the transaction is empty', async () => {

--- a/modules/account-lib/test/unit/coin/xtz/transactionBuilder.ts
+++ b/modules/account-lib/test/unit/coin/xtz/transactionBuilder.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 
 import { TransactionType } from '../../../../src/coin/baseCoin/';
@@ -575,14 +576,14 @@ describe('Tezos Transaction builder', function () {
     it('a transaction with no source account', async () => {
       const txBuilder: any = getBuilder('xtz');
       txBuilder.type(TransactionType.WalletInitialization);
-      should.throws(() => txBuilder.sign({ key: defaultKeyPair.getKeys().prv }));
+      assert.throws(() => txBuilder.sign({ key: defaultKeyPair.getKeys().prv }));
     });
 
     it('a transaction with a different private key than the source account', async () => {
       const txBuilder: any = getBuilder('xtz');
       txBuilder.from(testData.emptyUnsignedSerializedOriginationTransaction);
       txBuilder.type(TransactionType.WalletInitialization);
-      should.throws(() => txBuilder.sign({ key: new KeyPair().getKeys().prv }));
+      assert.throws(() => txBuilder.sign({ key: new KeyPair().getKeys().prv }));
     });
 
     it('a transaction with some keys with custom index', async () => {
@@ -590,7 +591,7 @@ describe('Tezos Transaction builder', function () {
       // Multisig keys
       genericTxBuilder.sign({ key: new KeyPair().getKeys().prv });
       genericTxBuilder.sign({ key: new KeyPair().getKeys().prv });
-      should.throws(
+      assert.throws(
         () => genericTxBuilder.sign({ key: new KeyPair().getKeys().prv, index: 2 }),
         new RegExp('Custom index has to be set for all multisig contract signing keys or none'),
       );
@@ -601,7 +602,7 @@ describe('Tezos Transaction builder', function () {
       // Multisig keys
       genericTxBuilder.sign({ key: new KeyPair().getKeys().prv, index: 0 });
       genericTxBuilder.sign({ key: new KeyPair().getKeys().prv, index: 1 });
-      should.throws(
+      assert.throws(
         () => genericTxBuilder.sign({ key: new KeyPair().getKeys().prv }),
         new RegExp('Custom index has to be set for all multisig contract signing keys or none'),
       );
@@ -609,7 +610,7 @@ describe('Tezos Transaction builder', function () {
 
     it('a transaction with a key with invalid custom index', async () => {
       genericTxBuilder.sign({ key: defaultKeyPair.getKeys().prv });
-      should.throws(
+      assert.throws(
         () => genericTxBuilder.sign({ key: new KeyPair().getKeys().prv, index: 3 }),
         new RegExp('Custom index cannot be greater'),
       );
@@ -622,13 +623,13 @@ describe('Tezos Transaction builder', function () {
       txBuilder.branch('BKnfiSVFTjixbhzsTbR1eDmit6yK7UBcgRJPhmgeWcZqiMHRZ6E');
       txBuilder.counter('1');
       txBuilder.source(defaultKeyPair.getAddress());
-      should.throws(() => txBuilder.sign({ key: defaultKeyPair.getKeys().prv }));
+      assert.throws(() => txBuilder.sign({ key: defaultKeyPair.getKeys().prv }));
     });
 
     it('an address initialization transaction without public key', async () => {
       const txBuilder: any = getBuilder('xtz');
       txBuilder.type(TransactionType.AccountUpdate);
-      should.throws(
+      assert.throws(
         () => txBuilder.sign({ key: defaultKeyPair.getKeys().prv }),
         new RegExp('Cannot sign a public key revelation transaction without public key'),
       );
@@ -640,34 +641,34 @@ describe('Tezos Transaction builder', function () {
       const txBuilder: any = getBuilder('xtz');
       txBuilder.type(TransactionType.WalletInitialization);
       txBuilder.owner(defaultKeyPair.getKeys().pub);
-      should.throws(() => txBuilder.type(TransactionType.Send));
+      assert.throws(() => txBuilder.type(TransactionType.Send));
     });
 
     it('build a send transaction with owners', async () => {
       const txBuilder: any = getBuilder('xtz');
-      should.throws(() => txBuilder.owner(defaultKeyPair.getKeys().pub));
+      assert.throws(() => txBuilder.owner(defaultKeyPair.getKeys().pub));
     });
 
     it('build a transaction with an invalid branch id', async () => {
       const txBuilder: any = getBuilder('xtz');
-      should.throws(() => txBuilder.branch(''));
+      assert.throws(() => txBuilder.branch(''));
     });
 
     it('build a transaction with an invalid value', async () => {
       const txBuilder: any = getBuilder('xtz');
-      should.throws(() => txBuilder.initialBalance('-1'));
+      assert.throws(() => txBuilder.initialBalance('-1'));
     });
 
     it('build a non wallet initialization transaction with initial balance', async () => {
       const txBuilder: any = getBuilder('xtz');
       txBuilder.type(TransactionType.Send);
-      should.throws(() => txBuilder.initialBalance('100'));
+      assert.throws(() => txBuilder.initialBalance('100'));
     });
 
     it('build transfer for non send-type transaction', async () => {
       const txBuilder: any = getBuilder('xtz');
       txBuilder.type(TransactionType.WalletInitialization);
-      should.throws(() => txBuilder.transfer('100'), new RegExp('Transfers can only be set for send transactions'));
+      assert.throws(() => txBuilder.transfer('100'), new RegExp('Transfers can only be set for send transactions'));
     });
 
     it('add more owners than the multisig maximum', async () => {
@@ -676,7 +677,7 @@ describe('Tezos Transaction builder', function () {
       txBuilder.owner('sppk7ZWB8diU2TWehxdkWCV2DTFvn1hPz4qLjiD3nJQozKnoSEnSC8b');
       txBuilder.owner('sppk7Zq9KPtwkzkgAsha4jU29C43McgP2skK56tjd7KJjhcmH6AZC1F');
       txBuilder.owner('sppk7d2ztzbrLdBaTB7yzaWRkPfcWGsrNQNJdkBE9bCTSSzekLNzpvf');
-      should.throws(
+      assert.throws(
         () => txBuilder.owner('sppk7d2ztzbrLdBaTB7yzaWRkPfcWGsrNQNJdkBE9bCTSSzekLNzpvf'),
         new RegExp('A maximum of 3 owners'),
       );
@@ -686,7 +687,7 @@ describe('Tezos Transaction builder', function () {
       const txBuilder: any = getBuilder('xtz');
       txBuilder.type(TransactionType.WalletInitialization);
       txBuilder.owner('sppk7d2ztzbrLdBaTB7yzaWRkPfcWGsrNQNJdkBE9bCTSSzekLNzpvf');
-      should.throws(
+      assert.throws(
         () => txBuilder.owner('sppk7d2ztzbrLdBaTB7yzaWRkPfcWGsrNQNJdkBE9bCTSSzekLNzpvf'),
         new RegExp('Repeated owner public key'),
       );
@@ -695,13 +696,13 @@ describe('Tezos Transaction builder', function () {
     it('add an invalid owner public key', async () => {
       const txBuilder: any = getBuilder('xtz');
       txBuilder.type(TransactionType.WalletInitialization);
-      should.throws(() => txBuilder.owner('sppk'), new RegExp('Invalid public key'));
+      assert.throws(() => txBuilder.owner('sppk'), new RegExp('Invalid public key'));
     });
 
     it('add an invalid public key to reveal', async () => {
       const txBuilder: any = getBuilder('xtz');
       txBuilder.type(TransactionType.AccountUpdate);
-      should.throws(() => txBuilder.publicKeyToReveal('sppk'), new RegExp('Unsupported public key'));
+      assert.throws(() => txBuilder.publicKeyToReveal('sppk'), new RegExp('Unsupported public key'));
     });
 
     it('add the same public key to reveal twice', async () => {
@@ -709,7 +710,7 @@ describe('Tezos Transaction builder', function () {
       txBuilder.type(TransactionType.AccountUpdate);
       txBuilder.source(defaultKeyPair.getAddress());
       txBuilder.publicKeyToReveal(defaultKeyPair.getKeys().pub);
-      should.throws(
+      assert.throws(
         () => txBuilder.publicKeyToReveal(defaultKeyPair.getKeys().pub),
         new RegExp('Public key to reveal already set'),
       );
@@ -719,7 +720,7 @@ describe('Tezos Transaction builder', function () {
       const txBuilder: any = getBuilder('xtz');
       txBuilder.type(TransactionType.AccountUpdate);
       txBuilder.source(defaultKeyPair.getAddress());
-      should.throws(
+      assert.throws(
         () => txBuilder.publicKeyToReveal('sppk7d2ztzbrLdBaTB7yzaWRkPfcWGsrNQNJdkBE9bCTSSzekLNzpvf'),
         new RegExp('Public key does not match the source address'),
       );
@@ -736,7 +737,7 @@ describe('Tezos Transaction builder', function () {
         .to('KT1HUrt6kfvYyDEYCJ2GSjvTPZ6KmRfxLBU8')
         .fee('4764');
       txBuilder.sign({ key: defaultKeyPair.getKeys().prv });
-      should.throws(
+      assert.throws(
         () => txBuilder.type(TransactionType.WalletInitialization),
         new RegExp('Transaction contains transfers and can only be labeled as Send'),
       );

--- a/modules/account-lib/test/unit/coin/xtz/transferBuilder.ts
+++ b/modules/account-lib/test/unit/coin/xtz/transferBuilder.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 
 import { TransferBuilder } from '../../../../src/coin/xtz/transferBuilder';
@@ -51,7 +52,7 @@ describe('Tezos Transfer builder', function () {
   describe('should fail to', () => {
     it('build an empty transfer', async () => {
       const builder = new TransferBuilder();
-      should.throws(() => builder.build(), new RegExp('Missing transfer mandatory fields'));
+      assert.throws(() => builder.build(), new RegExp('Missing transfer mandatory fields'));
     });
 
     it('build a transfer without amount', async () => {
@@ -59,17 +60,17 @@ describe('Tezos Transfer builder', function () {
         .from('KT1NH2M23xovhw7uwWVuoGTYxykeCcVfSqhL')
         .to('tz1VRjRpVKnv16AVprFH1tkDn4TDfVqA893A')
         .fee('20');
-      should.throws(() => builder.build(), new RegExp('Missing transfer mandatory fields'));
+      assert.throws(() => builder.build(), new RegExp('Missing transfer mandatory fields'));
     });
 
     it('build a transfer without from address', async () => {
       const builder = new TransferBuilder().amount('10').to('tz1VRjRpVKnv16AVprFH1tkDn4TDfVqA893A').fee('20');
-      should.throws(() => builder.build(), new RegExp('Missing transfer mandatory fields'));
+      assert.throws(() => builder.build(), new RegExp('Missing transfer mandatory fields'));
     });
 
     it('build a transfer without destination address', async () => {
       const builder = new TransferBuilder().amount('10').from('KT1NH2M23xovhw7uwWVuoGTYxykeCcVfSqhL').fee('20');
-      should.throws(() => builder.build(), new RegExp('Missing transfer mandatory fields'));
+      assert.throws(() => builder.build(), new RegExp('Missing transfer mandatory fields'));
     });
 
     it('build a transfer without fee', async () => {
@@ -77,7 +78,7 @@ describe('Tezos Transfer builder', function () {
         .amount('10')
         .from('KT1NH2M23xovhw7uwWVuoGTYxykeCcVfSqhL')
         .to('tz1VRjRpVKnv16AVprFH1tkDn4TDfVqA893A');
-      should.throws(() => builder.build(), new RegExp('Missing transfer mandatory fields'));
+      assert.throws(() => builder.build(), new RegExp('Missing transfer mandatory fields'));
     });
   });
 });

--- a/modules/account-lib/test/unit/coin/xtz/util.ts
+++ b/modules/account-lib/test/unit/coin/xtz/util.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 import * as Utils from '../../../../src/coin/xtz/utils';
 import {
@@ -212,7 +213,7 @@ describe('XTZ util library', function () {
     });
 
     it('should fail if the contract address has the wrong format', function () {
-      should.throws(
+      assert.throws(
         () =>
           Utils.generateDataToSign(
             'tz2PtJ9zgEgFVTRqy6GXsst54tH3ksEnYvvS',
@@ -225,7 +226,7 @@ describe('XTZ util library', function () {
     });
 
     it('should fail if the destination address has the wrong format', function () {
-      should.throws(
+      assert.throws(
         () => Utils.generateDataToSign('KT1NH2M23xovhw7uwWVuoGTYxykeCcVfSqhL', 'abc', '0', '0'),
         new RegExp('Invalid destination address'),
       );
@@ -281,7 +282,7 @@ describe('XTZ util library', function () {
       ];
 
       for (const data of invalidKeys) {
-        should.throws(
+        assert.throws(
           () => Utils.decodeKey(data[0] as string, data[1] as HashType),
           new RegExp('Unsupported private key'),
         );

--- a/modules/account-lib/test/unit/index.ts
+++ b/modules/account-lib/test/unit/index.ts
@@ -1,9 +1,10 @@
+import assert from 'assert';
 import should from 'should';
 import { getBuilder } from '../../src';
 
 describe('Coin factory', () => {
   it('should fail to instantiate an unsupported coin', () => {
-    should.throws(() => getBuilder('fakeUnsupported'));
+    assert.throws(() => getBuilder('fakeUnsupported'));
   });
 
   it('should instantiate TRX builder properly', () => {

--- a/modules/account-lib/test/unit/keyPair/index.ts
+++ b/modules/account-lib/test/unit/keyPair/index.ts
@@ -1,7 +1,7 @@
 /**
  * @prettier
  */
-import should from 'should';
+import assert from 'assert';
 import { register } from '../../../src/keyPair';
 import * as coinModules from '../../../src';
 import { coins } from '@bitgo/statics';
@@ -26,7 +26,7 @@ describe('Key Pair Factory', () => {
     });
 
     it('should fail to instantiate an unsupported coin', () => {
-      should.throws(() => register('fakeUnsupported'));
+      assert.throws(() => register('fakeUnsupported'));
     });
   });
 

--- a/modules/account-lib/test/unit/mpc/tss.ts
+++ b/modules/account-lib/test/unit/mpc/tss.ts
@@ -1,7 +1,7 @@
 /**
  * @prettier
  */
-import * as should from 'should';
+import assert from 'assert';
 import * as bs58 from 'bs58';
 import { randomBytes } from 'crypto';
 import * as sol from '@solana/web3.js';
@@ -317,8 +317,8 @@ describe('TSS EDDSA key generation and signing', function () {
     });
 
     it('should fail if seed is not length 64', function () {
-      should.throws(() => MPC.keyShare(1, 2, 3, randomBytes(33)), 'Seed must have length 64');
-      should.throws(() => MPC.keyShare(1, 2, 3, randomBytes(66)), 'Seed must have length 64');
+      assert.throws(() => MPC.keyShare(1, 2, 3, randomBytes(33)), /Seed must have length 64/);
+      assert.throws(() => MPC.keyShare(1, 2, 3, randomBytes(66)), /Seed must have length 64/);
     });
   });
 });

--- a/modules/account-lib/test/unit/utils/crypto.ts
+++ b/modules/account-lib/test/unit/utils/crypto.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import should from 'should';
 
 import * as Crypto from '../../../src/utils/crypto';
@@ -40,15 +41,15 @@ describe('Crypto utils', function () {
 
   describe('should fail', function () {
     it('to get a valid uncompressed public key from an invalid xpub', () => {
-      should.throws(() => Crypto.xpubToUncompressedPub('xpub'));
+      assert.throws(() => Crypto.xpubToUncompressedPub('xpub'));
     });
 
     it('to get a valid raw private key from an invalid xprv', () => {
-      should.throws(() => Crypto.xprvToRawPrv('xprv'));
+      assert.throws(() => Crypto.xprvToRawPrv('xprv'));
     });
 
     it('to get a valid extended keys from an invalid raw private key', () => {
-      should.throws(() => Crypto.rawPrvToExtendedKeys('ABCD'));
+      assert.throws(() => Crypto.rawPrvToExtendedKeys('ABCD'));
     });
   });
 });

--- a/modules/account-lib/tsconfig.json
+++ b/modules/account-lib/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": ".",
-    "target": "es5",
     "strictPropertyInitialization": false,
     "esModuleInterop": true,
     "typeRoots": ["../../types", "./node_modules/@types", "../../node_modules/@types"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -917,19 +917,6 @@
   dependencies:
     buffer "^5.4.3"
 
-"@bitgo/utxo-lib@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@bitgo/utxo-lib/-/utxo-lib-2.2.1.tgz#566a8aedbb42ffe9dd80f9db815bc316dcee3421"
-  integrity sha512-RqevJSXHYdzhwH8JACQ4q/pLTNt0obGZU0d19BY+k6CdpWil2RuPxybxlFN1OISCldw4Z7/kZuV1Nu3FcLCAbw==
-  dependencies:
-    "@bitgo/blake2b" "^3.0.2"
-    bitcoin-ops "^1.3.0"
-    bitcoinjs-lib "npm:@bitgo/bitcoinjs-lib@6.1.0-rc.3"
-    bs58check "^2.0.0"
-    cashaddress "^1.1.0"
-    typeforce "^1.11.3"
-    varuint-bitcoin "^1.0.4"
-
 "@celo/base@1.5.2":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@celo/base/-/base-1.5.2.tgz#168ab5e4e30b374079d8d139fafc52ca6bfd4100"


### PR DESCRIPTION
- sets account-lib's build target to same as root (es2019)
- replaces should.throws with assert.throws