### PR TITLE
feat(bitgo): handle new consolidation/build endpoint 204 response

### DIFF
--- a/modules/bitgo/test/v2/unit/accountConsolidations.ts
+++ b/modules/bitgo/test/v2/unit/accountConsolidations.ts
@@ -60,6 +60,23 @@ describe('Account Consolidations:', function () {
 
           scope.isDone().should.be.True();
         });
+
+        it('should throw no consolidations if sub addresses do not have enought amount', async function () {
+          if (coinName === 'talgo') {
+            // GIVEN an ALGO wallet with N receive addresses WITHOUT enough balance to consolidate
+            const scope = nock(bgUrl)
+              .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/consolidateAccount/build`)
+              .query({})
+              .reply(204, {});
+
+            // WHEN call built consolidation for that ALGO wallet
+            const accountConsolidationBuild = await wallet.buildAccountConsolidations();
+
+            // THEN length of built consolidations should be zero since it's a 204 HTTP response without body
+            accountConsolidationBuild.length.should.equal(0);
+            scope.isDone().should.be.True();
+          }
+        });
       });
 
       describe('Sending', function () {


### PR DESCRIPTION
[stlx-13299](https://bitgoinc.atlassian.net/browse/STLX-13299)
Handle new consolidation/build endpoint 204 - no content - response

Since we have this PR: https://github.com/BitGo/bitgo-microservices/pull/16613 on [this line](https://github.com/BitGo/bitgo-microservices/pull/16613/files#:~:text=if%20(!builtConsolidationTransactions.length,ctx%2C%20wallet%2C%20intent)%3B) on file `packages/wallet-platform/app/controllers/api/v2/transactions/buildConsolidation.ts`
![image](https://user-images.githubusercontent.com/83971037/170559380-062f78f0-549e-476a-a245-5ce6e41bc118.png)
The endpoint 'consolidation/build' will response a 204 HTTP no content if you try to consolidate a root address with addressess without balance to consolidate. So there is no error but there is nothing to do. 

This PR hanlde this situation. Without this changes the file `modules/bitgo/src/v2/wallet.ts` in line 2143 try to do a _for of_ on an empty object response and it respond **"buildResponse is not iterable"**. This is due the structure post().send().result() , this result catch the body response that has nothing in an 204 HTTP response.
