### PR TITLE
feat: move coin factory to sdk-core and add coin registration to sdk-api 

### DIFF
--- a/modules/bitgo/src/bitgo.ts
+++ b/modules/bitgo/src/bitgo.ts
@@ -24,7 +24,7 @@ const TravelRule = require('./travelRule');
 import Wallet = require('./wallet');
 const Wallets = require('./wallets');
 const Markets = require('./markets');
-import { GlobalCoinFactory } from './v2/coinFactory';
+import GlobalCoinFactory from './v2/coinFactory';
 import { BaseCoin, common, getSharedSecret } from '@bitgo/sdk-core';
 import {
   BitGoAPI,

--- a/modules/bitgo/src/index.ts
+++ b/modules/bitgo/src/index.ts
@@ -10,6 +10,7 @@ import * as _ from 'lodash';
 import { common, CustomSigningFunction, SignedTransaction, tss } from '@bitgo/sdk-core';
 export * from '@bitgo/sdk-api';
 import * as utxolib from '@bitgo/utxo-lib';
+import GlobalCoinFactory from './v2/coinFactory';
 
 export * from './bitgo';
 
@@ -27,8 +28,8 @@ export { Buffer } from 'buffer';
 export { CustomSigningFunction, SignedTransaction };
 
 export const Environments = _.cloneDeep(common.Environments);
-export { GlobalCoinFactory, CoinConstructor } from './v2/coinFactory';
-export { EnvironmentName, V1Network } from '@bitgo/sdk-core';
+export { CoinConstructor, EnvironmentName, V1Network } from '@bitgo/sdk-core';
+export { GlobalCoinFactory };
 export * from './v2';
 export { tss };
 

--- a/modules/bitgo/src/v2/coinFactory.ts
+++ b/modules/bitgo/src/v2/coinFactory.ts
@@ -1,34 +1,40 @@
 /**
  * @prettier
  */
-import { BaseCoin, UnsupportedCoinError } from '@bitgo/sdk-core';
-import { coins, BaseCoin as StaticsBaseCoin, CoinNotDefinedError } from '@bitgo/statics';
-import { BitGo } from '../bitgo';
+import { CoinFactory } from '@bitgo/sdk-core';
 import {
   Algo,
+  AlgoToken,
   AvaxC,
+  AvaxCToken,
   AvaxP,
   Bch,
   Bsv,
   Btc,
   Btg,
   Celo,
+  CeloToken,
   Cspr,
   Dash,
   Eos,
+  EosToken,
+  Erc20Token,
   Etc,
   Eth,
   Eth2,
-  Hbar,
-  Ltc,
-  Polygon,
-  Ofc,
-  Rbtc,
-  Sol,
-  Stx,
-  Susd,
   FiatEur,
   FiatUsd,
+  Gteth,
+  Hbar,
+  Ltc,
+  Ofc,
+  OfcToken,
+  Polygon,
+  Rbtc,
+  Sol,
+  StellarToken,
+  Stx,
+  Susd,
   Talgo,
   TavaxC,
   TavaxP,
@@ -42,7 +48,8 @@ import {
   Tetc,
   Teth,
   Teth2,
-  Gteth,
+  TfiatEur,
+  TfiatUsd,
   Thbar,
   Tltc,
   Tpolygon,
@@ -51,203 +58,134 @@ import {
   Tsol,
   Tstx,
   Tsusd,
-  TfiatEur,
-  TfiatUsd,
   Ttrx,
-  Xtz,
-  Txtz,
   Txlm,
   Txrp,
+  Txtz,
   Tzec,
   Xlm,
   Xrp,
-  Erc20Token,
-  CeloToken,
-  StellarToken,
-  AlgoToken,
-  OfcToken,
+  Xtz,
   Zec,
-  EosToken,
-  AvaxCToken,
 } from './coins';
-import { tokens } from '../config';
 import { Bcha } from './coins/bcha';
-import { Tbcha } from './coins/tbcha';
 import { Dot } from './coins/dot';
-import { Tdot } from './coins/tdot';
 import { Near } from './coins/near';
+import { Tbcha } from './coins/tbcha';
+import { Tdot } from './coins/tdot';
 import { TNear } from './coins/tnear';
+import { tokens } from '../config';
 
-export type CoinConstructor = (bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) => BaseCoin;
-
-function registerCoinConstructor(map: Map<string, CoinConstructor>, name: string, constructor: CoinConstructor): void {
-  if (map.has(name)) {
-    throw new Error(`coin '${name}' is already defined`);
-  }
-  map.set(name, constructor);
-}
-
-function getCoinConstructors(): Map<string, CoinConstructor> {
-  const m = new Map();
-  registerCoinConstructor(m, 'btc', Btc.createInstance);
-  registerCoinConstructor(m, 'tbtc', Tbtc.createInstance);
-  registerCoinConstructor(m, 'bch', Bch.createInstance);
-  registerCoinConstructor(m, 'tbch', Tbch.createInstance);
-  registerCoinConstructor(m, 'bcha', Bcha.createInstance);
-  registerCoinConstructor(m, 'tbcha', Tbcha.createInstance);
-  registerCoinConstructor(m, 'bsv', Bsv.createInstance);
-  registerCoinConstructor(m, 'tbsv', Tbsv.createInstance);
-  registerCoinConstructor(m, 'btg', Btg.createInstance);
-  registerCoinConstructor(m, 'dot', Dot.createInstance);
-  registerCoinConstructor(m, 'tdot', Tdot.createInstance);
-  registerCoinConstructor(m, 'ltc', Ltc.createInstance);
-  registerCoinConstructor(m, 'tltc', Tltc.createInstance);
-  registerCoinConstructor(m, 'eos', Eos.createInstance);
-  registerCoinConstructor(m, 'teos', Teos.createInstance);
-  registerCoinConstructor(m, 'eth', Eth.createInstance);
-  registerCoinConstructor(m, 'teth', Teth.createInstance);
-  registerCoinConstructor(m, 'gteth', Gteth.createInstance);
-  registerCoinConstructor(m, 'eth2', Eth2.createInstance);
-  registerCoinConstructor(m, 'teth2', Teth2.createInstance);
-  registerCoinConstructor(m, 'etc', Etc.createInstance);
-  registerCoinConstructor(m, 'tetc', Tetc.createInstance);
-  registerCoinConstructor(m, 'rbtc', Rbtc.createInstance);
-  registerCoinConstructor(m, 'trbtc', Trbtc.createInstance);
-  registerCoinConstructor(m, 'celo', Celo.createInstance);
-  registerCoinConstructor(m, 'tcelo', Tcelo.createInstance);
-  registerCoinConstructor(m, 'avaxc', AvaxC.createInstance);
-  registerCoinConstructor(m, 'tavaxc', TavaxC.createInstance);
-  registerCoinConstructor(m, 'avaxp', AvaxP.createInstance);
-  registerCoinConstructor(m, 'tavaxp', TavaxP.createInstance);
-  registerCoinConstructor(m, 'xrp', Xrp.createInstance);
-  registerCoinConstructor(m, 'txrp', Txrp.createInstance);
-  registerCoinConstructor(m, 'xlm', Xlm.createInstance);
-  registerCoinConstructor(m, 'txlm', Txlm.createInstance);
-  registerCoinConstructor(m, 'dash', Dash.createInstance);
-  registerCoinConstructor(m, 'tdash', Tdash.createInstance);
-  registerCoinConstructor(m, 'zec', Zec.createInstance);
-  registerCoinConstructor(m, 'tzec', Tzec.createInstance);
-  registerCoinConstructor(m, 'algo', Algo.createInstance);
-  registerCoinConstructor(m, 'talgo', Talgo.createInstance);
-  registerCoinConstructor(m, 'trx', Trx.createInstance);
-  registerCoinConstructor(m, 'ttrx', Ttrx.createInstance);
-  registerCoinConstructor(m, 'xtz', Xtz.createInstance);
-  registerCoinConstructor(m, 'txtz', Txtz.createInstance);
-  registerCoinConstructor(m, 'hbar', Hbar.createInstance);
-  registerCoinConstructor(m, 'thbar', Thbar.createInstance);
-  registerCoinConstructor(m, 'ofc', Ofc.createInstance);
-  registerCoinConstructor(m, 'susd', Susd.createInstance);
-  registerCoinConstructor(m, 'tsusd', Tsusd.createInstance);
-  registerCoinConstructor(m, 'fiatusd', FiatUsd.createInstance);
-  registerCoinConstructor(m, 'tfiatusd', TfiatUsd.createInstance);
-  registerCoinConstructor(m, 'fiateur', FiatEur.createInstance);
-  registerCoinConstructor(m, 'tfiateur', TfiatEur.createInstance);
-  registerCoinConstructor(m, 'cspr', Cspr.createInstance);
-  registerCoinConstructor(m, 'tcspr', Tcspr.createInstance);
-  registerCoinConstructor(m, 'stx', Stx.createInstance);
-  registerCoinConstructor(m, 'tstx', Tstx.createInstance);
-  registerCoinConstructor(m, 'sol', Sol.createInstance);
-  registerCoinConstructor(m, 'tsol', Tsol.createInstance);
-  registerCoinConstructor(m, 'near', Near.createInstance);
-  registerCoinConstructor(m, 'tnear', TNear.createInstance);
-  registerCoinConstructor(m, 'polygon', Polygon.createInstance);
-  registerCoinConstructor(m, 'tpolygon', Tpolygon.createInstance);
+function registerCoinConstructors(globalCoinFactory: CoinFactory): void {
+  globalCoinFactory.register('algo', Algo.createInstance);
+  globalCoinFactory.register('avaxc', AvaxC.createInstance);
+  globalCoinFactory.register('avaxp', AvaxP.createInstance);
+  globalCoinFactory.register('bch', Bch.createInstance);
+  globalCoinFactory.register('bcha', Bcha.createInstance);
+  globalCoinFactory.register('bsv', Bsv.createInstance);
+  globalCoinFactory.register('btc', Btc.createInstance);
+  globalCoinFactory.register('btg', Btg.createInstance);
+  globalCoinFactory.register('celo', Celo.createInstance);
+  globalCoinFactory.register('cspr', Cspr.createInstance);
+  globalCoinFactory.register('dash', Dash.createInstance);
+  globalCoinFactory.register('dot', Dot.createInstance);
+  globalCoinFactory.register('eos', Eos.createInstance);
+  globalCoinFactory.register('etc', Etc.createInstance);
+  globalCoinFactory.register('eth', Eth.createInstance);
+  globalCoinFactory.register('eth2', Eth2.createInstance);
+  globalCoinFactory.register('fiateur', FiatEur.createInstance);
+  globalCoinFactory.register('fiatusd', FiatUsd.createInstance);
+  globalCoinFactory.register('gteth', Gteth.createInstance);
+  globalCoinFactory.register('hbar', Hbar.createInstance);
+  globalCoinFactory.register('ltc', Ltc.createInstance);
+  globalCoinFactory.register('near', Near.createInstance);
+  globalCoinFactory.register('ofc', Ofc.createInstance);
+  globalCoinFactory.register('polygon', Polygon.createInstance);
+  globalCoinFactory.register('rbtc', Rbtc.createInstance);
+  globalCoinFactory.register('sol', Sol.createInstance);
+  globalCoinFactory.register('stx', Stx.createInstance);
+  globalCoinFactory.register('susd', Susd.createInstance);
+  globalCoinFactory.register('talgo', Talgo.createInstance);
+  globalCoinFactory.register('tavaxc', TavaxC.createInstance);
+  globalCoinFactory.register('tavaxp', TavaxP.createInstance);
+  globalCoinFactory.register('tbch', Tbch.createInstance);
+  globalCoinFactory.register('tbcha', Tbcha.createInstance);
+  globalCoinFactory.register('tbsv', Tbsv.createInstance);
+  globalCoinFactory.register('tbtc', Tbtc.createInstance);
+  globalCoinFactory.register('tcelo', Tcelo.createInstance);
+  globalCoinFactory.register('tcspr', Tcspr.createInstance);
+  globalCoinFactory.register('tdash', Tdash.createInstance);
+  globalCoinFactory.register('tdot', Tdot.createInstance);
+  globalCoinFactory.register('teos', Teos.createInstance);
+  globalCoinFactory.register('tetc', Tetc.createInstance);
+  globalCoinFactory.register('teth', Teth.createInstance);
+  globalCoinFactory.register('teth2', Teth2.createInstance);
+  globalCoinFactory.register('tfiateur', TfiatEur.createInstance);
+  globalCoinFactory.register('tfiatusd', TfiatUsd.createInstance);
+  globalCoinFactory.register('thbar', Thbar.createInstance);
+  globalCoinFactory.register('tltc', Tltc.createInstance);
+  globalCoinFactory.register('tnear', TNear.createInstance);
+  globalCoinFactory.register('tpolygon', Tpolygon.createInstance);
+  globalCoinFactory.register('trbtc', Trbtc.createInstance);
+  globalCoinFactory.register('trx', Trx.createInstance);
+  globalCoinFactory.register('tsol', Tsol.createInstance);
+  globalCoinFactory.register('tstx', Tstx.createInstance);
+  globalCoinFactory.register('tsusd', Tsusd.createInstance);
+  globalCoinFactory.register('ttrx', Ttrx.createInstance);
+  globalCoinFactory.register('txlm', Txlm.createInstance);
+  globalCoinFactory.register('txrp', Txrp.createInstance);
+  globalCoinFactory.register('txtz', Txtz.createInstance);
+  globalCoinFactory.register('tzec', Tzec.createInstance);
+  globalCoinFactory.register('xlm', Xlm.createInstance);
+  globalCoinFactory.register('xrp', Xrp.createInstance);
+  globalCoinFactory.register('xtz', Xtz.createInstance);
+  globalCoinFactory.register('zec', Zec.createInstance);
 
   for (const token of [...tokens.bitcoin.eth.tokens, ...tokens.testnet.eth.tokens]) {
     const tokenConstructor = Erc20Token.createTokenConstructor(token);
-    registerCoinConstructor(m, token.type, tokenConstructor);
-    registerCoinConstructor(m, token.tokenContractAddress, tokenConstructor);
+    globalCoinFactory.register(token.type, tokenConstructor);
+    globalCoinFactory.register(token.tokenContractAddress, tokenConstructor);
   }
 
   for (const token of [...tokens.bitcoin.xlm.tokens, ...tokens.testnet.xlm.tokens]) {
     const tokenConstructor = StellarToken.createTokenConstructor(token);
-    registerCoinConstructor(m, token.type, tokenConstructor);
+    globalCoinFactory.register(token.type, tokenConstructor);
   }
 
   for (const ofcToken of [...tokens.bitcoin.ofc.tokens, ...tokens.testnet.ofc.tokens]) {
     const tokenConstructor = OfcToken.createTokenConstructor(ofcToken);
-    registerCoinConstructor(m, ofcToken.type, tokenConstructor);
+    globalCoinFactory.register(ofcToken.type, tokenConstructor);
   }
 
   for (const token of [...tokens.bitcoin.celo.tokens, ...tokens.testnet.celo.tokens]) {
     const tokenConstructor = CeloToken.createTokenConstructor(token);
-    registerCoinConstructor(m, token.type, tokenConstructor);
-    registerCoinConstructor(m, token.tokenContractAddress, tokenConstructor);
+    globalCoinFactory.register(token.type, tokenConstructor);
+    globalCoinFactory.register(token.tokenContractAddress, tokenConstructor);
   }
 
   for (const token of [...tokens.bitcoin.eos.tokens, ...tokens.testnet.eos.tokens]) {
     const tokenConstructor = EosToken.createTokenConstructor(token);
-    registerCoinConstructor(m, token.type, tokenConstructor);
-    registerCoinConstructor(m, token.tokenContractAddress, tokenConstructor);
+    globalCoinFactory.register(token.type, tokenConstructor);
+    globalCoinFactory.register(token.tokenContractAddress, tokenConstructor);
   }
 
   for (const token of [...tokens.bitcoin.algo.tokens, ...tokens.testnet.algo.tokens]) {
     const tokenConstructor = AlgoToken.createTokenConstructor(token);
-    registerCoinConstructor(m, token.type, tokenConstructor);
+    globalCoinFactory.register(token.type, tokenConstructor);
     if (token.alias) {
-      registerCoinConstructor(m, token.alias, tokenConstructor);
+      globalCoinFactory.register(token.alias, tokenConstructor);
     }
   }
 
   for (const token of [...tokens.bitcoin.avaxc.tokens, ...tokens.testnet.avaxc.tokens]) {
     const tokenConstructor = AvaxCToken.createTokenConstructor(token);
-    registerCoinConstructor(m, token.type, tokenConstructor);
-    registerCoinConstructor(m, token.tokenContractAddress, tokenConstructor);
-  }
-
-  return m;
-}
-
-export class CoinFactory {
-  private coinConstructors?: Map<string, CoinConstructor>;
-
-  private getCoinConstructor(name: string): CoinConstructor | undefined {
-    if (this.coinConstructors === undefined) {
-      this.coinConstructors = getCoinConstructors();
-    }
-    return this.coinConstructors.get(name);
-  }
-
-  /**
-   *
-   * @param bitgo
-   * @param name
-   * @throws CoinNotDefinedError
-   * @throws UnsupportedCoinError
-   */
-  public getInstance(bitgo: BitGo, name: string): BaseCoin {
-    let staticsCoin;
-    try {
-      staticsCoin = coins.get(name);
-    } catch (e) {
-      if (!(e instanceof CoinNotDefinedError)) {
-        throw e;
-      }
-    }
-
-    const constructor = this.getCoinConstructor(name);
-    if (constructor) {
-      return constructor(bitgo, staticsCoin);
-    }
-
-    const ethConstructor = this.getCoinConstructor('eth');
-    if (ethConstructor) {
-      const ethCoin = ethConstructor(bitgo, staticsCoin);
-      if (ethCoin.isValidAddress(name)) {
-        const unknownTokenConstructor = Erc20Token.createTokenConstructor({
-          type: 'unknown',
-          coin: 'eth',
-          network: 'Mainnet',
-          name: 'Unknown',
-          tokenContractAddress: name,
-          decimalPlaces: 0,
-        });
-        return unknownTokenConstructor(bitgo);
-      }
-    }
-
-    throw new UnsupportedCoinError(name);
+    globalCoinFactory.register(token.type, tokenConstructor);
+    globalCoinFactory.register(token.tokenContractAddress, tokenConstructor);
   }
 }
 
-export const GlobalCoinFactory: CoinFactory = new CoinFactory();
+const GlobalCoinFactory: CoinFactory = new CoinFactory();
+
+registerCoinConstructors(GlobalCoinFactory);
+
+export default GlobalCoinFactory;

--- a/modules/bitgo/src/v2/coins/abstractEthLikeCoin.ts
+++ b/modules/bitgo/src/v2/coins/abstractEthLikeCoin.ts
@@ -8,6 +8,7 @@ import { randomBytes } from 'crypto';
 
 import {
   BaseCoin,
+  BitGoBase,
   FullySignedTransaction,
   HalfSignedAccountTransaction,
   KeyPair,
@@ -21,7 +22,6 @@ import {
   TransactionPrebuild as BaseTransactionPrebuild,
   TransactionExplanation,
 } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
 import BigNumber from 'bignumber.js';
 
 export interface EthSignTransactionOptions extends SignTransactionOptions {
@@ -71,7 +71,7 @@ export type SignedEthLikeTransaction = HalfSignedEthLikeTransaction | FullySigne
 export abstract class AbstractEthLikeCoin extends BaseCoin {
   protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
 
-  protected constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  protected constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo);
 
     if (!staticsCoin) {

--- a/modules/bitgo/src/v2/coins/algo.ts
+++ b/modules/bitgo/src/v2/coins/algo.ts
@@ -4,13 +4,13 @@
 import * as accountLib from '@bitgo/account-lib';
 import * as utxolib from '@bitgo/utxo-lib';
 import * as _ from 'lodash';
-import { BitGo } from '../../bitgo';
 import { SeedValidator } from '../internal/seedValidator';
 import { CoinFamily } from '@bitgo/statics';
 
 import {
   AddressCoinSpecific,
   BaseCoin,
+  BitGoBase,
   InvalidAddressError,
   InvalidKey,
   KeyIndices,
@@ -125,11 +125,11 @@ export class Algo extends BaseCoin {
   readonly ENABLE_TOKEN: TokenManagementType = 'enabletoken';
   readonly DISABLE_TOKEN: TokenManagementType = 'disabletoken';
 
-  constructor(bitgo: BitGo) {
+  constructor(bitgo: BitGoBase) {
     super(bitgo);
   }
 
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Algo(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/algoToken.ts
+++ b/modules/bitgo/src/v2/coins/algoToken.ts
@@ -1,10 +1,8 @@
 /**
  * @prettier
  */
-import { BitGo } from '../../bitgo';
 import { Algo } from './algo';
-import { CoinConstructor } from '../coinFactory';
-import { BitGoJsError } from '@bitgo/sdk-core';
+import { BitGoBase, BitGoJsError, CoinConstructor } from '@bitgo/sdk-core';
 
 export interface AlgoTokenConfig {
   name: string;
@@ -21,7 +19,7 @@ export class AlgoToken extends Algo {
   public readonly tokenConfig: AlgoTokenConfig;
   private readonly _code: string;
 
-  constructor(bitgo: BitGo, tokenConfig: AlgoTokenConfig) {
+  constructor(bitgo: BitGoBase, tokenConfig: AlgoTokenConfig) {
     super(bitgo);
     this.tokenConfig = tokenConfig;
 
@@ -40,7 +38,7 @@ export class AlgoToken extends Algo {
   }
 
   static createTokenConstructor(config: AlgoTokenConfig): CoinConstructor {
-    return (bitgo: BitGo) => new AlgoToken(bitgo, config);
+    return (bitgo: BitGoBase) => new AlgoToken(bitgo, config);
   }
 
   get type(): string {

--- a/modules/bitgo/src/v2/coins/avaxc.ts
+++ b/modules/bitgo/src/v2/coins/avaxc.ts
@@ -6,11 +6,11 @@ import * as bip32 from 'bip32';
 import * as Keccak from 'keccak';
 import * as secp256k1 from 'secp256k1';
 import * as _ from 'lodash';
-import { BitGo } from '../../bitgo';
 import { BaseCoin as StaticsBaseCoin, CoinFamily } from '@bitgo/statics';
 import { getBuilder, Eth, AvaxC as AvaxCAccountLib } from '@bitgo/account-lib';
 import {
   BaseCoin,
+  BitGoBase,
   common,
   FeeEstimateOptions,
   FullySignedTransaction,
@@ -189,7 +189,7 @@ export class AvaxC extends BaseCoin {
 
   protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
 
-  protected constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  protected constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo);
 
     if (!staticsCoin) {
@@ -199,7 +199,7 @@ export class AvaxC extends BaseCoin {
     this._staticsCoin = staticsCoin;
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new AvaxC(bitgo, staticsCoin);
   }
 

--- a/modules/bitgo/src/v2/coins/avaxcToken.ts
+++ b/modules/bitgo/src/v2/coins/avaxcToken.ts
@@ -1,10 +1,8 @@
 /**
  * @prettier
  */
-import { BitGo } from '../../bitgo';
-
 import { AvaxC, TransactionPrebuild } from './avaxc';
-import { CoinConstructor } from '../coinFactory';
+import { BitGoBase, CoinConstructor } from '@bitgo/sdk-core';
 import { coins } from '@bitgo/statics';
 
 export interface AvaxcTokenConfig {
@@ -19,14 +17,14 @@ export interface AvaxcTokenConfig {
 export class AvaxCToken extends AvaxC {
   public readonly tokenConfig: AvaxcTokenConfig;
 
-  constructor(bitgo: BitGo, tokenConfig: AvaxcTokenConfig) {
+  constructor(bitgo: BitGoBase, tokenConfig: AvaxcTokenConfig) {
     const staticsCoin = tokenConfig.network === 'Mainnet' ? coins.get('avaxc') : coins.get('tavaxc');
     super(bitgo, staticsCoin);
     this.tokenConfig = tokenConfig;
   }
 
   static createTokenConstructor(config: AvaxcTokenConfig): CoinConstructor {
-    return (bitgo: BitGo) => new AvaxCToken(bitgo, config);
+    return (bitgo: BitGoBase) => new AvaxCToken(bitgo, config);
   }
 
   get type(): string {

--- a/modules/bitgo/src/v2/coins/avaxp.ts
+++ b/modules/bitgo/src/v2/coins/avaxp.ts
@@ -1,6 +1,7 @@
 import { BaseCoin as StaticsBaseCoin, CoinFamily } from '@bitgo/statics';
 import {
   BaseCoin,
+  BitGoBase,
   KeyPair,
   VerifyAddressOptions,
   VerifyTransactionOptions,
@@ -11,7 +12,6 @@ import {
   TransactionPrebuild as BaseTransactionPrebuild,
   TransactionRecipient,
 } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
 import { MethodNotImplementedError } from '../../errors';
 
 export interface ExplainTransactionOptions {
@@ -42,7 +42,7 @@ export interface TransactionPrebuild extends BaseTransactionPrebuild {
 export class AvaxP extends BaseCoin {
   protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
 
-  constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo);
 
     if (!staticsCoin) {
@@ -52,7 +52,7 @@ export class AvaxP extends BaseCoin {
     this._staticsCoin = staticsCoin;
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new AvaxP(bitgo, staticsCoin);
   }
 

--- a/modules/bitgo/src/v2/coins/bch.ts
+++ b/modules/bitgo/src/v2/coins/bch.ts
@@ -1,16 +1,15 @@
-import { BaseCoin } from '@bitgo/sdk-core';
+import { BitGoBase, BaseCoin } from '@bitgo/sdk-core';
 import * as utxolib from '@bitgo/utxo-lib';
 
-import { BitGo } from '../../bitgo';
 import { AbstractUtxoCoin, UtxoNetwork } from './abstractUtxoCoin';
 
 export class Bch extends AbstractUtxoCoin {
 
-  protected constructor(bitgo: BitGo, network?: UtxoNetwork) {
+  protected constructor(bitgo: BitGoBase, network?: UtxoNetwork) {
     super(bitgo, network || utxolib.networks.bitcoincash);
   }
 
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Bch(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/bcha.ts
+++ b/modules/bitgo/src/v2/coins/bcha.ts
@@ -1,12 +1,11 @@
 /**
  * @prettier
  */
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BitGoBase, BaseCoin } from '@bitgo/sdk-core';
 import { Bch } from './bch';
 
 export class Bcha extends Bch {
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Bcha(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/bsv.ts
+++ b/modules/bitgo/src/v2/coins/bsv.ts
@@ -1,19 +1,18 @@
 /**
  * @prettier
  */
-import { BaseCoin } from '@bitgo/sdk-core';
+import { BitGoBase, BaseCoin } from '@bitgo/sdk-core';
 import * as utxolib from '@bitgo/utxo-lib';
 
 import { UtxoNetwork } from './abstractUtxoCoin';
 import { Bch } from './bch';
-import { BitGo } from '../../bitgo';
 
 export class Bsv extends Bch {
-  constructor(bitgo: BitGo, network?: UtxoNetwork) {
+  constructor(bitgo: BitGoBase, network?: UtxoNetwork) {
     super(bitgo, network || utxolib.networks.bitcoinsv);
   }
 
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Bsv(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/btc.ts
+++ b/modules/bitgo/src/v2/coins/btc.ts
@@ -1,7 +1,6 @@
 import * as utxolib from '@bitgo/utxo-lib';
 
-import { BitGo } from '../../bitgo';
-import { BaseCoin, VerifyRecoveryTransactionOptions as BaseVerifyRecoveryTransactionOptions } from '@bitgo/sdk-core';
+import { BitGoBase, BaseCoin, VerifyRecoveryTransactionOptions as BaseVerifyRecoveryTransactionOptions } from '@bitgo/sdk-core';
 import { AbstractUtxoCoin, UtxoNetwork } from './abstractUtxoCoin';
 
 export interface VerifyRecoveryTransactionOptions extends BaseVerifyRecoveryTransactionOptions {
@@ -9,11 +8,11 @@ export interface VerifyRecoveryTransactionOptions extends BaseVerifyRecoveryTran
 }
 
 export class Btc extends AbstractUtxoCoin {
-  constructor(bitgo: BitGo, network?: UtxoNetwork) {
+  constructor(bitgo: BitGoBase, network?: UtxoNetwork) {
     super(bitgo, network || utxolib.networks.bitcoin);
   }
 
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Btc(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/btg.ts
+++ b/modules/bitgo/src/v2/coins/btg.ts
@@ -1,11 +1,9 @@
-import { BaseCoin } from '@bitgo/sdk-core';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import * as utxolib from '@bitgo/utxo-lib';
-
-import { BitGo } from '../../bitgo';
 import { Btc } from './btc';
 
 export class Btg extends Btc {
-  constructor(bitgo: BitGo, network?: any) {
+  constructor(bitgo: BitGoBase, network?: any) {
     super(bitgo, network || utxolib.networks.bitcoingold);
   }
 

--- a/modules/bitgo/src/v2/coins/celo.ts
+++ b/modules/bitgo/src/v2/coins/celo.ts
@@ -1,18 +1,17 @@
 /**
  * @prettier
  */
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 import { AbstractEthLikeCoin } from './abstractEthLikeCoin';
 import { Celo as CeloAccountLib } from '@bitgo/account-lib';
 
 export class Celo extends AbstractEthLikeCoin {
-  protected constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  protected constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo, staticsCoin);
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Celo(bitgo, staticsCoin);
   }
 

--- a/modules/bitgo/src/v2/coins/celoToken.ts
+++ b/modules/bitgo/src/v2/coins/celoToken.ts
@@ -1,10 +1,8 @@
 /**
  * @prettier
  */
-import { BitGo } from '../../bitgo';
-
 import { Celo } from './celo';
-import { CoinConstructor } from '../coinFactory';
+import { BitGoBase, CoinConstructor } from '@bitgo/sdk-core';
 import { coins } from '@bitgo/statics';
 
 export interface CeloTokenConfig {
@@ -19,14 +17,14 @@ export interface CeloTokenConfig {
 export class CeloToken extends Celo {
   public readonly tokenConfig: CeloTokenConfig;
 
-  constructor(bitgo: BitGo, tokenConfig: CeloTokenConfig) {
+  constructor(bitgo: BitGoBase, tokenConfig: CeloTokenConfig) {
     const staticsCoin = tokenConfig.network === 'Mainnet' ? coins.get('celo') : coins.get('tcelo');
     super(bitgo, staticsCoin);
     this.tokenConfig = tokenConfig;
   }
 
   static createTokenConstructor(config: CeloTokenConfig): CoinConstructor {
-    return (bitgo: BitGo) => new CeloToken(bitgo, config);
+    return (bitgo: BitGoBase) => new CeloToken(bitgo, config);
   }
 
   get type() {

--- a/modules/bitgo/src/v2/coins/cspr.ts
+++ b/modules/bitgo/src/v2/coins/cspr.ts
@@ -5,10 +5,10 @@ import * as accountLib from '@bitgo/account-lib';
 import { ECPair } from '@bitgo/utxo-lib';
 import BigNumber from 'bignumber.js';
 
-import { BitGo } from '../../bitgo';
 import { BaseCoin as StaticsBaseCoin, CoinFamily } from '@bitgo/statics';
 import {
   BaseCoin,
+  BitGoBase,
   InvalidAddressError,
   InvalidTransactionError,
   KeyIndices,
@@ -67,7 +67,7 @@ interface TransactionOperation {
 export class Cspr extends BaseCoin {
   protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
 
-  constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo);
 
     if (!staticsCoin) {
@@ -77,7 +77,7 @@ export class Cspr extends BaseCoin {
     this._staticsCoin = staticsCoin;
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Cspr(bitgo, staticsCoin);
   }
 

--- a/modules/bitgo/src/v2/coins/dash.ts
+++ b/modules/bitgo/src/v2/coins/dash.ts
@@ -1,18 +1,17 @@
 /**
  * @prettier
  */
-import { BaseCoin } from '@bitgo/sdk-core';
+import { BitGoBase, BaseCoin } from '@bitgo/sdk-core';
 import * as utxolib from '@bitgo/utxo-lib';
 
 import { AbstractUtxoCoin, UtxoNetwork } from './abstractUtxoCoin';
-import { BitGo } from '../../bitgo';
 
 export class Dash extends AbstractUtxoCoin {
-  constructor(bitgo: BitGo, network?: UtxoNetwork) {
+  constructor(bitgo: BitGoBase, network?: UtxoNetwork) {
     super(bitgo, network || utxolib.networks.dash);
   }
 
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Dash(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/dot.ts
+++ b/modules/bitgo/src/v2/coins/dot.ts
@@ -1,8 +1,8 @@
 import * as accountLib from '@bitgo/account-lib';
 import * as _ from 'lodash';
-import { BitGo } from '../../bitgo';
 import {
   BaseCoin,
+  BitGoBase,
   KeyPair,
   MethodNotImplementedError,
   ParsedTransaction,
@@ -43,7 +43,7 @@ export class Dot extends BaseCoin {
   protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
   readonly MAX_VALIDITY_DURATION = 2400;
 
-  constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo);
 
     if (!staticsCoin) {
@@ -53,7 +53,7 @@ export class Dot extends BaseCoin {
     this._staticsCoin = staticsCoin;
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Dot(bitgo, staticsCoin);
   }
 

--- a/modules/bitgo/src/v2/coins/eos.ts
+++ b/modules/bitgo/src/v2/coins/eos.ts
@@ -12,11 +12,11 @@ import * as querystring from 'querystring';
 import * as request from 'superagent';
 import * as url from 'url';
 
-import { BitGo } from '../../bitgo';
 import { OfflineAbiProvider } from './eosutil/eosabiprovider';
 import { StringTextDecoder } from '../../stringTextDecoder';
 import {
   BaseCoin,
+  BitGoBase,
   checkKrsProvider,
   Environments,
   getBip32Keys,
@@ -203,7 +203,7 @@ export class Eos extends BaseCoin {
   public static VALID_ADDRESS_CHARS = '12345abcdefghijklmnopqrstuvwxyz'.split('');
   public static ADDRESS_LENGTH = 12;
 
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Eos(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/eosToken.ts
+++ b/modules/bitgo/src/v2/coins/eosToken.ts
@@ -1,10 +1,8 @@
 /**
  * @prettier
  */
-import { BitGo } from '../../bitgo';
-
 import { Eos } from './eos';
-import { CoinConstructor } from '../coinFactory';
+import { BitGoBase, CoinConstructor } from '@bitgo/sdk-core';
 
 export interface EosTokenConfig {
   name: string;
@@ -18,13 +16,13 @@ export interface EosTokenConfig {
 export class EosToken extends Eos {
   public readonly tokenConfig: EosTokenConfig;
 
-  constructor(bitgo: BitGo, tokenConfig: EosTokenConfig) {
+  constructor(bitgo: BitGoBase, tokenConfig: EosTokenConfig) {
     super(bitgo);
     this.tokenConfig = tokenConfig;
   }
 
   static createTokenConstructor(config: EosTokenConfig): CoinConstructor {
-    return (bitgo: BitGo) => new EosToken(bitgo, config);
+    return (bitgo: BitGoBase) => new EosToken(bitgo, config);
   }
 
   get type() {

--- a/modules/bitgo/src/v2/coins/erc20Token.ts
+++ b/modules/bitgo/src/v2/coins/erc20Token.ts
@@ -1,13 +1,18 @@
 /**
  * @prettier
  */
-import { Util, checkKrsProvider, getIsKrsRecovery, getIsUnsignedSweep } from '@bitgo/sdk-core';
+import {
+  BitGoBase,
+  CoinConstructor,
+  Util,
+  checkKrsProvider,
+  getIsKrsRecovery,
+  getIsUnsignedSweep,
+} from '@bitgo/sdk-core';
 import * as bip32 from 'bip32';
 import * as _ from 'lodash';
-import { BitGo } from '../../bitgo';
 
 import { Eth, RecoverOptions, RecoveryInfo, optionalDeps, TransactionPrebuild } from './eth';
-import { CoinConstructor } from '../coinFactory';
 
 export interface Erc20TokenConfig {
   name: string;
@@ -22,14 +27,14 @@ export class Erc20Token extends Eth {
   public readonly tokenConfig: Erc20TokenConfig;
   protected readonly sendMethodName: 'sendMultiSig' | 'sendMultiSigToken';
 
-  constructor(bitgo: BitGo, tokenConfig: Erc20TokenConfig) {
+  constructor(bitgo: BitGoBase, tokenConfig: Erc20TokenConfig) {
     super(bitgo);
     this.tokenConfig = tokenConfig;
     this.sendMethodName = 'sendMultiSigToken';
   }
 
   static createTokenConstructor(config: Erc20TokenConfig): CoinConstructor {
-    return (bitgo: BitGo) => new Erc20Token(bitgo, config);
+    return (bitgo: BitGoBase) => new Erc20Token(bitgo, config);
   }
 
   get type() {

--- a/modules/bitgo/src/v2/coins/etc.ts
+++ b/modules/bitgo/src/v2/coins/etc.ts
@@ -1,18 +1,17 @@
 /**
  * @prettier
  */
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 import { AbstractEthLikeCoin } from './abstractEthLikeCoin';
 import { Etc as EtcAccountLib } from '@bitgo/account-lib';
 
 export class Etc extends AbstractEthLikeCoin {
-  protected constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  protected constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo, staticsCoin);
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Etc(bitgo, staticsCoin);
   }
 

--- a/modules/bitgo/src/v2/coins/eth.ts
+++ b/modules/bitgo/src/v2/coins/eth.ts
@@ -11,10 +11,10 @@ import * as secp256k1 from 'secp256k1';
 import * as request from 'superagent';
 
 import { Erc20Token } from './erc20Token';
-import { BitGo } from '../../bitgo';
 import {
   AddressCoinSpecific,
   BaseCoin,
+  BitGoBase,
   checkKrsProvider,
   common,
   EthereumLibraryUnavailableError,
@@ -343,13 +343,13 @@ export class Eth extends BaseCoin {
 
   readonly staticsCoin?: Readonly<StaticsBaseCoin>;
 
-  protected constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  protected constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo);
     this.staticsCoin = staticsCoin;
     this.sendMethodName = 'sendMultiSig';
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Eth(bitgo, staticsCoin);
   }
 

--- a/modules/bitgo/src/v2/coins/eth2.ts
+++ b/modules/bitgo/src/v2/coins/eth2.ts
@@ -7,9 +7,9 @@ import * as request from 'superagent';
 import { Eth2 as Eth2AccountLib } from '@bitgo/account-lib';
 import BigNumber from 'bignumber.js';
 
-import { BitGo } from '../../bitgo';
 import {
   BaseCoin,
+  BitGoBase,
   common,
   HalfSignedAccountTransaction as BaseHalfSignedTransaction,
   IBlsKeyPair,
@@ -107,7 +107,7 @@ export interface RecoveryInfo {
 }
 
 export class Eth2 extends BaseCoin {
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Eth2(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/fiateur.ts
+++ b/modules/bitgo/src/v2/coins/fiateur.ts
@@ -1,9 +1,9 @@
 /**
  * @prettier
  */
-import { BitGo } from '../../bitgo';
 import {
   BaseCoin,
+  BitGoBase,
   KeyPair,
   MethodNotImplementedError,
   ParsedTransaction,
@@ -15,7 +15,7 @@ import {
 } from '@bitgo/sdk-core';
 
 export class FiatEur extends BaseCoin {
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new FiatEur(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/fiatusd.ts
+++ b/modules/bitgo/src/v2/coins/fiatusd.ts
@@ -1,9 +1,9 @@
 /**
  * @prettier
  */
-import { BitGo } from '../../bitgo';
 import {
   BaseCoin,
+  BitGoBase,
   KeyPair,
   MethodNotImplementedError,
   ParsedTransaction,
@@ -15,7 +15,7 @@ import {
 } from '@bitgo/sdk-core';
 
 export class FiatUsd extends BaseCoin {
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new FiatUsd(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/gteth.ts
+++ b/modules/bitgo/src/v2/coins/gteth.ts
@@ -1,17 +1,16 @@
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { Eth } from './eth';
 import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 
 export class Gteth extends Eth {
   protected readonly sendMethodName: 'sendMultiSig' | 'sendMultiSigToken';
 
-  protected constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  protected constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo, staticsCoin);
     this.sendMethodName = 'sendMultiSig';
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Gteth(bitgo, staticsCoin);
   }
 

--- a/modules/bitgo/src/v2/coins/hbar.ts
+++ b/modules/bitgo/src/v2/coins/hbar.ts
@@ -6,6 +6,7 @@ import * as bitgoAccountLib from '@bitgo/account-lib';
 
 import {
   BaseCoin,
+  BitGoBase,
   KeyPair,
   MethodNotImplementedError,
   ParsedTransaction,
@@ -19,7 +20,6 @@ import {
   TransactionPrebuild as BaseTransactionPrebuild,
   TransactionExplanation,
 } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
 import * as stellar from 'stellar-sdk';
 import { SeedValidator } from '../internal/seedValidator';
 
@@ -61,7 +61,7 @@ interface VerifyAddressOptions extends BaseVerifyAddressOptions {
 export class Hbar extends BaseCoin {
   protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
 
-  constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo);
 
     if (!staticsCoin) {
@@ -87,7 +87,7 @@ export class Hbar extends BaseCoin {
     return Math.pow(10, this._staticsCoin.decimalPlaces);
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Hbar(bitgo, staticsCoin);
   }
 

--- a/modules/bitgo/src/v2/coins/ltc.ts
+++ b/modules/bitgo/src/v2/coins/ltc.ts
@@ -1,14 +1,13 @@
 /**
  * @prettier
  */
-import { BaseCoin, InvalidAddressError } from '@bitgo/sdk-core';
+import { BaseCoin, BitGoBase, InvalidAddressError } from '@bitgo/sdk-core';
 import * as utxolib from '@bitgo/utxo-lib';
 
 import { AbstractUtxoCoin, UtxoNetwork } from './abstractUtxoCoin';
-import { BitGo } from '../../bitgo';
 
 export class Ltc extends AbstractUtxoCoin {
-  constructor(bitgo: BitGo, network?: UtxoNetwork) {
+  constructor(bitgo: BitGoBase, network?: UtxoNetwork) {
     super(bitgo, network || utxolib.networks.litecoin);
     // use legacy script hash version, which is the current Bitcoin one
     this.altScriptHash = utxolib.networks.bitcoin.scriptHash;
@@ -16,7 +15,7 @@ export class Ltc extends AbstractUtxoCoin {
     this.supportAltScriptDestination = false;
   }
 
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Ltc(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/near.ts
+++ b/modules/bitgo/src/v2/coins/near.ts
@@ -5,11 +5,11 @@
 import BigNumber from 'bignumber.js';
 import * as accountLib from '@bitgo/account-lib';
 import * as _ from 'lodash';
-import { BitGo } from '../../bitgo';
 import * as base58 from 'bs58';
 import { BaseCoin as StaticsBaseCoin, CoinFamily, coins } from '@bitgo/statics';
 import {
   BaseCoin,
+  BitGoBase,
   BaseTransaction,
   KeyPair,
   MethodNotImplementedError,
@@ -77,7 +77,7 @@ const nearUtils = accountLib.Near.Utils.default;
 
 export class Near extends BaseCoin {
   protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
-  constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo);
 
     if (!staticsCoin) {
@@ -87,7 +87,7 @@ export class Near extends BaseCoin {
     this._staticsCoin = staticsCoin;
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Near(bitgo, staticsCoin);
   }
 

--- a/modules/bitgo/src/v2/coins/ofc.ts
+++ b/modules/bitgo/src/v2/coins/ofc.ts
@@ -5,6 +5,7 @@ import { randomBytes } from 'crypto';
 import * as bip32 from 'bip32';
 import {
   BaseCoin,
+  BitGoBase,
   KeyPair,
   MethodNotImplementedError,
   ParsedTransaction,
@@ -14,10 +15,9 @@ import {
   VerifyAddressOptions,
   VerifyTransactionOptions,
 } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
 
 export class Ofc extends BaseCoin {
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Ofc(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/ofcToken.ts
+++ b/modules/bitgo/src/v2/coins/ofcToken.ts
@@ -2,11 +2,8 @@
  * @prettier
  */
 import { isString } from 'lodash';
-
-import { BitGo } from '../../bitgo';
-import { CoinConstructor } from '../coinFactory';
 import { Ofc } from './ofc';
-import { SignTransactionOptions as BaseSignTransactionOptions } from '@bitgo/sdk-core';
+import { BitGoBase, CoinConstructor, SignTransactionOptions as BaseSignTransactionOptions } from '@bitgo/sdk-core';
 import { SignedTransaction } from './eth';
 
 export interface OfcTokenConfig {
@@ -29,7 +26,7 @@ const publicIdRegex = /^[a-f\d]{32}$/i;
 export class OfcToken extends Ofc {
   public readonly tokenConfig: OfcTokenConfig;
 
-  constructor(bitgo: BitGo, tokenConfig: OfcTokenConfig) {
+  constructor(bitgo: BitGoBase, tokenConfig: OfcTokenConfig) {
     super(bitgo);
     this.tokenConfig = tokenConfig;
   }
@@ -79,7 +76,7 @@ export class OfcToken extends Ofc {
   }
 
   static createTokenConstructor(config: OfcTokenConfig): CoinConstructor {
-    return (bitgo: BitGo) => new OfcToken(bitgo, config);
+    return (bitgo: BitGoBase) => new OfcToken(bitgo, config);
   }
 
   /**

--- a/modules/bitgo/src/v2/coins/polygon.ts
+++ b/modules/bitgo/src/v2/coins/polygon.ts
@@ -1,18 +1,17 @@
 /**
  * @prettier
  */
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 import { AbstractEthLikeCoin } from './abstractEthLikeCoin';
 import { Polygon as PolygonAccountLib } from '@bitgo/account-lib';
 
 export class Polygon extends AbstractEthLikeCoin {
-  protected constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  protected constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo, staticsCoin);
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Polygon(bitgo, staticsCoin);
   }
 

--- a/modules/bitgo/src/v2/coins/rbtc.ts
+++ b/modules/bitgo/src/v2/coins/rbtc.ts
@@ -1,18 +1,17 @@
 /**
  * @prettier
  */
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 import { AbstractEthLikeCoin } from './abstractEthLikeCoin';
 import { Rbtc as RbtcAccountLib } from '@bitgo/account-lib';
 
 export class Rbtc extends AbstractEthLikeCoin {
-  protected constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  protected constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo, staticsCoin);
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Rbtc(bitgo, staticsCoin);
   }
 

--- a/modules/bitgo/src/v2/coins/sol.ts
+++ b/modules/bitgo/src/v2/coins/sol.ts
@@ -7,11 +7,11 @@ import * as base58 from 'bs58';
 
 import { BaseCoin as StaticsBaseCoin, CoinFamily, coins } from '@bitgo/statics';
 import * as accountLib from '@bitgo/account-lib';
-import { BitGo } from '../../bitgo';
 import * as _ from 'lodash';
 import { AtaInitializationBuilder } from '@bitgo/account-lib/dist/src/coin/sol';
 import {
   BaseCoin,
+  BitGoBase,
   BaseTransaction,
   Memo,
   KeyPair,
@@ -87,7 +87,7 @@ const HEX_REGEX = /^[0-9a-fA-F]+$/;
 export class Sol extends BaseCoin {
   protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
 
-  constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo);
 
     if (!staticsCoin) {
@@ -97,7 +97,7 @@ export class Sol extends BaseCoin {
     this._staticsCoin = staticsCoin;
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Sol(bitgo, staticsCoin);
   }
 

--- a/modules/bitgo/src/v2/coins/stellarToken.ts
+++ b/modules/bitgo/src/v2/coins/stellarToken.ts
@@ -2,10 +2,8 @@
  * @prettier
  */
 import * as _ from 'lodash';
-import { BitGo } from '../../bitgo';
 import { Xlm } from './xlm';
-import { CoinConstructor } from '../coinFactory';
-import { BitGoJsError } from '@bitgo/sdk-core';
+import { BitGoBase, BitGoJsError, CoinConstructor } from '@bitgo/sdk-core';
 import * as stellar from 'stellar-sdk';
 
 export interface StellarTokenConfig {
@@ -22,7 +20,7 @@ export class StellarToken extends Xlm {
   private readonly _code: string;
   private readonly _issuer: string;
 
-  constructor(bitgo: BitGo, tokenConfig: StellarTokenConfig) {
+  constructor(bitgo: BitGoBase, tokenConfig: StellarTokenConfig) {
     super(bitgo);
     this.tokenConfig = tokenConfig;
 
@@ -37,7 +35,7 @@ export class StellarToken extends Xlm {
   }
 
   static createTokenConstructor(config: StellarTokenConfig): CoinConstructor {
-    return (bitgo: BitGo) => new StellarToken(bitgo, config);
+    return (bitgo: BitGoBase) => new StellarToken(bitgo, config);
   }
 
   get type() {

--- a/modules/bitgo/src/v2/coins/stx.ts
+++ b/modules/bitgo/src/v2/coins/stx.ts
@@ -4,9 +4,9 @@
 import * as accountLib from '@bitgo/account-lib';
 import { BaseCoin as StaticsBaseCoin, CoinFamily } from '@bitgo/statics';
 
-import { BitGo } from '../../bitgo';
 import {
   BaseCoin,
+  BitGoBase,
   KeyPair,
   SignedTransaction,
   SignTransactionOptions,
@@ -58,7 +58,7 @@ export interface TransactionPrebuild extends BaseTransactionPrebuild {
 export class Stx extends BaseCoin {
   protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
 
-  constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo);
 
     if (!staticsCoin) {
@@ -68,7 +68,7 @@ export class Stx extends BaseCoin {
     this._staticsCoin = staticsCoin;
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Stx(bitgo, staticsCoin);
   }
 

--- a/modules/bitgo/src/v2/coins/susd.ts
+++ b/modules/bitgo/src/v2/coins/susd.ts
@@ -15,10 +15,6 @@ import {
 } from '@bitgo/sdk-core';
 
 export class Susd extends BaseCoin {
-  constructor(bitgo: BitGoBase) {
-    super(bitgo);
-  }
-
   static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Susd(bitgo);
   }

--- a/modules/bitgo/src/v2/coins/talgo.ts
+++ b/modules/bitgo/src/v2/coins/talgo.ts
@@ -1,8 +1,7 @@
 /**
  * @prettier
  */
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { Algo } from './algo';
 
 export class Talgo extends Algo {
@@ -10,7 +9,7 @@ export class Talgo extends Algo {
     super(bitgo);
   }
 
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Talgo(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/tavaxc.ts
+++ b/modules/bitgo/src/v2/coins/tavaxc.ts
@@ -1,18 +1,17 @@
 /**
  * @prettier
  */
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 
 import { AvaxC } from './avaxc';
 
 export class TavaxC extends AvaxC {
-  protected constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  protected constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo, staticsCoin);
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new TavaxC(bitgo, staticsCoin);
   }
 }

--- a/modules/bitgo/src/v2/coins/tavaxp.ts
+++ b/modules/bitgo/src/v2/coins/tavaxp.ts
@@ -1,5 +1,4 @@
-import { BitGo } from '../../bitgo';
-import { BaseCoin } from '@bitgo/sdk-core';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { AvaxP } from './avaxp';
 import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 
@@ -7,7 +6,7 @@ export class TavaxP extends AvaxP {
 
   protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
 
-  constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo, staticsCoin);
 
     if (!staticsCoin) {
@@ -17,7 +16,7 @@ export class TavaxP extends AvaxP {
     this._staticsCoin = staticsCoin;
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new TavaxP(bitgo, staticsCoin);
   }
 

--- a/modules/bitgo/src/v2/coins/tbch.ts
+++ b/modules/bitgo/src/v2/coins/tbch.ts
@@ -1,17 +1,16 @@
 /**
  * @prettier
  */
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { Bch } from './bch';
 import * as bitcoin from '@bitgo/utxo-lib';
 
 export class Tbch extends Bch {
-  constructor(bitgo: BitGo) {
+  constructor(bitgo: BitGoBase) {
     super(bitgo, bitcoin.networks.bitcoincashTestnet);
   }
 
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Tbch(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/tbcha.ts
+++ b/modules/bitgo/src/v2/coins/tbcha.ts
@@ -1,17 +1,16 @@
 /**
  * @prettier
  */
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { Bcha } from './bcha';
 import * as utxolib from '@bitgo/utxo-lib';
 
 export class Tbcha extends Bcha {
-  constructor(bitgo: BitGo) {
+  constructor(bitgo: BitGoBase) {
     super(bitgo, utxolib.networks.bitcoincashTestnet);
   }
 
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Tbcha(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/tbsv.ts
+++ b/modules/bitgo/src/v2/coins/tbsv.ts
@@ -1,17 +1,16 @@
 /**
  * @prettier
  */
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { Bsv } from './bsv';
 import * as utxolib from '@bitgo/utxo-lib';
 
 export class Tbsv extends Bsv {
-  constructor(bitgo: BitGo) {
+  constructor(bitgo: BitGoBase) {
     super(bitgo, utxolib.networks.bitcoinsvTestnet);
   }
 
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Tbsv(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/tbtc.ts
+++ b/modules/bitgo/src/v2/coins/tbtc.ts
@@ -1,8 +1,7 @@
 /**
  * @prettier
  */
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { Btc } from './btc';
 import * as utxolib from '@bitgo/utxo-lib';
 
@@ -11,7 +10,7 @@ export class Tbtc extends Btc {
     super(bitgo, utxolib.networks.testnet);
   }
 
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Tbtc(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/tcelo.ts
+++ b/modules/bitgo/src/v2/coins/tcelo.ts
@@ -1,17 +1,16 @@
 /**
  * @prettier
  */
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 import { AbstractEthLikeCoin } from './abstractEthLikeCoin';
 
 export class Tcelo extends AbstractEthLikeCoin {
-  protected constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  protected constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo, staticsCoin);
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Tcelo(bitgo, staticsCoin);
   }
 }

--- a/modules/bitgo/src/v2/coins/tcspr.ts
+++ b/modules/bitgo/src/v2/coins/tcspr.ts
@@ -1,5 +1,4 @@
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { Cspr } from './cspr';
 import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 
@@ -7,7 +6,7 @@ export class Tcspr extends Cspr {
 
   protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
 
-  constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo, staticsCoin);
 
     if (!staticsCoin) {
@@ -17,7 +16,7 @@ export class Tcspr extends Cspr {
     this._staticsCoin = staticsCoin;
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Tcspr(bitgo, staticsCoin);
   }
 

--- a/modules/bitgo/src/v2/coins/tdash.ts
+++ b/modules/bitgo/src/v2/coins/tdash.ts
@@ -1,17 +1,16 @@
 /**
  * @prettier
  */
-import { BaseCoin } from '@bitgo/sdk-core';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import * as utxolib from '@bitgo/utxo-lib';
-import { BitGo } from '../../bitgo';
 import { Dash } from './dash';
 
 export class Tdash extends Dash {
-  constructor(bitgo: BitGo) {
+  constructor(bitgo: BitGoBase) {
     super(bitgo, utxolib.networks.dashTest);
   }
 
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Tdash(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/tdot.ts
+++ b/modules/bitgo/src/v2/coins/tdot.ts
@@ -1,11 +1,10 @@
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
-import { Dot } from './dot';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
+import { Dot } from './dot';
 
 export class Tdot extends Dot {
   protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
-  constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo, staticsCoin);
 
     if (!staticsCoin) {
@@ -15,7 +14,7 @@ export class Tdot extends Dot {
     this._staticsCoin = staticsCoin;
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Tdot(bitgo, staticsCoin);
   }
 

--- a/modules/bitgo/src/v2/coins/teos.ts
+++ b/modules/bitgo/src/v2/coins/teos.ts
@@ -1,9 +1,8 @@
-import { BaseCoin, common } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase, common } from '@bitgo/sdk-core';
 import { Eos } from './eos';
 
 export class Teos extends Eos {
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Teos(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/tetc.ts
+++ b/modules/bitgo/src/v2/coins/tetc.ts
@@ -1,17 +1,16 @@
 /**
  * @prettier
  */
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 import { AbstractEthLikeCoin } from './abstractEthLikeCoin';
 
 export class Tetc extends AbstractEthLikeCoin {
-  protected constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  protected constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo, staticsCoin);
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Tetc(bitgo, staticsCoin);
   }
 }

--- a/modules/bitgo/src/v2/coins/teth.ts
+++ b/modules/bitgo/src/v2/coins/teth.ts
@@ -1,17 +1,16 @@
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { Eth } from './eth';
 import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 
 export class Teth extends Eth {
   protected readonly sendMethodName: 'sendMultiSig' | 'sendMultiSigToken';
 
-  protected constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  protected constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo, staticsCoin);
     this.sendMethodName = 'sendMultiSig';
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Teth(bitgo, staticsCoin);
   }
 

--- a/modules/bitgo/src/v2/coins/teth2.ts
+++ b/modules/bitgo/src/v2/coins/teth2.ts
@@ -1,9 +1,8 @@
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { Eth2 } from './eth2';
 
 export class Teth2 extends Eth2 {
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Teth2(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/tfiateur.ts
+++ b/modules/bitgo/src/v2/coins/tfiateur.ts
@@ -1,12 +1,11 @@
 /**
  * @prettier
  */
-import { BitGo } from '../../bitgo';
-import { BaseCoin } from '@bitgo/sdk-core';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { FiatEur } from './fiateur';
 
 export class TfiatEur extends FiatEur {
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new TfiatEur(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/tfiatusd.ts
+++ b/modules/bitgo/src/v2/coins/tfiatusd.ts
@@ -1,12 +1,11 @@
 /**
  * @prettier
  */
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { FiatUsd } from './fiatusd';
 
 export class TfiatUsd extends FiatUsd {
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new TfiatUsd(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/thbar.ts
+++ b/modules/bitgo/src/v2/coins/thbar.ts
@@ -1,8 +1,7 @@
 /**
  * @prettier
  */
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 import { Hbar } from './hbar';
 
@@ -10,11 +9,11 @@ import { Hbar } from './hbar';
  * Tezos testnet.
  */
 export class Thbar extends Hbar {
-  protected constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  protected constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo, staticsCoin);
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Thbar(bitgo, staticsCoin);
   }
 }

--- a/modules/bitgo/src/v2/coins/tltc.ts
+++ b/modules/bitgo/src/v2/coins/tltc.ts
@@ -1,20 +1,19 @@
 /**
  * @prettier
  */
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { Ltc } from './ltc';
 import * as utxolib from '@bitgo/utxo-lib';
 
 export class Tltc extends Ltc {
-  constructor(bitgo: BitGo) {
+  constructor(bitgo: BitGoBase) {
     super(bitgo, utxolib.networks.litecoinTest);
     this.altScriptHash = utxolib.networks.testnet.scriptHash;
     // support alt destinations on test
     this.supportAltScriptDestination = false;
   }
 
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Tltc(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/tnear.ts
+++ b/modules/bitgo/src/v2/coins/tnear.ts
@@ -1,10 +1,10 @@
-import { BitGo } from '../../bitgo';
-import { Near } from './near';
 import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
+import { BitGoBase } from '@bitgo/sdk-core';
+import { Near } from './near';
 
 export class TNear extends Near {
 
-  constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo, staticsCoin);
   }
 }

--- a/modules/bitgo/src/v2/coins/tpolygon.ts
+++ b/modules/bitgo/src/v2/coins/tpolygon.ts
@@ -1,17 +1,16 @@
 /**
  * @prettier
  */
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 import { AbstractEthLikeCoin } from './abstractEthLikeCoin';
 
 export class Tpolygon extends AbstractEthLikeCoin {
-  protected constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  protected constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo, staticsCoin);
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Tpolygon(bitgo, staticsCoin);
   }
 }

--- a/modules/bitgo/src/v2/coins/trbtc.ts
+++ b/modules/bitgo/src/v2/coins/trbtc.ts
@@ -1,17 +1,16 @@
 /**
  * @prettier
  */
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 import { AbstractEthLikeCoin } from './abstractEthLikeCoin';
 
 export class Trbtc extends AbstractEthLikeCoin {
-  protected constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  protected constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo, staticsCoin);
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Trbtc(bitgo, staticsCoin);
   }
 }

--- a/modules/bitgo/src/v2/coins/trx.ts
+++ b/modules/bitgo/src/v2/coins/trx.ts
@@ -10,6 +10,7 @@ import { networks } from '@bitgo/utxo-lib';
 import * as request from 'superagent';
 import {
   BaseCoin,
+  BitGoBase,
   common,
   getBip32Keys,
   getIsKrsRecovery,
@@ -27,8 +28,6 @@ import {
   VerifyAddressOptions,
   VerifyTransactionOptions,
 } from '@bitgo/sdk-core';
-
-import { BitGo } from '../../bitgo';
 
 export const MINIMUM_TRON_MSIG_TRANSACTION_FEE = 1e6;
 
@@ -96,7 +95,7 @@ export interface AccountResponse {
 export class Trx extends BaseCoin {
   protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
 
-  constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo);
 
     if (!staticsCoin) {
@@ -127,7 +126,7 @@ export class Trx extends BaseCoin {
     return true;
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Trx(bitgo, staticsCoin);
   }
 

--- a/modules/bitgo/src/v2/coins/tsol.ts
+++ b/modules/bitgo/src/v2/coins/tsol.ts
@@ -1,5 +1,4 @@
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { Sol } from './sol';
 import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 
@@ -7,7 +6,7 @@ export class Tsol extends Sol {
 
   protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
 
-  constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo, staticsCoin);
 
     if (!staticsCoin) {
@@ -17,7 +16,7 @@ export class Tsol extends Sol {
     this._staticsCoin = staticsCoin;
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Tsol(bitgo, staticsCoin);
   }
 

--- a/modules/bitgo/src/v2/coins/tstx.ts
+++ b/modules/bitgo/src/v2/coins/tstx.ts
@@ -1,5 +1,4 @@
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { Stx } from './stx';
 import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 
@@ -7,7 +6,7 @@ export class Tstx extends Stx {
 
   protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
 
-  constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo, staticsCoin);
 
     if (!staticsCoin) {
@@ -17,7 +16,7 @@ export class Tstx extends Stx {
     this._staticsCoin = staticsCoin;
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Tstx(bitgo, staticsCoin);
   }
 

--- a/modules/bitgo/src/v2/coins/tsusd.ts
+++ b/modules/bitgo/src/v2/coins/tsusd.ts
@@ -1,12 +1,11 @@
 /**
  * @prettier
  */
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { Susd } from './susd';
 
 export class Tsusd extends Susd {
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Tsusd(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/ttrx.ts
+++ b/modules/bitgo/src/v2/coins/ttrx.ts
@@ -3,17 +3,16 @@
  *
  * @format
  */
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 import { Trx } from './trx';
 
 export class Ttrx extends Trx {
-  protected constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  protected constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo, staticsCoin);
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Ttrx(bitgo, staticsCoin);
   }
 }

--- a/modules/bitgo/src/v2/coins/txlm.ts
+++ b/modules/bitgo/src/v2/coins/txlm.ts
@@ -1,14 +1,13 @@
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { Xlm } from './xlm';
 const stellar = require('stellar-sdk');
 
 export class Txlm extends Xlm {
-  constructor(bitgo: BitGo) {
+  constructor(bitgo: BitGoBase) {
     super(bitgo);
   }
 
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Txlm(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/txtz.ts
+++ b/modules/bitgo/src/v2/coins/txtz.ts
@@ -1,8 +1,7 @@
 /**
  * @prettier
  */
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 import { Xtz } from './xtz';
 
@@ -10,11 +9,11 @@ import { Xtz } from './xtz';
  * Tezos testnet.
  */
 export class Txtz extends Xtz {
-  protected constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  protected constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo, staticsCoin);
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Txtz(bitgo, staticsCoin);
   }
 }

--- a/modules/bitgo/src/v2/coins/tzec.ts
+++ b/modules/bitgo/src/v2/coins/tzec.ts
@@ -1,14 +1,13 @@
-import { BaseCoin } from '@bitgo/sdk-core';
-import { BitGo } from '../../bitgo';
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { Zec } from './zec';
 import * as utxolib from '@bitgo/utxo-lib';
 
 export class Tzec extends Zec {
-  constructor(bitgo: BitGo) {
+  constructor(bitgo: BitGoBase) {
     super(bitgo, utxolib.networks.zcashTest);
   }
 
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Tzec(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/xlm.ts
+++ b/modules/bitgo/src/v2/coins/xlm.ts
@@ -9,10 +9,10 @@ import * as url from 'url';
 import * as request from 'superagent';
 import * as stellar from 'stellar-sdk';
 import { BigNumber } from 'bignumber.js';
-import { BitGo } from '../../bitgo';
 
 import {
   BaseCoin,
+  BitGoBase,
   checkKrsProvider,
   common,
   ExtraPrebuildParamsOptions,
@@ -151,12 +151,12 @@ export class Xlm extends BaseCoin {
   // See: https://www.stellar.org/developers/guides/concepts/assets.html#amount-precision-and-representation
   static readonly maxTrustlineLimit: string = '9223372036854775807';
 
-  constructor(bitgo: BitGo) {
+  constructor(bitgo: BitGoBase) {
     super(bitgo);
     this.homeDomain = 'bitgo.com'; // used for reverse federation lookup
   }
 
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Xlm(bitgo);
   }
 

--- a/modules/bitgo/src/v2/coins/xtz.ts
+++ b/modules/bitgo/src/v2/coins/xtz.ts
@@ -5,10 +5,10 @@ import * as bip32 from 'bip32';
 import { CoinFamily, BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 import * as bitgoAccountLib from '@bitgo/account-lib';
 
-import { BitGo } from '../../bitgo';
 import BigNumber from 'bignumber.js';
 import {
   BaseCoin,
+  BitGoBase,
   BaseTransactionBuilder,
   KeyPair,
   MethodNotImplementedError,
@@ -67,7 +67,7 @@ export interface ExplainTransactionOptions {
 export class Xtz extends BaseCoin {
   protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
 
-  constructor(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>) {
+  constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo);
 
     if (!staticsCoin) {
@@ -93,7 +93,7 @@ export class Xtz extends BaseCoin {
     return Math.pow(10, this._staticsCoin.decimalPlaces);
   }
 
-  static createInstance(bitgo: BitGo, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Xtz(bitgo, staticsCoin);
   }
 

--- a/modules/bitgo/src/v2/coins/zec.ts
+++ b/modules/bitgo/src/v2/coins/zec.ts
@@ -1,17 +1,16 @@
 /**
  * @prettier
  */
-import { BaseCoin } from '@bitgo/sdk-core';
+import { BitGoBase, BaseCoin } from '@bitgo/sdk-core';
 import * as utxolib from '@bitgo/utxo-lib';
-import { BitGo } from '../../bitgo';
 import { AbstractUtxoCoin, UtxoNetwork } from './abstractUtxoCoin';
 
 export class Zec extends AbstractUtxoCoin {
-  constructor(bitgo: BitGo, network?: UtxoNetwork) {
+  constructor(bitgo: BitGoBase, network?: UtxoNetwork) {
     super(bitgo, network || utxolib.networks.zcash);
   }
 
-  static createInstance(bitgo: BitGo): BaseCoin {
+  static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Zec(bitgo);
   }
 

--- a/modules/bitgo/test/v2/unit/coins/token.ts
+++ b/modules/bitgo/test/v2/unit/coins/token.ts
@@ -12,7 +12,7 @@ describe('Virtual Token:', function () {
   });
 
   it('should not instantiate coin interface before loading client constants', function () {
-    (() => bitgo.coin('mycrappytoken')).should.throw('Coin or token type mycrappytoken not supported or not compiled. Please be sure that you are using the latest version of BitGoJS.');
+    (() => bitgo.coin('mycrappytoken')).should.throw('Coin or token type mycrappytoken not supported or not compiled. Please be sure that you are using the latest version of BitGoJS. If using @bitgo/sdk-api, please confirm you have registered mycrappytoken first.');
   });
 
   it('should wait for client constants before instantiating coin', async function () {

--- a/modules/sdk-api/src/bitgoAPI.ts
+++ b/modules/sdk-api/src/bitgoAPI.ts
@@ -20,11 +20,13 @@ import {
   AliasEnvironments,
   BitGoBase,
   BitGoRequest,
+  CoinConstructor,
   common,
   DecryptOptions,
   EncryptOptions,
   EnvironmentName,
   GetSharingKeyOptions,
+  GlobalCoinFactory,
   IBaseCoin,
   IRequestTracer,
   sanitizeLegacyPath,
@@ -33,26 +35,26 @@ import { getAddressP2PKH, makeRandomKey } from './util';
 import * as sjcl from '@bitgo/sjcl';
 import {
   AccessTokenOptions,
-  PingOptions,
+  AddAccessTokenOptions,
   AuthenticateOptions,
+  BitGoAPIOptions,
+  BitGoJson,
   CalculateHmacSubjectOptions,
   CalculateRequestHeadersOptions,
   CalculateRequestHmacOptions,
+  ExtendTokenOptions,
+  GetUserOptions,
+  PingOptions,
   ProcessedAuthenticationOptions,
+  RemoveAccessTokenOptions,
   RequestHeaders,
+  TokenIssuance,
+  TokenIssuanceResponse,
+  UnlockOptions,
+  User,
+  VerifyPasswordOptions,
   VerifyResponseInfo,
   VerifyResponseOptions,
-  BitGoAPIOptions,
-  User,
-  BitGoJson,
-  VerifyPasswordOptions,
-  TokenIssuanceResponse,
-  TokenIssuance,
-  RemoveAccessTokenOptions,
-  AddAccessTokenOptions,
-  GetUserOptions,
-  UnlockOptions,
-  ExtendTokenOptions,
 } from './types';
 import pjson = require('../package.json');
 import { decrypt, encrypt } from './encrypt';
@@ -234,8 +236,12 @@ export class BitGoAPI implements BitGoBase {
     throw new Error('Method not implemented.');
   }
 
-  coin(coinName: string): IBaseCoin {
-    throw new Error('Method not implemented.');
+  /**
+   * Create a basecoin object
+   * @param name
+   */
+  public coin(name: string): IBaseCoin {
+    return GlobalCoinFactory.getInstance(this, name);
   }
 
   getECDHSharingKeychain(): Promise<any> {
@@ -1160,5 +1166,15 @@ export class BitGoAPI implements BitGoBase {
       throw new Error('invalid argument');
     }
     this._validate = validate;
+  }
+
+  /**
+   * Register a new coin instance with its builder factory
+   * @param {string} name coin name as it was registered in @bitgo/statics
+   * @param {CoinConstructor} coin the builder factory class for that coin
+   * @returns {void}
+   */
+  public register(name: string, coin: CoinConstructor): void {
+    GlobalCoinFactory.register(name, coin);
   }
 }

--- a/modules/sdk-coin-xrp/src/xrp.ts
+++ b/modules/sdk-coin-xrp/src/xrp.ts
@@ -13,7 +13,6 @@ import * as rippleAddressCodec from 'ripple-address-codec';
 import * as rippleBinaryCodec from 'ripple-binary-codec';
 import { computeBinaryTransactionHash } from 'ripple-lib/dist/npm/common/hashes';
 import * as rippleKeypairs from 'ripple-keypairs';
-
 import {
   BaseCoin,
   BitGoBase,

--- a/modules/sdk-core/src/bitgo/coinFactory.ts
+++ b/modules/sdk-core/src/bitgo/coinFactory.ts
@@ -1,0 +1,68 @@
+/**
+ * @prettier
+ */
+import { coins, BaseCoin as StaticsBaseCoin, CoinNotDefinedError } from '@bitgo/statics';
+import { BaseCoin } from './baseCoin';
+import { BitGoBase } from './bitgoBase';
+import { UnsupportedCoinError } from './errors';
+
+export type CoinConstructor = (bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) => BaseCoin;
+
+export class CoinFactory {
+  private coinConstructors: Map<string, CoinConstructor>;
+
+  constructor() {
+    this.coinConstructors = new Map();
+  }
+
+  /**
+   * @param name Name of coin or address
+   * @returns {(Object|undefined)}
+   */
+  private getCoinConstructor(name: string): CoinConstructor | undefined {
+    if (this.coinConstructors === undefined) {
+      this.coinConstructors = new Map();
+    }
+    return this.coinConstructors.get(name);
+  }
+
+  /**
+   * @param name Name of coin or address
+   * @param coin Coin plugin's constructor
+   * @throws Error
+   */
+  public register(name: string, coin: CoinConstructor): void {
+    if (this.coinConstructors.has(name)) {
+      throw new Error(`coin '${name}' is already defined`);
+    }
+    this.coinConstructors.set(name, coin);
+  }
+
+  /**
+   * @param bitgo Instance of BitGo
+   * @param name Name of coin or address
+   * @throws CoinNotDefinedError
+   * @throws UnsupportedCoinError
+   */
+  public getInstance(bitgo: BitGoBase, name: string): BaseCoin {
+    let staticsCoin;
+
+    try {
+      staticsCoin = coins.get(name);
+    } catch (e) {
+      if (!(e instanceof CoinNotDefinedError)) {
+        throw e;
+      }
+    }
+
+    const constructor = this.getCoinConstructor(name);
+
+    if (constructor) {
+      return constructor(bitgo, staticsCoin);
+    }
+
+    throw new UnsupportedCoinError(name);
+  }
+}
+
+export const GlobalCoinFactory: CoinFactory = new CoinFactory();

--- a/modules/sdk-core/src/bitgo/errors.ts
+++ b/modules/sdk-core/src/bitgo/errors.ts
@@ -20,7 +20,7 @@ export class NodeEnvironmentError extends BitGoJsError {
 export class UnsupportedCoinError extends BitGoJsError {
   public constructor(coin: string) {
     super(
-      `Coin or token type ${coin} not supported or not compiled. Please be sure that you are using the latest version of BitGoJS.`
+      `Coin or token type ${coin} not supported or not compiled. Please be sure that you are using the latest version of BitGoJS. If using @bitgo/sdk-api, please confirm you have registered ${coin} first.`
     );
   }
 }

--- a/modules/sdk-core/src/bitgo/index.ts
+++ b/modules/sdk-core/src/bitgo/index.ts
@@ -6,6 +6,7 @@ export * from './bip32util';
 export * from './bitcoin';
 export * from './bitgoBase';
 export * from './config';
+export * from './coinFactory';
 export * from './ecdh';
 export * from './enterprise';
 export * from './environments';

--- a/modules/web-demo/src/components/BitGoAPI/index.tsx
+++ b/modules/web-demo/src/components/BitGoAPI/index.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import ReactJson from 'react-json-view';
 import { BitGoAPI } from '@bitgo/sdk-api';
+import { Txrp } from '@bitgo/sdk-coin-xrp';
 
 const sdk = new BitGoAPI();
+
+sdk.register('txrp', Txrp.createInstance);
 
 const BGApi = () => {
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -14315,7 +14315,7 @@ proto-list@~1.2.1:
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
 
-protobufjs@^6.10.0, protobufjs@^6.11.2, protobufjs@^6.8.9:
+protobufjs@^6.10.0, protobufjs@^6.11.2, protobufjs@^6.11.3:
   version "6.11.3"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.3.tgz#637a527205a35caa4f3e2a9a4a13ddffe0e7af74"
   integrity sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==


### PR DESCRIPTION
- BG-49173: Refactor CoinFactory to sdk-core
- BG-49173: Register coins from sdk-api

- Backwards compatibility allows all current coins to be registered in `bitgo`.
- `@bitgo/sdk-api` can now register coins independent from all other coins with all the same functionalities of `bitgo`.
- In `@bitgo/sdk-api`, `BitGoAPI` has been refactored to `AbstractBitGoAPI` with a consumer implementation of `BitGoAPI` now available.
  - Updated `web-demo` and `bitgo` to reflect the change.

## Specific PR Queries
- Is the `AbstractBitGoAPI` an acceptable change. I would have extended `class BitGo extends BitGoAPI` in `@bitgo/sdk-api`, except that would have created a duplicate export in `bitgo` since `bitgo` exports everything from `@bitgo/sdk-api`.
- erc20Token is a specific dependency of how `coinFactory` operates, but that would be counter to having `@bitgo/sdk-api` rely on this class.
  - All current coins properly register with the removal of the old implementation of the removed lines 223-237 of the ethConstructor/token check. Would like insight into if there is an instance where this is used that I may be missing.

## Example - Coin Registration

```javascript
import { BitGoAPI } from '@bitgo/sdk-api';
import { Txrp } from '@bitgo/sdk-coin-xrp';

const sdk = new BitGoAPI();

sdk.register('txrp', Txrp.createInstance);
```

BG-49173