### PR TITLE
feat: add u value proof during tss eddssa key creation

### DIFF
--- a/modules/bitgo/test/v2/unit/internal/tssUtils/eddsa.ts
+++ b/modules/bitgo/test/v2/unit/internal/tssUtils/eddsa.ts
@@ -22,6 +22,8 @@ import {
   Ed25519BIP32,
 } from '@bitgo/sdk-core';
 
+openpgp.config.rejectCurves = new Set();
+
 describe('TSS Utils:', async function () {
   let sandbox: sinon.SinonSandbox;
   let MPC: Eddsa;
@@ -135,6 +137,7 @@ describe('TSS Utils:', async function () {
             email: 'test@test.com',
           },
         ],
+        curve: 'secp256k1',
       });
 
       const nockedBitGoKeychain = await nockBitgoKeychain({
@@ -185,6 +188,7 @@ describe('TSS Utils:', async function () {
             email: 'test@test.com',
           },
         ],
+        curve: 'secp256k1',
       });
 
       const nockedBitGoKeychain = await nockBitgoKeychain({
@@ -233,6 +237,7 @@ describe('TSS Utils:', async function () {
             email: 'test@test.com',
           },
         ],
+        curve: 'secp256k1',
       });
 
       const nockedBitGoKeychain = await nockBitgoKeychain({

--- a/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
@@ -10,6 +10,7 @@ import { encryptText, getBitgoGpgPubKey } from './opengpgUtils';
 export interface MpcKeyShare {
   publicShare: string;
   privateShare: string;
+  privateShareProof?: string;
 }
 
 export abstract class MpcUtils {
@@ -58,12 +59,14 @@ export abstract class MpcUtils {
           to: 'bitgo',
           publicShare: userKeyShare.publicShare,
           privateShare: encUserToBitGoMessage,
+          privateShareProof: userKeyShare.privateShareProof,
         },
         {
           from: 'backup',
           to: 'bitgo',
           publicShare: backupKeyShare.publicShare,
           privateShare: encBackupToBitGoMessage,
+          privateShareProof: backupKeyShare.privateShareProof,
         },
       ],
       userGPGPublicKey: userGpgKey.publicKey,

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
@@ -8,7 +8,7 @@ import { Ed25519BIP32 } from '../../../../account-lib/mpc/hdTree';
 import Eddsa from '../../../../account-lib/mpc/tss';
 import { IRequestTracer } from '../../../../api';
 import { AddKeychainOptions, Keychain, KeyType } from '../../../keychain';
-import { encryptText, getBitgoGpgPubKey } from '../../opengpgUtils';
+import { encryptText, getBitgoGpgPubKey, createShareProof } from '../../opengpgUtils';
 import {
   createUserSignShare,
   createUserToBitGoGShare,
@@ -175,6 +175,7 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
     const userToBitgoKeyShare = {
       publicShare: userToBitgoPublicShare,
       privateShare: userToBitgoPrivateShare,
+      privateShareProof: await createShareProof(userGpgKey.privateKey, userToBitgoPrivateShare.slice(0, 64)),
     };
 
     const backupToBitgoPublicShare = Buffer.concat([
@@ -188,6 +189,7 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
     const backupToBitgoKeyShare = {
       publicShare: backupToBitgoPublicShare,
       privateShare: backupToBitgoPrivateShare,
+      privateShareProof: await createShareProof(userGpgKey.privateKey, backupToBitgoPrivateShare.slice(0, 64)),
     };
 
     return await this.createBitgoKeychainInWP(


### PR DESCRIPTION
u value proof will be required and validated by HSM during key creation.

Ticket: BG-52374

Verified creating hot wallets continue to work (HSM ignores the proof for now):
```
async function createHotWallet() {
  const newWallet = await bitgo.coin('tsol').wallets().generateWallet({
    label: 'tss sol 722',
    passphrase: 'Ghghjkg!455544llll',
    passcodeEncryptionCode: 'passcodeEncryptionCode',
    enterprise: '60c7f599fdbda8000657d147f5c08f6e'
  });

  console.log(JSON.stringify(newWallet, undefined, 2));
}
```