### PR TITLE
fix(account-lib): fix EDDSA MPC key validation for small number keys

### DIFF
--- a/modules/sdk-core/src/account-lib/mpc/curves/ed25519.ts
+++ b/modules/sdk-core/src/account-lib/mpc/curves/ed25519.ts
@@ -65,7 +65,7 @@ export class Ed25519Curve implements BaseCurve {
     const signedMessage = Buffer.concat([signature, message]);
     try {
       // Returns the message which was signed if the signature is valid
-      const result = Buffer.from(sodium.crypto_sign_open(signedMessage, bigIntToBufferLE(publicKey)));
+      const result = Buffer.from(sodium.crypto_sign_open(signedMessage, bigIntToBufferLE(publicKey, 32)));
       return Buffer.compare(message, result) === 0;
     } catch (error) {
       // Invalid signature causes an exception


### PR DESCRIPTION
We were converting our public keys to Buffers but were cutting off
leading zeroes during the process (because we first converted the
hex strings to BigInts). This led to us passing a buffer with less
than 32 Bytes into the sodium library as a public key. The library
then threw an error which we hid by assuming that any error means
that the signature we are verifying is invalid.
The fix is to always pass in a Buffer with a length of 32 Bytes and
to fill it with zeroes if necessary.

Ticket: BG-50442

## Description

<!--
Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## Issue Number

<!--
Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.
 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [x] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes