### PR TITLE
feat(sdk-coin-eth): add util for eth address from compressed point

### DIFF
--- a/modules/sdk-coin-eth/src/lib/utils.ts
+++ b/modules/sdk-coin-eth/src/lib/utils.ts
@@ -10,7 +10,7 @@ import {
   stripHexPrefix,
   toBuffer,
 } from '@bitgo/ethereumjs-utils-old';
-import { generateAddress2 } from 'ethereumjs-util';
+import { generateAddress2, importPublic, pubToAddress } from 'ethereumjs-util';
 import { BaseCoin, BaseNetwork, coins, ContractAddressDefinedToken, EthereumNetwork } from '@bitgo/statics';
 import EthereumAbi from 'ethereumjs-abi';
 import EthereumCommon from '@ethereumjs/common';
@@ -603,4 +603,15 @@ export function getToken(tokenContractAddress: string, network: BaseNetwork): Re
     return tokensArray[0];
   }
   return undefined;
+}
+
+/**
+ * Get Eth address from compressed secp256k1 public key
+ *
+ * @param {string} compressedPub the hex encoded compressed key
+ * @returns {string} Eth Address
+ */
+export function getEthAddressFromCompressedPub(compressedPub: string): string {
+  if (compressedPub.slice(0, 2) === '0x') compressedPub = compressedPub.slice(2);
+  return '0x' + pubToAddress(importPublic(Buffer.from(compressedPub, 'hex'))).toString('hex');
 }

--- a/modules/sdk-coin-eth/test/unit/utils.ts
+++ b/modules/sdk-coin-eth/test/unit/utils.ts
@@ -6,11 +6,13 @@ import {
   calculateForwarderAddress,
   calculateForwarderV1Address,
   getProxyInitcode,
+  getEthAddressFromCompressedPub,
 } from '../../src';
 import * as testData from '../resources/eth';
 import * as walletUtilConstants from '../../src/lib/walletUtil';
 import { bufferToHex, setLengthLeft } from 'ethereumjs-util';
 import EthereumAbi from 'ethereumjs-abi';
+import assert from 'assert';
 
 describe('ETH util library', function () {
   describe('sign operation', function () {
@@ -52,5 +54,15 @@ describe('ETH util library', function () {
       calculateForwarderV1Address(testData.FORWARDER_FACTORY_ADDRESS, calculationSalt, initCode),
       '0x7cdc37afc70221410bea40ce3b62c2f7bf383890'
     );
+  });
+
+  it('should generate valid public key from compressed secp256k1 point', function () {
+    const pointA = '0x0253d1672988675b36aaa3e905058667ff1559cb8edd8de2c5a4a0349db98238c5';
+    const pointB = '031d4cf63e53a54ea472ab4533b89031c20788c70043563c996c52bf655a078619';
+    const ethAddress = getEthAddressFromCompressedPub(pointA);
+    const ethAddressTwo = getEthAddressFromCompressedPub(pointB);
+    ethAddress.should.equal('0x5ddb50e341c8f222811450d1cb5b7a8cb134e35a');
+    ethAddressTwo.should.equal('0xb42817ef5f281ba8c7bc107f6e173ed2f014aed4');
+    assert.throws(() => getEthAddressFromCompressedPub(pointB.slice(2)));
   });
 });


### PR DESCRIPTION
this change adds a util function to create a eth
address from a compressed point

TICKET: BG-52320