### PR TITLE
perf(account-lib): remove unnecessary clamp in shamir

### DIFF
--- a/modules/account-lib/test/unit/mpc/shamir.ts
+++ b/modules/account-lib/test/unit/mpc/shamir.ts
@@ -1,0 +1,54 @@
+import { Ed25519Curve, ShamirSecret, Secp256k1Curve } from '@bitgo/sdk-core';
+import { strict as assert } from 'assert';
+
+const secret = BigInt(3012019);
+const secretString = secret.toString();
+let curves: Array<Ed25519Curve | Secp256k1Curve>;
+
+describe('Shamir Secret Sharing tests', async function () {
+  before(async () => {
+    const ed25519 = new Ed25519Curve();
+    await Ed25519Curve.initialize();
+    const secp256k1 = new Secp256k1Curve();
+    curves = [ed25519, secp256k1];
+  });
+
+  it('Should split secret and reconstruct properly', async () => {
+    for (let index = 0; index < curves.length; index++) {
+      const shamir = new ShamirSecret(curves[index]);
+      const shares = shamir.split(secret, 2, 3);
+
+      const combineSecret12 = shamir.combine({
+        1: shares[1],
+        2: shares[2],
+      });
+
+      combineSecret12.toString().should.equal(secretString);
+
+      const combineSecret23 = shamir.combine({
+        2: shares[2],
+        3: shares[3],
+      });
+
+      combineSecret23.toString().should.equal(secretString);
+
+      const combineSecret13 = shamir.combine({
+        1: shares[1],
+        3: shares[3],
+      });
+
+      combineSecret13.toString().should.equal(secretString);
+    }
+  });
+
+  it('Should throw exception for invalid threshold', async () => {
+    const shamir = new ShamirSecret(curves[0]);
+    assert.throws(() => {
+      shamir.split(secret, 0, 1);
+    });
+
+    assert.throws(() => {
+      shamir.split(secret, 4, 1);
+    });
+  });
+});

--- a/modules/sdk-core/src/account-lib/mpc/index.ts
+++ b/modules/sdk-core/src/account-lib/mpc/index.ts
@@ -1,5 +1,6 @@
 import HDTree, { Ed25519BIP32 } from './hdTree';
 import { EDDSA } from './tss';
+import ShamirSecret from './shamir';
 
 export { Ecdsa, ECDSA, Eddsa, EDDSA } from './tss';
 
@@ -8,4 +9,4 @@ export * from './util';
 
 type KeyShare = EDDSA.KeyShare;
 
-export { Ed25519BIP32, HDTree, KeyShare };
+export { Ed25519BIP32, HDTree, KeyShare, ShamirSecret };

--- a/modules/sdk-core/src/account-lib/mpc/shamir.ts
+++ b/modules/sdk-core/src/account-lib/mpc/shamir.ts
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const crypto = require('crypto');
 import Curve from './curves';
-import { bigIntFromBufferLE, bigIntToBufferLE, clamp } from './util';
+import { bigIntFromBufferLE, bigIntToBufferLE } from './util';
 
 export default class Shamir {
   curve: Curve;
@@ -35,8 +35,8 @@ export default class Shamir {
     assert(threshold <= numShares);
     const coefs: bigint[] = [];
     for (let ind = 0; ind < threshold - 1; ind++) {
-      const coeff = clamp(
-        bigIntFromBufferLE(crypto.createHmac('sha256', ind.toString(10)).update(bigIntToBufferLE(secret, 32)).digest())
+      const coeff = bigIntFromBufferLE(
+        crypto.createHmac('sha256', ind.toString(10)).update(bigIntToBufferLE(secret, 32)).digest()
       );
       coefs.push(coeff);
     }


### PR DESCRIPTION
this change removes unnecessary clamping for shamir secrets.
This change also adds some missing unit test cases for shamir
secret implementation.

TICKET: BG-52170