### PR TITLE
chore(sdk-core): move legacyBitcoin to sdk-core

### DIFF
--- a/modules/bitgo/src/index.ts
+++ b/modules/bitgo/src/index.ts
@@ -16,7 +16,7 @@ export * from './bitgo';
 
 // Expose legacy "bitcoin" API (mostly HDNode)
 /** @deprecated */
-export * as bitcoin from './legacyBitcoin';
+export { bitcoin } from '@bitgo/sdk-core';
 
 /** @deprecated */
 export const sjcl = require('@bitgo/sjcl');

--- a/modules/bitgo/test/unit/bip32path.ts
+++ b/modules/bitgo/test/unit/bip32path.ts
@@ -3,9 +3,10 @@
  */
 import 'should';
 import * as bip32 from 'bip32';
-import { sanitizeLegacyPath } from '@bitgo/sdk-core';
+import { sanitizeLegacyPath, bitcoin } from '@bitgo/sdk-core';
 import { getSeed } from '@bitgo/sdk-test';
-import { HDNode, Derivable, hdPath } from '../../src/legacyBitcoin';
+const { HDNode, hdPath } = bitcoin;
+type Derivable = bitcoin.Derivable;
 
 describe('bip32util', function () {
   const seed = getSeed('bip32test');

--- a/modules/bitgo/test/unit/hdnode.ts
+++ b/modules/bitgo/test/unit/hdnode.ts
@@ -5,7 +5,8 @@
 //
 
 import 'should';
-import { HDNode, hdPath } from '../../src/legacyBitcoin';
+import { bitcoin } from '@bitgo/sdk-core';
+const { HDNode, hdPath } = bitcoin;
 
 describe('HDNode', function () {
 

--- a/modules/sdk-core/src/bitgo/index.ts
+++ b/modules/sdk-core/src/bitgo/index.ts
@@ -13,6 +13,7 @@ export * from './environments';
 export * from './errors';
 export * from './internal';
 export * from './keychain';
+export * as bitcoin from './legacyBitcoin';
 export * from './market';
 export * from './pendingApproval';
 export * from './recovery';

--- a/modules/sdk-core/src/bitgo/legacyBitcoin.ts
+++ b/modules/sdk-core/src/bitgo/legacyBitcoin.ts
@@ -1,11 +1,7 @@
-/**
- * This file contains a compatability layer for some deprecated types and helper methods
- *
- * @prettier
- */
-import { bitcoinUtil, sanitizeLegacyPath } from '@bitgo/sdk-core';
 import * as utxolib from '@bitgo/utxo-lib';
 import * as bip32 from 'bip32';
+import { sanitizeLegacyPath } from '../api';
+import * as bitcoinUtil from './bitcoin';
 
 interface ECPairCompat extends utxolib.ECPairInterface {
   getPublicKeyBuffer(): Buffer;


### PR DESCRIPTION
- moves legacyBitcoin file to sdk-core, re-exports as bitcoin

Ticket: BG-53175