### PR TITLE
feat(express): Version 1 of external signer TSS support

### DIFF
--- a/modules/express/test/unit/clientRoutes/externalSign.ts
+++ b/modules/express/test/unit/clientRoutes/externalSign.ts
@@ -2,7 +2,7 @@
  * @prettier
  */
 
-import { common } from '@bitgo/sdk-core';
+import { common, Ed25519BIP32, Eddsa, HDTree, SignatureShareType, ShareKeyPosition } from '@bitgo/sdk-core';
 import { TestBitGo, TestBitGoAPI } from '@bitgo/sdk-test';
 import * as should from 'should';
 import * as sinon from 'sinon';
@@ -12,16 +12,22 @@ import 'should-sinon';
 import '../../lib/asserts';
 
 import * as express from 'express';
-import { handleV2Sign } from '../../../src/clientRoutes';
+import { handleV2GenerateShareTSS, handleV2Sign } from '../../../src/clientRoutes';
 import { fetchKeys } from '../../../src/fetchEncryptedPrivKeys';
 import * as fs from 'fs';
 import { Coin, BitGo, SignedTransaction } from 'bitgo';
 import * as nock from 'nock';
 nock.restore();
 
+type Output = {
+  [key: string]: string;
+};
+
 describe('External signer', () => {
   let bitgo: TestBitGoAPI;
   let bgUrl;
+  let MPC: Eddsa;
+  let hdTree: HDTree;
 
   const walletId = '61f039aad587c2000745c687373e0fa9';
   const secret =
@@ -30,7 +36,7 @@ describe('External signer', () => {
   const validPrv =
     '{"61f039aad587c2000745c687373e0fa9":"{\\"iv\\":\\"+1u1Y9cvsYuRMeyH2slnXQ==\\",\\"v\\":1,\\"iter\\":10000,\\"ks\\":256,\\"ts\\":64,\\"mode\\":\\"ccm\\",\\"adata\\":\\"\\",\\"cipher\\":\\"aes\\",\\"salt\\":\\"54kOXTqJ9mc=\\",\\"ct\\":\\"JF5wQ82wa1dYyFxFlbHCvK4a+A6MTHdhOqc5uXsz2icWhkY2Lin/3Ab8ZwvwDaR1JYKmC/g1gXIGwVZEOl1M/bRHY420h7sDtmTS6Ebse5NWbF0ItfUJlk6HVATGa+C6mkbaVxJ4kQW/ehnT3riqzU069ATPz8E=\\"}"}';
 
-  before(function () {
+  before(async function () {
     if (!nock.isActive()) {
       nock.activate();
     }
@@ -39,6 +45,8 @@ describe('External signer', () => {
     bitgo.initializeTestVars();
 
     bgUrl = common.Environments[bitgo.getEnv()].uri;
+    hdTree = await Ed25519BIP32.initialize();
+    MPC = await Eddsa.initialize(hdTree);
   });
 
   after(() => {
@@ -79,6 +87,105 @@ describe('External signer', () => {
     );
     readFileStub.restore();
     signTransactionStub.restore();
+    envStub.restore();
+  });
+  it('should read an encrypted prv from signerFileSystemPath and pass it to R and G share generators', async () => {
+    const walletID = '62fe536a6b4cf70007acb48c0e7bb0b0';
+    const user = MPC.keyShare(1, 2, 3);
+    const backup = MPC.keyShare(2, 2, 3);
+    const bitgo = MPC.keyShare(3, 2, 3);
+    const userSigningMaterial = {
+      uShare: user.uShare,
+      bitgoYShare: bitgo.yShares[1],
+      backupYShare: backup.yShares[1],
+    };
+    const bg = new BitGo({ env: 'test' });
+    const walletPassphrase = 'testPass';
+    const validPrv = bg.encrypt({ input: JSON.stringify(userSigningMaterial), password: walletPassphrase });
+    const output: Output = {};
+    output[walletID] = validPrv;
+    const readFileStub = sinon.stub(fs.promises, 'readFile').resolves(JSON.stringify(output));
+    const envStub = sinon
+      .stub(process, 'env')
+      .value({ WALLET_62fe536a6b4cf70007acb48c0e7bb0b0_PASSPHRASE: walletPassphrase });
+    const tMessage = 'testMessage';
+    const bgTest = new BitGo({ env: 'test' });
+    const reqR = {
+      bitgo: bgTest,
+      body: {
+        txRequest: {
+          apiVersion: 'full',
+          walletId: walletID,
+          transactions: [
+            {
+              unsignedTx: {
+                derivationPath: 'm/0',
+                signableHex: tMessage,
+              },
+            },
+          ],
+        },
+      },
+      params: {
+        coin: 'tsol',
+        sharetype: 'R',
+      },
+      config: {
+        signerFileSystemPath: 'signerFileSystemPath',
+      },
+    } as unknown as express.Request;
+    const result = await handleV2GenerateShareTSS(reqR);
+    const bitgoCombine = MPC.keyCombine(bitgo.uShare, [result.signingKeyYShare, backup.yShares[3]]);
+    const bitgoSignShare = MPC.signShare(Buffer.from(tMessage, 'hex'), bitgoCombine.pShare, [bitgoCombine.jShares[1]]);
+    const signatureShareRec = {
+      from: SignatureShareType.BITGO,
+      to: SignatureShareType.USER,
+      share: bitgoSignShare.rShares[1].r + bitgoSignShare.rShares[1].R,
+    };
+    const reqG = {
+      bitgo: bgTest,
+      body: {
+        txRequest: {
+          apiVersion: 'full',
+          walletId: walletID,
+          transactions: [
+            {
+              unsignedTx: {
+                derivationPath: 'm/0',
+                signableHex: tMessage,
+              },
+            },
+          ],
+        },
+        userToBitgoRShare: result.rShare,
+        bitgoToUserRShare: signatureShareRec,
+      },
+      params: {
+        coin: 'tsol',
+        sharetype: 'G',
+      },
+      config: {
+        signerFileSystemPath: 'signerFileSystemPath',
+      },
+    } as unknown as express.Request;
+    const userGShare = await handleV2GenerateShareTSS(reqG);
+    const userToBitgoRShare = {
+      i: ShareKeyPosition.BITGO,
+      j: ShareKeyPosition.USER,
+      u: result.signingKeyYShare.u,
+      r: result.rShare.rShares[3].r,
+      R: result.rShare.rShares[3].R,
+    };
+    const bitgoGShare = MPC.sign(
+      Buffer.from(tMessage, 'hex'),
+      bitgoSignShare.xShare,
+      [userToBitgoRShare],
+      [backup.yShares[3]]
+    );
+    const signature = MPC.signCombine([userGShare, bitgoGShare]);
+    const veriResult = MPC.verify(Buffer.from(tMessage, 'hex'), signature);
+    veriResult.should.be.true();
+    readFileStub.restore();
     envStub.restore();
   });
 

--- a/modules/sdk-core/src/bitgo/tss/common.ts
+++ b/modules/sdk-core/src/bitgo/tss/common.ts
@@ -38,10 +38,11 @@ export async function sendSignatureShare(
   txRequestId: string,
   signatureShare: SignatureShareRecord,
   signerShare?: string,
-  mpcAlgorithm: 'eddsa' | 'ecdsa' = 'eddsa'
+  mpcAlgorithm: 'eddsa' | 'ecdsa' = 'eddsa',
+  apiMode: 'full' | 'lite' = 'lite'
 ): Promise<SignatureShareRecord> {
   let transactions = '';
-  if (mpcAlgorithm === 'ecdsa') {
+  if (mpcAlgorithm === 'ecdsa' || apiMode === 'full') {
     transactions = '/transactions/0';
   }
 

--- a/modules/sdk-core/src/bitgo/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/bitgo/tss/eddsa/eddsa.ts
@@ -156,7 +156,8 @@ export async function offerUserToBitgoRShare(
   walletId: string,
   txRequestId: string,
   userSignShare: SignShare,
-  encryptedSignerShare: string
+  encryptedSignerShare: string,
+  apiMode: 'full' | 'lite' = 'lite'
 ): Promise<void> {
   const rShare: RShare = userSignShare.rShares[ShareKeyPosition.BITGO];
   if (_.isNil(rShare)) {
@@ -170,8 +171,7 @@ export async function offerUserToBitgoRShare(
     to: SignatureShareType.BITGO,
     share: rShare.r + rShare.R,
   };
-
-  await sendSignatureShare(bitgo, walletId, txRequestId, signatureShare, encryptedSignerShare);
+  await sendSignatureShare(bitgo, walletId, txRequestId, signatureShare, encryptedSignerShare, 'eddsa', apiMode);
 }
 
 /**
@@ -216,7 +216,8 @@ export async function sendUserToBitgoGShare(
   bitgo: BitGoBase,
   walletId: string,
   txRequestId: string,
-  userToBitgoGShare: GShare
+  userToBitgoGShare: GShare,
+  apiMode: 'full' | 'lite' = 'lite'
 ): Promise<void> {
   if (userToBitgoGShare.i !== ShareKeyPosition.USER) {
     throw new Error('Invalid GShare, doesnt belong to the User');
@@ -227,7 +228,7 @@ export async function sendUserToBitgoGShare(
     share: userToBitgoGShare.R + userToBitgoGShare.gamma,
   };
 
-  await sendSignatureShare(bitgo, walletId, txRequestId, signatureShare);
+  await sendSignatureShare(bitgo, walletId, txRequestId, signatureShare, undefined, 'eddsa', apiMode);
 }
 
 /**

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
@@ -8,6 +8,8 @@ import { IWallet } from '../../wallet';
 import { MpcUtils } from '../mpcUtils';
 import * as _ from 'lodash';
 import {
+  CustomGShareGeneratingFunction,
+  CustomRShareGeneratingFunction,
   ITssUtils,
   PrebuildTransactionWithIntentOptions,
   SignatureShareRecord,
@@ -15,6 +17,7 @@ import {
   TxRequest,
   TxRequestVersion,
 } from './baseTypes';
+import { SignShare, YShare, GShare } from '../../../account-lib/mpc/tss/eddsa/types';
 
 /**
  * BaseTssUtil class which different signature schemes have to extend
@@ -78,6 +81,54 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
   }
 
   signTxRequestForMessage(params: TSSParams): Promise<TxRequest> {
+    throw new Error('Method not implemented.');
+  }
+
+  /**
+   * Signs a transaction using TSS for EdDSA and through utilization of custom share generators
+   *
+   * @param {string | TxRequest} txRequest - transaction request with unsigned transaction
+   * @param {CustomRShareGeneratingFunction} externalSignerRShareGenerator a function that creates R shares in the EdDSA TSS flow
+   * @param {CustomGShareGeneratingFunction} externalSignerGShareGenerator a function that creates G shares in the EdDSA TSS flow
+   * @returns {Promise<TxRequest>} - a signed tx request
+   */
+  signUsingExternalSigner(
+    txRequest: string | TxRequest,
+    externalSignerRShareGenerator: CustomRShareGeneratingFunction,
+    externalSignerGShareGenerator: CustomGShareGeneratingFunction
+  ): Promise<TxRequest> {
+    throw new Error('Method not implemented.');
+  }
+
+  /**
+   * Create an R (User to BitGo) share from an unsigned transaction and private user signing material
+   *
+   * @param {TxRequest} txRequest - transaction request with unsigned transaction
+   * @param {string} prv - user signing material
+   * @returns {Promise<{ rShare: SignShare; signingKeyYShare: YShare }>} - R Share and the Signing Key's Y share to BitGo
+   */
+  createRShareFromTxRequest(params: {
+    txRequest: TxRequest;
+    prv: string;
+  }): Promise<{ rShare: SignShare; signingKeyYShare: YShare }> {
+    throw new Error('Method not implemented.');
+  }
+
+  /**
+   * Create a G (User to BitGo) share from an unsigned transaction and private user signing material
+   *
+   * @param {TxRequest} txRequest - transaction request with unsigned transaction
+   * @param {string} prv - user signing material
+   * @param {SignatureShareRecord} bitgoToUserRShare - BitGo to User R Share
+   * @param {SignShare} userToBitgoRShare - User to BitGo R Share
+   * @returns {Promise<GShare>} - GShare from User to BitGo
+   */
+  createGShareFromTxRequest(params: {
+    txRequest: TxRequest;
+    prv: string;
+    bitgoToUserRShare: SignatureShareRecord;
+    userToBitgoRShare: SignShare;
+  }): Promise<GShare> {
     throw new Error('Method not implemented.');
   }
 

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -12,7 +12,7 @@ import { Keychain } from '../keychain';
 import { IPendingApproval, PendingApprovalData } from '../pendingApproval';
 import { IStakingWallet } from '../staking';
 import { ITradingAccount } from '../trading';
-import { TokenEnablement } from '../utils';
+import { CustomGShareGeneratingFunction, CustomRShareGeneratingFunction, TokenEnablement } from '../utils';
 import { ILightning } from '../lightning';
 
 export interface MaximumSpendableOptions {
@@ -122,6 +122,7 @@ export interface WalletSignBaseOptions {
   reqId?: IRequestTracer;
   prv?: string;
   pubs?: string[];
+  txRequestId?: string;
   cosignerPub?: string;
   isLastSignature?: boolean;
   customSigningFunction?: CustomSigningFunction;
@@ -129,6 +130,8 @@ export interface WalletSignBaseOptions {
 
 export interface WalletSignTransactionOptions extends WalletSignBaseOptions {
   txPrebuild?: TransactionPrebuild;
+  customRShareGeneratingFunction?: CustomRShareGeneratingFunction;
+  customGShareGeneratingFunction?: CustomGShareGeneratingFunction;
   [index: string]: unknown;
 }
 

--- a/modules/sdk-core/src/index.ts
+++ b/modules/sdk-core/src/index.ts
@@ -4,5 +4,8 @@ export * from './api';
 export * from './bitgo';
 export * from './bitgojsError';
 export * as coins from './coins';
+import { EddsaUtils } from './bitgo/utils/tss/eddsa/eddsa';
+export { EddsaUtils };
+export { GShare, SignShare, YShare } from './account-lib/mpc/tss/eddsa/types';
 import * as common from './common';
 export { common };


### PR DESCRIPTION
The purpose of this PR is to add support for TSS EdDSA signing through using the external signer. In summary, the approach taken is as follows:

External signer is responsible for generating R and G shares destined to BitGo. This is achieved by refactoring the existing code that performs TSS for EdDSA signing. Through modularization of R and G share generation we can now have the external signer call the separate modules according to the current step in TSS signing.

Please refer to this link for the multisig endpoint for signing at external signer: https://github.com/BitGo/BitGoJS/blob/997dcfb5bc2812a56459c19b2613a8ee32bcee91/modules/express/src/clientRoutes.ts#L385