### PR TITLE
feat: update TxRequest schema for full version

### DIFF
--- a/modules/bitgo/test/v2/unit/coins/sol.ts
+++ b/modules/bitgo/test/v2/unit/coins/sol.ts
@@ -908,6 +908,7 @@ describe('SOL:', function () {
           signableHex: 'serializedTxHex',
           derivationPath: 'm/0',
         }],
+        transactions: [],
       };
 
       const stubTssUtils = sandbox.createStubInstance(TssUtils);

--- a/modules/bitgo/test/v2/unit/internal/tssUtils.ts
+++ b/modules/bitgo/test/v2/unit/internal/tssUtils.ts
@@ -279,6 +279,7 @@ describe('TSS Utils:', async function () {
     const txRequestId = 'randomid';
     const txRequest: TxRequest = {
       txRequestId,
+      transactions: [],
       unsignedTxs: [
         {
           serializedTxHex: 'ababfefe',

--- a/modules/bitgo/test/v2/unit/pendingApproval.ts
+++ b/modules/bitgo/test/v2/unit/pendingApproval.ts
@@ -129,6 +129,7 @@ describe('Pending Approvals:', () => {
           share: '9d7159a76700635TEST',
         },
       ],
+      transactions: [],
     };
 
     const decryptedPrv = sandbox.stub(Wallet.prototype, 'getPrv');

--- a/modules/sdk-core/src/bitgo/utils/iTssUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/iTssUtils.ts
@@ -19,20 +19,32 @@ export interface PrebuildTransactionWithIntentOptions {
   nonce?: string;
 }
 
+export type TxRequestVersion = 'full' | 'lite';
+
+export type UnsignedTransaction = {
+  serializedTxHex: string;
+  signableHex: string;
+  feeInfo?: {
+    fee: number;
+    feeString: string;
+  };
+  derivationPath: string;
+};
+
 // complete with more props if neccesary
 export interface TxRequest {
   txRequestId: string;
-  unsignedTxs: {
-    serializedTxHex: string;
-    signableHex: string;
-    feeInfo?: {
-      fee: number;
-      feeString: string;
-    };
-    derivationPath: string;
-  }[];
+  // Only available in 'lite' version
+  unsignedTxs: UnsignedTransaction[];
   signatureShares?: SignatureShareRecord[];
-  apiVersion?: string;
+  // Only available in 'full' version
+  transactions: {
+    state: string;
+    unsignedTx: UnsignedTransaction;
+    privateSignatureShares: SignatureShareRecord[];
+    signatureShares: SignatureShareRecord[];
+  }[];
+  apiVersion?: TxRequestVersion;
 }
 
 export enum SignatureShareType {
@@ -75,7 +87,7 @@ export interface ITssUtils {
     originalPasscodeEncryptionCode?: string;
   }): Promise<KeychainsTriplet>;
   signTxRequest(params: { txRequest: string | TxRequest; prv: string; reqId: IRequestTracer }): Promise<TxRequest>;
-  prebuildTxWithIntent(params: PrebuildTransactionWithIntentOptions, apiVersion?: string): Promise<TxRequest>;
+  prebuildTxWithIntent(params: PrebuildTransactionWithIntentOptions, apiVersion?: TxRequestVersion): Promise<TxRequest>;
   deleteSignatureShares(txRequestId: string): Promise<SignatureShareRecord[]>;
   sendTxRequest(txRequestId: string): Promise<any>;
   recreateTxRequest(txRequestId: string, decryptedPrv: string, reqId: IRequestTracer): Promise<TxRequest>;

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -21,7 +21,7 @@ import { drawKeycard } from '../internal/keycard';
 import { Keychain } from '../keychain';
 import { IPendingApproval, PendingApproval } from '../pendingApproval';
 import { TradingAccount } from '../trading/tradingAccount';
-import { inferAddressType, ITssUtils, RequestTracer, TssUtils, TxRequest } from '../utils';
+import { inferAddressType, ITssUtils, RequestTracer, TssUtils, TxRequest, UnsignedTransaction } from '../utils';
 import {
   AccelerateTransactionOptions,
   AddressesOptions,
@@ -2265,46 +2265,63 @@ export class Wallet implements IWallet {
   private async prebuildTransactionTss(params: PrebuildTransactionOptions = {}): Promise<PrebuildTransactionResult> {
     const reqId = params.reqId || new RequestTracer();
     this.bitgo.setRequestTracer(reqId);
+    const apiVersion = this._wallet.type === 'custodial' ? 'full' : 'lite';
 
-    let unsignedTxRequest: TxRequest;
+    let txRequest: TxRequest;
     switch (params.type) {
       case 'transfer':
-        unsignedTxRequest = await this.tssUtils.prebuildTxWithIntent({
-          reqId,
-          intentType: 'payment',
-          sequenceId: params.sequenceId,
-          comment: params.comment,
-          recipients: params.recipients || [],
-          memo: params.memo,
-          nonce: params.nonce,
-        });
+        txRequest = await this.tssUtils.prebuildTxWithIntent(
+          {
+            reqId,
+            intentType: 'payment',
+            sequenceId: params.sequenceId,
+            comment: params.comment,
+            recipients: params.recipients || [],
+            memo: params.memo,
+            nonce: params.nonce,
+          },
+          apiVersion
+        );
         break;
       case 'enabletoken':
-        unsignedTxRequest = await this.tssUtils.prebuildTxWithIntent({
-          reqId,
-          intentType: 'createAccount',
-          recipients: params.recipients || [],
-          tokenName: params.tokenName,
-          memo: params.memo,
-        });
+        txRequest = await this.tssUtils.prebuildTxWithIntent(
+          {
+            reqId,
+            intentType: 'createAccount',
+            recipients: params.recipients || [],
+            tokenName: params.tokenName,
+            memo: params.memo,
+          },
+          apiVersion
+        );
         break;
       default:
         throw new Error(`transaction type not supported: ${params.type}`);
     }
 
-    const unsignedTxs = unsignedTxRequest.unsignedTxs;
-    if (unsignedTxs.length !== 1) {
-      throw new Error(`Expected a single unsigned tx for tx request with id: ${unsignedTxRequest.txRequestId}`);
+    let unsignedTx: UnsignedTransaction;
+
+    if (txRequest.apiVersion === 'full') {
+      if (txRequest.transactions.length !== 1) {
+        throw new Error(`Expected a single unsigned tx for tx request with id: ${txRequest.txRequestId}`);
+      }
+
+      unsignedTx = txRequest.transactions[0].unsignedTx;
+    } else {
+      if (txRequest.unsignedTxs.length !== 1) {
+        throw new Error(`Expected a single unsigned tx for tx request with id: ${txRequest.txRequestId}`);
+      }
+      unsignedTx = txRequest.unsignedTxs[0];
     }
 
     const whitelistedParams = _.pick(params, this.prebuildWhitelistedParams());
     return {
       walletId: this.id(),
       wallet: this,
-      txRequestId: unsignedTxRequest.txRequestId,
-      txHex: unsignedTxs[0].serializedTxHex,
+      txRequestId: txRequest.txRequestId,
+      txHex: unsignedTx.serializedTxHex,
       buildParams: whitelistedParams,
-      feeInfo: unsignedTxs[0].feeInfo,
+      feeInfo: unsignedTx.feeInfo,
     };
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5227,6 +5227,18 @@ bigi@1.4.2, bigi@^1.1.0, bigi@^1.4.0, bigi@^1.4.2:
   resolved "https://registry.yarnpkg.com/bigi/-/bigi-1.4.2.tgz#9c665a95f88b8b08fc05cfd731f561859d725825"
   integrity sha1-nGZalfiLiwj8Bc/XMfVhhZ1yWCU=
 
+bigint-crypto-utils@^3.0.17:
+  version "3.0.24"
+  resolved "https://registry.yarnpkg.com/bigint-crypto-utils/-/bigint-crypto-utils-3.0.24.tgz#ae8b4f3d6236a7a34df13d411b7c3bbe6779c5d8"
+  integrity sha512-TZZ04h0BCfE5kAR5VTiUp+8eWHcclXFCI+4EFL5Y8z0++XJqqUnEjgwzBbVIpMHbSBu3Gjv7VT6msIXJzzSfTg==
+  dependencies:
+    bigint-mod-arith "^3.0.1"
+
+bigint-mod-arith@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/bigint-mod-arith/-/bigint-mod-arith-3.0.2.tgz#a25a723af3ee3a79d452c370a55e3adc0e3f0cc3"
+  integrity sha512-tlhD4h/D1sv4pJfZzBesKOlfXRCQTeMMUrGbpc2PAawMAjb/S/OPAQfi667w6COt/UHOfvOW47sCSMaSEj4zIg==
+
 bignumber.js@8.1.1, bignumber.js@^8.0.1:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-8.1.1.tgz#4b072ae5aea9c20f6730e4e5d529df1271c4d885"
@@ -13574,6 +13586,13 @@ paged-request@^2.0.1:
   integrity sha512-NWrGqneZImDdcMU/7vMcAOo1bIi5h/pmpJqe7/jdsy85BA/s5MSaU/KlpxwW/IVPmIwBcq2uKPrBWWhEWhtxag==
   dependencies:
     axios "^0.21.1"
+
+paillier-bigint@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/paillier-bigint/-/paillier-bigint-3.3.0.tgz#25afb724fdce8359625d3eea93bf80cb6024065a"
+  integrity sha512-Aa8a75dODYOGxLYQhi1Y0Xsi0Vbl+5gzPvaVfxuCA/zT8CK/keXv5CA2Ddn5AV9VxmTkpIEdYs40hv1rkFcODg==
+  dependencies:
+    bigint-crypto-utils "^3.0.17"
 
 pako@2.0.3:
   version "2.0.3"


### PR DESCRIPTION
TSS custodial wallets will use TxRequest full.
This change updates the TxRequest interface to match 'full' and updates
impl to fix building transactions using full.

Ticket: BG-49655