### PR TITLE
feat(account-lib): add support for chaincode for key derivation in ecdsa

### DIFF
--- a/modules/account-lib/test/unit/mpc/tss/ecdsa/ecdsa.ts
+++ b/modules/account-lib/test/unit/mpc/tss/ecdsa/ecdsa.ts
@@ -24,6 +24,7 @@ describe('TSS ECDSA key generation', function () {
       keyShares[index].xShare.m.should.not.be.Null;
       keyShares[index].xShare.l.should.not.be.Null;
       keyShares[index].xShare.n.should.not.be.Null;
+      keyShares[index].xShare.chaincode.should.not.be.Null;
 
       keyShares[index].yShares[participantTwo].i.should.equal(participantOne);
       keyShares[index].yShares[participantThree].i.should.equal(participantOne);

--- a/modules/sdk-core/src/account-lib/mpc/tss/ecdsa/types.ts
+++ b/modules/sdk-core/src/account-lib/mpc/tss/ecdsa/types.ts
@@ -6,6 +6,7 @@ export interface PShare {
   u: string; // shamir share of secret
   n: string; // n => (p . q) where p and q are the two random prime numbers chosen for paillier encryption
   y: string;
+  chaincode: string;
 }
 
 // NShares which is shared to the other participants during key generation
@@ -15,6 +16,7 @@ export interface NShare {
   n: string;
   u: string; // shamir share of secret at j'th index
   y: string;
+  chaincode: string;
 }
 
 export type KeyShare = {
@@ -30,6 +32,7 @@ export interface XShare {
   n: string;
   y: string; // combined public key
   x: string; // combined secret
+  chaincode: string;
 }
 
 // YShares used during signature generation


### PR DESCRIPTION
this change add support for chaincode which is needed when we implement
key derivation for ecdsa

TICKET: BG-49979