### PR TITLE
refactor(account-lib): refactor tss folder to easily add new signature schemes

### DIFF
--- a/modules/account-lib/src/mpc/tss/eddsa/eddsa.ts
+++ b/modules/account-lib/src/mpc/tss/eddsa/eddsa.ts
@@ -31,94 +31,27 @@
  */
 const assert = require('assert');
 import { randomBytes, createHash } from 'crypto';
-import { Ed25519Curve } from './curves';
-import Shamir from './shamir';
-import HDTree from './hdTree';
-import { bigIntFromBufferLE, bigIntToBufferLE, bigIntFromBufferBE, bigIntToBufferBE, clamp } from './util';
+import { Ed25519Curve } from '../../curves';
+import Shamir from '../../shamir';
+import HDTree from '../../hdTree';
+import { bigIntFromBufferLE, bigIntToBufferLE, bigIntFromBufferBE, bigIntToBufferBE, clamp } from '../../util';
+import {
+  KeyShare,
+  UShare,
+  YShare,
+  KeyCombine,
+  PShare,
+  SubkeyShare,
+  JShare,
+  SignShare,
+  Signature,
+  XShare,
+  RShare,
+  GShare,
+} from './types';
 
 // 2^256
 const base = BigInt('0x010000000000000000000000000000000000000000000000000000000000000000');
-
-export interface UShare {
-  i: number;
-  t: number;
-  n: number;
-  y: string;
-  seed: string;
-  chaincode: string;
-}
-
-export interface YShare {
-  i: number;
-  j: number;
-  y: string;
-  u: string;
-  chaincode: string;
-}
-
-export interface KeyShare {
-  uShare: UShare;
-  yShares: Record<number, YShare>;
-}
-
-export interface PShare {
-  i: number;
-  t: number;
-  n: number;
-  y: string;
-  u: string;
-  prefix: string;
-  chaincode: string;
-}
-
-export interface JShare {
-  i: number;
-  j: number;
-}
-
-interface KeyCombine {
-  pShare: PShare;
-  jShares: Record<number, JShare>;
-}
-
-interface SubkeyShare {
-  pShare: PShare;
-  yShares: Record<number, YShare>;
-}
-
-export interface XShare {
-  i: number;
-  y: string;
-  u: string;
-  r: string;
-  R: string;
-}
-
-export interface RShare {
-  i: number;
-  j: number;
-  u: string;
-  r: string;
-  R: string;
-}
-
-export interface SignShare {
-  xShare: XShare;
-  rShares: Record<number, RShare>;
-}
-
-export interface GShare {
-  i: number;
-  y: string;
-  gamma: string;
-  R: string;
-}
-
-interface Signature {
-  y: string;
-  R: string;
-  sigma: string;
-}
 
 export default class Eddsa {
   static curve: Ed25519Curve = new Ed25519Curve();
@@ -142,7 +75,7 @@ export default class Eddsa {
 
   keyShare(index: number, threshold: number, numShares: number, seed?: Buffer): KeyShare {
     assert(index > 0 && index <= numShares);
-    if (seed && seed.length != 64) {
+    if (seed && seed.length !== 64) {
       throw new Error('Seed must have length 64');
     }
 

--- a/modules/account-lib/src/mpc/tss/eddsa/index.ts
+++ b/modules/account-lib/src/mpc/tss/eddsa/index.ts
@@ -1,0 +1,6 @@
+import Eddsa from './eddsa';
+
+// EDDSA Specific types
+export * as EDDSA from './types';
+
+export default Eddsa;

--- a/modules/account-lib/src/mpc/tss/eddsa/types.ts
+++ b/modules/account-lib/src/mpc/tss/eddsa/types.ts
@@ -1,0 +1,80 @@
+export interface UShare {
+  i: number;
+  t: number;
+  n: number;
+  y: string;
+  seed: string;
+  chaincode: string;
+}
+
+export interface YShare {
+  i: number;
+  j: number;
+  y: string;
+  u: string;
+  chaincode: string;
+}
+
+export interface KeyShare {
+  uShare: UShare;
+  yShares: Record<number, YShare>;
+}
+
+export interface PShare {
+  i: number;
+  t: number;
+  n: number;
+  y: string;
+  u: string;
+  prefix: string;
+  chaincode: string;
+}
+
+export interface JShare {
+  i: number;
+  j: number;
+}
+
+export interface KeyCombine {
+  pShare: PShare;
+  jShares: Record<number, JShare>;
+}
+
+export interface SubkeyShare {
+  pShare: PShare;
+  yShares: Record<number, YShare>;
+}
+
+export interface XShare {
+  i: number;
+  y: string;
+  u: string;
+  r: string;
+  R: string;
+}
+
+export interface RShare {
+  i: number;
+  j: number;
+  u: string;
+  r: string;
+  R: string;
+}
+
+export interface SignShare {
+  xShare: XShare;
+  rShares: Record<number, RShare>;
+}
+
+export interface GShare {
+  i: number;
+  y: string;
+  gamma: string;
+  R: string;
+}
+
+export interface Signature {
+  y: string;
+  R: string;
+  sigma: string;
+}

--- a/modules/account-lib/src/mpc/tss/index.ts
+++ b/modules/account-lib/src/mpc/tss/index.ts
@@ -1,0 +1,7 @@
+import Eddsa, { EDDSA } from './eddsa';
+
+// exporting all eddsa types and making eddsa as default for backward compatibility
+export * from './eddsa/types';
+export default Eddsa;
+
+export { Eddsa, EDDSA };

--- a/modules/account-lib/test/unit/mpc/tss/eddsa/eddsa.ts
+++ b/modules/account-lib/test/unit/mpc/tss/eddsa/eddsa.ts
@@ -6,12 +6,17 @@ import * as bs58 from 'bs58';
 import { randomBytes } from 'crypto';
 import * as sol from '@solana/web3.js';
 
-import { Dot, Sol } from '../../../src';
+import { Dot, Sol } from '../../../../../src';
 
-import Eddsa from '../../../src/mpc/tss';
-import HDTree, { Ed25519BIP32 } from '../../../src/mpc/hdTree';
+import Eddsa from '../../../../../src/mpc/tss';
+import HDTree, { Ed25519BIP32 } from '../../../../../src/mpc/hdTree';
 
-import { bigIntFromBufferLE, bigIntToBufferLE, bigIntFromBufferBE, bigIntToBufferBE } from '../../../src/mpc/util';
+import {
+  bigIntFromBufferLE,
+  bigIntToBufferLE,
+  bigIntFromBufferBE,
+  bigIntToBufferBE,
+} from '../../../../../src/mpc/util';
 
 describe('TSS EDDSA key generation and signing', function () {
   let MPC: Eddsa;


### PR DESCRIPTION
## Problem
Since different signature schemes have its own specific functions without having necessary similarity in function parameters and intermediate steps needed, it's not feasible to properly define a base class / interface. But that said, the naming convention may be similar especially when it comes to shares which may have different parameters for different signature schemes causing name collisions. 

## Solution
This PR proposes a new architecture to define signature schemes in its on sub modules there by abstracting its own implementation avoiding potential collisions.

```
├── eddsa
│   ├── eddsa.ts
│   ├── index.ts
│   └── types.ts
├── ecdsa
│   ├── ecdsa.ts
│   ├── index.ts
│   └── types.ts
└── index.ts
```
 All implemenation specific to a signature scheme can be accessed from importing like as below


```
import {Eddsa, EDDSA} from './mpc/tss'; // Eddsa -> Implementation, EDDSA --> Interfaces
const shares: EDDSA.KeyShare = {\\* Eddsa specifc keyshare *\\}
```

TICKET:BG-48307