### PR TITLE
refactor(account-lib): deprecate hbar to and amount function

### DIFF
--- a/modules/sdk-coin-hbar/src/lib/coinTransferBuilder.ts
+++ b/modules/sdk-coin-hbar/src/lib/coinTransferBuilder.ts
@@ -13,8 +13,9 @@ declare class DuplicateMethodError extends ExtendableError {
 }
 
 export class CoinTransferBuilder extends TransferBuilder {
-  // TODO: [BG-51282] Deprecate once wp work for multi recipients
+  // @deprecated Use _recipients field instead
   private _toAddress: string;
+  // @deprecated Use _recipients field instead
   private _amount: string;
 
   constructor(_coinConfig: Readonly<CoinConfig>) {
@@ -78,10 +79,11 @@ export class CoinTransferBuilder extends TransferBuilder {
   }
 
   // region Transfer fields
-  /** TODO: [BG-51282] Deprecate to and amount once wp has been fixed
-      Currently work for one recipient by using exatcly one of to + amount or send function
-   */
+
+  // Currently works for one recipient by using exatcly one of to + amount or send function
   /**
+   * @deprecated - Use the send method instead
+   *
    * Set the destination address where the funds will be sent,
    * it may take the format `'<shard>.<realm>.<account>'` or `'<account>'`
    *
@@ -100,6 +102,8 @@ export class CoinTransferBuilder extends TransferBuilder {
   }
 
   /**
+   * @deprecated - Use the send method instead
+   *
    * Set the amount to be transferred
    *
    * @param {string} amount - Amount to transfer in tinyBars (there are 100,000,000 tinyBars in one Hbar)
@@ -131,7 +135,6 @@ export class CoinTransferBuilder extends TransferBuilder {
   // region Validators
   /** @inheritdoc */
   validateMandatoryFields(): void {
-    // TODO: [BG-51282] Remove once to and amount function is deprecated
     if (this._toAddress && this._amount) {
       this._recipients.push({
         address: this._toAddress,

--- a/modules/sdk-coin-hbar/src/lib/iface.ts
+++ b/modules/sdk-coin-hbar/src/lib/iface.ts
@@ -11,9 +11,10 @@ export interface TxData {
   validDuration: string;
   node: string;
   memo?: string;
-  to?: string; // TODO: [BG-51282] Deprecate once wp work for multi recipients
+  /** @deprecated Use instructionsData.params.recipients instead */
+  to?: string;
+  /** @deprecated Use instructionsData.params.recipients instead */
   amount?: string;
-  tokenName?: string;
   instructionsData?: InstructionParams;
 }
 

--- a/modules/sdk-coin-hbar/src/lib/transaction.ts
+++ b/modules/sdk-coin-hbar/src/lib/transaction.ts
@@ -96,10 +96,9 @@ export class Transaction extends BaseTransaction {
 
     switch (this._txBody.data) {
       case HederaTransactionTypes.Transfer:
-        const transferData = this.getTransferData();
         result.instructionsData = {
           type: HederaTransactionTypes.Transfer,
-          params: transferData,
+          params: this.getTransferData(),
         };
         result.to = result.instructionsData.params.recipients[0].address;
         result.amount = result.instructionsData.params.recipients[0].amount;

--- a/modules/sdk-coin-hbar/test/unit/hbar.ts
+++ b/modules/sdk-coin-hbar/test/unit/hbar.ts
@@ -1,3 +1,4 @@
+import { TxData, Transfer } from '../../src/lib/iface';
 import { TestBitGo, TestBitGoAPI } from '@bitgo/sdk-test';
 import { BitGoAPI } from '@bitgo/sdk-api';
 import * as TestData from '../fixtures/hbar';
@@ -274,10 +275,14 @@ describe('Hedera Hashgraph:', function () {
       const factory = getBuilderFactory('thbar');
       const txBuilder = factory.from(tx.halfSigned.txHex);
       const signedTx = await txBuilder.build();
-      const txJson = signedTx.toJson();
-      txJson.to.should.equal(destination);
-      txJson.from.should.equal(source);
-      txJson.amount.should.equal(amount);
+      const txJson = signedTx.toJson() as TxData;
+      txJson.to!.should.equal(destination);
+      txJson.from!.should.equal(source);
+      txJson.amount!.should.equal(amount);
+      (txJson.instructionsData as Transfer).params.recipients[0].should.deepEqual({
+        address: destination,
+        amount,
+      });
       signedTx.signature.length.should.equal(1);
     });
   });

--- a/modules/sdk-coin-hbar/test/unit/transactionBuilder/transferBuilder.ts
+++ b/modules/sdk-coin-hbar/test/unit/transactionBuilder/transferBuilder.ts
@@ -287,7 +287,7 @@ describe('HBAR Transfer Builder', () => {
       );
     });
 
-    it('a transfer transaction with an invalid destination address', () => {
+    it('a transfer transaction with an invalid destination address using deprecated to method', () => {
       const txBuilder = factory.getTransferBuilder();
       assert.throws(
         () => txBuilder.to('invalidaddress'),
@@ -295,7 +295,7 @@ describe('HBAR Transfer Builder', () => {
       );
     });
 
-    it('a transfer transaction with an invalid amount: text value', () => {
+    it('a transfer transaction with an invalid amount using deprecated amount method: text value', () => {
       const txBuilder = factory.getTransferBuilder();
       assert.throws(
         () => txBuilder.amount('invalidamount'),
@@ -303,10 +303,46 @@ describe('HBAR Transfer Builder', () => {
       );
     });
 
-    it('a transfer transaction with an invalid amount: negative value', () => {
+    it('a transfer transaction with an invalid amount using deprecated amount method: negative value', () => {
       const txBuilder = factory.getTransferBuilder();
       assert.throws(
         () => txBuilder.amount('-5'),
+        (e) => e.message === 'Invalid amount'
+      );
+    });
+
+    it('a transfer transaction with an invalid destination address', () => {
+      const txBuilder = factory.getTransferBuilder();
+      assert.throws(
+        () =>
+          txBuilder.send({
+            address: 'invalidaddress',
+            amount: '10000',
+          }),
+        (e) => e.message === 'Invalid address'
+      );
+    });
+
+    it('a transfer transaction with an invalid amount: text value', () => {
+      const txBuilder = factory.getTransferBuilder();
+      assert.throws(
+        () =>
+          txBuilder.send({
+            address: testData.ACCOUNT_2.accountId,
+            amount: 'invalidamount',
+          }),
+        (e) => e.message === 'Invalid amount'
+      );
+    });
+
+    it('a transfer transaction with an invalid amount: negative value', () => {
+      const txBuilder = factory.getTransferBuilder();
+      assert.throws(
+        () =>
+          txBuilder.send({
+            address: testData.ACCOUNT_2.accountId,
+            amount: '-5',
+          }),
         (e) => e.message === 'Invalid amount'
       );
     });


### PR DESCRIPTION
Ticket: BG-51282

Rather than removing `to` and `amount` as in https://github.com/BitGo/BitGoJS/pull/2568, we have decided to just mark them as deprecated instead.