### PR TITLE
feat(bitgo): add api version input

### DIFF
--- a/modules/sdk-coin-sol/src/sol.ts
+++ b/modules/sdk-coin-sol/src/sol.ts
@@ -453,11 +453,21 @@ export class Sol extends BaseCoin {
 
     await tssUtils!.deleteSignatureShares(txRequestId);
     const recreated = await tssUtils!.getTxRequest(txRequestId);
+    let txHex = '';
+    if (recreated.unsignedTxs) {
+      txHex = recreated.unsignedTxs[0]?.serializedTxHex;
+    } else {
+      txHex = recreated.transactions ? recreated.transactions[0]?.unsignedTx.serializedTxHex : '';
+    }
+
+    if (!txHex) {
+      throw new Error('Missing serialized tx hex');
+    }
 
     return Promise.resolve({
       ...params,
       txPrebuild: recreated,
-      txHex: recreated.unsignedTxs[0].serializedTxHex,
+      txHex,
     });
   }
 

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -2,7 +2,7 @@ import { SerializedKeyPair } from 'openpgp';
 import { IRequestTracer } from '../../../api';
 import { KeychainsTriplet } from '../../baseCoin';
 import { ApiKeyShare, Keychain } from '../../keychain';
-import { Memo, WalletType } from '../../wallet';
+import { ApiVersion, Memo, WalletType } from '../../wallet';
 import { EDDSA, GShare, SignShare, YShare } from '../../../account-lib/mpc/tss';
 import { KeyShare } from './ecdsa';
 
@@ -227,6 +227,7 @@ export type TSSParams = {
   txRequest: string | TxRequest; // can be either a string or TxRequest
   prv: string;
   reqId: IRequestTracer;
+  apiVersion?: ApiVersion;
 };
 
 export type TSSParamsForMessage = TSSParams & {

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
@@ -457,7 +457,7 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
     let txRequestResolved: TxRequest;
     let txRequestId: string;
 
-    const { txRequest, prv } = params;
+    const { txRequest, prv, apiVersion } = params;
 
     if (typeof txRequest === 'string') {
       txRequestResolved = await getTxRequest(this.bitgo, this.wallet.id(), txRequest);
@@ -495,7 +495,14 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
     const bitgoGpgKey = await getBitgoGpgPubKey(this.bitgo);
     const encryptedSignerShare = await encryptText(signerShare, bitgoGpgKey);
 
-    await offerUserToBitgoRShare(this.bitgo, this.wallet.id(), txRequestId, userSignShare, encryptedSignerShare);
+    await offerUserToBitgoRShare(
+      this.bitgo,
+      this.wallet.id(),
+      txRequestId,
+      userSignShare,
+      encryptedSignerShare,
+      apiVersion
+    );
 
     const bitgoToUserRShare = await getBitgoToUserRShare(this.bitgo, this.wallet.id(), txRequestId);
 
@@ -507,7 +514,7 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
       signablePayload
     );
 
-    await sendUserToBitgoGShare(this.bitgo, this.wallet.id(), txRequestId, userToBitGoGShare);
+    await sendUserToBitgoGShare(this.bitgo, this.wallet.id(), txRequestId, userToBitGoGShare, apiVersion);
 
     return await getTxRequest(this.bitgo, this.wallet.id(), txRequestId);
   }

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -52,6 +52,8 @@ export interface BuildTokenEnablementOptions extends PrebuildTransactionOptions 
   enableTokens: TokenEnablement[];
 }
 
+export type ApiVersion = 'lite' | 'full';
+
 export interface PrebuildTransactionOptions {
   reqId?: IRequestTracer;
   recipients?: {
@@ -104,6 +106,7 @@ export interface PrebuildTransactionOptions {
   lowFeeTxid?: string;
   isTss?: boolean;
   custodianTransactionId?: string;
+  apiVersion?: ApiVersion;
 }
 
 export interface PrebuildAndSignTransactionOptions extends PrebuildTransactionOptions, WalletSignTransactionOptions {
@@ -143,6 +146,7 @@ export interface WalletSignTransactionOptions extends WalletSignBaseOptions {
   txPrebuild?: TransactionPrebuild;
   customRShareGeneratingFunction?: CustomRShareGeneratingFunction;
   customGShareGeneratingFunction?: CustomGShareGeneratingFunction;
+  apiVersion?: ApiVersion;
   [index: string]: unknown;
 }
 


### PR DESCRIPTION
Add API version input to prebuildTransactionTss method

[BG-57753](https://bitgoinc.atlassian.net/browse/BG-57753)

This PR changes the default version of the API from lite to full. This causes the txRequest endpoint to fail when prebuilding transactions without sending the preview param true.

- To prebuild transactions is needed to use the preview param true.
- To send transactions needed to send the OTP to unlock the token.