### PR TITLE
fix(account-lib): fix sdk avax build issues

### DIFF
--- a/modules/bitgo/src/v2/coins/avaxp.ts
+++ b/modules/bitgo/src/v2/coins/avaxp.ts
@@ -1,5 +1,6 @@
 import { BaseCoin as StaticsBaseCoin, CoinFamily } from '@bitgo/statics';
 import {
+  BaseCoin,
   KeyPair,
   VerifyAddressOptions,
   VerifyTransactionOptions,
@@ -10,7 +11,6 @@ import {
   TransactionPrebuild as BaseTransactionPrebuild,
   TransactionRecipient,
 } from '@bitgo/sdk-core';
-import { BaseCoin } from '../baseCoin';
 import { BitGo } from '../../bitgo';
 import { MethodNotImplementedError } from '../../errors';
 

--- a/modules/bitgo/src/v2/coins/tavaxp.ts
+++ b/modules/bitgo/src/v2/coins/tavaxp.ts
@@ -1,5 +1,5 @@
 import { BitGo } from '../../bitgo';
-import { BaseCoin } from '../baseCoin';
+import { BaseCoin } from '@bitgo/sdk-core';
 import { AvaxP } from './avaxp';
 import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 


### PR DESCRIPTION
this change fixes build issues caused by avax files by correctly importing basecoin from sdk core

TICKET: BG-49438