### PR TITLE
fix(sdk-coin-sol): added missing member to export

### DIFF
--- a/modules/sdk-coin-sol/src/lib/index.ts
+++ b/modules/sdk-coin-sol/src/lib/index.ts
@@ -6,6 +6,7 @@ export { Transaction } from './transaction';
 export { TransactionBuilder } from './transactionBuilder';
 export { TransactionBuilderFactory } from './transactionBuilderFactory';
 export { TransferBuilder } from './transferBuilder';
+export { TransferBuilderV2 } from './transferBuilderV2';
 export { TokenTransferBuilder } from './tokenTransferBuilder';
 export { WalletInitializationBuilder } from './walletInitializationBuilder';
 export { AtaInitializationBuilder } from './ataInitializationBuilder';


### PR DESCRIPTION
Ticket: BG-00000

was missing exporting TransferBuilderV2 in `index.ts`, needed for sol token consolidation