### PR TITLE
fix: sol ata init transactions

### DIFF
--- a/modules/account-lib/src/coin/sol/ataInitializationTransaction.ts
+++ b/modules/account-lib/src/coin/sol/ataInitializationTransaction.ts
@@ -44,12 +44,12 @@ export class AtaInitializationTransaction extends Transaction {
         inputs.push({
           address: instruction.params.ownerAddress,
           value: this.tokenAccountRentExemptAmount || TRANSFER_AMOUNT_UNKNOWN_TEXT,
-          coin: token.name,
+          coin: this._coinConfig.name,
         });
         outputs.push({
           address: instruction.params.ataAddress,
           value: this.tokenAccountRentExemptAmount || TRANSFER_AMOUNT_UNKNOWN_TEXT,
-          coin: token.name,
+          coin: this._coinConfig.name,
         });
       }
     }

--- a/modules/account-lib/src/coin/sol/iface.ts
+++ b/modules/account-lib/src/coin/sol/iface.ts
@@ -87,7 +87,7 @@ export interface StakingWithdraw {
 
 export interface AtaInit {
   type: InstructionBuilderTypes.CreateAssociatedTokenAccount;
-  params: { mintAddress: string; ataAddress: string; ownerAddress: string; payerAddress: string };
+  params: { mintAddress: string; ataAddress: string; ownerAddress: string; payerAddress: string; tokenName: string };
 }
 
 export type ValidInstructionTypes =

--- a/modules/account-lib/test/unit/coin/sol/instructionParamsFactory.ts
+++ b/modules/account-lib/test/unit/coin/sol/instructionParamsFactory.ts
@@ -154,7 +154,7 @@ describe('Instruction Parser Tests: ', function () {
 
       const createATA: InstructionParams = {
         type: InstructionBuilderTypes.CreateAssociatedTokenAccount,
-        params: { mintAddress, ataAddress, ownerAddress, payerAddress },
+        params: { mintAddress, ataAddress, ownerAddress, payerAddress, tokenName: 'sol:orca' },
       };
 
       const result = instructionParamsFactory(TransactionType.AssociatedTokenAccountInitialization, [instruction]);

--- a/modules/account-lib/test/unit/coin/sol/solInstructionFactory.ts
+++ b/modules/account-lib/test/unit/coin/sol/solInstructionFactory.ts
@@ -91,7 +91,13 @@ describe('Instruction Builder Tests: ', function () {
       const payerAddress = testData.associatedTokenAccounts.accounts[0].pub;
       const createATAParams: InstructionParams = {
         type: InstructionBuilderTypes.CreateAssociatedTokenAccount,
-        params: { mintAddress, ataAddress, ownerAddress, payerAddress },
+        params: {
+          mintAddress,
+          ataAddress,
+          ownerAddress,
+          payerAddress,
+          tokenName: testData.associatedTokenAccounts.mint,
+        },
       };
 
       const result = solInstructionFactory(createATAParams);

--- a/modules/account-lib/test/unit/coin/sol/transactionBuilder/ataInitBuilder.ts
+++ b/modules/account-lib/test/unit/coin/sol/transactionBuilder/ataInitBuilder.ts
@@ -14,14 +14,24 @@ describe('Sol Associated Token Account Builder', () => {
     tx.inputs[0].should.deepEqual({
       address: owner.pubkey,
       value: rentAmount,
-      coin: mint,
+      coin: 'sol',
     });
     tx.outputs.length.should.equal(1);
     tx.outputs[0].should.deepEqual({
       address: owner.ataPubkey,
       value: rentAmount,
-      coin: mint,
+      coin: 'sol',
     });
+    const instructions = tx.toJson().instructionsData;
+    let ataInitInstruction;
+    for (const instruction of instructions) {
+      if (instruction.type === 'CreateAssociatedTokenAccount') {
+        ataInitInstruction = instruction;
+        break;
+      }
+    }
+    should.exist(ataInitInstruction);
+    ataInitInstruction.params.tokenName.should.equal(mint);
 
     should.equal(Utils.isValidRawTransaction(rawTx), true);
   }
@@ -148,7 +158,9 @@ describe('Sol Associated Token Account Builder', () => {
     describe('Fail', () => {
       it('build an associated token account init tx when mint is invalid', () => {
         const txBuilder = ataInitBuilder();
-        should(() => txBuilder.mint('invalidToken')).throwError('Invalid transaction: invalid mint, got: invalidToken');
+        should(() => txBuilder.mint('invalidToken')).throwError(
+          'Invalid transaction: invalid token name, got: invalidToken',
+        );
       });
 
       it('build a wallet init tx and sign with an incorrect account', async () => {
@@ -185,7 +197,7 @@ describe('Sol Associated Token Account Builder', () => {
       it('build when mint is invalid', async () => {
         const txBuilder = factory.getAtaInitializationBuilder();
         should(() => txBuilder.mint('sol:invalid mint')).throwError(
-          'Invalid transaction: invalid mint, got: sol:invalid mint',
+          'Invalid transaction: invalid token name, got: sol:invalid mint',
         );
       });
 


### PR DESCRIPTION
fixes a couple of issues with solana token init transactions
- output should be in base SOL instead of token (transferring sol for
  rent exemption)
- add token name to parsed output

Ticket: BG-51901