### PR TITLE
feat(sdk-core): added large value support while calling WP

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -64,6 +64,7 @@ import { supportedCrossChainRecoveries } from './config';
 const { getExternalChainCode, isChainCode, scriptTypeForChain, outputScripts, toOutput, verifySignatureWithUnspent } =
   bitgo;
 type Unspent<TNumber extends number | bigint = number> = bitgo.Unspent<TNumber>;
+
 type RootWalletKeys = bitgo.RootWalletKeys;
 export interface VerifyAddressOptions extends BaseVerifyAddressOptions {
   chain: number;

--- a/modules/bitgo/test/v2/unit/unspents.ts
+++ b/modules/bitgo/test/v2/unit/unspents.ts
@@ -1,0 +1,143 @@
+import * as nock from 'nock';
+import * as sinon from 'sinon';
+import { common, Wallet } from '@bitgo/sdk-core';
+import { TestBitGo } from '@bitgo/sdk-test';
+import { BitGo } from '../../../src';
+
+describe('Verify string type is used for value of unspent', function () {
+  const bitgo = TestBitGo.decorate(BitGo, { env: 'test' });
+  bitgo.initializeTestVars();
+  const basecoin: any = bitgo.coin('tdoge');
+  const walletData = {
+    id: '5b34252f1bf349930e34020a00000000',
+    coin: 'tdoge',
+    keys: [
+      '5b3424f91bf349930e34017500000000',
+      '5b3424f91bf349930e34017600000000',
+      '5b3424f91bf349930e34017700000000',
+    ],
+    coinSpecific: {},
+  };
+  const wallet = new Wallet(bitgo, basecoin, walletData);
+  const bgUrl = common.Environments[bitgo.getEnv()].uri;
+  const highPrecisionBigInt = BigInt(1e16) + BigInt(1);
+
+  function matchMinMaxValue(minValue: string, maxValue: string): boolean {
+    return minValue === '1' && maxValue === highPrecisionBigInt.toString();
+  }
+
+  describe('unspents APIs with string type minValue and maxValue', function () {
+    after(function () {
+      nock.cleanAll();
+    });
+
+    ['consolidate', 'fanout'].forEach( (manageUnspentType) => {
+      it(manageUnspentType + ' should handle string type minValue and maxValue', async function () {
+        const params = { minValue: '1', maxValue: highPrecisionBigInt.toString() };
+
+        const consolidateUnspentsScope = nock(bgUrl)
+          .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/${manageUnspentType}Unspents`, body => {
+            return matchMinMaxValue(body.minValue, body.maxValue);
+          })
+          .reply(200, {
+            txInfo: {
+              unspents: [{
+                id: 123,
+                address: 'sfajlkjad',
+                value: 1242123,
+                valueString: '1242123',
+              }],
+            },
+          });
+
+        wallet.keyIds().forEach((keyId) => nock(bgUrl)
+          .get(`/api/v2/${wallet.coin()}/key/${keyId}`)
+          .reply(200, {}));
+
+        sinon.stub(wallet, 'signTransaction').resolves({});
+
+        const sendScope = nock(bgUrl)
+          .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/send`, { type: manageUnspentType })
+          .reply(200, {});
+
+        await wallet[manageUnspentType + 'Unspents'](params);
+
+        consolidateUnspentsScope.done();
+        sendScope.done();
+        sinon.restore();
+      });
+    });
+
+    it('maximumSpendable should handle string type minValue and maxValue', async function () {
+      const params = { minValue: '1', maxValue: highPrecisionBigInt.toString(), target: highPrecisionBigInt.toString() };
+
+      const maximumSpendableScope = nock(bgUrl)
+        .get(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/maximumSpendable`)
+        .query(queryParams => {
+          return matchMinMaxValue(queryParams.minValue, queryParams.maxValue);
+        })
+        .reply(200, {});
+
+      await wallet.maximumSpendable(params);
+
+      maximumSpendableScope.done();
+    });
+
+    it('get unspents should handle string type minValue and maxValue', async function () {
+      const params = { minValue: '1', maxValue: highPrecisionBigInt.toString(), target: highPrecisionBigInt.toString() };
+
+      const unspentsScope = nock(bgUrl)
+        .get(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/unspents`)
+        .query(queryParams => {
+          return matchMinMaxValue(queryParams.minValue, queryParams.maxValue);
+        })
+        .reply(200, {});
+
+      await wallet.unspents(params);
+
+      unspentsScope.done();
+    });
+  });
+
+  describe('build and send transaction APIs with string type minValue and maxValue', function () {
+    after(function () {
+      nock.cleanAll();
+    });
+
+    it('sendmany should handle string type minValue and maxValue', async function () {
+      const params = { minValue: '1', maxValue: highPrecisionBigInt.toString() };
+
+      const sendScope = nock(bgUrl)
+        .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/send`, body => {
+          return matchMinMaxValue(body.minValue, body.maxValue);
+        })
+        .reply(200, {});
+
+      const prebuildAndSignTransactionStub = sinon.stub(wallet, 'prebuildAndSignTransaction').resolves({});
+
+      await wallet.sendMany(params);
+
+      prebuildAndSignTransactionStub.should.calledOnce();
+      sendScope.done();
+    });
+
+    it('prebuildTransaction should handle string type minValue and maxValue', async function () {
+      const params = { minValue: '1', maxValue: highPrecisionBigInt.toString() };
+
+      const buildScope = nock(bgUrl)
+        .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/build`, (body) => {
+          return matchMinMaxValue(body.minValue, body.maxValue);
+        })
+        .reply(200, { txHex: '010000000197c9d011880ce52e1730d7e18d4877db343b61c7369e3274b9c0f176349137840000000000ffffffff0132000000000000001976a9146ba5752fb24f37d99db121975d8d68f0c6204d9188ac00000000' });
+
+      nock(bgUrl)
+        .get(`/api/v2/${wallet.coin()}/public/block/latest`)
+        .twice()
+        .reply(200, {});
+
+      await wallet.prebuildTransaction(params);
+
+      buildScope.done();
+    });
+  });
+});

--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -4,7 +4,6 @@
 
 import * as should from 'should';
 import * as sinon from 'sinon';
-require('should-sinon');
 import '../lib/asserts';
 import * as nock from 'nock';
 import * as _ from 'lodash';
@@ -12,18 +11,20 @@ import * as _ from 'lodash';
 import {
   common,
   CustomSigningFunction,
+  ECDSAUtils,
   RequestTracer,
+  TokenType,
   TssUtils,
   TxRequest,
   Wallet,
-  ECDSAUtils,
-  TokenType,
 } from '@bitgo/sdk-core';
 
 import { TestBitGo } from '@bitgo/sdk-test';
 import { BitGo } from '../../../src/bitgo';
 import { bip32 } from '@bitgo/utxo-lib';
 import { randomBytes } from 'crypto';
+
+require('should-sinon');
 
 nock.disableNetConnect();
 

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -30,7 +30,7 @@ export interface MaximumSpendableOptions {
   maxFeeRate?: number;
   recipientAddress?: string;
   limit?: number;
-  target?: number;
+  target?: number | string;
   plainTarget?: number;
 }
 
@@ -65,8 +65,8 @@ export interface PrebuildTransactionOptions {
   minConfirms?: number;
   enforceMinConfirmsForChange?: boolean;
   targetWalletUnspents?: number;
-  minValue?: number;
-  maxValue?: number;
+  minValue?: number | string;
+  maxValue?: number | string;
   sequenceId?: string;
   lastLedgerSequence?: number;
   ledgerSequenceDelta?: number;
@@ -194,11 +194,11 @@ export interface TransferBySequenceIdOptions {
 }
 
 export interface UnspentsOptions extends PaginationOptions {
-  minValue?: number;
-  maxValue?: number;
+  minValue?: number | string;
+  maxValue?: number | string;
   minHeight?: number;
   minConfirms?: number;
-  target?: number;
+  target?: number | string;
   segwit?: boolean;
   chains?: number[];
 }
@@ -206,8 +206,8 @@ export interface UnspentsOptions extends PaginationOptions {
 export interface ConsolidateUnspentsOptions extends WalletSignTransactionOptions {
   walletPassphrase?: string;
   xprv?: string;
-  minValue?: number;
-  maxValue?: number;
+  minValue?: number | string;
+  maxValue?: number | string;
   minHeight?: number;
   numUnspentsToMake?: number;
   feeTxConfirmTarget?: number;
@@ -226,8 +226,8 @@ export interface ConsolidateUnspentsOptions extends WalletSignTransactionOptions
 export interface FanoutUnspentsOptions extends WalletSignTransactionOptions {
   walletPassphrase?: string;
   xprv?: string;
-  minValue?: number;
-  maxValue?: number;
+  minValue?: number | string;
+  maxValue?: number | string;
   minHeight?: number;
   maxNumInputsToUse?: number;
   numUnspentsToMake?: number;
@@ -421,8 +421,8 @@ export interface SendManyOptions extends PrebuildAndSignTransactionOptions {
   enforceMinConfirmsForChange?: boolean;
   targetWalletUnspents?: number;
   message?: string;
-  minValue?: number;
-  maxValue?: number;
+  minValue?: number | string;
+  maxValue?: number | string;
   sequenceId?: string;
   lastLedgerSequence?: number;
   ledgerSequenceDelta?: number;

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -510,8 +510,8 @@ export class Wallet implements IWallet {
    *
    * @param {Object} params - parameters object
    * @param {Number} params.limit - maximum number of selectable unspents
-   * @param {Number} params.minValue - the minimum value of unspents to use in satoshis
-   * @param {Number} params.maxValue - the maximum value of unspents to use in satoshis
+   * @param {Number | String} params.minValue - the minimum value of unspents to use in satoshis
+   * @param {Number | String} params.maxValue - the maximum value of unspents to use in satoshis
    * @param {Number} params.minHeight - the minimum height of unspents on the block chain to use
    * @param {Number} params.minConfirms - all selected unspents will have at least this many confirmations
    * @param {Boolean} params.enforceMinConfirmsForChange - Enforces minConfirms on change inputs
@@ -578,8 +578,8 @@ export class Wallet implements IWallet {
    * @param {Number} params.feeTxConfirmTarget - estimate the fees to aim for first confirmation with this number of blocks
    *
    * Input parameters:
-   * @param {Number} params.minValue - the minimum value of unspents to use in satoshis
-   * @param {Number} params.maxValue - the maximum value of unspents to use in satoshis
+   * @param {Number | String} params.minValue - the minimum value of unspents to use in satoshis
+   * @param {Number | String} params.maxValue - the maximum value of unspents to use in satoshis
    * @param {Number} params.minHeight - the minimum height of unspents on the block chain to use
    * @param {Number} params.minConfirms - all selected unspents will have at least this many confirmations
    * @param {Boolean} params.enforceMinConfirmsForChange - if true, minConfirms also applies to change outputs
@@ -649,8 +649,8 @@ export class Wallet implements IWallet {
    * @param {Number} params.maxFeeRate - upper limit for feeRate in satoshis/kB
    * @param {Number} params.maxFeePercentage - the maximum relative portion that you're willing to spend towards fees
    * @param {Number} params.feeTxConfirmTarget - estimate the fees to aim for first confirmation with this number of blocks
-   * @param {Number} params.minValue - the minimum value of unspents to use in satoshis
-   * @param {Number} params.maxValue - the maximum value of unspents to use in satoshis
+   * @param {Number | String} params.minValue - the minimum value of unspents to use in satoshis
+   * @param {Number | String} params.maxValue - the maximum value of unspents to use in satoshis
    * @param {Number} params.minHeight - the minimum height of unspents on the block chain to use
    * @param {Number} params.minConfirms - all selected unspents will have at least this many confirmations
    * @param {Boolean} params.enforceMinConfirmsForChange - if true, minConfirms also applies to change outputs
@@ -669,8 +669,8 @@ export class Wallet implements IWallet {
    * @param {Object} params - parameters object
    * @param {String} params.walletPassphrase - the users wallet passphrase
    * @param {String} params.xprv - the private key in string form if the walletPassphrase is not available
-   * @param {Number} params.minValue - the minimum value of unspents to use
-   * @param {Number} params.maxValue - the maximum value of unspents to use
+   * @param {Number | String} params.minValue - the minimum value of unspents to use
+   * @param {Number | String} params.maxValue - the maximum value of unspents to use
    * @param {Number} params.minHeight - the minimum height of unspents on the block chain to use
    * @param {Number} params.minConfirms - all selected unspents will have at least this many confirmations
    * @param {Number} params.maxFeePercentage - the maximum proportion of an unspent you are willing to lose to fees
@@ -1449,8 +1449,8 @@ export class Wallet implements IWallet {
    * @param {Number} params.minConfirms - Minimum number of confirmations unspents going into this transaction should have
    * @param {Boolean} params.enforceMinConfirmsForChange - Enforce minimum number of confirmations on change (internal) inputs.
    * @param {Number} params.targetWalletUnspents - The desired count of unspents in the wallet. If the wallet’s current unspent count is lower than the target, up to four additional change outputs will be added to the transaction.
-   * @param {Number} params.minValue - Ignore unspents smaller than this amount of base units
-   * @param {Number} params.maxValue - Ignore unspents larger than this amount of base units
+   * @param {Number | String} params.minValue - Ignore unspents smaller than this amount of base units
+   * @param {Number | String} params.maxValue - Ignore unspents larger than this amount of base units
    * @param {Number} params.sequenceId - The sequence ID of the transaction
    * @param {Number} params.lastLedgerSequence - Absolute max ledger the transaction should be accepted in, whereafter it will be rejected.
    * @param {Number} params.ledgerSequenceDelta - Relative ledger height (in relation to the current ledger) that the transaction should be accepted in, whereafter it will be rejected.
@@ -1866,8 +1866,8 @@ export class Wallet implements IWallet {
    * @param {Boolean} params.enforceMinConfirmsForChange - Enforces minConfirms on change inputs
    * @param {Number} params.targetWalletUnspents - The desired count of unspents in the wallet
    * @param {String} params.message - optional message to attach to transaction
-   * @param {Number} params.minValue - Ignore unspents smaller than this amount of satoshis
-   * @param {Number} params.maxValue - Ignore unspents larger than this amount of satoshis
+   * @param {Number | String} params.minValue - Ignore unspents smaller than this amount of satoshis
+   * @param {Number | String} params.maxValue - Ignore unspents larger than this amount of satoshis
    * @param {Number} params.sequenceId - The sequence ID of the transaction
    * @param {Number} params.lastLedgerSequence - Absolute max ledger the transaction should be accepted in, whereafter it will be rejected.
    * @param {Number} params.ledgerSequenceDelta - Relative ledger height (in relation to the current ledger) that the transaction should be accepted in, whereafter it will be rejected.


### PR DESCRIPTION
Changed type of minValue, maxValue and target params to support both number and string in different APIs.
Wallet platform will support both types for all the coins except for doge and for doge it will only support string

Ticket: BG-57258