### PR TITLE
fix(sdk-coin-sol): update validateTransaction for leading zero transfer amounts

### DIFF
--- a/modules/sdk-coin-sol/src/sol.ts
+++ b/modules/sdk-coin-sol/src/sol.ts
@@ -179,10 +179,10 @@ export class Sol extends BaseCoin {
         filteredRecipients.map(async (recipientFromUser, index) => {
           const recipientFromTx = filteredOutputs[index]; // This address should be an ATA
 
-          // Compare the amount string values because amount is (string | number)
-          const userAmountString = recipientFromUser.amount.toString();
-          const txAmountString = recipientFromTx.amount.toString();
-          if (userAmountString !== txAmountString) {
+          // Compare the BigNumber values because amount is (string | number)
+          const userAmount = new BigNumber(recipientFromUser.amount);
+          const txAmount = new BigNumber(recipientFromTx.amount);
+          if (!userAmount.isEqualTo(txAmount)) {
             return false;
           }
 

--- a/modules/sdk-coin-sol/test/unit/sol.ts
+++ b/modules/sdk-coin-sol/test/unit/sol.ts
@@ -330,6 +330,33 @@ describe('SOL:', function () {
       validTransaction.should.equal(true);
     });
 
+    it('should succeed to verify token transaction with leading zero recipient amount', async function () {
+      const txParams = newTxParamsTokenTransfer();
+      const address = 'AF5H6vBkFnJuVqChRPgPQ4JRcQ5Gk25HBFhQQkyojmvg'; // Native SOL address
+      txParams.recipients = [{ address, amount: '0001', tokenName: 'tsol:usdc' }];
+      const txPrebuild = newTxPrebuildTokenTransfer();
+      const feePayerWalletData = {
+        id: '5b34252f1bf349930e34020a00000000',
+        coin: 'tsol',
+        keys: [
+          '5b3424f91bf349930e34017500000000',
+          '5b3424f91bf349930e34017600000000',
+          '5b3424f91bf349930e34017700000000',
+        ],
+        coinSpecific: {
+          rootAddress: '4DujymUFbQ8GBKtAwAZrQ6QqpvtBEivL48h4ta2oJGd2',
+        },
+        multisigType: 'tss',
+      };
+      const feePayerWallet = new Wallet(bitgo, basecoin, feePayerWalletData);
+      const validTransaction = await basecoin.verifyTransaction({
+        txParams,
+        txPrebuild,
+        wallet: feePayerWallet,
+      } as any);
+      validTransaction.should.equal(true);
+    });
+
     it('should fail to verify token transaction with different recipient tokenName', async function () {
       const txParams = newTxParamsTokenTransfer();
       const address = 'AF5H6vBkFnJuVqChRPgPQ4JRcQ5Gk25HBFhQQkyojmvg'; // Native SOL address


### PR DESCRIPTION
A user recently reported an issue where they were unable to create a transfer where the amount was a leading zero `0002`.

This updates validateTransaction for SOL to account for this case and adds a unit test to ensure the input is now valid.

TICKET: BG-56546