### PR TITLE
feat(statics): add TSS as a coin feature

### DIFF
--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -123,10 +123,15 @@ export enum CoinFeature {
    * This coin requires that accounts keep a minimum balance as reserve
    */
   REQUIRES_RESERVE = 'requires-reserve',
-  /**
+  /*
    * This coin supports custodial wallet types
    */
   CUSTODY = 'custody',
+
+  /*
+  This coin uses TSS for key creation and signing
+   */
+  TSS = 'tss',
 }
 
 /**

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -38,10 +38,15 @@ const XTZ_FEATURES = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.ENTERPRISE_PA
 );
 const CSPR_FEATURES = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.REQUIRES_RESERVE];
 const ALGO_FEATURES = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.SUPPORTS_TOKENS];
-const DOT_FEATURES = [...AccountCoin.DEFAULT_FEATURES];
+const DOT_FEATURES = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.TSS];
 const EOS_FEATURES = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.SUPPORTS_TOKENS];
-const SOL_FEATURES = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.REQUIRES_RESERVE, CoinFeature.SUPPORTS_TOKENS];
-const NEAR_FEATURES = [...AccountCoin.DEFAULT_FEATURES];
+const SOL_FEATURES = [
+  ...AccountCoin.DEFAULT_FEATURES,
+  CoinFeature.TSS,
+  CoinFeature.REQUIRES_RESERVE,
+  CoinFeature.SUPPORTS_TOKENS,
+];
+const NEAR_FEATURES = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.TSS];
 
 export const coins = CoinMap.fromCoins([
   utxo('bch', 'Bitcoin Cash', Networks.main.bitcoinCash, UnderlyingAsset.BCH),


### PR DESCRIPTION
Adds TSS as a coin feature.
Updates Sol, Dot, and Near to include TSS as a coin feature.

Motivation is to provide a generic solution to determine which coins
use TSS.

Ticket: BG-00000