### PR TITLE
feat(utxo-lib): set default version for zcash and dash

### DIFF
--- a/modules/utxo-lib/src/bitgo/transaction.ts
+++ b/modules/utxo-lib/src/bitgo/transaction.ts
@@ -136,6 +136,17 @@ export function setPsbtDefaults(
         throw new Error(`invalid version`);
       }
       break;
+    case networks.zcash:
+      if (
+        ![
+          ZcashTransaction.VERSION4_BRANCH_CANOPY,
+          ZcashTransaction.VERSION4_BRANCH_NU5,
+          ZcashTransaction.VERSION5_BRANCH_NU5,
+        ].includes(version)
+      ) {
+        throw new Error(`invalid version`);
+      }
+      break;
     default:
       if (version !== 1) {
         throw new Error(`invalid version`);
@@ -162,10 +173,13 @@ export function createPsbtForNetwork(
       psbt = new UtxoPsbt({ network });
       break;
     }
-    case networks.dash:
-      throw new Error('Dash psbt not implemented');
+    case networks.dash: {
+      psbt = new DashPsbt({ network });
+      break;
+    }
     case networks.zcash: {
-      throw new Error('Zcash psbt not implemented');
+      psbt = new ZcashPsbt({ network });
+      break;
     }
     default:
       throw new Error(`unsupported network`);


### PR DESCRIPTION
BG-58711

## Description

Add Zcash and Dash PSBT classes to the `setPsbtDefaults`. This was originally throwing a not implemented error before we implemented the [DashPsbt](https://github.com/BitGo/BitGoJS/blob/master/modules/utxo-lib/src/bitgo/dash/DashPsbt.ts#L7) and [ZcashPsbt](https://github.com/BitGo/BitGoJS/blob/master/modules/utxo-lib/src/bitgo/zcash/ZcashPsbt.ts#L23) classes.

This is necessary for development in BGMS.

<!--
Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## Issue Number

<!--
Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.
 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [x] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes