### PR TITLE
feat(utxo-lib): add round-trip test with high-precision values

### DIFF
--- a/modules/utxo-lib/test/integration_local_rpc/parse.ts
+++ b/modules/utxo-lib/test/integration_local_rpc/parse.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert';
+import { describe, it } from 'mocha';
 import { BIP32Interface } from 'bip32';
 
 import { isTestnet, TxOutput, getNetworkList, getNetworkName, networks } from '../../src';

--- a/modules/utxo-lib/test/integration_local_rpc/parse.ts
+++ b/modules/utxo-lib/test/integration_local_rpc/parse.ts
@@ -47,7 +47,7 @@ function runTestParse<TNumber extends number | bigint>(
   protocol: Protocol,
   txType: FixtureTxType,
   scriptType: ScriptType,
-  amountType: 'number' | 'bigint' = 'number'
+  amountType: 'number' | 'bigint'
 ) {
   if (txType === 'deposit' && !isSupportedDepositType(protocol.network, scriptType)) {
     return;
@@ -58,7 +58,7 @@ function runTestParse<TNumber extends number | bigint>(
   }
 
   const fixtureName = `${txType}_${scriptType}.json`;
-  describe(fixtureName, function () {
+  describe(`${fixtureName} amountType=${amountType}`, function () {
     let fixture: TransactionFixtureWithInputs;
     let parsedTx: UtxoTransaction<TNumber>;
 
@@ -122,6 +122,27 @@ function runTestParse<TNumber extends number | bigint>(
         getPrevOutputs(),
         amountType
       );
+    });
+
+    it(`round-trip (high-precision values)`, function () {
+      if (amountType !== 'bigint') {
+        return;
+      }
+      const tx = createTransactionFromBuffer<TNumber>(
+        Buffer.from(fixture.transaction.hex, 'hex'),
+        protocol.network,
+        {},
+        amountType
+      );
+      tx.outs.forEach((o) => {
+        o.value = (BigInt(1e16) + BigInt(1)) as TNumber;
+        assert.notStrictEqual(BigInt(Number(o.value)), o.value);
+      });
+      const txRoundTrip = parseTransactionRoundTrip(tx.toBuffer(), protocol.network, undefined, amountType);
+      assert.strictEqual(txRoundTrip.outs.length, tx.outs.length);
+      txRoundTrip.outs.forEach((o, i) => {
+        assert.deepStrictEqual(o, tx.outs[i]);
+      });
     });
 
     it(`recreate from unsigned hex`, function () {


### PR DESCRIPTION
Issue: BG-56226

----

5aba693b0
fix(utxo-lib): import describe/it from `parse.ts`

Otherwise IntelliJ-initiated test runs will complain about incorrect type
definitions (picked up from `jasmine` instead of `mocha`)