### PR TITLE
feat(account-lib): fix is valid account id

### DIFF
--- a/modules/account-lib/src/coin/near/utils.ts
+++ b/modules/account-lib/src/coin/near/utils.ts
@@ -46,16 +46,12 @@ export class Utils implements BaseUtils {
    * or can create a new keyPair
    */
   isValidAccountId(accountId: string): boolean {
-    try {
-      // this regex is from near doc, https://docs.near.org/docs/concepts/account
+    return (
       (/^(([a-z\d]+[\-_])*[a-z\d]+\.)*([a-z\d]+[\-_])*[a-z\d]+$/.test(accountId) &&
-        accountId.length > 2 &&
-        accountId.length < 64) ||
-        new KeyPair({ pub: accountId });
-      return true;
-    } catch {
-      return false;
-    }
+        accountId.length >= 2 &&
+        accountId.length <= 64) ||
+      isBase58(accountId, 32)
+    );
   }
 
   /** @inheritdoc */

--- a/modules/account-lib/test/resources/near/index.ts
+++ b/modules/account-lib/test/resources/near/index.ts
@@ -31,6 +31,7 @@ export const accounts = {
     address3: 'me@google.com',
     address4: '$$$',
     address5: 'abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz',
+    address6: '',
   },
   default: {
     secretKey: '0000000000000000000000000000000000000000000000000000000000000000',

--- a/modules/account-lib/test/unit/coin/near/utils.ts
+++ b/modules/account-lib/test/unit/coin/near/utils.ts
@@ -71,5 +71,6 @@ describe('utils', () => {
     should.equal(utils.isValidAddress(accounts.errorsAccounts.address3), false);
     should.equal(utils.isValidAddress(accounts.errorsAccounts.address4), false);
     should.equal(utils.isValidAddress(accounts.errorsAccounts.address5), false);
+    should.equal(utils.isValidAddress(accounts.errorsAccounts.address6), false);
   });
 });


### PR DESCRIPTION
fix isValidAccountId method

What happened?
If an empty string is sent to isValidAccountId it returns true.

Requeriments:
Should not pass for empty strings ' '.
STLX-16458