### PR TITLE
fix(sdk-coin-eos): Fix precision for EOS:CHEX tokens

### DIFF
--- a/modules/bitgo/test/v2/unit/baseCoin.ts
+++ b/modules/bitgo/test/v2/unit/baseCoin.ts
@@ -18,9 +18,12 @@ describe('V2 Base Coin:', function () {
   let basecoinBtc;
   let basecoinXlm;
   let basecoinNear;
+  let basecoinEos;
+  let basecoinEosChex;
   let basecoinErc20TokenWithName;
   let basecoinErc20TokenWithContractHash;
   let baseCoinStellarToken;
+
 
   before(function () {
     bitgo = TestBitGo.decorate(BitGo, { env: 'test' });
@@ -29,6 +32,8 @@ describe('V2 Base Coin:', function () {
     basecoinBtc = bitgo.coin('tbtc');
     basecoinXlm = bitgo.coin('txlm');
     basecoinNear = bitgo.coin('tnear');
+    basecoinEos = bitgo.coin('teos');
+    basecoinEosChex = bitgo.coin('teos:CHEX');
     basecoinEth.keychains();
     basecoinErc20TokenWithName = bitgo.coin('terc');
     basecoinErc20TokenWithContractHash = bitgo.coin('0x945ac907cf021a6bcd07852bb3b8c087051706a9');
@@ -79,6 +84,21 @@ describe('V2 Base Coin:', function () {
 
       basecoinNear.baseUnitsToBigUnits('197895229538867437499999802').should.equal('197.895229538867437499999802');
 
+    });
+
+    it('should convert amounts to EOS', function () {
+      basecoinEos.baseUnitsToBigUnits('1').should.equal('0.0001');
+
+      basecoinEos.baseUnitsToBigUnits('1234').should.equal('0.1234');
+
+      basecoinEos.baseUnitsToBigUnits('123456788').should.equal('12345.6788');
+
+      // for chex token, we need to round to 8 decimal places
+      basecoinEosChex.baseUnitsToBigUnits('1').should.equal('0.00000001');
+
+      basecoinEosChex.baseUnitsToBigUnits('1234').should.equal('0.00001234');
+
+      basecoinEosChex.baseUnitsToBigUnits('123456788').should.equal('1.23456788');
     });
 
   });

--- a/modules/sdk-coin-eos/src/eos.ts
+++ b/modules/sdk-coin-eos/src/eos.ts
@@ -226,6 +226,10 @@ export class Eos extends BaseCoin {
     return 1e4;
   }
 
+  get decimalPlaces() {
+    return 4;
+  }
+
   /**
    * Flag for sending value of 0
    * @returns {boolean} True if okay to send 0 value, false otherwise
@@ -364,7 +368,7 @@ export class Eos extends BaseCoin {
     const dividend = this.getBaseFactor();
     const bigNumber = new BigNumber(baseUnits).dividedBy(dividend);
     // set the format so commas aren't added to large coin amounts
-    return bigNumber.toFormat(4, null as any, { groupSeparator: '', decimalSeparator: '.' });
+    return bigNumber.toFormat(this.decimalPlaces, null as any, { groupSeparator: '', decimalSeparator: '.' });
   }
 
   /**


### PR DESCRIPTION
Currently, when withdrawing CHEX tokens on EOS mainnet, the amount is shown with 4 decimals of precision on the FE.
However, the precision should be 8 decimals for CHEX specifically. This fix includes the modification of a decimalPlaces getter in eos. When the token is CHEX, this getter will retrieve the decimal place from statics.

Ticket: BG-47340