### PR TITLE
feat(wp): add acceleration capability for eth

### DIFF
--- a/modules/sdk-coin-eth/src/eth.ts
+++ b/modules/sdk-coin-eth/src/eth.ts
@@ -1626,10 +1626,13 @@ export class Eth extends BaseCoin {
 
   verifyTssTransaction(params: VerifyEthTransactionOptions): boolean {
     const { txParams, txPrebuild, wallet } = params;
-    if (!txParams?.recipients || !wallet || !txPrebuild) {
+    if (!txParams?.recipients && txParams.type !== 'acceleration') {
+      throw new Error(`missing txParams`);
+    }
+    if (!wallet || !txPrebuild) {
       throw new Error(`missing params`);
     }
-    if (txParams.hop && txParams.recipients.length > 1) {
+    if (txParams.hop && txParams.recipients && txParams.recipients.length > 1) {
       throw new Error(`tx cannot be both a batch and hop transaction`);
     }
     return true;

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -59,7 +59,7 @@ export interface PrebuildTransactionWithIntentOptions {
   reqId: IRequestTracer;
   intentType: string;
   sequenceId?: string;
-  recipients: {
+  recipients?: {
     address: string;
     amount: string | number;
     tokenName?: string;
@@ -74,6 +74,7 @@ export interface PrebuildTransactionWithIntentOptions {
   feeOptions?: FeeOption | EIP1559FeeOptions;
   hopParams?: HopParams;
   isTss?: boolean;
+  lowFeeTxid?: string;
 }
 export interface IntentRecipient {
   address: {
@@ -87,7 +88,7 @@ export interface IntentRecipient {
 }
 export interface PopulatedIntent {
   intentType: string;
-  recipients: IntentRecipient[];
+  recipients?: IntentRecipient[];
   sequenceId?: string;
   comment?: string;
   nonce?: string;
@@ -99,6 +100,7 @@ export interface PopulatedIntent {
   feeOptions?: FeeOption | EIP1559FeeOptions;
   hopParams?: HopParams;
   isTss?: boolean;
+  txid?: string;
 }
 
 export type TxRequestState =

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -99,6 +99,9 @@ export interface PrebuildTransactionOptions {
   enableTokens?: TokenEnablement[];
   nonce?: string;
   preview?: boolean;
+  eip1559?: EIP1559;
+  gasLimit?: number;
+  lowFeeTxid?: string;
   isTss?: boolean;
 }
 
@@ -436,6 +439,8 @@ export interface SendManyOptions extends PrebuildAndSignTransactionOptions {
   memo?: Memo;
   transferId?: number;
   [index: string]: unknown;
+  eip1559?: EIP1559;
+  gasLimit?: number;
 }
 
 export type WalletType = 'backing' | 'cold' | 'custodial' | 'custodialPaired' | 'hot' | 'trading';


### PR DESCRIPTION
Add the ability to make tx accelerations for eth through the acceleration intent. Added unit tests

Ticket: bg-53422