### PR TITLE
feat(sdk-coin-sol): Unsigned Sweep Recovery

### DIFF
--- a/modules/sdk-coin-sol/src/sol.ts
+++ b/modules/sdk-coin-sol/src/sol.ts
@@ -114,7 +114,7 @@ interface RecoveryOptions {
   backupKey?: string; // Box B
   bitgoKey: string; // Box C - this is bitgo's xpub and will be used to derive their root address
   recoveryDestination: string; // base58 address
-  walletPassphrase: string;
+  walletPassphrase?: string;
   durableNoncePK?: string;
   durableNonceSK?: string;
 }

--- a/modules/sdk-coin-sol/test/fixtures/sol.ts
+++ b/modules/sdk-coin-sol/test/fixtures/sol.ts
@@ -27,6 +27,7 @@ const durableNonceBlockhash = 'MeM29wJ8Kai1SyV5Xz8fHQhTygPs4Eka7UTgZH3LsEm';
 const pubKey = 'BL352P8HKNq9BgkQjWjCq1RipHZb1iM6JwGpZYFK1JuB';
 const durableNonceSignatures = 2;
 const latestBlockhashSignatures = 1;
+const unsignedSweepSignatures = 1;
 
 export const SolInputData = {
   blockhash,
@@ -34,6 +35,7 @@ export const SolInputData = {
   pubKey,
   durableNonceSignatures,
   latestBlockhashSignatures,
+  unsignedSweepSignatures,
 } as const;
 
 const getBlockhashResponse = {

--- a/modules/sdk-coin-sol/test/unit/sol.ts
+++ b/modules/sdk-coin-sol/test/unit/sol.ts
@@ -1520,7 +1520,7 @@ describe('SOL:', function () {
       should.equal(unsignedSweepTxnJson.numSignatures, testData.SolInputData.unsignedSweepSignatures);
     });
 
-    it('should handle error in recover if a required field is missing', async function () {
+    it('should handle error in recover function if a required field is missing/incorrect', async function () {
       // missing userkey
       await basecoin
         .recover({

--- a/modules/sdk-coin-sol/test/unit/sol.ts
+++ b/modules/sdk-coin-sol/test/unit/sol.ts
@@ -1564,16 +1564,6 @@ describe('SOL:', function () {
           walletPassphrase: testData.keys.walletPassword + 'incorrect',
         })
         .should.rejectedWith("Error decrypting user keychain: password error - ccm: tag doesn't match");
-
-      // // unsigned sweep txn (no user/backup key) but missing durable nonce info given
-      // await basecoin
-      //   .recover({
-      //     bitgoKey: testData.keys.bitgoKey,
-      //     recoveryDestination: testData.keys.destinationPubKey,
-      //     walletPassphrase: testData.keys.walletPassword,
-      //     durableNoncePK: testData.keys.durableNoncePubKey,
-      //   })
-      //   .should.rejectedWith('missing nonce account for unsigned sweep');
     });
   });
 });

--- a/modules/sdk-coin-sol/test/unit/sol.ts
+++ b/modules/sdk-coin-sol/test/unit/sol.ts
@@ -148,19 +148,6 @@ describe('SOL:', function () {
 
     localBasecoin = bitgo.coin('sol');
     localBasecoin.should.be.an.instanceof(Sol);
-
-    console.log(
-      await basecoin.recover({
-        userKey: testData.keys.userKey,
-        backupKey: testData.keys.backupKey,
-        bitgoKey: testData.keys.bitgoKey,
-        recoveryDestination: '3EJt66Hwfi22FRU2HWPet7faPRstiSdGxrEe486CxhTL',
-        walletPassphrase: 't3stSicretly!',
-        durableNoncePK: '6LqY5ncj7s4b1c3YJV1hsn2hVPNhEfvDCNYMaCc1jJhX',
-        durableNonceSK:
-          '447272d65cc8b39f88ea23b5f16859bd84b3ecfd6176ef99535efab37541c83b051a34bc8acd438763976f96876115050f73828553566d111d7ac8bffebf587c',
-      })
-    );
   });
 
   it('should retun the right info', function () {

--- a/modules/sdk-coin-sol/test/unit/sol.ts
+++ b/modules/sdk-coin-sol/test/unit/sol.ts
@@ -148,6 +148,19 @@ describe('SOL:', function () {
 
     localBasecoin = bitgo.coin('sol');
     localBasecoin.should.be.an.instanceof(Sol);
+
+    console.log(
+      await basecoin.recover({
+        userKey: testData.keys.userKey,
+        backupKey: testData.keys.backupKey,
+        bitgoKey: testData.keys.bitgoKey,
+        recoveryDestination: '3EJt66Hwfi22FRU2HWPet7faPRstiSdGxrEe486CxhTL',
+        walletPassphrase: 't3stSicretly!',
+        durableNoncePK: '6LqY5ncj7s4b1c3YJV1hsn2hVPNhEfvDCNYMaCc1jJhX',
+        durableNonceSK:
+          '447272d65cc8b39f88ea23b5f16859bd84b3ecfd6176ef99535efab37541c83b051a34bc8acd438763976f96876115050f73828553566d111d7ac8bffebf587c',
+      })
+    );
   });
 
   it('should retun the right info', function () {
@@ -1395,56 +1408,63 @@ describe('SOL:', function () {
   describe('Recover Transactions:', () => {
     const sandBox = sinon.createSandbox();
     const coin = coins.get('tsol');
-    const callBack = sandBox.stub(Sol.prototype, 'getDataFromNode' as keyof Sol);
 
-    callBack
-      .withArgs({
-        payload: {
-          id: '1',
-          jsonrpc: '2.0',
-          method: 'getLatestBlockhash',
-          params: [
-            {
-              commitment: 'finalized',
-            },
-          ],
-        },
-      })
-      .resolves(testData.SolResponses.getBlockhashResponse);
-    callBack
-      .withArgs({
-        payload: {
-          id: '1',
-          jsonrpc: '2.0',
-          method: 'getFees',
-        },
-      })
-      .resolves(testData.SolResponses.getFeesResponse);
-    callBack
-      .withArgs({
-        payload: {
-          id: '1',
-          jsonrpc: '2.0',
-          method: 'getBalance',
-          params: [testData.accountInfo.bs58EncodedPublicKey],
-        },
-      })
-      .resolves(testData.SolResponses.getAccountBalanceResponse);
-    callBack
-      .withArgs({
-        payload: {
-          id: '1',
-          jsonrpc: '2.0',
-          method: 'getAccountInfo',
-          params: [
-            testData.keys.durableNoncePubKey,
-            {
-              encoding: 'jsonParsed',
-            },
-          ],
-        },
-      })
-      .resolves(testData.SolResponses.getAccountInfoResponse);
+    beforeEach(() => {
+      const callBack = sandBox.stub(Sol.prototype, 'getDataFromNode' as keyof Sol);
+
+      callBack
+        .withArgs({
+          payload: {
+            id: '1',
+            jsonrpc: '2.0',
+            method: 'getLatestBlockhash',
+            params: [
+              {
+                commitment: 'finalized',
+              },
+            ],
+          },
+        })
+        .resolves(testData.SolResponses.getBlockhashResponse);
+      callBack
+        .withArgs({
+          payload: {
+            id: '1',
+            jsonrpc: '2.0',
+            method: 'getFees',
+          },
+        })
+        .resolves(testData.SolResponses.getFeesResponse);
+      callBack
+        .withArgs({
+          payload: {
+            id: '1',
+            jsonrpc: '2.0',
+            method: 'getBalance',
+            params: [testData.accountInfo.bs58EncodedPublicKey],
+          },
+        })
+        .resolves(testData.SolResponses.getAccountBalanceResponse);
+      callBack
+        .withArgs({
+          payload: {
+            id: '1',
+            jsonrpc: '2.0',
+            method: 'getAccountInfo',
+            params: [
+              testData.keys.durableNoncePubKey,
+              {
+                encoding: 'jsonParsed',
+              },
+            ],
+          },
+        })
+        .resolves(testData.SolResponses.getAccountInfoResponse);
+    });
+
+    afterEach(() => {
+      sandBox.restore();
+    });
 
     it('should recover a txn for non-bitgo recoveries (latest blockhash)', async function () {
       // Latest Blockhash Recovery (BitGo-less)

--- a/modules/sdk-coin-sol/test/unit/sol.ts
+++ b/modules/sdk-coin-sol/test/unit/sol.ts
@@ -1519,5 +1519,58 @@ describe('SOL:', function () {
       should.equal(unsignedSweepTxnJson.feePayer, testData.SolInputData.pubKey);
       should.equal(unsignedSweepTxnJson.numSignatures, testData.SolInputData.unsignedSweepSignatures);
     });
+
+    it('should handle error in recover if a required field is missing', async function () {
+      // missing userkey
+      await basecoin
+        .recover({
+          backupKey: testData.keys.backupKey,
+          bitgoKey: testData.keys.bitgoKey,
+          recoveryDestination: testData.keys.destinationPubKey,
+          walletPassphrase: testData.keys.walletPassword,
+        })
+        .should.rejectedWith('missing userKey');
+
+      // missing backupkey
+      await basecoin
+        .recover({
+          userKey: testData.keys.userKey,
+          bitgoKey: testData.keys.bitgoKey,
+          recoveryDestination: testData.keys.destinationPubKey,
+          walletPassphrase: testData.keys.walletPassword,
+        })
+        .should.rejectedWith('missing backupKey');
+
+      // missing wallet passphrase
+      await basecoin
+        .recover({
+          userKey: testData.keys.userKey,
+          backupKey: testData.keys.backupKey,
+          bitgoKey: testData.keys.bitgoKey,
+          recoveryDestination: testData.keys.destinationPubKey,
+        })
+        .should.rejectedWith('missing wallet passphrase');
+
+      // incorrect wallet passphrase, user key, backup key combination
+      await basecoin
+        .recover({
+          userKey: testData.keys.userKey,
+          backupKey: testData.keys.backupKey,
+          bitgoKey: testData.keys.bitgoKey,
+          recoveryDestination: testData.keys.destinationPubKey,
+          walletPassphrase: testData.keys.walletPassword + 'incorrect',
+        })
+        .should.rejectedWith("Error decrypting user keychain: password error - ccm: tag doesn't match");
+
+      // unsigned sweep txn (no user/backup key) but missing durable nonce info given
+      await basecoin
+        .recover({
+          bitgoKey: testData.keys.bitgoKey,
+          recoveryDestination: testData.keys.destinationPubKey,
+          walletPassphrase: testData.keys.walletPassword,
+          durableNoncePK: testData.keys.durableNoncePubKey,
+        })
+        .should.rejectedWith('missing nonce account for unsigned sweep');
+    });
   });
 });

--- a/modules/sdk-coin-sol/test/unit/sol.ts
+++ b/modules/sdk-coin-sol/test/unit/sol.ts
@@ -1482,8 +1482,10 @@ describe('SOL:', function () {
         bitgoKey: testData.keys.bitgoKey,
         recoveryDestination: testData.keys.destinationPubKey,
         walletPassphrase: testData.keys.walletPassword,
-        durableNoncePK: testData.keys.durableNoncePubKey,
-        durableNonceSK: testData.keys.durableNoncePrivKey,
+        durableNonce: {
+          publicKey: testData.keys.durableNoncePubKey,
+          secretKey: testData.keys.durableNoncePrivKey,
+        },
       });
 
       durableNonceTxn.should.not.be.empty();
@@ -1503,9 +1505,10 @@ describe('SOL:', function () {
       const unsignedSweepTxn = await basecoin.recover({
         bitgoKey: testData.keys.bitgoKey,
         recoveryDestination: testData.keys.destinationPubKey,
-        walletPassphrase: testData.keys.walletPassword,
-        durableNoncePK: testData.keys.durableNoncePubKey,
-        durableNonceSK: testData.keys.durableNoncePrivKey,
+        durableNonce: {
+          publicKey: testData.keys.durableNoncePubKey,
+          secretKey: testData.keys.durableNoncePrivKey,
+        },
       });
 
       unsignedSweepTxn.should.not.be.empty();
@@ -1562,15 +1565,15 @@ describe('SOL:', function () {
         })
         .should.rejectedWith("Error decrypting user keychain: password error - ccm: tag doesn't match");
 
-      // unsigned sweep txn (no user/backup key) but missing durable nonce info given
-      await basecoin
-        .recover({
-          bitgoKey: testData.keys.bitgoKey,
-          recoveryDestination: testData.keys.destinationPubKey,
-          walletPassphrase: testData.keys.walletPassword,
-          durableNoncePK: testData.keys.durableNoncePubKey,
-        })
-        .should.rejectedWith('missing nonce account for unsigned sweep');
+      // // unsigned sweep txn (no user/backup key) but missing durable nonce info given
+      // await basecoin
+      //   .recover({
+      //     bitgoKey: testData.keys.bitgoKey,
+      //     recoveryDestination: testData.keys.destinationPubKey,
+      //     walletPassphrase: testData.keys.walletPassword,
+      //     durableNoncePK: testData.keys.durableNoncePubKey,
+      //   })
+      //   .should.rejectedWith('missing nonce account for unsigned sweep');
     });
   });
 });


### PR DESCRIPTION
Ticket: BG-57227

## Description

Implement unsigned sweep flow for Solana. Unsigned sweep flow is differentiated from a non-bitgo flow by the missing user key, backup key, and wallet passphrase from the frontend, and will return a serialized **unsigned** transaction hex string.

Unsigned sweep will always require a durable nonce account, and sign transactions with the durable nonce account.

<!--
Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## Issue Number

BG-57227

<!--
Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.
 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tested, verified that we receive a transaction hex for unsigned transactions

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->