### PR TITLE
chore(bitgo): set latest buffer polyfil

### DIFF
--- a/modules/web-demo/package.json
+++ b/modules/web-demo/package.json
@@ -41,6 +41,7 @@
     "@types/react": "17.0.24",
     "@types/react-dom": "17.0.16",
     "@types/styled-components": "^5.1.25",
+    "chai": "^4.3.6",
     "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^8.1.1",
     "css-loader": "^5.2.4",

--- a/modules/web-demo/src/components/BitGoAPI/bitgo-api.spec.tsx
+++ b/modules/web-demo/src/components/BitGoAPI/bitgo-api.spec.tsx
@@ -12,6 +12,6 @@ it('renders the api-sdk', () => {
 });
 
 it('CR-686: uses the correct version of Buffer', () => {
-  const webBuffer: WebBuffer = new Buffer('') as unknown as WebBuffer;
+  const webBuffer = new Buffer('') as unknown as WebBuffer;
   expect(webBuffer.readBigUInt64BE).not.to.be.undefined;
 });

--- a/modules/web-demo/src/components/BitGoAPI/bitgo-api.spec.tsx
+++ b/modules/web-demo/src/components/BitGoAPI/bitgo-api.spec.tsx
@@ -1,9 +1,17 @@
 import React from 'react';
 import { mount } from '@cypress/react';
 import BGApi from './index';
+import type { Buffer as WebBuffer } from 'buffer/index';
+import { Buffer } from 'buffer';
+import { expect } from 'chai';
 
 it('renders the api-sdk', () => {
   mount(<BGApi />);
   cy.get('h3').contains('BitGo SDK API');
   cy.get('div').contains('https://app.bitgo-test.com');
+});
+
+it('CR-686: uses the correct version of Buffer', () => {
+  const webBuffer: WebBuffer = new Buffer('') as unknown as WebBuffer;
+  expect(webBuffer.readBigUInt64BE).not.to.be.undefined;
 });

--- a/modules/web-demo/src/components/BitGoJS/bitgojs.spec.tsx
+++ b/modules/web-demo/src/components/BitGoJS/bitgojs.spec.tsx
@@ -12,6 +12,6 @@ it('renders the BitGoJS SDK', () => {
 });
 
 it('CR-686: uses the correct version of Buffer', () => {
-  const webBuffer: WebBuffer = new Buffer('') as unknown as WebBuffer;
+  const webBuffer = new Buffer('') as unknown as WebBuffer;
   expect(webBuffer.readBigUInt64BE).not.to.be.undefined;
 });

--- a/modules/web-demo/src/components/BitGoJS/bitgojs.spec.tsx
+++ b/modules/web-demo/src/components/BitGoJS/bitgojs.spec.tsx
@@ -1,9 +1,17 @@
 import React from 'react';
 import { mount } from '@cypress/react';
 import BitGoJSComponent from './index';
+import type { Buffer as WebBuffer } from 'buffer/index';
+import { Buffer } from 'buffer';
+import { expect } from 'chai';
 
 it('renders the BitGoJS SDK', () => {
   mount(<BitGoJSComponent />);
   cy.get('h3').contains('BitGoJS SDK');
   cy.get('div').contains('https://app.bitgo-test.com');
+});
+
+it('CR-686: uses the correct version of Buffer', () => {
+  const webBuffer: WebBuffer = new Buffer('') as unknown as WebBuffer;
+  expect(webBuffer.readBigUInt64BE).not.to.be.undefined;
 });

--- a/modules/web-demo/tsconfig.json
+++ b/modules/web-demo/tsconfig.json
@@ -21,13 +21,14 @@
       "@src/*": ["src/*"],
       "@images/*": ["src/images/*"],
       "@styles/*": ["src/styles/*"],
-      "@components/*": ["src/components/*"]
+      "@components/*": ["src/components/*"],
+      "buffer": ["../../node_modules/buffer/index"]
     },
     "removeComments": true,
     "skipLibCheck": true,
     "strict": true,
     "target": "es6",
-    "types": ["node", "cypress", "@testing-library/cypress"]
+    "types": ["cypress", "@testing-library/cypress"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"],

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@typescript-eslint/eslint-plugin": "^4.23.0",
     "@typescript-eslint/parser": "^4.23.0",
     "babel-loader": "^8.2.4",
+    "buffer": "^6.0.3",
     "cross-env": "^7.0.3",
     "crypto-browserify": "^3.12.0",
     "depcheck": "^1.4.3",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "resolutions": {
     "@types/react": "17.0.24",
     "@types/react-dom": "17.0.16",
+    "buffer": "^6.0.3",
     "eventsource": "2.0.2",
     "minimist": "1.2.6",
     "parse-path": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5572,7 +5572,7 @@ base64-arraybuffer@0.1.4:
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz#9818c79e059b1355f97e0428a017c838e90ba812"
   integrity sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=
 
-base64-js@^1.0.2, base64-js@^1.3.0, base64-js@^1.3.1:
+base64-js@^1.3.0, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -6184,38 +6184,13 @@ buffer-xor@^1.0.2, buffer-xor@^1.0.3:
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
-buffer@4.9.2:
-  version "4.9.2"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
-  integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
-  dependencies:
-    base64-js "^1.0.2"
-    ieee754 "^1.1.4"
-    isarray "^1.0.0"
-
-buffer@6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.1.tgz#3cbea8c1463e5a0779e30b66d4c88c6ffa182ac2"
-  integrity sha512-rVAXBwEcEoYtxnHSO5iWyhzV/O1WMtkUYWlfdLS7FjU4PnSJJHEfHXi/uHPI5EwltmOA794gN3bm3/pzuctWjQ==
-  dependencies:
-    base64-js "^1.3.1"
-    ieee754 "^1.2.1"
-
-buffer@6.0.3, buffer@^6.0.1, buffer@^6.0.2, buffer@^6.0.3, buffer@~6.0.3:
+buffer@4.9.2, buffer@6.0.1, buffer@6.0.3, buffer@^5.0.2, buffer@^5.0.5, buffer@^5.1.0, buffer@^5.4.3, buffer@^5.5.0, buffer@^5.6.0, buffer@^6.0.1, buffer@^6.0.2, buffer@^6.0.3, buffer@~6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
   integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
-
-buffer@^5.0.2, buffer@^5.0.5, buffer@^5.1.0, buffer@^5.4.3, buffer@^5.5.0, buffer@^5.6.0:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
-  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
-  dependencies:
-    base64-js "^1.3.1"
-    ieee754 "^1.1.13"
 
 bufferutil@^4.0.1:
   version "4.0.6"
@@ -10335,7 +10310,7 @@ ieee754@1.1.13:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
 
-ieee754@^1.1.13, ieee754@^1.1.4, ieee754@^1.2.1:
+ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -10955,7 +10930,7 @@ isarray@0.0.1:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
   integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
-isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
+isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=


### PR DESCRIPTION
- webpack will use latest buffer explicitly instead of implicit dep

Ticket: BG-54987

## Test
- after running yarn install, go to `/modules/sdk-api` & run `yarn webpack-dev`.
- search generated file `/dist/web/main.js` for `Buffer.prototype.readBigUInt64BE` to verify the latest version is present. 