### PR TITLE
refactor(statics): update sol token asset

### DIFF
--- a/modules/sdk-coin-sol/test/unit/transaction.ts
+++ b/modules/sdk-coin-sol/test/unit/transaction.ts
@@ -552,7 +552,7 @@ describe('Sol Transaction', () => {
         .fee({ amount: 5000 })
         .sender(sender)
         .nonce(blockHash)
-        .mint('tsol:orca')
+        .mint('tsol:usdc')
         .rentExemptAmount(amount)
         .build();
 
@@ -577,7 +577,7 @@ describe('Sol Transaction', () => {
         outputAmount: '10000',
         outputs: [
           {
-            address: '9nEfQqahxpyYP5RPExt9TGssPmV5MxjEw9YjGWmepMAt',
+            address: '141BFNem3pknc8CzPVLv1Ri3btgKdCsafYP5nXwmXfxU',
             amount: '10000',
           },
         ],
@@ -729,7 +729,7 @@ describe('Sol Transaction', () => {
         .getTokenTransferBuilder()
         .nonce(blockHash)
         .sender(sender)
-        .send({ address, amount, tokenName: 'tsol:orca' })
+        .send({ address, amount, tokenName: 'tsol:usdc' })
         .fee({ amount: 5000 })
         .build();
 
@@ -756,7 +756,7 @@ describe('Sol Transaction', () => {
           {
             address: 'DesU7XscZjng8yj5VX6AZsk3hWSW4sQ3rTG2LuyQ2P4H',
             amount: '10000',
-            tokenName: 'tsol:orca',
+            tokenName: 'tsol:usdc',
           },
         ],
         fee: {
@@ -775,9 +775,9 @@ describe('Sol Transaction', () => {
         .nonce(blockHash, { walletNonceAddress: testData.nonceAccount.pub, authWalletAddress: sender })
         .sender(sender)
         .memo('memo text')
-        .send({ address, amount, tokenName: 'tsol:orca' })
-        .send({ address: testData.addresses.validAddresses[1], amount, tokenName: 'tsol:orca' })
-        .send({ address: testData.addresses.validAddresses[2], amount, tokenName: 'tsol:orca' })
+        .send({ address, amount, tokenName: 'tsol:usdc' })
+        .send({ address: testData.addresses.validAddresses[1], amount, tokenName: 'tsol:usdc' })
+        .send({ address: testData.addresses.validAddresses[2], amount, tokenName: 'tsol:usdc' })
         .build();
 
       const explainedTransaction = tx.explainTransaction();
@@ -803,17 +803,17 @@ describe('Sol Transaction', () => {
           {
             address: 'DesU7XscZjng8yj5VX6AZsk3hWSW4sQ3rTG2LuyQ2P4H',
             amount: '10000',
-            tokenName: 'tsol:orca',
+            tokenName: 'tsol:usdc',
           },
           {
             address: 'Azz9EmNuhtjoYrhWvidWx1Hfd14SNBsYyzXhA9Tnoca8',
             amount: '10000',
-            tokenName: 'tsol:orca',
+            tokenName: 'tsol:usdc',
           },
           {
             address: '2n2xqWM9Z18LqxfJzkNrMMFWiDUFYA2k6WSgSnf6EnJs',
             amount: '10000',
-            tokenName: 'tsol:orca',
+            tokenName: 'tsol:usdc',
           },
         ],
         fee: {

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -1580,14 +1580,6 @@ export const coins = CoinMap.fromCoins([
     AccountCoin.DEFAULT_FEATURES
   ),
   solToken(
-    'sol:orca',
-    'Orca',
-    6,
-    'orcaEKTdK7LKz57vaAYr9QeNsVEPfiu6QeMU1kektZE', // https://explorer.solana.com/address/orcaEKTdK7LKz57vaAYr9QeNsVEPfiu6QeMU1kektZE
-    UnderlyingAsset.ORCA,
-    AccountCoin.DEFAULT_FEATURES
-  ),
-  solToken(
     'sol:usdc',
     'USD Coin',
     6,
@@ -1604,27 +1596,19 @@ export const coins = CoinMap.fromCoins([
     AccountCoin.DEFAULT_FEATURES
   ),
   solToken(
-    'sol:mnde',
-    'Marinade',
-    9,
-    'MNDEFzGvMt87ueuHvVU9VcTqsAP5b3fTGPsHuuPA5ey', // https://explorer.solana.com/address/MNDEFzGvMt87ueuHvVU9VcTqsAP5b3fTGPsHuuPA5ey/metadata
-    UnderlyingAsset.MNDE,
-    AccountCoin.DEFAULT_FEATURES
-  ),
-  solToken(
-    'sol:slnd',
-    'Solend',
-    6,
-    'SLNDpmoWTVADgEdndyvWzroNL7zSi1dF9PC3xHGtPwp', // https://explorer.solana.com/address/SLNDpmoWTVADgEdndyvWzroNL7zSi1dF9PC3xHGtPwp
-    UnderlyingAsset.SLND,
-    AccountCoin.DEFAULT_FEATURES
-  ),
-  solToken(
     'sol:gmt',
     'GMT',
     9,
     '7i5KKsX2weiTkry7jA4ZwSuXGhs5eJBEjY8vVxR4pfRx', // https://explorer.solana.com/address/7i5KKsX2weiTkry7jA4ZwSuXGhs5eJBEjY8vVxR4pfRx
     UnderlyingAsset.GMT,
+    AccountCoin.DEFAULT_FEATURES
+  ),
+  solToken(
+    'sol:usdt',
+    'USD Tether',
+    6,
+    'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB', // https://explorer.solana.com/address/Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB
+    UnderlyingAsset.USDT,
     AccountCoin.DEFAULT_FEATURES
   ),
   tsolToken(
@@ -1633,14 +1617,6 @@ export const coins = CoinMap.fromCoins([
     9,
     'D8YXLiwWQMibWRaxCTs9k6HwaYE6vtsbzK9KrQVMXU1K',
     UnderlyingAsset.SRM,
-    AccountCoin.DEFAULT_FEATURES
-  ),
-  tsolToken(
-    'tsol:orca',
-    'Orca',
-    9,
-    '9cgpBeNZ2HnLda7NWaaU1i3NyTstk2c4zCMUcoAGsi9C',
-    UnderlyingAsset.ORCA,
     AccountCoin.DEFAULT_FEATURES
   ),
   tsolToken(
@@ -1660,27 +1636,19 @@ export const coins = CoinMap.fromCoins([
     AccountCoin.DEFAULT_FEATURES
   ),
   tsolToken(
-    'tsol:mnde',
-    'Marinade',
-    9,
-    '7gRLy19WNhGx5D4znmak436sa1ZMqYkxF7aNi5fL1ZXg',
-    UnderlyingAsset.MNDE,
-    AccountCoin.DEFAULT_FEATURES
-  ),
-  tsolToken(
-    'tsol:slnd',
-    'Solend',
-    9,
-    'Ex6rHLLmvZoP9mpunMFvew424seSjPp5PQb5hDy8KJu6',
-    UnderlyingAsset.SLND,
-    AccountCoin.DEFAULT_FEATURES
-  ),
-  tsolToken(
     'tsol:gmt',
     'GMT',
     9,
     '64bco36MjrZ8K26FXZGoSrnDFDSCZhvJGfQ5ywLRFUpF',
     UnderlyingAsset.GMT,
+    AccountCoin.DEFAULT_FEATURES
+  ),
+  tsolToken(
+    'tsol:usdt',
+    'USD Tether',
+    9,
+    '9cgpBeNZ2HnLda7NWaaU1i3NyTstk2c4zCMUcoAGsi9C',
+    UnderlyingAsset.USDT,
     AccountCoin.DEFAULT_FEATURES
   ),
   fiat('fiatusd', 'US Dollar', Networks.main.fiat, 2, UnderlyingAsset.USD),


### PR DESCRIPTION
BG-52918

BREAKING CHANGE: This breaks the provided token asset used for wp in bitgo-ms, will require to change
available sokana token asset in wp once this merged.
BG-52918