### PR TITLE
chore(bitgo-express): add unhandledRejection hook to bitgo express

### DIFF
--- a/modules/express/bin/bitgo-express
+++ b/modules/express/bin/bitgo-express
@@ -1,5 +1,13 @@
 #!/usr/bin/env node
 
+// TODO: Remove this unhandledRejection hook once BG-49996 is implemented.
+process.on('unhandledRejection', (reason, promise) => {
+  console.error('----- Unhandled Rejection at -----');
+  console.error(promise);
+  console.error('----- Reason -----');
+  console.error(reason);
+});
+
 const { init } = require('../dist/src/expressApp');
 
 if (require.main === module) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14315,7 +14315,7 @@ proto-list@~1.2.1:
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
 
-protobufjs@^6.10.0, protobufjs@^6.11.2, protobufjs@^6.11.3:
+protobufjs@^6.10.0, protobufjs@^6.11.2, protobufjs@^6.8.9:
   version "6.11.3"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.3.tgz#637a527205a35caa4f3e2a9a4a13ddffe0e7af74"
   integrity sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==


### PR DESCRIPTION
- Prevented express from crashing on unhandled promise rejections.
- This fix should be removed once BG-49996 is implemented.

Ticket: BG-48910

Starting from version 15, node process would terminate if there’s any unhandled promised rejection without the unhandledRejection hook. More info could be found [here](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V15.md#throw-on-unhandled-rejections---33021) and [here](https://nodejs.org/docs/latest-v16.x/api/cli.html#--unhandled-rejectionsmode).