### PR TITLE
fix(bitgo): rounded value on spendable balance

### DIFF
--- a/modules/bitgo/test/v2/unit/baseCoin.ts
+++ b/modules/bitgo/test/v2/unit/baseCoin.ts
@@ -18,6 +18,7 @@ describe('V2 Base Coin:', function () {
   let basecoinEth;
   let basecoinBtc;
   let basecoinXlm;
+  let basecoinNear;
   let basecoinErc20TokenWithName;
   let basecoinErc20TokenWithContractHash;
   let baseCoinStellarToken;
@@ -28,6 +29,7 @@ describe('V2 Base Coin:', function () {
     basecoinEth = bitgo.coin('teth');
     basecoinBtc = bitgo.coin('tbtc');
     basecoinXlm = bitgo.coin('txlm');
+    basecoinNear = bitgo.coin('tnear');
     basecoinEth.keychains();
     basecoinErc20TokenWithName = bitgo.coin('terc');
     basecoinErc20TokenWithContractHash = bitgo.coin('0x945ac907cf021a6bcd07852bb3b8c087051706a9');
@@ -69,6 +71,17 @@ describe('V2 Base Coin:', function () {
       // others
       basecoinXlm.baseUnitsToBigUnits('10000001').should.equal('1.0000001');
     });
+
+    it('should convert amounts to NEAR', function () {
+
+      basecoinNear.baseUnitsToBigUnits('5348162392287187499999010').should.equal('5.34816239228718749999901');
+
+      basecoinNear.baseUnitsToBigUnits('5555555555555555555555550').should.equal('5.55555555555555555555555');
+
+      basecoinNear.baseUnitsToBigUnits('197895229538867437499999802').should.equal('197.895229538867437499999802');
+
+    });
+
   });
 
   describe('supportsBlockTarget', function () {

--- a/modules/sdk-core/src/bitgo/baseCoin/baseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/baseCoin.ts
@@ -179,6 +179,7 @@ export abstract class BaseCoin implements IBaseCoin {
    * to big units (btc, eth, xrp, xlm)
    */
   baseUnitsToBigUnits(baseUnits: string | number): string {
+    BigNumber.set({ DECIMAL_PLACES: 24 });
     const dividend = this.getBaseFactor();
     const bigNumber = new BigNumber(baseUnits).dividedBy(dividend);
     // set the format so commas aren't added to large coin amounts


### PR DESCRIPTION
rounded value on spendable balance.
i add this line of code because by default bigNumber use 20 decimal places 
https://mikemcl.github.io/bignumber.js/#decimal-places
![image](https://user-images.githubusercontent.com/85512331/175935812-f03eccf5-4fa4-4ca8-8f99-ec1c9769f5a2.png)
and near need 24 
image of the fix
![image](https://user-images.githubusercontent.com/85512331/175936544-cc43569f-9283-4808-ab0a-ac7d0acba8af.png)

STLX-17105