### PR TITLE
chore: update express build package scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "dev": "tsc -b ./tsconfig.packages.json -w",
     "prepare": "husky install",
     "sdk-coin:new": "yo ./scripts/sdk-coin-generator && yarn update-dockerfile",
-    "build-docker-express": "yarn update-dockerfile && docker build -t bitgosdk/express:latest -t bitgosdk/express:$(jq -r .version < modules/express/package.json) .",
+    "build-docker-express": "yarn update-dockerfile && docker build --platform=linux/amd64 -t bitgosdk/express:latest -t bitgosdk/express:$(jq -r .version < modules/express/package.json) .",
     "push-docker-express": "docker push bitgosdk/express:latest bitgosdk/express:$(jq -r .version < modules/express/package.json)",
     "update-dockerfile": "ts-node scripts/update-dockerfile.ts",
     "precommit": "lint-staged"


### PR DESCRIPTION
Update root command to match `express` package command in scripts.

BG-000000