### PR TITLE
refactor(account-lib): modify random gen for nu0 and beta0

### DIFF
--- a/modules/sdk-core/package.json
+++ b/modules/sdk-core/package.json
@@ -40,6 +40,7 @@
     "@noble/secp256k1": "1.6.0",
     "@stablelib/hex": "^1.0.0",
     "big.js": "^3.1.3",
+    "bigint-crypto-utils": "3.1.4",
     "bignumber.js": "^9.0.0",
     "bip32": "^3.0.1",
     "bitcoinjs-message": "^2.0.0",

--- a/modules/sdk-core/src/account-lib/mpc/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/account-lib/mpc/tss/ecdsa/ecdsa.ts
@@ -1,4 +1,5 @@
 import * as paillierBigint from 'paillier-bigint';
+import * as bigintCryptoUtils from 'bigint-crypto-utils';
 import * as secp from '@noble/secp256k1';
 import { randomBytes, createHash } from 'crypto';
 import { hexToBigInt } from '../../../util/crypto';
@@ -28,6 +29,9 @@ import {
   XShare,
   YShare,
 } from './types';
+
+const _1n = BigInt(1);
+const _3n = BigInt(3);
 
 /**
  * ECDSA TSS implementation supporting 2:n Threshold
@@ -225,15 +229,17 @@ export default class Ecdsa {
       let pk = getPaillierPublicKey(n);
       const k = hexToBigInt(shareToBeSend['k']);
 
-      const beta0 = Ecdsa.curve.scalarRandom();
-      shareParticipant.beta = bigIntToBufferBE(Ecdsa.curve.scalarReduce(Ecdsa.curve.scalarNegate(beta0)), 32).toString(
+      const beta0 = bigintCryptoUtils.randBetween(n / _3n - _1n);
+      shareParticipant.beta = bigIntToBufferBE(Ecdsa.curve.scalarNegate(Ecdsa.curve.scalarReduce(beta0)), 32).toString(
         'hex'
       );
       const alpha = pk.addition(pk.multiply(k, hexToBigInt(shareParticipant.gamma)), pk.encrypt(beta0));
       shareToBeSend.alpha = bigIntToBufferBE(alpha, 32).toString('hex');
 
-      const nu0 = Ecdsa.curve.scalarRandom();
-      shareParticipant.nu = bigIntToBufferBE(Ecdsa.curve.scalarNegate(nu0), 32).toString('hex');
+      const nu0 = bigintCryptoUtils.randBetween(n / _3n - _1n);
+      shareParticipant.nu = bigIntToBufferBE(Ecdsa.curve.scalarNegate(Ecdsa.curve.scalarReduce(nu0)), 32).toString(
+        'hex'
+      );
       const mu = pk.addition(pk.multiply(k, hexToBigInt(shareParticipant.w)), pk.encrypt(nu0));
       shareToBeSend.mu = bigIntToBufferBE(mu, 32).toString('hex');
       if (shareParticipant['alpha']) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5397,7 +5397,7 @@ bigint-buffer@^1.1.5:
   dependencies:
     bindings "^1.3.0"
 
-bigint-crypto-utils@^3.0.17:
+bigint-crypto-utils@3.1.4, bigint-crypto-utils@^3.0.17:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/bigint-crypto-utils/-/bigint-crypto-utils-3.1.4.tgz#b00aa00eb792b14f2f71ead916105c17aac98a4c"
   integrity sha512-niSkvARUEe8MiAiH+zKXPkgXzlvGDbOqXL3JDevWaA1TrPhUGSCgV+iedm8qMEBQwvSlMMn8GpSuoUjvsm2QfQ==


### PR DESCRIPTION
this change expands the random number
range for nuo and beta0 in ecdsa tss
to be within [1:n] where n is maxint
of paillier keys

TICKET: BG-55963