### PR TITLE
fix(bitgo): add token to whitelistedParams in eddsa prebuildTxWithIntent BG-52482

### DIFF
--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
@@ -355,6 +355,7 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
         recipients: intentRecipients,
         memo: params.memo?.value,
         nonce: params.nonce,
+        token: params.tokenName,
       },
       apiVersion: apiVersion,
       preview,


### PR DESCRIPTION
There is a bug regarding build intent with the `enabletoken` `createAccount` intent flow when enabling tokens on Solana.
We need to add the missing tokenName to the token property of the whitelistedParams in prebuildTxWithIntent.

Previously, the bug would output this when trying to use the `enabletoken` flow on the txrequests endpoint:
```
(node:65500) UnhandledPromiseRejectionWarning: ApiResponseError: .intent.intentType should be equal to one of the allowed values, .intent should have required property 'token', .intent.intentType should be equal to one of the allowed values, .intent should have required property 'stakingRequestId', .intent should have required property 'stakingRequestId', .intent should have required property 'stakingRequestId', .intent should match some schema in anyOf
    at errFromResponse (/Users/michaelgallegos/git/BitGoJS/modules/sdk-api/dist/src/api.js:62:12)
    at handleResponseError (/Users/michaelgallegos/git/BitGoJS/modules/sdk-api/dist/src/api.js:71:15)
    at /Users/michaelgallegos/git/BitGoJS/modules/sdk-api/dist/src/api.js:30:101
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async EddsaUtils.prebuildTxWithIntent (/Users/michaelgallegos/git/BitGoJS/modules/sdk-core/dist/src/bitgo/utils/tss/eddsa/eddsa.js:275:29)
    at async Wallet.prebuildTransactionTss (/Users/michaelgallegos/git/BitGoJS/modules/sdk-core/dist/src/bitgo/wallet/wallet.js:1973:29)
    at async Wallet.prebuildAndSignTransaction (/Users/michaelgallegos/git/BitGoJS/modules/sdk-core/dist/src/bitgo/wallet/wallet.js:1381:29)
    at async Wallet.sendManyTss (/Users/michaelgallegos/git/BitGoJS/modules/sdk-core/dist/src/bitgo/wallet/wallet.js:2042:36)
    at async enableToken 
```

This PR alleviates this issue.

Ticket: https://bitgoinc.atlassian.net/browse/BG-52482