### PR TITLE
feat(btc): keypair

### DIFF
--- a/modules/sdk-coin-btc/src/index.ts
+++ b/modules/sdk-coin-btc/src/index.ts
@@ -1,2 +1,3 @@
 export * from './btc';
 export * from './tbtc';
+export * from './lib';

--- a/modules/sdk-coin-btc/src/lib/index.ts
+++ b/modules/sdk-coin-btc/src/lib/index.ts
@@ -1,0 +1,1 @@
+export { KeyPair } from './keyPair';

--- a/modules/sdk-coin-btc/src/lib/keyPair.ts
+++ b/modules/sdk-coin-btc/src/lib/keyPair.ts
@@ -1,0 +1,108 @@
+import { randomBytes } from 'crypto';
+import * as bip32 from 'bip32';
+import {
+  AddressFormat as BaseAddressFormat,
+  DefaultKeys,
+  isPrivateKey,
+  isPublicKey,
+  isSeed,
+  KeyPairOptions,
+  NotImplementedError,
+  NotSupported,
+  Secp256k1ExtendedKeyPair,
+} from '@bitgo/sdk-core';
+import { address, crypto, networks } from 'bitcoinjs-lib';
+
+const DEFAULT_SEED_SIZE_BYTES = 16;
+const COMPRESSED_PUBLIC_KEY_BYTE_LENGTH = 33;
+
+// TODO: extend the AddressFormat enum in @bitgo/sdk-core with these values
+enum ExtendedAddressFormat {
+  mainnetBech32 = 'mainnetBech32',
+  testnetBech32 = 'testnetBech32',
+  mainnetMultisig = 'mainnetBech32',
+  testnetMultisig = 'testnetBech32',
+}
+
+export type AddressFormatType = BaseAddressFormat | ExtendedAddressFormat;
+export const AddressFormat = { ...BaseAddressFormat, ...ExtendedAddressFormat };
+
+/** Bitcoin key management. */
+export class KeyPair extends Secp256k1ExtendedKeyPair {
+  /**
+   * Public constructor. By default, creates a key pair with a random master seed.
+   *
+   * @param { KeyPairOptions } source Either a master seed, a private key (extended or raw), or a public key
+   *     (extended, compressed, or uncompressed)
+   */
+  constructor(source?: KeyPairOptions) {
+    super(source);
+    if (!source) {
+      const seed = randomBytes(DEFAULT_SEED_SIZE_BYTES);
+      this.hdNode = bip32.fromSeed(seed);
+    } else if (isSeed(source)) {
+      this.hdNode = bip32.fromSeed(source.seed);
+    } else if (isPrivateKey(source)) {
+      this.recordKeysFromPrivateKey(source.prv);
+    } else if (isPublicKey(source)) {
+      this.recordKeysFromPublicKey(source.pub);
+      // TODO: move this to Secp256k1ExtendedKeyPair
+      this.keyPair.compressed = Buffer.from(source.pub, 'hex').length === COMPRESSED_PUBLIC_KEY_BYTE_LENGTH;
+    } else {
+      throw new Error('Invalid key pair options');
+    }
+
+    if (this.hdNode) {
+      this.keyPair = Secp256k1ExtendedKeyPair.toKeyPair(this.hdNode);
+    }
+  }
+
+  /**
+   * Bitcoin uncompressed public and private keys in hex format.
+   *
+   * @returns { DefaultKeys } The keys in the protocol default key format
+   */
+  getKeys(): DefaultKeys {
+    return {
+      pub: this.getPublicKey({ compressed: this.keyPair.compressed }).toString('hex'),
+      prv: this.getPrivateKey()?.toString('hex'),
+    };
+  }
+
+  /**
+   * Get a bitcoin address in legacy or bech32 format.
+   *
+   * @param {AddressFormatType} format One of mainnet, testnet, mainnetBech32, or testnetBech32. mainnetMultisig is not
+   *    supported since it requires multiple key pairs.
+   * @returns {string} The address derived from the public key
+   */
+  getAddress(format?: AddressFormatType): string {
+    const compressed = this.keyPair.compressed;
+    const publicKeyHash160 = crypto.ripemd160(crypto.sha256(this.getPublicKey({ compressed })));
+
+    if (!format) {
+      // Return mainnet legacy addresses by default
+      return address.toBase58Check(publicKeyHash160, networks.bitcoin.pubKeyHash);
+    }
+
+    switch (format) {
+      case AddressFormat.mainnet:
+        return address.toBase58Check(publicKeyHash160, networks.bitcoin.pubKeyHash);
+      case AddressFormat.testnet:
+        return address.toBase58Check(publicKeyHash160, networks.testnet.pubKeyHash);
+      case AddressFormat.mainnetBech32:
+        return address.toBech32(publicKeyHash160, 0, networks.bitcoin.bech32);
+      case AddressFormat.testnetBech32:
+        return address.toBech32(publicKeyHash160, 0, networks.testnet.bech32);
+      case AddressFormat.mainnetMultisig:
+      case AddressFormat.testnetMultisig:
+        throw new NotSupported(
+          'Unsupported address format: ' +
+            format +
+            '. Multisig addresses require multiple key sets and is not supported in the KeyPair class '
+        );
+      default:
+        throw new NotImplementedError('Unsupported address format: ' + format);
+    }
+  }
+}

--- a/modules/sdk-coin-btc/test/unit/fixture/keys.json
+++ b/modules/sdk-coin-btc/test/unit/fixture/keys.json
@@ -1,0 +1,120 @@
+{
+  "valid": [
+    {
+      "d": "0000000000000000000000000000000000000000000000000000000000000001",
+      "Q": "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+      "compressed": true,
+      "network": "bitcoin",
+      "address": "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
+      "WIF": "KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn"
+    },
+    {
+      "d": "0000000000000000000000000000000000000000000000000000000000000001",
+      "Q": "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
+      "compressed": false,
+      "network": "bitcoin",
+      "address": "1EHNa6Q4Jz2uvNExL497mE43ikXhwF6kZm",
+      "WIF": "5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf"
+    },
+    {
+      "d": "2bfe58ab6d9fd575bdc3a624e4825dd2b375d64ac033fbc46ea79dbab4f69a3e",
+      "Q": "02b80011a883a0fd621ad46dfc405df1e74bf075cbaf700fd4aebef6e96f848340",
+      "compressed": true,
+      "network": "bitcoin",
+      "address": "1MasfEKgSiaSeri2C6kgznaqBNtyrZPhNq",
+      "WIF": "KxhEDBQyyEFymvfJD96q8stMbJMbZUb6D1PmXqBWZDU2WvbvVs9o"
+    },
+    {
+      "d": "6c4313b03f2e7324d75e642f0ab81b734b724e13fec930f309e222470236d66b",
+      "Q": "024289801366bcee6172b771cf5a7f13aaecd237a0b9a1ff9d769cabc2e6b70a34",
+      "compressed": true,
+      "network": "bitcoin",
+      "address": "1LwwMWdSEMHJ2dMhSvAHZ3g95tG2UBv9jg",
+      "WIF": "KzrA86mCVMGWnLGBQu9yzQa32qbxb5dvSK4XhyjjGAWSBKYX4rHx"
+    },
+    {
+      "d": "6c4313b03f2e7324d75e642f0ab81b734b724e13fec930f309e222470236d66b",
+      "Q": "044289801366bcee6172b771cf5a7f13aaecd237a0b9a1ff9d769cabc2e6b70a34cec320a0565fb7caf11b1ca2f445f9b7b012dda5718b3cface369ee3a034ded6",
+      "compressed": false,
+      "network": "bitcoin",
+      "address": "1zXcfvKCLgsFdJDYPuqpu1sF3q92tnnUM",
+      "WIF": "5JdxzLtFPHNe7CAL8EBC6krdFv9pwPoRo4e3syMZEQT9srmK8hh"
+    },
+    {
+      "d": "6c4313b03f2e7324d75e642f0ab81b734b724e13fec930f309e222470236d66b",
+      "Q": "024289801366bcee6172b771cf5a7f13aaecd237a0b9a1ff9d769cabc2e6b70a34",
+      "compressed": true,
+      "network": "testnet",
+      "address": "n1TteZiR3NiYojqKAV8fNxtTwsrjM7kVdj",
+      "WIF": "cRD9b1m3vQxmwmjSoJy7Mj56f4uNFXjcWMCzpQCEmHASS4edEwXv"
+    },
+    {
+      "d": "6c4313b03f2e7324d75e642f0ab81b734b724e13fec930f309e222470236d66b",
+      "Q": "044289801366bcee6172b771cf5a7f13aaecd237a0b9a1ff9d769cabc2e6b70a34cec320a0565fb7caf11b1ca2f445f9b7b012dda5718b3cface369ee3a034ded6",
+      "compressed": false,
+      "network": "testnet",
+      "address": "mgWUuj1J1N882jmqFxtDepEC73Rr22E9GU",
+      "WIF": "92Qba5hnyWSn5Ffcka56yMQauaWY6ZLd91Vzxbi4a9CCetaHtYj"
+    },
+    {
+      "d": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+      "Q": "0379be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+      "compressed": true,
+      "network": "bitcoin",
+      "address": "1GrLCmVQXoyJXaPJQdqssNqwxvha1eUo2E",
+      "WIF": "L5oLkpV3aqBjhki6LmvChTCV6odsp4SXM6FfU2Gppt5kFLaHLuZ9"
+    }
+  ],
+  "invalid": {
+    "fromPrivateKey": [
+      {
+        "exception": "Private key not in range \\[1, n\\)",
+        "d": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      {
+        "exception": "Private key not in range \\[1, n\\)",
+        "d": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141"
+      },
+      {
+        "exception": "Private key not in range \\[1, n\\)",
+        "d": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142"
+      }
+    ],
+    "fromPublicKey": [
+      {
+        "exception": "Expected isPoint, got Buffer",
+        "Q": "",
+        "options": {}
+      },
+      {
+        "description": "Bad X coordinate (== P)",
+        "exception": "Expected isPoint, got Buffer",
+        "Q": "040000000000000000000000000000000000000000000000000000000000000001fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+        "options": {}
+      }
+    ],
+    "fromWIF": [
+      {
+        "exception": "Invalid network version",
+        "network": "bitcoin",
+        "WIF": "92Qba5hnyWSn5Ffcka56yMQauaWY6ZLd91Vzxbi4a9CCetaHtYj"
+      },
+      {
+        "exception": "Unknown network version",
+        "WIF": "brQnSed3Fia1w9VcbbS6ZGDgJ6ENkgwuQY2LS7pEC5bKHD1fMF"
+      },
+      {
+        "exception": "Invalid compression flag",
+        "WIF": "KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sfZr2ym"
+      },
+      {
+        "exception": "Invalid WIF length",
+        "WIF": "3tq8Vmhh9SN5XhjTGSWgx8iKk59XbKG6UH4oqpejRuJhfYD"
+      },
+      {
+        "exception": "Invalid WIF length",
+        "WIF": "38uMpGARR2BJy5p4dNFKYg9UsWNoBtkpbdrXDjmfvz8krCtw3T1W92ZDSR"
+      }
+    ]
+  }
+}

--- a/modules/sdk-coin-btc/test/unit/lib/keyPair.ts
+++ b/modules/sdk-coin-btc/test/unit/lib/keyPair.ts
@@ -1,0 +1,116 @@
+import assert from 'assert';
+import should from 'should';
+import { KeyPair } from '../../../src';
+import { AddressFormat } from '../../../src/lib/keyPair';
+
+const fixtures = require('../fixture/keys.json');
+
+describe('BTC Key Pair', () => {
+  describe('should create a valid KeyPair', () => {
+    fixtures.valid
+      .filter((f) => f.network === 'bitcoin')
+      .forEach((f) => {
+        it('from mainnet public key ' + f.Q, () => {
+          const kp = new KeyPair({ pub: f.Q });
+          const address = kp.getAddress(AddressFormat.mainnet);
+          should.equal(address, f.address);
+        });
+      });
+
+    fixtures.valid
+      .filter((f) => f.network === 'testnet')
+      .forEach((f) => {
+        it('from testnet public key ' + f.Q, () => {
+          const kp = new KeyPair({ pub: f.Q });
+          const address = kp.getAddress(AddressFormat.testnet);
+          should.equal(address, f.address);
+        });
+      });
+
+    fixtures.valid
+      .filter((f) => f.network === 'bitcoin')
+      .filter((f) => f.compressed) // Address will be generated using the compressed version of the pub key
+      .forEach((f) => {
+        it('from mainnet private key ' + f.d, () => {
+          const kp = new KeyPair({ prv: f.d });
+          const address = kp.getAddress(AddressFormat.mainnet);
+          should.equal(address, f.address);
+        });
+      });
+
+    fixtures.valid
+      .filter((f) => f.network === 'testnet')
+      .filter((f) => f.compressed) // Address will be generated using the compressed version of the pub key
+      .forEach((f) => {
+        it('from testnet private key ' + f.d, () => {
+          const kp = new KeyPair({ prv: f.d });
+          const address = kp.getAddress(AddressFormat.testnet);
+          should.equal(address, f.address);
+        });
+      });
+
+    it('from an empty value', () => {
+      const kp = new KeyPair();
+
+      const address = kp.getAddress();
+      should.exists(address);
+
+      const keys = kp.getKeys();
+      should.exists(keys.prv);
+      should.exists(keys.pub);
+      should.equal(keys.prv!.length, 64);
+      should.equal(keys.pub.length, 66);
+
+      const extendedKeys = kp.getExtendedKeys();
+      should.exists(extendedKeys.xprv);
+      should.exists(extendedKeys.xpub);
+    });
+
+    it('from an existing uncompressed pub', () => {
+      const kp = new KeyPair({
+        pub: '04c2ebca315e72045af26ab178fd2a943f5b6ed72f55d5c648e6c125d785bba546f131b3c74fa79a078c0ecfb00e006b67c59a91e17874409606f519462464d2a0',
+      });
+
+      const address = kp.getAddress(AddressFormat.testnetBech32);
+      should.exists(address);
+      should.equal(address, 'tb1qlsugvel9v83ugxrc9vqlhpphnhsqzmxhavtcvx');
+
+      const keys = kp.getKeys();
+      should.not.exists(keys.prv);
+      should.exists(keys.pub);
+      should.equal(keys.pub.length, 66);
+    });
+
+    it('from an existing compressed pub', () => {
+      const kp = new KeyPair({
+        pub: '02c2ebca315e72045af26ab178fd2a943f5b6ed72f55d5c648e6c125d785bba546',
+      });
+
+      const address = kp.getAddress(AddressFormat.testnetBech32);
+      should.exists(address);
+      should.equal(address, 'tb1qk48g5mtmqad6tehuf5cyfwgmsfmklqv4fwd6rf');
+
+      const keys = kp.getKeys();
+      should.not.exists(keys.prv);
+      should.exists(keys.pub);
+      should.equal(keys.pub.length, 66);
+    });
+  });
+  describe('should throw', () => {
+    fixtures.invalid.fromPrivateKey.forEach((f) => {
+      it('for an invalid private key when ' + f.exception, () => {
+        assert.throws(() => {
+          new KeyPair({ prv: f.d });
+        });
+      });
+    });
+
+    fixtures.invalid.fromPublicKey.forEach((f) => {
+      it('for an invalid public key when ' + f.exception, () => {
+        assert.throws(() => {
+          new KeyPair({ pub: f.Q });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Add a KeyPair class for BTC with identical behavior to the account-based coins in an effort to generalize key management across assets.