### PR TITLE
fix: fix case where there is no change to be sent back to wallet

### DIFF
--- a/modules/sdk-coin-avaxp/src/lib/delegatorTxBuilder.ts
+++ b/modules/sdk-coin-avaxp/src/lib/delegatorTxBuilder.ts
@@ -272,7 +272,7 @@ export class DelegatorTxBuilder extends TransactionBuilder {
       utils.addressToString(this.transaction._network.hrp, this.transaction._network.alias, b)
     );
 
-    /* 
+    /*
     A = user key
     B = hsm key
     C = backup key
@@ -379,7 +379,7 @@ export class DelegatorTxBuilder extends TransactionBuilder {
     // get outputs and credentials from the deserialized transaction if we are in OVC
     return {
       inputs,
-      outputs: outputs.length === 0 ? (this.transaction.avaxPTransaction as PVMBaseTx).getOuts() : outputs,
+      outputs: !buildOutputs ? (this.transaction.avaxPTransaction as PVMBaseTx).getOuts() : outputs,
       credentials: credentials.length === 0 ? this.transaction.credentials : credentials,
     };
   }

--- a/modules/sdk-coin-avaxp/test/unit/lib/validateTxBuilder.ts
+++ b/modules/sdk-coin-avaxp/test/unit/lib/validateTxBuilder.ts
@@ -129,6 +129,23 @@ describe('AvaxP Validate Tx Builder', () => {
       rawTx.should.equal(testData.ADDVALIDATOR_SAMPLES.unsignedTxHex);
     });
 
+    it('Should create AddValidator tx when change amount is 0', async () => {
+      const txBuilder = new TransactionBuilderFactory(coins.get('tavaxp'))
+        .getValidatorBuilder()
+        .threshold(testData.ADDVALIDATOR_SAMPLES.threshold)
+        .locktime(testData.ADDVALIDATOR_SAMPLES.locktime)
+        .fromPubKey(testData.ADDVALIDATOR_SAMPLES.pAddresses)
+        .startTime(testData.ADDVALIDATOR_SAMPLES.startTime)
+        .endTime(testData.ADDVALIDATOR_SAMPLES.endTime)
+        .stakeAmount('24938830298') // stake amount is total amount in outputs
+        .delegationFeeRate(testData.ADDVALIDATOR_SAMPLES.delegationFee)
+        .nodeID(testData.ADDVALIDATOR_SAMPLES.nodeID)
+        .memo(testData.ADDVALIDATOR_SAMPLES.memo)
+        .utxos(testData.ADDVALIDATOR_SAMPLES.outputs);
+
+      await txBuilder.build().should.not.throw();
+    });
+
     it('Should recover AddValidator tx from raw tx', async () => {
       const txBuilder = new TransactionBuilderFactory(coins.get('tavaxp')).from(
         testData.ADDVALIDATOR_SAMPLES.unsignedTxHex


### PR DESCRIPTION
When there is no change to be sent back to the wallet the sdk throws an error. Fix is to use `!buildOutputs` as the conditional

Unit test has been added to validate that no errors is thrown when stake amount is total amount in the outputs.

TICKET: BG-57097
