### PR TITLE
fix(sdk-core): allow undefined for amtPaidSats

### DIFF
--- a/modules/bitgo/test/v2/fixtures/lightning/lightning.ts
+++ b/modules/bitgo/test/v2/fixtures/lightning/lightning.ts
@@ -20,6 +20,26 @@ export default {
       updatedAt: '2022-08-16T22:47:28.133Z',
       amtPaidSats: 1000,
     },
+    {
+      paymentHash: '03c34d3a86bbcdb84d5c4a05419f58aa360735bd5d093b68e39782d57d070d33',
+      walletId: '62b9b5d140bc322459967cf764949ae3',
+      status: 'settled',
+      value: 2500,
+      expiresAt: '2022-09-13T05:29:18.199Z',
+      createdAt: '2022-09-13T05:29:18.199Z',
+      updatedAt: '2022-09-13T05:29:18.199Z',
+      amtPaidSats: 2500,
+    },
+    {
+      paymentHash: '3ba07eca2d45a76a38ce9cf5c8e99f0c46a5f6188833a7d8def3f9cbc7c3ffa6',
+      walletId: '62b9b5d140bc322459967cf764949ae3',
+      status: 'open',
+      value: 50000,
+      expiresAt: '2022-09-13T05:30:06Z.723Z',
+      createdAt: '2022-09-13T05:30:06Z.723Z',
+      updatedAt: '2022-09-13T05:30:06Z.723Z',
+      amtPaidSats: undefined,
+    },
   ],
 
   payment: {

--- a/modules/bitgo/test/v2/unit/lightning.ts
+++ b/modules/bitgo/test/v2/unit/lightning.ts
@@ -80,10 +80,18 @@ describe('lightning API requests', function () {
 
   it('should fetch lightning invoices', async function () {
     const scope = nock(bgUrl).get(`/api/v2/wallet/${wallet.id()}/lightning/invoices`)
-      .query({ status: 'settled', limit: 1 })
       .reply(200, fixtures.invoices);
-    const res = await wallet.lightning().getInvoices({ status: 'settled', limit: 1 });
+    const res = await wallet.lightning().getInvoices();
     assert.deepStrictEqual(res, fixtures.invoices);
+    scope.done();
+  });
+
+  it('should fetch filtered lightning invoices', async function () {
+    const scope = nock(bgUrl).get(`/api/v2/wallet/${wallet.id()}/lightning/invoices`)
+      .query({ status: 'settled', limit: 1 })
+      .reply(200, [fixtures.invoices[0]]);
+    const res = await wallet.lightning().getInvoices({ status: 'settled', limit: 1 });
+    assert.deepStrictEqual(res, [fixtures.invoices[0]]);
     scope.done();
   });
   

--- a/modules/sdk-core/src/bitgo/lightning/iLightning.ts
+++ b/modules/sdk-core/src/bitgo/lightning/iLightning.ts
@@ -142,12 +142,12 @@ export type GetBalanceResponse = t.TypeOf<typeof GetBalanceResponse>;
 const InvoiceInfo = t.strict({
   paymentHash: t.string,
   walletId: t.string,
-  status: t.string,
+  status: t.union([t.literal('open'), t.literal('settled'), t.literal('canceled')]),
   value: t.number,
   expiresAt: t.string,
   createdAt: t.string,
   updatedAt: t.string,
-  amtPaidSats: t.number,
+  amtPaidSats: t.union([t.number, t.undefined]),
 });
 
 export const GetInvoicesResponse = t.array(InvoiceInfo);


### PR DESCRIPTION
## Description

This fix allows for unpaid invoices, which do not have any value for `amtPaidSats` yet, to be properly decoded. Without this, calling `getInvoices` when there are any unpaid invoices in the result set fails.

## Issue Number

NEW TICKET: BG-43813

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been tested both manually with a testnet BitGo wallet that had open invoices which were triggering this bug, and by expanding the test cases for fetching invoices to include open invoices.