### PR TITLE
fix(sdk-coin-sol): fix sol deserialize incorrect feePayer

### DIFF
--- a/modules/sdk-coin-sol/src/lib/transactionBuilderFactory.ts
+++ b/modules/sdk-coin-sol/src/lib/transactionBuilderFactory.ts
@@ -33,9 +33,7 @@ export class TransactionBuilderFactory extends BaseTransactionBuilderFactory {
             .map((input) => input.coin)
             .filter((coin, index, arr) => arr.indexOf(coin) === index);
           if (uniqueInputCoins.includes('sol') || uniqueInputCoins.includes('tsol')) {
-            // multi-assets transfer tx including native and token transfer contains more than 1 unique input coin names
-            // native: 'sol'/'tsol', token: 'sol:<tokenName>'/'tsol:<tokenName>'
-            return uniqueInputCoins.length > 1 ? this.getTransferBuilderV2(tx) : this.getTransferBuilder(tx);
+            return this.getTransferBuilderV2(tx);
           } else {
             return this.getTokenTransferBuilder(tx);
           }

--- a/modules/sdk-coin-sol/test/unit/transactionBuilder/transferBuilderV2.ts
+++ b/modules/sdk-coin-sol/test/unit/transactionBuilder/transferBuilderV2.ts
@@ -50,6 +50,9 @@ describe('Sol Transfer Builder V2', () => {
       const rawTx = tx.toBroadcastFormat();
       should.equal(Utils.isValidRawTransaction(rawTx), true);
       should.equal(rawTx, testData.NATIVE_TRANSFERV2_UNSIGNED_WITH_MEMO);
+      const reserialized = await factory.from(rawTx).build();
+      reserialized.should.be.deepEqual(tx);
+      reserialized.toBroadcastFormat().should.equal(rawTx);
     });
     it('build a transfer tx unsigned with durable nonce', async () => {
       const txBuilder = factory.getTransferBuilderV2();


### PR DESCRIPTION
Ticket: BG-58613

Currently the sol tx deserialize doesn't set feePayer, so when the feePayer is different than the sender, it throws unknown signer error. Fixed with adding feePayer.

## Description

<!--
Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## Issue Number

<!--
Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.
 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes