### PR TITLE
fix: fix tss wallet creation

### DIFF
--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
@@ -235,13 +235,16 @@ export class TssUtils extends MpcUtils implements ITssUtils {
 
     const randomHexString = crypto.randomBytes(12).toString('hex');
 
+    // Allow generating secp256k1 key pairs
+    openpgp.config.rejectCurves = new Set();
     const userGpgKey = await openpgp.generateKey({
       userIDs: [
         {
           name: randomHexString,
-          email: `${randomHexString}@${randomHexString}.com`,
+          email: `user-${randomHexString}@${randomHexString}.com`,
         },
       ],
+      curve: 'secp256k1',
     });
 
     const bitgoKeychain = await this.createBitgoKeychain(userGpgKey, userKeyShare, backupKeyShare, params.enterprise);


### PR DESCRIPTION
HSM is now expecting secp2561k key pairs instead of the default ed25519.

Ticket: BG-50200

Verified by creating a wallet in test:
```
async function createTssWallet() {
  const newWallet = await bitgo.coin('tsol').wallets().generateWallet({
    label: 'tss sol 605',
    passphrase: 'Ghghjkg!455544llll',
    multisigType: 'tss',
    passcodeEncryptionCode: 'passcodeEncryptionCode',
    // enterprise: '60c7f599fdbda8000657d147f5c08f6e'
  });

  console.log(JSON.stringify(newWallet, undefined, 2));
}
```