### PR TITLE
fix(sdk-core): default wallet to non tss

### DIFF
--- a/modules/sdk-core/src/bitgo/wallet/wallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallets.ts
@@ -179,7 +179,7 @@ export class Wallets implements IWallets {
       throw new Error('missing required string parameter label');
     }
 
-    const isTss = params.multisigType ? params.multisigType === 'tss' : this.baseCoin.supportsTss();
+    const isTss = params.multisigType === 'tss' && this.baseCoin.supportsTss();
     const label = params.label;
     const passphrase = params.passphrase;
     const canEncrypt = !!passphrase && typeof passphrase === 'string';


### PR DESCRIPTION
Ticket: BG-57787

# Description

Coins that support tss are defaulting to tss wallets, we wants wallets to be tss only if users explicitly ask for tss wallets. This change makes tss not the default type for wallets.

# Issue Number

Ticket: BG-57787

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Updated test to reflect the current flow.
