### PR TITLE
feat(bitgo): add explain tx polygon

### DIFF
--- a/modules/bitgo/src/v2/coins/polygon.ts
+++ b/modules/bitgo/src/v2/coins/polygon.ts
@@ -1,18 +1,31 @@
 /**
  * @prettier
  */
-import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
+import { BaseCoin, BitGoBase, TransactionExplanation } from '@bitgo/sdk-core';
 import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
-import { AbstractEthLikeCoin } from './abstractEthLikeCoin';
-import { Polygon as PolygonAccountLib } from '@bitgo/account-lib';
+import { Eth } from './eth';
+import { getBuilder, Polygon as PolygonAccountLib } from '@bitgo/account-lib';
+import BigNumber from 'bignumber.js';
+import { ExplainTransactionOptions } from './abstractEthLikeCoin';
 
-export class Polygon extends AbstractEthLikeCoin {
+export class Polygon extends Eth {
   protected constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo, staticsCoin);
   }
 
   static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Polygon(bitgo, staticsCoin);
+  }
+
+  getChain(): string {
+    return 'polygon';
+  }
+
+  /**
+   * Get the base chain that the coin exists on.
+   */
+  getBaseChain(): string {
+    return this.getChain();
   }
 
   isValidPub(pub: string): boolean {
@@ -23,5 +36,44 @@ export class Polygon extends AbstractEthLikeCoin {
       valid = false;
     }
     return valid;
+  }
+
+  /** @inheritDoc */
+  async explainTransaction(options: ExplainTransactionOptions): Promise<TransactionExplanation> {
+    const txHex = options.txHex || (options.halfSigned && options.halfSigned.txHex);
+    if (!txHex || !options.feeInfo) {
+      throw new Error('missing explain tx parameters');
+    }
+    const txBuilder = this.getTransactionBuilder();
+    txBuilder.from(txHex);
+    const tx = await txBuilder.build();
+    const outputs = tx.outputs.map((output) => {
+      return {
+        address: output.address,
+        amount: output.value,
+      };
+    });
+
+    const displayOrder = ['id', 'outputAmount', 'changeAmount', 'outputs', 'changeOutputs', 'fee'];
+
+    return {
+      displayOrder,
+      id: tx.id,
+      outputs: outputs,
+      outputAmount: outputs
+        .reduce((accumulator, output) => accumulator.plus(output.amount), new BigNumber('0'))
+        .toFixed(0),
+      changeOutputs: [], // account based does not use change outputs
+      changeAmount: '0', // account base does not make change
+      fee: options.feeInfo,
+    };
+  }
+
+  /**
+   * Create a new transaction builder for the current chain
+   * @return a new transaction builder
+   */
+  protected getTransactionBuilder(): PolygonAccountLib.TransactionBuilder {
+    return getBuilder(this.getBaseChain()) as PolygonAccountLib.TransactionBuilder;
   }
 }

--- a/modules/bitgo/src/v2/coins/tpolygon.ts
+++ b/modules/bitgo/src/v2/coins/tpolygon.ts
@@ -3,14 +3,18 @@
  */
 import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
 import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
-import { AbstractEthLikeCoin } from './abstractEthLikeCoin';
+import { Polygon } from './polygon';
 
-export class Tpolygon extends AbstractEthLikeCoin {
+export class Tpolygon extends Polygon {
   protected constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo, staticsCoin);
   }
 
   static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Tpolygon(bitgo, staticsCoin);
+  }
+
+  getChain(): string {
+    return 'tpolygon';
   }
 }

--- a/modules/bitgo/test/v2/unit/coins/polygon.ts
+++ b/modules/bitgo/test/v2/unit/coins/polygon.ts
@@ -1,20 +1,101 @@
 import { TestBitGo } from '../../../lib/test_bitgo';
 import { Polygon } from '../../../../src/v2/coins/polygon';
 import { Tpolygon } from '../../../../src/v2/coins/tpolygon';
+import * as should from 'should';
+import { getBuilder, Polygon as PolygonAccountLib } from '@bitgo/account-lib';
+import { TransactionType } from '@bitgo/sdk-core';
 
 describe('Polygon', function () {
   let bitgo;
+  let basecoin;
+
+  /**
+   * Build an unsigned account-lib multi-signature send transactino
+   * @param destination The destination address of the transaction
+   * @param contractAddress The address of the smart contract processing the transaction
+   * @param contractSequenceId The sequence id of the contract
+   * @param nonce The nonce of the sending address
+   * @param expireTime The expire time of the transaction
+   * @param amount The amount to send to the recipient
+   * @param gasPrice The gas price of the transaction
+   * @param gasLimit The gas limit of the transaction
+   */
+  const buildUnsignedTransaction = async function ({
+    destination,
+    contractAddress,
+    contractSequenceId = 1,
+    nonce = 0,
+    expireTime = Math.floor(new Date().getTime() / 1000),
+    amount = '100000',
+    gasPrice = '10000',
+    gasLimit = '20000',
+  }) {
+    const txBuilder: PolygonAccountLib.TransactionBuilder = getBuilder('tpolygon') as PolygonAccountLib.TransactionBuilder;
+    txBuilder.type(TransactionType.Send);
+    txBuilder.fee({
+      fee: gasPrice,
+      gasLimit: gasLimit,
+    });
+    txBuilder.counter(nonce);
+    txBuilder.contract(contractAddress);
+    const transferBuilder = txBuilder.transfer() as PolygonAccountLib.TransferBuilder;
+
+    transferBuilder
+      .coin('tpolygon')
+      .expirationTime(expireTime)
+      .amount(amount)
+      .to(destination)
+      .contractSequenceId(contractSequenceId);
+
+    return await txBuilder.build();
+  };
 
   before(function () {
     bitgo = new TestBitGo({ env: 'mock' });
     bitgo.initializeTestVars();
+    basecoin = bitgo.coin('tpolygon');
   });
 
-  it('should instantiate the coin', function () {
-    let localBasecoin = bitgo.coin('tpolygon');
-    localBasecoin.should.be.an.instanceof(Tpolygon);
+  describe('Instantiate', () => {
 
-    localBasecoin = bitgo.coin('polygon');
-    localBasecoin.should.be.an.instanceof(Polygon);
+    it('should instantiate the coin', function () {
+      let localBasecoin = bitgo.coin('tpolygon');
+      localBasecoin.should.be.an.instanceof(Tpolygon);
+
+      localBasecoin = bitgo.coin('polygon');
+      localBasecoin.should.be.an.instanceof(Polygon);
+    });
+
+  });
+
+  describe('Explain transaction:', () => {
+
+    it('should fail if the options object is missing parameters', async function () {
+      const explainParams = {
+        feeInfo: { fee: 1 },
+        txHex: null,
+      };
+      await basecoin.explainTransaction(explainParams).should.be.rejectedWith('missing explain tx parameters');
+    });
+
+    it('explain a transfer transaction', async function () {
+      const destination = '0xfaa8f14f46a99eb439c50e0c3b835cc21dad51b4';
+      const contractAddress = '0x9e2c5712ab4caf402a98c4bf58c79a0dfe718ad1';
+
+      const unsignedTransaction = await buildUnsignedTransaction({
+        destination,
+        contractAddress,
+      });
+
+      const explainParams = {
+        halfSigned: {
+          txHex: unsignedTransaction.toBroadcastFormat(),
+        },
+        feeInfo: { fee: 1 },
+      };
+      const explanation = await basecoin.explainTransaction(explainParams);
+      should.exist(explanation.id);
+    });
+
   });
 });


### PR DESCRIPTION
This commit adds an implementation of explainTransaction for Polygon

Ticket: [BG-41729](https://bitgoinc.atlassian.net/browse/BG-41729)