### PR TITLE
feat: allow the sdk to optionally send cookies with the request to cu…

### DIFF
--- a/modules/bitgo/test/unit/local.ts
+++ b/modules/bitgo/test/unit/local.ts
@@ -43,6 +43,50 @@ describe('Constructor', function () {
     bitgo.should.have.property('decrypt');
     bitgo.should.have.property('_validate');
   });
+
+  describe('cookiesPropagationEnabled argument', function () {
+    it('fail to instantiate with invalid combinations of arguments', function() {
+      (() => {
+        new BitGoJS.BitGo({ env: 'testnet', cookiesPropagationEnabled: true } as any);
+      }).should.throw(/Cookies are only allowed when custom URIs are in use/);
+      (() => {
+        new BitGoJS.BitGo({ env: 'custom', customRootURI: 'https://app.bitgo.com', cookiesPropagationEnabled: true } as any);
+      }).should.throw(/Cookies are only allowed when custom URIs are in use/);
+    });
+
+    it('cookiesPropagationEnabled is enabled explicitly', function() {
+      const bitgo = new BitGoJS.BitGo({
+        env: 'custom',
+        customRootURI: 'https://app.example.local',
+        cookiesPropagationEnabled: true,
+      });
+
+      bitgo.should.have.property('cookiesPropagationEnabled');
+      bitgo.cookiesPropagationEnabled.should.equal(true);
+    });
+
+    it('cookiesPropagationEnabled is disabled explicitly', function() {
+      const bitgo = new BitGoJS.BitGo({
+        env: 'custom',
+        customRootURI: 'https://app.example.local',
+        cookiesPropagationEnabled: false,
+      });
+
+      bitgo.should.have.property('cookiesPropagationEnabled');
+      bitgo.cookiesPropagationEnabled.should.equal(false);
+    });
+
+    it('cookiesPropagationEnabled is disabled by default', function() {
+      const bitgo = new BitGoJS.BitGo({
+        env: 'custom',
+        customRootURI: 'https://app.example.local',
+      });
+
+      bitgo.should.have.property('cookiesPropagationEnabled');
+      bitgo.cookiesPropagationEnabled.should.equal(false);
+    });
+  });
+
 });
 
 describe('BitGo environment', function () {

--- a/modules/sdk-api/src/types.ts
+++ b/modules/sdk-api/src/types.ts
@@ -20,6 +20,7 @@ export interface BitGoAPIOptions {
   useProduction?: boolean;
   userAgent?: string;
   validate?: boolean;
+  cookiesPropagationEnabled?: boolean;
 }
 
 export interface AccessTokenOptions {


### PR DESCRIPTION
…stom domains

TICKET: BG-59381

## Description
This PR adds an optional argument to the constructor which enables sending cookies if requested but only for custom URIs.
  
<!--
Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## Issue Number

<!--
Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.
 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?
unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes