### PR TITLE
fix(account-lib): fix proper format for compressed hex points

### DIFF
--- a/modules/account-lib/test/unit/mpc/tss/ecdsa/ecdsa.ts
+++ b/modules/account-lib/test/unit/mpc/tss/ecdsa/ecdsa.ts
@@ -51,6 +51,10 @@ describe('TSS ECDSA TESTS', function () {
       keyShares[index].yShares[participantThree].j.should.equal(participantThree);
       keyShares[index].yShares[participantTwo].n.should.not.be.Null;
       keyShares[index].yShares[participantThree].n.should.not.be.Null;
+
+      const publicKeyPrefix = keyShares[index].xShare.y.slice(0, 2);
+      const isRightPrefix = publicKeyPrefix === '03' || publicKeyPrefix === '02';
+      isRightPrefix.should.equal(true);
     }
   });
 

--- a/modules/sdk-core/src/account-lib/mpc/curves/secp256k1.ts
+++ b/modules/sdk-core/src/account-lib/mpc/curves/secp256k1.ts
@@ -10,7 +10,7 @@ export class Secp256k1Curve implements BaseCurve {
   }
 
   scalarAdd(x: bigint, y: bigint): bigint {
-    return bigIntFromU8ABE(secp.utils.privateAdd(x, bigIntToBufferBE(y)));
+    return bigIntFromU8ABE(secp.utils.privateAdd(x, bigIntToBufferBE(y, 32)));
   }
 
   scalarSub(x: bigint, y: bigint): bigint {
@@ -35,23 +35,23 @@ export class Secp256k1Curve implements BaseCurve {
   }
 
   pointAdd(a: bigint, b: bigint): bigint {
-    const pointA = secp.Point.fromHex(bigIntToBufferBE(a));
-    const pointB = secp.Point.fromHex(bigIntToBufferBE(b));
+    const pointA = secp.Point.fromHex(bigIntToBufferBE(a, 32));
+    const pointB = secp.Point.fromHex(bigIntToBufferBE(b, 32));
     return bigIntFromU8ABE(pointA.add(pointB).toRawBytes(true));
   }
 
   pointMultiply(p: bigint, s: bigint): bigint {
-    const pointA = secp.Point.fromHex(bigIntToBufferBE(p));
+    const pointA = secp.Point.fromHex(bigIntToBufferBE(p, 32));
     return bigIntFromU8ABE(pointA.multiply(s).toRawBytes(true));
   }
 
   basePointMult(n: bigint): bigint {
-    const point = bigIntToBufferBE(n);
+    const point = bigIntToBufferBE(n, 32);
     return bigIntFromU8ABE(secp.getPublicKey(point, true));
   }
 
   verify(message: Buffer, signature: Buffer, publicKey: bigint): boolean {
-    return secp.verify(signature, message, bigIntToBufferBE(publicKey));
+    return secp.verify(signature, message, bigIntToBufferBE(publicKey, 33));
   }
 
   order(): bigint {


### PR DESCRIPTION
This change fixes the issue while representing a compressed point. 

Interesting issue to note is that converting to a hex from a equivalent value in buffer and bigint do not give equivalent result especially in cases where you have a parity bit like '0x02' in compressed points, bigInt.toString(16) will skip the leading zero but Buffer.toString('hex') gives expected results.

TICKET: BG-52274