### PR TITLE
feat(utxo-bin): improve output scripts parsing

### DIFF
--- a/modules/utxo-bin/src/commands.ts
+++ b/modules/utxo-bin/src/commands.ts
@@ -51,6 +51,7 @@ export const cmdParse = {
       .option('parseScriptAsm', { alias: 'scriptasm', type: 'boolean', default: false })
       .option('parseScriptData', { alias: 'scriptdata', type: 'boolean', default: false })
       .option('parseSignatureData', { alias: 'sigdata', type: 'boolean', default: false })
+      .option('parseOutputScript', { type: 'boolean', default: false })
       .option('maxOutputs', { type: 'number' })
       .option('all', { type: 'boolean', default: false })
       .option('format', { choices: ['tree', 'json'], default: 'tree' } as const);

--- a/modules/utxo-bin/src/format.ts
+++ b/modules/utxo-bin/src/format.ts
@@ -2,7 +2,7 @@ import { Chalk, Instance } from 'chalk';
 import * as archy from 'archy';
 import { TxNode, TxNodeValue } from './parse';
 
-const hideDefault = ['pubkeys', 'sequence', 'locktime', 'script', 'witness'];
+const hideDefault = ['pubkeys', 'sequence', 'locktime', 'scriptSig', 'witness'];
 
 export function formatTree(
   n: TxNode,
@@ -32,7 +32,7 @@ export function formatTree(
           return v.length === 0 ? '[]' : v.toString('hex');
         }
     }
-    throw new Error(`could not get lavel from value`);
+    throw new Error(`could not get label from value`);
   }
 
   function toArchy(n: TxNode): archy.Data {

--- a/modules/utxo-bin/src/parse.ts
+++ b/modules/utxo-bin/src/parse.ts
@@ -100,7 +100,7 @@ export class Parser {
     });
   }
 
-  parseScript(buffer: Buffer): TxNode {
+  parseInputScript(buffer: Buffer): TxNode {
     let value;
     let nodes;
     if (buffer.length && this.params.parseSignatureData) {
@@ -114,7 +114,7 @@ export class Parser {
       value = buffer;
     }
 
-    return this.node('script', value, nodes);
+    return this.node('scriptSig', value, nodes);
   }
 
   parseWitness(script: Buffer[]): TxNode {
@@ -216,7 +216,7 @@ export class Parser {
     return ins.map((input, i) => {
       return this.node(i, utxolib.bitgo.formatOutputId(utxolib.bitgo.getOutputIdForInput(input)), [
         this.node('sequence', toBufferUInt32BE(input.sequence)),
-        this.parseScript(input.script),
+        this.parseInputScript(input.script),
         this.parseWitness(input.witness),
         this.parseSigScript(tx, i, outputInfo.prevOutputs),
         ...this.parsePrevOut(input, i, tx.network, outputInfo.prevOutputs),

--- a/modules/utxo-bin/src/parse.ts
+++ b/modules/utxo-bin/src/parse.ts
@@ -28,6 +28,7 @@ export type TxNode = {
 export type ParserArgs = {
   parseScriptData: boolean;
   parseScriptAsm: boolean;
+  parseOutputScript: boolean;
   parseSignatureData: boolean;
   hide?: string[];
   maxOutputs?: number;
@@ -56,6 +57,7 @@ export class Parser {
     parseScriptData: true,
     parseScriptAsm: true,
     parseSignatureData: true,
+    parseOutputScript: true,
   };
 
   constructor(private params: ParserArgs) {}
@@ -242,24 +244,36 @@ export class Parser {
       } catch (e) {
         // ignore
       }
-      return this.node(i, `${buf.length} bytes`, [
+      return this.node(`OP_RETURN ${i}`, `${buf.length} bytes`, [
         this.node('hex', buf),
         ...(utf8 && isPrintable(utf8) ? [this.node('utf8', utf8)] : []),
       ]);
     });
   }
 
-  tryFormatAddress(script: Buffer, network: utxolib.Network): string | Buffer {
-    const opReturnNodes = this.tryParseOpReturn(script);
-    if (opReturnNodes.length) {
-      return `OP_RETURN`;
-    }
+  parseOutputScript(buffer: Buffer): TxNode[] {
+    return [
+      this.node('scriptPubKey', `${buffer.length} bytes`, [
+        this.node('hex', buffer.toString('hex')),
+        this.node('asm', utxolib.script.toASM(buffer), this.tryParseOpReturn(buffer)),
+      ]),
+    ];
+  }
 
+  parseOutput(txid: string, o: utxolib.TxOutput, i: number, network: utxolib.Network, params: ChainInfo): TxNode {
+    const type = utxolib.classify.output(o.script);
+
+    let address;
     try {
-      return utxolib.address.fromOutputScript(script, network);
-    } catch (e) {
-      return script;
-    }
+      address = utxolib.address.fromOutputScript(o.script, network);
+    } catch (e) {}
+
+    return this.node(i, address ?? '(no address)', [
+      this.node(`value`, formatSat(o.value)),
+      this.node(`type`, type),
+      ...(this.params.parseOutputScript || address === undefined ? this.parseOutputScript(o.script) : []),
+      ...this.parseSpend(txid, i, params.outputSpends, { conflict: false }),
+    ]);
   }
 
   parseOuts(outs: utxolib.TxOutput[], tx: utxolib.bitgo.UtxoTransaction, params: ChainInfo): TxNode[] {
@@ -268,13 +282,7 @@ export class Parser {
     }
 
     const txid = tx.getId();
-    return outs.map((o, i) =>
-      this.node(i, this.tryFormatAddress(o.script, tx.network), [
-        ...this.tryParseOpReturn(o.script),
-        this.node(`value`, o.value / 1e8),
-        ...this.parseSpend(txid, i, params.outputSpends, { conflict: false }),
-      ])
-    );
+    return outs.map((o, i) => this.parseOutput(txid, o, i, tx.network, params));
   }
 
   parseStatus(tx: utxolib.bitgo.UtxoTransaction, status?: TransactionStatus): TxNode[] {

--- a/modules/utxo-bin/test/fixtures/format_p2shP2wsh_all.txt
+++ b/modules/utxo-bin/test/fixtures/format_p2shP2wsh_all.txt
@@ -13,4 +13,8 @@ transaction: a7b64a92c6fb7e0c6ea0b95c0db8a3253347d22f76562df4dc187ed5d442767b
 │     └── signatures: [72byte] [71byte]
 └─┬ outputs: 1 sum=1.99999000
   └─┬ 0: 2MvPeRFSGYJq9BXoV2fxrMpJjsZMGx2m6Zk
-    └── value: 1.99999
+    ├── value: 1.99999000
+    ├── type: scripthash
+    └─┬ scriptPubKey: 23 bytes
+      ├── hex: a9142280193aca8462021ec369d4e2ff1c95741fba7f87
+      └── asm: OP_HASH160 2280193aca8462021ec369d4e2ff1c95741fba7f OP_EQUAL

--- a/modules/utxo-bin/test/fixtures/format_p2shP2wsh_all_prevOuts.txt
+++ b/modules/utxo-bin/test/fixtures/format_p2shP2wsh_all_prevOuts.txt
@@ -23,4 +23,8 @@ transaction: a7b64a92c6fb7e0c6ea0b95c0db8a3253347d22f76562df4dc187ed5d442767b
 │     └── address: 2MvPeRFSGYJq9BXoV2fxrMpJjsZMGx2m6Zk
 └─┬ outputs: 1 sum=1.99999000
   └─┬ 0: 2MvPeRFSGYJq9BXoV2fxrMpJjsZMGx2m6Zk
-    └── value: 1.99999
+    ├── value: 1.99999000
+    ├── type: scripthash
+    └─┬ scriptPubKey: 23 bytes
+      ├── hex: a9142280193aca8462021ec369d4e2ff1c95741fba7f87
+      └── asm: OP_HASH160 2280193aca8462021ec369d4e2ff1c95741fba7f OP_EQUAL

--- a/modules/utxo-bin/test/fixtures/format_p2shP2wsh_default.txt
+++ b/modules/utxo-bin/test/fixtures/format_p2shP2wsh_default.txt
@@ -13,4 +13,5 @@ transaction: a7b64a92c6fb7e0c6ea0b95c0db8a3253347d22f76562df4dc187ed5d442767b
 │     └── signatures: [72byte] [71byte]
 └─┬ outputs: 1 sum=1.99999000
   └─┬ 0: 2MvPeRFSGYJq9BXoV2fxrMpJjsZMGx2m6Zk
-    └── value: 1.99999
+    ├── value: 1.99999000
+    └── type: scripthash

--- a/modules/utxo-bin/test/fixtures/format_p2shP2wsh_default_prevOuts.txt
+++ b/modules/utxo-bin/test/fixtures/format_p2shP2wsh_default_prevOuts.txt
@@ -23,4 +23,5 @@ transaction: a7b64a92c6fb7e0c6ea0b95c0db8a3253347d22f76562df4dc187ed5d442767b
 │     └── address: 2MvPeRFSGYJq9BXoV2fxrMpJjsZMGx2m6Zk
 └─┬ outputs: 1 sum=1.99999000
   └─┬ 0: 2MvPeRFSGYJq9BXoV2fxrMpJjsZMGx2m6Zk
-    └── value: 1.99999
+    ├── value: 1.99999000
+    └── type: scripthash

--- a/modules/utxo-bin/test/fixtures/format_p2sh_all.txt
+++ b/modules/utxo-bin/test/fixtures/format_p2sh_all.txt
@@ -13,4 +13,8 @@ transaction: 58603ea06d55bd9dd6fec9b0d1ea5662d622f923e0f10045507723a893388e7f
 │     └── signatures: [72byte] [71byte]
 └─┬ outputs: 1 sum=1.99999000
   └─┬ 0: 2NGSAkyhiWMZPcrfiwmcRWf9HQgpsiRGKv4
-    └── value: 1.99999
+    ├── value: 1.99999000
+    ├── type: scripthash
+    └─┬ scriptPubKey: 23 bytes
+      ├── hex: a914fe5cc5d87e3348a5f3eaa316898a0f05d520876e87
+      └── asm: OP_HASH160 fe5cc5d87e3348a5f3eaa316898a0f05d520876e OP_EQUAL

--- a/modules/utxo-bin/test/fixtures/format_p2sh_all_prevOuts.txt
+++ b/modules/utxo-bin/test/fixtures/format_p2sh_all_prevOuts.txt
@@ -23,4 +23,8 @@ transaction: 58603ea06d55bd9dd6fec9b0d1ea5662d622f923e0f10045507723a893388e7f
 │     └── address: 2NGSAkyhiWMZPcrfiwmcRWf9HQgpsiRGKv4
 └─┬ outputs: 1 sum=1.99999000
   └─┬ 0: 2NGSAkyhiWMZPcrfiwmcRWf9HQgpsiRGKv4
-    └── value: 1.99999
+    ├── value: 1.99999000
+    ├── type: scripthash
+    └─┬ scriptPubKey: 23 bytes
+      ├── hex: a914fe5cc5d87e3348a5f3eaa316898a0f05d520876e87
+      └── asm: OP_HASH160 fe5cc5d87e3348a5f3eaa316898a0f05d520876e OP_EQUAL

--- a/modules/utxo-bin/test/fixtures/format_p2sh_default.txt
+++ b/modules/utxo-bin/test/fixtures/format_p2sh_default.txt
@@ -13,4 +13,5 @@ transaction: 58603ea06d55bd9dd6fec9b0d1ea5662d622f923e0f10045507723a893388e7f
 │     └── signatures: [72byte] [71byte]
 └─┬ outputs: 1 sum=1.99999000
   └─┬ 0: 2NGSAkyhiWMZPcrfiwmcRWf9HQgpsiRGKv4
-    └── value: 1.99999
+    ├── value: 1.99999000
+    └── type: scripthash

--- a/modules/utxo-bin/test/fixtures/format_p2sh_default_prevOuts.txt
+++ b/modules/utxo-bin/test/fixtures/format_p2sh_default_prevOuts.txt
@@ -23,4 +23,5 @@ transaction: 58603ea06d55bd9dd6fec9b0d1ea5662d622f923e0f10045507723a893388e7f
 │     └── address: 2NGSAkyhiWMZPcrfiwmcRWf9HQgpsiRGKv4
 └─┬ outputs: 1 sum=1.99999000
   └─┬ 0: 2NGSAkyhiWMZPcrfiwmcRWf9HQgpsiRGKv4
-    └── value: 1.99999
+    ├── value: 1.99999000
+    └── type: scripthash

--- a/modules/utxo-bin/test/fixtures/format_p2tr_all.txt
+++ b/modules/utxo-bin/test/fixtures/format_p2tr_all.txt
@@ -13,4 +13,8 @@ transaction: 02ebf7ae9f4d0bd6c5c661e992485f328495fb1edcce2d37de5103066a2ee97b
 │     └── signatures: [64byte] [64byte]
 └─┬ outputs: 1 sum=1.99999000
   └─┬ 0: tb1pcnnt6rgns609syxzsvufd6t2x7ksqh6glelnhmtddhdk3ca6e0uq7cz9fh
-    └── value: 1.99999
+    ├── value: 1.99999000
+    ├── type: taproot
+    └─┬ scriptPubKey: 34 bytes
+      ├── hex: 5120c4e6bd0d13869e5810c2833896e96a37ad005f48fe7f3bed6d6ddb68e3bacbf8
+      └── asm: OP_1 c4e6bd0d13869e5810c2833896e96a37ad005f48fe7f3bed6d6ddb68e3bacbf8

--- a/modules/utxo-bin/test/fixtures/format_p2tr_all_prevOuts.txt
+++ b/modules/utxo-bin/test/fixtures/format_p2tr_all_prevOuts.txt
@@ -23,4 +23,8 @@ transaction: 02ebf7ae9f4d0bd6c5c661e992485f328495fb1edcce2d37de5103066a2ee97b
 │     └── address: tb1pcnnt6rgns609syxzsvufd6t2x7ksqh6glelnhmtddhdk3ca6e0uq7cz9fh
 └─┬ outputs: 1 sum=1.99999000
   └─┬ 0: tb1pcnnt6rgns609syxzsvufd6t2x7ksqh6glelnhmtddhdk3ca6e0uq7cz9fh
-    └── value: 1.99999
+    ├── value: 1.99999000
+    ├── type: taproot
+    └─┬ scriptPubKey: 34 bytes
+      ├── hex: 5120c4e6bd0d13869e5810c2833896e96a37ad005f48fe7f3bed6d6ddb68e3bacbf8
+      └── asm: OP_1 c4e6bd0d13869e5810c2833896e96a37ad005f48fe7f3bed6d6ddb68e3bacbf8

--- a/modules/utxo-bin/test/fixtures/format_p2tr_default.txt
+++ b/modules/utxo-bin/test/fixtures/format_p2tr_default.txt
@@ -13,4 +13,5 @@ transaction: 02ebf7ae9f4d0bd6c5c661e992485f328495fb1edcce2d37de5103066a2ee97b
 │     └── signatures: [64byte] [64byte]
 └─┬ outputs: 1 sum=1.99999000
   └─┬ 0: tb1pcnnt6rgns609syxzsvufd6t2x7ksqh6glelnhmtddhdk3ca6e0uq7cz9fh
-    └── value: 1.99999
+    ├── value: 1.99999000
+    └── type: taproot

--- a/modules/utxo-bin/test/fixtures/format_p2tr_default_prevOuts.txt
+++ b/modules/utxo-bin/test/fixtures/format_p2tr_default_prevOuts.txt
@@ -23,4 +23,5 @@ transaction: 02ebf7ae9f4d0bd6c5c661e992485f328495fb1edcce2d37de5103066a2ee97b
 │     └── address: tb1pcnnt6rgns609syxzsvufd6t2x7ksqh6glelnhmtddhdk3ca6e0uq7cz9fh
 └─┬ outputs: 1 sum=1.99999000
   └─┬ 0: tb1pcnnt6rgns609syxzsvufd6t2x7ksqh6glelnhmtddhdk3ca6e0uq7cz9fh
-    └── value: 1.99999
+    ├── value: 1.99999000
+    └── type: taproot

--- a/modules/utxo-bin/test/fixtures/format_p2wsh_all.txt
+++ b/modules/utxo-bin/test/fixtures/format_p2wsh_all.txt
@@ -13,4 +13,8 @@ transaction: 2fedaa3661f6251d1a4ca23e5d4bb03fab5b75e8e471281f554755c439cd9924
 │     └── signatures: [71byte] [71byte]
 └─┬ outputs: 1 sum=1.99999000
   └─┬ 0: tb1qz4flxx37yhnhpdaus4ac9yy7sde5m0lyhnd45hn0csvmdysv8x9qw8zyk7
-    └── value: 1.99999
+    ├── value: 1.99999000
+    ├── type: witnessscripthash
+    └─┬ scriptPubKey: 34 bytes
+      ├── hex: 00201553f31a3e25e770b7bc857b82909e83734dbfe4bcdb5a5e6fc419b6920c398a
+      └── asm: OP_0 1553f31a3e25e770b7bc857b82909e83734dbfe4bcdb5a5e6fc419b6920c398a

--- a/modules/utxo-bin/test/fixtures/format_p2wsh_all_prevOuts.txt
+++ b/modules/utxo-bin/test/fixtures/format_p2wsh_all_prevOuts.txt
@@ -23,4 +23,8 @@ transaction: 2fedaa3661f6251d1a4ca23e5d4bb03fab5b75e8e471281f554755c439cd9924
 │     └── address: tb1qz4flxx37yhnhpdaus4ac9yy7sde5m0lyhnd45hn0csvmdysv8x9qw8zyk7
 └─┬ outputs: 1 sum=1.99999000
   └─┬ 0: tb1qz4flxx37yhnhpdaus4ac9yy7sde5m0lyhnd45hn0csvmdysv8x9qw8zyk7
-    └── value: 1.99999
+    ├── value: 1.99999000
+    ├── type: witnessscripthash
+    └─┬ scriptPubKey: 34 bytes
+      ├── hex: 00201553f31a3e25e770b7bc857b82909e83734dbfe4bcdb5a5e6fc419b6920c398a
+      └── asm: OP_0 1553f31a3e25e770b7bc857b82909e83734dbfe4bcdb5a5e6fc419b6920c398a

--- a/modules/utxo-bin/test/fixtures/format_p2wsh_default.txt
+++ b/modules/utxo-bin/test/fixtures/format_p2wsh_default.txt
@@ -13,4 +13,5 @@ transaction: 2fedaa3661f6251d1a4ca23e5d4bb03fab5b75e8e471281f554755c439cd9924
 │     └── signatures: [71byte] [71byte]
 └─┬ outputs: 1 sum=1.99999000
   └─┬ 0: tb1qz4flxx37yhnhpdaus4ac9yy7sde5m0lyhnd45hn0csvmdysv8x9qw8zyk7
-    └── value: 1.99999
+    ├── value: 1.99999000
+    └── type: witnessscripthash

--- a/modules/utxo-bin/test/fixtures/format_p2wsh_default_prevOuts.txt
+++ b/modules/utxo-bin/test/fixtures/format_p2wsh_default_prevOuts.txt
@@ -23,4 +23,5 @@ transaction: 2fedaa3661f6251d1a4ca23e5d4bb03fab5b75e8e471281f554755c439cd9924
 │     └── address: tb1qz4flxx37yhnhpdaus4ac9yy7sde5m0lyhnd45hn0csvmdysv8x9qw8zyk7
 └─┬ outputs: 1 sum=1.99999000
   └─┬ 0: tb1qz4flxx37yhnhpdaus4ac9yy7sde5m0lyhnd45hn0csvmdysv8x9qw8zyk7
-    └── value: 1.99999
+    ├── value: 1.99999000
+    └── type: witnessscripthash


### PR DESCRIPTION
Output scripts (scriptPubKey) is shown if there is no corresponding address
or if `--parseOutputScript` is set.

Issue: BG-53109