### PR TITLE
feat(sdk-coin-avaxp): inputs normalized to be uses in unique double sp…

### DIFF
--- a/modules/sdk-coin-avaxp/src/lib/iface.ts
+++ b/modules/sdk-coin-avaxp/src/lib/iface.ts
@@ -58,6 +58,8 @@ export type DecodedUtxoObj = {
  */
 export const SECP256K1_Transfer_Output = 7;
 
+export const ADDRESS_SEPARATOR = '~';
+export const INPUT_SEPARATOR = ':';
 export type Tx = PMVTx | EMVTx;
 export type BaseTx = PMVBaseTx | EVMBaseTx;
 export type Output = TransferableOutput | EVMOutput;

--- a/modules/sdk-coin-avaxp/src/lib/transaction.ts
+++ b/modules/sdk-coin-avaxp/src/lib/transaction.ts
@@ -9,7 +9,7 @@ import {
   TransactionType,
 } from '@bitgo/sdk-core';
 import { KeyPair } from './keyPair';
-import { BaseTx, DecodedUtxoObj, TransactionExplanation, Tx, TxData } from './iface';
+import { BaseTx, DecodedUtxoObj, TransactionExplanation, Tx, TxData, INPUT_SEPARATOR } from './iface';
 import { AddDelegatorTx, AmountInput, BaseTx as PVMBaseTx, ExportTx, ImportTx } from 'avalanche/dist/apis/platformvm';
 import { ExportTx as EVMExportTx, ImportTx as EVMImportTx } from 'avalanche/dist/apis/evm';
 import { BinTools, BN, Buffer as BufferAvax } from 'avalanche';
@@ -282,7 +282,7 @@ export class Transaction extends BaseTransaction {
     return inputs.map((input) => {
       const amountInput = input.getInput() as any as AmountInput;
       return {
-        address: utils.cb58Encode(input.getTxID()) + '~' + new BN(input.getOutputIdx()).toString(),
+        address: utils.cb58Encode(input.getTxID()) + INPUT_SEPARATOR + new BN(input.getOutputIdx()).toString(),
         value: amountInput.getAmount().toString(),
       };
     });

--- a/modules/sdk-coin-avaxp/src/lib/utils.ts
+++ b/modules/sdk-coin-avaxp/src/lib/utils.ts
@@ -17,7 +17,7 @@ import { AvalancheNetwork } from '@bitgo/statics';
 import { Signature } from 'avalanche/dist/common';
 import * as createHash from 'create-hash';
 import { EVMOutput } from 'avalanche/dist/apis/evm';
-import { Output, Tx } from './iface';
+import { ADDRESS_SEPARATOR, Output, Tx } from './iface';
 
 export class Utils implements BaseUtils {
   private binTools = BinTools.getInstance();
@@ -298,7 +298,7 @@ export class Utils implements BaseUtils {
           .getAddresses()
           .map((a) => this.addressToString(network.hrp, network.alias, a))
           .sort()
-          .join('~');
+          .join(ADDRESS_SEPARATOR);
         return {
           value: amountOutput.getAmount().toString(),
           address,


### PR DESCRIPTION
…end prevetion ids


## Description

The inputs address are the utxo identify. The unique double spend prevetion ids of a transaction are made with those addresses. Sendqueue convetion uses ':' as field separrator. This changes avoid addresses manipularon in WP.


## Issue Number

Ticket: BG-58637

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes