### PR TITLE
feat(abstract-utxo): cross chain recovery support for bigint coins (doge)

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -1298,9 +1298,9 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
    * @param params.xprv the unencrypted xprv (used instead of wallet passphrase)
    * @returns {*}
    */
-  async recoverFromWrongChain(
+  async recoverFromWrongChain<TNumber extends number | bigint = number>(
     params: RecoverFromWrongChainOptions
-  ): Promise<CrossChainRecoverySigned | CrossChainRecoveryUnsigned> {
+  ): Promise<CrossChainRecoverySigned<TNumber> | CrossChainRecoveryUnsigned<TNumber>> {
     const { txid, recoveryAddress, wallet, walletPassphrase, xprv } = params;
 
     // params.recoveryCoin used to be params.coin, backwards compatibility
@@ -1319,7 +1319,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       throw new Error(`Recovery of ${sourceCoinFamily} balances from ${recoveryCoinFamily} wallets is not supported.`);
     }
 
-    return await recoverCrossChain(this.bitgo, {
+    return await recoverCrossChain<TNumber>(this.bitgo, {
       sourceCoin: this,
       recoveryCoin,
       walletId: wallet,

--- a/modules/abstract-utxo/src/config.ts
+++ b/modules/abstract-utxo/src/config.ts
@@ -1,8 +1,9 @@
 // Supported cross-chain recovery routes. The coin to be recovered is the index, the valid coins for recipient wallets
 // are listed in the array.
 export const supportedCrossChainRecoveries = {
-  btc: ['bch', 'ltc', 'bsv'],
-  bch: ['btc', 'ltc', 'bsv'],
-  ltc: ['btc', 'bch', 'bsv'],
-  bsv: ['btc', 'ltc', 'bch'],
+  btc: ['bch', 'ltc', 'bsv', 'doge'],
+  bch: ['btc', 'ltc', 'bsv', 'doge'],
+  ltc: ['btc', 'bch', 'bsv', 'doge'],
+  bsv: ['btc', 'ltc', 'bch', 'doge'],
+  doge: ['btc', 'bch', 'ltc', 'bsv'],
 };

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/bch/recovery/crossChainRecovery-doge-signed.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/bch/recovery/crossChainRecovery-doge-signed.json
@@ -1,0 +1,72 @@
+{
+  "version": 2,
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "txHex": "0200000001526eda15b11314f6ca3ee949a43e3d0e045eb86cdb38515c573359fcdac94ce600000000b700483045022100baffdbce5b48a4744604041d3ac2ca021cad8124fb0779aa20e329d66d02fa500220381a4afa1d142a7ade7799d779e8b5216ec5ab9852ac79ae2773335a47cb51074100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff0188c2f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": 99999000,
+    "outputAmount": 99992200,
+    "minerFee": 6800,
+    "spendAmount": 99992200,
+    "inputs": [
+      {
+        "id": "e64cc9dafc5933575c5138db6cb85e040e3d3ea449e93ecaf61413b115da6e52:0",
+        "address": "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "e64cc9dafc5933575c5138db6cb85e040e3d3ea449e93ecaf61413b115da6e52:0",
+        "address": "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "3FwJAxqdqfhe4esUv4smhM3zzbE3KAyD88",
+        "valueString": "99992200",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "3FwJAxqdqfhe4esUv4smhM3zzbE3KAyD88",
+        "valueString": "99992200",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "sourceCoin": "bch",
+  "recoveryCoin": "doge",
+  "recoveryAmount": 99992200,
+  "tx": {
+    "id": "af71df9520a054e7b7b05657e66ba213b8766550913a7ad09dd898ce917d6869",
+    "hex": "0200000001526eda15b11314f6ca3ee949a43e3d0e045eb86cdb38515c573359fcdac94ce600000000b700483045022100baffdbce5b48a4744604041d3ac2ca021cad8124fb0779aa20e329d66d02fa500220381a4afa1d142a7ade7799d779e8b5216ec5ab9852ac79ae2773335a47cb51074100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff0188c2f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "e64cc9dafc5933575c5138db6cb85e040e3d3ea449e93ecaf61413b115da6e52",
+        "index": 0,
+        "script": "00483045022100baffdbce5b48a4744604041d3ac2ca021cad8124fb0779aa20e329d66d02fa500220381a4afa1d142a7ade7799d779e8b5216ec5ab9852ac79ae2773335a47cb51074100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": 99992200
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/bch/recovery/crossChainRecovery-doge-unsigned.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/bch/recovery/crossChainRecovery-doge-unsigned.json
@@ -1,0 +1,76 @@
+{
+  "txHex": "0200000001526eda15b11314f6ca3ee949a43e3d0e045eb86cdb38515c573359fcdac94ce60000000000ffffffff0188c2f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": 99999000,
+    "outputAmount": 99992200,
+    "minerFee": 6800,
+    "spendAmount": 99992200,
+    "inputs": [
+      {
+        "id": "e64cc9dafc5933575c5138db6cb85e040e3d3ea449e93ecaf61413b115da6e52:0",
+        "address": "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "e64cc9dafc5933575c5138db6cb85e040e3d3ea449e93ecaf61413b115da6e52:0",
+        "address": "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "3FwJAxqdqfhe4esUv4smhM3zzbE3KAyD88",
+        "valueString": "99992200",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "3FwJAxqdqfhe4esUv4smhM3zzbE3KAyD88",
+        "valueString": "99992200",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "feeInfo": {
+    "size": 340,
+    "fee": 6800,
+    "feeRate": 20,
+    "payGoFee": 0
+  },
+  "address": "3FwJAxqdqfhe4esUv4smhM3zzbE3KAyD88",
+  "coin": "bch",
+  "tx": {
+    "id": "0e0ca4a6e479a6ff31fff43bb59c2fb498c8d8e84d2ea1e608feb2ffd8e91261",
+    "hex": "0200000001526eda15b11314f6ca3ee949a43e3d0e045eb86cdb38515c573359fcdac94ce60000000000ffffffff0188c2f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "e64cc9dafc5933575c5138db6cb85e040e3d3ea449e93ecaf61413b115da6e52",
+        "index": 0,
+        "script": "",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": 99992200
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/bsv/recovery/crossChainRecovery-doge-signed.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/bsv/recovery/crossChainRecovery-doge-signed.json
@@ -1,0 +1,72 @@
+{
+  "version": 2,
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "txHex": "0200000001526eda15b11314f6ca3ee949a43e3d0e045eb86cdb38515c573359fcdac94ce600000000b700483045022100baffdbce5b48a4744604041d3ac2ca021cad8124fb0779aa20e329d66d02fa500220381a4afa1d142a7ade7799d779e8b5216ec5ab9852ac79ae2773335a47cb51074100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff0188c2f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": 99999000,
+    "outputAmount": 99992200,
+    "minerFee": 6800,
+    "spendAmount": 99992200,
+    "inputs": [
+      {
+        "id": "e64cc9dafc5933575c5138db6cb85e040e3d3ea449e93ecaf61413b115da6e52:0",
+        "address": "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "e64cc9dafc5933575c5138db6cb85e040e3d3ea449e93ecaf61413b115da6e52:0",
+        "address": "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "3FwJAxqdqfhe4esUv4smhM3zzbE3KAyD88",
+        "valueString": "99992200",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "3FwJAxqdqfhe4esUv4smhM3zzbE3KAyD88",
+        "valueString": "99992200",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "sourceCoin": "bsv",
+  "recoveryCoin": "doge",
+  "recoveryAmount": 99992200,
+  "tx": {
+    "id": "af71df9520a054e7b7b05657e66ba213b8766550913a7ad09dd898ce917d6869",
+    "hex": "0200000001526eda15b11314f6ca3ee949a43e3d0e045eb86cdb38515c573359fcdac94ce600000000b700483045022100baffdbce5b48a4744604041d3ac2ca021cad8124fb0779aa20e329d66d02fa500220381a4afa1d142a7ade7799d779e8b5216ec5ab9852ac79ae2773335a47cb51074100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff0188c2f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "e64cc9dafc5933575c5138db6cb85e040e3d3ea449e93ecaf61413b115da6e52",
+        "index": 0,
+        "script": "00483045022100baffdbce5b48a4744604041d3ac2ca021cad8124fb0779aa20e329d66d02fa500220381a4afa1d142a7ade7799d779e8b5216ec5ab9852ac79ae2773335a47cb51074100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": 99992200
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/bsv/recovery/crossChainRecovery-doge-unsigned.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/bsv/recovery/crossChainRecovery-doge-unsigned.json
@@ -1,0 +1,76 @@
+{
+  "txHex": "0200000001526eda15b11314f6ca3ee949a43e3d0e045eb86cdb38515c573359fcdac94ce60000000000ffffffff0188c2f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": 99999000,
+    "outputAmount": 99992200,
+    "minerFee": 6800,
+    "spendAmount": 99992200,
+    "inputs": [
+      {
+        "id": "e64cc9dafc5933575c5138db6cb85e040e3d3ea449e93ecaf61413b115da6e52:0",
+        "address": "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "e64cc9dafc5933575c5138db6cb85e040e3d3ea449e93ecaf61413b115da6e52:0",
+        "address": "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "3FwJAxqdqfhe4esUv4smhM3zzbE3KAyD88",
+        "valueString": "99992200",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "3FwJAxqdqfhe4esUv4smhM3zzbE3KAyD88",
+        "valueString": "99992200",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "feeInfo": {
+    "size": 340,
+    "fee": 6800,
+    "feeRate": 20,
+    "payGoFee": 0
+  },
+  "address": "3FwJAxqdqfhe4esUv4smhM3zzbE3KAyD88",
+  "coin": "bsv",
+  "tx": {
+    "id": "0e0ca4a6e479a6ff31fff43bb59c2fb498c8d8e84d2ea1e608feb2ffd8e91261",
+    "hex": "0200000001526eda15b11314f6ca3ee949a43e3d0e045eb86cdb38515c573359fcdac94ce60000000000ffffffff0188c2f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "e64cc9dafc5933575c5138db6cb85e040e3d3ea449e93ecaf61413b115da6e52",
+        "index": 0,
+        "script": "",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": 99992200
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/btc/recovery/crossChainRecovery-doge-signed.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/btc/recovery/crossChainRecovery-doge-signed.json
@@ -1,0 +1,72 @@
+{
+  "version": 2,
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "txHex": "010000000198893311f7b5ac4e5c574ff6547320c326bb6297abbbbee30d2ed8b195b6a48c00000000b700483045022100f838f9ceb618e70975a0763cbc2d310d834a00341808e1d71191c0f600c2dd08022041da427e81dab6b18c22739b545ebb24dfaad43554c838844931425c62ffce270100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff01d872f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": 99999000,
+    "outputAmount": 99971800,
+    "minerFee": 27200,
+    "spendAmount": 99971800,
+    "inputs": [
+      {
+        "id": "8ca4b695b1d82e0de3bebbab9762bb26c3207354f64f575c4eacb5f711338998:0",
+        "address": "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "8ca4b695b1d82e0de3bebbab9762bb26c3207354f64f575c4eacb5f711338998:0",
+        "address": "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "3FwJAxqdqfhe4esUv4smhM3zzbE3KAyD88",
+        "valueString": "99971800",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "3FwJAxqdqfhe4esUv4smhM3zzbE3KAyD88",
+        "valueString": "99971800",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "sourceCoin": "btc",
+  "recoveryCoin": "doge",
+  "recoveryAmount": 99971800,
+  "tx": {
+    "id": "a7269fe5336aefaed46fbe9ea9c6acf6955578497535ec10f3fb38539c51c0a5",
+    "hex": "010000000198893311f7b5ac4e5c574ff6547320c326bb6297abbbbee30d2ed8b195b6a48c00000000b700483045022100f838f9ceb618e70975a0763cbc2d310d834a00341808e1d71191c0f600c2dd08022041da427e81dab6b18c22739b545ebb24dfaad43554c838844931425c62ffce270100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff01d872f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "8ca4b695b1d82e0de3bebbab9762bb26c3207354f64f575c4eacb5f711338998",
+        "index": 0,
+        "script": "00483045022100f838f9ceb618e70975a0763cbc2d310d834a00341808e1d71191c0f600c2dd08022041da427e81dab6b18c22739b545ebb24dfaad43554c838844931425c62ffce270100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": 99971800
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/btc/recovery/crossChainRecovery-doge-unsigned.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/btc/recovery/crossChainRecovery-doge-unsigned.json
@@ -1,0 +1,76 @@
+{
+  "txHex": "010000000198893311f7b5ac4e5c574ff6547320c326bb6297abbbbee30d2ed8b195b6a48c0000000000ffffffff01d872f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": 99999000,
+    "outputAmount": 99971800,
+    "minerFee": 27200,
+    "spendAmount": 99971800,
+    "inputs": [
+      {
+        "id": "8ca4b695b1d82e0de3bebbab9762bb26c3207354f64f575c4eacb5f711338998:0",
+        "address": "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "8ca4b695b1d82e0de3bebbab9762bb26c3207354f64f575c4eacb5f711338998:0",
+        "address": "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "3FwJAxqdqfhe4esUv4smhM3zzbE3KAyD88",
+        "valueString": "99971800",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "3FwJAxqdqfhe4esUv4smhM3zzbE3KAyD88",
+        "valueString": "99971800",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "feeInfo": {
+    "size": 340,
+    "fee": 27200,
+    "feeRate": 80,
+    "payGoFee": 0
+  },
+  "address": "3FwJAxqdqfhe4esUv4smhM3zzbE3KAyD88",
+  "coin": "btc",
+  "tx": {
+    "id": "b7c7fa95c49bf8108937b81eb56e36ca72c0f9df77c17e21a5763b98f7d549a1",
+    "hex": "010000000198893311f7b5ac4e5c574ff6547320c326bb6297abbbbee30d2ed8b195b6a48c0000000000ffffffff01d872f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "8ca4b695b1d82e0de3bebbab9762bb26c3207354f64f575c4eacb5f711338998",
+        "index": 0,
+        "script": "",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": 99971800
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/doge/recovery/crossChainRecovery-bch-signed.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/doge/recovery/crossChainRecovery-bch-signed.json
@@ -1,0 +1,74 @@
+{
+  "version": 2,
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "txHex": "01000000013fb46a25cece060fdeaba4a8055b3b702cac3ba18e26de5ef2e5343ce22810f300000000b700483045022100d01c6a1973f4f660c8724759908f055d23d2cc4f89a0cb896cade7c12335ccd0022010df536b2bb1633939cb5436133b00a672f090faa6d8ccb448ee937e4bc7f0900100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": "10999999799999001",
+    "outputAmount": "10999999799659001",
+    "minerFee": "340000",
+    "spendAmount": "10999999799659001",
+    "inputs": [
+      {
+        "id": "f31028e23c34e5f25ede268ea13bac2c703b5b05a8a4abde0f06cece256ab43f:0",
+        "address": "9uChwvGYk4DRR7HBrWtAAwvg8925VtQqDn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "f31028e23c34e5f25ede268ea13bac2c703b5b05a8a4abde0f06cece256ab43f:0",
+        "address": "9uChwvGYk4DRR7HBrWtAAwvg8925VtQqDn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "A6gYuouXujaXy2ExLCYBwUgNhAc5NGDDzw",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "A6gYuouXujaXy2ExLCYBwUgNhAc5NGDDzw",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "sourceCoin": "doge",
+  "recoveryCoin": "bch",
+  "recoveryAmount": "10999999799659001",
+  "tx": {
+    "id": "b20fba0fee6706cd85b6f6eb264ead52073e404b0165c81d327bc69b7d6a0a3e",
+    "hex": "01000000013fb46a25cece060fdeaba4a8055b3b702cac3ba18e26de5ef2e5343ce22810f300000000b700483045022100d01c6a1973f4f660c8724759908f055d23d2cc4f89a0cb896cade7c12335ccd0022010df536b2bb1633939cb5436133b00a672f090faa6d8ccb448ee937e4bc7f0900100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "f31028e23c34e5f25ede268ea13bac2c703b5b05a8a4abde0f06cece256ab43f",
+        "index": 0,
+        "script": "00483045022100d01c6a1973f4f660c8724759908f055d23d2cc4f89a0cb896cade7c12335ccd0022010df536b2bb1633939cb5436133b00a672f090faa6d8ccb448ee937e4bc7f0900100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": "10999999799659001"
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/doge/recovery/crossChainRecovery-bch-unsigned.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/doge/recovery/crossChainRecovery-bch-unsigned.json
@@ -1,0 +1,78 @@
+{
+  "txHex": "01000000013fb46a25cece060fdeaba4a8055b3b702cac3ba18e26de5ef2e5343ce22810f30000000000ffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": "10999999799999001",
+    "outputAmount": "10999999799659001",
+    "minerFee": "340000",
+    "spendAmount": "10999999799659001",
+    "inputs": [
+      {
+        "id": "f31028e23c34e5f25ede268ea13bac2c703b5b05a8a4abde0f06cece256ab43f:0",
+        "address": "9uChwvGYk4DRR7HBrWtAAwvg8925VtQqDn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "f31028e23c34e5f25ede268ea13bac2c703b5b05a8a4abde0f06cece256ab43f:0",
+        "address": "9uChwvGYk4DRR7HBrWtAAwvg8925VtQqDn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "A6gYuouXujaXy2ExLCYBwUgNhAc5NGDDzw",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "A6gYuouXujaXy2ExLCYBwUgNhAc5NGDDzw",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "feeInfo": {
+    "size": 340,
+    "fee": 340000,
+    "feeRate": 1000,
+    "payGoFee": 0
+  },
+  "address": "A6gYuouXujaXy2ExLCYBwUgNhAc5NGDDzw",
+  "coin": "doge",
+  "tx": {
+    "id": "f7020065ebd1e2b4acb15c0ff09389961687fcea7e4fac13c4be3ab56ebed69f",
+    "hex": "01000000013fb46a25cece060fdeaba4a8055b3b702cac3ba18e26de5ef2e5343ce22810f30000000000ffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "f31028e23c34e5f25ede268ea13bac2c703b5b05a8a4abde0f06cece256ab43f",
+        "index": 0,
+        "script": "",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": "10999999799659001"
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/doge/recovery/crossChainRecovery-bsv-signed.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/doge/recovery/crossChainRecovery-bsv-signed.json
@@ -1,0 +1,74 @@
+{
+  "version": 2,
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "txHex": "01000000013fb46a25cece060fdeaba4a8055b3b702cac3ba18e26de5ef2e5343ce22810f300000000b700483045022100d01c6a1973f4f660c8724759908f055d23d2cc4f89a0cb896cade7c12335ccd0022010df536b2bb1633939cb5436133b00a672f090faa6d8ccb448ee937e4bc7f0900100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": "10999999799999001",
+    "outputAmount": "10999999799659001",
+    "minerFee": "340000",
+    "spendAmount": "10999999799659001",
+    "inputs": [
+      {
+        "id": "f31028e23c34e5f25ede268ea13bac2c703b5b05a8a4abde0f06cece256ab43f:0",
+        "address": "9uChwvGYk4DRR7HBrWtAAwvg8925VtQqDn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "f31028e23c34e5f25ede268ea13bac2c703b5b05a8a4abde0f06cece256ab43f:0",
+        "address": "9uChwvGYk4DRR7HBrWtAAwvg8925VtQqDn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "A6gYuouXujaXy2ExLCYBwUgNhAc5NGDDzw",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "A6gYuouXujaXy2ExLCYBwUgNhAc5NGDDzw",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "sourceCoin": "doge",
+  "recoveryCoin": "bsv",
+  "recoveryAmount": "10999999799659001",
+  "tx": {
+    "id": "b20fba0fee6706cd85b6f6eb264ead52073e404b0165c81d327bc69b7d6a0a3e",
+    "hex": "01000000013fb46a25cece060fdeaba4a8055b3b702cac3ba18e26de5ef2e5343ce22810f300000000b700483045022100d01c6a1973f4f660c8724759908f055d23d2cc4f89a0cb896cade7c12335ccd0022010df536b2bb1633939cb5436133b00a672f090faa6d8ccb448ee937e4bc7f0900100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "f31028e23c34e5f25ede268ea13bac2c703b5b05a8a4abde0f06cece256ab43f",
+        "index": 0,
+        "script": "00483045022100d01c6a1973f4f660c8724759908f055d23d2cc4f89a0cb896cade7c12335ccd0022010df536b2bb1633939cb5436133b00a672f090faa6d8ccb448ee937e4bc7f0900100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": "10999999799659001"
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/doge/recovery/crossChainRecovery-bsv-unsigned.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/doge/recovery/crossChainRecovery-bsv-unsigned.json
@@ -1,0 +1,78 @@
+{
+  "txHex": "01000000013fb46a25cece060fdeaba4a8055b3b702cac3ba18e26de5ef2e5343ce22810f30000000000ffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": "10999999799999001",
+    "outputAmount": "10999999799659001",
+    "minerFee": "340000",
+    "spendAmount": "10999999799659001",
+    "inputs": [
+      {
+        "id": "f31028e23c34e5f25ede268ea13bac2c703b5b05a8a4abde0f06cece256ab43f:0",
+        "address": "9uChwvGYk4DRR7HBrWtAAwvg8925VtQqDn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "f31028e23c34e5f25ede268ea13bac2c703b5b05a8a4abde0f06cece256ab43f:0",
+        "address": "9uChwvGYk4DRR7HBrWtAAwvg8925VtQqDn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "A6gYuouXujaXy2ExLCYBwUgNhAc5NGDDzw",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "A6gYuouXujaXy2ExLCYBwUgNhAc5NGDDzw",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "feeInfo": {
+    "size": 340,
+    "fee": 340000,
+    "feeRate": 1000,
+    "payGoFee": 0
+  },
+  "address": "A6gYuouXujaXy2ExLCYBwUgNhAc5NGDDzw",
+  "coin": "doge",
+  "tx": {
+    "id": "f7020065ebd1e2b4acb15c0ff09389961687fcea7e4fac13c4be3ab56ebed69f",
+    "hex": "01000000013fb46a25cece060fdeaba4a8055b3b702cac3ba18e26de5ef2e5343ce22810f30000000000ffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "f31028e23c34e5f25ede268ea13bac2c703b5b05a8a4abde0f06cece256ab43f",
+        "index": 0,
+        "script": "",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": "10999999799659001"
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/doge/recovery/crossChainRecovery-btc-signed.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/doge/recovery/crossChainRecovery-btc-signed.json
@@ -1,0 +1,74 @@
+{
+  "version": 2,
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "txHex": "01000000013fb46a25cece060fdeaba4a8055b3b702cac3ba18e26de5ef2e5343ce22810f300000000b700483045022100d01c6a1973f4f660c8724759908f055d23d2cc4f89a0cb896cade7c12335ccd0022010df536b2bb1633939cb5436133b00a672f090faa6d8ccb448ee937e4bc7f0900100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": "10999999799999001",
+    "outputAmount": "10999999799659001",
+    "minerFee": "340000",
+    "spendAmount": "10999999799659001",
+    "inputs": [
+      {
+        "id": "f31028e23c34e5f25ede268ea13bac2c703b5b05a8a4abde0f06cece256ab43f:0",
+        "address": "9uChwvGYk4DRR7HBrWtAAwvg8925VtQqDn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "f31028e23c34e5f25ede268ea13bac2c703b5b05a8a4abde0f06cece256ab43f:0",
+        "address": "9uChwvGYk4DRR7HBrWtAAwvg8925VtQqDn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "A6gYuouXujaXy2ExLCYBwUgNhAc5NGDDzw",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "A6gYuouXujaXy2ExLCYBwUgNhAc5NGDDzw",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "sourceCoin": "doge",
+  "recoveryCoin": "btc",
+  "recoveryAmount": "10999999799659001",
+  "tx": {
+    "id": "b20fba0fee6706cd85b6f6eb264ead52073e404b0165c81d327bc69b7d6a0a3e",
+    "hex": "01000000013fb46a25cece060fdeaba4a8055b3b702cac3ba18e26de5ef2e5343ce22810f300000000b700483045022100d01c6a1973f4f660c8724759908f055d23d2cc4f89a0cb896cade7c12335ccd0022010df536b2bb1633939cb5436133b00a672f090faa6d8ccb448ee937e4bc7f0900100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "f31028e23c34e5f25ede268ea13bac2c703b5b05a8a4abde0f06cece256ab43f",
+        "index": 0,
+        "script": "00483045022100d01c6a1973f4f660c8724759908f055d23d2cc4f89a0cb896cade7c12335ccd0022010df536b2bb1633939cb5436133b00a672f090faa6d8ccb448ee937e4bc7f0900100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": "10999999799659001"
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/doge/recovery/crossChainRecovery-btc-unsigned.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/doge/recovery/crossChainRecovery-btc-unsigned.json
@@ -1,0 +1,78 @@
+{
+  "txHex": "01000000013fb46a25cece060fdeaba4a8055b3b702cac3ba18e26de5ef2e5343ce22810f30000000000ffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": "10999999799999001",
+    "outputAmount": "10999999799659001",
+    "minerFee": "340000",
+    "spendAmount": "10999999799659001",
+    "inputs": [
+      {
+        "id": "f31028e23c34e5f25ede268ea13bac2c703b5b05a8a4abde0f06cece256ab43f:0",
+        "address": "9uChwvGYk4DRR7HBrWtAAwvg8925VtQqDn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "f31028e23c34e5f25ede268ea13bac2c703b5b05a8a4abde0f06cece256ab43f:0",
+        "address": "9uChwvGYk4DRR7HBrWtAAwvg8925VtQqDn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "A6gYuouXujaXy2ExLCYBwUgNhAc5NGDDzw",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "A6gYuouXujaXy2ExLCYBwUgNhAc5NGDDzw",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "feeInfo": {
+    "size": 340,
+    "fee": 340000,
+    "feeRate": 1000,
+    "payGoFee": 0
+  },
+  "address": "A6gYuouXujaXy2ExLCYBwUgNhAc5NGDDzw",
+  "coin": "doge",
+  "tx": {
+    "id": "f7020065ebd1e2b4acb15c0ff09389961687fcea7e4fac13c4be3ab56ebed69f",
+    "hex": "01000000013fb46a25cece060fdeaba4a8055b3b702cac3ba18e26de5ef2e5343ce22810f30000000000ffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "f31028e23c34e5f25ede268ea13bac2c703b5b05a8a4abde0f06cece256ab43f",
+        "index": 0,
+        "script": "",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": "10999999799659001"
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/doge/recovery/crossChainRecovery-ltc-signed.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/doge/recovery/crossChainRecovery-ltc-signed.json
@@ -1,0 +1,74 @@
+{
+  "version": 2,
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "txHex": "01000000013fb46a25cece060fdeaba4a8055b3b702cac3ba18e26de5ef2e5343ce22810f300000000b700483045022100d01c6a1973f4f660c8724759908f055d23d2cc4f89a0cb896cade7c12335ccd0022010df536b2bb1633939cb5436133b00a672f090faa6d8ccb448ee937e4bc7f0900100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": "10999999799999001",
+    "outputAmount": "10999999799659001",
+    "minerFee": "340000",
+    "spendAmount": "10999999799659001",
+    "inputs": [
+      {
+        "id": "f31028e23c34e5f25ede268ea13bac2c703b5b05a8a4abde0f06cece256ab43f:0",
+        "address": "9uChwvGYk4DRR7HBrWtAAwvg8925VtQqDn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "f31028e23c34e5f25ede268ea13bac2c703b5b05a8a4abde0f06cece256ab43f:0",
+        "address": "9uChwvGYk4DRR7HBrWtAAwvg8925VtQqDn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "A6gYuouXujaXy2ExLCYBwUgNhAc5NGDDzw",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "A6gYuouXujaXy2ExLCYBwUgNhAc5NGDDzw",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "sourceCoin": "doge",
+  "recoveryCoin": "ltc",
+  "recoveryAmount": "10999999799659001",
+  "tx": {
+    "id": "b20fba0fee6706cd85b6f6eb264ead52073e404b0165c81d327bc69b7d6a0a3e",
+    "hex": "01000000013fb46a25cece060fdeaba4a8055b3b702cac3ba18e26de5ef2e5343ce22810f300000000b700483045022100d01c6a1973f4f660c8724759908f055d23d2cc4f89a0cb896cade7c12335ccd0022010df536b2bb1633939cb5436133b00a672f090faa6d8ccb448ee937e4bc7f0900100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "f31028e23c34e5f25ede268ea13bac2c703b5b05a8a4abde0f06cece256ab43f",
+        "index": 0,
+        "script": "00483045022100d01c6a1973f4f660c8724759908f055d23d2cc4f89a0cb896cade7c12335ccd0022010df536b2bb1633939cb5436133b00a672f090faa6d8ccb448ee937e4bc7f0900100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": "10999999799659001"
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/doge/recovery/crossChainRecovery-ltc-unsigned.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/doge/recovery/crossChainRecovery-ltc-unsigned.json
@@ -1,0 +1,78 @@
+{
+  "txHex": "01000000013fb46a25cece060fdeaba4a8055b3b702cac3ba18e26de5ef2e5343ce22810f30000000000ffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": "10999999799999001",
+    "outputAmount": "10999999799659001",
+    "minerFee": "340000",
+    "spendAmount": "10999999799659001",
+    "inputs": [
+      {
+        "id": "f31028e23c34e5f25ede268ea13bac2c703b5b05a8a4abde0f06cece256ab43f:0",
+        "address": "9uChwvGYk4DRR7HBrWtAAwvg8925VtQqDn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "f31028e23c34e5f25ede268ea13bac2c703b5b05a8a4abde0f06cece256ab43f:0",
+        "address": "9uChwvGYk4DRR7HBrWtAAwvg8925VtQqDn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "A6gYuouXujaXy2ExLCYBwUgNhAc5NGDDzw",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "A6gYuouXujaXy2ExLCYBwUgNhAc5NGDDzw",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "feeInfo": {
+    "size": 340,
+    "fee": 340000,
+    "feeRate": 1000,
+    "payGoFee": 0
+  },
+  "address": "A6gYuouXujaXy2ExLCYBwUgNhAc5NGDDzw",
+  "coin": "doge",
+  "tx": {
+    "id": "f7020065ebd1e2b4acb15c0ff09389961687fcea7e4fac13c4be3ab56ebed69f",
+    "hex": "01000000013fb46a25cece060fdeaba4a8055b3b702cac3ba18e26de5ef2e5343ce22810f30000000000ffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "f31028e23c34e5f25ede268ea13bac2c703b5b05a8a4abde0f06cece256ab43f",
+        "index": 0,
+        "script": "",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": "10999999799659001"
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/ltc/recovery/crossChainRecovery-doge-signed.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/ltc/recovery/crossChainRecovery-doge-signed.json
@@ -1,0 +1,72 @@
+{
+  "version": 2,
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "txHex": "0100000001bedd686d17a031d0651dfdd68b28f8f3a247aface8cacccff7fbf13147184d7200000000b7004830450221008d4182eb1f78ffc9dc1b318d589ad594065034d32e6076580ad0145d8746738d022015a8911551c259cb52c6601e2dfcc8c4bd1ec5de54ceab98f95df41f4dc2d38d0100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff014858f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": 99999000,
+    "outputAmount": 99965000,
+    "minerFee": 34000,
+    "spendAmount": 99965000,
+    "inputs": [
+      {
+        "id": "724d184731f1fbf7cfcccae8acaf47a2f3f8288bd6fd1d65d031a0176d68ddbe:0",
+        "address": "MAfbWxccd7BxKFBcYGD5kTYhkGEVTkPv3o",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "724d184731f1fbf7cfcccae8acaf47a2f3f8288bd6fd1d65d031a0176d68ddbe:0",
+        "address": "MAfbWxccd7BxKFBcYGD5kTYhkGEVTkPv3o",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "MN9SUrFbnnZ4sA9P1ws7WzJQKHpVEoUdwA",
+        "valueString": "99965000",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "MN9SUrFbnnZ4sA9P1ws7WzJQKHpVEoUdwA",
+        "valueString": "99965000",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "sourceCoin": "ltc",
+  "recoveryCoin": "doge",
+  "recoveryAmount": 99965000,
+  "tx": {
+    "id": "967a23999d45905288aefa6739d5595aa2be7c4d2797b4ac65bf3ec68ff5f9eb",
+    "hex": "0100000001bedd686d17a031d0651dfdd68b28f8f3a247aface8cacccff7fbf13147184d7200000000b7004830450221008d4182eb1f78ffc9dc1b318d589ad594065034d32e6076580ad0145d8746738d022015a8911551c259cb52c6601e2dfcc8c4bd1ec5de54ceab98f95df41f4dc2d38d0100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff014858f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "724d184731f1fbf7cfcccae8acaf47a2f3f8288bd6fd1d65d031a0176d68ddbe",
+        "index": 0,
+        "script": "004830450221008d4182eb1f78ffc9dc1b318d589ad594065034d32e6076580ad0145d8746738d022015a8911551c259cb52c6601e2dfcc8c4bd1ec5de54ceab98f95df41f4dc2d38d0100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": 99965000
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/ltc/recovery/crossChainRecovery-doge-unsigned.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/ltc/recovery/crossChainRecovery-doge-unsigned.json
@@ -1,0 +1,76 @@
+{
+  "txHex": "0100000001bedd686d17a031d0651dfdd68b28f8f3a247aface8cacccff7fbf13147184d720000000000ffffffff014858f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": 99999000,
+    "outputAmount": 99965000,
+    "minerFee": 34000,
+    "spendAmount": 99965000,
+    "inputs": [
+      {
+        "id": "724d184731f1fbf7cfcccae8acaf47a2f3f8288bd6fd1d65d031a0176d68ddbe:0",
+        "address": "MAfbWxccd7BxKFBcYGD5kTYhkGEVTkPv3o",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "724d184731f1fbf7cfcccae8acaf47a2f3f8288bd6fd1d65d031a0176d68ddbe:0",
+        "address": "MAfbWxccd7BxKFBcYGD5kTYhkGEVTkPv3o",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "MN9SUrFbnnZ4sA9P1ws7WzJQKHpVEoUdwA",
+        "valueString": "99965000",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "MN9SUrFbnnZ4sA9P1ws7WzJQKHpVEoUdwA",
+        "valueString": "99965000",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "feeInfo": {
+    "size": 340,
+    "fee": 34000,
+    "feeRate": 100,
+    "payGoFee": 0
+  },
+  "address": "MN9SUrFbnnZ4sA9P1ws7WzJQKHpVEoUdwA",
+  "coin": "ltc",
+  "tx": {
+    "id": "6d9d7b291646cab8c88451946d0ab8d1b115a3d66dfa73f0d872adc5363e10fc",
+    "hex": "0100000001bedd686d17a031d0651dfdd68b28f8f3a247aface8cacccff7fbf13147184d720000000000ffffffff014858f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "724d184731f1fbf7cfcccae8acaf47a2f3f8288bd6fd1d65d031a0176d68ddbe",
+        "index": 0,
+        "script": "",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": 99965000
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tbch/recovery/crossChainRecovery-tdoge-signed.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tbch/recovery/crossChainRecovery-tdoge-signed.json
@@ -1,0 +1,72 @@
+{
+  "version": 2,
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "txHex": "02000000014b0158b39d55b07ff198dc19f2c5c36b74408204a83ab9160523f0c2111b789100000000b7004830450221009c29a7f6f5473fd3b2b3177f0f61de0162b339342605ecadd8f04b39bca9139802207937a1a4f66037d1d6238c5c9b2def7895af1e222bba6fab135fd83edb92feab4100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff0188c2f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": 99999000,
+    "outputAmount": 99992200,
+    "minerFee": 6800,
+    "spendAmount": 99992200,
+    "inputs": [
+      {
+        "id": "91781b11c2f0230516b93aa8048240746bc3c5f219dc98f17fb0559db358014b:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "91781b11c2f0230516b93aa8048240746bc3c5f219dc98f17fb0559db358014b:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "99992200",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "99992200",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "sourceCoin": "tbch",
+  "recoveryCoin": "tdoge",
+  "recoveryAmount": 99992200,
+  "tx": {
+    "id": "2275206740b703571cdad163f897c8164ceca17754f3b1aabcad3a34dc0cf89d",
+    "hex": "02000000014b0158b39d55b07ff198dc19f2c5c36b74408204a83ab9160523f0c2111b789100000000b7004830450221009c29a7f6f5473fd3b2b3177f0f61de0162b339342605ecadd8f04b39bca9139802207937a1a4f66037d1d6238c5c9b2def7895af1e222bba6fab135fd83edb92feab4100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff0188c2f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "91781b11c2f0230516b93aa8048240746bc3c5f219dc98f17fb0559db358014b",
+        "index": 0,
+        "script": "004830450221009c29a7f6f5473fd3b2b3177f0f61de0162b339342605ecadd8f04b39bca9139802207937a1a4f66037d1d6238c5c9b2def7895af1e222bba6fab135fd83edb92feab4100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": 99992200
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tbch/recovery/crossChainRecovery-tdoge-unsigned.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tbch/recovery/crossChainRecovery-tdoge-unsigned.json
@@ -1,0 +1,76 @@
+{
+  "txHex": "02000000014b0158b39d55b07ff198dc19f2c5c36b74408204a83ab9160523f0c2111b78910000000000ffffffff0188c2f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": 99999000,
+    "outputAmount": 99992200,
+    "minerFee": 6800,
+    "spendAmount": 99992200,
+    "inputs": [
+      {
+        "id": "91781b11c2f0230516b93aa8048240746bc3c5f219dc98f17fb0559db358014b:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "91781b11c2f0230516b93aa8048240746bc3c5f219dc98f17fb0559db358014b:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "99992200",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "99992200",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "feeInfo": {
+    "size": 340,
+    "fee": 6800,
+    "feeRate": 20,
+    "payGoFee": 0
+  },
+  "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+  "coin": "tbch",
+  "tx": {
+    "id": "dc5dc3a049907cc0a2a07bb7e492c7eac88f68984c42ebe5c9e4da3886f2f776",
+    "hex": "02000000014b0158b39d55b07ff198dc19f2c5c36b74408204a83ab9160523f0c2111b78910000000000ffffffff0188c2f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "91781b11c2f0230516b93aa8048240746bc3c5f219dc98f17fb0559db358014b",
+        "index": 0,
+        "script": "",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": 99992200
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tbsv/recovery/crossChainRecovery-tdoge-signed.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tbsv/recovery/crossChainRecovery-tdoge-signed.json
@@ -1,0 +1,72 @@
+{
+  "version": 2,
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "txHex": "02000000014b0158b39d55b07ff198dc19f2c5c36b74408204a83ab9160523f0c2111b789100000000b7004830450221009c29a7f6f5473fd3b2b3177f0f61de0162b339342605ecadd8f04b39bca9139802207937a1a4f66037d1d6238c5c9b2def7895af1e222bba6fab135fd83edb92feab4100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff0188c2f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": 99999000,
+    "outputAmount": 99992200,
+    "minerFee": 6800,
+    "spendAmount": 99992200,
+    "inputs": [
+      {
+        "id": "91781b11c2f0230516b93aa8048240746bc3c5f219dc98f17fb0559db358014b:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "91781b11c2f0230516b93aa8048240746bc3c5f219dc98f17fb0559db358014b:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "99992200",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "99992200",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "sourceCoin": "tbsv",
+  "recoveryCoin": "tdoge",
+  "recoveryAmount": 99992200,
+  "tx": {
+    "id": "2275206740b703571cdad163f897c8164ceca17754f3b1aabcad3a34dc0cf89d",
+    "hex": "02000000014b0158b39d55b07ff198dc19f2c5c36b74408204a83ab9160523f0c2111b789100000000b7004830450221009c29a7f6f5473fd3b2b3177f0f61de0162b339342605ecadd8f04b39bca9139802207937a1a4f66037d1d6238c5c9b2def7895af1e222bba6fab135fd83edb92feab4100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff0188c2f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "91781b11c2f0230516b93aa8048240746bc3c5f219dc98f17fb0559db358014b",
+        "index": 0,
+        "script": "004830450221009c29a7f6f5473fd3b2b3177f0f61de0162b339342605ecadd8f04b39bca9139802207937a1a4f66037d1d6238c5c9b2def7895af1e222bba6fab135fd83edb92feab4100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": 99992200
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tbsv/recovery/crossChainRecovery-tdoge-unsigned.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tbsv/recovery/crossChainRecovery-tdoge-unsigned.json
@@ -1,0 +1,76 @@
+{
+  "txHex": "02000000014b0158b39d55b07ff198dc19f2c5c36b74408204a83ab9160523f0c2111b78910000000000ffffffff0188c2f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": 99999000,
+    "outputAmount": 99992200,
+    "minerFee": 6800,
+    "spendAmount": 99992200,
+    "inputs": [
+      {
+        "id": "91781b11c2f0230516b93aa8048240746bc3c5f219dc98f17fb0559db358014b:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "91781b11c2f0230516b93aa8048240746bc3c5f219dc98f17fb0559db358014b:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "99992200",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "99992200",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "feeInfo": {
+    "size": 340,
+    "fee": 6800,
+    "feeRate": 20,
+    "payGoFee": 0
+  },
+  "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+  "coin": "tbsv",
+  "tx": {
+    "id": "dc5dc3a049907cc0a2a07bb7e492c7eac88f68984c42ebe5c9e4da3886f2f776",
+    "hex": "02000000014b0158b39d55b07ff198dc19f2c5c36b74408204a83ab9160523f0c2111b78910000000000ffffffff0188c2f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "91781b11c2f0230516b93aa8048240746bc3c5f219dc98f17fb0559db358014b",
+        "index": 0,
+        "script": "",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": 99992200
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tbtc/recovery/crossChainRecovery-tdoge-signed.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tbtc/recovery/crossChainRecovery-tdoge-signed.json
@@ -1,0 +1,72 @@
+{
+  "version": 2,
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "txHex": "0100000001cc08db9a579b62f920fe1f1211b83ccc15fd39f3f16ca0f3bee646158ca77b1700000000b60047304402203ec75e52b1447333f31de5c356ca55f4d065d0a9da5413a2d1c40834f99171fe02204ea08b77331edc8a34f0db97ebd6fd2cc7cd17160f76a7ad96ade8ae6a00bf980100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff01d872f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": 99999000,
+    "outputAmount": 99971800,
+    "minerFee": 27200,
+    "spendAmount": 99971800,
+    "inputs": [
+      {
+        "id": "177ba78c1546e6bef3a06cf1f339fd15cc3cb811121ffe20f9629b579adb08cc:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "177ba78c1546e6bef3a06cf1f339fd15cc3cb811121ffe20f9629b579adb08cc:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "99971800",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "99971800",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "sourceCoin": "tbtc",
+  "recoveryCoin": "tdoge",
+  "recoveryAmount": 99971800,
+  "tx": {
+    "id": "b2719f060902353b2f982e766acd537909c7c7f17f0f9173789b3f8781c7a300",
+    "hex": "0100000001cc08db9a579b62f920fe1f1211b83ccc15fd39f3f16ca0f3bee646158ca77b1700000000b60047304402203ec75e52b1447333f31de5c356ca55f4d065d0a9da5413a2d1c40834f99171fe02204ea08b77331edc8a34f0db97ebd6fd2cc7cd17160f76a7ad96ade8ae6a00bf980100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff01d872f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "177ba78c1546e6bef3a06cf1f339fd15cc3cb811121ffe20f9629b579adb08cc",
+        "index": 0,
+        "script": "0047304402203ec75e52b1447333f31de5c356ca55f4d065d0a9da5413a2d1c40834f99171fe02204ea08b77331edc8a34f0db97ebd6fd2cc7cd17160f76a7ad96ade8ae6a00bf980100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": 99971800
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tbtc/recovery/crossChainRecovery-tdoge-unsigned.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tbtc/recovery/crossChainRecovery-tdoge-unsigned.json
@@ -1,0 +1,76 @@
+{
+  "txHex": "0100000001cc08db9a579b62f920fe1f1211b83ccc15fd39f3f16ca0f3bee646158ca77b170000000000ffffffff01d872f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": 99999000,
+    "outputAmount": 99971800,
+    "minerFee": 27200,
+    "spendAmount": 99971800,
+    "inputs": [
+      {
+        "id": "177ba78c1546e6bef3a06cf1f339fd15cc3cb811121ffe20f9629b579adb08cc:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "177ba78c1546e6bef3a06cf1f339fd15cc3cb811121ffe20f9629b579adb08cc:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "99971800",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "99971800",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "feeInfo": {
+    "size": 340,
+    "fee": 27200,
+    "feeRate": 80,
+    "payGoFee": 0
+  },
+  "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+  "coin": "tbtc",
+  "tx": {
+    "id": "ad8089c9ada59a93fbb1c5e967b152ef3300ca34ffa1a81d79059c19f57e001f",
+    "hex": "0100000001cc08db9a579b62f920fe1f1211b83ccc15fd39f3f16ca0f3bee646158ca77b170000000000ffffffff01d872f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "177ba78c1546e6bef3a06cf1f339fd15cc3cb811121ffe20f9629b579adb08cc",
+        "index": 0,
+        "script": "",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": 99971800
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tdoge/recovery/crossChainRecovery-tbch-signed.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tdoge/recovery/crossChainRecovery-tbch-signed.json
@@ -1,0 +1,74 @@
+{
+  "version": 2,
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "txHex": "010000000117debd497710d8fb88ae869004a43201d65e4194a7342b9e552a4bd6eb1032fa00000000b60047304402201719c56e2d140767105a1d6599f0a0c429e134ff62cf0f03955e2663ca2e0e3e022034247c75255305571cfc3790f0806052d8bb6e1a43e0487e3d58988b0779bcd10100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": "10999999799999001",
+    "outputAmount": "10999999799659001",
+    "minerFee": "340000",
+    "spendAmount": "10999999799659001",
+    "inputs": [
+      {
+        "id": "fa3210ebd64b2a559e2b34a794415ed60132a4049086ae88fbd8107749bdde17:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "fa3210ebd64b2a559e2b34a794415ed60132a4049086ae88fbd8107749bdde17:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "sourceCoin": "tdoge",
+  "recoveryCoin": "tbch",
+  "recoveryAmount": "10999999799659001",
+  "tx": {
+    "id": "8364aee26647e1e585fcf96345cb9f7d4e1444b7fc748ff4eb072299535f369b",
+    "hex": "010000000117debd497710d8fb88ae869004a43201d65e4194a7342b9e552a4bd6eb1032fa00000000b60047304402201719c56e2d140767105a1d6599f0a0c429e134ff62cf0f03955e2663ca2e0e3e022034247c75255305571cfc3790f0806052d8bb6e1a43e0487e3d58988b0779bcd10100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "fa3210ebd64b2a559e2b34a794415ed60132a4049086ae88fbd8107749bdde17",
+        "index": 0,
+        "script": "0047304402201719c56e2d140767105a1d6599f0a0c429e134ff62cf0f03955e2663ca2e0e3e022034247c75255305571cfc3790f0806052d8bb6e1a43e0487e3d58988b0779bcd10100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": "10999999799659001"
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tdoge/recovery/crossChainRecovery-tbch-unsigned.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tdoge/recovery/crossChainRecovery-tbch-unsigned.json
@@ -1,0 +1,78 @@
+{
+  "txHex": "010000000117debd497710d8fb88ae869004a43201d65e4194a7342b9e552a4bd6eb1032fa0000000000ffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": "10999999799999001",
+    "outputAmount": "10999999799659001",
+    "minerFee": "340000",
+    "spendAmount": "10999999799659001",
+    "inputs": [
+      {
+        "id": "fa3210ebd64b2a559e2b34a794415ed60132a4049086ae88fbd8107749bdde17:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "fa3210ebd64b2a559e2b34a794415ed60132a4049086ae88fbd8107749bdde17:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "feeInfo": {
+    "size": 340,
+    "fee": 340000,
+    "feeRate": 1000,
+    "payGoFee": 0
+  },
+  "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+  "coin": "tdoge",
+  "tx": {
+    "id": "5d1ac4016a842ea01d8382fb6c9bd3cb6b1d5b3eeb1aa3ba812ed4f92c0566c2",
+    "hex": "010000000117debd497710d8fb88ae869004a43201d65e4194a7342b9e552a4bd6eb1032fa0000000000ffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "fa3210ebd64b2a559e2b34a794415ed60132a4049086ae88fbd8107749bdde17",
+        "index": 0,
+        "script": "",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": "10999999799659001"
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tdoge/recovery/crossChainRecovery-tbsv-signed.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tdoge/recovery/crossChainRecovery-tbsv-signed.json
@@ -1,0 +1,74 @@
+{
+  "version": 2,
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "txHex": "010000000117debd497710d8fb88ae869004a43201d65e4194a7342b9e552a4bd6eb1032fa00000000b60047304402201719c56e2d140767105a1d6599f0a0c429e134ff62cf0f03955e2663ca2e0e3e022034247c75255305571cfc3790f0806052d8bb6e1a43e0487e3d58988b0779bcd10100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": "10999999799999001",
+    "outputAmount": "10999999799659001",
+    "minerFee": "340000",
+    "spendAmount": "10999999799659001",
+    "inputs": [
+      {
+        "id": "fa3210ebd64b2a559e2b34a794415ed60132a4049086ae88fbd8107749bdde17:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "fa3210ebd64b2a559e2b34a794415ed60132a4049086ae88fbd8107749bdde17:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "sourceCoin": "tdoge",
+  "recoveryCoin": "tbsv",
+  "recoveryAmount": "10999999799659001",
+  "tx": {
+    "id": "8364aee26647e1e585fcf96345cb9f7d4e1444b7fc748ff4eb072299535f369b",
+    "hex": "010000000117debd497710d8fb88ae869004a43201d65e4194a7342b9e552a4bd6eb1032fa00000000b60047304402201719c56e2d140767105a1d6599f0a0c429e134ff62cf0f03955e2663ca2e0e3e022034247c75255305571cfc3790f0806052d8bb6e1a43e0487e3d58988b0779bcd10100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "fa3210ebd64b2a559e2b34a794415ed60132a4049086ae88fbd8107749bdde17",
+        "index": 0,
+        "script": "0047304402201719c56e2d140767105a1d6599f0a0c429e134ff62cf0f03955e2663ca2e0e3e022034247c75255305571cfc3790f0806052d8bb6e1a43e0487e3d58988b0779bcd10100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": "10999999799659001"
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tdoge/recovery/crossChainRecovery-tbsv-unsigned.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tdoge/recovery/crossChainRecovery-tbsv-unsigned.json
@@ -1,0 +1,78 @@
+{
+  "txHex": "010000000117debd497710d8fb88ae869004a43201d65e4194a7342b9e552a4bd6eb1032fa0000000000ffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": "10999999799999001",
+    "outputAmount": "10999999799659001",
+    "minerFee": "340000",
+    "spendAmount": "10999999799659001",
+    "inputs": [
+      {
+        "id": "fa3210ebd64b2a559e2b34a794415ed60132a4049086ae88fbd8107749bdde17:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "fa3210ebd64b2a559e2b34a794415ed60132a4049086ae88fbd8107749bdde17:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "feeInfo": {
+    "size": 340,
+    "fee": 340000,
+    "feeRate": 1000,
+    "payGoFee": 0
+  },
+  "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+  "coin": "tdoge",
+  "tx": {
+    "id": "5d1ac4016a842ea01d8382fb6c9bd3cb6b1d5b3eeb1aa3ba812ed4f92c0566c2",
+    "hex": "010000000117debd497710d8fb88ae869004a43201d65e4194a7342b9e552a4bd6eb1032fa0000000000ffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "fa3210ebd64b2a559e2b34a794415ed60132a4049086ae88fbd8107749bdde17",
+        "index": 0,
+        "script": "",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": "10999999799659001"
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tdoge/recovery/crossChainRecovery-tbtc-signed.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tdoge/recovery/crossChainRecovery-tbtc-signed.json
@@ -1,0 +1,74 @@
+{
+  "version": 2,
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "txHex": "010000000117debd497710d8fb88ae869004a43201d65e4194a7342b9e552a4bd6eb1032fa00000000b60047304402201719c56e2d140767105a1d6599f0a0c429e134ff62cf0f03955e2663ca2e0e3e022034247c75255305571cfc3790f0806052d8bb6e1a43e0487e3d58988b0779bcd10100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": "10999999799999001",
+    "outputAmount": "10999999799659001",
+    "minerFee": "340000",
+    "spendAmount": "10999999799659001",
+    "inputs": [
+      {
+        "id": "fa3210ebd64b2a559e2b34a794415ed60132a4049086ae88fbd8107749bdde17:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "fa3210ebd64b2a559e2b34a794415ed60132a4049086ae88fbd8107749bdde17:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "sourceCoin": "tdoge",
+  "recoveryCoin": "tbtc",
+  "recoveryAmount": "10999999799659001",
+  "tx": {
+    "id": "8364aee26647e1e585fcf96345cb9f7d4e1444b7fc748ff4eb072299535f369b",
+    "hex": "010000000117debd497710d8fb88ae869004a43201d65e4194a7342b9e552a4bd6eb1032fa00000000b60047304402201719c56e2d140767105a1d6599f0a0c429e134ff62cf0f03955e2663ca2e0e3e022034247c75255305571cfc3790f0806052d8bb6e1a43e0487e3d58988b0779bcd10100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "fa3210ebd64b2a559e2b34a794415ed60132a4049086ae88fbd8107749bdde17",
+        "index": 0,
+        "script": "0047304402201719c56e2d140767105a1d6599f0a0c429e134ff62cf0f03955e2663ca2e0e3e022034247c75255305571cfc3790f0806052d8bb6e1a43e0487e3d58988b0779bcd10100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": "10999999799659001"
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tdoge/recovery/crossChainRecovery-tbtc-unsigned.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tdoge/recovery/crossChainRecovery-tbtc-unsigned.json
@@ -1,0 +1,78 @@
+{
+  "txHex": "010000000117debd497710d8fb88ae869004a43201d65e4194a7342b9e552a4bd6eb1032fa0000000000ffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": "10999999799999001",
+    "outputAmount": "10999999799659001",
+    "minerFee": "340000",
+    "spendAmount": "10999999799659001",
+    "inputs": [
+      {
+        "id": "fa3210ebd64b2a559e2b34a794415ed60132a4049086ae88fbd8107749bdde17:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "fa3210ebd64b2a559e2b34a794415ed60132a4049086ae88fbd8107749bdde17:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "feeInfo": {
+    "size": 340,
+    "fee": 340000,
+    "feeRate": 1000,
+    "payGoFee": 0
+  },
+  "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+  "coin": "tdoge",
+  "tx": {
+    "id": "5d1ac4016a842ea01d8382fb6c9bd3cb6b1d5b3eeb1aa3ba812ed4f92c0566c2",
+    "hex": "010000000117debd497710d8fb88ae869004a43201d65e4194a7342b9e552a4bd6eb1032fa0000000000ffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "fa3210ebd64b2a559e2b34a794415ed60132a4049086ae88fbd8107749bdde17",
+        "index": 0,
+        "script": "",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": "10999999799659001"
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tdoge/recovery/crossChainRecovery-tltc-signed.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tdoge/recovery/crossChainRecovery-tltc-signed.json
@@ -1,0 +1,74 @@
+{
+  "version": 2,
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "txHex": "010000000117debd497710d8fb88ae869004a43201d65e4194a7342b9e552a4bd6eb1032fa00000000b60047304402201719c56e2d140767105a1d6599f0a0c429e134ff62cf0f03955e2663ca2e0e3e022034247c75255305571cfc3790f0806052d8bb6e1a43e0487e3d58988b0779bcd10100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": "10999999799999001",
+    "outputAmount": "10999999799659001",
+    "minerFee": "340000",
+    "spendAmount": "10999999799659001",
+    "inputs": [
+      {
+        "id": "fa3210ebd64b2a559e2b34a794415ed60132a4049086ae88fbd8107749bdde17:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "fa3210ebd64b2a559e2b34a794415ed60132a4049086ae88fbd8107749bdde17:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "sourceCoin": "tdoge",
+  "recoveryCoin": "tltc",
+  "recoveryAmount": "10999999799659001",
+  "tx": {
+    "id": "8364aee26647e1e585fcf96345cb9f7d4e1444b7fc748ff4eb072299535f369b",
+    "hex": "010000000117debd497710d8fb88ae869004a43201d65e4194a7342b9e552a4bd6eb1032fa00000000b60047304402201719c56e2d140767105a1d6599f0a0c429e134ff62cf0f03955e2663ca2e0e3e022034247c75255305571cfc3790f0806052d8bb6e1a43e0487e3d58988b0779bcd10100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "fa3210ebd64b2a559e2b34a794415ed60132a4049086ae88fbd8107749bdde17",
+        "index": 0,
+        "script": "0047304402201719c56e2d140767105a1d6599f0a0c429e134ff62cf0f03955e2663ca2e0e3e022034247c75255305571cfc3790f0806052d8bb6e1a43e0487e3d58988b0779bcd10100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": "10999999799659001"
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tdoge/recovery/crossChainRecovery-tltc-unsigned.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tdoge/recovery/crossChainRecovery-tltc-unsigned.json
@@ -1,0 +1,78 @@
+{
+  "txHex": "010000000117debd497710d8fb88ae869004a43201d65e4194a7342b9e552a4bd6eb1032fa0000000000ffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": "10999999799999001",
+    "outputAmount": "10999999799659001",
+    "minerFee": "340000",
+    "spendAmount": "10999999799659001",
+    "inputs": [
+      {
+        "id": "fa3210ebd64b2a559e2b34a794415ed60132a4049086ae88fbd8107749bdde17:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "fa3210ebd64b2a559e2b34a794415ed60132a4049086ae88fbd8107749bdde17:0",
+        "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
+        "value": "10999999799999001",
+        "valueString": "10999999799999001",
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+        "valueString": "10999999799659001",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "feeInfo": {
+    "size": 340,
+    "fee": 340000,
+    "feeRate": 1000,
+    "payGoFee": 0
+  },
+  "address": "2N7VWEhmfT8CzGSW2bCVeKJ3GCwSD1nsL2V",
+  "coin": "tdoge",
+  "tx": {
+    "id": "5d1ac4016a842ea01d8382fb6c9bd3cb6b1d5b3eeb1aa3ba812ed4f92c0566c2",
+    "hex": "010000000117debd497710d8fb88ae869004a43201d65e4194a7342b9e552a4bd6eb1032fa0000000000ffffffff01f98996087114270017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "fa3210ebd64b2a559e2b34a794415ed60132a4049086ae88fbd8107749bdde17",
+        "index": 0,
+        "script": "",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": "10999999799659001"
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tltc/recovery/crossChainRecovery-tdoge-signed.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tltc/recovery/crossChainRecovery-tdoge-signed.json
@@ -1,0 +1,72 @@
+{
+  "version": 2,
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "txHex": "0100000001429825a0b57b8c7e649ffd4f86b90bb1ff4e83c62b92a9deda511bc6afe2a94700000000b60047304402204517ad5f3f326413242bdb490e1bf96f7a33f084785c0113705b22385771cb2e02202276cf3a12ff0b5520a2713b060abcc6bcc60ab2b0d0ee8262bc785aba7725f10100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff014858f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": 99999000,
+    "outputAmount": 99965000,
+    "minerFee": 34000,
+    "spendAmount": 99965000,
+    "inputs": [
+      {
+        "id": "47a9e2afc61b51dadea9922bc6834effb10bb9864ffd9f647e8c7bb5a0259842:0",
+        "address": "QPNRPpzvJYtxriJJjcsddTiznJJ35u6Chk",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "47a9e2afc61b51dadea9922bc6834effb10bb9864ffd9f647e8c7bb5a0259842:0",
+        "address": "QPNRPpzvJYtxriJJjcsddTiznJJ35u6Chk",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "QarGMiduUEG5QdG5DJXfPzUhMKt2vtZkew",
+        "valueString": "99965000",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "QarGMiduUEG5QdG5DJXfPzUhMKt2vtZkew",
+        "valueString": "99965000",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "sourceCoin": "tltc",
+  "recoveryCoin": "tdoge",
+  "recoveryAmount": 99965000,
+  "tx": {
+    "id": "9aa74f48bb61646f27d89265bb8f9c6fab59b80941f3c7bbb31ebfc89963a48c",
+    "hex": "0100000001429825a0b57b8c7e649ffd4f86b90bb1ff4e83c62b92a9deda511bc6afe2a94700000000b60047304402204517ad5f3f326413242bdb490e1bf96f7a33f084785c0113705b22385771cb2e02202276cf3a12ff0b5520a2713b060abcc6bcc60ab2b0d0ee8262bc785aba7725f10100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853aeffffffff014858f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "47a9e2afc61b51dadea9922bc6834effb10bb9864ffd9f647e8c7bb5a0259842",
+        "index": 0,
+        "script": "0047304402204517ad5f3f326413242bdb490e1bf96f7a33f084785c0113705b22385771cb2e02202276cf3a12ff0b5520a2713b060abcc6bcc60ab2b0d0ee8262bc785aba7725f10100004c695221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": 99965000
+      }
+    ]
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tltc/recovery/crossChainRecovery-tdoge-unsigned.json
+++ b/modules/bitgo/test/v2/unit/coins/utxo/fixtures/tltc/recovery/crossChainRecovery-tdoge-unsigned.json
@@ -1,0 +1,76 @@
+{
+  "txHex": "0100000001429825a0b57b8c7e649ffd4f86b90bb1ff4e83c62b92a9deda511bc6afe2a9470000000000ffffffff014858f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+  "txInfo": {
+    "inputAmount": 99999000,
+    "outputAmount": 99965000,
+    "minerFee": 34000,
+    "spendAmount": 99965000,
+    "inputs": [
+      {
+        "id": "47a9e2afc61b51dadea9922bc6834effb10bb9864ffd9f647e8c7bb5a0259842:0",
+        "address": "QPNRPpzvJYtxriJJjcsddTiznJJ35u6Chk",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "unspents": [
+      {
+        "id": "47a9e2afc61b51dadea9922bc6834effb10bb9864ffd9f647e8c7bb5a0259842:0",
+        "address": "QPNRPpzvJYtxriJJjcsddTiznJJ35u6Chk",
+        "value": 99999000,
+        "chain": 0,
+        "index": 0,
+        "wallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "fromWallet": "5abacebe28d72fbd07e0b8cbba0ff39e",
+        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
+      }
+    ],
+    "outputs": [
+      {
+        "address": "QarGMiduUEG5QdG5DJXfPzUhMKt2vtZkew",
+        "valueString": "99965000",
+        "change": false
+      }
+    ],
+    "externalOutputs": [
+      {
+        "address": "QarGMiduUEG5QdG5DJXfPzUhMKt2vtZkew",
+        "valueString": "99965000",
+        "change": false
+      }
+    ],
+    "changeOutputs": [],
+    "payGoFee": 0
+  },
+  "walletId": "5abacebe28d72fbd07e0b8cbba0ff39e",
+  "feeInfo": {
+    "size": 340,
+    "fee": 34000,
+    "feeRate": 100,
+    "payGoFee": 0
+  },
+  "address": "QarGMiduUEG5QdG5DJXfPzUhMKt2vtZkew",
+  "coin": "tltc",
+  "tx": {
+    "id": "dde0515200aeaee90acc6cc3bf082af801b98d88fb2340c6da693c208448cedc",
+    "hex": "0100000001429825a0b57b8c7e649ffd4f86b90bb1ff4e83c62b92a9deda511bc6afe2a9470000000000ffffffff014858f5050000000017a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f8700000000",
+    "ins": [
+      {
+        "txid": "47a9e2afc61b51dadea9922bc6834effb10bb9864ffd9f647e8c7bb5a0259842",
+        "index": 0,
+        "script": "",
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "script": "a9149c4525e9e9fc92cdda2043d35ad699c343dbab0f87",
+        "value": 99965000
+      }
+    ]
+  }
+}

--- a/modules/sdk-coin-doge/src/doge.ts
+++ b/modules/sdk-coin-doge/src/doge.ts
@@ -7,6 +7,9 @@ import {
   ParseTransactionOptions,
   ParsedTransaction,
   VerifyTransactionOptions,
+  CrossChainRecoverySigned,
+  CrossChainRecoveryUnsigned,
+  RecoverFromWrongChainOptions,
 } from '@bitgo/abstract-utxo';
 import { BaseCoin, BitGoBase, HalfSignedUtxoTransaction, SignedTransaction } from '@bitgo/sdk-core';
 import * as utxolib from '@bitgo/utxo-lib';
@@ -68,5 +71,11 @@ export class Doge extends AbstractUtxoCoin {
     params: ExplainTransactionOptions<TNumber>
   ): Promise<TransactionExplanation> {
     return super.explainTransaction(params);
+  }
+
+  async recoverFromWrongChain<TNumber extends number | bigint = bigint>(
+    params: RecoverFromWrongChainOptions
+  ): Promise<CrossChainRecoverySigned<TNumber> | CrossChainRecoveryUnsigned<TNumber>> {
+    return super.recoverFromWrongChain(params);
   }
 }


### PR DESCRIPTION
BG-49873

depends on https://github.com/BitGo/BitGoJS/pull/2617