### PR TITLE
feat(sdk-coin-ada): add getfee to transaction class

### DIFF
--- a/modules/sdk-coin-ada/src/lib/transaction.ts
+++ b/modules/sdk-coin-ada/src/lib/transaction.ts
@@ -37,6 +37,7 @@ export interface TxData {
 
 export class Transaction extends BaseTransaction {
   private _transaction: CardanoWasm.Transaction;
+  private _fee: string;
 
   constructor(coinConfig: Readonly<CoinConfig>) {
     super(coinConfig);
@@ -151,6 +152,7 @@ export class Transaction extends BaseTransaction {
       this._transaction = txn;
       this._id = Buffer.from(CardanoWasm.hash_transaction(txn.body()).to_bytes()).toString('hex');
       this._type = TransactionType.Send;
+      this._fee = txn.body().fee().to_str();
       this.loadInputsAndOutputs();
     } catch (e) {
       throw new InvalidTransactionError('unable to build transaction from raw');
@@ -179,7 +181,23 @@ export class Transaction extends BaseTransaction {
       outputAmount: outputAmount,
       changeOutputs: [],
       changeAmount: '0',
-      fee: { fee: '0' },
+      fee: { fee: this._fee },
     };
+  }
+
+  /**
+   * Get transaction fee
+   */
+  get getFee(): string {
+    return this._fee;
+  }
+
+  /**
+   * Set transaction fee
+   *
+   * @param fee
+   */
+  fee(fee: string) {
+    this._fee = fee;
   }
 }

--- a/modules/sdk-coin-ada/test/unit/ada.ts
+++ b/modules/sdk-coin-ada/test/unit/ada.ts
@@ -55,7 +55,7 @@ describe('ADA', function () {
       },
     ],
     fee: {
-      fee: '0',
+      fee: '167173',
     },
   };
 

--- a/modules/sdk-coin-ada/test/unit/transaction.ts
+++ b/modules/sdk-coin-ada/test/unit/transaction.ts
@@ -51,7 +51,7 @@ describe('ADA Transaction', () => {
       explain.outputAmount.should.equal('253329150');
       explain.outputs[0].amount.should.equal(resources.rawTx.outputAddress1.value);
       explain.outputs[0].address.should.equal(resources.rawTx.outputAddress1.address);
-      explain.fee.fee.should.equal('0');
+      explain.fee.fee.should.equal('167085');
       explain.changeAmount.should.equal('0');
     });
 

--- a/modules/sdk-coin-ada/test/unit/transactionBuilder.ts
+++ b/modules/sdk-coin-ada/test/unit/transactionBuilder.ts
@@ -4,6 +4,7 @@ import * as testData from '../resources';
 import { TransactionBuilderFactory, KeyPair } from '../../src';
 import { coins } from '@bitgo/statics';
 import * as CardanoWasm from '@emurgo/cardano-serialization-lib-nodejs';
+import { Transaction } from '../../src/lib/transaction';
 
 describe('ADA Transaction Builder', async () => {
   const factory = new TransactionBuilderFactory(coins.get('tada'));
@@ -62,8 +63,8 @@ describe('ADA Transaction Builder', async () => {
     txBuilder.changeAddress(testData.address.address2, '1000000000');
     txBuilder.ttl(800000000);
     txBuilder.sign({ key: testData.privateKeys.prvKey4 });
-    await txBuilder.build();
-    txBuilder.getFee.should.equal('168405');
+    const builtTx = (await txBuilder.build()) as Transaction;
+    builtTx.getFee.should.equal('168405');
   });
 
   it('should add a change address and a change output', async () => {
@@ -113,4 +114,93 @@ describe('ADA Transaction Builder', async () => {
     const sig2 = Buffer.from(keyPair.signMessage(txRaw)).toString('hex');
     should.equal(sig1, sig2);
   });
+
+  // NOTE: The two tests below have been commented out as they are for testing during development changes. We don't
+  // want full node tests as part of our sdk unit tests. If you are commenting these back in, add axios and
+  // AddressFormat imports.
+  // it('should submit a transaction', async () => {
+  //   const keyPair = new KeyPair({prv: testData.privateKeys.prvKey4});
+  //   const senderAddress = keyPair.getAddress(AddressFormat.testnet);
+  //
+  //   const axiosConfig = {
+  //     headers: {
+  //       'Content-Type': 'application/cbor',
+  //     },
+  //     timeout: 10000,
+  //   };
+  //
+  //   const txBuilder = factory.getTransferBuilder();
+  //   const utxoData = await axios.get('https://testnet.koios.rest/api/v0/address_info?_address=' + senderAddress);
+  //   const senderBalance = utxoData.data[0].balance;
+  //   txBuilder.changeAddress(senderAddress, senderBalance);
+  //   const utxoSet = utxoData.data[0].utxo_set;
+  //   for (const utxo of utxoSet) {
+  //     txBuilder.input({ transaction_id: utxo.tx_hash, transaction_index: utxo.tx_index });
+  //   }
+  //
+  //   txBuilder.output({
+  //     address:
+  //       'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp',
+  //     amount: '5000000',
+  //   });
+  //
+  //   txBuilder.ttl(800000000);
+  //   txBuilder.sign({ key: keyPair.getKeys().prv });
+  //
+  //   const tx = await txBuilder.build();
+  //   const serializedTx = tx.toBroadcastFormat();
+  //   const bytes = Uint8Array.from(Buffer.from(serializedTx, 'hex'));
+  //
+  //   try {
+  //     const res = await axios.post("https://testnet.koios.rest/api/v0/submittx", bytes, axiosConfig)
+  //     console.log(res.data);
+  //   } catch (err) {
+  //     console.log(err);
+  //   }
+  // });
+
+  // it('should submit a transaction using signature interface', async () => {
+  //   const keyPair = new KeyPair({prv: testData.privateKeys.prvKey4});
+  //   const senderAddress = keyPair.getAddress(AddressFormat.testnet);
+  //   const axiosConfig = {
+  //     headers: {
+  //       'Content-Type': 'application/cbor',
+  //     },
+  //     timeout: 10000,
+  //   };
+  //   const txBuilder = factory.getTransferBuilder();
+  //   const utxoData = await await axios.get('https://testnet.koios.rest/api/v0/address_info?_address=' + senderAddress);
+  //   const senderBalance = utxoData.data[0].balance;
+  //   txBuilder.changeAddress(senderAddress, senderBalance);
+  //   const utxoSet = utxoData.data[0].utxo_set;
+  //   for (const utxo of utxoSet) {
+  //     txBuilder.input({ transaction_id: utxo.tx_hash, transaction_index: utxo.tx_index });
+  //   }
+  //   txBuilder.output({
+  //     address:
+  //       'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp',
+  //     amount: '5000000',
+  //   });
+  //
+  //   txBuilder.ttl(800000000);
+  //
+  //   const unsignedTx = await txBuilder.build();
+  //   const serializedTx = unsignedTx.toBroadcastFormat();
+  //
+  //   const txBuilder2 = factory.from(serializedTx);
+  //   const tx = await txBuilder2.build();
+  //   const signableHex = tx.signablePayload.toString('hex');
+  //   const signature = keyPair.signMessage(signableHex);
+  //   txBuilder2.addSignature({ pub: keyPair.getKeys().pub }, Buffer.from(signature));
+  //   const signedTransaction = await txBuilder2.build();
+  //   const serializedTransaction = signedTransaction.toBroadcastFormat();
+  //   const bytes = Uint8Array.from(Buffer.from(serializedTransaction, 'hex'));
+  //
+  //   try {
+  //     const res = await axios.post('https://testnet.koios.rest/api/v0/submittx', bytes, axiosConfig);
+  //     console.log(res.data);
+  //   } catch (err) {
+  //     console.log(err);
+  //   }
+  // });
 });


### PR DESCRIPTION
Add transaction fee and getFee to transaction class. The transaction fee and getFee were then de-duplicated from the transaction builder class. Tests were updated accordingly to reflect changes. 

TICKET: [BG-55867](https://bitgoinc.atlassian.net/browse/BG-55867?atlOrigin=eyJpIjoiNzhlNjIyMjFjZTUxNDlhYjkxZjFhYmY3YWExYzA2YTkiLCJwIjoiaiJ9)