### PR TITLE
fix(bitgo): remove address param from lightning().deposit

### DIFF
--- a/modules/bitgo/test/v2/unit/lightning.ts
+++ b/modules/bitgo/test/v2/unit/lightning.ts
@@ -73,9 +73,13 @@ describe('lightning API requests', function () {
   });
 
   it('should deposit an amount from on-chain wallet to lightning wallet', async function () {
+    const scope = nock(bgUrl).post(`/api/v2/wallet/${wallet.id()}/lightning/address`).reply(200, {
+      address,
+    });
     sinon.stub(wallet, 'send').resolves(fixtures.deposit);
-    const res = await wallet.lightning().deposit({ amount: 100000, address: 'fake_address' });
+    const res = await wallet.lightning().deposit({ amount: 100000 });
     assert.deepStrictEqual(res, fixtures.deposit);
+    scope.done();
   });
 
   it('should fetch lightning invoices', async function () {

--- a/modules/sdk-core/src/bitgo/lightning/iLightning.ts
+++ b/modules/sdk-core/src/bitgo/lightning/iLightning.ts
@@ -14,7 +14,6 @@ export interface LightningWithdrawalParams {
 
 export interface LightningDepositParams {
   amount: number;
-  address?: string;
 }
 
 export interface PayInvoiceParams {

--- a/modules/sdk-core/src/bitgo/lightning/lightning.ts
+++ b/modules/sdk-core/src/bitgo/lightning/lightning.ts
@@ -91,11 +91,7 @@ export class Lightning implements ILightning {
 
   public async deposit(params: LightningDepositParams): Promise<DepositResponse> {
     const { amount } = params;
-    let { address } = params;
-
-    if (address === undefined) {
-      address = (await this.createDepositAddress()).address;
-    }
+    const address = (await this.createDepositAddress()).address;
 
     const res = await this.wallet.send({ amount, address });
 


### PR DESCRIPTION
Removed `address` param for `lightning().deposit` from SDK because there is no easy way to check if address is lightning address. A user could potentially provide an arbitrary, non-lightning address which we’d send funds to and end up not adding anything to the wallet’s custodial lightning balance

Ticket: BG-57388