### PR TITLE
fix(sdk-coin-eth): create custom ETH common for unsupported chain ids

### DIFF
--- a/modules/sdk-coin-eth/src/eth.ts
+++ b/modules/sdk-coin-eth/src/eth.ts
@@ -354,10 +354,17 @@ export class Eth extends BaseCoin {
 
     // if replay protection options are set, override the default common setting
     const ethCommon = params.replayProtectionOptions
-      ? new optionalDeps.EthCommon.default({
-          chain: params.replayProtectionOptions.chain,
-          hardfork: params.replayProtectionOptions.hardfork,
-        })
+      ? optionalDeps.EthCommon.default.isSupportedChainId(
+          new optionalDeps.ethUtil.BN(params.replayProtectionOptions.chain)
+        )
+        ? new optionalDeps.EthCommon.default({
+            chain: params.replayProtectionOptions.chain,
+            hardfork: params.replayProtectionOptions.hardfork,
+          })
+        : optionalDeps.EthCommon.default.custom({
+            chainId: new optionalDeps.ethUtil.BN(params.replayProtectionOptions.chain),
+            defaultHardfork: params.replayProtectionOptions.hardfork,
+          })
       : defaultCommon;
 
     const baseParams = {

--- a/modules/sdk-coin-ethw/test/unit/index.ts
+++ b/modules/sdk-coin-ethw/test/unit/index.ts
@@ -49,6 +49,10 @@ describe('Ethereum pow', function () {
         walletPassphrase: TestBitGo.V2.TEST_RECOVERY_PASSCODE,
         walletContractAddress: '0x5df5a96b478bb1808140d87072143e60262e8670',
         recoveryDestination: '0xac05da78464520aa7c9d4c19bd7a440b111b3054',
+        replayProtectionOptions: {
+          chain: 10001,
+          hardfork: 'london',
+        },
       };
     });
 


### PR DESCRIPTION
When building an ETH tx, create a custom ETH common if chain id is not supported by ethereumjs. This is needed to support ETHw.

BG-55611

## Description

<!--
Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## Issue Number

<!--
Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.
 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes