### PR TITLE
feat(sdk-core): add staking SDK functionality

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -18,6 +18,7 @@ module.exports = {
         'BG-',
         'CR-',
         'STLX-',
+        'BOS-',
       ],
     },
   },

--- a/modules/bitgo/src/v2/coins/eth.ts
+++ b/modules/bitgo/src/v2/coins/eth.ts
@@ -1694,6 +1694,10 @@ export class Eth extends BaseCoin {
     return true;
   }
 
+  supportsStaking(): boolean {
+    return true;
+  }
+
   private isETHAddress(address: string): boolean {
     return !!address.match(/0x[a-fA-F0-9]{40}/);
   }

--- a/modules/bitgo/src/v2/coins/near.ts
+++ b/modules/bitgo/src/v2/coins/near.ts
@@ -103,6 +103,10 @@ export class Near extends BaseCoin {
     return true;
   }
 
+  supportsStaking(): boolean {
+    return true;
+  }
+
   getChain(): string {
     return this._staticsCoin.name;
   }

--- a/modules/bitgo/test/v2/fixtures/staking/stakingWallet.ts
+++ b/modules/bitgo/test/v2/fixtures/staking/stakingWallet.ts
@@ -1,0 +1,60 @@
+import {
+  PrebuildTransactionOptions,
+  StakingRequest,
+  StakingTransaction,
+} from '@bitgo/sdk-core';
+
+export default {
+  txRequestId: '55ba0198-0b1f-44f6-94fe-8d782d633dde',
+  stakingRequest: function(transactions: StakingTransaction[]) : StakingRequest {
+    return {
+      id: '8638284a-dab2-46b9-b07f-21109a6e7220',
+      amount: '1234',
+      withdrawalAddress: 'DM24xSVH88kSSKWa6ujYomLVsPwZajhZHzYiQDo7Ntn8',
+      clientId: '13f3f4fe-bff2-46df-97e8-53d914dcbbdd',
+      requestingUserId: '691823db-c57b-4c7c-a3e8-7e8d7c997e6c',
+      type: 'STAKE',
+      enterpriseId: '4517abfb-f567-4b7a-9f91-407509d29403',
+      walletId: '03564b8e-e8e7-476e-b33c-2b0ffce0b49a',
+      walletType: 'hot',
+      coin: 'near',
+      status: 'NEW',
+      statusModifiedDate: '2022-01-03T22:04:29.264Z',
+      createdDate: '2019-01-03T22:04:29.264Z',
+      transactions: transactions,
+    };
+  },
+  transaction: function(status: string, buildParams?: PrebuildTransactionOptions): StakingTransaction {
+    const transaction: StakingTransaction = {
+      id: '00566722-daef-40eb-b0ac-fa5402bbfe72',
+      stakingRequestId: '8638284a-dab2-46b9-b07f-21109a6e7220',
+      delegationId: '505bda16-a000-461a-8421-1cf3f8617883',
+      transactionType: 'DELEGATE',
+      createdDate: '2022-01-03T22:04:29.264Z',
+      status: status,
+      statusModifiedDate: '2022-01-03T22:04:29.264Z',
+      amount: '1234',
+      pendingApprovalId: 'd99e3ae1-d2a6-4f57-87b6-d04c24854739',
+      transferId: 'e4b482b0-54d5-474b-bb2b-c56ce8516b5e',
+      txRequestId: this.txRequestId,
+    };
+    if (buildParams) {
+      transaction.buildParams = buildParams;
+    }
+    return transaction;
+  },
+  buildParams: {
+    recipients: [{
+      amount: '1234',
+      address: 'address',
+      data: 'data',
+    }],
+    stakingParams: {
+      requestId: '8638284a-dab2-46b9-b07f-21109a6e7220',
+      amount: '1234',
+      validator: 'validator',
+      actionType: 'DELEGATE',
+    },
+  },
+};
+

--- a/modules/bitgo/test/v2/unit/staking/stakingWalletCommon.ts
+++ b/modules/bitgo/test/v2/unit/staking/stakingWalletCommon.ts
@@ -1,0 +1,206 @@
+import * as should from 'should';
+import * as nock from 'nock';
+import fixtures from '../../fixtures/staking/stakingWallet';
+
+import {
+  Enterprise,
+  Environments,
+  StakingRequest,
+  StakingWallet,
+  Wallet,
+} from '@bitgo/sdk-core';
+import { TestBitGo } from '@bitgo/sdk-test';
+import { BitGo } from '../../../../src';
+
+describe('Staking Wallet Common', function () {
+  const microservicesUri = Environments['mock'].uri;
+  let bitgo;
+  let baseCoin;
+  let enterprise;
+  let stakingWallet: StakingWallet;
+
+  before(function () {
+    bitgo = TestBitGo.decorate(BitGo, { env: 'mock', microservicesUri } as any);
+    bitgo.initializeTestVars();
+    baseCoin = bitgo.coin('eth');
+    baseCoin.keychains();
+    enterprise = new Enterprise(bitgo, baseCoin, { id: '5cf940949449412d00f53b3d92dbcaa3', name: 'Test Enterprise' });
+    const walletData = {
+      id: 'walletId',
+      coin: 'eth',
+      enterprise: enterprise.id,
+      keys: ['5b3424f91bf349930e340175'],
+    };
+    const wallet = new Wallet(bitgo, baseCoin, walletData);
+    stakingWallet = wallet.toStakingWallet();
+  });
+
+  describe('stake', function () {
+    it('should call staking-service to stake', async function () {
+      const expected = fixtures.stakingRequest(
+        [
+          fixtures.transaction('NEW'),
+        ]
+      );
+      const msScope = nock(microservicesUri)
+        .post(`/api/staking/v1/${stakingWallet.coin}/wallets/${stakingWallet.walletId}/requests`, {
+          amount: '1',
+          clientId: 'clientId',
+          type: 'STAKE',
+        })
+        .reply(201, expected);
+
+      const stakingRequest = await stakingWallet.stake({
+        amount: '1',
+        clientId: 'clientId',
+      });
+
+      should.exist(stakingRequest);
+
+      stakingRequest.should.deepEqual(expected);
+      msScope.isDone().should.be.True();
+    });
+  });
+
+  describe('unstake', function () {
+    it('should call staking-service to unstake', async function () {
+      const expected = fixtures.stakingRequest(
+        [
+          fixtures.transaction('NEW'),
+        ]);
+      const msScope = nock(microservicesUri)
+        .post(`/api/staking/v1/${stakingWallet.coin}/wallets/${stakingWallet.walletId}/requests`, {
+          amount: '1',
+          clientId: 'clientId',
+          type: 'UNSTAKE',
+        })
+        .reply(201, expected);
+
+      const stakingRequest = await stakingWallet.unstake({
+        amount: '1',
+        clientId: 'clientId',
+      });
+
+      should.exist(stakingRequest);
+
+      stakingRequest.should.deepEqual(expected);
+      msScope.isDone().should.be.True();
+    });
+  });
+
+  describe('getStakingRequest', function () {
+    it('should call staking-service to get staking request', async function () {
+      const stakingRequestId = '8638284a-dab2-46b9-b07f-21109a6e7220';
+      const expected = fixtures.stakingRequest(
+        [
+          fixtures.transaction('NEW'),
+        ]);
+      const msScope = nock(microservicesUri)
+        .get(`/api/staking/v1/${stakingWallet.coin}/wallets/${stakingWallet.walletId}/requests/${stakingRequestId}`)
+        .reply(200, expected);
+
+      const stakingRequest = await stakingWallet.getStakingRequest(stakingRequestId);
+
+      should.exist(stakingRequest);
+
+      stakingRequest.should.deepEqual(expected);
+      msScope.isDone().should.be.True();
+    });
+  });
+
+  describe('getTransactionsReadyToSign', function () {
+    function mockGetStakingRequest(stakingRequestId: string, expected: StakingRequest) {
+      return nock(microservicesUri)
+        .get(`/api/staking/v1/${stakingWallet.coin}/wallets/${stakingWallet.walletId}/requests/${stakingRequestId}`)
+        .reply(200, expected);
+    }
+
+    it('should return allSigningComplete false when no transactions exist', async function () {
+      const stakingRequestId = '8638284a-dab2-46b9-b07f-21109a6e7220';
+      const expected = fixtures.stakingRequest(
+        []);
+      const msScope = mockGetStakingRequest(stakingRequestId, expected);
+
+      const transactionsReadyToSign = await stakingWallet.getTransactionsReadyToSign(stakingRequestId);
+
+      should.exist(transactionsReadyToSign);
+      transactionsReadyToSign.allSigningComplete.should.be.False();
+      transactionsReadyToSign.transactions.should.be.empty();
+
+      msScope.isDone().should.be.True();
+    });
+
+    it('should return allSigningComplete true and 0 transactions when only a CONFIRMED transaction exists', async function () {
+      const stakingRequestId = '8638284a-dab2-46b9-b07f-21109a6e7220';
+      const expected = fixtures.stakingRequest(
+        [
+          fixtures.transaction('CONFIRMED'),
+        ]);
+      const msScope = mockGetStakingRequest(stakingRequestId, expected);
+
+      const transactionsReadyToSign = await stakingWallet.getTransactionsReadyToSign(stakingRequestId);
+
+      should.exist(transactionsReadyToSign);
+      transactionsReadyToSign.allSigningComplete.should.be.True();
+      transactionsReadyToSign.transactions.should.be.empty();
+
+      msScope.isDone().should.be.True();
+    });
+
+    it('should return allSigningComplete false and 0 transactions when only a NEW transaction exists', async function () {
+      const stakingRequestId = '8638284a-dab2-46b9-b07f-21109a6e7220';
+      const expectedStakingRequest = fixtures.stakingRequest(
+        [
+          fixtures.transaction('NEW'),
+        ]);
+      const msScope = mockGetStakingRequest(stakingRequestId, expectedStakingRequest);
+
+      const transactionsReadyToSign = await stakingWallet.getTransactionsReadyToSign(stakingRequestId);
+
+      should.exist(transactionsReadyToSign);
+      transactionsReadyToSign.allSigningComplete.should.be.False();
+      transactionsReadyToSign.transactions.should.be.empty();
+
+      msScope.isDone().should.be.True();
+    });
+
+    it('should return allSigningComplete false and 1 transactions when only a READY transaction exists', async function () {
+      const stakingRequestId = '8638284a-dab2-46b9-b07f-21109a6e7220';
+      const expectedTransaction = fixtures.transaction('READY');
+      const expectedStakingRequest = fixtures.stakingRequest(
+        [
+          expectedTransaction,
+        ]);
+      const msScope = mockGetStakingRequest(stakingRequestId, expectedStakingRequest);
+
+      const transactionsReadyToSign = await stakingWallet.getTransactionsReadyToSign(stakingRequestId);
+
+      should.exist(transactionsReadyToSign);
+      transactionsReadyToSign.allSigningComplete.should.be.False();
+      transactionsReadyToSign.transactions.should.containEql(expectedTransaction);
+
+      msScope.isDone().should.be.True();
+    });
+
+    it('should return allSigningComplete false and 1 transaction when NEW and READY transaction exists', async function () {
+      const stakingRequestId = '8638284a-dab2-46b9-b07f-21109a6e7220';
+      const expectedTransaction = fixtures.transaction('READY');
+      const expectedStakingRequest = fixtures.stakingRequest(
+        [
+          expectedTransaction,
+          fixtures.transaction('NEW'),
+        ]);
+      const msScope = mockGetStakingRequest(stakingRequestId, expectedStakingRequest);
+
+      const transactionsReadyToSign = await stakingWallet.getTransactionsReadyToSign(stakingRequestId);
+
+      should.exist(transactionsReadyToSign);
+      transactionsReadyToSign.allSigningComplete.should.be.False();
+      transactionsReadyToSign.transactions.should.containEql(expectedTransaction);
+
+      msScope.isDone().should.be.True();
+    });
+  });
+
+
+});

--- a/modules/bitgo/test/v2/unit/staking/stakingWalletNonTSS.ts
+++ b/modules/bitgo/test/v2/unit/staking/stakingWalletNonTSS.ts
@@ -1,0 +1,121 @@
+import * as _ from 'lodash';
+
+import * as nock from 'nock';
+import fixtures from '../../fixtures/staking/stakingWallet';
+
+import {
+  Enterprise,
+  Environments,
+  Keychains,
+  StakingWallet,
+  Wallet,
+} from '@bitgo/sdk-core';
+import { TestBitGo } from '@bitgo/sdk-test';
+import { BitGo } from '../../../../src';
+import * as sinon from 'sinon';
+
+describe('non-TSS Staking Wallet', function () {
+  const microservicesUri = Environments['mock'].uri;
+  let bitgo;
+  let baseCoin;
+  let enterprise;
+  let stakingWallet: StakingWallet;
+
+  before(function () {
+    bitgo = TestBitGo.decorate(BitGo, { env: 'mock', microservicesUri } as any);
+    bitgo.initializeTestVars();
+    baseCoin = bitgo.coin('eth');
+    baseCoin.keychains();
+    enterprise = new Enterprise(bitgo, baseCoin, { id: '5cf940949449412d00f53b3d92dbcaa3', name: 'Test Enterprise' });
+    const walletData = {
+      id: 'walletId',
+      coin: 'eth',
+      enterprise: enterprise.id,
+      keys: ['5b3424f91bf349930e340175'],
+    };
+    const wallet = new Wallet(bitgo, baseCoin, walletData);
+    stakingWallet = wallet.toStakingWallet();
+  });
+
+  describe('buildSignAndSend', function () {
+    const sandbox = sinon.createSandbox();
+
+    afterEach(function () {
+      sandbox.verifyAndRestore();
+    });
+
+    it('should build, sign and send transaction', async function () {
+      const walletPassphrase = 'passphrase';
+      const transaction = fixtures.transaction('READY', fixtures.buildParams);
+
+      // BUILD
+      nock(microservicesUri)
+        .get(`/api/staking/v1/${stakingWallet.coin}/wallets/${stakingWallet.walletId}/requests/${transaction.stakingRequestId}/transactions/${transaction.id}`)
+        .query({ expandBuildParams: true })
+        .reply(200, transaction);
+
+      const prebuildTransaction = sandbox.stub(Wallet.prototype, 'prebuildTransaction');
+      const txPrebuild = {
+        walletId: stakingWallet.walletId,
+        txHex: 'hex',
+        buildParams: transaction.buildParams,
+      };
+      prebuildTransaction.resolves(txPrebuild);
+      prebuildTransaction.calledOnceWithExactly(transaction.buildParams);
+
+      // SIGN
+      const getKeysForSigning = sandbox.stub(Keychains.prototype, 'getKeysForSigning');
+      const keyChain = {
+        id: 'id',
+        pub: 'pub',
+      };
+      getKeysForSigning.resolves([keyChain]);
+      getKeysForSigning.calledOnce;
+
+      const signTransaction = sandbox.stub(Wallet.prototype, 'signTransaction');
+      const signed = {
+        halfSigned: {
+          txHex: 'hex',
+          payload: 'payload',
+          txBase64: 'base64',
+        },
+      };
+      signTransaction.resolves(signed);
+      signTransaction.calledOnceWithExactly({
+        txPrebuild: txPrebuild,
+        walletPassphrase: walletPassphrase,
+        keychain: keyChain,
+      });
+
+      // SEND
+      nock(microservicesUri)
+        .post(`/api/staking/v1/${stakingWallet.coin}/wallets/${stakingWallet.walletId}/requests/${transaction.stakingRequestId}/transactions/${transaction.id}`,
+          _.matches(signed))
+        .reply(200, transaction);
+
+      const stakingTransaction = await stakingWallet.buildSignAndSend(
+        { walletPassphrase: walletPassphrase },
+        transaction,
+      );
+
+      stakingTransaction.should.deepEqual(transaction);
+    });
+
+    it('should throw error when buildParams are not expanded', async function () {
+      const walletPassphrase = 'passphrase';
+      const transaction = fixtures.transaction('READY');
+
+      // BUILD
+      nock(microservicesUri)
+        .get(`/api/staking/v1/${stakingWallet.coin}/wallets/${stakingWallet.walletId}/requests/${transaction.stakingRequestId}/transactions/${transaction.id}`)
+        .query({ expandBuildParams: true })
+        .reply(200, transaction);
+
+      await stakingWallet.buildSignAndSend(
+        { walletPassphrase: walletPassphrase },
+        transaction,
+      ).should.rejectedWith(`Staking transaction ${transaction.id} build params not expanded`);
+    });
+
+  });
+});

--- a/modules/bitgo/test/v2/unit/staking/stakingWalletTSS.ts
+++ b/modules/bitgo/test/v2/unit/staking/stakingWalletTSS.ts
@@ -1,0 +1,97 @@
+import * as _ from 'lodash';
+
+import * as nock from 'nock';
+import fixtures from '../../fixtures/staking/stakingWallet';
+
+import {
+  Enterprise,
+  Environments,
+  Keychains,
+  StakingWallet,
+  TssUtils,
+  Wallet,
+} from '@bitgo/sdk-core';
+import { TestBitGo } from '@bitgo/sdk-test';
+import { BitGo } from '../../../../src';
+
+import * as sinon from 'sinon';
+
+describe('TSS Staking Wallet', function () {
+  const microservicesUri = Environments['mock'].uri;
+  let bitgo;
+  let baseCoin;
+  let enterprise;
+  let stakingWallet: StakingWallet;
+
+  before(function () {
+    bitgo = TestBitGo.decorate(BitGo, { env: 'mock', microservicesUri } as any);
+    bitgo.initializeTestVars();
+    baseCoin = bitgo.coin('near');
+    baseCoin.keychains();
+    enterprise = new Enterprise(bitgo, baseCoin, { id: '5cf940949449412d00f53b3d92dbcaa3', name: 'TSS Test Enterprise' });
+    const tssWalletData = {
+      id: 'walletIdTss',
+      coin: 'near',
+      enterprise: enterprise.id,
+      keys: ['5b3424f91bf349930e340175'],
+    };
+    const wallet = new Wallet(bitgo, baseCoin, tssWalletData);
+    stakingWallet = wallet.toStakingWallet();
+  });
+
+  describe('buildSignAndSend', function () {
+    const sandbox = sinon.createSandbox();
+
+    afterEach(function () {
+      sandbox.verifyAndRestore();
+    });
+
+    it('should throw error when txRequestId is not defined', async function () {
+      const transaction = fixtures.transaction('READY');
+      transaction.txRequestId = undefined;
+      await stakingWallet.buildSignAndSend(
+        { walletPassphrase: 'passphrase' },
+        transaction,
+      ).should.rejectedWith('txRequestId is required to sign and send');
+    });
+
+    it('should build, sign and send transaction', async function () {
+      const walletPassphrase = 'passphrase';
+      const transaction = fixtures.transaction('READY');
+      const deleteSignatureShares = sandbox.stub(TssUtils.prototype, 'deleteSignatureShares');
+      deleteSignatureShares.resolves([]);
+      deleteSignatureShares.calledOnceWithExactly(transaction.id);
+
+      const getKeysForSigning = sandbox.stub(Keychains.prototype, 'getKeysForSigning');
+      const keyChain = {
+        id: 'id',
+        pub: 'pub',
+      };
+      getKeysForSigning.resolves([keyChain]);
+      getKeysForSigning.calledOnce;
+
+      const signTransaction = sandbox.stub(Wallet.prototype, 'signTransaction');
+      signTransaction.resolves({ txRequestId: fixtures.txRequestId });
+      signTransaction.calledOnceWithExactly({
+        txPrebuild: {
+          txRequestId: fixtures.txRequestId,
+        },
+        walletPassphrase: walletPassphrase,
+        keychain: keyChain,
+      });
+
+      nock(microservicesUri)
+        .post(`/api/staking/v1/${stakingWallet.coin}/wallets/${stakingWallet.walletId}/requests/${transaction.stakingRequestId}/transactions/${transaction.id}`,
+          _.matches({ txRequestId: fixtures.txRequestId }))
+        .reply(200, transaction);
+
+      const stakingTransaction = await stakingWallet.buildSignAndSend(
+        { walletPassphrase: walletPassphrase },
+        transaction,
+      );
+
+      stakingTransaction.should.deepEqual(transaction);
+    });
+
+  });
+});

--- a/modules/sdk-core/src/bitgo/baseCoin/baseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/baseCoin.ts
@@ -153,6 +153,14 @@ export abstract class BaseCoin implements IBaseCoin {
   }
 
   /**
+   * Flag indicating if this coin supports staking.
+   * @returns {boolean} True if staking is supported for this coin, False otherwise
+   */
+  supportsStaking(): boolean {
+    return false;
+  }
+
+  /**
    * Flag indicating if this coin supports BLS-DKG wallets.
    * @returns {boolean} True if BLS-DKG Wallets can be created for this coin
    */

--- a/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
@@ -261,6 +261,7 @@ export interface IBaseCoin {
   transactionDataAllowed(): boolean;
   allowsAccountConsolidations(): boolean;
   supportsTss(): boolean;
+  supportsStaking(): boolean;
   supportsBlsDkg(): boolean;
   getBaseFactor(): number | string;
   baseUnitsToBigUnits(baseUnits: string | number): string;

--- a/modules/sdk-core/src/bitgo/index.ts
+++ b/modules/sdk-core/src/bitgo/index.ts
@@ -16,6 +16,7 @@ export * from './keychain';
 export * from './market';
 export * from './pendingApproval';
 export * from './recovery';
+export * from './staking';
 export * from './trading';
 export * from './tss';
 export * from './types';

--- a/modules/sdk-core/src/bitgo/staking/iStakingWallet.ts
+++ b/modules/sdk-core/src/bitgo/staking/iStakingWallet.ts
@@ -1,0 +1,80 @@
+import { PrebuildTransactionOptions, PrebuildTransactionResult } from '../wallet';
+import { SignedTransaction } from '../baseCoin';
+
+export interface StakingRequest {
+  id: string;
+  amount: string;
+  withdrawalAddress: string;
+  clientId?: string;
+  requestingUserId: string;
+  type: string;
+  enterpriseId: string;
+  walletId: string;
+  walletType: string;
+  coin: string;
+  status: string;
+  statusModifiedDate: string;
+  createdDate: string;
+  transactions: StakingTransaction[];
+}
+
+export interface StakeOptions {
+  amount: string;
+  clientId?: string;
+}
+
+export interface UnstakeOptions {
+  amount: string;
+  clientId?: string;
+}
+
+export interface TransactionsReadyToSign {
+  allSigningComplete: boolean;
+  transactions: StakingTransaction[];
+}
+
+export interface StakingTransaction {
+  id: string;
+  stakingRequestId: string;
+  delegationId: string;
+  transactionType: string;
+  createdDate: string;
+  status: string;
+  statusModifiedDate: string;
+  amount: string;
+  pendingApprovalId?: string;
+  transferId?: string;
+  txRequestId?: string;
+  buildParams?: PrebuildTransactionOptions;
+  gasPrice?: string;
+}
+
+export interface StakingPrebuildTransactionResult {
+  transaction: StakingTransaction;
+  result: PrebuildTransactionResult;
+}
+
+export interface StakingSignedTransaction {
+  transaction: StakingTransaction;
+  signed: SignedTransaction;
+}
+
+export interface StakingSignOptions {
+  walletPassphrase: string;
+}
+
+export interface IStakingWallet {
+  readonly walletId: string;
+  readonly coin: string;
+  stake(options: StakeOptions): Promise<StakingRequest>;
+  unstake(options: UnstakeOptions): Promise<StakingRequest>;
+  getStakingRequest(stakingRequestId: string): Promise<StakingRequest>;
+  getTransactionsReadyToSign(stakingRequestId: string): Promise<TransactionsReadyToSign>;
+  build(transaction: StakingTransaction): Promise<StakingPrebuildTransactionResult>;
+  sign(
+    signOptions: StakingSignOptions,
+    stakingPrebuildTransaction: StakingPrebuildTransactionResult
+  ): Promise<StakingSignedTransaction>;
+  send(signedTransaction: StakingSignedTransaction): Promise<StakingTransaction>;
+  buildSignAndSend(signOptions: StakingSignOptions, transaction: StakingTransaction);
+}

--- a/modules/sdk-core/src/bitgo/staking/index.ts
+++ b/modules/sdk-core/src/bitgo/staking/index.ts
@@ -1,0 +1,2 @@
+export * from './iStakingWallet';
+export * from './stakingWallet';

--- a/modules/sdk-core/src/bitgo/staking/stakingWallet.ts
+++ b/modules/sdk-core/src/bitgo/staking/stakingWallet.ts
@@ -1,0 +1,196 @@
+/**
+ * @prettier
+ */
+import {
+  IStakingWallet,
+  StakingRequest,
+  TransactionsReadyToSign,
+  StakingTransaction,
+  StakingPrebuildTransactionResult,
+  StakingSignedTransaction,
+  StakingSignOptions,
+  StakeOptions,
+  UnstakeOptions,
+} from './iStakingWallet';
+import { BitGoBase } from '../bitgoBase';
+import { IWallet } from '../wallet';
+import { ITssUtils, RequestTracer, TssUtils } from '../utils';
+
+export class StakingWallet implements IStakingWallet {
+  private readonly bitgo: BitGoBase;
+
+  public wallet: IWallet;
+  public tssUtil: ITssUtils;
+
+  constructor(wallet: IWallet) {
+    this.wallet = wallet;
+    this.bitgo = wallet.bitgo;
+    this.tssUtil = new TssUtils(this.bitgo, this.wallet.baseCoin, this.wallet);
+  }
+
+  get walletId(): string {
+    return this.wallet.id();
+  }
+
+  get coin(): string {
+    return this.wallet.coin();
+  }
+
+  /**
+   * Stake coins
+   * @param options - stake options
+   * @return StakingRequest
+   */
+  async stake(options: StakeOptions): Promise<StakingRequest> {
+    return await this.createStakingRequest(options.amount, 'STAKE', options.clientId);
+  }
+
+  /**
+   * Unstake coins
+   * @param options - unstake options
+   * @return StakingRequest
+   */
+  async unstake(options: UnstakeOptions): Promise<StakingRequest> {
+    return await this.createStakingRequest(options.amount, 'UNSTAKE', options.clientId);
+  }
+
+  /**
+   * Get a staking request by ID
+   * @param stakingRequestId - id of the staking request to retrieve
+   * @return StakingRequest
+   */
+  async getStakingRequest(stakingRequestId: string): Promise<StakingRequest> {
+    return await this.bitgo.get(this.bitgo.microservicesUrl(this.stakingRequestUrl(stakingRequestId))).result();
+  }
+
+  /**
+   * Get transactions ready to sign
+   * @param stakingRequestId
+   * @return TransactionsReadyToSign
+   */
+  async getTransactionsReadyToSign(stakingRequestId: string): Promise<TransactionsReadyToSign> {
+    const stakingRequest: StakingRequest = await this.getStakingRequest(stakingRequestId);
+    const readyToSign: StakingTransaction[] = stakingRequest.transactions.filter(
+      (transaction: StakingTransaction) => transaction.status === `READY`
+    );
+    const newTransactions: StakingTransaction[] = stakingRequest.transactions.filter(
+      (transaction: StakingTransaction) => transaction.status === `NEW`
+    );
+
+    return Promise.resolve({
+      allSigningComplete:
+        stakingRequest.transactions.length > 0 && newTransactions.length === 0 && readyToSign.length === 0,
+      transactions: readyToSign,
+    });
+  }
+
+  /**
+   * Build the staking transaction
+   * If TSS delete signature shares, else expand build params and then build
+   * @param transaction - staking transaction to build
+   */
+  async build(transaction: StakingTransaction): Promise<StakingPrebuildTransactionResult> {
+    if (this.wallet.baseCoin.supportsTss()) {
+      if (!transaction.txRequestId) {
+        throw new Error('txRequestId is required to sign and send');
+      }
+      // delete signature shares before signing for transaction request API
+      await this.tssUtil.deleteSignatureShares(transaction.txRequestId);
+      return {
+        transaction: transaction,
+        result: {
+          walletId: this.walletId,
+          txRequestId: transaction.txRequestId,
+        },
+      };
+    } else {
+      transaction = await this.expandBuildParams(transaction);
+      if (!transaction.buildParams) {
+        throw Error(`Staking transaction ${transaction.id} build params not expanded`);
+      }
+      return {
+        transaction: transaction,
+        result: await this.wallet.prebuildTransaction(transaction.buildParams),
+      };
+    }
+  }
+
+  /**
+   * Sign the staking transaction
+   * @param signOptions
+   * @param stakingPrebuildTransaction
+   */
+  async sign(
+    signOptions: StakingSignOptions,
+    stakingPrebuildTransaction: StakingPrebuildTransactionResult
+  ): Promise<StakingSignedTransaction> {
+    const reqId = new RequestTracer();
+    const keychain = await this.wallet.baseCoin.keychains().getKeysForSigning({
+      wallet: this.wallet,
+      reqId: reqId,
+    });
+    return {
+      transaction: stakingPrebuildTransaction.transaction,
+      signed: await this.wallet.signTransaction({
+        txPrebuild: stakingPrebuildTransaction.result,
+        walletPassphrase: signOptions.walletPassphrase,
+        keychain: keychain[0],
+      }),
+    };
+  }
+
+  /**
+   * Send the signed staking transaction
+   * @param signedTransaction
+   */
+  async send(signedTransaction: StakingSignedTransaction): Promise<StakingTransaction> {
+    return await this.bitgo
+      .post(this.bitgo.microservicesUrl(this.stakingTransactionURL(signedTransaction.transaction)))
+      .send(signedTransaction.signed)
+      .result();
+  }
+
+  /**
+   * Build, sign and send the transaction.
+   * @param signOptions
+   * @param transaction
+   */
+  async buildSignAndSend(
+    signOptions: StakingSignOptions,
+    transaction: StakingTransaction
+  ): Promise<StakingTransaction> {
+    return await this.build(transaction)
+      .then((result: StakingPrebuildTransactionResult) => this.sign(signOptions, result))
+      .then((result: StakingSignedTransaction) => this.send(result));
+  }
+
+  private async expandBuildParams(stakingTransaction: StakingTransaction): Promise<StakingTransaction> {
+    return await this.bitgo
+      .get(this.bitgo.microservicesUrl(this.stakingTransactionURL(stakingTransaction)))
+      .query({ expandBuildParams: true })
+      .result();
+  }
+
+  private async createStakingRequest(amount: string, type: string, clientId?: string): Promise<StakingRequest> {
+    return await this.bitgo
+      .post(this.bitgo.microservicesUrl(this.stakingRequestsURL()))
+      .send({
+        amount: amount,
+        clientId: clientId,
+        type: type,
+      })
+      .result();
+  }
+
+  private stakingRequestsURL() {
+    return `/api/staking/v1/${this.coin}/wallets/${this.walletId}/requests`;
+  }
+
+  private stakingRequestUrl(stakingRequestId: string): string {
+    return `${this.stakingRequestsURL()}/${stakingRequestId}`;
+  }
+
+  private stakingTransactionURL(stakingTransaction: StakingTransaction): string {
+    return `${this.stakingRequestUrl(stakingTransaction.stakingRequestId)}/transactions/${stakingTransaction.id}`;
+  }
+}

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -3,6 +3,7 @@ import { IBaseCoin, SignedTransaction, TransactionPrebuild, VerificationOptions 
 import { BitGoBase } from '../bitgoBase';
 import { Keychain } from '../keychain';
 import { IPendingApproval, PendingApprovalData } from '../pendingApproval';
+import { IStakingWallet } from '../staking';
 import { ITradingAccount } from '../trading';
 
 export interface MaximumSpendableOptions {
@@ -543,6 +544,7 @@ export interface IWallet {
   remove(params?: Record<string, never>): Promise<any>;
   toJSON(): WalletData;
   toTradingAccount(): ITradingAccount;
+  toStakingWallet(): IStakingWallet;
   downloadKeycard(params?: DownloadKeycardOptions): void;
   buildAccountConsolidations(params?: BuildConsolidationTransactionOptions): Promise<PrebuildTransactionResult[]>;
   sendAccountConsolidation(params?: PrebuildAndSignTransactionOptions): Promise<any>;

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -67,6 +67,7 @@ import {
   WalletData,
   WalletSignTransactionOptions,
 } from './iWallet';
+import { StakingWallet } from '../staking/stakingWallet';
 
 const debug = require('debug')('bitgo:v2:wallet');
 
@@ -2038,6 +2039,16 @@ export class Wallet implements IWallet {
       throw new Error('Can only convert an Offchain (OFC) wallet to a trading account');
     }
     return new TradingAccount(this._wallet.enterprise, this, this.bitgo);
+  }
+
+  /**
+   * Create a staking wallet from this wallet
+   */
+  toStakingWallet(): StakingWallet {
+    if (!this.baseCoin.supportsStaking()) {
+      throw new Error(`Staking not supported for ${this.coin()}`);
+    }
+    return new StakingWallet(this);
   }
 
   /**


### PR DESCRIPTION
- Adds staking functionality via `IStakingWallet`
> - Currently only supports NEAR and ETH
- Added `supportsStaking` method to `IBaseCoin`
- Added `toStakingWallet` method to `IWallet`
- IStakingWallet methods
> - `stakingWallet.stake`
> - `stakingWallet.unstake`
> - `stakingWallet.getTransactionsReadyToSign`
> - `stakingWallet.build`
> - `stakingWallet.sign`
> - `stakingWallet.send`
> - `stakingWallet.signSendAndBuild` 

Ticket: BOS-360