### PR TITLE
xtz: fix to enable typescript to infer types from xtz multisigUtils

### DIFF
--- a/modules/sdk-coin-xtz/src/lib/index.ts
+++ b/modules/sdk-coin-xtz/src/lib/index.ts
@@ -6,6 +6,6 @@ export { TransactionBuilder } from './transactionBuilder';
 import * as Interface from './iface';
 import * as Utils from './utils';
 import * as MultisigUtils from './multisigUtils';
-Object.assign(Utils, MultisigUtils);
+const mergedUtils = Object.assign(Utils, MultisigUtils);
 
-export { Interface, Utils };
+export { Interface, mergedUtils as Utils };


### PR DESCRIPTION
BG-53852