### PR TITLE
fix(statics): add terc721:bitgoerc721 to coins map BG-59021

### DIFF
--- a/modules/sdk-coin-eth/test/unit/ethToken.ts
+++ b/modules/sdk-coin-eth/test/unit/ethToken.ts
@@ -1,0 +1,40 @@
+import 'should';
+
+import { TestBitGo } from '@bitgo/sdk-test';
+import { BitGoAPI } from '@bitgo/sdk-api';
+import { Erc20Token } from '../../src';
+
+describe('Eth Token: ', function () {
+  let bitgo;
+
+  describe('Eth NFTs in test env:', function () {
+    const tokenNames = ['terc721:bitgoerc721'];
+
+    before(function () {
+      bitgo = TestBitGo.decorate(BitGoAPI, { env: 'test' });
+      // TODO(BG-59021) SHOULD USE A SEPARATE CLASS TO CREATE NFT CONSTRUCTORS
+      Erc20Token.createTokenConstructors().forEach(({ name, coinConstructor }) => {
+        bitgo.safeRegister(name, coinConstructor);
+      });
+      bitgo.initializeTestVars();
+    });
+
+    tokenNames.forEach((tokenName: string) => {
+      it('should return constants', function () {
+        const ercToken = bitgo.coin(tokenName);
+        ercToken.getChain().should.equal(tokenName);
+        // TODO(BG-59021): uncomment test
+        // ercToken.getFullName().should.equal('Test BITGO ERC 721 Token');
+        ercToken.type.should.equal(tokenName);
+        ercToken.coin.should.equal('gteth');
+        ercToken.network.should.equal('Testnet');
+      });
+
+      it('should return same token by contract address', function () {
+        const ercToken = bitgo.coin(tokenName);
+        const tokencoinBycontractAddress = bitgo.coin(ercToken.tokenContractAddress);
+        ercToken.should.deepEqual(tokencoinBycontractAddress);
+      });
+    });
+  });
+});

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -895,6 +895,8 @@ export enum UnderlyingAsset {
   ERC721 = 'erc721',
   ERC1155 = 'erc1155',
 
+  'terc721:bitgoerc721' = 'terc721:bitgoerc721',
+
   // Cardano Token
   adaTestnetToken = 'temporary-placeholder',
 }

--- a/modules/statics/src/tokenConfig.ts
+++ b/modules/statics/src/tokenConfig.ts
@@ -1,18 +1,18 @@
 import {
-  Erc20Coin,
-  StellarCoin,
+  AdaCoin,
+  AlgoCoin,
+  AvaxERC20Token,
+  BscCoin,
   CeloCoin,
   EosCoin,
-  AvaxERC20Token,
-  AlgoCoin,
-  SolCoin,
+  Erc20Coin,
+  Erc721Coin,
   HederaToken,
   PolygonERC20Token,
-  BscCoin,
-  AdaCoin,
-  Erc721Coin,
+  SolCoin,
+  StellarCoin,
 } from './account';
-import { CoinKind } from './base';
+import { CoinFamily, CoinKind } from './base';
 import { coins } from './coins';
 import { Networks, NetworkType } from './networks';
 import { OfcCoin } from './ofc';
@@ -140,7 +140,7 @@ export interface Tokens {
 
 // Get the list of ERC-20 tokens from statics and format it properly
 const formattedErc20Tokens = coins.reduce((acc: Erc20TokenConfig[], coin) => {
-  if (coin instanceof Erc20Coin) {
+  if (coin instanceof Erc20Coin || (coin instanceof Erc721Coin && coin.family === CoinFamily.ETH)) {
     let baseCoin: string;
     switch (coin.network) {
       case Networks.main.ethereum:
@@ -263,7 +263,7 @@ const formattedAvaxCTokens = coins.reduce((acc: AvaxcTokenConfig[], coin) => {
 }, []);
 
 const formattedPolygonTokens = coins.reduce((acc: EthLikeTokenConfig[], coin) => {
-  if (coin instanceof PolygonERC20Token || coin instanceof Erc721Coin) {
+  if (coin instanceof PolygonERC20Token || (coin instanceof Erc721Coin && coin.family === CoinFamily.POLYGON)) {
     acc.push({
       type: coin.name,
       coin: coin.network.type === NetworkType.MAINNET ? 'polygon' : 'tpolygon',


### PR DESCRIPTION
## Description

BitGo ERC721 token needs to be able to get instantiated on the bitgo instance to be able to send NFTs from a wallet. This functionality is needed in order to avoid an approval for using calldata to send an NFT. 

There needs to be a follow up PR to build out the Erc721Token class, right now the ERC721 is borrowing functionality from the Erc20Token class.

JIRA ticket: https://bitgoinc.atlassian.net/browse/BG-59021