### PR TITLE
Bg 58807 fix eth tss signing verifying

### DIFF
--- a/modules/bitgo/test/v2/unit/tss/ecdsa.ts
+++ b/modules/bitgo/test/v2/unit/tss/ecdsa.ts
@@ -604,11 +604,11 @@ describe('Ecdsa tss helper functions tests', function () {
 
       it('should successfully convert signature share to signature share record', function () {
         const share = {
-          to: SignatureShareType.USER,
-          from: SignatureShareType.BITGO,
+          to: SignatureShareType.BITGO,
+          from: SignatureShareType.USER,
           share: `${mockSShareFromUser.R}${ECDSAMethods.delimeter}${mockSShareFromUser.s}${ECDSAMethods.delimeter}${mockSShareFromUser.y}`,
         } as SignatureShareRecord;
-        const signatureShare = ECDSAMethods.convertSignatureShare(mockSShareFromUser, ECDSAMethods.getParticipantIndex('bitgo'));
+        const signatureShare = ECDSAMethods.convertSignatureShare(mockSShareFromUser, ECDSAMethods.getParticipantIndex('user'), ECDSAMethods.getParticipantIndex('bitgo'));
         signatureShare.from.should.equal(share.from);
         signatureShare.to.should.equal(share.to);
         signatureShare.share.should.equal(share.share);

--- a/modules/sdk-core/src/bitgo/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/bitgo/tss/ecdsa/ecdsa.ts
@@ -223,7 +223,7 @@ export async function sendShareToBitgo(
       break;
     case SendShareType.SShare:
       const sShare = share as SShare;
-      signatureShare = convertSignatureShare(sShare, 3);
+      signatureShare = convertSignatureShare(sShare, 1, 3);
       await sendSignatureShare(bitgo, walletId, txRequestId, signatureShare, requestType, signerShare, 'ecdsa');
       responseFromBitgo = sShare;
       break;
@@ -573,9 +573,13 @@ export function parseCombinedSignature(share: SignatureShareRecord): Signature {
  * @param share - Signature share
  * @returns signature share record
  */
-export function convertSignatureShare(share: SignatureShare, senderIndex: number): SignatureShareRecord {
+export function convertSignatureShare(
+  share: SignatureShare,
+  senderIndex: number,
+  recipientIndex: number
+): SignatureShareRecord {
   return {
-    to: getParticipantFromIndex(share.i),
+    to: getParticipantFromIndex(recipientIndex),
     from: getParticipantFromIndex(senderIndex),
     share: `${share.R}${delimeter}${share.s}${delimeter}${share.y}`,
   };

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
@@ -309,7 +309,7 @@ export class EcdsaUtils extends baseTSSUtils<KeyShare> {
     let signablePayload;
 
     if (requestType === RequestType.tx) {
-      signablePayload = Buffer.from(txRequestResolved.transactions[0].unsignedTx.serializedTxHex, 'hex');
+      signablePayload = Buffer.from(txRequestResolved.transactions[0].unsignedTx.signableHex, 'hex');
     } else if (requestType === RequestType.message) {
       assert(txRequestResolved.unsignedMessages?.[0]);
       signablePayload = Buffer.from(txRequestResolved.unsignedMessages[0].message, 'hex');


### PR DESCRIPTION
## Description
SDK fixes for ETH TSS. This change includes 2 fixes
1. fix to/from of how we're sending user s share to pass signature share validation in platform
2. fix how we are signing eth tss txs to ensure we sign the hashed, RLP encoded tx rather than the hashed serialized tx
<!--
Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## Issue Number
bg-58807
<!--
Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.
 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [x] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes