### PR TITLE
fix(sdk-coin-near): remove mocha should for BG-57708

### DIFF
--- a/modules/sdk-coin-near/src/near.ts
+++ b/modules/sdk-coin-near/src/near.ts
@@ -383,7 +383,9 @@ export class Near extends BaseCoin {
     );
     const signature = MPC.signCombine([userSign, backupSign]);
     const result = MPC.verify(messageBuffer, signature);
-    result.should.equal(true);
+    if (!result) {
+      throw new Error('Invalid signature');
+    }
     const rawSignature = Buffer.concat([Buffer.from(signature.R, 'hex'), Buffer.from(signature.sigma, 'hex')]);
     return rawSignature;
   }


### PR DESCRIPTION
## Description
 Remove should from near.ts which does not use the mocha test framework.
<!--
Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## Issue Number

BG-57708
<!--
Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.
 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes