### PR TITLE
feat(sdk-core): Add enable token support for sol

### DIFF
--- a/modules/sdk-coin-sol/src/sol.ts
+++ b/modules/sdk-coin-sol/src/sol.ts
@@ -24,6 +24,7 @@ import {
   SignTransactionOptions,
   TransactionPrebuild as BaseTransactionPrebuild,
   PresignTransactionOptions,
+  TokenEnablementConfig,
 } from '@bitgo/sdk-core';
 import { AtaInitializationBuilder, KeyPair as SolKeyPair, Transaction, TransactionBuilderFactory } from './lib';
 import { isValidAddress, isValidPrivateKey, isValidPublicKey } from './lib/utils';
@@ -364,6 +365,13 @@ export class Sol extends BaseCoin {
       txPrebuild: recreated,
       txHex: recreated.unsignedTxs[0].serializedTxHex,
     });
+  }
+
+  getTokenEnablementConfig(): TokenEnablementConfig {
+    return {
+      requiresTokenEnablement: true,
+      supportsMultipleTokenEnablements: true,
+    };
   }
 
   private getBuilder(): TransactionBuilderFactory {

--- a/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
@@ -126,6 +126,7 @@ export abstract class MpcUtils {
       ...baseIntent,
       memo: params.memo?.value,
       token: params.tokenName,
+      enableTokens: params.enableTokens,
     };
   }
 }

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -26,6 +26,11 @@ export interface FeeOption {
   gasPrice?: number;
 }
 
+export interface TokenEnablement {
+  name: string;
+  address?: string; // Some chains like Solana require tokens to be enabled for specific address. If absent, we will enable it for the wallet's root address
+}
+
 export interface PrebuildTransactionWithIntentOptions {
   reqId: IRequestTracer;
   intentType: string;
@@ -38,6 +43,7 @@ export interface PrebuildTransactionWithIntentOptions {
   comment?: string;
   memo?: Memo;
   tokenName?: string;
+  enableTokens?: TokenEnablement[];
   nonce?: string;
   selfSend?: boolean;
   feeOptions?: FeeOption | EIP1559FeeOptions;

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -5,6 +5,7 @@ import { Keychain } from '../keychain';
 import { IPendingApproval, PendingApprovalData } from '../pendingApproval';
 import { IStakingWallet } from '../staking';
 import { ITradingAccount } from '../trading';
+import { TokenEnablement } from '../utils';
 
 export interface MaximumSpendableOptions {
   minValue?: number | string;
@@ -34,13 +35,8 @@ export interface BuildConsolidationTransactionOptions extends PrebuildTransactio
   consolidateAddresses?: string[];
 }
 
-export interface TokenEnablement {
-  name: string;
-  address?: string; // Some chains like Solana require tokens to be enabled for specific address. If absent, we will enable it for the wallet's root address
-}
-
 export interface BuildTokenEnablementOptions extends PrebuildTransactionOptions {
-  tokens: TokenEnablement[];
+  enableTokens: TokenEnablement[];
 }
 
 export interface PrebuildTransactionOptions {
@@ -86,6 +82,7 @@ export interface PrebuildTransactionOptions {
   comment?: string;
   [index: string]: unknown;
   tokenName?: string;
+  enableTokens?: TokenEnablement[];
   nonce?: string;
   preview?: boolean;
 }


### PR DESCRIPTION
Ticket: BG-53197

BREAKING CHANGE: This breaks buildTransactionWithIntent in the case where we want to enable tokens. This is only currently being used for solana tokens which are not on prod yet. We will need to add the enableToken intent type and add logic to deal with these types for solana on wp.

BG-53197