### PR TITLE
Bg 58778 add eth fillnonce capability

### DIFF
--- a/modules/sdk-coin-eth/src/eth.ts
+++ b/modules/sdk-coin-eth/src/eth.ts
@@ -1626,7 +1626,7 @@ export class Eth extends BaseCoin {
 
   verifyTssTransaction(params: VerifyEthTransactionOptions): boolean {
     const { txParams, txPrebuild, wallet } = params;
-    if (!txParams?.recipients && txParams.type !== 'acceleration') {
+    if (!txParams?.recipients && !(txParams.type && ['acceleration', 'fillNonce'].includes(txParams.type))) {
       throw new Error(`missing txParams`);
     }
     if (!wallet || !txPrebuild) {

--- a/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
@@ -102,7 +102,7 @@ export abstract class MpcUtils {
   populateIntent(baseCoin: IBaseCoin, params: PrebuildTransactionWithIntentOptions): PopulatedIntent {
     const chain = this.baseCoin.getChain();
 
-    if (params.intentType !== 'acceleration') {
+    if (!['acceleration', 'fillNonce'].includes(params.intentType)) {
       assert(params.recipients, `'recipients' is a required parameter for ${params.intentType} intent`);
     }
     const intentRecipients = params.recipients?.map((recipient) => {
@@ -135,6 +135,7 @@ export abstract class MpcUtils {
       switch (params.intentType) {
         case 'payment':
         case 'tokenTransfer':
+        case 'fillNonce':
           return {
             ...baseIntent,
             selfSend: params.selfSend,

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -2550,6 +2550,20 @@ export class Wallet implements IWallet {
           params.preview
         );
         break;
+      case 'fillNonce':
+        txRequest = await this.tssUtils!.prebuildTxWithIntent(
+          {
+            reqId,
+            intentType: 'fillNonce',
+            comment: params.comment,
+            nonce: params.nonce,
+            isTss: params.isTss,
+            feeOptions,
+          },
+          apiVersion,
+          params.preview
+        );
+        break;
       default:
         throw new Error(`transaction type not supported: ${params.type}`);
     }


### PR DESCRIPTION
## Description
Adds the ability to build eth txs with the fillNonce intent. Adds unit tests as well.
<!--
Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## Issue Number

<!--
Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.
 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes