### PR TITLE
chore(express): bump bitgo version in express

### DIFF
--- a/modules/express/package.json
+++ b/modules/express/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "argparse": "^1.0.10",
-    "bitgo": "^14.1.0",
+    "bitgo": "^14.2.0-rc.7",
     "bluebird": "^3.5.3",
     "body-parser": "^1.19.0",
     "connect-timeout": "^1.9.0",


### PR DESCRIPTION
This version corrects the environment to get the right hsmpub key
https://github.com/BitGo/BitGoJS/pull/2278

STLX-16438