### PR TITLE
fix(wp): allow for optional passphrase on tss wallets

### DIFF
--- a/modules/bitgo/test/v2/unit/wallets.ts
+++ b/modules/bitgo/test/v2/unit/wallets.ts
@@ -403,10 +403,6 @@ describe('V2 Wallets:', function () {
       await wallets.generateWallet({ ...params, multisigType: 'tss' });
 
       const tsolWallets = new Wallets(bitgo, tsol);
-      await tsolWallets.generateWallet({
-        multisigType: 'tss',
-        label: 'tss wallet',
-      }).should.be.rejectedWith('cannot generate TSS keys without passphrase');
 
       await tsolWallets.generateWallet({
         label: 'tss cold wallet',

--- a/modules/sdk-core/src/bitgo/keychain/iKeychains.ts
+++ b/modules/sdk-core/src/bitgo/keychain/iKeychains.ts
@@ -100,7 +100,7 @@ export interface CreateBitGoOptions {
 
 export interface CreateMpcOptions {
   multisigType: 'onchain' | 'tss' | 'blsdkg';
-  passphrase: string;
+  passphrase?: string;
   originalPasscodeEncryptionCode?: string;
   enterprise?: string;
 }

--- a/modules/sdk-core/src/bitgo/keychain/keychains.ts
+++ b/modules/sdk-core/src/bitgo/keychain/keychains.ts
@@ -244,7 +244,7 @@ export class Keychains implements IKeychains {
   async createBackup(params: CreateBackupOptions = {}): Promise<Keychain> {
     params.source = 'backup';
 
-    const isTssBackupKey = params.prv && params.encryptedPrv && (params.commonKeychain || params.commonPub);
+    const isTssBackupKey = params.prv && (params.commonKeychain || params.commonPub);
 
     if (_.isUndefined(params.provider) && !isTssBackupKey) {
       // if the provider is undefined, we generate a local key and add the source details
@@ -278,16 +278,15 @@ export class Keychains implements IKeychains {
    * @return {Promise<KeychainsTriplet>} newly created User, Backup, and BitGo keys
    */
   async createMpc(params: CreateMpcOptions): Promise<KeychainsTriplet> {
-    if (_.isUndefined(params.passphrase)) {
-      throw new Error('missing required param passphrase');
-    }
-
     let MpcUtils;
     switch (params.multisigType) {
       case 'tss':
         MpcUtils = this.baseCoin.getMPCAlgorithm() === 'ecdsa' ? ECDSAUtils.EcdsaUtils : EDDSAUtils.default;
         break;
       case 'blsdkg':
+        if (_.isUndefined(params.passphrase)) {
+          throw new Error('missing required param passphrase');
+        }
         MpcUtils = BlsUtils;
         break;
       default:

--- a/modules/sdk-core/src/bitgo/wallet/iWallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallets.ts
@@ -17,7 +17,7 @@ export interface GetWalletOptions {
 export interface GenerateMpcWalletOptions {
   multisigType: 'onchain' | 'tss' | 'blsdkg';
   label: string;
-  passphrase: string;
+  passphrase?: string;
   originalPasscodeEncryptionCode?: string;
   enterprise?: string;
   walletVersion?: number;

--- a/modules/sdk-core/src/bitgo/wallet/wallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallets.ts
@@ -183,7 +183,7 @@ export class Wallets implements IWallets {
     const label = params.label;
     const passphrase = params.passphrase;
     const canEncrypt = !!passphrase && typeof passphrase === 'string';
-    const isCold = !canEncrypt || !!params.userKey;
+    const isCold = !!params.userKey;
     const walletParams: SupplementGenerateWalletOptions = {
       label: label,
       m: 2,
@@ -206,10 +206,6 @@ export class Wallets implements IWallets {
     }
 
     if (isTss) {
-      if (!canEncrypt) {
-        throw new Error('cannot generate TSS keys without passphrase');
-      }
-
       if (isCold) {
         throw new Error('TSS cold wallets are not supported at this time');
       }
@@ -221,7 +217,7 @@ export class Wallets implements IWallets {
       return this.generateMpcWallet({
         multisigType: 'tss',
         label,
-        passphrase: passphrase!,
+        passphrase,
         originalPasscodeEncryptionCode: params.passcodeEncryptionCode,
         enterprise: params.enterprise,
         walletVersion: params.walletVersion,
@@ -242,7 +238,7 @@ export class Wallets implements IWallets {
         throw new Error(`coin ${this.baseCoin.getFamily()} does not support BLS-DKG at this time`);
       }
 
-      return this.generateMpcWallet({ multisigType: 'blsdkg', label, passphrase: passphrase! });
+      return this.generateMpcWallet({ multisigType: 'blsdkg', label, passphrase });
     }
 
     const hasBackupXpub = !!params.backupXpub;


### PR DESCRIPTION
## Description

Making an update to the generate wallet flow for TSS wallets, to allow for the passphrase to be optional.

## Issue Number

https://bitgoinc.atlassian.net/browse/BG-56687

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [x] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes