### PR TITLE
chore(avaxp): create change only

### DIFF
--- a/modules/sdk-coin-avaxp/src/avaxp.ts
+++ b/modules/sdk-coin-avaxp/src/avaxp.ts
@@ -172,7 +172,8 @@ export class AvaxP extends BaseCoin {
   }
 
   async feeEstimate(params: FeeEstimateOptions): Promise<TransactionFee> {
-    return { fee: (this._staticsCoin.network as AvalancheNetwork).txFee };
+    // staking transactions are fee-less
+    return { fee: '0' };
   }
 
   parseTransaction(params: ParseTransactionOptions): Promise<ParseTransactionOptions> {

--- a/modules/sdk-coin-avaxp/src/lib/transaction.ts
+++ b/modules/sdk-coin-avaxp/src/lib/transaction.ts
@@ -67,8 +67,8 @@ export class Transaction extends BaseTransaction {
   public _threshold = 2;
   public _locktime: BN = new BN(0);
   public _fromAddresses: BufferAvax[] = [];
+  public _rewardAddresses: BufferAvax[];
   public _utxos: DecodedUtxoObj[] = [];
-  public _txFee: BN;
 
   constructor(coinConfig: Readonly<CoinConfig>) {
     super(coinConfig);
@@ -76,7 +76,6 @@ export class Transaction extends BaseTransaction {
     this._assetId = utils.cb58Decode(this._network.avaxAssetID);
     this._blockchainID = utils.cb58Decode(this._network.blockchainID);
     this._networkID = this._network.networkID;
-    this._txFee = new BN(this._network.txFee);
   }
 
   get avaxPTransaction(): BaseTx {
@@ -210,6 +209,11 @@ export class Transaction extends BaseTransaction {
   get fromAddresses(): string[] {
     return this._fromAddresses.map((a) => utils.addressToString(this._network.hrp, this._network.alias, a));
   }
+
+  get rewardAddresses(): string[] {
+    return this._rewardAddresses.map((a) => utils.addressToString(this._network.hrp, this._network.alias, a));
+  }
+
   /**
    * Get the list of outputs. Amounts are expressed in absolute value.
    */
@@ -262,7 +266,7 @@ export class Transaction extends BaseTransaction {
       outputAmount: txJson.outputs.reduce((p, n) => p.add(new BN(n.value)), new BN(0)).toString(),
       changeOutputs: [], // account based does not use change outputs
       changeAmount: '0', // account base does not make change
-      fee: { fee: this._txFee.toString() },
+      fee: { fee: '0' },
       type: txJson.type,
     };
   }

--- a/modules/sdk-coin-avaxp/src/lib/transactionBuilder.ts
+++ b/modules/sdk-coin-avaxp/src/lib/transactionBuilder.ts
@@ -14,7 +14,7 @@ import { KeyPair } from './keyPair';
 import { BN, Buffer as BufferAvax } from 'avalanche';
 import utils from './utils';
 import { DecodedUtxoObj } from './iface';
-import { Tx } from 'avalanche/dist/apis/platformvm';
+import { AddDelegatorTx, Tx } from 'avalanche/dist/apis/platformvm';
 
 export abstract class TransactionBuilder extends BaseTransactionBuilder {
   private _transaction: Transaction;
@@ -36,12 +36,6 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
     this._transaction = new Transaction(_coinConfig);
   }
 
-  /**
-   * commented out check until multisig signing is in effect
-   * TODO: STLX-17077
-   * @param value
-   */
-
   threshold(value: number): this {
     this.validateThreshold(value);
     this._transaction._threshold = value;
@@ -57,6 +51,12 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
   fromPubKey(senderPubKey: string | string[]): this {
     const pubKeys = senderPubKey instanceof Array ? senderPubKey : [senderPubKey];
     this._transaction._fromAddresses = pubKeys.map(utils.parseAddress);
+    return this;
+  }
+
+  rewardAddresses(address: string | string[]): this {
+    const rewardAddresses = address instanceof Array ? address : [address];
+    this._transaction._rewardAddresses = rewardAddresses.map(utils.parseAddress);
     return this;
   }
 
@@ -102,6 +102,7 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
     this._transaction._locktime = secpOut.getLocktime();
     this._transaction._threshold = secpOut.getThreshold();
     this._transaction._fromAddresses = secpOut.getAddresses();
+    this._transaction._rewardAddresses = (baseTx as AddDelegatorTx).getRewardOwners().getOutput().getAddresses();
     this._transaction.setTransaction(tx);
     return this;
   }


### PR DESCRIPTION
Don't calculate outputs in SDK since IMS has already selected unspents. Doing this can lead to utxo selection issues since the outputs are sorted during serialization. 

BG-00000