### PR TITLE
fix(bitgo): use dynamic config for eos decimal places

### DIFF
--- a/modules/bitgo/src/v2/coins/eos.ts
+++ b/modules/bitgo/src/v2/coins/eos.ts
@@ -223,6 +223,10 @@ export class Eos extends BaseCoin {
     return 1e4;
   }
 
+  get decimalPlaces(): number {
+    return 4;
+  }
+
   /**
    * Flag for sending value of 0
    * @returns {boolean} True if okay to send 0 value, false otherwise
@@ -361,7 +365,7 @@ export class Eos extends BaseCoin {
     const dividend = this.getBaseFactor();
     const bigNumber = new BigNumber(baseUnits).dividedBy(dividend);
     // set the format so commas aren't added to large coin amounts
-    return bigNumber.toFormat(4, null as any, { groupSeparator: '', decimalSeparator: '.' });
+    return bigNumber.toFormat(this.decimalPlaces, null as any, { groupSeparator: '', decimalSeparator: '.' });
   }
 
   /**

--- a/modules/bitgo/src/v2/coins/eosToken.ts
+++ b/modules/bitgo/src/v2/coins/eosToken.ts
@@ -47,7 +47,7 @@ export class EosToken extends Eos {
     return this.tokenConfig.tokenContractAddress;
   }
 
-  get decimalPlaces() {
+  get decimalPlaces(): number {
     return this.tokenConfig.decimalPlaces;
   }
 


### PR DESCRIPTION
CHEX is having issue displaying bignumber decimals where we
output 4 digits of decimals while they output 8 decimals.

Rounding up the number to reflect the changes.

Ticket: BG-47340