### PR TITLE
chore(root): add steps to automate publishing @bitgo-beta

### DIFF
--- a/.github/workflows/beta-publish.yml
+++ b/.github/workflows/beta-publish.yml
@@ -1,0 +1,38 @@
+name: Publish @bitgo-beta
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish Beta Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+
+      - name: Install BitGoJS
+        run: yarn install --with-frozen-lockfile
+
+      - name: Configure NPM
+        run: |
+          echo "email=${{ secrets.BETA_EMAIL }}" > .npmrc
+          echo "@bitgo-beta:registry=https://registry.npmjs.org" >> .npmrc
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.BETA_TOKEN }}" >> .npmrc
+          echo "//registry.npmjs.org/:always-auth=true" >> .npmrc
+          
+      - name: Prepare Beta
+        run: |
+          rm -rfd ./modules/web-demo
+          rm -rfd ./modules/express
+          npx ts-node ./scripts/prepare-beta.ts
+      
+      - name: Rebuild Beta
+        run: yarn
+
+      - name: Publish Canary
+        run: yarn lerna publish from-package --preid beta --dist-tag beta --force-publish --no-git-reset

--- a/scripts/prepare-beta.ts
+++ b/scripts/prepare-beta.ts
@@ -1,0 +1,97 @@
+import * as execa from 'execa';
+import { readFileSync, readdirSync, writeFileSync, statSync } from 'fs';
+import * as path from 'path';
+
+let lernaModules: string[] = [];
+const SCOPE = '@bitgo-beta';
+
+/**
+ * Create a function which can run lerna commands
+ * @param {String} lernaPath - path to lerna binary
+ * @returns {function(string, string[], Object.<string, string>): Promise<string>}
+ */
+function getLernaRunner(lernaPath: string) {
+  return async (command: string, args: string[] = [], options = {}) => {
+    const { stdout } = await execa(
+      lernaPath,
+      [command, ...args],
+      options,
+    );
+    return stdout;
+  };
+}
+
+const getLernaModules = async (): Promise<void> => {
+  const { stdout: lernaBinary } = await execa('yarn', ['bin', 'lerna'], { cwd: process.cwd() });
+
+  const lerna = getLernaRunner(lernaBinary);
+  const modules: Array<{name: string}> = JSON.parse(await lerna('list', ['--loglevel', 'silent', '--json', '--all']));
+  lernaModules = modules.map(({ name }) => name);
+};
+
+const walk = (dir: string): string[] => {
+  let results: string[] = [];
+  const ignoredFolders = [/modules\/bitgo\/example/, /node_modules/];
+  try {
+    const list = readdirSync(dir);
+    list.forEach((file) => {
+      file = path.join(dir, file);
+      const stat = statSync(file);
+      if (stat && stat.isDirectory()) {
+        if (!ignoredFolders.some((folder) => folder.test(file))) {
+          results = [
+            ...results,
+            ...walk(file),
+          ];
+        }
+      } else if (['.ts', '.tsx', '.js', '.json'].includes(path.extname(file))) {
+        // Is a file
+        results.push(file);
+      }
+    });
+  } catch (error) {
+    console.error(`Error when walking dir ${dir}`, error);
+  }
+  return results;
+};
+
+const edit = (filePath:string): void => {
+  const oldContent = readFileSync(filePath, { encoding: 'utf8' });
+  let newContent = oldContent;
+  lernaModules.forEach((moduleName) => {
+    const newName = `${moduleName.replace('@bitgo/', `${SCOPE}/`)}`;
+    newContent = newContent.replace(new RegExp(moduleName, 'g'), newName);
+  });
+  if (newContent !== oldContent) {
+    writeFileSync(filePath, newContent, { encoding: 'utf-8' });
+  }
+};
+
+const replacePackageScopes = () => {
+  // replace all @bitgo packages & source code with alternate SCOPE 
+  const filePaths = [
+    ...walk(path.join(__dirname, '../', 'modules')),
+    ...walk(path.join(__dirname, '../', 'webpack')),
+  ];
+  filePaths.forEach((file) => edit(file));
+};
+
+// modules/bitgo is the only package we publish without an `@bitgo` prefix, so
+// we must manually set one
+const replaceBitGoPackageScope = () => {
+  const cwd = path.join(__dirname, '../', 'modules', 'bitgo');
+  const json = JSON.parse(readFileSync(path.join(cwd, 'package.json'), { encoding: 'utf-8' }));
+  json.name = `${SCOPE}/bitgo`;
+  writeFileSync(
+    path.join(cwd, 'package.json'),
+    JSON.stringify(json, null, 2) + '\n'
+  );
+};
+
+const main = async () => {
+  await getLernaModules();
+  replacePackageScopes();
+  replaceBitGoPackageScope();
+};
+
+main();

--- a/scripts/prepare-beta.ts
+++ b/scripts/prepare-beta.ts
@@ -3,7 +3,8 @@ import { readFileSync, readdirSync, writeFileSync, statSync } from 'fs';
 import * as path from 'path';
 
 let lernaModules: string[] = [];
-const SCOPE = '@bitgo-beta';
+let TARGET_SCOPE = '@bitgo-beta';
+let filesChanged = 0;
 
 /**
  * Create a function which can run lerna commands
@@ -32,38 +33,35 @@ const getLernaModules = async (): Promise<void> => {
 const walk = (dir: string): string[] => {
   let results: string[] = [];
   const ignoredFolders = [/modules\/bitgo\/example/, /node_modules/];
-  try {
-    const list = readdirSync(dir);
-    list.forEach((file) => {
-      file = path.join(dir, file);
-      const stat = statSync(file);
-      if (stat && stat.isDirectory()) {
-        if (!ignoredFolders.some((folder) => folder.test(file))) {
-          results = [
-            ...results,
-            ...walk(file),
-          ];
-        }
-      } else if (['.ts', '.tsx', '.js', '.json'].includes(path.extname(file))) {
-        // Is a file
-        results.push(file);
+  const list = readdirSync(dir);
+  list.forEach((file) => {
+    file = path.join(dir, file);
+    const stat = statSync(file);
+    if (stat && stat.isDirectory()) {
+      if (!ignoredFolders.some((folder) => folder.test(file))) {
+        results = [
+          ...results,
+          ...walk(file),
+        ];
       }
-    });
-  } catch (error) {
-    console.error(`Error when walking dir ${dir}`, error);
-  }
+    } else if (['.ts', '.tsx', '.js', '.json'].includes(path.extname(file))) {
+      // Is a file
+      results.push(file);
+    }
+  });
   return results;
 };
 
-const edit = (filePath:string): void => {
+const changeScopeInFile = (filePath:string): void => {
   const oldContent = readFileSync(filePath, { encoding: 'utf8' });
   let newContent = oldContent;
   lernaModules.forEach((moduleName) => {
-    const newName = `${moduleName.replace('@bitgo/', `${SCOPE}/`)}`;
+    const newName = `${moduleName.replace('@bitgo/', `${TARGET_SCOPE}/`)}`;
     newContent = newContent.replace(new RegExp(moduleName, 'g'), newName);
   });
   if (newContent !== oldContent) {
     writeFileSync(filePath, newContent, { encoding: 'utf-8' });
+    ++filesChanged;
   }
 };
 
@@ -73,7 +71,7 @@ const replacePackageScopes = () => {
     ...walk(path.join(__dirname, '../', 'modules')),
     ...walk(path.join(__dirname, '../', 'webpack')),
   ];
-  filePaths.forEach((file) => edit(file));
+  filePaths.forEach((file) => changeScopeInFile(file));
 };
 
 // modules/bitgo is the only package we publish without an `@bitgo` prefix, so
@@ -81,17 +79,35 @@ const replacePackageScopes = () => {
 const replaceBitGoPackageScope = () => {
   const cwd = path.join(__dirname, '../', 'modules', 'bitgo');
   const json = JSON.parse(readFileSync(path.join(cwd, 'package.json'), { encoding: 'utf-8' }));
-  json.name = `${SCOPE}/bitgo`;
+  json.name = `${TARGET_SCOPE}/bitgo`;
   writeFileSync(
     path.join(cwd, 'package.json'),
     JSON.stringify(json, null, 2) + '\n'
   );
 };
 
+const getArgs = () => {
+  const args = process.argv.slice(2) || [];
+  const scopeArg = args.find((arg) => arg.startsWith('scope='));
+  if (scopeArg) {
+    const split = scopeArg.split('=');
+    TARGET_SCOPE = split[1] || TARGET_SCOPE;
+  }
+  console.log(`Preparing to re-target to ${TARGET_SCOPE}`);
+};
+
 const main = async () => {
+  getArgs();
   await getLernaModules();
   replacePackageScopes();
   replaceBitGoPackageScope();
+  if (filesChanged) {
+    console.log(`Successfully re-targeted ${filesChanged} files.`);
+    process.exit(0);
+  } else {
+    console.error('No files were changed, something must have gone wrong.');
+    process.exit(1);
+  }
 };
 
 main();


### PR DESCRIPTION
- adds script to rename packages to @bitgo-beta scope
- adds github action to generate a beta on demand. Will wire up to master once we confirm this works with secrets

Ticket: BG-57161

## Description
- Once the secrets are configured in GitHub we can then publish beta builds to https://www.npmjs.com/search?q=%40bitgo-beta
