### PR TITLE
chore(lumina): add missing teur to statics

### DIFF
--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -687,6 +687,7 @@ export enum UnderlyingAsset {
   TEN = 'ten',
   TENX = 'tenx',
   TERC = 'terc',
+  TEUR = 'teur',
   TEUROC = 'teuroc',
   TERC2DP = 'terc2dp',
   TERC6DP = 'terc6dp',

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -757,6 +757,7 @@ export const coins = CoinMap.fromCoins([
   erc20('tel', 'Telcoin', 2, '0x467bccd9d29f223bce8043b84e8c8b282827790f', UnderlyingAsset.TEL),
   erc20('ten', 'Tokenomy', 18, '0xdd16ec0f66e54d453e6756713e533355989040e4', UnderlyingAsset.TEN),
   erc20('tenx', 'TenX Token', 18, '0x515ba0a2e286af10115284f151cf398688a69170', UnderlyingAsset.TENX),
+  erc20('teur', 'TrueEUR', 18, '???????????????????????????', UnderlyingAsset.TEUR),  
   erc20('tgbp', 'TrueGBP', 18, '0x00000000441378008ea67f4284a57932b1c000a5', UnderlyingAsset.TGBP),
   erc20('thkd', 'TrueHKD', 18, '0x0000852600ceb001e08e00bc008be620d60031f2', UnderlyingAsset.THKD),
   erc20('tiox', 'Trade Token X', 18, '0xd947b0ceab2a8885866b9a04a06ae99de852a3d4', UnderlyingAsset.TIOX),


### PR DESCRIPTION

Ticket: BG-51472

## Description

- teur is missing from statics causing some issues downstream with filtering logic and coins.get("teur") will return undefined. coins is part of statics


## Issue Number
- BG-51472

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?
- Not able to test it's a statics const

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes