### PR TITLE
feat(sdk-coin-dot): update dot recover function to traverse addresses

### DIFF
--- a/modules/sdk-coin-dot/test/fixtures.ts
+++ b/modules/sdk-coin-dot/test/fixtures.ts
@@ -159,5 +159,6 @@ export const wrwUser = {
     '2f209ca7f5c749d36813468dced481af1bc843fc45d990241bd57eee7991f9ea109f534e543\n' +
     '6a45cbe94bb61ba64e103389f18333004efd4cd15457957b5ff67',
   walletPassphrase: 'Ghghjkg!455544llll',
-  walletAddress: '5DT27GZcKRumteFW6PDpLaA64TbnKGoHpYbSYrCrFfTLhsq2',
+  walletAddress0: '5DT27GZcKRumteFW6PDpLaA64TbnKGoHpYbSYrCrFfTLhsq2',
+  walletAddress1: '5CTtvzgJGjV3HJdv7uKgpd7N4McYhivkMf1r2ZBhtzPatMCF',
 };


### PR DESCRIPTION
## Description

Add support to sweep wallet with multiple addresses; these addresses derivation path are 0 indexed and Users must pass in the index to start the search at. User can also optionally pass in how many iteration to search for (ie iteration of 20 with starting index 0 results in index 19 being the last index searched). The default iteration to search for is 20.

Recover function now returns the serialized transaction hex plus the index of the address with the funds being swept so that the user can start at this index + 1 for the next recover call.

## Issue Number

BG-58560

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tests, and end to end test confirming that we were able to sweep address 1 of a test wallet