### PR TITLE
feat(statics): introduce deprecation coin feature

### DIFF
--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -139,6 +139,10 @@ export enum CoinFeature {
    * This coin supports staking
    */
   STAKING = 'staking',
+  /**
+   * This coin is deprecated
+   */
+  DEPRECATED = 'deprecated',
 }
 
 /**

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -99,7 +99,10 @@ export const coins = CoinMap.fromCoins([
   account('dot', 'Polkadot', Networks.main.dot, 10, UnderlyingAsset.DOT, DOT_FEATURES, KeyCurve.Ed25519),
   account('tdot', 'Testnet Polkadot', Networks.test.dot, 12, UnderlyingAsset.DOT, DOT_FEATURES, KeyCurve.Ed25519),
   account('eth', 'Ethereum', Networks.main.ethereum, 18, UnderlyingAsset.ETH, ETH_FEATURES_WITH_STAKING),
-  account('teth', 'Kovan Testnet Ethereum (Deprecated)', Networks.test.kovan, 18, UnderlyingAsset.ETH, ETH_FEATURES),
+  account('teth', 'Kovan Testnet Ethereum (Deprecated)', Networks.test.kovan, 18, UnderlyingAsset.ETH, [
+    ...ETH_FEATURES,
+    CoinFeature.DEPRECATED,
+  ]),
   account(
     'gteth',
     'Goerli Testnet Ethereum',


### PR DESCRIPTION
this change introduce a new coin deprecation feature. This helps to distinguish coins which are
currently being deprecated.This is especially helpful when coins have multiple testnets which were previously supported but deprecated now. This change also deprecates teth.

TICKET: BG-59177