### PR TITLE
chore(root): disable closing issues for being stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,11 +14,8 @@ jobs:
       - uses: actions/stale@v4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
-          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
           close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
-          days-before-issue-stale: 30
+          days-before-issue-stale: -1
           days-before-pr-stale: 45
-          days-before-issue-close: 5
           days-before-pr-close: 10


### PR DESCRIPTION
This is very unfriendly for users who report longer term issues.

We don't have so many issues that we need to close them for being stale
automatically. Let's make sure we're handling all relevant issues
reported by users and closing them with fixes instead of timeouts.

See https://github.com/BitGo/BitGoJS/issues/1631#issuecomment-1223440714

Ticket: BG-55730