### PR TITLE
Revert "feat(bitgo): handle new response for consolidateAccount/build…

### DIFF
--- a/modules/bitgo/test/v2/unit/accountConsolidations.ts
+++ b/modules/bitgo/test/v2/unit/accountConsolidations.ts
@@ -61,23 +61,6 @@ describe('Account Consolidations:', function () {
 
           scope.isDone().should.be.True();
         });
-
-        it('should throw no consolidations if sub addresses do not have enought amount', async function () {
-          if (coinName === 'talgo') {
-            // GIVEN an ALGO wallet with N receive addresses WITHOUT enough balance to consolidate
-            const scope = nock(bgUrl)
-              .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/consolidateAccount/build`)
-              .query({})
-              .reply(204, {});
-
-            // WHEN call built consolidation for that ALGO wallet
-            const accountConsolidationBuild = await wallet.buildAccountConsolidations();
-
-            // THEN length of built consolidations should be zero since it's a 204 HTTP response without body
-            accountConsolidationBuild.length.should.equal(0);
-            scope.isDone().should.be.True();
-          }
-        });
       });
 
       describe('Sending', function () {

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -2171,18 +2171,12 @@ export class Wallet implements IWallet {
     // this could return 100 build transactions
     const buildResponse = (await this.bitgo
       .post(this.baseCoin.url('/wallet/' + this.id() + '/consolidateAccount/build'))
-      .send(whitelistedParams)) as any;
-
-    const consolidations: PrebuildTransactionResult[] = [];
-    // When call '/consolidateAccount/build' endpoint and all receive addresses
-    // do not have spendable balance to consolidate this endpoint will return
-    // 204 HTTP response since it isn't an error that there isn't any amount to consolidate
-    if (buildResponse.status === 204) {
-      return consolidations;
-    }
+      .send(whitelistedParams)
+      .result()) as any;
 
     // we need to step over each prebuild now - should be in an array in the body
-    for (const consolidateAccountBuild of buildResponse.body) {
+    const consolidations: PrebuildTransactionResult[] = [];
+    for (const consolidateAccountBuild of buildResponse) {
       let prebuild: PrebuildTransactionResult = (await this.baseCoin.postProcessPrebuild(
         Object.assign(consolidateAccountBuild, { wallet: this, buildParams: whitelistedParams })
       )) as PrebuildTransactionResult;


### PR DESCRIPTION
This reverts commit a333c5f347aeab789414945aff5ed4281f3be296.

Revering this commit as it breaks consolidation and was pushed to early before wallet-platform changes. These changes will be reimplemented correctly once wallet-platform work is complete.