### PR TITLE
Bg 57232 implement unsigned sweep recovery support

### DIFF
--- a/modules/sdk-coin-dot/test/unit/dot.ts
+++ b/modules/sdk-coin-dot/test/unit/dot.ts
@@ -183,10 +183,11 @@ describe('DOT:', function () {
     });
   });
   describe('Recover Transactions:', () => {
-    it('should recover a txn for non-bitgo recoveries', async function () {
-      const destAddr = testData.accounts.account1.address;
-      const nonce = 123;
-      const sandBox = sinon.createSandbox();
+    const sandBox = sinon.createSandbox();
+    const destAddr = testData.accounts.account1.address;
+    const nonce = 123;
+
+    beforeEach(function () {
       const accountInfoCB = sandBox.stub(Dot.prototype, 'getAccountInfo' as keyof Dot);
       accountInfoCB.withArgs(testData.wrwUser.walletAddress).resolves({ nonce: nonce });
       const headerInfoCB = sandBox.stub(Dot.prototype, 'getHeaderInfo' as keyof Dot);
@@ -194,7 +195,13 @@ describe('DOT:', function () {
         headerNumber: testData.westendBlock.blockNumber,
         headerHash: testData.westendBlock.hash,
       });
+    });
 
+    afterEach(function () {
+      sandBox.restore();
+    });
+
+    it('should recover a txn for non-bitgo recoveries', async function () {
       const res = await basecoin.recover({
         userKey: testData.wrwUser.userKey,
         backupKey: testData.wrwUser.backupKey,
@@ -210,13 +217,48 @@ describe('DOT:', function () {
       // deserialize the txn and verify the fields are what we expect
       const txBuilder = basecoin.getBuilder().from(res.serializedTx);
       // some information isn't deserialized by the from method, so we will
-      // supply it again
+      // supply it again in order to re-build the txn
       txBuilder
         .validity({
           firstValid: testData.westendBlock.blockNumber,
           maxDuration: basecoin.SWEEP_TXN_DURATION,
         })
         .referenceBlock(testData.westendBlock.hash);
+      const tx = await txBuilder.build();
+      const txJson = tx.toJson();
+      should.deepEqual(txJson.sender, testData.wrwUser.walletAddress);
+      should.deepEqual(txJson.blockNumber, testData.westendBlock.blockNumber);
+      should.deepEqual(txJson.referenceBlock, testData.westendBlock.hash);
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
+      should.deepEqual(txJson.nonce, nonce);
+      should.deepEqual(txJson.tip, 0);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
+      should.deepEqual(txJson.eraPeriod, basecoin.SWEEP_TXN_DURATION);
+    });
+
+    it('should recover a txn for unsigned-sweep recoveries', async function () {
+      const res = await basecoin.recover({
+        bitgoKey: testData.wrwUser.bitgoKey,
+        recoveryDestination: destAddr,
+      });
+      res.should.not.be.empty();
+      res.should.hasOwnProperty('serializedTx');
+      sandBox.assert.calledOnce(basecoin.getAccountInfo);
+      sandBox.assert.calledOnce(basecoin.getHeaderInfo);
+
+      // deserialize the txn and verify the fields are what we expect
+      const txBuilder = basecoin.getBuilder().from(res.serializedTx);
+      // some information isn't deserialized by the from method, so we will
+      // supply it again in order to re-build the txn
+      txBuilder
+        .validity({
+          firstValid: testData.westendBlock.blockNumber,
+          maxDuration: basecoin.SWEEP_TXN_DURATION,
+        })
+        .referenceBlock(testData.westendBlock.hash)
+        .sender({ address: testData.wrwUser.walletAddress });
       const tx = await txBuilder.build();
       const txJson = tx.toJson();
       should.deepEqual(txJson.sender, testData.wrwUser.walletAddress);


### PR DESCRIPTION
## Description

Implement unsigned sweep flow for Polkadot. Unsigned sweep flow is differentiated from a non-bitgo flow by the missing user key, backup key, and wallet passphrase from the frontend, and will instead return a serialized **unsigned** transaction hex string.

## Issue Number

BG-57232

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit test added to validate unsigned sweep recover flow