### PR TITLE
refactor(sdk-core): tss refactor moving eddsa into a sub folder

### DIFF
--- a/modules/bitgo/test/v2/unit/tss/eddsa.ts
+++ b/modules/bitgo/test/v2/unit/tss/eddsa.ts
@@ -19,7 +19,7 @@ import * as openpgp from 'openpgp';
 import * as should from 'should';
 import * as nock from 'nock';
 import * as _ from 'lodash';
-import { TestBitGo } from '../../lib/test_bitgo';
+import { TestBitGo } from '../../../lib/test_bitgo';
 
 describe('test tss helper functions', function () {
   let mpc: Eddsa;

--- a/modules/sdk-core/src/bitgo/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/bitgo/tss/eddsa/eddsa.ts
@@ -1,6 +1,7 @@
 import Eddsa, { GShare, JShare, KeyShare, PShare, RShare, SignShare, YShare } from './../../../account-lib/mpc/tss';
 import { BitGoBase } from './../../bitgoBase';
-import { DecryptableYShare, CombinedKey, SigningMaterial, ShareKeyPosition, EncryptedYShare } from './../types';
+import { DecryptableYShare, CombinedKey, SigningMaterial, EncryptedYShare } from './types';
+import { ShareKeyPosition } from './../types';
 import {
   encryptAndSignText,
   readSignedMessage,

--- a/modules/sdk-core/src/bitgo/tss/eddsa/index.ts
+++ b/modules/sdk-core/src/bitgo/tss/eddsa/index.ts
@@ -1,3 +1,9 @@
+import * as EDDSAMethods from './eddsa';
+export * as EDDSAMethodTypes from './types';
+
+export default EDDSAMethods;
+
+// exporting this types for backward compatibility.
 export {
   createCombinedKey,
   createUserSignShare,
@@ -9,3 +15,5 @@ export {
   sendSignatureShare,
   encryptYShare,
 } from './eddsa';
+
+export { EncryptedYShare, DecryptableYShare, CombinedKey, SigningMaterial } from './types';

--- a/modules/sdk-core/src/bitgo/tss/eddsa/types.ts
+++ b/modules/sdk-core/src/bitgo/tss/eddsa/types.ts
@@ -1,0 +1,31 @@
+import { UShare, YShare } from './../../../account-lib/mpc/tss';
+
+// YShare that has been encrypted and signed via GPG
+export type EncryptedYShare = {
+  i: number;
+  j: number;
+  publicShare: string;
+  // signed and encrypted gpg armor
+  encryptedPrivateShare: string;
+};
+
+// YShare with information needed to decrypt and verify a GPG mesasge
+export type DecryptableYShare = {
+  yShare: EncryptedYShare;
+  recipientPrivateArmor: string;
+  senderPublicArmor: string;
+};
+
+// Final TSS "Keypair"
+export type CombinedKey = {
+  commonKeychain: string;
+  signingMaterial: SigningMaterial;
+};
+
+// Private portion of a TSS key, this must be handled like any other private key
+export type SigningMaterial = {
+  uShare: UShare;
+  bitgoYShare: YShare;
+  backupYShare?: YShare;
+  userYShare?: YShare;
+};

--- a/modules/sdk-core/src/bitgo/tss/index.ts
+++ b/modules/sdk-core/src/bitgo/tss/index.ts
@@ -1,5 +1,9 @@
-export { EncryptedYShare, DecryptableYShare, CombinedKey, SigningMaterial, ShareKeyPosition } from './types';
+import EDDSAMethods, { EDDSAMethodTypes } from './eddsa';
 
+export { EDDSAMethods, EDDSAMethodTypes };
+export { ShareKeyPosition } from './types';
+
+// exporting this types for backward compatibility.
 export {
   createCombinedKey,
   createUserSignShare,
@@ -10,4 +14,8 @@ export {
   getTxRequest,
   sendSignatureShare,
   encryptYShare,
+  EncryptedYShare,
+  DecryptableYShare,
+  CombinedKey,
+  SigningMaterial,
 } from './eddsa';

--- a/modules/sdk-core/src/bitgo/tss/types.ts
+++ b/modules/sdk-core/src/bitgo/tss/types.ts
@@ -1,35 +1,3 @@
-import { UShare, YShare } from './../../account-lib/mpc/tss';
-
-// YShare that has been encrypted and signed via GPG
-export type EncryptedYShare = {
-  i: number;
-  j: number;
-  publicShare: string;
-  // signed and encrypted gpg armor
-  encryptedPrivateShare: string;
-};
-
-// YShare with information needed to decrypt and verify a GPG mesasge
-export type DecryptableYShare = {
-  yShare: EncryptedYShare;
-  recipientPrivateArmor: string;
-  senderPublicArmor: string;
-};
-
-// Final TSS "Keypair"
-export type CombinedKey = {
-  commonKeychain: string;
-  signingMaterial: SigningMaterial;
-};
-
-// Private portion of a TSS key, this must be handled like any other private key
-export type SigningMaterial = {
-  uShare: UShare;
-  bitgoYShare: YShare;
-  backupYShare?: YShare;
-  userYShare?: YShare;
-};
-
 export enum ShareKeyPosition {
   USER = 1,
   BACKUP = 2,

--- a/modules/sdk-core/src/bitgo/utils/index.ts
+++ b/modules/sdk-core/src/bitgo/utils/index.ts
@@ -3,12 +3,11 @@ import * as openpgpUtils from './opengpgUtils';
 export * from './abstractUtxoCoinUtil';
 export * from './blsUtils';
 export * from './iBlsUtils';
-export * from './iTssUtils';
 export * from './mpcUtils';
 export * from './opengpgUtils';
 export * from './promise-utils';
 export * from './triple';
-export * from './tssUtils';
+export * from './tss';
 export * from './util';
 
 export { openpgpUtils };

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
@@ -5,16 +5,16 @@ import * as bs58 from 'bs58';
 import * as crypto from 'crypto';
 import * as _ from 'lodash';
 import * as openpgp from 'openpgp';
-import { Ed25519BIP32 } from '../../account-lib/mpc/hdTree';
-import Eddsa, { KeyShare, YShare } from '../../account-lib/mpc/tss';
-import { IRequestTracer } from '../../api';
-import { IBaseCoin, KeychainsTriplet } from '../baseCoin';
-import { BitGoBase } from '../bitgoBase';
-import { AddKeychainOptions, Keychain, KeyType } from '../keychain';
-import { IWallet } from '../wallet';
-import { ITssUtils, PrebuildTransactionWithIntentOptions, SignatureShareRecord, TxRequest } from './iTssUtils';
-import { MpcUtils } from './mpcUtils';
-import { encryptText, getBitgoGpgPubKey } from './opengpgUtils';
+import { Ed25519BIP32 } from '../../../../account-lib/mpc/hdTree';
+import Eddsa, { KeyShare, YShare } from '../../../../account-lib/mpc/tss';
+import { IRequestTracer } from '../../../../api';
+import { IBaseCoin, KeychainsTriplet } from '../../../baseCoin';
+import { BitGoBase } from '../../../bitgoBase';
+import { AddKeychainOptions, Keychain, KeyType } from '../../../keychain';
+import { IWallet } from '../../../wallet';
+import { ITssUtils, PrebuildTransactionWithIntentOptions, SignatureShareRecord, TxRequest } from './types';
+import { MpcUtils } from '../../mpcUtils';
+import { encryptText, getBitgoGpgPubKey } from '../../opengpgUtils';
 import {
   createUserSignShare,
   createUserToBitGoGShare,
@@ -23,7 +23,7 @@ import {
   offerUserToBitgoRShare,
   sendUserToBitgoGShare,
   SigningMaterial,
-} from '../tss';
+} from '../../../tss';
 
 /**
  * Utility functions for TSS work flows.

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/index.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/index.ts
@@ -1,0 +1,14 @@
+import { TssUtils } from './eddsa';
+export * as TssUtilsTypes from './types';
+
+export default TssUtils;
+
+// exporting this types for backward compatibility.
+export {
+  ITssUtils,
+  PrebuildTransactionWithIntentOptions,
+  SignatureShareRecord,
+  SignatureShareType,
+  TxRequest,
+  UnsignedTransaction,
+} from './types';

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/types.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/types.ts
@@ -1,9 +1,9 @@
 import type { SerializedKeyPair } from 'openpgp';
-import { KeyShare } from '../../account-lib/mpc/tss';
-import { IRequestTracer } from '../../api';
-import { KeychainsTriplet } from '../baseCoin';
-import { Keychain } from '../keychain';
-import { Memo } from '../wallet';
+import { KeyShare } from '../../../../account-lib/mpc/tss';
+import { IRequestTracer } from '../../../../api';
+import { KeychainsTriplet } from '../../../baseCoin';
+import { Keychain } from '../../../keychain';
+import { Memo } from '../../../wallet';
 
 export interface PrebuildTransactionWithIntentOptions {
   reqId: IRequestTracer;

--- a/modules/sdk-core/src/bitgo/utils/tss/index.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/index.ts
@@ -1,0 +1,12 @@
+import TssUtils, { TssUtilsTypes } from './eddsa';
+export { TssUtils, TssUtilsTypes };
+
+// exporting this types for backward compatibility.
+export {
+  ITssUtils,
+  PrebuildTransactionWithIntentOptions,
+  SignatureShareRecord,
+  SignatureShareType,
+  TxRequest,
+  UnsignedTransaction,
+} from './eddsa';


### PR DESCRIPTION
This pr is moving eddsa into a sub folder of tss so we can ecdsa to tss. 

Ticket: BG-49287