### PR TITLE
feat(sdk-core): add includeTokens wallet.addresses parameter

### DIFF
--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -197,7 +197,7 @@ describe('V2 Wallet:', function () {
     });
 
     it('search list addresses should return success', async function () {
-      const params = { includeBalances: true, returnBalancesForToken: 'gterc6dp', pendingDeployment: false, includeTotalAddressCount: true };
+      const params = { includeBalances: true, includeTokens: true, returnBalancesForToken: 'gterc6dp', pendingDeployment: false, includeTotalAddressCount: true };
 
       const scope =
         nock(bgUrl)
@@ -219,6 +219,8 @@ describe('V2 Wallet:', function () {
       await ethWallet.addresses({ pendingDeployment: 1 }).should.be.rejectedWith('invalid pendingDeployment argument, expecting boolean');
 
       await ethWallet.addresses({ includeBalances: 1 }).should.be.rejectedWith('invalid includeBalances argument, expecting boolean');
+
+      await ethWallet.addresses({ includeTokens: 1 }).should.be.rejectedWith('invalid includeTokens argument, expecting boolean');
 
       await ethWallet.addresses({ includeTotalAddressCount: 1 }).should.be.rejectedWith('invalid includeTotalAddressCount argument, expecting boolean');
     });

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -239,6 +239,7 @@ export interface AddressesOptions extends PaginationOptions {
   segwit?: boolean;
   chains?: number[];
   includeBalances?: boolean;
+  includeTokens?: boolean;
   includeTotalAddressCount?: boolean;
   returnBalancesForToken?: string;
   pendingDeployment?: boolean;

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -915,6 +915,13 @@ export class Wallet implements IWallet {
       query.includeBalances = params.includeBalances;
     }
 
+    if (!_.isNil(params.includeTokens)) {
+      if (!_.isBoolean(params.includeTokens)) {
+        throw new Error('invalid includeTokens argument, expecting boolean');
+      }
+      query.includeTokens = params.includeTokens;
+    }
+
     if (!_.isNil(params.includeTotalAddressCount)) {
       if (!_.isBoolean(params.includeTotalAddressCount)) {
         throw new Error('invalid includeTotalAddressCount argument, expecting boolean');


### PR DESCRIPTION
We recently introduced an includeTokens param to Wallet Platform.
This makes it easier to filter out wallet addresses with/without the token property.
Adding the param as an option to the SDK.

Additions:
- includeTokens param in Wallet.addresses
- Unit test to ensure non-boolean input is rejected

TICKET: BG-53596