### PR TITLE
fix(sdk-api): api uses own version

### DIFF
--- a/modules/bitgo/src/bitgo.ts
+++ b/modules/bitgo/src/bitgo.ts
@@ -163,6 +163,7 @@ export class BitGo extends BitGoAPI {
     this._version = pjson.version;
     this._keychains = null;
     this._wallets = null;
+    this._userAgent = params.userAgent || 'BitGoJS/' + this.version();
   }
 
   /**

--- a/modules/sdk-api/src/bitgoAPI.ts
+++ b/modules/sdk-api/src/bitgoAPI.ts
@@ -66,7 +66,7 @@ if (!(process as any)?.browser) {
 
 const patchedRequestMethods = ['get', 'post', 'put', 'del', 'patch'] as const;
 
-export abstract class BitGoAPI implements BitGoBase {
+export class BitGoAPI implements BitGoBase {
   protected static _constants: any;
   protected static _constantsExpire: any;
   protected static _testnetWarningMessage = false;
@@ -188,7 +188,7 @@ export abstract class BitGoAPI implements BitGoBase {
     this._baseApiUrl = this._baseUrl + '/api/v1';
     this._baseApiUrlV2 = this._baseUrl + '/api/v2';
     this._token = params.accessToken;
-    this._userAgent = params.userAgent || 'BitGoJS/' + this.version();
+    this._userAgent = params.userAgent || 'BitGoJS-api/' + this.version();
     this._reqId = undefined;
     this._refreshToken = params.refreshToken;
     this._clientId = params.clientId;

--- a/modules/web-demo/src/components/BitGoAPI/index.tsx
+++ b/modules/web-demo/src/components/BitGoAPI/index.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 import ReactJson from 'react-json-view';
 import { BitGoAPI } from '@bitgo/sdk-api';
 
-class MyAPI extends BitGoAPI {}
+const sdk = new BitGoAPI();
 
-const sdk = new MyAPI();
 const BGApi = () => {
   return (
     <React.Fragment>


### PR DESCRIPTION
- BitGoAPI uses distinct version & userAgent string
- BitGoAPI no longer abstract
- Bitgo uses own version & userAgent string

Ticket: BG-49713

![Screen Shot 2022-06-06 at 1 15 01 PM](https://user-images.githubusercontent.com/49656094/172240907-7b51595d-c035-4131-a964-45bc62b5a0a3.png)

![Screen Shot 2022-06-06 at 1 14 55 PM](https://user-images.githubusercontent.com/49656094/172240911-2461cf1e-d6bf-4491-a1e3-7f12f6805a47.png)