### PR TITLE
chore: use the same version of @solana/web3 that spl-token depends on

### DIFF
--- a/modules/account-lib/package.json
+++ b/modules/account-lib/package.json
@@ -51,7 +51,7 @@
     "bs58": "^4.0.1"
   },
   "devDependencies": {
-    "@solana/web3.js": "1.31.0",
+    "@solana/web3.js": "1.56.0",
     "@types/bs58": "^4.0.1",
     "@types/keccak": "^3.0.1",
     "keccak": "3.0.2",

--- a/modules/sdk-coin-sol/package.json
+++ b/modules/sdk-coin-sol/package.json
@@ -43,7 +43,7 @@
     "@bitgo/sdk-core": "^1.1.0",
     "@bitgo/statics": "^7.0.0",
     "@solana/spl-token": "0.3.1",
-    "@solana/web3.js": "1.31.0",
+    "@solana/web3.js": "1.56.0",
     "bignumber.js": "^9.0.0",
     "bs58": "^4.0.1",
     "lodash": "^4.17.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1636,7 +1636,7 @@
     "@ethersproject/bytes" "^5.6.1"
     "@ethersproject/logger" "^5.6.0"
 
-"@ethersproject/sha2@5.6.1", "@ethersproject/sha2@^5.5.0", "@ethersproject/sha2@^5.6.1":
+"@ethersproject/sha2@5.6.1", "@ethersproject/sha2@^5.6.1":
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.6.1.tgz#211f14d3f5da5301c8972a8827770b6fd3e51656"
   integrity sha512-5K2GyqcW7G4Yo3uenHegbXRPDgARpWUiXc6RiF7b6i/HXUoWlb7uCARh7BAHg7/qT/Q5ydofNwiZcim9qpjB6g==
@@ -3469,13 +3469,6 @@
     bigint-buffer "^1.1.5"
     bignumber.js "^9.0.1"
 
-"@solana/buffer-layout@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@solana/buffer-layout/-/buffer-layout-3.0.0.tgz#b9353caeb9a1589cb77a1b145bcb1a9a93114326"
-  integrity sha512-MVdgAKKL39tEs0l8je0hKaXLQFb7Rdfb0Xg2LjFZd8Lfdazkg6xiS98uAZrEKvaoF3i4M95ei9RydkGIDMeo3w==
-  dependencies:
-    buffer "~6.0.3"
-
 "@solana/buffer-layout@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@solana/buffer-layout/-/buffer-layout-4.0.0.tgz#75b1b11adc487234821c81dfae3119b73a5fd734"
@@ -3492,27 +3485,7 @@
     "@solana/buffer-layout-utils" "^0.2.0"
     "@solana/web3.js" "^1.41.0"
 
-"@solana/web3.js@1.31.0":
-  version "1.31.0"
-  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.31.0.tgz#7a313d4c1a90b77f27ddbfe845a10d6883e06452"
-  integrity sha512-7nHHx1JNFnrt15e9y8m38I/EJCbaB+bFC3KZVM1+QhybCikFxGMtGA5r7PDC3GEL1R2RZA8yKoLkDKo3vzzqnw==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@ethersproject/sha2" "^5.5.0"
-    "@solana/buffer-layout" "^3.0.0"
-    bn.js "^5.0.0"
-    borsh "^0.4.0"
-    bs58 "^4.0.1"
-    buffer "6.0.1"
-    cross-fetch "^3.1.4"
-    jayson "^3.4.4"
-    js-sha3 "^0.8.0"
-    rpc-websockets "^7.4.2"
-    secp256k1 "^4.0.2"
-    superstruct "^0.14.2"
-    tweetnacl "^1.0.0"
-
-"@solana/web3.js@^1.32.0", "@solana/web3.js@^1.41.0":
+"@solana/web3.js@1.56.0", "@solana/web3.js@^1.32.0", "@solana/web3.js@^1.41.0":
   version "1.56.0"
   resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.56.0.tgz#312bccde0ddeeffa7a48af16a945cc4d1f863395"
   integrity sha512-YfQAIvsllVP3Y5QSs/TdJJFwTgFQuXybg+ouwyNE8cmq3+r2Nmvsj69DGWGbN41jy0is8foZf0yruuLQfWxOmQ==
@@ -5661,16 +5634,6 @@ boolbase@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
-
-borsh@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/borsh/-/borsh-0.4.0.tgz#9dd6defe741627f1315eac2a73df61421f6ddb9f"
-  integrity sha512-aX6qtLya3K0AkT66CmYWCCDr77qsE9arV05OmdFpmat9qu8Pg9J5tBUPDztAW5fNh/d/MyVG/OYziP52Ndzx1g==
-  dependencies:
-    "@types/bn.js" "^4.11.5"
-    bn.js "^5.0.0"
-    bs58 "^4.0.0"
-    text-encoding-utf-8 "^1.0.2"
 
 borsh@^0.6.0:
   version "0.6.0"
@@ -14718,7 +14681,7 @@ rlp@^2.0.0, rlp@^2.2.3, rlp@^2.2.4:
   dependencies:
     bn.js "^5.2.0"
 
-rpc-websockets@^7.4.2, rpc-websockets@^7.5.0:
+rpc-websockets@^7.5.0:
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/rpc-websockets/-/rpc-websockets-7.5.0.tgz#bbeb87572e66703ff151e50af1658f98098e2748"
   integrity sha512-9tIRi1uZGy7YmDjErf1Ax3wtqdSSLIlnmL5OtOzgd5eqPKbsPpwDP5whUDO2LQay3Xp0CcHlcNSGzacNRluBaQ==
@@ -16406,7 +16369,7 @@ tweetnacl-util@^0.15.0:
   resolved "https://registry.yarnpkg.com/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz#b80fcdb5c97bcc508be18c44a4be50f022eea00b"
   integrity sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==
 
-tweetnacl@1.x.x, tweetnacl@^1.0.0, tweetnacl@^1.0.1, tweetnacl@^1.0.3:
+tweetnacl@1.x.x, tweetnacl@^1.0.1, tweetnacl@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
   integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==


### PR DESCRIPTION
older versions of @solana/web3 pulls in a broken version of
@solana/buffer-layout.

this updates it so buffer-layout uses ^4.0.0

Ticket: BG-56444

Fix / Context: https://github.com/solana-labs/solana-program-library/issues/2683
This causes an error in Lumina after bumping dependencies:
```
runtime.js:39 Uncaught TypeError: fields must be array of Layout instances
    at new Structure (Layout.js?3cb5:999:1)
    at exports.struct (Layout.js?3cb5:2373:1)
    at eval (multisig.js?5689:18:1)
    at ../client-dashboard-shared/node_modules/@solana/spl-token/lib/cjs/state/multisig.js (npm.solana.js:1018:1)
    at __webpack_require__ (runtime.js:36:33)
    at fn (runtime.js:423:21)
    at eval (account.js?7c6a:17:1)
    at ../client-dashboard-shared/node_modules/@solana/spl-token/lib/cjs/state/account.js (npm.solana.js:988:1)
    at __webpack_require__ (runtime.js:36:33)
    at fn (runtime.js:423:21)
    at eval (extensionType.js?8190:4:1)
    at ../client-dashboard-shared/node_modules/@solana/spl-token/lib/cjs/extensions/extensionType.js (npm.solana.js:498:1)
    at __webpack_require__ (runtime.js:36:33)
    at fn (runtime.js:423:21)
    at eval (state.js?c2fa:5:1)
    at ../client-dashboard-shared/node_modules/@solana/spl-token/lib/cjs/extensions/defaultAccountState/state.js (npm.solana.js:488:1)
    at __webpack_require__ (runtime.js:36:33)
    at fn (runtime.js:423:21)
    at eval (index.js?b35d:15:1)
    at ../client-dashboard-shared/node_modules/@solana/spl-token/lib/cjs/extensions/defaultAccountState/index.js (npm.solana.js:468:1)
    at __webpack_require__ (runtime.js:36:33)
    at fn (runtime.js:423:21)
```