### PR TITLE
fix: update AddWalletOptions

### DIFF
--- a/modules/sdk-core/src/bitgo/wallet/iWallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallets.ts
@@ -65,23 +65,48 @@ export interface AcceptShareOptions {
 }
 
 export interface AddWalletOptions {
-  type?: string;
+  coinSpecific?: any;
+  enterprise?: string;
+  isCold?: IsCold;
+  isCustodial?: IsCustodial;
   keys?: string[];
+  keySignatures?: KeySignatures;
+  label: string;
+  multisigType?: 'onchain' | 'tss' | 'blsdkg';
+  address?: string;
   m?: number;
   n?: number;
   tags?: string[];
+  type?: string;
+  walletVersion?: number;
+  eip1559?: Eip1559;
   clientFlags?: string[];
-  isCold?: boolean;
-  isCustodial?: boolean;
-  address?: string;
+  // Additional params needed for xrp
   rootPub?: string;
+  // In XRP, XLM and CSPR this private key is used only for wallet creation purposes,
+  // once the wallet is initialized then we update its weight to 0 making it an invalid key.
+  // https://www.stellar.org/developers/guides/concepts/multi-sig.html#additional-signing-keys
   rootPrivateKey?: string;
   initializationTxs?: any;
   disableTransactionNotifications?: boolean;
   gasPrice?: number;
-  walletVersion?: number;
-  multisigType?: 'onchain' | 'tss' | 'blsdkg';
 }
+
+type KeySignatures = {
+  backup?: string;
+  bitgo?: string;
+};
+
+/** @deprecated */
+type IsCold = boolean;
+
+/** @deprecated */
+type IsCustodial = boolean;
+
+type Eip1559 = {
+  maxPriorityFeePerGas: string;
+  maxFeePerGas: string;
+};
 
 export interface ListWalletOptions extends PaginationOptions {
   skip?: number;

--- a/modules/sdk-core/src/bitgo/wallet/wallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallets.ts
@@ -95,8 +95,14 @@ export class Wallets implements IWallets {
    *    "n": number of keys available on the wallet (3)
    *    "keys": array of keychain ids
    */
-  async add(params: AddWalletOptions = {}): Promise<any> {
+  async add(params: AddWalletOptions): Promise<any> {
+    params = params || {};
+
     common.validateParams(params, [], ['label', 'enterprise', 'type']);
+
+    if (typeof params.label !== 'string') {
+      throw new Error('missing required string parameter label');
+    }
 
     // no need to pass keys for (single) custodial wallets
     if (params.type !== 'custodial') {
@@ -138,47 +144,7 @@ export class Wallets implements IWallets {
       throw new Error('invalid argument for address - valid address string expected');
     }
 
-    const walletParams = _.pick(params, [
-      'label',
-      'm',
-      'n',
-      'keys',
-      'enterprise',
-      'isCold',
-      'isCustodial',
-      'tags',
-      'clientFlags',
-      'type',
-      'address',
-      'gasPrice',
-      'walletVersion',
-    ]);
-
-    // Additional params needed for xrp
-    if (params.rootPub) {
-      walletParams.rootPub = params.rootPub;
-    }
-
-    // In XRP, XLM and CSPR this private key is used only for wallet creation purposes,
-    // once the wallet is initialized then we update its weight to 0 making it an invalid key.
-    // https://www.stellar.org/developers/guides/concepts/multi-sig.html#additional-signing-keys
-    if (params.rootPrivateKey) {
-      walletParams.rootPrivateKey = params.rootPrivateKey;
-    }
-
-    if (params.initializationTxs) {
-      walletParams.initializationTxs = params.initializationTxs;
-    }
-
-    if (params.disableTransactionNotifications) {
-      walletParams.disableTransactionNotifications = params.disableTransactionNotifications;
-    }
-
-    if (params.multisigType) {
-      walletParams.multisigType = params.multisigType;
-    }
-
-    const newWallet = await this.bitgo.post(this.baseCoin.url('/wallet')).send(walletParams).result();
+    const newWallet = await this.bitgo.post(this.baseCoin.url('/wallet')).send(params).result();
     return {
       wallet: new Wallet(this.bitgo, this.baseCoin, newWallet),
     };
@@ -209,7 +175,7 @@ export class Wallets implements IWallets {
    */
   async generateWallet(params: GenerateWalletOptions = {}): Promise<WalletWithKeychains> {
     common.validateParams(params, ['label'], ['passphrase', 'userKey', 'backupXpub']);
-    if (!_.isString(params.label)) {
+    if (typeof params.label !== 'string') {
       throw new Error('missing required string parameter label');
     }
 


### PR DESCRIPTION
walletes.add was missing a required "label" field and optional fields
All defined parameters will now be pass to request if included

BG-51948