### PR TITLE
chore(blsdkg): fix bls-dkg package UT failing because of timeout

### DIFF
--- a/modules/bls-dkg/.mocharc.js
+++ b/modules/bls-dkg/.mocharc.js
@@ -1,6 +1,6 @@
 'use strict';
 
 module.exports = {
-  timeout: '5000',
+  timeout: '20000',
   exit: true,
 }


### PR DESCRIPTION
A bls-dkg UT is failing because of timeout. There is nothing causing it to not return successfully
or an error, seems that sometimes it takes longer than expected. BTW, it just takes as much as 300ms
to complete on local. So increase the timeout property for mocha when running UT on this package.

BG-50890