### PR TITLE
fix: add ability to use unencrypted private key

### DIFF
--- a/modules/express/package.json
+++ b/modules/express/package.json
@@ -51,6 +51,7 @@
     "superagent": "^3.8.3"
   },
   "devDependencies": {
+    "@bitgo/sdk-test": "^1.0.1",
     "@types/argparse": "^1.0.36",
     "@types/bluebird": "^3.5.25",
     "@types/body-parser": "^1.17.0",

--- a/modules/express/src/fetchEncryptedPrivKeys.ts
+++ b/modules/express/src/fetchEncryptedPrivKeys.ts
@@ -14,36 +14,57 @@ type Output = {
   [key: string]: string
 }
 
+type Credentials = {
+  id: string,
+  secret: string,
+  password: string,
+}
+
 type WalletIds = {
-  [key: string]: string[]
+  [key: string]: (string | Credentials)[]
 }
 
 // TODO: set env to 'test' or 'prod'
 const bg = new BitGo({ env: 'test' });
-// TODO: set your access token here
-const accessToken = '';
-// // TODO: set your coin type and wallet ids here e.g.
-const walletIds: WalletIds = {
-  // tbtc: ['61f039aad587c2000745c687373e0111', '6225b081cd291300071fed36b1362222'],
-  // gteth: ['61fb21819c54dd000755f8de3a18e333'],
-};
 
-async function main() {
-  bg.authenticateWithAccessToken({ accessToken });
+// TODO: set your access token here
+// const accessToken = '';
+
+// TODO: set your coin type and wallet ids here e.g.
+// const walletIds: WalletIds = {
+// tbtc: ['61f039aad587c2000745c687373e0111', '6225b081cd291300071fed36b1362222'],
+// tbtc: [{
+// id: '<WALLET_ID>',
+// secret: 'xprv...',
+// password: '<WALLET_PASSWORD>'
+// }],
+// gteth: ['61fb21819c54dd000755f8de3a18e333'],
+// };
+
+export async function fetchKeys(ids: WalletIds, token: string): Promise<Record<string, string>> {
+  bg.authenticateWithAccessToken({ accessToken: token });
 
   // get the encrypted user privKey for each walletId and store in the JSON output
   const output: Output = {};
-  for (const [coinName, ids] of Object.entries(walletIds)) {
+  for (const [coinName, credentials] of Object.entries(ids)) {
     const coin = bg.coin(coinName);
-    for (const id of ids) {
+    for (const credential of credentials) {
+      const id = typeof credential === 'string' ? credential : credential.id;
       const wallet = await coin.wallets().get({ id });
       const userKeyId = wallet.keyIds()[0];
       const keychain = await coin.keychains().get({ id: userKeyId });
+
       if (keychain.encryptedPrv === undefined) {
-        console.warn(`could not find a ${coinName} encrypted user private key for wallet id ${id}, skipping`);
-        continue;
+        if (typeof credential === 'object') {
+          const encryptedPrv = bg.encrypt({ password: credential.password, input: credential.secret });
+          output[id] = encryptedPrv;
+        } else {
+          console.warn(`could not find a ${coinName} encrypted user private key for wallet id ${id}, skipping`);
+          continue;
+        }
+      } else {
+        output[id] = keychain.encryptedPrv;
       }
-      output[id] = keychain.encryptedPrv;
     }
   }
 
@@ -55,6 +76,8 @@ async function main() {
     }
     console.log(`Wallet IDs and encrypted private keys saved to ${fileName}`);
   });
+
+  return Promise.resolve(output);
 }
 
-main().catch((e) => console.error(e));
+// fetchKeys(walletIds, accessToken).catch((e) => console.error(e));

--- a/modules/express/test/unit/clientRoutes/externalSign.ts
+++ b/modules/express/test/unit/clientRoutes/externalSign.ts
@@ -1,6 +1,10 @@
 /**
  * @prettier
  */
+
+import { common } from '@bitgo/sdk-core';
+import { TestBitGo, TestBitGoAPI } from '@bitgo/sdk-test';
+import * as should from 'should';
 import * as sinon from 'sinon';
 
 import 'should-http';
@@ -9,26 +13,52 @@ import '../../lib/asserts';
 
 import * as express from 'express';
 import { handleV2Sign } from '../../../src/clientRoutes';
+import { fetchKeys } from '../../../src/fetchEncryptedPrivKeys';
 import * as fs from 'fs';
 import { Coin, BitGo, SignedTransaction } from 'bitgo';
+import * as nock from 'nock';
+nock.restore();
 
 describe('External signer', () => {
+  let bitgo: TestBitGoAPI;
+  let bgUrl;
+
+  const walletId = '61f039aad587c2000745c687373e0fa9';
+  const secret =
+    'xprv9s21ZrQH143K3EuPWCBuqnWxydaQV6et9htQige4EswvcHKEzNmkVmwTwKoadyHzJYppuADB7Us7AbaNLToNvoFoSxuWqndQRYtnNy5DUY2';
+  const password = 'wDX058%c4plL1@pP';
+  const validPrv =
+    '{"61f039aad587c2000745c687373e0fa9":"{\\"iv\\":\\"+1u1Y9cvsYuRMeyH2slnXQ==\\",\\"v\\":1,\\"iter\\":10000,\\"ks\\":256,\\"ts\\":64,\\"mode\\":\\"ccm\\",\\"adata\\":\\"\\",\\"cipher\\":\\"aes\\",\\"salt\\":\\"54kOXTqJ9mc=\\",\\"ct\\":\\"JF5wQ82wa1dYyFxFlbHCvK4a+A6MTHdhOqc5uXsz2icWhkY2Lin/3Ab8ZwvwDaR1JYKmC/g1gXIGwVZEOl1M/bRHY420h7sDtmTS6Ebse5NWbF0ItfUJlk6HVATGa+C6mkbaVxJ4kQW/ehnT3riqzU069ATPz8E=\\"}"}';
+
+  before(function () {
+    if (!nock.isActive()) {
+      nock.activate();
+    }
+
+    bitgo = TestBitGo.decorate(BitGo, { env: 'test' });
+    bitgo.initializeTestVars();
+
+    bgUrl = common.Environments[bitgo.getEnv()].uri;
+  });
+
+  after(() => {
+    if (nock.isActive()) {
+      nock.restore();
+    }
+  });
+
   it('should read an encrypted prv from signerFileSystemPath and pass it to coin.signTransaction', async () => {
-    const validPrv =
-      '{"61f039aad587c2000745c687373e0fa9":"{\\"iv\\":\\"+1u1Y9cvsYuRMeyH2slnXQ==\\",\\"v\\":1,\\"iter\\":10000,\\"ks\\":256,\\"ts\\":64,\\"mode\\":\\"ccm\\",\\"adata\\":\\"\\",\\"cipher\\":\\"aes\\",\\"salt\\":\\"54kOXTqJ9mc=\\",\\"ct\\":\\"JF5wQ82wa1dYyFxFlbHCvK4a+A6MTHdhOqc5uXsz2icWhkY2Lin/3Ab8ZwvwDaR1JYKmC/g1gXIGwVZEOl1M/bRHY420h7sDtmTS6Ebse5NWbF0ItfUJlk6HVATGa+C6mkbaVxJ4kQW/ehnT3riqzU069ATPz8E=\\"}"}';
     const readFileStub = sinon.stub(fs.promises, 'readFile').resolves(validPrv);
-    const envStub = sinon
-      .stub(process, 'env')
-      .value({ WALLET_61f039aad587c2000745c687373e0fa9_PASSPHRASE: 'wDX058%c4plL1@pP' });
+    const envStub = sinon.stub(process, 'env').value({ WALLET_61f039aad587c2000745c687373e0fa9_PASSPHRASE: password });
     const signTransactionStub = sinon
       .stub(Coin.Btc.prototype, 'signTransaction')
       .resolves({ txHex: 'signedTx', txRequestId: '' } as SignedTransaction);
 
     const req = {
-      bitgo: new BitGo({ env: 'test' }),
+      bitgo: bitgo,
       body: {
         txPrebuild: {
-          walletId: '61f039aad587c2000745c687373e0fa9',
+          walletId: walletId,
         },
       },
       params: {
@@ -44,11 +74,41 @@ describe('External signer', () => {
     readFileStub.should.be.calledOnceWith('signerFileSystemPath');
     signTransactionStub.should.be.calledOnceWith(
       sinon.match({
-        prv: 'xprv9s21ZrQH143K3EuPWCBuqnWxydaQV6et9htQige4EswvcHKEzNmkVmwTwKoadyHzJYppuADB7Us7AbaNLToNvoFoSxuWqndQRYtnNy5DUY2',
+        prv: secret,
       })
     );
     readFileStub.restore();
     signTransactionStub.restore();
     envStub.restore();
+  });
+
+  it('should accept a local secret and password for a wallet', async () => {
+    const accessToken = '';
+    const walletIds = {
+      tbtc: [
+        {
+          id: walletId,
+          secret,
+          password,
+        },
+      ],
+    };
+
+    const walletResult = {
+      id: walletId,
+      keys: [walletId, walletId, walletId],
+    };
+
+    const keyResult = {
+      id: walletId,
+    };
+
+    nock(bgUrl).get(`/api/v2/tbtc/wallet/${walletId}`).reply(200, walletResult);
+    nock(bgUrl).get(`/api/v2/tbtc/key/${walletId}`).reply(200, keyResult);
+
+    const data = await fetchKeys(walletIds, accessToken);
+
+    should.exist(data[walletId]);
+    data[walletId].should.startWith('{"iv":"');
   });
 });


### PR DESCRIPTION
Users with unencrypted keys using external signing will now be able to
identify and use wallet credentials to manual sign transactions where an
encrypted key is unavailable

BG-54633