### PR TITLE
chore: move avaxp addrss validation logic to account-lib

### DIFF
--- a/modules/sdk-coin-avaxp/src/avaxp.ts
+++ b/modules/sdk-coin-avaxp/src/avaxp.ts
@@ -201,16 +201,7 @@ export class AvaxP extends BaseCoin {
       return false;
     }
 
-    const addressArr: string[] = Array.isArray(address) ? address : address.split('~');
-
-    // multisig wallet have an array of addresses. validate each address
-    for (const address of addressArr) {
-      if (!AvaxpLib.Utils.isValidAddress(address)) {
-        return false;
-      }
-    }
-
-    return true;
+    return AvaxpLib.Utils.isValidAddress(address);
   }
 
   /**

--- a/modules/sdk-coin-avaxp/src/lib/utils.ts
+++ b/modules/sdk-coin-avaxp/src/lib/utils.ts
@@ -44,7 +44,19 @@ export class Utils implements BaseUtils {
    * @returns {boolean} - the validation result
    */
   /** @inheritdoc */
-  isValidAddress(address: string): boolean {
+  isValidAddress(address: string | string[]): boolean {
+    const addressArr: string[] = Array.isArray(address) ? address : address.split('~');
+
+    for (const address of addressArr) {
+      if (!this.isValidAddressRegex(address)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private isValidAddressRegex(address: string): boolean {
     return /^(^P||NodeID)-[a-zA-Z0-9]+$/.test(address);
   }
 

--- a/modules/sdk-coin-avaxp/test/unit/lib/utils.ts
+++ b/modules/sdk-coin-avaxp/test/unit/lib/utils.ts
@@ -27,15 +27,21 @@ describe('Avaxp Utils', () => {
       Utils.isValidAddress(address).should.be.false();
     });
 
-    it('should validate an address', function () {
+    it('should validate an address array', function () {
       const validAddresses = [
         'P-fuji15jamwukfqkwhe8z26tjqxejtjd3jk9vj4kmxwa',
         'NodeID-MdteS9U987PY7iwA5Pcz3sKVprJAbAvE7',
         'NodeID-P1KjdPNrap8LHfx5AstcXxsHjk3jbbyF',
       ];
-      for (const address of validAddresses) {
-        Utils.isValidAddress(address).should.be.true();
-      }
+
+      Utils.isValidAddress(validAddresses).should.be.true();
+    });
+
+    it('should validate an address multiSig string', function () {
+      const stringMultiSigAddress =
+        'P-fuji15jamwukfqkwhe8z26tjqxejtjd3jk9vj4kmxwa~NodeID-MdteS9U987PY7iwA5Pcz3sKVprJAbAvE7~NodeID-P1KjdPNrap8LHfx5AstcXxsHjk3jbbyF';
+
+      Utils.isValidAddress(stringMultiSigAddress).should.be.true();
     });
 
     it('should fail to validate an invalid block id', function () {


### PR DESCRIPTION
The validation logic was added to avaxp coin class but instead should be moved to the account-lib method so it can be reused within wallet-platform and IMS.

TICKET: BG-57410