### PR TITLE
fix(sdk-core): ecdsa commonkeychain validation

### DIFF
--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
@@ -1,3 +1,4 @@
+import * as bs58 from 'bs58';
 import { ECDSA, Ecdsa } from '../../../../account-lib/mpc/tss';
 import * as openpgp from 'openpgp';
 import { SerializedKeyPair } from 'openpgp';
@@ -40,6 +41,20 @@ export class EcdsaUtils extends baseTSSUtils<KeyShare> {
     }
 
     return this.bitgoPublicGpgKey;
+  }
+
+  /**
+   * Gets the common public key from commonKeychain.
+   *
+   * @param {String} commonKeychain common key chain between n parties
+   * @returns {string} encoded public key
+   */
+  static getPublicKeyFromCommonKeychain(commonKeychain: string): string {
+    if (commonKeychain.length !== 130) {
+      throw new Error(`Invalid commonKeychain length, expected 130, got ${commonKeychain.length}`);
+    }
+    const commonPubHexStr = commonKeychain.slice(0, 66);
+    return bs58.encode(Buffer.from(commonPubHexStr, 'hex'));
   }
 
   /** @inheritdoc */

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -22,14 +22,7 @@ import { drawKeycard } from '../internal/keycard';
 import { Keychain } from '../keychain';
 import { IPendingApproval, PendingApproval } from '../pendingApproval';
 import { TradingAccount } from '../trading/tradingAccount';
-import {
-  inferAddressType,
-  RequestTracer,
-  TssUtils,
-  TxRequest,
-  EddsaUnsignedTransaction,
-  EIP1559FeeOptions,
-} from '../utils';
+import { inferAddressType, RequestTracer, TxRequest, EddsaUnsignedTransaction, EIP1559FeeOptions } from '../utils';
 import {
   AccelerateTransactionOptions,
   AddressesOptions,
@@ -1388,7 +1381,10 @@ export class Wallet implements IWallet {
           // Only one of pub/commonPub/commonKeychain should be present in the keychain
           let pub = keychain.pub ?? keychain.commonPub;
           if (keychain.commonKeychain) {
-            pub = TssUtils.getPublicKeyFromCommonKeychain(keychain.commonKeychain);
+            pub =
+              this.baseCoin.getMPCAlgorithm() === 'eddsa'
+                ? EddsaUtils.getPublicKeyFromCommonKeychain(keychain.commonKeychain)
+                : EcdsaUtils.getPublicKeyFromCommonKeychain(keychain.commonKeychain);
           }
           sharedKeychain = {
             pub,


### PR DESCRIPTION
Ticket: BG-58636

## Description

when sharing ecdsa wallet common key chain validation fails because currently it uses eddsa getPublicKeyFromCommonKeychain. This pr changes it where the wallet uses the correct curve method.

<!--
Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## Issue Number

<!--
Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.
 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Updated old test

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [x] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes