### PR TITLE
fix: v1 getWallet call

### DIFF
--- a/modules/bitgo/src/v2/coins/utxo/recovery/crossChainRecovery.ts
+++ b/modules/bitgo/src/v2/coins/utxo/recovery/crossChainRecovery.ts
@@ -103,9 +103,9 @@ export async function getWallet(bitgo: BitGo, coin: AbstractUtxoCoin, walletId: 
   }
 
   try {
-    return await this.bitgo.wallets().get({ id: walletId });
+    return await bitgo.wallets().get({ id: walletId });
   } catch (e) {
-    throw new Error(`could not get wallet ${walletId} from v1 or v2`);
+    throw new Error(`could not get wallet ${walletId} from v1 or v2: ${e.toString()}`);
   }
 }
 

--- a/modules/bitgo/test/v2/unit/coins/utxo/recovery/crossChainRecovery.ts
+++ b/modules/bitgo/test/v2/unit/coins/utxo/recovery/crossChainRecovery.ts
@@ -263,11 +263,13 @@ describe(`Cross-Chain Recovery getWallet`, async function () {
       const nockV2Wallet = nockBitGo(bitgo)
         .get(`/api/v2/${recoveryCoin.getChain()}/wallet/${recoveryWalletId}`)
         .reply(error);
+      const nockV1Wallet = nockBitGo(bitgo).get(`/api/v1/wallet/${recoveryWalletId}`).reply(error);
       await assert.rejects(
         () => getWallet(bitgo, recoveryCoin, recoveryWalletId),
-        Error(`could not get wallet ${recoveryWalletId} from v1 or v2`)
+        Error(`could not get wallet ${recoveryWalletId} from v1 or v2: ApiResponseError: ${error}`)
       );
       nockV2Wallet.done();
+      nockV1Wallet.done();
     }
   });
 


### PR DESCRIPTION
`bitgo.wallets().get()` mistakenly had a `this.` in front of it, causing the function to be `undefined`.  

This type of bug isn't caught automatically by typescript (surprisingly), but we can add `no-invalid-this` to the lint rules to prevent it. A ticket for that has been created: https://bitgoinc.atlassian.net/browse/BG-48397

Ticket: BG-48417