### PR TITLE
fix: allow token enablement for cold wallet

### DIFF
--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -2343,9 +2343,8 @@ export class Wallet implements IWallet {
    * Signs and sends a single unsigned token enablement transaction
    * @param params
    * @returns
-   *   - The response from sending the transaction for hot wallets
+   *   - The response from sending the transaction for hot/cold wallets
    *   - The response from initiating the transaction for custodial wallets
-   *   - The included prebuilt transaction for cold wallets
    */
   public async sendTokenEnablement(params: PrebuildAndSignTransactionOptions = {}): Promise<any> {
     const teConfig = this.baseCoin.getTokenEnablementConfig();
@@ -2362,11 +2361,9 @@ export class Wallet implements IWallet {
     } else {
       switch (this._wallet.type) {
         case 'hot':
+        case 'cold':
           const signedPrebuild = await this.prebuildAndSignTransaction(params);
           return await this.submitTransaction(signedPrebuild);
-        case 'cold':
-          // Don't sign or send and just return the built transaction
-          return params.txPrebuild;
         case 'custodial':
           const url = this.baseCoin.url('/wallet/' + this.id() + '/tx/initiate');
           return await this.bitgo.post(url).send(params.prebuildTx.buildParams).result();


### PR DESCRIPTION
Allow signing cold wallet token enablement transactions. For cold wallets users have to pass their private key in plain text format in the request body like `prv: "<prvKey>"`

i.e:

```
  const result = await wallet.sendTokenEnablements({
    enableTokens: [{ name: 'thbar:usdc' }],
    prv: 'prvKey',
  });
```

TICKET: BG-0000