### PR TITLE
fix: use correct address encoding when decoding polkadot txn

### DIFF
--- a/modules/account-lib/src/coin/dot/claimBuilder.ts
+++ b/modules/account-lib/src/coin/dot/claimBuilder.ts
@@ -2,7 +2,7 @@ import { BaseCoin as CoinConfig } from '@bitgo/statics';
 import { DecodedSignedTx, DecodedSigningPayload, UnsignedTransaction } from '@substrate/txwrapper-core';
 import { methods } from '@substrate/txwrapper-polkadot';
 import BigNumber from 'bignumber.js';
-import { BaseAddress, InvalidTransactionError, TransactionType } from '@bitgo/sdk-core';
+import { BaseAddress, DotAssetTypes, InvalidTransactionError, TransactionType } from '@bitgo/sdk-core';
 import { ClaimArgs, MethodNames } from './iface';
 import { Transaction } from './transaction';
 import { TransactionBuilder } from './transactionBuilder';
@@ -90,7 +90,12 @@ export class ClaimBuilder extends TransactionBuilder {
     const tx = super.fromImplementation(rawTransaction);
     if (this._method?.name === MethodNames.PayoutStakers) {
       const txMethod = this._method.args as ClaimArgs;
-      this.validatorStash({ address: utils.decodeDotAddress(txMethod.validatorStash) });
+      this.validatorStash({
+        address: utils.decodeDotAddress(
+          txMethod.validatorStash,
+          utils.getAddressFormat(this._coinConfig.name as DotAssetTypes),
+        ),
+      });
       this.claimEra(txMethod.era);
     } else {
       throw new InvalidTransactionError(`Invalid Transaction Type: ${this._method?.name}. Expected payoutStakers`);

--- a/modules/account-lib/src/coin/dot/keyPair.ts
+++ b/modules/account-lib/src/coin/dot/keyPair.ts
@@ -1,12 +1,11 @@
 import { Keyring } from '@polkadot/keyring';
 import { createPair } from '@polkadot/keyring/pair';
 import { KeyringPair } from '@polkadot/keyring/types';
-import { DefaultKeys, KeyPairOptions, AddressFormat, Ed25519KeyPair, toHex, isBase58 } from '@bitgo/sdk-core';
+import { DotAddressFormat, DefaultKeys, Ed25519KeyPair, isBase58, KeyPairOptions, toHex } from '@bitgo/sdk-core';
 import utils from './utils';
 import bs58 from 'bs58';
 
 const TYPE = 'ed25519';
-const MAINNET_FORMAT = 0;
 const keyring = new Keyring({ type: TYPE });
 
 export class KeyPair extends Ed25519KeyPair {
@@ -37,14 +36,11 @@ export class KeyPair extends Ed25519KeyPair {
    * Returns the address in either mainnet polkadot format (starts with 1)
    * or substrate format used for westend (starts with 5)
    */
-  getAddress(format?: AddressFormat): string {
-    const substrateAddress = this.createPolkadotPair().address;
-    // generate polkadot (mainnet) address format
-    if (format && format === AddressFormat.polkadot) {
-      return keyring.encodeAddress(substrateAddress, MAINNET_FORMAT);
-    }
+  getAddress(format: DotAddressFormat): string {
+    let encodedAddress = this.createPolkadotPair().address;
+    encodedAddress = keyring.encodeAddress(encodedAddress, format as number);
 
-    return substrateAddress;
+    return encodedAddress;
   }
 
   /** @inheritdoc */

--- a/modules/account-lib/src/coin/dot/stakingBuilder.ts
+++ b/modules/account-lib/src/coin/dot/stakingBuilder.ts
@@ -3,7 +3,7 @@ import { DecodedSignedTx, DecodedSigningPayload, UnsignedTransaction } from '@su
 import { methods } from '@substrate/txwrapper-polkadot';
 import BigNumber from 'bignumber.js';
 import utils from './utils';
-import { BaseAddress, InvalidTransactionError, TransactionType } from '@bitgo/sdk-core';
+import { BaseAddress, DotAssetTypes, InvalidTransactionError, TransactionType } from '@bitgo/sdk-core';
 import { MethodNames, StakeArgs, StakeArgsPayee, StakeArgsPayeeRaw } from './iface';
 import { Transaction } from './transaction';
 import { TransactionBuilder } from './transactionBuilder';
@@ -110,11 +110,21 @@ export class StakingBuilder extends TransactionBuilder {
     if (this._method?.name === MethodNames.Bond) {
       const txMethod = this._method.args as StakeArgs;
       this.amount(txMethod.value);
-      this.owner({ address: utils.decodeDotAddress(txMethod.controller.id) });
+      this.owner({
+        address: utils.decodeDotAddress(
+          txMethod.controller.id,
+          utils.getAddressFormat(this._coinConfig.name as DotAssetTypes),
+        ),
+      });
 
       const payee = txMethod.payee as StakeArgsPayeeRaw;
       if (payee.account) {
-        this.payee({ Account: utils.decodeDotAddress(payee.account) });
+        this.payee({
+          Account: utils.decodeDotAddress(
+            payee.account,
+            utils.getAddressFormat(this._coinConfig.name as DotAssetTypes),
+          ),
+        });
       } else {
         const payeeType = utils.capitalizeFirstLetter(Object.keys(payee)[0]) as StakeArgsPayee;
         this.payee(payeeType);

--- a/modules/account-lib/src/coin/dot/transaction.ts
+++ b/modules/account-lib/src/coin/dot/transaction.ts
@@ -2,6 +2,7 @@ import { BaseCoin as CoinConfig } from '@bitgo/statics';
 import {
   BaseKey,
   BaseTransaction,
+  DotAssetTypes,
   InvalidTransactionError,
   ParseTransactionError,
   SigningError,
@@ -17,15 +18,15 @@ import {
   AddAnonymousProxyArgs,
   AddProxyArgs,
   BatchArgs,
+  ClaimArgs,
   DecodedTx,
+  HexString,
   StakeArgs,
   StakeArgsPayeeRaw,
   TransactionExplanation,
-  HexString,
   TxData,
   UnstakeArgs,
   WithdrawUnstakedArgs,
-  ClaimArgs,
 } from './iface';
 import utils from './utils';
 import { u8aToBuffer } from '@polkadot/util';
@@ -44,7 +45,7 @@ export class Transaction extends BaseTransaction {
   /** @inheritdoc */
   canSign({ key }: BaseKey): boolean {
     const kp = new KeyPair({ prv: key });
-    const addr = kp.getAddress();
+    const addr = kp.getAddress(utils.getAddressFormat(this._coinConfig.name as DotAssetTypes));
     return addr === this._sender;
   }
 
@@ -153,7 +154,7 @@ export class Transaction extends BaseTransaction {
         const keypairReal = new KeyPair({
           pub: Buffer.from(decodeAddress(txMethod.real)).toString('hex'),
         });
-        result.owner = keypairReal.getAddress();
+        result.owner = keypairReal.getAddress(utils.getAddressFormat(this._coinConfig.name as DotAssetTypes));
         result.forceProxyType = txMethod.forceProxyType;
         const decodedCall = utils.decodeCallMethod(this._dotTransaction, {
           metadataRpc: this._dotTransaction.metadataRpc,
@@ -162,13 +163,13 @@ export class Transaction extends BaseTransaction {
         const keypairDest = new KeyPair({
           pub: Buffer.from(decodeAddress(decodedCall.dest.id)).toString('hex'),
         });
-        result.to = keypairDest.getAddress();
+        result.to = keypairDest.getAddress(utils.getAddressFormat(this._coinConfig.name as DotAssetTypes));
         result.amount = decodedCall.value;
       } else if (utils.isTransfer(txMethod)) {
         const keypairDest = new KeyPair({
           pub: Buffer.from(decodeAddress(txMethod.dest.id)).toString('hex'),
         });
-        result.to = keypairDest.getAddress();
+        result.to = keypairDest.getAddress(utils.getAddressFormat(this._coinConfig.name as DotAssetTypes));
         result.amount = txMethod.value;
       } else {
         throw new ParseTransactionError(`Serializing unknown Transfer type parameters`);
@@ -181,7 +182,7 @@ export class Transaction extends BaseTransaction {
         pub: Buffer.from(decodeAddress(txMethod.controller.id, false, this._registry.chainSS58)).toString('hex'),
       });
 
-      result.controller = keypair.getAddress();
+      result.controller = keypair.getAddress(utils.getAddressFormat(this._coinConfig.name as DotAssetTypes));
       result.amount = txMethod.value;
 
       const payee = txMethod.payee as StakeArgsPayeeRaw;
@@ -189,7 +190,7 @@ export class Transaction extends BaseTransaction {
         const keypair = new KeyPair({
           pub: Buffer.from(decodeAddress(payee.account, false, this._registry.chainSS58)).toString('hex'),
         });
-        result.payee = keypair.getAddress();
+        result.payee = keypair.getAddress(utils.getAddressFormat(this._coinConfig.name as DotAssetTypes));
       } else {
         const payeeType = utils.capitalizeFirstLetter(Object.keys(payee)[0]) as string;
         result.payee = payeeType;
@@ -203,7 +204,7 @@ export class Transaction extends BaseTransaction {
         const keypair = new KeyPair({
           pub: Buffer.from(decodeAddress(txMethod.delegate, false, this._registry.chainSS58)).toString('hex'),
         });
-        result.owner = keypair.getAddress();
+        result.owner = keypair.getAddress(utils.getAddressFormat(this._coinConfig.name as DotAssetTypes));
       } else {
         txMethod = decodedTx.method.args as AddAnonymousProxyArgs;
         result.index = txMethod.index;
@@ -354,14 +355,14 @@ export class Transaction extends BaseTransaction {
         const keypairFrom = new KeyPair({
           pub: Buffer.from(decodeAddress(txMethod.real)).toString('hex'),
         });
-        to = keypairDest.getAddress();
+        to = keypairDest.getAddress(utils.getAddressFormat(this._coinConfig.name as DotAssetTypes));
         value = `${decodedCall.value}`;
-        from = keypairFrom.getAddress();
+        from = keypairFrom.getAddress(utils.getAddressFormat(this._coinConfig.name as DotAssetTypes));
       } else if (utils.isTransfer(txMethod)) {
         const keypairDest = new KeyPair({
           pub: Buffer.from(decodeAddress(txMethod.dest.id)).toString('hex'),
         });
-        to = keypairDest.getAddress();
+        to = keypairDest.getAddress(utils.getAddressFormat(this._coinConfig.name as DotAssetTypes));
         value = txMethod.value;
         from = decodedTx.address;
       } else {

--- a/modules/account-lib/src/coin/dot/transactionBuilder.ts
+++ b/modules/account-lib/src/coin/dot/transactionBuilder.ts
@@ -9,6 +9,7 @@ import {
   BaseKey,
   BaseTransactionBuilder,
   BuildTransactionError,
+  DotAssetTypes,
   FeeOptions,
   InvalidTransactionError,
   isValidEd25519Seed,
@@ -195,7 +196,7 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
       this.referenceBlock(decodedTxn.blockHash);
     } else {
       const keypair = utils.decodeDotAddressToKeyPair(decodedTxn.address);
-      this.sender({ address: keypair.getAddress() });
+      this.sender({ address: keypair.getAddress(utils.getAddressFormat(this._coinConfig.name as DotAssetTypes)) });
       const edSignature = utils.recoverSignatureFromRawTx(rawTransaction, { registry: this._registry });
       this.addSignature(keypair.getKeys(), Buffer.from(edSignature, 'hex'));
     }

--- a/modules/account-lib/src/coin/dot/transferBuilder.ts
+++ b/modules/account-lib/src/coin/dot/transferBuilder.ts
@@ -1,7 +1,7 @@
 import { BaseCoin as CoinConfig } from '@bitgo/statics';
 import { methods } from '@substrate/txwrapper-polkadot';
 import BigNumber from 'bignumber.js';
-import { BaseAddress, InvalidTransactionError, TransactionType } from '@bitgo/sdk-core';
+import { BaseAddress, DotAssetTypes, InvalidTransactionError, TransactionType } from '@bitgo/sdk-core';
 import { TransactionBuilder } from './transactionBuilder';
 import { Transaction } from './transaction';
 import { DecodedSignedTx, DecodedSigningPayload, UnsignedTransaction } from '@substrate/txwrapper-core';
@@ -148,10 +148,17 @@ export class TransferBuilder extends TransactionBuilder {
     if (this._method?.name === MethodNames.TransferKeepAlive) {
       const txMethod = this._method.args as TransferArgs;
       this.amount(txMethod.value);
-      this.to({ address: utils.decodeDotAddress(txMethod.dest.id) });
+      this.to({
+        address: utils.decodeDotAddress(
+          txMethod.dest.id,
+          utils.getAddressFormat(this._coinConfig.name as DotAssetTypes),
+        ),
+      });
     } else if (this._method?.name === MethodNames.Proxy) {
       const txMethod = this._method.args as ProxyArgs;
-      this.owner({ address: utils.decodeDotAddress(txMethod.real) });
+      this.owner({
+        address: utils.decodeDotAddress(txMethod.real, utils.getAddressFormat(this._coinConfig.name as DotAssetTypes)),
+      });
       this.forceProxyType(txMethod.forceProxyType);
       const decodedCall = utils.decodeCallMethod(rawTransaction, {
         registry: SingletonRegistry.getInstance(this._material),
@@ -163,7 +170,12 @@ export class TransferBuilder extends TransactionBuilder {
         );
       }
       this.amount(`${decodedCall.value}`);
-      this.to({ address: utils.decodeDotAddress(decodedCall.dest.id) });
+      this.to({
+        address: utils.decodeDotAddress(
+          decodedCall.dest.id,
+          utils.getAddressFormat(this._coinConfig.name as DotAssetTypes),
+        ),
+      });
     } else {
       throw new InvalidTransactionError(
         `Invalid Transaction Type: ${this._method?.name}. Expected a transferKeepAlive or a proxy transferKeepAlive transaction`,

--- a/modules/account-lib/src/coin/hbar/keyPair.ts
+++ b/modules/account-lib/src/coin/hbar/keyPair.ts
@@ -1,5 +1,5 @@
 import { PrivateKey, PublicKey } from '@hashgraph/sdk';
-import { DefaultKeys, Ed25519KeyPair, InvalidKey, KeyPairOptions, NotSupported } from '@bitgo/sdk-core';
+import { AddressFormat, DefaultKeys, Ed25519KeyPair, InvalidKey, KeyPairOptions, NotSupported } from '@bitgo/sdk-core';
 import { removePrefix } from './utils';
 
 const PUBLIC_KEY_PREFIX = '302a300506032b6570032100';
@@ -35,7 +35,7 @@ export class KeyPair extends Ed25519KeyPair {
   }
 
   /** @inheritdoc */
-  getAddress(format?: string): string {
+  getAddress(format?: AddressFormat): string {
     throw new NotSupported('Address derivation is not supported in Hedera');
   }
 

--- a/modules/account-lib/test/unit/coin/dot/address.ts
+++ b/modules/account-lib/test/unit/coin/dot/address.ts
@@ -1,0 +1,48 @@
+import { register } from '../../../../src';
+import { TransactionBuilderFactory } from '../../../../src/coin/dot';
+
+describe('Polkadot and Westend Address Validation', function () {
+  describe('Polkadot Address Validation', function () {
+    it('should have polkadot address (starting with 1) in input and output after building transaction', async () => {
+      const senderAddress = '13QgbfCNWka9Cz8BaYjzCiSYq8dA3fdfC8MCwwZ4GMh3AeYY';
+      const receiverAddress = '14q3D8ZHe89jpFSi3bwXJXnaKcWuHSUPCBhHwy6UF7UmQ4E7';
+
+      const factory = register('dot', TransactionBuilderFactory);
+      const txBulider = factory
+        .getTransferBuilder()
+        .amount('90034235235322')
+        .sender({ address: senderAddress })
+        .to({ address: receiverAddress })
+        .validity({ firstValid: 3933, maxDuration: 64 })
+        .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
+        .sequenceId({ name: 'Nonce', keyword: 'nonce', value: 200 })
+        .fee({ amount: 0, type: 'tip' });
+      const tx = await txBulider.build();
+
+      tx.outputs[0].address.should.equal(receiverAddress);
+      tx.inputs[0].address.should.equal(senderAddress);
+    });
+  });
+
+  describe('Westend Address Validation', function () {
+    it('should have substrate address (starting with 5) in input and output after building transaction', async () => {
+      const senderAddress = '5DLkMpzjemtsMh4kkEJ1jmu3kYagqJ4QWZShrg4MYDknGcah';
+      const receiverAddress = '5F5jseDA8j47dUdGznCic6ZxqfZBS77j12avJxqK8gx5PHRE';
+
+      const factory = register('tdot', TransactionBuilderFactory);
+      const txBulider = factory
+        .getTransferBuilder()
+        .amount('90034235235322')
+        .sender({ address: senderAddress })
+        .to({ address: receiverAddress })
+        .validity({ firstValid: 3933, maxDuration: 64 })
+        .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
+        .sequenceId({ name: 'Nonce', keyword: 'nonce', value: 200 })
+        .fee({ amount: 0, type: 'tip' });
+      const tx = await txBulider.build();
+
+      tx.outputs[0].address.should.equal(receiverAddress);
+      tx.inputs[0].address.should.equal(senderAddress);
+    });
+  });
+});

--- a/modules/account-lib/test/unit/coin/dot/keypair.ts
+++ b/modules/account-lib/test/unit/coin/dot/keypair.ts
@@ -4,7 +4,7 @@ import { Dot } from '../../../../src';
 import { accounts } from '../../../resources/dot';
 import bs58 from 'bs58';
 import utils from '../../../../src/coin/dot/utils';
-import { AddressFormat } from '@bitgo/sdk-core';
+import { DotAddressFormat } from '@bitgo/sdk-core';
 
 describe('Dot KeyPair', () => {
   const defaultSeed = { seed: Buffer.alloc(32) };
@@ -53,7 +53,7 @@ describe('Dot KeyPair', () => {
       const derivedKeyPair = new Dot.KeyPair({
         prv: derived.prv || '',
       });
-      should.exists(derivedKeyPair.getAddress());
+      should.exists(derivedKeyPair.getAddress(DotAddressFormat.substrate));
       should.exists(derivedKeyPair.getKeys().prv);
       should.exists(derivedKeyPair.getKeys().pub);
       should.equal(derivedKeyPair.getKeys().prv?.length, 64);
@@ -90,24 +90,24 @@ describe('Dot KeyPair', () => {
   describe('getAddress', () => {
     it('should get an address', () => {
       let keyPair = new Dot.KeyPair(defaultSeed);
-      let address = keyPair.getAddress();
+      let address = keyPair.getAddress(DotAddressFormat.substrate);
       address.should.equal(defaultAccount.address);
 
       keyPair = new Dot.KeyPair({ prv: account2.secretKey });
-      address = keyPair.getAddress();
+      address = keyPair.getAddress(DotAddressFormat.substrate);
       address.should.equal(account2.address);
     });
 
     it('should get an address with bs58 pub key', () => {
       const keyPair = new Dot.KeyPair({ pub: bs58Account.publicKey });
-      const address = keyPair.getAddress();
+      const address = keyPair.getAddress(DotAddressFormat.substrate);
       address.should.equal(bs58Account.address);
       utils.isValidAddress(address).should.equal(true);
     });
 
     it('should get a polkadot network address', () => {
       const keyPair = new Dot.KeyPair({ pub: bs58Account.publicKey });
-      const address = keyPair.getAddress(AddressFormat.polkadot);
+      const address = keyPair.getAddress(DotAddressFormat.polkadot);
       address.should.equal(bs58Account.polkadotAddress);
       utils.isValidAddress(address).should.equal(true);
     });
@@ -116,7 +116,7 @@ describe('Dot KeyPair', () => {
   describe('getSigningKeyPair', () => {
     it('should create a signing keypair', () => {
       const keyPair = new Dot.KeyPair({ prv: account1.secretKey });
-      const address = keyPair.getAddress();
+      const address = keyPair.getAddress(DotAddressFormat.substrate);
       address.should.equal(account1.address);
     });
   });

--- a/modules/account-lib/test/unit/coin/dot/transactionBuilder/base.ts
+++ b/modules/account-lib/test/unit/coin/dot/transactionBuilder/base.ts
@@ -3,11 +3,11 @@ import { DecodedSignedTx, DecodedSigningPayload, UnsignedTransaction } from '@su
 import assert from 'assert';
 import should from 'should';
 import sinon from 'sinon';
-import { BaseKey, Eddsa, TransactionType } from '@bitgo/sdk-core';
-import { TransactionBuilder, Transaction, KeyPair, TransactionBuilderFactory } from '../../../../../src/coin/dot';
+import { BaseKey, DotAddressFormat, Eddsa, TransactionType } from '@bitgo/sdk-core';
+import { KeyPair, Transaction, TransactionBuilder, TransactionBuilderFactory } from '../../../../../src/coin/dot';
 import { Material } from '../../../../../src/coin/dot/iface';
 import utils from '../../../../../src/coin/dot/utils';
-import { rawTx, accounts, specName, specVersion, genesisHash, chainName } from '../../../../resources/dot';
+import { accounts, chainName, genesisHash, rawTx, specName, specVersion } from '../../../../resources/dot';
 import { register } from '../../../../../src';
 
 export interface TestDotNetwork extends DotNetwork {
@@ -193,7 +193,7 @@ describe('Dot Transfer Builder', () => {
 
       const commonPub = A_combine.pShare.y;
       const dotKeyPair = new KeyPair({ pub: commonPub });
-      const sender = dotKeyPair.getAddress();
+      const sender = dotKeyPair.getAddress(DotAddressFormat.substrate);
 
       let transferBuilder = factory
         .getTransferBuilder()

--- a/modules/account-lib/test/unit/coin/dot/utils.ts
+++ b/modules/account-lib/test/unit/coin/dot/utils.ts
@@ -4,6 +4,7 @@ import { accounts, blockHash, signatures, txIds, rawTx } from '../../../resource
 import { TypeRegistry } from '@substrate/txwrapper-core/lib/types';
 import * as material from '../../../resources/dot/materialData.json';
 import { SingletonRegistry } from '../../../../src/coin/dot';
+import { DotAddressFormat } from '@bitgo/sdk-core';
 
 describe('utils', () => {
   const registry: TypeRegistry = SingletonRegistry.getInstance(material);
@@ -77,11 +78,17 @@ describe('utils', () => {
   });
 
   it('should decode DOT address correctly', () => {
-    should.equal(utils.decodeDotAddress(accounts.account1.address), '5EGoFA95omzemRssELLDjVenNZ68aXyUeqtKQScXSEBvVJkr');
+    should.equal(
+      utils.decodeDotAddress(accounts.account1.address, DotAddressFormat.substrate),
+      '5EGoFA95omzemRssELLDjVenNZ68aXyUeqtKQScXSEBvVJkr',
+    );
   });
 
   it('should encode DOT address correctly', () => {
-    should.equal(utils.encodeDotAddress(accounts.account1.address), '5EGoFA95omzemRssELLDjVenNZ68aXyUeqtKQScXSEBvVJkr');
+    should.equal(
+      utils.encodeDotAddress(accounts.account1.address, DotAddressFormat.substrate),
+      '5EGoFA95omzemRssELLDjVenNZ68aXyUeqtKQScXSEBvVJkr',
+    );
   });
 
   it('should recover signature from raw tx correctly', () => {

--- a/modules/bitgo/src/v2/coins/dot.ts
+++ b/modules/bitgo/src/v2/coins/dot.ts
@@ -3,6 +3,7 @@ import * as _ from 'lodash';
 import {
   BaseCoin,
   BitGoBase,
+  DotAssetTypes,
   KeyPair,
   MethodNotImplementedError,
   ParsedTransaction,
@@ -275,6 +276,7 @@ export class Dot extends BaseCoin {
   }
 
   getAddressFromPublicKey(Pubkey: string): string {
-    return new accountLib.Dot.KeyPair({ pub: Pubkey }).getAddress();
+    return new accountLib.Dot.KeyPair({ pub: Pubkey }).getAddress(
+      accountLib.Dot.Utils.default.getAddressFormat(this.getChain() as DotAssetTypes));
   }
 }

--- a/modules/sdk-core/src/account-lib/baseCoin/ed25519KeyPair.ts
+++ b/modules/sdk-core/src/account-lib/baseCoin/ed25519KeyPair.ts
@@ -8,7 +8,7 @@ import {
 } from '../util/crypto';
 import { Ed25519KeyDeriver } from '../util/ed25519KeyDeriver';
 import { BaseKeyPair } from './baseKeyPair';
-import { AddressFormat } from './enum';
+import { AddressFormat, DotAddressFormat } from './enum';
 import { isPrivateKey, isPublicKey, isSeed, DefaultKeys, KeyPairOptions } from './iface';
 
 const DEFAULT_SEED_SIZE_BYTES = 32;
@@ -80,7 +80,7 @@ export abstract class Ed25519KeyPair implements BaseKeyPair {
   abstract recordKeysFromPublicKeyInProtocolFormat(pub: string): DefaultKeys;
 
   /** @inheritdoc */
-  abstract getAddress(format?: AddressFormat): string;
+  abstract getAddress(format?: AddressFormat | DotAddressFormat): string;
 
   /** @inheritdoc */
   abstract getKeys(): any;

--- a/modules/sdk-core/src/account-lib/baseCoin/enum.ts
+++ b/modules/sdk-core/src/account-lib/baseCoin/enum.ts
@@ -53,11 +53,18 @@ export enum TransactionType {
 export enum AddressFormat {
   hex = 'hex',
   base58 = 'base58',
-  // format for westend addresses
-  substrate = 'substrate',
-  // format for polkadot mainnet addresses
-  polkadot = 'polkadot',
 }
+
+// TODO(): create union type of all address formats enums
+// list of ss58 format encoding types for Dot ecosystem
+export enum DotAddressFormat {
+  // format for westend (generic substrate) addresses
+  substrate = 42,
+  // format for polkadot mainnet addresses
+  polkadot = 0,
+}
+
+export type DotAssetTypes = 'dot' | 'tdot';
 
 export enum StakingOperationTypes {
   LOCK,

--- a/modules/sdk-core/src/account-lib/baseCoin/index.ts
+++ b/modules/sdk-core/src/account-lib/baseCoin/index.ts
@@ -4,7 +4,7 @@ export { BaseTransactionBuilderFactory } from './baseTransactionBuilderFactory';
 export { BaseUtils } from './baseUtils';
 export { BaseKeyPair } from './baseKeyPair';
 export { Ed25519KeyPair } from './ed25519KeyPair';
-export { TransactionType, StakingOperationTypes, AddressFormat } from './enum';
+export { TransactionType, StakingOperationTypes, AddressFormat, DotAddressFormat, DotAssetTypes } from './enum';
 export { BlsKeyPair } from './blsKeyPair';
 export * from './secp256k1ExtendedKeyPair';
 export * from './errors';


### PR DESCRIPTION
TICKET: BG-51443

### Issue:

The outputs/inputs of a built dot transaction were always showing the generic substrate address. This data is used within wallet-platform when whitelisting addresses. Whitelisting was failing since we were whitelisting a polkadot address (starting with `1`) but our logic used the address in the outputs which was a generic substrate address (starting with `5`). 

### Changes In this PR:

The changes in this PR enforce that an Address Format must be passed when calling getAddress() in the Dot Keypair class. We leverage the statics data to determine whether we're building a transaction for `dot` which uses address starting with `1` and `tdot` which uses addresses starting with `5`.

A new util method was [added](https://github.com/BitGo/BitGoJS/pull/2449/files#diff-9265d4394b8add7bea465014873d17751e57c03138751229b4e334aaaaf757faR309) that can be used outside of account-lib to help determine what address encoding format needs to be used depending on the coin name. 