### PR TITLE
chore(bitgo): refactor tss utils

### DIFF
--- a/modules/sdk-core/src/bitgo/tss/common.ts
+++ b/modules/sdk-core/src/bitgo/tss/common.ts
@@ -1,0 +1,49 @@
+import { BitGoBase } from '../bitgoBase';
+import { TxRequest } from '../utils';
+import { SignatureShareRecord } from '../utils/tss/baseTypes';
+
+/**
+ * Gets the latest Tx Request by id
+ *
+ * @param {BitGoBase} bitgo - the bitgo instance
+ * @param {String} walletId - the wallet id
+ * @param {String} txRequestId - the txRequest Id
+ * @returns {Promise<TxRequest>}
+ */
+export async function getTxRequest(bitgo: BitGoBase, walletId: string, txRequestId: string): Promise<TxRequest> {
+  const txRequestRes = await bitgo
+    .get(bitgo.url('/wallet/' + walletId + '/txrequests', 2))
+    .query({ txRequestIds: txRequestId, latest: 'true' })
+    .result();
+
+  if (txRequestRes.txRequests.length <= 0) {
+    throw new Error(`Unable to find TxRequest with id ${txRequestId}`);
+  }
+
+  return txRequestRes.txRequests[0];
+}
+
+/**
+ * Sends a Signature Share
+ *
+ * @param {BitGoBase} bitgo - the bitgo instance
+ * @param {String} walletId - the wallet id  *
+ * @param {String} txRequestId - the txRequest Id
+ * @param {SignatureShareRecord} signatureShare - a Signature Share
+ * @returns {Promise<SignatureShareRecord>} - a Signature Share
+ */
+export async function sendSignatureShare(
+  bitgo: BitGoBase,
+  walletId: string,
+  txRequestId: string,
+  signatureShare: SignatureShareRecord,
+  signerShare?: string
+): Promise<SignatureShareRecord> {
+  return bitgo
+    .post(bitgo.url('/wallet/' + walletId + '/txrequests/' + txRequestId + '/signatureshares', 2))
+    .send({
+      signatureShare,
+      signerShare,
+    })
+    .result();
+}

--- a/modules/sdk-core/src/bitgo/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/bitgo/tss/eddsa/eddsa.ts
@@ -2,14 +2,10 @@ import Eddsa, { GShare, JShare, KeyShare, PShare, RShare, SignShare, YShare } fr
 import { BitGoBase } from './../../bitgoBase';
 import { DecryptableYShare, CombinedKey, SigningMaterial, EncryptedYShare } from './types';
 import { ShareKeyPosition } from './../types';
-import {
-  encryptAndSignText,
-  readSignedMessage,
-  SignatureShareRecord,
-  SignatureShareType,
-  TxRequest,
-} from './../../utils';
+import { encryptAndSignText, readSignedMessage, SignatureShareRecord, SignatureShareType } from './../../utils';
 import _ = require('lodash');
+import { getTxRequest, sendSignatureShare } from '../common';
+export { getTxRequest, sendSignatureShare };
 
 /**
  * Combines YShares to combine the final TSS key
@@ -232,52 +228,6 @@ export async function sendUserToBitgoGShare(
   };
 
   await sendSignatureShare(bitgo, walletId, txRequestId, signatureShare);
-}
-
-/**
- * Gets the latest Tx Request by id
- *
- * @param {BitGoBase} bitgo - the bitgo instance
- * @param {String} walletId - the wallet id
- * @param {String} txRequestId - the txRequest Id
- * @returns {Promise<TxRequest>}
- */
-export async function getTxRequest(bitgo: BitGoBase, walletId: string, txRequestId: string): Promise<TxRequest> {
-  const txRequestRes = await bitgo
-    .get(bitgo.url('/wallet/' + walletId + '/txrequests', 2))
-    .query({ txRequestIds: txRequestId, latest: 'true' })
-    .result();
-
-  if (txRequestRes.txRequests.length <= 0) {
-    throw new Error(`Unable to find TxRequest with id ${txRequestId}`);
-  }
-
-  return txRequestRes.txRequests[0];
-}
-
-/**
- * Sends a Signature Share
- *
- * @param {BitGoBase} bitgo - the bitgo instance
- * @param {String} walletId - the wallet id  *
- * @param {String} txRequestId - the txRequest Id
- * @param {SignatureShareRecord} signatureShare - a Signature Share
- * @returns {Promise<SignatureShareRecord>} - a Signature Share
- */
-export async function sendSignatureShare(
-  bitgo: BitGoBase,
-  walletId: string,
-  txRequestId: string,
-  signatureShare: SignatureShareRecord,
-  signerShare?: string
-): Promise<SignatureShareRecord> {
-  return bitgo
-    .post(bitgo.url('/wallet/' + walletId + '/txrequests/' + txRequestId + '/signatureshares', 2))
-    .send({
-      signatureShare,
-      signerShare,
-    })
-    .result();
 }
 
 /**

--- a/modules/sdk-core/src/bitgo/tss/index.ts
+++ b/modules/sdk-core/src/bitgo/tss/index.ts
@@ -5,6 +5,7 @@ export { EDDSAMethods, EDDSAMethodTypes, ECDSAMethods, ECDSAMethodTypes };
 export { ShareKeyPosition } from './types';
 
 // exporting this types for backward compatibility.
+/** @deprecated Use EDDSAMethods */
 export {
   createCombinedKey,
   createUserSignShare,
@@ -20,3 +21,5 @@ export {
   CombinedKey,
   SigningMaterial,
 } from './eddsa';
+
+export * as commonTssMethods from './common';

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
@@ -1,0 +1,140 @@
+import { IRequestTracer } from '../../../api';
+import { SerializedKeyPair } from 'openpgp';
+import { KeychainsTriplet, IBaseCoin } from '../../baseCoin';
+import { BitGoBase } from '../../bitgoBase';
+import { Keychain } from '../../keychain';
+import { getTxRequest } from '../../tss';
+import { IWallet } from '../../wallet';
+import { MpcUtils } from '../mpcUtils';
+import * as _ from 'lodash';
+import {
+  ITssUtils,
+  PrebuildTransactionWithIntentOptions,
+  SignatureShareRecord,
+  TxRequest,
+  TxRequestVersion,
+} from './baseTypes';
+
+/**
+ * BaseTssUtil class which different signature schemes have to extend
+ */
+export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtils<KeyShare> {
+  private _wallet?: IWallet;
+
+  constructor(bitgo: BitGoBase, baseCoin: IBaseCoin, wallet?: IWallet) {
+    super(bitgo, baseCoin);
+    this._wallet = wallet;
+  }
+
+  get wallet(): IWallet {
+    if (_.isNil(this._wallet)) {
+      throw new Error('Wallet not defined');
+    }
+    return this._wallet;
+  }
+
+  createUserKeychain(
+    userGpgKey: SerializedKeyPair<string>,
+    userKeyShare: KeyShare,
+    backupKeyShare: KeyShare,
+    bitgoKeychain: Keychain,
+    passphrase: string,
+    originalPasscodeEncryptionCode: string,
+    recipientIndex?: number | undefined
+  ): Promise<Keychain> {
+    throw new Error('Method not implemented.');
+  }
+
+  createBackupKeychain(
+    userGpgKey: SerializedKeyPair<string>,
+    userKeyShare: KeyShare,
+    backupKeyShare: KeyShare,
+    bitgoKeychain: Keychain,
+    passphrase: string
+  ): Promise<Keychain> {
+    throw new Error('Method not implemented.');
+  }
+
+  createBitgoKeychain(
+    userGpgKey: SerializedKeyPair<string>,
+    userKeyShare: KeyShare,
+    backupKeyShare: KeyShare,
+    enterprise: string
+  ): Promise<Keychain> {
+    throw new Error('Method not implemented.');
+  }
+
+  createKeychains(params: {
+    passphrase: string;
+    enterprise?: string | undefined;
+    originalPasscodeEncryptionCode?: string | undefined;
+  }): Promise<KeychainsTriplet> {
+    throw new Error('Method not implemented.');
+  }
+
+  signTxRequest(params: { txRequest: string | TxRequest; prv: string; reqId: IRequestTracer }): Promise<TxRequest> {
+    throw new Error('Method not implemented.');
+  }
+
+  prebuildTxWithIntent(
+    params: PrebuildTransactionWithIntentOptions,
+    apiVersion?: TxRequestVersion | undefined,
+    preview?: boolean | undefined
+  ): Promise<TxRequest> {
+    throw new Error('Method not implemented.');
+  }
+
+  /**
+   * Call delete signature shares for a txRequest, the endpoint delete the signatures and return them
+   *
+   * @param {string} txRequestId tx id reference to delete signature shares
+   * @returns {SignatureShareRecord[]}
+   */
+  async deleteSignatureShares(txRequestId: string): Promise<SignatureShareRecord[]> {
+    return this.bitgo
+      .del(this.bitgo.url(`/wallet/${this.wallet.id()}/txrequests/${txRequestId}/signatureshares`, 2))
+      .send()
+      .result();
+  }
+
+  /**
+   * Initialize the send procedure once Bitgo has the User To Bitgo GShare
+   *
+   * @param {String} txRequestId - the txRequest Id
+   * @returns {Promise<any>}
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async sendTxRequest(txRequestId: string): Promise<any> {
+    return this.bitgo
+      .post(this.baseCoin.url('/wallet/' + this.wallet.id() + '/tx/send'))
+      .send({ txRequestId })
+      .result();
+  }
+
+  /**
+   * Delete signature shares, get the tx request without them from the db and sign it to finally send it.
+   *
+   * Note : This can be performed in order to reach latest network conditions required on pending approval flow.
+   *
+   * @param {String} txRequestId - the txRequest Id to make the requests.
+   * @param {String} decryptedPrv - decrypted prv to sign the tx request.
+   * @param {RequestTracer} reqId id tracer.
+   * @returns {Promise<any>}
+   */
+  async recreateTxRequest(txRequestId: string, decryptedPrv: string, reqId: IRequestTracer): Promise<TxRequest> {
+    await this.deleteSignatureShares(txRequestId);
+    // after delete signatures shares get the tx without them
+    const txRequest = await getTxRequest(this.bitgo, this.wallet.id(), txRequestId);
+    return await this.signTxRequest({ txRequest, prv: decryptedPrv, reqId });
+  }
+
+  /**
+   * Gets the latest Tx Request by id
+   *
+   * @param {String} txRequestId - the txRequest Id
+   * @returns {Promise<TxRequest>}
+   */
+  async getTxRequest(txRequestId: string): Promise<TxRequest> {
+    return getTxRequest(this.bitgo, this.wallet.id(), txRequestId);
+  }
+}

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -1,0 +1,146 @@
+import { SerializedKeyPair } from 'openpgp';
+import { IRequestTracer } from '../../../api';
+import { KeychainsTriplet } from '../../baseCoin';
+import { Keychain } from '../../keychain';
+import { Memo, WalletType } from '../../wallet/iWallet';
+import { EDDSA } from '../../../account-lib/mpc/tss';
+
+export type TxRequestVersion = 'full' | 'lite';
+
+export interface PrebuildTransactionWithIntentOptions {
+  reqId: IRequestTracer;
+  intentType: string;
+  sequenceId?: string;
+  recipients: {
+    address: string;
+    amount: string | number;
+    tokenName?: string;
+  }[];
+  comment?: string;
+  memo?: Memo;
+  tokenName?: string;
+  nonce?: string;
+}
+
+export type TxRequestState =
+  | 'pendingApproval'
+  | 'canceled'
+  | 'rejected'
+  | 'initialized'
+  | 'pendingDelivery'
+  | 'delivered'
+  | 'pendingUserSignature'
+  | 'signed';
+
+export type TransactionState =
+  | 'initialized'
+  | 'pendingSignature'
+  | 'signed'
+  | 'held'
+  | 'delivered'
+  | 'invalidSignature'
+  | 'rejected';
+
+// Type used to sign a TSS transaction
+export type SignableTransaction = {
+  // unsigned transaction in broadcast format
+  serializedTxHex: string;
+  // portion of a transaction used to generate a signature
+  signableHex: string;
+};
+
+export type UnsignedTransactionTss = SignableTransaction & {
+  // derivation path of the signer
+  derivationPath: string;
+  // transaction fees
+  feeInfo?: {
+    fee: number;
+    feeString: string;
+  };
+  coinSpecific?: Record<string, unknown>;
+  parsedTx?: unknown;
+};
+
+export type TxRequest = {
+  txRequestId: string;
+  walletId: string;
+  walletType: WalletType;
+  version: number;
+  enterpriseId?: string;
+  state: TxRequestState;
+  date: string;
+  userId: string;
+  intent: unknown; // Should override with sig scheme specific intent
+  pendingApprovalId?: string;
+  policiesChecked: boolean;
+  signatureShares?: SignatureShareRecord[];
+  pendingTxHashes?: string[];
+  txHashes?: string[];
+  // Only available in 'lite' version
+  unsignedTxs: UnsignedTransactionTss[]; // Should override with blockchain / sig scheme specific unsigned tx
+  // Only available in 'full' version
+  transactions: {
+    state: TransactionState;
+    unsignedTx: UnsignedTransactionTss; // Should override with blockchain / sig specific unsigned tx
+    signatureShares: SignatureShareRecord[];
+  }[];
+  apiVersion?: TxRequestVersion;
+  latest: boolean;
+};
+
+export enum SignatureShareType {
+  USER = 'user',
+  BACKUP = 'backup',
+  BITGO = 'bitgo',
+}
+
+export interface SignatureShareRecord {
+  from: SignatureShareType;
+  to: SignatureShareType;
+  share: string;
+}
+
+/**
+ * Common Interface for implementing signature scheme specific
+ * util functions
+ */
+export interface ITssUtils<KeyShare = EDDSA.KeyShare> {
+  createUserKeychain(
+    userGpgKey: SerializedKeyPair<string>,
+    userKeyShare: KeyShare,
+    backupKeyShare: KeyShare,
+    bitgoKeychain: Keychain,
+    passphrase: string,
+    originalPasscodeEncryptionCode: string,
+    recipientIndex?: number
+  ): Promise<Keychain>;
+  createBackupKeychain(
+    userGpgKey: SerializedKeyPair<string>,
+    userKeyShare: KeyShare,
+    backupKeyShare: KeyShare,
+    bitgoKeychain: Keychain,
+    passphrase: string
+  ): Promise<Keychain>;
+  createBitgoKeychain(
+    userGpgKey: SerializedKeyPair<string>,
+    userKeyShare: KeyShare,
+    backupKeyShare: KeyShare,
+    enterprise: string
+  ): Promise<Keychain>;
+  createKeychains(params: {
+    passphrase: string;
+    enterprise?: string;
+    originalPasscodeEncryptionCode?: string;
+  }): Promise<KeychainsTriplet>;
+  signTxRequest(params: { txRequest: string | TxRequest; prv: string; reqId: IRequestTracer }): Promise<TxRequest>;
+  prebuildTxWithIntent(
+    params: PrebuildTransactionWithIntentOptions,
+    apiVersion?: TxRequestVersion,
+    preview?: boolean
+  ): Promise<TxRequest>;
+  deleteSignatureShares(txRequestId: string): Promise<SignatureShareRecord[]>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sendTxRequest(txRequestId: string): Promise<any>;
+  recreateTxRequest(txRequestId: string, decryptedPrv: string, reqId: IRequestTracer): Promise<TxRequest>;
+  getTxRequest(txRequestId: string): Promise<TxRequest>;
+}

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
@@ -3,17 +3,11 @@
  */
 import * as bs58 from 'bs58';
 import * as crypto from 'crypto';
-import * as _ from 'lodash';
 import * as openpgp from 'openpgp';
 import { Ed25519BIP32 } from '../../../../account-lib/mpc/hdTree';
-import Eddsa, { KeyShare, YShare } from '../../../../account-lib/mpc/tss';
+import Eddsa from '../../../../account-lib/mpc/tss';
 import { IRequestTracer } from '../../../../api';
-import { IBaseCoin, KeychainsTriplet } from '../../../baseCoin';
-import { BitGoBase } from '../../../bitgoBase';
 import { AddKeychainOptions, Keychain, KeyType } from '../../../keychain';
-import { IWallet } from '../../../wallet';
-import { ITssUtils, PrebuildTransactionWithIntentOptions, SignatureShareRecord, TxRequest } from './types';
-import { MpcUtils } from '../../mpcUtils';
 import { encryptText, getBitgoGpgPubKey } from '../../opengpgUtils';
 import {
   createUserSignShare,
@@ -24,26 +18,15 @@ import {
   sendUserToBitgoGShare,
   SigningMaterial,
 } from '../../../tss';
-
+import { PrebuildTransactionWithIntentOptions, TxRequest } from '../baseTypes';
+import { KeyShare, YShare } from './types';
+import baseTSSUtils from '../baseTSSUtils';
+import { KeychainsTriplet } from '../../../baseCoin';
 /**
  * Utility functions for TSS work flows.
  */
 
-export class TssUtils extends MpcUtils implements ITssUtils {
-  private _wallet?: IWallet;
-
-  constructor(bitgo: BitGoBase, baseCoin: IBaseCoin, wallet?: IWallet) {
-    super(bitgo, baseCoin);
-    this._wallet = wallet;
-  }
-
-  private get wallet(): IWallet {
-    if (_.isNil(this._wallet)) {
-      throw new Error('Wallet not defined');
-    }
-    return this._wallet;
-  }
-
+export class EddsaUtils extends baseTSSUtils<KeyShare> {
   /**
    * Creates a Keychain containing the User's TSS signing materials.
    *
@@ -381,59 +364,6 @@ export class TssUtils extends MpcUtils implements ITssUtils {
   }
 
   /**
-   * Call delete signature shares for a txRequest, the endpoint delete the signatures and return them
-   *
-   * @param {string} txRequestId tx id reference to delete signature shares
-   * @returns {SignatureShareRecord[]}
-   */
-  async deleteSignatureShares(txRequestId: string): Promise<SignatureShareRecord[]> {
-    return this.bitgo
-      .del(this.bitgo.url(`/wallet/${this.wallet.id()}/txrequests/${txRequestId}/signatureshares`, 2))
-      .send()
-      .result();
-  }
-
-  /**
-   * Initialize the send procedure once Bitgo has the User To Bitgo GShare
-   *
-   * @param {String} txRequestId - the txRequest Id
-   * @returns {Promise<any>}
-   */
-  async sendTxRequest(txRequestId: string): Promise<any> {
-    return this.bitgo
-      .post(this.baseCoin.url('/wallet/' + this.wallet.id() + '/tx/send'))
-      .send({ txRequestId })
-      .result();
-  }
-
-  /**
-   * Delete signature shares, get the tx request without them from the db and sign it to finally send it.
-   *
-   * Note : This can be performed in order to reach latest network conditions required on pending approval flow.
-   *
-   * @param {String} txRequestId - the txRequest Id to make the requests.
-   * @param {String} decryptedPrv - decrypted prv to sign the tx request.
-   * @param {RequestTracer} reqId id tracer.
-   * @returns {Promise<any>}
-   */
-  async recreateTxRequest(txRequestId: string, decryptedPrv: string, reqId: IRequestTracer): Promise<TxRequest> {
-    await this.deleteSignatureShares(txRequestId);
-    // after delete signatures shares get the tx without them
-    const txRequest = await getTxRequest(this.bitgo, this.wallet.id(), txRequestId);
-    return await this.signTxRequest({ txRequest, prv: decryptedPrv, reqId });
-  }
-
-  /**
-   * Gets the latest Tx Request by id
-   *
-   * @param {String} txRequestId - the txRequest Id
-   * @returns {Promise<TxRequest>}
-   */
-  async getTxRequest(txRequestId: string): Promise<TxRequest> {
-    return getTxRequest(this.bitgo, this.wallet.id(), txRequestId);
-  }
-
-  /**
    * Get the commonPub portion of the commonKeychain.
    *
    * @param {String} commonKeychain
@@ -447,3 +377,7 @@ export class TssUtils extends MpcUtils implements ITssUtils {
     return bs58.encode(Buffer.from(commonPubHexStr, 'hex'));
   }
 }
+/**
+ * @deprecated - use EddsaUtils
+ */
+export const TssUtils = EddsaUtils;

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/index.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/index.ts
@@ -1,14 +1,15 @@
-import { TssUtils } from './eddsa';
+import { EddsaUtils } from './eddsa';
+/** @deprecated use EddsaUtilsTypes */
 export * as TssUtilsTypes from './types';
+export * as EddsaUtilsTypes from './types';
 
-export default TssUtils;
+export default EddsaUtils;
 
 // exporting this types for backward compatibility.
+export { ITssUtils, IEddsaUtils, EddsaUnsignedTransaction } from './types';
 export {
-  ITssUtils,
   PrebuildTransactionWithIntentOptions,
   SignatureShareRecord,
   SignatureShareType,
   TxRequest,
-  EddsaUnsignedTransaction,
-} from './types';
+} from '../baseTypes';

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/types.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/types.ts
@@ -1,131 +1,22 @@
-import type { SerializedKeyPair } from 'openpgp';
-import { KeyShare } from '../../../../account-lib/mpc/tss';
-import { IRequestTracer } from '../../../../api';
-import { KeychainsTriplet } from '../../../baseCoin';
-import { Keychain } from '../../../keychain';
-import { Memo } from '../../../wallet';
-import { WalletType } from '../../../wallet/iWallet';
+import { EDDSA } from '../../../../account-lib/mpc/tss';
+import BaseTSSUtils from '../baseTSSUtils';
+import { UnsignedTransactionTss } from '../baseTypes';
 
-export interface PrebuildTransactionWithIntentOptions {
-  reqId: IRequestTracer;
-  intentType: string;
-  sequenceId?: string;
-  recipients: {
-    address: string;
-    amount: string | number;
-    tokenName?: string;
-  }[];
-  comment?: string;
-  memo?: Memo;
-  tokenName?: string;
-  nonce?: string;
-}
+export type KeyShare = EDDSA.KeyShare;
+export type YShare = EDDSA.YShare;
+/** @deprected use UnsignedTransactionTss from baseTypes */
+export type EddsaUnsignedTransaction = UnsignedTransactionTss;
 
-export type TxRequestVersion = 'full' | 'lite';
+export type IEddsaUtils = BaseTSSUtils<KeyShare>;
+/** @deprecated Use IEddsaUtils */
+export type ITssUtils = IEddsaUtils;
 
-export type EddsaUnsignedTransaction = {
-  serializedTxHex: string;
-  signableHex: string;
-  feeInfo?: {
-    fee: number;
-    feeString: string;
-  };
-  derivationPath: string;
-};
-
-export type TxRequestState =
-  | 'pendingApproval'
-  | 'canceled'
-  | 'rejected'
-  | 'initialized'
-  | 'pendingDelivery'
-  | 'delivered'
-  | 'pendingUserSignature'
-  | 'signed';
-
-export type TransactionState =
-  | 'initialized'
-  | 'pendingSignature'
-  | 'signed'
-  | 'held'
-  | 'delivered'
-  | 'invalidSignature'
-  | 'rejected';
-
-export type TxRequest = {
-  txRequestId: string;
-  walletId: string;
-  walletType: WalletType;
-  version: number;
-  enterpriseId?: string;
-  state: TxRequestState;
-  date: string;
-  userId: string;
-  intent: any;
-  pendingApprovalId?: string;
-  policiesChecked: boolean;
-  signatureShares?: SignatureShareRecord[];
-  pendingTxHashes?: string[];
-  txHashes?: string[];
-  // Only available in 'lite' version
-  unsignedTxs: EddsaUnsignedTransaction[];
-  // Only available in 'full' version
-  transactions: {
-    state: TransactionState;
-    unsignedTx: EddsaUnsignedTransaction;
-    signatureShares: SignatureShareRecord[];
-  }[];
-  apiVersion?: TxRequestVersion;
-  latest: boolean;
-};
-
-export enum SignatureShareType {
-  USER = 'user',
-  BACKUP = 'backup',
-  BITGO = 'bitgo',
-}
-
-export interface SignatureShareRecord {
-  from: SignatureShareType;
-  to: SignatureShareType;
-  share: string;
-}
-
-export interface ITssUtils {
-  createUserKeychain(
-    userGpgKey: SerializedKeyPair<string>,
-    userKeyShare: KeyShare,
-    backupKeyShare: KeyShare,
-    bitgoKeychain: Keychain,
-    passphrase: string,
-    originalPasscodeEncryptionCode: string
-  ): Promise<Keychain>;
-  createBackupKeychain(
-    userGpgKey: SerializedKeyPair<string>,
-    userKeyShare: KeyShare,
-    backupKeyShare: KeyShare,
-    bitgoKeychain: Keychain,
-    passphrase: string
-  ): Promise<Keychain>;
-  createBitgoKeychain(
-    userGpgKey: SerializedKeyPair<string>,
-    userKeyShare: KeyShare,
-    backupKeyShare: KeyShare,
-    enterprise: string
-  ): Promise<Keychain>;
-  createKeychains(params: {
-    passphrase: string;
-    enterprise?: string;
-    originalPasscodeEncryptionCode?: string;
-  }): Promise<KeychainsTriplet>;
-  signTxRequest(params: { txRequest: string | TxRequest; prv: string; reqId: IRequestTracer }): Promise<TxRequest>;
-  prebuildTxWithIntent(
-    params: PrebuildTransactionWithIntentOptions,
-    apiVersion?: TxRequestVersion,
-    preview?: boolean
-  ): Promise<TxRequest>;
-  deleteSignatureShares(txRequestId: string): Promise<SignatureShareRecord[]>;
-  sendTxRequest(txRequestId: string): Promise<any>;
-  recreateTxRequest(txRequestId: string, decryptedPrv: string, reqId: IRequestTracer): Promise<TxRequest>;
-  getTxRequest(txRequestId: string): Promise<TxRequest>;
-}
+// For backward compatibility
+export {
+  PrebuildTransactionWithIntentOptions,
+  TxRequestVersion,
+  TxRequestState,
+  TransactionState,
+  SignatureShareRecord,
+  SignatureShareType,
+} from '../baseTypes';

--- a/modules/sdk-core/src/bitgo/utils/tss/index.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/index.ts
@@ -1,14 +1,16 @@
-import TssUtils, { TssUtilsTypes } from './eddsa';
-export { TssUtils, TssUtilsTypes };
-
+import TssUtils, { TssUtilsTypes, EddsaUtilsTypes } from './eddsa';
 export * as ECDSAUtils from './ecdsa';
+export * as EDDSAUtils from './ecdsa';
+
+/** @deprecated use EDDSAUtils */
+export { TssUtils };
+/** @deprecated use EDDSAUtilsTypes */
+export { TssUtilsTypes };
+export { EddsaUtilsTypes };
 
 // exporting this types for backward compatibility.
-export {
-  ITssUtils,
-  PrebuildTransactionWithIntentOptions,
-  SignatureShareRecord,
-  SignatureShareType,
-  TxRequest,
-  EddsaUnsignedTransaction,
-} from './eddsa';
+/** @deprecated use EDDSAUtils.<type/method> */
+export { ITssUtils, IEddsaUtils, TxRequest, EddsaUnsignedTransaction } from './eddsa';
+
+export * as BaseTssUtils from './baseTSSUtils';
+export * from './baseTypes';


### PR DESCRIPTION
## Summary
This change refactors tss utils for reusing common functionalities for different signature schemes. The major changes can be summarised as follows

## Changes
1. Introduced a new `BaseTssUtils` class which each signature scheme has to inherit. This class has implementations which can be reused for different schems
2. Introduced baseType and common files which will have methods and types which can be reused for every scheme
3. Introduced scheme specific naming to avoid confusions and added relevant deprecation flags to prompt people to use scheme specific names (eg TssUtils --> EDDSAUtils)
4. All changes are backward compatible

Will be porting ECDSA to use this in a separate PR for ease of review

TICKET: BG-52194