### PR TITLE
demo

### DIFF
--- a/modules/bitgo/test/v2/unit/internal/tssUtils.ts
+++ b/modules/bitgo/test/v2/unit/internal/tssUtils.ts
@@ -346,6 +346,39 @@ describe('TSS Utils:', async function () {
     });
   });
 
+  describe('demo', async function () {
+    const userPrv = '{"uShare":{"i":1,"t":2,"n":3,"y":"f64e064e630ef21034182e48305f026dac7c0245ed07208b41d54e5ecb7b0a93","seed":"56e480a8ad430ae1f279ab7181c7df40634c6c128c0c3ad24391b8fd588d5ce7","chaincode":"0472849c477591d232c2e0caee2c4e5435ec73a4e9343e632e105dddff95e444"},"bitgoYShare":{"i":1,"j":3,"y":"572622e04a3104791f4c39c3f79062e6239d330d0a560ec85f1eab1faea6f05b","u":"07989726475f972477b5346ae6b98b482acd462db1868b979db475e32fc9bf0a","chaincode":"4c74d65b7865e441040e9f3078579aaef61ea80401e23a9891ae928bcd7f1941"},"backupYShare":{"i":1,"j":2,"y":"2c18fb8faf76e946cda3b413751bae16bb28c6d264de39a23b29a662b176a3e1","u":"c49a7e8d7146a0c8d1b3058577ed077227ccb83f9209a49175a6588b50d0f505","chaincode":"2fdf4d95ea4fe89a9f4e8e9491c0f4152a28057f8b9a66bbd88d3f6d482a62a6"}}';
+    const signableHex = '6d9fbd7e6e3d48f142288d054f8f38d0a65bbadf867f8313937c8f3c8b63731a';
+
+    it('should generate r share', async function () {
+
+      const derivationPath = 'm/999999/187246649/33072247/0';
+
+      const rShare = await tssUtils.demo_createUserRShare({
+        signableHex,
+        derivationPath,
+        prv: userPrv,
+      });
+
+      console.log(JSON.stringify(rShare, undefined, 2));
+    });
+
+    it('should generate g share', async function () {
+      // Copy over from test output above
+      const userSignShare = '';
+      // Get signature share record from DB
+      const bitgoToUserRShare = '';
+      const gShare = await tssUtils.demo_createUserGShare({
+        prv: userPrv,
+        userSignShare,
+        bitgoToUserRShare,
+        signableHex,
+      });
+
+      console.log(JSON.stringify(gShare, undefined, 2));
+    });
+  });
+
   describe('prebuildTxWithIntent:', async function() {
     it('should build single recipient tx', async function () {
       const nockedCreateTx = await nockCreateTxRequest({

--- a/modules/sdk-core/src/bitgo/utils/iTssUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/iTssUtils.ts
@@ -1,5 +1,5 @@
 import type { SerializedKeyPair } from 'openpgp';
-import { KeyShare } from '../../account-lib/mpc/tss';
+import { KeyShare, SignShare } from '../../account-lib/mpc/tss';
 import { IRequestTracer } from '../../api';
 import { KeychainsTriplet } from '../baseCoin';
 import { Keychain } from '../keychain';
@@ -80,4 +80,15 @@ export interface ITssUtils {
   sendTxRequest(txRequestId: string): Promise<any>;
   recreateTxRequest(txRequestId: string, decryptedPrv: string, reqId: IRequestTracer): Promise<TxRequest>;
   getTxRequest(txRequestId: string): Promise<TxRequest>;
+  demo_createUserRShare(params: {
+    signableHex: string;
+    derivationPath: string;
+    prv: string;
+  }): Promise<{ signatureShare: SignatureShareRecord; signerShare: string; userSignShare: SignShare }>;
+  demo_createUserGShare(params: {
+    signableHex: string;
+    bitgoToUserRShare: string;
+    prv: string;
+    userSignShare: string;
+  }): Promise<SignatureShareRecord>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14315,7 +14315,7 @@ proto-list@~1.2.1:
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
 
-protobufjs@^6.10.0, protobufjs@^6.11.2, protobufjs@^6.11.3:
+protobufjs@^6.10.0, protobufjs@^6.11.2, protobufjs@^6.8.9:
   version "6.11.3"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.3.tgz#637a527205a35caa4f3e2a9a4a13ddffe0e7af74"
   integrity sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==


### PR DESCRIPTION
For TSS Custodial Testing against Test.

Usage:
1. update `signableHex` with value from TxRequest you want to sign
2. run test `should generate r share`, which should output something that looks like:
```
{
  "signatureShare": {
    "from": "user",
    "to": "bitgo",
    "share": "0199c738c4ae72d6d50023620810ae73bf44eabfe3788a8f96286ffb977b1b019c2290768fbeb3c087052aa911043b0874db91ae0f2f9387f8638f862c2e1ea1"
  },
  "signerShare": "-----BEGIN PGP MESSAGE-----\n\nwV4DdzH1fjYwAPoSAQdA7GUHIXshxZibxMaA7CQ1oMIoRONnBKTCzMO0RSGT\n6hwwb4d9b3XRw6bDYV/eZ6TKskOBWXZeCIDG3LiZ37kadL4cAn1wrEFP8QB2\nS/XELL+20rEB6YCLCl7l6A9wJyOfHLdTIoJbuhx4GVt7wqJTMgbXc+EJpFnw\nFc1T9iugcjFn88PtC1ZAEKbUcO1JNUxqa/GcJ0XkjRQbFWIJuGz1QcrgrlIJ\nnNSerdmBoxnwcJhAX5zclODZZ+0pefscOBwgfrovOH4xe8Up+B1741AACq0z\nBzsDtjs7SNzdfmInlyGDPCcFvGUgxRioP245kxwxp/zArEP2WugifIJLf/p8\niHfqGxo=\n=fbCF\n-----END PGP MESSAGE-----\n",
  "userSignShare": {
    "xShare": {
      "i": 1,
      "y": "e0d51c683ae06d2e6d74eaffc3c18801b0c5475802fab584ad7641bc2874c3e9",
      "u": "11051138ab93b6b28425f8590a30cdeea18cc6c1536d3cfdeb96720b23d5ed0d",
      "r": "9a5fe72affc5dd5006cf7976c651272f35ebe37ba343e3d98b5fa5acefe4f30e",
      "R": "9c2290768fbeb3c087052aa911043b0874db91ae0f2f9387f8638f862c2e1ea1"
    },
    "rShares": {
      "3": {
        "i": 3,
        "j": 1,
        "u": "ff7700a92acc53dd6e812504cfe44bf11e2a27892e48e281c9a2fb5def313a0c",
        "r": "0199c738c4ae72d6d50023620810ae73bf44eabfe3788a8f96286ffb977b1b01",
        "R": "9c2290768fbeb3c087052aa911043b0874db91ae0f2f9387f8638f862c2e1ea1"
      }
    }
  }
}
```
3. upload `signatureShare` and `signerShare` from output to admin route
4. copy `userSignShare` from output and use it in `should generate g share` (stored as a json string)
5. get bitgoToUserRShare from TxRequest in DB and use it in `should generate g share` (stored as a json string)
6. run test `should generate g share`
7. upload output as g share using admin api