### PR TITLE
chore(bitgo): improve docker build caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "modules/*"
   ],
   "scripts": {
-    "postinstall": "lerna run build --stream",
+    "postinstall": "test -n \"$NOYARNPOSTINSTALL\" || lerna run build --stream",
     "gen-drone": "chmod 0666 .drone.yml && drone jsonnet --stream && drone sign BitGo/BitGoJS --save && chmod 0444 .drone.yml",
     "audit": "yarn audit --group dependencies optionalDependencies peerDependencies ; test $? -lt 8",
     "audit-dev": "yarn audit --group devDependencies ; test $? -lt 8",


### PR DESCRIPTION


## Bench

This cuts the build time (when I try it locally) from:

```
Executed in  293.18 secs      fish           external
   usr time  349.22 millis  446.00 micros  348.77 millis
   sys time  174.63 millis  239.00 micros  174.39 millis
```

to:

```
Executed in  116.04 secs      fish           external
   usr time  348.85 millis  688.00 micros  348.16 millis
   sys time  147.11 millis    0.00 micros  147.11 millis
```

when the cache is warm (no dependency changes, just a typical source code change).

Ticket: BG-00000