### PR TITLE
fix(bitgo): Add missing examples and filters for list addresses API

### DIFF
--- a/modules/bitgo/example/js/eth/list-wallet-addresses.js
+++ b/modules/bitgo/example/js/eth/list-wallet-addresses.js
@@ -1,0 +1,32 @@
+/**
+ * List deployed receive addresses of a eth wallet and their given token balances.
+ *
+ * This tool will help you see how to use the BitGo API to easily list your
+ * BitGo wallets.
+ *
+ * Copyright 2022, BitGo, Inc.  All Rights Reserved.
+ */
+import { BitGo } from 'bitgo';
+const bitgo = new BitGo({ env: 'test' });
+
+const coin = 'teth';
+const basecoin = bitgo.coin(coin);
+// TODO: set your access token here
+const accessToken = '';
+const walletId = '';
+
+async function main() {
+  bitgo.authenticateWithAccessToken({ accessToken });
+
+  const walletInstance = await basecoin.wallets().get({ id: walletId });
+  const addresses = await walletInstance.addresses({ includeBalances: true, returnBalancesForToken: 'gterc6dp', pendingDeployment: false });
+
+  console.log('Wallet ID:', walletInstance.id());
+  for (const address of addresses.addresses) {
+    console.log(`Address id: ${address.id}`);
+    console.log(`Address: ${address.address}`);
+    console.log(`Balance: ${address.balance.balance}`);
+  }
+}
+
+main().catch((e) => console.error(e));

--- a/modules/bitgo/example/js/list-wallet-addresses.js
+++ b/modules/bitgo/example/js/list-wallet-addresses.js
@@ -1,0 +1,31 @@
+/**
+ * List receive addresses on a wallet.
+ *
+ * This tool will help you see how to use the BitGo API to easily list your
+ * BitGo wallets.
+ *
+ * Copyright 2022, BitGo, Inc.  All Rights Reserved.
+ */
+import { BitGo } from 'bitgo';
+const bitgo = new BitGo({ env: 'test' });
+
+const coin = 'tbtc';
+const basecoin = bitgo.coin(coin);
+// TODO: set your access token here
+const accessToken = '';
+const walletId = '';
+
+async function main() {
+  bitgo.authenticateWithAccessToken({ accessToken });
+
+  const walletInstance = await basecoin.wallets().get({ id: walletId });
+  const addresses = await walletInstance.addresses();
+
+  console.log('Wallet ID:', walletInstance.id());
+  for (const address of addresses.addresses) {
+    console.log(`Address id: ${address.id}`);
+    console.log(`Address: ${address.address}`);
+  }
+}
+
+main().catch((e) => console.error(e));

--- a/modules/bitgo/example/ts/eth/list-wallet-addresses.ts
+++ b/modules/bitgo/example/ts/eth/list-wallet-addresses.ts
@@ -1,0 +1,32 @@
+/**
+ * List deployed receive addresses of a eth wallet and their given token balances.
+ *
+ * This tool will help you see how to use the BitGo API to easily list your
+ * BitGo wallets.
+ *
+ * Copyright 2022, BitGo, Inc.  All Rights Reserved.
+ */
+import { BitGo } from 'bitgo';
+const bitgo = new BitGo({ env: 'test' });
+
+const coin = 'teth';
+const basecoin = bitgo.coin(coin);
+// TODO: set your access token here
+const accessToken = '';
+const walletId = '';
+
+async function main() {
+  bitgo.authenticateWithAccessToken({ accessToken });
+
+  const walletInstance = await basecoin.wallets().get({ id: walletId });
+  const addresses = await walletInstance.addresses({ includeBalances: true, returnBalancesForToken: 'gterc6dp', pendingDeployment: false });
+
+  console.log('Wallet ID:', walletInstance.id());
+  for (const address of addresses.addresses) {
+    console.log(`Address id: ${address.id}`);
+    console.log(`Address: ${address.address}`);
+    console.log(`Balance: ${address.balance.balance}`);
+  }
+}
+
+main().catch((e) => console.error(e));

--- a/modules/bitgo/example/ts/list-wallet-addresses.ts
+++ b/modules/bitgo/example/ts/list-wallet-addresses.ts
@@ -1,0 +1,31 @@
+/**
+ * List receive addresses on a wallet.
+ *
+ * This tool will help you see how to use the BitGo API to easily list your
+ * BitGo wallets.
+ *
+ * Copyright 2022, BitGo, Inc.  All Rights Reserved.
+ */
+import { BitGo } from 'bitgo';
+const bitgo = new BitGo({ env: 'test' });
+
+const coin = 'tbtc';
+const basecoin = bitgo.coin(coin);
+// TODO: set your access token here
+const accessToken = '';
+const walletId = '';
+
+async function main() {
+  bitgo.authenticateWithAccessToken({ accessToken });
+
+  const walletInstance = await basecoin.wallets().get({ id: walletId });
+  const addresses = await walletInstance.addresses();
+
+  console.log('Wallet ID:', walletInstance.id());
+  for (const address of addresses.addresses) {
+    console.log(`Address id: ${address.id}`);
+    console.log(`Address: ${address.address}`);
+  }
+}
+
+main().catch((e) => console.error(e));

--- a/modules/bitgo/src/v2/wallet.ts
+++ b/modules/bitgo/src/v2/wallet.ts
@@ -909,6 +909,34 @@ export class Wallet implements IWallet {
       query.chains = params.chains;
     }
 
+    if (!_.isNil(params.includeBalances)) {
+      if (!_.isBoolean(params.includeBalances)) {
+        throw new Error('invalid includeBalances argument, expecting boolean');
+      }
+      query.includeBalances = params.includeBalances;
+    }
+
+    if (!_.isNil(params.includeTotalAddressCount)) {
+      if (!_.isBoolean(params.includeTotalAddressCount)) {
+        throw new Error('invalid includeTotalAddressCount argument, expecting boolean');
+      }
+      query.includeTotalAddressCount = params.includeTotalAddressCount;
+    }
+
+    if (params.returnBalancesForToken) {
+      if (!_.isString(params.returnBalancesForToken)) {
+        throw new Error('invalid returnBalancesForToken argument, expecting string');
+      }
+      query.returnBalancesForToken = params.returnBalancesForToken;
+    }
+
+    if (!_.isNil(params.pendingDeployment)) {
+      if (!_.isBoolean(params.pendingDeployment)) {
+        throw new Error('invalid pendingDeployment argument, expecting boolean');
+      }
+      query.pendingDeployment = params.pendingDeployment;
+    }
+
     return this.bitgo
       .get(this.baseCoin.url('/wallet/' + this._wallet.id + '/addresses'))
       .query(query)

--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -182,6 +182,33 @@ describe('V2 Wallet:', function () {
     });
   });
 
+  describe('TETH Wallet Addresses', function () {
+    let ethWallet;
+
+    before(async function () {
+      const walletData = {
+        id: '598f606cd8fc24710d2ebadb1d9459bb',
+        coin: 'teth',
+        keys: [
+          '598f606cd8fc24710d2ebad89dce86c2',
+          '598f606cc8e43aef09fcb785221d9dd2',
+          '5935d59cf660764331bafcade1855fd7',
+        ],
+      };
+      ethWallet = new Wallet(bitgo, bitgo.coin('teth'), walletData);
+    });
+
+    it('should throw errors for invalid expected parameters', async function () {
+      await ethWallet.addresses({ includeBalances: true, returnBalancesForToken: 1 }).should.be.rejectedWith('invalid returnBalancesForToken argument, expecting string');
+
+      await ethWallet.addresses({ pendingDeployment: 1 }).should.be.rejectedWith('invalid pendingDeployment argument, expecting boolean');
+
+      await ethWallet.addresses({ includeBalances: 1 }).should.be.rejectedWith('invalid includeBalances argument, expecting boolean');
+
+      await ethWallet.addresses({ includeTotalAddressCount: 1 }).should.be.rejectedWith('invalid includeTotalAddressCount argument, expecting boolean');
+    });
+  });
+
   describe('Get User Prv', () => {
     const prv = 'xprv9s21ZrQH143K3hekyNj7TciR4XNYe1kMj68W2ipjJGNHETWP7o42AjDnSPgKhdZ4x8NBAvaL72RrXjuXNdmkMqLERZza73oYugGtbLFXG8g';
     const derivedPrv = 'xprv9yoG67Td11uwjXwbV8zEmrySVXERu5FZAsLD9suBeEJbgJqANs8Yng5dEJoii7hag5JermK6PbfxgDmSzW7ewWeLmeJEkmPfmZUSLdETtHx';

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -235,6 +235,10 @@ export interface AddressesOptions extends PaginationOptions {
   labelContains?: string;
   segwit?: boolean;
   chains?: number[];
+  includeBalances?: boolean;
+  includeTotalAddressCount?: boolean;
+  returnBalancesForToken?: string;
+  pendingDeployment?: boolean;
 }
 
 export interface GetAddressOptions {


### PR DESCRIPTION
List addresses API supports the following query parameters to filter the response.

includeBalances - Whether to include address balances

includeTotalAddressCount - For large wallets (>100k addresses), include total count of addresses (including addresses pending on-chain) matching the query.

returnBalancesForToken - Name of the token that the response should include balances for. (Eth and Celo only)

pendingDeployment - Filter the addresses based on their deployment status. Return the deployed addresses if this param is passed as false and return undeployed addresses if it is passed as true. (Eth only)

But currently the SDK method ‘addresses’ which calls the API is not supporting the mentioned filters. So, this fix adds the missing filters to the SDK method along with unit test changes.

Also examples for the addresses SDK method are missing. So they are also added along with pendingDeployment, includeBalance & returnBalancesForToken filter usage example. These 3 filters example is for those who want the use case from  BG-37593.

Ticket: BG-39897