### PR TITLE
feat(core): support transfertoken type transactions

### DIFF
--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -43,7 +43,19 @@ export interface CustomGShareGeneratingFunction {
     bitgoToUserRShare: SignatureShareRecord;
   }): Promise<GShare>;
 }
-
+export enum TokenType {
+  ERC721 = 'ERC721',
+  ERC1155 = 'ERC1155',
+  ERC20 = 'ERC20',
+}
+export interface TokenTransferRecipientParams {
+  tokenType: TokenType;
+  tokenQuantity: string;
+  tokenContractAddress?: string;
+  tokenName?: string;
+  tokenId?: string;
+  decimalPlaces?: number;
+}
 export interface PrebuildTransactionWithIntentOptions {
   reqId: IRequestTracer;
   intentType: string;
@@ -52,12 +64,38 @@ export interface PrebuildTransactionWithIntentOptions {
     address: string;
     amount: string | number;
     tokenName?: string;
+    tokenData?: TokenTransferRecipientParams;
   }[];
   comment?: string;
   memo?: Memo;
   tokenName?: string;
   enableTokens?: TokenEnablement[];
   nonce?: string;
+  selfSend?: boolean;
+  feeOptions?: FeeOption | EIP1559FeeOptions;
+  hopParams?: HopParams;
+  isTss?: boolean;
+}
+export interface IntentRecipient {
+  address: {
+    address: string;
+  };
+  amount: {
+    value: string | number;
+    symbol: string;
+  };
+  tokenData?: TokenTransferRecipientParams;
+}
+export interface PopulatedIntent {
+  intentType: string;
+  recipients: IntentRecipient[];
+  sequenceId?: string;
+  comment?: string;
+  nonce?: string;
+  memo?: string;
+  token?: string;
+  enableTokens?: TokenEnablement[];
+  // ETH & ETH-like params
   selfSend?: boolean;
   feeOptions?: FeeOption | EIP1559FeeOptions;
   hopParams?: HopParams;

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -12,7 +12,12 @@ import { Keychain } from '../keychain';
 import { IPendingApproval, PendingApprovalData } from '../pendingApproval';
 import { IStakingWallet } from '../staking';
 import { ITradingAccount } from '../trading';
-import { CustomGShareGeneratingFunction, CustomRShareGeneratingFunction, TokenEnablement } from '../utils';
+import {
+  CustomGShareGeneratingFunction,
+  CustomRShareGeneratingFunction,
+  TokenEnablement,
+  TokenTransferRecipientParams,
+} from '../utils';
 import { ILightning } from '../lightning';
 
 export interface MaximumSpendableOptions {
@@ -53,6 +58,7 @@ export interface PrebuildTransactionOptions {
     address: string;
     amount: string | number;
     tokenName?: string;
+    tokenData?: TokenTransferRecipientParams;
   }[];
   numBlocks?: number;
   maxFeeRate?: number;

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -2498,6 +2498,20 @@ export class Wallet implements IWallet {
           params.preview
         );
         break;
+      case 'transfertoken':
+        txRequest = await this.tssUtils!.prebuildTxWithIntent(
+          {
+            reqId,
+            isTss: params.isTss,
+            intentType: 'transferToken',
+            recipients: params.recipients || [],
+            nonce: params.nonce,
+            feeOptions: params.feeOptions as EIP1559FeeOptions,
+          },
+          apiVersion,
+          params.preview
+        );
+        break;
       case 'enabletoken':
         txRequest = await this.tssUtils!.prebuildTxWithIntent(
           {


### PR DESCRIPTION
Expand typing of recipient array for token related transfer data. Add transfertoken type to switch/case to call prebuildTxWithInent for tokenTransfer intent.
Add unit tests to make sure requestst to WP are made with proper/expected params.

BG-57935