### PR TITLE
chore: move lintstaged to root level

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,4 +3,4 @@
 rootDir=$(pwd)
 cd "$rootDir"
 ## only run on packages that have changed
-yarn lerna run precommit -- --since $(git rev-parse --short HEAD)
+yarn precommit

--- a/modules/abstract-eth/package.json
+++ b/modules/abstract-eth/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build"
   },
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",

--- a/modules/abstract-utxo/package.json
+++ b/modules/abstract-utxo/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build"
   },
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",

--- a/modules/account-lib/package.json
+++ b/modules/account-lib/package.json
@@ -10,7 +10,6 @@
     "coverage": "npm run gen-coverage && npm run upload-coverage",
     "lint": "eslint --quiet 'src/**/*.ts' 'test/**/*.ts'",
     "lint-fix": "eslint --fix 'src/**/*.ts' 'test/**/*.ts'",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build-ts && cp -r ./resources ./dist",
     "build-ts": "tsc --build --incremental --verbose .",
     "unit-test": "nyc -- mocha",

--- a/modules/bitgo/package.json
+++ b/modules/bitgo/package.json
@@ -38,7 +38,6 @@
     "prepublishOnly": "npm run compile",
     "upload-artifacts": "node scripts/upload-test-reports.js",
     "check-fmt": "prettier --check '{src,test}/**/*.{ts,js,json}'",
-    "precommit": "yarn lint-staged",
     "unprettied": "grep -R -L --include '*.ts' --include '*.js' --include '*.json' '@prettier' src test",
     "fmt": "prettier --write '{src,test}/**/*.{ts,js,json}'",
     "upload-docs": "node scripts/upload-docs.js",

--- a/modules/blockapis/package.json
+++ b/modules/blockapis/package.json
@@ -14,7 +14,6 @@
     "build": "yarn tsc --build --incremental --verbose .",
     "lint": "eslint --quiet .",
     "unit-test": "mocha",
-    "precommit": "yarn lint-staged",
     "fmt": "prettier --write '{bin,src,test}/**/*.{ts,js}'"
   },
   "repository": {

--- a/modules/express/package.json
+++ b/modules/express/package.json
@@ -32,7 +32,6 @@
     "update-bitgo": "bash ./scripts/update-bitgo.sh",
     "build-docker": "docker build -f ../../Dockerfile --platform=linux/amd64 -t bitgosdk/express:latest -t bitgosdk/express:$(jq -r .version < package.json) ../..",
     "push-docker": "docker push bitgosdk/express:latest bitgosdk/express:$(jq -r .version < package.json)",
-    "precommit": "yarn lint-staged",
     "check-fmt": "yarn prettier --check '{src,test}/**/*.{ts,js,json}'",
     "unprettied": "grep -R -L --include '*.ts' --include '*.js' --include '*.json' '@prettier' src test",
     "fmt": "yarn prettier --write '{src,test}/**/*.{ts,js,json}'"

--- a/modules/sdk-api/package.json
+++ b/modules/sdk-api/package.json
@@ -20,7 +20,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "webpack-dev": "yarn webpack",
     "webpack-prod": "yarn webpack --mode=production --node-env=production",

--- a/modules/sdk-coin-ada/package.json
+++ b/modules/sdk-coin-ada/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-algo/package.json
+++ b/modules/sdk-coin-algo/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-avaxc/package.json
+++ b/modules/sdk-coin-avaxc/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-avaxp/package.json
+++ b/modules/sdk-coin-avaxp/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-bch/package.json
+++ b/modules/sdk-coin-bch/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-bcha/package.json
+++ b/modules/sdk-coin-bcha/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-bsc/package.json
+++ b/modules/sdk-coin-bsc/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-bsv/package.json
+++ b/modules/sdk-coin-bsv/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-btc/package.json
+++ b/modules/sdk-coin-btc/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-btg/package.json
+++ b/modules/sdk-coin-btg/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-celo/package.json
+++ b/modules/sdk-coin-celo/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-cspr/package.json
+++ b/modules/sdk-coin-cspr/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-dash/package.json
+++ b/modules/sdk-coin-dash/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-doge/package.json
+++ b/modules/sdk-coin-doge/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-dot/package.json
+++ b/modules/sdk-coin-dot/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-eos/package.json
+++ b/modules/sdk-coin-eos/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-etc/package.json
+++ b/modules/sdk-coin-etc/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-eth/package.json
+++ b/modules/sdk-coin-eth/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-eth2/package.json
+++ b/modules/sdk-coin-eth2/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-hbar/package.json
+++ b/modules/sdk-coin-hbar/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-ltc/package.json
+++ b/modules/sdk-coin-ltc/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-near/package.json
+++ b/modules/sdk-coin-near/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-polygon/package.json
+++ b/modules/sdk-coin-polygon/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-rbtc/package.json
+++ b/modules/sdk-coin-rbtc/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-sol/package.json
+++ b/modules/sdk-coin-sol/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-stx/package.json
+++ b/modules/sdk-coin-stx/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-trx/package.json
+++ b/modules/sdk-coin-trx/package.json
@@ -11,7 +11,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build-ts && cp -r ./resources ./dist",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-xlm/package.json
+++ b/modules/sdk-coin-xlm/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-xrp/package.json
+++ b/modules/sdk-coin-xrp/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-xtz/package.json
+++ b/modules/sdk-coin-xtz/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-coin-zec/package.json
+++ b/modules/sdk-coin-zec/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",

--- a/modules/sdk-core/package.json
+++ b/modules/sdk-core/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build"
   },
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",

--- a/modules/sdk-test/package.json
+++ b/modules/sdk-test/package.json
@@ -11,7 +11,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build"
   },
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",

--- a/modules/statics/package.json
+++ b/modules/statics/package.json
@@ -11,7 +11,6 @@
     "fmt": "prettier --write .",
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build"
   },
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",

--- a/modules/unspents/package.json
+++ b/modules/unspents/package.json
@@ -12,7 +12,6 @@
     "test": "mocha",
     "lint": "eslint --quiet .",
     "prepare": "npm run build",
-    "precommit": "yarn lint-staged",
     "unit-test": "npm run test"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
     "sdk-coin:new": "yo ./scripts/sdk-coin-generator && yarn update-dockerfile",
     "build-docker-express": "yarn update-dockerfile && docker build -t bitgosdk/express:latest -t bitgosdk/express:$(jq -r .version < modules/express/package.json) .",
     "push-docker-express": "docker push bitgosdk/express:latest bitgosdk/express:$(jq -r .version < modules/express/package.json)",
-    "update-dockerfile": "ts-node scripts/update-dockerfile.ts"
+    "update-dockerfile": "ts-node scripts/update-dockerfile.ts",
+    "precommit": "lint-staged"
   },
   "dependencies": {}
 }

--- a/scripts/sdk-coin-generator/template/base/package.json
+++ b/scripts/sdk-coin-generator/template/base/package.json
@@ -10,7 +10,6 @@
     "check-fmt": "prettier --check .",
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
-    "precommit": "yarn lint-staged",
     "prepare": "npm run build",
     "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",


### PR DESCRIPTION
## Problem
Constantly running into:
```
[STARTED] Preparing lint-staged...
[STARTED] Running tasks for staged files...
[SKIPPED] Running tasks for staged files...
[STARTED] Applying modifications from tasks...
[SKIPPED] 
[SKIPPED]   ✖ lint-staged failed due to a git error.
[STARTED] Cleaning up temporary files...
[SKIPPED] 
[SKIPPED]   ✖ lint-staged failed due to a git error.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
lerna ERR! yarn run precommit stderr:

  ✖ lint-staged failed due to a git error.
  Any lost modifications can be restored from a git stash:

    > git stash list
    stash@{0}: automatic lint-staged backup
    > git stash apply --index stash@{0}

error Command failed with exit code 1.
error Command failed with exit code 1.
lerna ERR! yarn run precommit exited 1 in '@bitgo/utxo-lib'
```
when I merge master into the release branch and `lint-staged` was being run in parallel. As it was pointed out here: https://github.com/okonet/lint-staged/issues/1105#issuecomment-1038809975 and here: https://github.com/okonet/lint-staged/issues/1105#issuecomment-1039140085, in workspace config, it should not be run in parallel, otherwise, git will fail on locks. 

## What is included in this PR
Similar to this PR: https://github.com/BitGo/api-ts/pull/6, moving the pre-commit step to the root level and removing package level parallelized Lerna runs to avoid locking git. 

Ticket: BG-00000