### PR TITLE
chore: remove old style of export

### DIFF
--- a/modules/bitgo/package.json
+++ b/modules/bitgo/package.json
@@ -106,6 +106,7 @@
     "karma-chrome-launcher": "^3.1.0",
     "karma-jasmine": "^4.0.0",
     "karma-typescript": "^5.0.3",
+    "libsodium-wrappers-sumo": "^0.7.9",
     "puppeteer": "2.1.1",
     "q": "^1.1.2",
     "request": "^2.88.0",

--- a/scripts/sdk-coin-generator/template/boilerplates/account/index.ts
+++ b/scripts/sdk-coin-generator/template/boilerplates/account/index.ts
@@ -1,3 +1,3 @@
-export * as <%= constructor %>Lib from './lib';
+export * from './lib';
 export * from './<%= symbol %>';
 export * from './<%= testnetSymbol %>';


### PR DESCRIPTION
Quick removal of old way of exports so that new coins aren't implemented this way.

BG-000000