### PR TITLE
feat(statics): support NAME NFT on tpolygon BG-58416

### DIFF
--- a/modules/sdk-coin-polygon/test/unit/polygonToken.ts
+++ b/modules/sdk-coin-polygon/test/unit/polygonToken.ts
@@ -35,4 +35,34 @@ describe('Polygon Token: ', function () {
       polygonToken.should.deepEqual(tokencoinBycontractAddress);
     });
   });
+
+  describe('Polyon NFTs in test env:', function () {
+    const tokenNames = ['tpolygon:name'];
+
+    before(function () {
+      bitgo = TestBitGo.decorate(BitGoAPI, { env: 'test' });
+      PolygonToken.createTokenConstructors().forEach(({ name, coinConstructor }) => {
+        bitgo.safeRegister(name, coinConstructor);
+      });
+      bitgo.initializeTestVars();
+    });
+
+    tokenNames.forEach((tokenName: string) => {
+      it('should return constants', function () {
+        const polygonToken = bitgo.coin(tokenName);
+        polygonToken.getChain().should.equal(tokenName);
+        polygonToken.getBaseChain().should.equal('tpolygon');
+        polygonToken.getFullName().should.equal('Polygon Token');
+        polygonToken.type.should.equal(tokenName);
+        polygonToken.coin.should.equal('tpolygon');
+        polygonToken.network.should.equal('Testnet');
+      });
+
+      it('should return same token by contract address', function () {
+        const polygonToken = bitgo.coin(tokenName);
+        const tokencoinBycontractAddress = bitgo.coin(polygonToken.tokenContractAddress);
+        polygonToken.should.deepEqual(tokencoinBycontractAddress);
+      });
+    });
+  });
 });

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -889,6 +889,7 @@ export enum UnderlyingAsset {
   // Polygon testnet tokens
   'tpolygon:derc20' = 'tpolygon:derc20',
   'tpolygon:link' = 'tpolygon:link',
+  'tpolygon:name' = 'tpolygon:name',
 
   ERC721 = 'erc721',
   ERC1155 = 'erc1155',

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -2024,6 +2024,16 @@ export const coins = CoinMap.fromCoins([
     '0x326c977e6efc84e512bb9c30f76e30c160ed06fb',
     UnderlyingAsset['tpolygon:link']
   ),
+  terc721(
+    'tpolygon:name',
+    'Polygon Test NAME',
+    '0x53225dcd075677f7d9a40baa8f65a8f0043b6af5',
+    AccountCoin.DEFAULT_FEATURES,
+    '',
+    '',
+    Networks.test.polygon,
+    KeyCurve.Secp256k1
+  ),
   fiat('fiatusd', 'US Dollar', Networks.main.fiat, 2, UnderlyingAsset.USD),
   fiat('tfiatusd', 'Testnet US Dollar', Networks.test.fiat, 2, UnderlyingAsset.USD),
   fiat('fiateur', 'European Union Euro', Networks.main.fiat, 2, UnderlyingAsset.EUR),

--- a/modules/statics/src/tokenConfig.ts
+++ b/modules/statics/src/tokenConfig.ts
@@ -10,6 +10,7 @@ import {
   PolygonERC20Token,
   BscCoin,
   AdaCoin,
+  Erc721Coin,
 } from './account';
 import { CoinKind } from './base';
 import { coins } from './coins';
@@ -262,7 +263,7 @@ const formattedAvaxCTokens = coins.reduce((acc: AvaxcTokenConfig[], coin) => {
 }, []);
 
 const formattedPolygonTokens = coins.reduce((acc: EthLikeTokenConfig[], coin) => {
-  if (coin instanceof PolygonERC20Token) {
+  if (coin instanceof PolygonERC20Token || coin instanceof Erc721Coin) {
     acc.push({
       type: coin.name,
       coin: coin.network.type === NetworkType.MAINNET ? 'polygon' : 'tpolygon',


### PR DESCRIPTION
## Changes
- adds NAME NFT to Statics within Polygon Mumbai testnet
- if coin instance is of ERC721 class then the coin should be added to the polygon constructor so that `bitgo.coin(<tokenName>)` works

JIRA ticket: https://bitgoinc.atlassian.net/browse/BG-58416