### PR TITLE
build(express): add label metadata to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -153,6 +153,12 @@ RUN cd /var/bitgo-express && \
     yarn link @bitgo/sdk-coin-zec
 #LINK_END
 
+#LABEL_START
+LABEL created="Mon, 18 Jul 2022 20:03:36 GMT"
+LABEL version=9.12.0
+LABEL git_hash=973a8b01131f5958dd5b588a17dc4346b148acb3
+#LABEL_END
+
 USER node
 ENV NODE_ENV production
 ENV BITGO_BIND 0.0.0.0


### PR DESCRIPTION
When pushing docker images, `LABEL` was not included. As feature
requested, release information such as created timestamps, version
and git hash will be added.

You can verify it after the image is built with `docker image inspect localhost/bitgosdk/express:latest | jq '.[0].Config'`: 
```
...
    "Config": {
      "User": "node",
      ...
      "Entrypoint": [
        "/sbin/tini",
        "--",
        "/usr/local/bin/node",
        "/var/bitgo-express/bin/bitgo-express"
      ],
      "Labels": {
        "created": "Mon, 18 Jul 2022 20:03:36 GMT",
        "git_hash": "973a8b01131f5958dd5b588a17dc4346b148acb3",
        "io.buildah.version": "1.26.1",
        "version": "9.12.0"
      }
    },
...
```
Ticket: BG-52008