### PR TITLE
chore: add sdk-coin generator to monorepo

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,42 +1,40 @@
 # Installing
 
 In the BitGoJS/ directory: 
+
 ```bash
 $ yarn install
 ```
 
 # Documentation
+
 API and SDK documentation can be found at: https://app.bitgo.com/docs/.
 
 # Pull Requests
 
-Pull requests from third parties are more than welcome! When creating a pull
-request, a BitGo engineer will be automatically added as a reviewer.
+Pull requests from third parties are more than welcome! When creating a pull request, a BitGo engineer will be automatically added as a reviewer.
 
-If you notice that the integration test job never runs, don't worry - that's
-expected. The integration tests use a secret testing password, and so we can't
-run these tests on untrusted code (PRs from third parties) without reviewing
-first. Once your code is passing unit tests and has an initial review, a BitGo
-engineer will re-create your PR and sign your commits, and link back to the
-original PR.
+If you notice that the integration test job never runs, don't worry - that's expected. The integration tests use a secret testing password, and so we can't run these tests on untrusted code (PRs from third parties) without reviewing first. Once your code is passing unit tests and has an initial review, a BitGo engineer will re-create your PR and sign your commits, and link back to the original PR.
 
 # Things to Avoid
-You should not be using the `tsc` command in terminal. Doing so WITHOUT a tsconfig file
-(which informs tsc where to install files) would lead to translation files
-(ending with `d.ts` and `d.ts.map`) installed in an incorrect location.
 
-If this happens, navigate to the BitGoJs directory and run `git clean -f -d` to remove
-any errant files. Avoid using npm commands and stick with yarn.
+You should not be using the `tsc` command in terminal. Doing so WITHOUT a tsconfig file (which informs tsc where to install files) would lead to translation files (ending with `d.ts` and `d.ts.map`) installed in an incorrect location.
 
- Instead, you should just run 
-```
+If this happens, navigate to the BitGoJs directory and run `git clean -f -d` to remove any errant files. Avoid using npm commands and stick with yarn.
+
+Instead, you should just run:
+
+```bash
 yarn dev
 ```
-from the root of the repo while developing. This will compile all of the linked TypeScript packages & begin watching for changes. If you want to just do a one time build, then simply running
-```
+
+from the root of the repo while developing. This will compile all of the linked TypeScript packages & begin watching for changes. If you want to just do a one time build, then simply running:
+
+```bash
 yarn
 ```
-from the root of the repo is what you'll want to do.
+
+From the root of the repo is what you'll want to do.
 
 # Commit Messages
 
@@ -54,6 +52,7 @@ $ yarn run unit-test --scope bitgo
 ```
 
 You can also run unit tests for all modules in parallel:
+
 ```bash
 $ yarn run unit-test
 ```
@@ -66,13 +65,13 @@ $ yarn run unit-test-changed
 Or the file that contains a specific string
  - if you are a specific module:
 
-```
+```bash
 $ yarn run unit-test --grep"keyword"
 ```
 
 - if you are in the BitGoJs/ top-level directory
  
-```
+```bash
 $ yarn run unit-test -- -- --grep "keyword"
 ```                                        
 **Note:** Each module's output will be prefixed with it's name, but it may be difficult to unmangle the test output.
@@ -82,7 +81,8 @@ To aid with evaluating test results, and especially test failures, a fancy test 
 The link to this report is output in the "upload reports" stage of each build pipeline.
 
 Here is an example of this output:
-```
+
+```bash
 @bitgo/express: === TEST REPORT UPLOADED SUCCESSFULLY ===
 @bitgo/express: https://bitgo-sdk-test-reports.s3.amazonaws.com/1036/express/unit tests (node:6).html
 ```
@@ -91,23 +91,22 @@ Here is an example of this output:
 
 ## Should I make a new module for my contribution?
 
-This is a question you should ask before making large changes to the SDK. The original goal of modularizing the SDK was
-to allow users to only include support for the features they actually want to use, instead of bringing in hundreds of
-megabytes of dependencies which they won't use.
+This is a question you should ask before making large changes to the SDK. The original goal of modularizing the SDK was to allow users to only include support for the features they actually want to use, instead of bringing in hundreds of megabytes of dependencies which they won't use.
 
-Therefore, if your feature meets the following criteria, then it is a good candidate for being its own module.
-Otherwise, perhaps not.
+Therefore, if your feature meets the following criteria, then it is a good candidate for being its own module. Otherwise, perhaps not.
 
 1. Will this feature require additional dependencies to be added? How heavy are those dependencies?
 1. Is this feature something which would only be used by a small fraction of SDK users?
-1. Is this feature extending existing bitgo functionality, or is it providing entirely new functionality? For example,
-   adding a new coin would be extending existing bitgo functionality.
+1. Is this feature extending existing bitgo functionality, or is it providing entirely new functionality? For example, adding a new coin would be extending existing bitgo functionality.
 
-These recommendations are just that, recommendations. Please use your best judgement when it comes to how your change is
-architected.
+These recommendations are just that, recommendations. Please use your best judgement when it comes to how your change is architected.
 
 ## Module Configuration
+
+If you are implementing a new coin, skip to [Coin Implementation](#coin-implementation-new)
+
 Each module should have the following basic file structure:
+
 ```
 - modules/
   - mymodule/
@@ -122,33 +121,33 @@ Each module should have the following basic file structure:
     - README.md
 ```
 
-## `package.json`
+### `package.json`
 
-* ### `name`
+* #### `name`
 For a binary application module named "fooapp", this should be set to `@bitgo/fooapp`.
 
 For a generic library module named "bar", this should be set to `@bitgo/sdk-lib-bar`.
 
 For a coin library module which supports a coin with ticker "BAZ", this should be set to `@bitgo/sdk-coin-baz`.
 
-* ### `scripts`
+* #### `scripts`
 
 These npm scripts may be run during lifecycle events and by lerna across all modules. If a script is not present in a module, that module will be skipped.
 
-| Name | Description | Required? |
-| --- | --- | --- |
-| `test` / `unit-test` | Run module unit tests | Yes |
-| `integration-test` | Run module integration tests. These are run when a PR is targeted to merge against master. | No |
-| `prepare` / `build` | Compile typescript sources | No |
-| `clean` | Clean up generated build files | No |
-| `audit` | Run a vulnerability against the module dependencies | Yes |
-| `gen-coverage` | Generate a code coverage report | No |
-| `upload-coverage` | Upload a code coverage report | No |
-| `upload-artifacts` | Upload any artifacts produced by the build and test process | No |
+| Name                 | Description                                                                                | Required? |
+|----------------------|--------------------------------------------------------------------------------------------|-----------|
+| `test` / `unit-test` | Run module unit tests                                                                      | Yes       |
+| `integration-test`   | Run module integration tests. These are run when a PR is targeted to merge against master. | No        |
+| `prepare` / `build`  | Compile typescript sources                                                                 | No        |
+| `clean`              | Clean up generated build files                                                             | No        |
+| `audit`              | Run a vulnerability against the module dependencies                                        | Yes       |
+| `gen-coverage`       | Generate a code coverage report                                                            | No        |
+| `upload-coverage`    | Upload a code coverage report                                                              | No        |
+| `upload-artifacts`   | Upload any artifacts produced by the build and test process                                | No        |
 
 Additional scripts which are too large for the package.json file should be placed in `scripts/` and should be plain javascript or bash.
 
-* ### `repository`
+* #### `repository`
 
 This shall always be set for all modules to:
 ```json
@@ -160,23 +159,23 @@ This shall always be set for all modules to:
 }
 ```
 
-* ### `license`
+* #### `license`
 
 License shall be `Apache-2.0`.
 
-* ### `engines`
+* #### `engines`
 
 Engines should be set to the following:
 ```json
 {
   "engines": {
-    "node": ">=6.12.3 <13.0.0",
+    "node": ">=14 <17",
     "npm": ">=3.10.10"
   }
 }
 ```
 
-## `tsconfig.json`
+### `tsconfig.json`
 
 There are a few things each module's `tsconfig.json` must do:
 * Extend the root tsconfig.json
@@ -208,5 +207,39 @@ Here is a template to help get started:</br>
 }
 ```
 
-## `tsconfig.packages.json`
+### `tsconfig.packages.json`
 Each package should also be listed in the root level `tsconfig.packages.json` as well. 
+
+## New Coin Implementation
+
+SDK coins provide a modular approach to a monolithic architecture. This and all BitGoJS SDK coins allow developers to use only the coins needed for a given project.
+
+To implement a new coin for BitGoJS, from the root BitGoJS/ run:
+
+```bash
+npm install -g yo
+```
+
+You can now run the coin generation script:
+
+```bash
+yarn sdk-coin:new
+```
+
+This will prompt you for both the coin's name (mainnet and testnet), symbol, and base factor. A new coin folder will be autogenerated in the `/modules` folder. This new coin folder will follow all the above conventions and set you up with the base implementation to implement coin specific packages with BitGo required classes.
+
+Additional information about coin development can be found in the newly created coin's README.md file.
+
+Due to supporting legacy versions of registering coins to `bitgo`, you will continue to add new coin definitions to `@bitgo/statics` **AND** the coin registration to `bitgo`'s CoinFactory.
+
+### Coin Creation Options
+
+Upon creating coins, you are given different options to choose from to create your boilerplate. This skeleton gives you the base needs for implementing a coin to interact with BitGo services. You will need to install coin specific packages into your newly created and registered bitgo package. You will then need to hook up coin package methods into the boilerplate provided.
+
+> Do not install coin packages in the root of BitGoJS. They must be scoped to their respective package.
+
+| Option | Description |
+|--------|-------------|
+| Account | Used for account based coins. Eth based or "Eth like". |
+| Utxo | Used for utxo based coins. Bitcoin, Litecoin, etc... |
+| Simple | Base implementation extending BaseCoin. |

--- a/modules/bitgo/tsconfig.json
+++ b/modules/bitgo/tsconfig.json
@@ -3,11 +3,19 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./",
-    "typeRoots": ["./types", "../../types", "./node_modules/@types", "../../node_modules/@types"],
+    "typeRoots": [
+      "./types",
+      "../../types",
+      "./node_modules/@types",
+      "../../node_modules/@types"
+    ],
     "declarationDir": "./dist/types",
     "esModuleInterop": false
   },
-  "include": ["src/**/*", "package.json"],
+  "include": [
+    "src/**/*",
+    "package.json"
+  ],
   "typedocOptions": {
     "mode": "modules",
     "out": "docs",
@@ -34,10 +42,10 @@
       "path": "../sdk-core"
     },
     {
-      "path": "../statics"
+      "path": "../sdk-test"
     },
     {
-      "path": "../sdk-test"
+      "path": "../statics"
     }
   ]
 }

--- a/modules/sdk-api/package.json
+++ b/modules/sdk-api/package.json
@@ -17,7 +17,7 @@
     "webpack-prod": "webpack --mode=production --node-env=production",
     "prepublishOnly": "npm run webpack-prod"
   },
-  "author": "BitGo Inc.",
+  "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/modules/sdk-core/package.json
+++ b/modules/sdk-core/package.json
@@ -13,7 +13,7 @@
     "precommit": "yarn lint-staged",
     "prepare": "npm run build"
   },
-  "author": "BitGo Inc.",
+  "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/modules/utxo-lib/package.json
+++ b/modules/utxo-lib/package.json
@@ -71,5 +71,6 @@
   "publishConfig": {
     "access": "public"
   },
+  "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "prettier": "^2.3.0",
     "rimraf": "^3.0.2",
     "ts-node": "10.8.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.2.4",
+    "yeoman-generator": "^5.6.1"
   },
   "resolutions": {
     "minimist": "1.2.6",
@@ -62,6 +63,8 @@
     "check-commits": "yarn commitlint --from=origin/${DRONE_REPO_BRANCH:-master} -V",
     "check-versions": "node ./check-package-versions.js",
     "dev": "tsc -b ./tsconfig.packages.json -w",
-    "prepare": "husky install"
-  }
+    "prepare": "husky install",
+    "sdk-coin:new": "yo ./scripts/sdk-coin-generator"
+  },
+  "dependencies": {}
 }

--- a/scripts/sdk-coin-generator/index.js
+++ b/scripts/sdk-coin-generator/index.js
@@ -1,0 +1,235 @@
+const Generator = require('yeoman-generator');
+const fs = require('fs');
+
+require('yeoman-generator/lib/actions/install');
+
+module.exports = class extends Generator {
+  constructor(args, opts) {
+    super(args, opts, { customInstallTask: true });
+    this.env.options.nodePackageManager = 'npm';
+  }
+
+  async prompting() {
+    const answers = await this.prompt([
+      {
+        type: 'input',
+        name: 'coin',
+        message: 'What is the name of your coin? (e.g. Bitcoin) - Sentence Case',
+        validate: function(input) {
+          const done = this.async();
+          if (!input) {
+            done('Please provide the name of the coin.');
+          }
+          done(null, true);
+        },
+      },
+      {
+        type: 'input',
+        name: 'symbol',
+        message: 'What is the symbol of your coin? (e.g. btc) - Lowercase',
+        validate: function(input) {
+          const done = this.async();
+          if (!input) {
+            done('Please provide a symbol.');
+          }
+          done(null, true);
+        },
+      },
+      {
+        type: 'confirm',
+        name: 'testnetConfirm',
+        message: 'Would you like to add a testnet symbol?',
+      },
+      {
+        type: 'input',
+        name: 'testnetSymbol',
+        message: 'What is the testnet symbol of your coin? (e.g. tbtc) - Lowercase',
+        validate: function(input) {
+          const done = this.async();
+          if (!input) {
+            done('Please provide a testnet symbol.');
+          }
+          done(null, true);
+        },
+        when: function(answers) {
+          if (answers.testnetConfirm) {
+            return true;
+          }
+        },
+      },
+      {
+        type: 'input',
+        name: 'baseFactor',
+        message: 'What is the base factor? (e.g. 1e6)',
+        validate: function(input) {
+          const done = this.async();
+          if (!input) {
+            done('Please provide a base factor.');
+          }
+          done(null, true);
+        },
+      },
+      {
+        type: 'list',
+        name: 'boilerplate',
+        message: 'Which boilerplate would you like?',
+        choices: [
+          { name: 'Simple (default)', value: 'simple' },
+          { name: 'Account', value: 'account' },
+          { name: 'Utxo', value: 'utxo' },
+        ],
+      },
+    ]);
+
+    answers.symbol.toLowerCase();
+    if (answers.testnetSymbol) {
+      answers.testnetSymbol.toLowerCase();
+    } else {
+      answers.testnetSymbol = answers.symbol;
+    }
+    answers.coin = toSentenceCase(answers.coin);
+    answers.constructor = toSentenceCase(answers.symbol);
+    if (answers.testnetSymbol) {
+      answers.testnetConstructor = toSentenceCase(answers.testnetSymbol);
+    } else {
+      answers.testnetConstructor = toSentenceCase(answers.constructor);
+    }
+    this.answers = { ...answers };
+  }
+  
+  paths() {
+    const destinationPath = `${this.contextRoot}/modules/sdk-coin-${this.answers.symbol}`;
+    const templatePath = `${this.contextRoot}/scripts/sdk-coin-generator/template`;
+
+    this.destinationRoot(destinationPath);
+    this.sourceRoot(templatePath);
+  }
+  
+  async writing() {
+    this.fs.copyTpl(
+      this.templatePath('./base'),
+      this.destinationPath(),
+      { ...this.answers }
+    );
+    this.fs.copyTpl(
+      this.templatePath('./base/.eslintignore'),
+      this.destinationPath('.eslintignore')
+    );
+    this.fs.copyTpl(
+      this.templatePath('./base/.gitignore'),
+      this.destinationPath('.gitignore')
+    );
+    this.fs.copyTpl(
+      this.templatePath('./base/.mocharc.js'),
+      this.destinationPath('.mocharc.js')
+    );
+    this.fs.copyTpl(
+      this.templatePath('./base/.npmignore'),
+      this.destinationPath('.npmignore')
+    );
+    this.fs.copyTpl(
+      this.templatePath('./base/.prettierignore'),
+      this.destinationPath('.prettierignore')
+    );
+    this.fs.copyTpl(
+      this.templatePath('./base/.prettierrc.yml'),
+      this.destinationPath('.prettierrc.yml')
+    );
+
+    let templatePath = './boilerplates/simple';
+
+    switch (this.answers.boilerplate) {
+      case 'account':
+        templatePath = './boilerplates/account';
+        break;
+      case 'utxo':
+        templatePath = './boilerplates/utxo';
+        break;
+      default:
+        templatePath = './boilerplates/simple';
+        break;
+    }
+
+    this.fs.copyTpl(
+      this.templatePath(templatePath),
+      this.destinationPath('./src'),
+      { ...this.answers }
+    );
+
+    this.fs.copyTpl(
+      this.templatePath(`${templatePath}/.mainnet.ts`),
+      this.destinationPath(`./src/${this.answers.symbol}.ts`),
+      { ...this.answers }
+    );
+
+    if (this.answers.testnetSymbol) {
+      this.fs.copyTpl(
+        this.templatePath(`${templatePath}/.testnet.ts`),
+        this.destinationPath(`./src/${this.answers.testnetSymbol}.ts`),
+        { ...this.answers }
+      );
+    }
+
+    addNewCoinToTsConfig(this.contextRoot, this.answers);
+    addNewCoinToBitgo(this.contextRoot, this.answers);
+    addNewCoinToBitgoTsConfig(this.contextRoot, this.answers);
+
+    await this.addDependencies({
+      '@bitgo/sdk-core': '^1.0.1',
+    });
+
+    await this.addDevDependencies({
+      '@bitgo/sdk-test': '^1.0.0',
+    });
+  }
+};
+
+function addNewCoinToTsConfig(contextRoot, answers) {
+  const file = `${contextRoot}/tsconfig.packages.json`;
+
+  const rawData = fs.readFileSync(file);
+  const data = JSON.parse(rawData);
+  
+  data.references.push({ path: `./modules/sdk-coin-${answers.symbol}` });
+  data.references = data.references.filter((value, index, self) =>
+    index === self.findIndex((t) => (t.path === value.path)));
+  data.references.sort((a, b) => a.path > b.path ? 1 : -1);
+
+  fs.writeFileSync(file, JSON.stringify(data, null, 2).concat('\n'));
+}
+
+function addNewCoinToBitgo(contextRoot, answers) {
+  const file = `${contextRoot}/modules/bitgo/package.json`;
+
+  const rawData = fs.readFileSync(file);
+  const data = JSON.parse(rawData);
+
+  data.dependencies[`@bitgo/sdk-coin-${answers.symbol}`] = '^1.0.0';
+
+  const depArr = Object.entries(data.dependencies).sort((a, b) => a[0] > b[0] ? 1 : -1);
+  data.dependencies = depArr.reduce((acc, cur) => {
+    acc[cur[0]] = cur[1];
+    return acc;
+  }, {});
+
+  fs.writeFileSync(file, JSON.stringify(data, null, 2).concat('\n'));
+}
+
+function addNewCoinToBitgoTsConfig(contextRoot, answers) {
+  const file = `${contextRoot}/modules/bitgo/tsconfig.json`;
+
+  const rawData = fs.readFileSync(file);
+  const data = JSON.parse(rawData);
+
+  data.references.push({ path: `../sdk-coin-${answers.symbol}` });
+  data.references = data.references.filter((value, index, self) =>
+    index === self.findIndex((t) => (t.path === value.path)));
+  data.references.sort((a, b) => a.path > b.path ? 1 : -1);
+
+  fs.writeFileSync(file, JSON.stringify(data, null, 2).concat('\n'));
+}
+
+function toSentenceCase(theString) {
+  const newString = theString.toLowerCase().replace(/(^\s*\w|[\.\!\?]\s*\w)/g, function(c) {return c.toUpperCase();});
+  return newString;
+}

--- a/scripts/sdk-coin-generator/template/base/.eslintignore
+++ b/scripts/sdk-coin-generator/template/base/.eslintignore
@@ -1,0 +1,5 @@
+node_modules
+.idea
+public
+dist
+

--- a/scripts/sdk-coin-generator/template/base/.gitignore
+++ b/scripts/sdk-coin-generator/template/base/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.idea/
+dist/

--- a/scripts/sdk-coin-generator/template/base/.mocharc.js
+++ b/scripts/sdk-coin-generator/template/base/.mocharc.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = {
+  require: 'ts-node/register',
+  timeout: '20000',
+  reporter: 'mochawesome',
+  'reporter-option': ['cdn=true', 'json=false'],
+  exit: true,
+  spec: ['test/unit/*.ts'],
+};

--- a/scripts/sdk-coin-generator/template/base/.npmignore
+++ b/scripts/sdk-coin-generator/template/base/.npmignore
@@ -1,0 +1,13 @@
+!dist/
+.idea/
+.prettierrc.yml
+tsconfig.json
+src/
+mochawesome-report/
+test/
+scripts/
+.nyc_output
+CODEOWNERS
+node_modules/
+.prettierignore
+.mocharc.js

--- a/scripts/sdk-coin-generator/template/base/.prettierignore
+++ b/scripts/sdk-coin-generator/template/base/.prettierignore
@@ -1,0 +1,3 @@
+.nyc_output/
+dist/
+mochawesome-report/

--- a/scripts/sdk-coin-generator/template/base/.prettierrc.yml
+++ b/scripts/sdk-coin-generator/template/base/.prettierrc.yml
@@ -1,0 +1,3 @@
+printWidth: 120
+singleQuote: true
+trailingComma: 'es5'

--- a/scripts/sdk-coin-generator/template/base/README.md
+++ b/scripts/sdk-coin-generator/template/base/README.md
@@ -1,0 +1,36 @@
+# BitGo sdk-coin-<%= symbol %>
+
+SDK coins provide a modular approach to a monolithic architecture. This and all BitGoJS SDK coins allow developers to use only the coins needed for a given project.
+
+## Installation
+
+All coins are loaded traditionally through the `bitgo` package. If you are using coins individually, you will be accessing the coin via the `@bitgo/sdk-api` package.
+
+In your project install both `@bitgo/sdk-api` and `@bitgo/sdk-coin-<%= symbol %>`.
+
+```shell
+npm i @bitgo/sdk-api @bitgo/sdk-coin-<%= symbol %>
+```
+
+Next, you will be able to initialize an instance of "bitgo" through `@bitgo/sdk-api` instead of via `bitgo`.
+
+```javascript
+import { BitGo } from '@bitgo/sdk-api';
+
+async function init() {
+  const <%= symbol %> = await import('@bitgo/sdk-coin-<%= symbol %>');
+  BitGo.register(<%= coin %>, <%= symbol %>);
+  return new BitGo()
+}
+
+async function main() {
+  (await init()).coin('<%= symbol %>');
+}
+
+```
+
+## Development
+
+Most of the coin implementations are derived from `@bitgo/sdk-core`, `@bitgo/statics`, and coin specific packages. These implementations are used to interact with the BitGo API and BitGo platform services.
+
+You will notice that the basic version of common class extensions have been provided to you and must be resolved before the package build will succeed. Upon initiation of a given SDK coin, you will need to verify that your coin has been included in the root `tsconfig.packages.json` and that the linting, formatting, and testing succeeds when run both within the coin and from the root of BitGoJS.

--- a/scripts/sdk-coin-generator/template/base/package.json
+++ b/scripts/sdk-coin-generator/template/base/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@bitgo/sdk-coin-<%= symbol %>",
+  "version": "1.0.0",
+  "description": "BitGo SDK coin library for <%= coin %>",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "yarn tsc --build --incremental --verbose .",
+    "fmt": "prettier --write .",
+    "check-fmt": "prettier --check .",
+    "clean": "rm -r ./dist",
+    "lint": "eslint --quiet .",
+    "precommit": "yarn lint-staged",
+    "prepare": "npm run build",
+    "test": "npm run coverage",
+    "coverage": "nyc -- npm run unit-test",
+    "unit-test": "mocha"
+  },
+  "author": "BitGo SDK Team <sdkteam@bitgo.com>",
+  "license": "MIT",
+  "engines": {
+    "node": ">=14 <17"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BitGo/BitGoJS.git",
+    "directory": "modules/sdk-coin-<%= symbol %>"
+  },
+  "lint-staged": {
+    "*.{js,ts}": [
+      "yarn prettier --write",
+      "yarn eslint --fix"
+    ]
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "nyc": {
+    "extension": [
+      ".ts"
+    ]
+  }
+}

--- a/scripts/sdk-coin-generator/template/base/test/unit/index.ts
+++ b/scripts/sdk-coin-generator/template/base/test/unit/index.ts
@@ -1,0 +1,46 @@
+import * as nock from 'nock';
+import 'should';
+
+import { TestBitGo, TestBitGoAPI } from '@bitgo/sdk-test';
+import { BitGoAPI } from '@bitgo/sdk-api';
+
+import { <%= testnetConstructor %> } from '../../src/index';
+
+nock.disableNetConnect();
+
+const bitgo: TestBitGoAPI = TestBitGo.decorate(BitGoAPI, { env: 'test' });
+bitgo.safeRegister('<%= testnetSymbol %>', <%= testnetConstructor %>.createInstance);
+
+describe('<%= coin %>', function () {
+  let bitgo;
+  let basecoin;
+
+  before(function () {
+    bitgo.initializeTestVars();
+    basecoin = bitgo.coin('<%= testnetSymbol %>');
+  });
+
+  after(function () {
+    nock.pendingMocks().should.be.empty();
+  });
+
+  it('should instantiate the coin', function () {
+    const basecoin = bitgo.coin('<%= testnetSymbol %>');
+    basecoin.should.be.an.instanceof(<%= testnetConstructor %>);
+  });
+
+  it('isValidAddress should be correct', function () {
+    // Add valid addresses for testing
+    basecoin.isValidAddress('').should.be.True();
+    basecoin.isValidAddress('').should.be.True();
+    basecoin.isValidAddress('').should.be.True();
+  });
+
+  it('verifyAddress should work', function () {
+
+  }
+
+  it('Should be able to explain an <%= coin %> transaction', async function () {
+    
+  });
+});

--- a/scripts/sdk-coin-generator/template/base/tsconfig.json
+++ b/scripts/sdk-coin-generator/template/base/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strictPropertyInitialization": false,
+    "esModuleInterop": true,
+    "typeRoots": ["../../types", "./node_modules/@types", "../../node_modules/@types"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "references": [
+    {
+      "path": "../sdk-core"
+    },
+    {
+      "path": "../sdk-test"
+    },
+  ]
+}

--- a/scripts/sdk-coin-generator/template/boilerplates/account/.mainnet.ts
+++ b/scripts/sdk-coin-generator/template/boilerplates/account/.mainnet.ts
@@ -1,0 +1,44 @@
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
+import { BaseCoin as StaticsBaseCoin, CoinFamily } from '@bitgo/statics';
+import { AbstractEthLikeCoin } from '@bitgo/abstract-eth';
+
+export class <%= constructor %> extends AbstractEthLikeCoin {
+  protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
+
+  protected constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
+    super(bitgo);
+
+    if (!staticsCoin) {
+      throw new Error('missing required constructor parameter staticsCoin');
+    }
+
+    this._staticsCoin = staticsCoin;
+  }
+
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+    return new <%= constructor %>(bitgo, staticsCoin);
+  }
+
+  getBaseFactor(): number {
+    return Math.pow(10, this._staticsCoin.decimalPlaces);
+  }
+
+  getChain() {
+    return this._staticsCoin.name;
+  }
+
+  /**
+   * Get the base chain that the coin exists on.
+   */
+  getBaseChain() {
+    return this.getChain();
+  }
+
+  getFamily(): CoinFamily {
+    return this._staticsCoin.family;
+  }
+
+  getFullName() {
+    return this._staticsCoin.fullName;
+  }
+}

--- a/scripts/sdk-coin-generator/template/boilerplates/account/.testnet.ts
+++ b/scripts/sdk-coin-generator/template/boilerplates/account/.testnet.ts
@@ -1,0 +1,18 @@
+/**
+ * Testnet <%= constructor %>
+ *
+ * @format
+ */
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
+import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
+import { <%= constructor %> } from './<%= symbol %>';
+
+export class <%= testnetConstructor %> extends <%= constructor %> {
+  protected constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
+    super(bitgo, staticsCoin);
+  }
+
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+    return new <%= testnetConstructor %>(bitgo, staticsCoin);
+  }
+}

--- a/scripts/sdk-coin-generator/template/boilerplates/account/common/address.ts
+++ b/scripts/sdk-coin-generator/template/boilerplates/account/common/address.ts
@@ -1,0 +1,3 @@
+import { BaseAddress } from '@bitgo/sdk-core';
+
+export class Address implements BaseAddress {}

--- a/scripts/sdk-coin-generator/template/boilerplates/account/common/enum.ts
+++ b/scripts/sdk-coin-generator/template/boilerplates/account/common/enum.ts
@@ -1,0 +1,3 @@
+export enum ContractType {}
+
+export enum PermissionType {}

--- a/scripts/sdk-coin-generator/template/boilerplates/account/common/index.ts
+++ b/scripts/sdk-coin-generator/template/boilerplates/account/common/index.ts
@@ -1,0 +1,10 @@
+// import * as Utils from './utils';
+// import * as Interface from './iface';
+
+export { Address } from './address';
+export { KeyPair } from './keyPair';
+export { Transaction } from './transaction';
+export { TransactionBuilder } from './transactionBuilder';
+export { TransactionBuilderFactory } from './transactionBuilderFactory';
+
+// export { Utils, Interface };

--- a/scripts/sdk-coin-generator/template/boilerplates/account/common/keyPair.ts
+++ b/scripts/sdk-coin-generator/template/boilerplates/account/common/keyPair.ts
@@ -1,0 +1,42 @@
+import {
+  AddressFormat,
+  BaseKeyPair,
+  BlsKeyPair,
+  DefaultKeys,
+  Ed25519KeyPair,
+  Secp256k1ExtendedKeyPair,
+} from '@bitgo/sdk-core';
+
+export class KeyPair implements BaseKeyPair {
+  recordKeysFromPrivateKey(prv: string): void {
+    throw new Error('Method not implemented.');
+  }
+  recordKeysFromPublicKey(pub: string): void {
+    throw new Error('Method not implemented.');
+  }
+  getKeys() {
+    throw new Error('Method not implemented.');
+  }
+  getAddress(format?: AddressFormat): string {
+    throw new Error('Method not implemented.');
+  }
+}
+
+export class KeyPair1 extends BlsKeyPair {}
+
+export class KeyPair2 extends Ed25519KeyPair {
+  recordKeysFromPrivateKeyInProtocolFormat(prv: string): DefaultKeys {
+    throw new Error('Method not implemented.');
+  }
+  recordKeysFromPublicKeyInProtocolFormat(pub: string): DefaultKeys {
+    throw new Error('Method not implemented.');
+  }
+  getAddress(format?: AddressFormat): string {
+    throw new Error('Method not implemented.');
+  }
+  getKeys() {
+    throw new Error('Method not implemented.');
+  }
+}
+
+export class KeyPair3 extends Secp256k1ExtendedKeyPair {}

--- a/scripts/sdk-coin-generator/template/boilerplates/account/common/transaction.ts
+++ b/scripts/sdk-coin-generator/template/boilerplates/account/common/transaction.ts
@@ -1,0 +1,13 @@
+import { BaseKey, BaseTransaction } from '@bitgo/sdk-core';
+
+export class Transaction extends BaseTransaction {
+  canSign(key: BaseKey): boolean {
+    throw new Error('Method not implemented.');
+  }
+  toJson() {
+    throw new Error('Method not implemented.');
+  }
+  toBroadcastFormat() {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/scripts/sdk-coin-generator/template/boilerplates/account/common/transactionBuilder.ts
+++ b/scripts/sdk-coin-generator/template/boilerplates/account/common/transactionBuilder.ts
@@ -1,0 +1,35 @@
+import { BaseAddress, BaseKey, BaseTransaction, BaseTransactionBuilder } from '@bitgo/sdk-core';
+import BigNumber from 'bignumber.js';
+
+export class TransactionBuilder extends BaseTransactionBuilder {
+  protected fromImplementation(rawTransaction: any): BaseTransaction {
+    throw new Error('Method not implemented.');
+  }
+  protected signImplementation(key: BaseKey): BaseTransaction {
+    throw new Error('Method not implemented.');
+  }
+  protected buildImplementation(): Promise<BaseTransaction> {
+    throw new Error('Method not implemented.');
+  }
+  validateKey(key: BaseKey): void {
+    throw new Error('Method not implemented.');
+  }
+  validateAddress(address: BaseAddress, addressFormat?: string): void {
+    throw new Error('Method not implemented.');
+  }
+  validateValue(value: BigNumber): void {
+    throw new Error('Method not implemented.');
+  }
+  validateRawTransaction(rawTransaction: any): void {
+    throw new Error('Method not implemented.');
+  }
+  validateTransaction(transaction?: BaseTransaction): void {
+    throw new Error('Method not implemented.');
+  }
+  protected get transaction(): BaseTransaction {
+    throw new Error('Method not implemented.');
+  }
+  protected set transaction(transaction: BaseTransaction) {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/scripts/sdk-coin-generator/template/boilerplates/account/common/transactionBuilderFactory.ts
+++ b/scripts/sdk-coin-generator/template/boilerplates/account/common/transactionBuilderFactory.ts
@@ -1,0 +1,13 @@
+import { BaseTransactionBuilderFactory } from '@bitgo/sdk-core';
+
+export class TransactionBuilderFactory extends BaseTransactionBuilderFactory {
+  public getWalletInitializationBuilder() {
+    throw new Error('Method not implemented.');
+  }
+  public getTransferBuilder() {
+    throw new Error('Method not implemented.');
+  }
+  public from(raw: string | Uint8Array) {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/scripts/sdk-coin-generator/template/boilerplates/account/index.ts
+++ b/scripts/sdk-coin-generator/template/boilerplates/account/index.ts
@@ -1,0 +1,3 @@
+export * from './common';
+export * from './<%= symbol %>';
+export * from './<%= testnetSymbol %>';

--- a/scripts/sdk-coin-generator/template/boilerplates/simple/.mainnet.ts
+++ b/scripts/sdk-coin-generator/template/boilerplates/simple/.mainnet.ts
@@ -1,0 +1,68 @@
+import {
+  BaseCoin,
+  BitGoBase,
+  KeyPair,
+  ParsedTransaction,
+  ParseTransactionOptions,
+  SignedTransaction,
+  SignTransactionOptions,
+  VerifyAddressOptions,
+  VerifyTransactionOptions,
+} from '@bitgo/sdk-core';
+
+export class <%= constructor %> extends BaseCoin {
+  protected constructor(bitgo: BitGoBase) {
+    super(bitgo);
+  }
+
+  static createInstance(bitgo: BitGoBase): BaseCoin {
+    return new <%= constructor %>(bitgo);
+  }
+
+  /**
+   * Factor between the coin's base unit and its smallest subdivison
+   */
+  public getBaseFactor(): number {
+    return <%= baseFactor %>;
+  }
+
+  public getChain(): string {
+    return '<%= symbol %>';
+  }
+
+  public getFamily(): string {
+    return '<%= symbol %>';
+  }
+
+  public getFullName(): string {
+    return '<%= coin %>';
+  }
+
+  verifyTransaction(params: VerifyTransactionOptions): Promise<boolean> {
+    throw new Error('Method not implemented.');
+  }
+
+  isWalletAddress(params: VerifyAddressOptions): boolean {
+    throw new Error('Method not implemented.');
+  }
+
+  parseTransaction(params: ParseTransactionOptions): Promise<ParsedTransaction> {
+    throw new Error('Method not implemented.');
+  }
+
+  generateKeyPair(seed?: Buffer): KeyPair {
+    throw new Error('Method not implemented.');
+  }
+
+  isValidPub(pub: string): boolean {
+    throw new Error('Method not implemented.');
+  }
+
+  isValidAddress(address: string): boolean {
+    throw new Error('Method not implemented.');
+  }
+
+  signTransaction(params: SignTransactionOptions): Promise<SignedTransaction> {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/scripts/sdk-coin-generator/template/boilerplates/simple/.testnet.ts
+++ b/scripts/sdk-coin-generator/template/boilerplates/simple/.testnet.ts
@@ -1,0 +1,35 @@
+/**
+ * Testnet <%= constructor %>
+ *
+ * @format
+ */
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
+import { <%= constructor %> } from './<%= symbol %>';
+
+export class <%= testnetConstructor %> extends <%= constructor %> {
+  protected constructor(bitgo: BitGoBase) {
+    super(bitgo);
+  }
+
+  static createInstance(bitgo: BitGoBase): BaseCoin {
+    return new <%= testnetConstructor %>(bitgo);
+  }
+
+  /**
+   * Identifier for the blockchain which supports this coin
+   */
+  public getChain(): string {
+    return '<%= testnetSymbol %>';
+  }
+
+  getFamily(): string {
+    return '<%= testnetSymbol %>';
+  }
+
+  /**
+   * Complete human-readable name of this coin
+   */
+  public getFullName(): string {
+    return 'Testnet <%= coin %>';
+  }
+}

--- a/scripts/sdk-coin-generator/template/boilerplates/simple/index.ts
+++ b/scripts/sdk-coin-generator/template/boilerplates/simple/index.ts
@@ -1,0 +1,2 @@
+export * from './<%= symbol %>';
+export * from './<%= testnetSymbol %>';

--- a/scripts/sdk-coin-generator/template/boilerplates/utxo/.mainnet.ts
+++ b/scripts/sdk-coin-generator/template/boilerplates/utxo/.mainnet.ts
@@ -1,0 +1,25 @@
+import { AbstractUtxoCoin, UtxoNetwork } from '@bitgo/abstract-utxo';
+import { BitGoBase, BaseCoin } from '@bitgo/sdk-core';
+import * as utxolib from '@bitgo/utxo-lib';
+
+export class <%= constructor %> extends AbstractUtxoCoin {
+  protected constructor(bitgo: BitGoBase, network?: UtxoNetwork) {
+    super(bitgo, network || utxolib.networks.bitcoincash);
+  }
+
+  static createInstance(bitgo: BitGoBase): BaseCoin {
+    return new <%= constructor %>(bitgo);
+  }
+
+  getChain() {
+    return '<%= symbol %>';
+  }
+
+  getFamily() {
+    return '<%= symbol %>';
+  }
+
+  getFullName() {
+    return '<%= coin %>';
+  }
+}

--- a/scripts/sdk-coin-generator/template/boilerplates/utxo/.testnet.ts
+++ b/scripts/sdk-coin-generator/template/boilerplates/utxo/.testnet.ts
@@ -1,0 +1,23 @@
+/**
+ * @prettier
+ */
+import { BitGoBase, BaseCoin } from '@bitgo/sdk-core';
+import { <%= constructor %> } from './<%= symbol %>';
+
+export class <%= testnetConstructor %> extends <%= constructor %> {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
+    return new <%= testnetConstructor %>(bitgo);
+  }
+
+  getChain(): string {
+    return '<%= testnetSymbol %>';
+  }
+
+  getFamily(): string {
+    return '<%= testnetSymbol %>';
+  }
+
+  getFullName(): string {
+    return 'Testnet <%= coin %>';
+  }
+}

--- a/scripts/sdk-coin-generator/template/boilerplates/utxo/index.ts
+++ b/scripts/sdk-coin-generator/template/boilerplates/utxo/index.ts
@@ -1,0 +1,4 @@
+export * from './<%= symbol %>';
+export * from './<%= testnetSymbol %>';
+export * from './transaction';
+export * from './transactionBuilder';

--- a/scripts/sdk-coin-generator/template/boilerplates/utxo/transaction.ts
+++ b/scripts/sdk-coin-generator/template/boilerplates/utxo/transaction.ts
@@ -1,0 +1,19 @@
+// Install and import coin specific packages
+import bitgo from '@bitgo/utxo-lib';
+
+const { networks, UtxoTransaction } = bitgo
+
+// Add networks.<%= symbol => and networks.<%= symbol %>Test to @bitgo/utxo-lib
+export type <%= constructor %>Network = typeof networks.<%= symbol %> | typeof networks.<%= symbol %>Test;
+
+export class UnsupportedTransactionError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+export class <%= constructor %>Transaction extends UtxoTransaction {
+  constructor(public network: <%= constructor %>Network, tx?: <%= constructor %>Transaction) {
+    super(network, tx);
+  }
+}

--- a/scripts/sdk-coin-generator/template/boilerplates/utxo/transactionBuilder.ts
+++ b/scripts/sdk-coin-generator/template/boilerplates/utxo/transactionBuilder.ts
@@ -1,0 +1,11 @@
+// Install and import coin specific packages
+import bitgo, { Network } from '@bitgo/utxo-lib';
+import { <%= constructor %>Transaction } from './transaction';
+
+const { UtxoTransactionBuilder } = bitgo
+
+export class <%= constructor %>TransactionBuilder extends UtxoTransactionBuilder<<%= constructor %>Transaction> {
+  constructor(network: Network, txb?: UtxoTransactionBuilder) {
+    super(network, txb);
+  }
+}

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -20,10 +20,16 @@
       "path": "./modules/sdk-api"
     },
     {
+      "path": "./modules/sdk-coin-avaxp"
+    },
+    {
       "path": "./modules/sdk-coin-xrp"
     },
     {
       "path": "./modules/sdk-core"
+    },
+    {
+      "path": "./modules/sdk-test"
     },
     {
       "path": "./modules/statics"
@@ -36,12 +42,6 @@
     },
     {
       "path": "./modules/web-demo"
-    },
-    {
-      "path": "./modules/sdk-coin-avaxp"
-    },
-    {
-      "path": "./modules/sdk-test"
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2827,7 +2827,7 @@
     node-fetch "^2.6.7"
     universal-user-agent "^6.0.0"
 
-"@octokit/rest@^18.1.0":
+"@octokit/rest@^18.0.6", "@octokit/rest@^18.1.0":
   version "18.12.0"
   resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.12.0.tgz#f06bc4952fc87130308d810ca9d00e79f6988881"
   integrity sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==
@@ -8599,7 +8599,7 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
-execa@4.1.0, execa@^4.0.0:
+execa@4.1.0, execa@^4.0.0, execa@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
   integrity sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==
@@ -9529,6 +9529,13 @@ github-username@^3.0.0:
   integrity sha1-CnciGbMTB0NCnyRW0L3T21Xc57E=
   dependencies:
     gh-got "^5.0.0"
+
+github-username@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/github-username/-/github-username-6.0.0.tgz#d543eced7295102996cd8e4e19050ebdcbe60658"
+  integrity sha512-7TTrRjxblSI5l6adk9zd+cV5d6i1OrJSo3Vr9xdGqFLBQo0mz5P9eIfKCDJ7eekVGGFLbce0qbPSnktXV2BjDQ==
+  dependencies:
+    "@octokit/rest" "^18.0.6"
 
 glob-parent@^3.1.0:
   version "3.1.0"
@@ -15667,7 +15674,7 @@ shell-quote@^1.6.1:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.3.tgz#aa40edac170445b9a431e17bb62c0b881b9c4123"
   integrity sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==
 
-shelljs@^0.8.4:
+shelljs@^0.8.4, shelljs@^0.8.5:
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
   integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
@@ -15989,7 +15996,7 @@ sort-keys@^2.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
-sort-keys@^4.0.0:
+sort-keys@^4.0.0, sort-keys@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-4.2.0.tgz#6b7638cee42c506fff8c1cecde7376d21315be18"
   integrity sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg==
@@ -18714,6 +18721,25 @@ yeoman-generator@^4.12.0, yeoman-generator@^4.8.2:
   optionalDependencies:
     grouped-queue "^1.1.0"
     yeoman-environment "^2.9.5"
+
+yeoman-generator@^5.6.1:
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/yeoman-generator/-/yeoman-generator-5.6.1.tgz#850fd266a5ab26d9d1cb9c46ad646f06eade4a1d"
+  integrity sha512-XllgFvmDEwoPMq2rKtL4/N52WlINJW6a3I3XtlCrMb3/dqO5dW0nPNgR0L3IIUIdf9y1EHb1ZFMs2Qp3ZEEFxg==
+  dependencies:
+    chalk "^4.1.0"
+    dargs "^7.0.0"
+    debug "^4.1.1"
+    execa "^4.1.0"
+    github-username "^6.0.0"
+    lodash "^4.17.11"
+    minimist "^1.2.5"
+    read-pkg-up "^7.0.1"
+    run-async "^2.0.0"
+    semver "^7.2.1"
+    shelljs "^0.8.5"
+    sort-keys "^4.2.0"
+    text-table "^0.2.0"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
* Created generator to initiate new sdk-coins via command `yarn sdk-coin:new`.
* Updated authors
* Updated developer docs to include new sdk coin initiation.

> Note: New coin intitation is part of the larger in development scope of modularizing coins via `@bitgo/sdk-api`.

BG-48589