### PR TITLE
refactor(account-lib): preferring exception over assertion MPC implementation

### DIFF
--- a/modules/account-lib/test/unit/mpc/shamir.ts
+++ b/modules/account-lib/test/unit/mpc/shamir.ts
@@ -43,12 +43,7 @@ describe('Shamir Secret Sharing tests', async function () {
 
   it('Should throw exception for invalid threshold', async () => {
     const shamir = new ShamirSecret(curves[0]);
-    assert.throws(() => {
-      shamir.split(secret, 0, 1);
-    });
-
-    assert.throws(() => {
-      shamir.split(secret, 4, 1);
-    });
+    assert.throws(() => shamir.split(secret, 0, 1), /Threshold cannot be less than two/);
+    assert.throws(() => shamir.split(secret, 4, 1), /Threshold cannot be greater than the total number of shares/);
   });
 });

--- a/modules/account-lib/test/unit/mpc/shamir.ts
+++ b/modules/account-lib/test/unit/mpc/shamir.ts
@@ -1,0 +1,54 @@
+import { Ed25519Curve, ShamirSecret, Secp256k1Curve } from '@bitgo/sdk-core';
+import { strict as assert } from 'assert';
+
+const secret = BigInt(3012019);
+const secretString = secret.toString();
+let curves: Array<Ed25519Curve | Secp256k1Curve>;
+
+describe('Shamir Secret Sharing tests', async function () {
+  before(async () => {
+    const ed25519 = new Ed25519Curve();
+    await Ed25519Curve.initialize();
+    const secp256k1 = new Secp256k1Curve();
+    curves = [ed25519, secp256k1];
+  });
+
+  it('Should split secret and reconstruct properly', async () => {
+    for (let index = 0; index < curves.length; index++) {
+      const shamir = new ShamirSecret(curves[index]);
+      const shares = shamir.split(secret, 2, 3);
+
+      const combineSecret12 = shamir.combine({
+        1: shares[1],
+        2: shares[2],
+      });
+
+      combineSecret12.toString().should.equal(secretString);
+
+      const combineSecret23 = shamir.combine({
+        2: shares[2],
+        3: shares[3],
+      });
+
+      combineSecret23.toString().should.equal(secretString);
+
+      const combineSecret13 = shamir.combine({
+        1: shares[1],
+        3: shares[3],
+      });
+
+      combineSecret13.toString().should.equal(secretString);
+    }
+  });
+
+  it('Should throw exception for invalid threshold', async () => {
+    const shamir = new ShamirSecret(curves[0]);
+    assert.throws(() => {
+      shamir.split(secret, 0, 1);
+    });
+
+    assert.throws(() => {
+      shamir.split(secret, 4, 1);
+    });
+  });
+});

--- a/modules/account-lib/test/unit/mpc/tss/eddsa/eddsa.ts
+++ b/modules/account-lib/test/unit/mpc/tss/eddsa/eddsa.ts
@@ -27,6 +27,11 @@ describe('TSS EDDSA key generation and signing', function () {
     MPC = await Eddsa.initialize(hdTree);
   });
 
+  it('should fail to generate keys with invalid config', function () {
+    assert.throws(() => MPC.keyShare(0, 2, 3), /Invalid KeyShare config/);
+    assert.throws(() => MPC.keyShare(5, 2, 3), /Invalid KeyShare config/);
+  });
+
   it('should generate keys and sign message', function () {
     const A = MPC.keyShare(1, 2, 3);
     const B = MPC.keyShare(2, 2, 3);

--- a/modules/sdk-core/src/account-lib/mpc/index.ts
+++ b/modules/sdk-core/src/account-lib/mpc/index.ts
@@ -1,5 +1,6 @@
 import HDTree, { Ed25519BIP32 } from './hdTree';
 import { EDDSA } from './tss';
+import ShamirSecret from './shamir';
 
 export { Ecdsa, ECDSA, Eddsa, EDDSA } from './tss';
 
@@ -8,4 +9,4 @@ export * from './util';
 
 type KeyShare = EDDSA.KeyShare;
 
-export { Ed25519BIP32, HDTree, KeyShare };
+export { Ed25519BIP32, HDTree, KeyShare, ShamirSecret };

--- a/modules/sdk-core/src/account-lib/mpc/shamir.ts
+++ b/modules/sdk-core/src/account-lib/mpc/shamir.ts
@@ -1,4 +1,3 @@
-const assert = require('assert');
 const crypto = require('crypto');
 import Curve from './curves';
 import { bigIntFromBufferLE, bigIntToBufferLE } from './util';
@@ -31,8 +30,14 @@ export default class Shamir {
         .fill(null)
         .map((_, i) => BigInt(i + 1));
     }
-    assert(threshold > 1);
-    assert(threshold <= numShares);
+    if (threshold < 2) {
+      throw new Error('Threshold cannot be less than two');
+    }
+
+    if (threshold > numShares) {
+      throw new Error('Threshold cannot be greater than the total number of shares');
+    }
+
     const coefs: bigint[] = [];
     for (let ind = 0; ind < threshold - 1; ind++) {
       const coeff = bigIntFromBufferLE(

--- a/modules/sdk-core/src/account-lib/mpc/shamir.ts
+++ b/modules/sdk-core/src/account-lib/mpc/shamir.ts
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const crypto = require('crypto');
 import Curve from './curves';
-import { bigIntFromBufferLE, bigIntToBufferLE, clamp } from './util';
+import { bigIntFromBufferLE, bigIntToBufferLE } from './util';
 
 export default class Shamir {
   curve: Curve;
@@ -35,8 +35,8 @@ export default class Shamir {
     assert(threshold <= numShares);
     const coefs: bigint[] = [];
     for (let ind = 0; ind < threshold - 1; ind++) {
-      const coeff = clamp(
-        bigIntFromBufferLE(crypto.createHmac('sha256', ind.toString(10)).update(bigIntToBufferLE(secret, 32)).digest())
+      const coeff = bigIntFromBufferLE(
+        crypto.createHmac('sha256', ind.toString(10)).update(bigIntToBufferLE(secret, 32)).digest()
       );
       coefs.push(coeff);
     }

--- a/modules/sdk-core/src/account-lib/mpc/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/account-lib/mpc/tss/eddsa/eddsa.ts
@@ -29,7 +29,6 @@
  * 4. This results in each signer having a public g-share which they send to the other signers.
  * 5. After the signers broadcast their g-shares, the final signature can be re-constructed independently.
  */
-const assert = require('assert');
 import { randomBytes, createHash } from 'crypto';
 import { Ed25519Curve } from '../../curves';
 import Shamir from '../../shamir';
@@ -74,7 +73,9 @@ export default class Eddsa {
   }
 
   keyShare(index: number, threshold: number, numShares: number, seed?: Buffer): KeyShare {
-    assert(index > 0 && index <= numShares);
+    if (!(index > 0 && index <= numShares)) {
+      throw new Error('Invalid KeyShare config');
+    }
     if (seed && seed.length !== 64) {
       throw new Error('Seed must have length 64');
     }


### PR DESCRIPTION
This change prefers using try catch with meaningful error messages for shamir and eddsa tss implementations over asserts. While assert successfully aborts execution, the fact that the functions throw uncaught exceptions means that function termination can lead to unpredictable program behavior. Note that uncaught exceptions also concern outright program terminations executed at the top-level function, though this is not the case here.

TICKET: BG-52167