### PR TITLE
fix(bitgo): fix v1 wallet get address

### DIFF
--- a/modules/bitgo/src/wallet.ts
+++ b/modules/bitgo/src/wallet.ts
@@ -449,9 +449,10 @@ Wallet.prototype.address = function (params, callback) {
 
   const url = this.url('/addresses/' + params.address);
 
-  return this.bitgo.get(url)
-    .result()
-    .nodeify(callback);
+  return Bluebird.resolve(
+    this.bitgo.get(url)
+      .result()
+  ).nodeify(callback);
 };
 
 /**


### PR DESCRIPTION
Add missing 'Bluebird.resolve()' to get address call

Ticket: BG-44440