### PR TITLE
feat(account-lib): get rid of old ethereum lib

### DIFF
--- a/modules/bitgo/package.json
+++ b/modules/bitgo/package.json
@@ -130,7 +130,7 @@
     "@ethereumjs/common": "^2.4.0",
     "@ethereumjs/tx": "^3.3.0",
     "ethereumjs-abi": "^0.6.5",
-    "ethereumjs-util": "6.2.1"
+    "ethereumjs-util": "7.1.5"
   },
   "nyc": {
     "extension": [

--- a/modules/bitgo/src/v2/coins/polygon.ts
+++ b/modules/bitgo/src/v2/coins/polygon.ts
@@ -107,7 +107,7 @@ export class Polygon extends Eth {
         'POLYGON',
         new optionalDeps.ethUtil.BN(optionalDeps.ethUtil.stripHexPrefix(recipient.address), 16),
         recipient.amount,
-        Buffer.from(optionalDeps.ethUtil.stripHexPrefix(recipient.data) || '', 'hex'),
+        Buffer.from(optionalDeps.ethUtil.stripHexPrefix(optionalDeps.ethUtil.padToEven(recipient.data || '')), 'hex'),
         expireTime,
         contractSequenceId,
       ],

--- a/modules/sdk-coin-avaxc/package.json
+++ b/modules/sdk-coin-avaxc/package.json
@@ -48,7 +48,7 @@
     "bignumber.js": "^8.0.1",
     "bip32": "^2.0.6",
     "ethereumjs-abi": "^0.6.5",
-    "ethereumjs-util": "6.2.1",
+    "ethereumjs-util": "7.1.5",
     "keccak": "^3.0.2",
     "lodash": "^4.17.14",
     "secp256k1": "^4.0.2"

--- a/modules/sdk-coin-avaxc/src/lib/utils.ts
+++ b/modules/sdk-coin-avaxc/src/lib/utils.ts
@@ -50,7 +50,14 @@ export function isValidEthAddress(address: string): boolean {
  * @returns {boolean} - the validation result
  */
 export function isValidEthPrivateKey(privateKey: string): boolean {
+  if (privateKey.length !== 64) {
+    return false;
+  }
   const privateKeyBuffer = Buffer.from(privateKey, 'hex');
+
+  if (privateKeyBuffer.length !== 32) {
+    return false;
+  }
   return isValidPrivate(privateKeyBuffer);
 }
 

--- a/modules/sdk-coin-celo/package.json
+++ b/modules/sdk-coin-celo/package.json
@@ -42,7 +42,6 @@
   },
   "dependencies": {
     "@bitgo/abstract-eth": "^1.0.0",
-    "@bitgo/ethereumjs-utils-old": "npm:ethereumjs-util@5.2.0",
     "@bitgo/sdk-coin-eth": "^1.0.0",
     "@bitgo/sdk-core": "^1.0.1",
     "@bitgo/statics": "^6.17.0",
@@ -52,7 +51,7 @@
     "@ethereumjs/common": "^2.4.0",
     "bignumber.js": "^9.0.0",
     "ethereumjs-abi": "^0.6.5",
-    "ethereumjs-util": "6.2.1",
+    "ethereumjs-util": "7.1.5",
     "ethers": "^5.1.3"
   },
   "devDependencies": {

--- a/modules/sdk-coin-celo/src/lib/stakingBuilder.ts
+++ b/modules/sdk-coin-celo/src/lib/stakingBuilder.ts
@@ -1,4 +1,4 @@
-import ethUtil from '@bitgo/ethereumjs-utils-old';
+import * as ethUtil from 'ethereumjs-util';
 import { BaseCoin as CoinConfig } from '@bitgo/statics';
 import {
   isValidAmount,
@@ -257,36 +257,36 @@ export class StakingBuilder {
       case StakingOperationTypes.VOTE:
         this.validateDecodedDataLength(decoded.length, 4, data);
         const [groupToVote, amount, lesser, greater] = decoded;
-        this._amount = ethUtil.bufferToHex(amount);
-        this._validatorGroup = ethUtil.addHexPrefix(groupToVote);
-        this._lesser = ethUtil.addHexPrefix(lesser);
-        this._greater = ethUtil.addHexPrefix(greater);
+        this._amount = ethUtil.bufferToHex(amount as Buffer);
+        this._validatorGroup = ethUtil.addHexPrefix(groupToVote as string);
+        this._lesser = ethUtil.addHexPrefix(lesser as string);
+        this._greater = ethUtil.addHexPrefix(greater as string);
         break;
       case StakingOperationTypes.UNVOTE:
         this.validateDecodedDataLength(decoded.length, 5, data);
         const [groupToUnvote, amountUnvote, lesserUnvote, greaterUnvote, indexUnvote] = decoded;
-        this._validatorGroup = ethUtil.addHexPrefix(groupToUnvote);
-        this._amount = ethUtil.bufferToHex(amountUnvote);
-        this._lesser = ethUtil.addHexPrefix(lesserUnvote);
-        this._greater = ethUtil.addHexPrefix(greaterUnvote);
-        this._index = hexStringToNumber(ethUtil.bufferToHex(indexUnvote));
+        this._validatorGroup = ethUtil.addHexPrefix(groupToUnvote as string);
+        this._amount = ethUtil.bufferToHex(amountUnvote as Buffer);
+        this._lesser = ethUtil.addHexPrefix(lesserUnvote as string);
+        this._greater = ethUtil.addHexPrefix(greaterUnvote as string);
+        this._index = hexStringToNumber(ethUtil.bufferToHex(indexUnvote as Buffer));
         break;
       case StakingOperationTypes.ACTIVATE:
         this.validateDecodedDataLength(decoded.length, 1, data);
         const [groupToActivate] = decoded;
-        this._validatorGroup = ethUtil.addHexPrefix(groupToActivate);
+        this._validatorGroup = ethUtil.addHexPrefix(groupToActivate as string);
         break;
       case StakingOperationTypes.UNLOCK:
         if (decoded.length !== 1) {
           throw new BuildTransactionError(`Invalid unlock decoded data: ${data}`);
         }
         const [decodedAmount] = decoded;
-        this._amount = ethUtil.bufferToHex(decodedAmount);
+        this._amount = ethUtil.bufferToHex(decodedAmount as Buffer);
         break;
       case StakingOperationTypes.WITHDRAW:
         this.validateDecodedDataLength(decoded.length, 1, data);
         const [index] = decoded;
-        this._index = hexStringToNumber(ethUtil.bufferToHex(index));
+        this._index = hexStringToNumber(ethUtil.bufferToHex(index as Buffer));
         break;
       default:
         throw new BuildTransactionError(`Invalid staking data: ${this._type}`);

--- a/modules/sdk-coin-celo/src/lib/types.ts
+++ b/modules/sdk-coin-celo/src/lib/types.ts
@@ -9,8 +9,8 @@ import {
   rlphash,
   ecrecover,
   publicToAddress,
-} from '@bitgo/ethereumjs-utils-old';
-import { unpad } from 'ethereumjs-util';
+  unpadBuffer,
+} from 'ethereumjs-util';
 import { CeloTx, EncodedTransaction } from '@celo/connect';
 import { EthLikeTransactionData, ETHTransactionType, KeyPair, LegacyTxData } from '@bitgo/sdk-coin-eth';
 
@@ -49,7 +49,7 @@ export class CeloTransaction {
   }
 
   constructor(tx: LegacyTxData) {
-    this.nonce = unpad(toBuffer(tx.nonce));
+    this.nonce = unpadBuffer(toBuffer(tx.nonce));
     this.gasLimit = toBuffer(this.sanitizeHexString(tx.gasLimit));
     this.gasPrice = toBuffer(this.sanitizeHexString(tx.gasPrice));
     this.data = toBuffer(tx.data);
@@ -94,7 +94,9 @@ export class CeloTransaction {
     if (includeSignature) {
       items = this.raw;
     } else {
-      items = this.raw.slice(0, 9).concat([toBuffer(this.getChainId()), unpad(toBuffer(0)), unpad(toBuffer(0))]);
+      items = this.raw
+        .slice(0, 9)
+        .concat([toBuffer(this.getChainId()), unpadBuffer(toBuffer(0)), unpadBuffer(toBuffer(0))]);
     }
     return rlphash(items);
   }

--- a/modules/sdk-coin-celo/test/unit/transactionBuilder/send.ts
+++ b/modules/sdk-coin-celo/test/unit/transactionBuilder/send.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import should from 'should';
-import * as ethUtil from '@bitgo/ethereumjs-utils-old';
+import * as ethUtil from 'ethereumjs-util';
 import EthereumAbi from 'ethereumjs-abi';
 import { BaseTransaction, TransactionType } from '@bitgo/sdk-core';
 import { getBuilder } from '../getBuilder';
@@ -30,12 +30,12 @@ describe('Send transaction', function () {
         'CELO-ERC20',
         new ethUtil.BN(ethUtil.stripHexPrefix(to), 16),
         amount,
-        new ethUtil.BN(ethUtil.stripHexPrefix(tokenContractAddress), 16),
+        new ethUtil.BN(ethUtil.stripHexPrefix(tokenContractAddress || ''), 16),
         expireTime,
         sequenceId,
       ],
     ];
-    return EthereumAbi.soliditySHA3(...operationParams);
+    return EthereumAbi.soliditySHA3(...operationParams).toString('hex');
   };
 
   describe('should sign and build', () => {
@@ -70,7 +70,7 @@ describe('Send transaction', function () {
       const operationHash = getOperationHash(tx);
 
       const { v, r, s } = ethUtil.fromRpcSig(signature);
-      const senderPubKey = ethUtil.ecrecover(operationHash, v, r, s);
+      const senderPubKey = ethUtil.ecrecover(Buffer.from(ethUtil.padToEven(operationHash || ''), 'hex'), v, r, s);
       const senderAddress = ethUtil.pubToAddress(senderPubKey);
       const senderKey = new KeyPair({ prv: testData.PRIVATE_KEY });
       ethUtil.bufferToHex(senderAddress).should.equal(senderKey.getAddress());
@@ -108,7 +108,7 @@ describe('Send transaction', function () {
       const operationHash = getOperationHash(tx);
 
       const { v, r, s } = ethUtil.fromRpcSig(signature);
-      const senderPubKey = ethUtil.ecrecover(operationHash, v, r, s);
+      const senderPubKey = ethUtil.ecrecover(Buffer.from(ethUtil.padToEven(operationHash || ''), 'hex'), v, r, s);
       const senderAddress = ethUtil.pubToAddress(senderPubKey);
       const senderKey = new KeyPair({ prv: testData.PRIVATE_KEY });
       ethUtil.bufferToHex(senderAddress).should.equal(senderKey.getAddress());
@@ -124,7 +124,7 @@ describe('Send transaction', function () {
       const operationHash = getOperationHash(tx);
 
       const { v, r, s } = ethUtil.fromRpcSig(signature);
-      const senderPubKey = ethUtil.ecrecover(operationHash, v, r, s);
+      const senderPubKey = ethUtil.ecrecover(Buffer.from(ethUtil.padToEven(operationHash || ''), 'hex'), v, r, s);
       const senderAddress = ethUtil.pubToAddress(senderPubKey);
       const senderKey = new KeyPair({ prv: testData.PRIVATE_KEY });
       ethUtil.bufferToHex(senderAddress).should.equal(senderKey.getAddress());
@@ -140,7 +140,7 @@ describe('Send transaction', function () {
       const operationHash = getOperationHash(tx);
 
       const { v, r, s } = ethUtil.fromRpcSig(signature);
-      const senderPubKey = ethUtil.ecrecover(operationHash, v, r, s);
+      const senderPubKey = ethUtil.ecrecover(Buffer.from(ethUtil.padToEven(operationHash || ''), 'hex'), v, r, s);
       const senderAddress = ethUtil.pubToAddress(senderPubKey);
       const senderKey = new KeyPair({ prv: testData.PRIVATE_KEY });
       ethUtil.bufferToHex(senderAddress).should.equal(senderKey.getAddress());

--- a/modules/sdk-coin-eth/package.json
+++ b/modules/sdk-coin-eth/package.json
@@ -42,7 +42,6 @@
   },
   "dependencies": {
     "@bitgo/sdk-core": "^1.0.1",
-    "@bitgo/ethereumjs-utils-old": "npm:ethereumjs-util@5.2.0",
     "@bitgo/statics": "^6.17.0",
     "@ethereumjs/common": "^2.4.0",
     "@ethereumjs/tx": "^3.3.0",
@@ -51,7 +50,7 @@
     "bn.js": "^5.2.1",
     "debug": "^3.1.0",
     "ethereumjs-abi": "^0.6.5",
-    "ethereumjs-util": "6.2.1",
+    "ethereumjs-util": "7.1.5",
     "ethers": "^5.1.3",
     "keccak": "^3.0.2",
     "lodash": "^4.17.14",

--- a/modules/sdk-coin-eth/test/unit/utils.ts
+++ b/modules/sdk-coin-eth/test/unit/utils.ts
@@ -42,7 +42,7 @@ describe('ETH util library', function () {
 
   it('should generate a proper forwarder version 1 address', function () {
     const initCode = getProxyInitcode(testData.FORWARDER_IMPLEMENTATION_ADDRESS);
-    const saltBuffer = setLengthLeft('0x02', 32);
+    const saltBuffer = setLengthLeft(Buffer.from('02', 'hex'), 32);
 
     // Hash the wallet base address with the given salt, so the address directly relies on the base address
     const calculationSalt = bufferToHex(

--- a/modules/sdk-coin-rbtc/test/unit/transactionBuilder/send.ts
+++ b/modules/sdk-coin-rbtc/test/unit/transactionBuilder/send.ts
@@ -1,5 +1,5 @@
 import should from 'should';
-import * as ethUtil from '@bitgo/ethereumjs-utils-old';
+import * as ethUtil from 'ethereumjs-util';
 import EthereumAbi from 'ethereumjs-abi';
 import { BaseTransaction, TransactionType } from '@bitgo/sdk-core';
 import { KeyPair, TransactionBuilder } from '../../../src';
@@ -30,7 +30,7 @@ describe('Rbtc send transaction', function () {
         'RSK-ERC20',
         new ethUtil.BN(ethUtil.stripHexPrefix(to), 16),
         amount,
-        new ethUtil.BN(ethUtil.stripHexPrefix(tokenContractAddress), 16),
+        new ethUtil.BN(ethUtil.stripHexPrefix(tokenContractAddress || ''), 16),
         expireTime,
         sequenceId,
       ],
@@ -110,7 +110,7 @@ describe('Rbtc send transaction', function () {
     const operationHash = getOperationHash(tx);
 
     const { v, r, s } = ethUtil.fromRpcSig(signature);
-    const senderPubKey = ethUtil.ecrecover(operationHash, v, r, s);
+    const senderPubKey = ethUtil.ecrecover(Buffer.from(operationHash, 'hex'), v, r, s);
     const senderAddress = ethUtil.pubToAddress(senderPubKey);
     const senderKey = new KeyPair({ prv: testData.PRIVATE_KEY_1 });
     ethUtil.bufferToHex(senderAddress).should.equal(senderKey.getAddress());
@@ -126,7 +126,7 @@ describe('Rbtc send transaction', function () {
     const operationHash = getOperationHash(tx);
 
     const { v, r, s } = ethUtil.fromRpcSig(signature);
-    const senderPubKey = ethUtil.ecrecover(operationHash, v, r, s);
+    const senderPubKey = ethUtil.ecrecover(Buffer.from(operationHash || ''), v, r, s);
     const senderAddress = ethUtil.pubToAddress(senderPubKey);
     const senderKey = new KeyPair({ prv: testData.PRIVATE_KEY_1 });
     ethUtil.bufferToHex(senderAddress).should.equal(senderKey.getAddress());

--- a/modules/sdk-coin-stx/package.json
+++ b/modules/sdk-coin-stx/package.json
@@ -42,7 +42,6 @@
   },
   "dependencies": {
     "@bitgo/sdk-core": "^1.0.1",
-    "@bitgo/ethereumjs-utils-old": "npm:ethereumjs-util@5.2.0",
     "@bitgo/statics": "^6.17.0",
     "@stacks/network": "^4.3.0",
     "@stacks/transactions": "2.0.1",
@@ -51,6 +50,7 @@
     "bitcoinjs-lib": "npm:@bitgo/bitcoinjs-lib@6.1.0-rc.3",
     "bn.js": "^5.2.1",
     "elliptic": "^6.5.2",
+    "ethereumjs-util": "7.1.5",
     "lodash": "^4.17.15"
   },
   "devDependencies": {

--- a/modules/sdk-coin-stx/src/lib/utils.ts
+++ b/modules/sdk-coin-stx/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import * as url from 'url';
 import BigNumber from 'bignumber.js';
-import { bufferToHex, stripHexPrefix } from '@bitgo/ethereumjs-utils-old';
+import { bufferToHex, stripHexPrefix } from 'ethereumjs-util';
 import {
   addressFromPublicKeys,
   addressFromVersionHash,

--- a/modules/sdk-core/package.json
+++ b/modules/sdk-core/package.json
@@ -48,7 +48,7 @@
     "bs58": "^4.0.1",
     "create-hmac": "^1.1.7",
     "debug": "^3.1.0",
-    "ethereumjs-util": "6.2.1",
+    "ethereumjs-util": "7.1.5",
     "libsodium-wrappers-sumo": "^0.7.9",
     "lodash": "^4.17.15",
     "noble-bls12-381": "0.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1003,19 +1003,6 @@
   dependencies:
     buffer "^5.4.3"
 
-"@bitgo/ethereumjs-utils-old@npm:ethereumjs-util@5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz#3e0c0d1741471acf1036052d048623dee54ad642"
-  integrity sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==
-  dependencies:
-    bn.js "^4.11.0"
-    create-hash "^1.1.2"
-    ethjs-util "^0.1.3"
-    keccak "^1.0.2"
-    rlp "^2.0.0"
-    safe-buffer "^5.1.1"
-    secp256k1 "^3.0.1"
-
 "@celo/base@2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@celo/base/-/base-2.0.0.tgz#2cf054759ac37faea2a7e8bed7868e45adce24a5"
@@ -5440,7 +5427,7 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-bindings@^1.2.1, bindings@^1.3.0, bindings@^1.5.0:
+bindings@^1.3.0, bindings@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
@@ -8435,18 +8422,16 @@ ethereumjs-tx@^2.1.1:
     ethereumjs-common "^1.5.0"
     ethereumjs-util "^6.0.0"
 
-ethereumjs-util@6.2.1, ethereumjs-util@^6.0.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz#fcb4e4dd5ceacb9d2305426ab1a5cd93e3163b69"
-  integrity sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==
+ethereumjs-util@7.1.5:
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz#9ecf04861e4fbbeed7465ece5f23317ad1129181"
+  integrity sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==
   dependencies:
-    "@types/bn.js" "^4.11.3"
-    bn.js "^4.11.0"
+    "@types/bn.js" "^5.1.0"
+    bn.js "^5.1.2"
     create-hash "^1.1.2"
-    elliptic "^6.5.2"
     ethereum-cryptography "^0.1.3"
-    ethjs-util "0.1.6"
-    rlp "^2.2.3"
+    rlp "^2.2.4"
 
 ethereumjs-util@^5.2.0:
   version "5.2.1"
@@ -8460,6 +8445,19 @@ ethereumjs-util@^5.2.0:
     ethjs-util "^0.1.3"
     rlp "^2.0.0"
     safe-buffer "^5.1.1"
+
+ethereumjs-util@^6.0.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz#fcb4e4dd5ceacb9d2305426ab1a5cd93e3163b69"
+  integrity sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==
+  dependencies:
+    "@types/bn.js" "^4.11.3"
+    bn.js "^4.11.0"
+    create-hash "^1.1.2"
+    elliptic "^6.5.2"
+    ethereum-cryptography "^0.1.3"
+    ethjs-util "0.1.6"
+    rlp "^2.2.3"
 
 ethereumjs-util@^7.1.4:
   version "7.1.4"
@@ -11231,16 +11229,6 @@ karma@^5.1.1:
     ua-parser-js "0.7.22"
     yargs "^15.3.1"
 
-keccak@^1.0.2:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/keccak/-/keccak-1.4.0.tgz#572f8a6dbee8e7b3aa421550f9e6408ca2186f80"
-  integrity sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==
-  dependencies:
-    bindings "^1.2.1"
-    inherits "^2.0.3"
-    nan "^2.2.1"
-    safe-buffer "^5.1.0"
-
 keccak@^3.0.0, keccak@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/keccak/-/keccak-3.0.2.tgz#4c2c6e8c54e04f2670ee49fa734eb9da152206e0"
@@ -12417,7 +12405,7 @@ nan@2.14.0:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
-nan@^2.13.2, nan@^2.14.0, nan@^2.2.1:
+nan@^2.13.2, nan@^2.14.0:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
   integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==


### PR DESCRIPTION
It pulls in some old dependencies, that waste time and fail to build in our CI (and falls back to slower JS variants).

I tried to keep things minimal and as close to the previous version as possible.


Please be aware of this node.js papercut:

```
> Buffer.from('abc', 'hex').toString('hex');
'ab'
```

Ticket: BG-45514