### PR TITLE
fix(bitgo): `Buffer` does not exist in browsers

### DIFF
--- a/modules/sdk-coin-eth/src/lib/utils.ts
+++ b/modules/sdk-coin-eth/src/lib/utils.ts
@@ -567,7 +567,7 @@ export function hasSignature(txData: TxData): boolean {
   );
 }
 
-type RecursiveBufferOrString = string | Buffer | RecursiveBufferOrString[];
+type RecursiveBufferOrString = string | Buffer | BN | RecursiveBufferOrString[];
 
 /**
  * Get the raw data decoded for some types
@@ -579,7 +579,7 @@ type RecursiveBufferOrString = string | Buffer | RecursiveBufferOrString[];
 export function getRawDecoded(types: string[], serializedArgs: Buffer): RecursiveBufferOrString[] {
   function normalize(v: unknown, i: number): unknown {
     if (BN.isBN(v)) {
-      return v.toBuffer();
+      return v;
     } else if (typeof v === 'string' || Buffer.isBuffer(v)) {
       return v;
     } else if (Array.isArray(v)) {


### PR DESCRIPTION
Instead of converting `BN` to `Buffer` eagerly,
just make it another case that we can return, and let
the code outside use it directly as they see fit.

Ticket: BG-00000