### PR TITLE
feat(root): improve CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,22 @@ jobs:
         run: |
           git fetch origin $GITHUB_BASE_REF
 
+      - name: restore lerna dependencies
+        id: lerna-cache
+        uses: actions/cache@v3
+        with:
+          path:  |
+            node_modules
+            modules/*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+
       - name: Install Packages
+        if: steps.lerna-cache.outputs.cache-hit != 'true'
         run: yarn install --with-frozen-lockfile
+      
+      - name: build packages
+        if: steps.lerna-cache.outputs.cache-hit == 'true'
+        run: yarn run postinstall
 
       - name: Lint Commit Messages
         if: ${{ startsWith(matrix.node-version, '14') }}
@@ -149,8 +163,23 @@ jobs:
             xdg-utils \
             wget
 
+      - name: restore lerna dependencies
+        id: lerna-cache
+        uses: actions/cache@v3
+        with:
+          path:  |
+            node_modules
+            modules/*/node_modules
+            /home/runner/.cache/Cypress
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+
       - name: Install Packages
+        if: steps.lerna-cache.outputs.cache-hit != 'true'
         run: yarn install --with-frozen-lockfile
+
+      - name: build packages
+        if: steps.lerna-cache.outputs.cache-hit == 'true'
+        run: yarn run postinstall
 
       - name: Browser Tests
         run: yarn run browser-tests


### PR DESCRIPTION
CI Checks running unit test cases for both 14.x and 16.x roughly takes 8+ minutes where roughly 50%-60% time is taken for dependency installation + build (~4 minutes) which is essentially redundant if packages are not updated. This changes adds the ability to cache dependencies and install if and only if packages are updated saving roughly 2-3 mins CI build time per workflow (14.x and 16.x). Reference [here](https://github.com/actions/cache/blob/main/examples.md#node---lerna)

TICKET:  BG-00000