### PR TITLE
feat(sdk-coin-near): implement address scanning for near recover

### DIFF
--- a/modules/sdk-coin-near/test/fixtures/near.ts
+++ b/modules/sdk-coin-near/test/fixtures/near.ts
@@ -102,6 +102,23 @@ const getAccountResponse = {
   },
 };
 
+const getZeroBalanceAccountResponse = {
+  status: 200,
+  body: {
+    jsonrpc: '2.0',
+    result: {
+      amount: '0',
+      block_hash: '3wdCKZM5FUDXbNMGH91s3Qz6PgBrBk2ewRfvY2CkP2mv',
+      block_height: 93510153,
+      code_hash: '11111111111111111111111111111111',
+      locked: '0',
+      storage_paid_at: 0,
+      storage_usage: 0,
+    },
+    id: 'dontcare',
+  },
+};
+
 const getProtocolConfigResp = {
   status: 200,
   body: {
@@ -333,6 +350,7 @@ const getGasPriceResponse = {
 export const NearResponses = {
   getAccessKeyResponse,
   getAccountResponse,
+  getZeroBalanceAccountResponse,
   getGasPriceResponse,
   getProtocolConfigResp,
 } as const;


### PR DESCRIPTION
## Description

Update Near recover function to perform address scanning. Logic is the same as for Sol, Dot, and Ada.

## Issue Number

BG-59027

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

3 new unit tests