### PR TITLE
feat(sdk-core): tss ecdsa key creation flow with third party backup

### DIFF
--- a/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsa.ts
+++ b/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsa.ts
@@ -20,6 +20,7 @@ import {
   SignatureShareRecord,
   RequestTracer,
   BitgoHeldBackupKeyShare,
+  BackupKeyShare,
 } from '@bitgo/sdk-core';
 import { keyShares, mockAShare, mockDShare, otherKeyShares } from '../../../fixtures/tss/ecdsaFixtures';
 import { nockSendSignatureShareWithResponse } from './common';
@@ -152,8 +153,57 @@ describe('TSS Ecdsa Utils:', async function () {
       result.should.eql(expectedFinalKeyShare);
     });
 
+    it('should create a user keychain from third party backup provider', async function() {
+      const backupKeyShares = await createIncompleteBitgoHeldBackupKeyShare(userGpgKey, backupKeyShare, bitGoGPGKey);
+      const backupShareHolder: BackupKeyShare = {
+        bitGoHeldKeyShares: backupKeyShares,
+      };
+      assert(backupShareHolder.bitGoHeldKeyShares);
+      const userKeychain = await tssUtils.createUserKeychainFromThirdPartyBackup(userGpgKey, userKeyShare, backupShareHolder.bitGoHeldKeyShares?.keyShares, nockedBitGoKeychain, 'password', '1234');
+      userKeychain.should.deepEqual(nockedUserKeychain);
+    });
+
+    it('should get the respective backup key shares based on provider', async function() {
+      await nockCreateBitgoHeldBackupKeyShare(coinName, userGpgKey, backupKeyShare, bitGoGPGKey);
+      let backupKeyShares = await tssUtils.createBackupKeyShares(true, userGpgKey);
+      should.exist(backupKeyShares.bitGoHeldKeyShares);
+      should.not.exist(backupKeyShares.userHeldKeyShare);
+
+      await nockCreateBitgoHeldBackupKeyShare(coinName, userGpgKey, backupKeyShare, bitGoGPGKey);
+      backupKeyShares = await tssUtils.createBackupKeyShares(false, userGpgKey);
+      should.exist(backupKeyShares.userHeldKeyShare);
+      should.not.exist(backupKeyShares.bitGoHeldKeyShares);
+    });
+
+    it('getBackupEncryptedNShare should get valid encrypted n shares based on provider', async function() {
+      // Backup key held by third party
+      const bitgoHeldBackupKeyShare = await createIncompleteBitgoHeldBackupKeyShare(userGpgKey, backupKeyShare, bitGoGPGKey);
+      const backupShareHolder: BackupKeyShare = {
+        bitGoHeldKeyShares: bitgoHeldBackupKeyShare,
+      };
+      const backupToBitgoShare = bitgoHeldBackupKeyShare.keyShares.find(
+        (keyShare) => keyShare.from === 'backup' && keyShare.to === 'bitgo'
+      );
+      const bitgoGpgKeyPubKey = await tssUtils.getBitgoPublicGpgKey();
+      let backupToBitgoEncryptedNShare = await tssUtils.getBackupEncryptedNShare(backupShareHolder, 3, bitgoGpgKeyPubKey.armor(), true);
+      should.exist(backupToBitgoEncryptedNShare);
+      should.equal(backupToBitgoEncryptedNShare.encryptedPrivateShare, backupToBitgoShare?.privateShare);
+
+      // Backup key held by user
+      const backupShareHolderNew: BackupKeyShare = {
+        userHeldKeyShare: backupKeyShare,
+      };
+      backupToBitgoEncryptedNShare = await tssUtils.getBackupEncryptedNShare(backupShareHolderNew, 3, bitgoGpgKeyPubKey.armor(), false);
+      const encryptedNShare = await encryptNShare(backupKeyShare, 3, bitgoGpgKeyPubKey.armor());
+      // cant verify the encrypted shares, since they will be encrypted with diff. values
+      should.equal(backupToBitgoEncryptedNShare.publicShare, encryptedNShare.publicShare);
+    });
+
     it('should generate TSS key chains', async function () {
-      const bitgoKeychain = await tssUtils.createBitgoKeychain(userGpgKey, userKeyShare, backupKeyShare);
+      const backupShareHolder: BackupKeyShare = {
+        userHeldKeyShare: backupKeyShare,
+      };
+      const bitgoKeychain = await tssUtils.createBitgoKeychain(userGpgKey, userKeyShare, backupShareHolder);
       const usersKeyChainPromises = [tssUtils.createParticipantKeychain(
         userGpgKey,
         1,
@@ -180,9 +230,46 @@ describe('TSS Ecdsa Utils:', async function () {
       should.exist(backupKeychain.encryptedPrv);
     });
 
+    it('should generate TSS key chains when backup provider is BitGo', async function () {
+      const backupProvider = 'BitGoKRS';
+      const isThirdPartyBackup = true;
+      const bitgoHeldBackupShares = await createIncompleteBitgoHeldBackupKeyShare(userGpgKey, backupKeyShare, bitGoGPGKey);
+      const backupShareHolder: BackupKeyShare = {
+        bitGoHeldKeyShares: bitgoHeldBackupShares,
+      };
+      const bitgoKeychain = await tssUtils.createBitgoKeychain(userGpgKey, userKeyShare, backupShareHolder, undefined, isThirdPartyBackup);
+      assert(bitgoKeychain.commonKeychain);
+
+      await nockFinalizeBitgoHeldBackupKeyShare(coinName, bitgoHeldBackupShares, bitgoKeychain.commonKeychain, userKeyShare, bitGoGPGKey, bitgoKeychain);
+
+      const userBackupKeyChainPromises = [tssUtils.createUserKeychain(
+        userGpgKey,
+        userKeyShare,
+        backupShareHolder,
+        bitgoKeychain,
+        'passphrase',
+        undefined,
+        isThirdPartyBackup), tssUtils.createBackupKeychain(
+        userGpgKey,
+        userKeyShare,
+        backupShareHolder,
+        bitgoKeychain,
+        undefined,
+        backupProvider)];
+      const [userKeychain, backupKeychain] = await Promise.all(userBackupKeyChainPromises);
+
+      bitgoKeychain.should.deepEqual(nockedBitGoKeychain);
+      userKeychain.should.deepEqual(nockedUserKeychain);
+      backupKeychain.id.should.equal('2');
+      backupKeychain.provider?.should.equal(backupProvider);
+    });
+
     it('should generate TSS key chains with optional params', async function () {
       const enterprise = 'enterprise';
-      const bitgoKeychain = await tssUtils.createBitgoKeychain(userGpgKey, userKeyShare, backupKeyShare, enterprise);
+      const backupShareHolder: BackupKeyShare = {
+        userHeldKeyShare: backupKeyShare,
+      };
+      const bitgoKeychain = await tssUtils.createBitgoKeychain(userGpgKey, userKeyShare, backupShareHolder, enterprise);
       const usersKeyChainPromises = [tssUtils.createParticipantKeychain(
         userGpgKey,
         1,
@@ -211,7 +298,10 @@ describe('TSS Ecdsa Utils:', async function () {
     });
 
     it('should fail to generate TSS key chains', async function () {
-      const bitgoKeychain = await tssUtils.createBitgoKeychain(userGpgKey, userKeyShare, backupKeyShare);
+      const backupShareHolder: BackupKeyShare = {
+        userHeldKeyShare: backupKeyShare,
+      };
+      const bitgoKeychain = await tssUtils.createBitgoKeychain(userGpgKey, userKeyShare, backupShareHolder);
       bitgoKeychain.should.deepEqual(nockedBitGoKeychain);
       const testKeyShares = otherKeyShares;
       const testCasesPromises = [
@@ -510,17 +600,27 @@ describe('TSS Ecdsa Utils:', async function () {
       false,
     )];
 
+    const backupToUserPublicShare = Buffer.concat([
+      Buffer.from(backupKeyShare.nShares[1].y, 'hex'),
+      Buffer.from(backupKeyShare.nShares[1].chaincode, 'hex'),
+    ]).toString('hex');
+
+    const backupToBitgoPublicShare = Buffer.concat([
+      Buffer.from(backupKeyShare.nShares[3].y, 'hex'),
+      Buffer.from(backupKeyShare.nShares[3].chaincode, 'hex'),
+    ]).toString('hex');
+
     return {
       id: '4711',
       keyShares: [{
         from: 'backup',
         to: 'user',
-        publicShare: backupKeyShare.nShares[1].y,
+        publicShare: backupToUserPublicShare,
         privateShare: (await nSharePromises[0]).encryptedPrivateShare,
       }, {
         from: 'backup',
         to: 'bitgo',
-        publicShare: backupKeyShare.nShares[3].y,
+        publicShare: backupToBitgoPublicShare,
         privateShare: (await nSharePromises[1]).encryptedPrivateShare,
       }],
     };
@@ -544,7 +644,8 @@ describe('TSS Ecdsa Utils:', async function () {
       false,
     );
 
-    const bitgoToBackupKeyShare = bitgoKeychain.keyShares?.find((keyShare) => keyShare.from === 'bitgo' && keyShare.to === 'backup');
+    assert(bitgoKeychain.keyShares);
+    const bitgoToBackupKeyShare = bitgoKeychain.keyShares.find((keyShare) => keyShare.from === 'bitgo' && keyShare.to === 'backup');
     assert(bitgoToBackupKeyShare);
 
     const expectedKeyShares = [{
@@ -555,7 +656,7 @@ describe('TSS Ecdsa Utils:', async function () {
       // to this nock. We cannot recreate the same encrypted value here because gpg encryption is not deterministic
     }, bitgoToBackupKeyShare];
 
-    const updatedKeyShare = {
+    const updatedKeyShare: BitgoHeldBackupKeyShare = {
       id: originalKeyShare.id,
       commonKeychain,
       keyShares: [

--- a/modules/bitgo/test/v2/unit/wallets.ts
+++ b/modules/bitgo/test/v2/unit/wallets.ts
@@ -380,6 +380,43 @@ describe('V2 Wallets:', function () {
       sandbox.verifyAndRestore();
     });
 
+    it('should create a new TSS wallet with BitGoKRS as backup provider', async function () {
+      const sandbox = sinon.createSandbox();
+      const stubbedKeychainsTriplet = {
+        userKeychain: {
+          id: '1',
+          pub: 'userPub',
+        },
+        backupKeychain: {
+          id: '2',
+          pub: 'userPub',
+        },
+        bitgoKeychain: {
+          id: '3',
+          pub: 'userPub',
+        },
+      };
+      sandbox.stub(TssUtils.prototype, 'createKeychains').resolves(stubbedKeychainsTriplet);
+
+      const walletNock = nock('https://bitgo.fakeurl')
+        .post('/api/v2/tsol/wallet')
+        .reply(200);
+
+      const wallets = new Wallets(bitgo, tsol);
+
+      await wallets.generateWallet({
+        label: 'tss wallet',
+        passphrase: 'tss password',
+        multisigType: 'tss',
+        enterprise: 'enterprise',
+        passcodeEncryptionCode: 'originalPasscodeEncryptionCode',
+        backupProvider: 'BitGoKRS',
+      });
+
+      walletNock.isDone().should.be.true();
+      sandbox.verifyAndRestore();
+    });
+
     it('should fail to create TSS wallet with invalid inputs', async function () {
       const tbtc = bitgo.coin('tbtc');
       const params = {

--- a/modules/sdk-core/src/bitgo/keychain/iKeychains.ts
+++ b/modules/sdk-core/src/bitgo/keychain/iKeychains.ts
@@ -70,10 +70,11 @@ export interface AddKeychainOptions {
 }
 
 export interface ApiKeyShare {
-  from: string;
-  to: string;
+  from: 'user' | 'backup' | 'bitgo';
+  to: 'user' | 'backup' | 'bitgo';
   publicShare: string;
   privateShare: string;
+  privateShareProof?: string;
   n?: string;
 }
 
@@ -103,6 +104,7 @@ export interface CreateMpcOptions {
   passphrase?: string;
   originalPasscodeEncryptionCode?: string;
   enterprise?: string;
+  backupProvider?: string;
 }
 
 export interface GetKeysForSigningOptions {

--- a/modules/sdk-core/src/bitgo/keychain/keychains.ts
+++ b/modules/sdk-core/src/bitgo/keychain/keychains.ts
@@ -292,12 +292,12 @@ export class Keychains implements IKeychains {
       default:
         throw new Error('Unsupported multi-sig type');
     }
-
     const mpcUtils = new MpcUtils(this.bitgo, this.baseCoin);
     return await mpcUtils.createKeychains({
       passphrase: params.passphrase,
       enterprise: params.enterprise,
       originalPasscodeEncryptionCode: params.originalPasscodeEncryptionCode,
+      backupProvider: params.backupProvider,
     });
   }
 }

--- a/modules/sdk-core/src/bitgo/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/bitgo/tss/ecdsa/ecdsa.ts
@@ -34,6 +34,7 @@ import { bip32 } from '@bitgo/utxo-lib';
 import * as pgp from 'openpgp';
 import { PrivateKey } from 'openpgp';
 import bs58 from 'bs58';
+import { ApiKeyShare } from '../../keychain';
 
 const MPC = new Ecdsa();
 
@@ -319,6 +320,23 @@ export async function encryptNShare(
     publicShare,
     encryptedPrivateShare,
     n: nShare.n,
+  };
+}
+
+/**
+ * Prepares a NShare to be exchanged with other key holders.
+ * An API key share received from a third party should already be encrypted
+ *
+ * @param keyShare - TSS key share of the party preparing exchange materials
+ * @returns encrypted N Share
+ */
+export async function buildNShareFromAPIKeyShare(keyShare: ApiKeyShare): Promise<EncryptedNShare> {
+  return {
+    i: getParticipantIndex(keyShare.to),
+    j: getParticipantIndex(keyShare.from),
+    publicShare: keyShare.publicShare,
+    encryptedPrivateShare: keyShare.privateShare,
+    n: keyShare.n ?? '', // this is not currently needed for key creation
   };
 }
 

--- a/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
@@ -5,7 +5,7 @@ import assert from 'assert';
 import { decrypt, readMessage, readPrivateKey, SerializedKeyPair } from 'openpgp';
 import { IBaseCoin, KeychainsTriplet } from '../baseCoin';
 import { BitGoBase } from '../bitgoBase';
-import { Keychain, KeyType } from '../keychain';
+import { AddKeychainOptions, Keychain, KeyType } from '../keychain';
 import { encryptText, getBitgoGpgPubKey } from './opengpgUtils';
 import { IntentRecipient, PopulatedIntent, PrebuildTransactionWithIntentOptions } from './tss/baseTypes';
 
@@ -52,7 +52,7 @@ export abstract class MpcUtils {
     const encUserToBitGoMessage = await encryptText(userKeyShare.privateShare, bitgoKey);
     const encBackupToBitGoMessage = await encryptText(backupKeyShare.privateShare, bitgoKey);
 
-    const createBitGoMPCParams = {
+    const createBitGoMPCParams: AddKeychainOptions = {
       keyType,
       source: 'bitgo',
       keyShares: [

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
@@ -17,6 +17,7 @@ import {
   TSSParams,
   TxRequest,
   TxRequestVersion,
+  BackupKeyShare,
 } from './baseTypes';
 import { SignShare, YShare, GShare } from '../../../account-lib/mpc/tss/eddsa/types';
 
@@ -59,11 +60,11 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
   createUserKeychain(
     userGpgKey: SerializedKeyPair<string>,
     userKeyShare: KeyShare,
-    backupKeyShare: KeyShare,
+    backupKeyShare: KeyShare | BackupKeyShare,
     bitgoKeychain: Keychain,
     passphrase: string,
     originalPasscodeEncryptionCode: string,
-    recipientIndex?: number | undefined
+    isThirdPartyBackup?: boolean
   ): Promise<Keychain> {
     throw new Error('Method not implemented.');
   }
@@ -71,9 +72,11 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
   createBackupKeychain(
     userGpgKey: SerializedKeyPair<string>,
     userKeyShare: KeyShare,
-    backupKeyShare: KeyShare,
+    backupKeyShare: KeyShare | BackupKeyShare,
     bitgoKeychain: Keychain,
-    passphrase: string
+    passphrase?: string,
+    backupXpubProvider?: string,
+    isThirdPartyBackup?: boolean
   ): Promise<Keychain> {
     throw new Error('Method not implemented.');
   }
@@ -81,8 +84,9 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
   createBitgoKeychain(
     userGpgKey: SerializedKeyPair<string>,
     userKeyShare: KeyShare,
-    backupKeyShare: KeyShare,
-    enterprise: string
+    backupKeyShare: KeyShare | BackupKeyShare,
+    enterprise: string,
+    isThirdPartyBackup?: boolean
   ): Promise<Keychain> {
     throw new Error('Method not implemented.');
   }
@@ -91,6 +95,7 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
     passphrase: string;
     enterprise?: string | undefined;
     originalPasscodeEncryptionCode?: string | undefined;
+    isThirdPartyBackup?: boolean;
   }): Promise<KeychainsTriplet> {
     throw new Error('Method not implemented.');
   }
@@ -234,5 +239,14 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
    */
   async getTxRequest(txRequestId: string): Promise<TxRequest> {
     return getTxRequest(this.bitgo, this.wallet.id(), txRequestId);
+  }
+
+  /**
+   * Checks whether the third party backup provider is valid/supported
+   * @param backupProvider - the backup provider client selected
+   */
+  isValidThirdPartyBackupProvider(backupProvider: string | undefined): boolean {
+    // As of now, BitGo is the only supported KRS provider for TSS
+    return !!(backupProvider && backupProvider === 'BitGoKRS');
   }
 }

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -4,6 +4,7 @@ import { KeychainsTriplet } from '../../baseCoin';
 import { ApiKeyShare, Keychain } from '../../keychain';
 import { Memo, WalletType } from '../../wallet';
 import { EDDSA, GShare, SignShare, YShare } from '../../../account-lib/mpc/tss';
+import { KeyShare } from './ecdsa';
 
 export type TxRequestVersion = 'full' | 'lite';
 export interface HopParams {
@@ -204,6 +205,11 @@ export interface BitgoHeldBackupKeyShare {
   keyShares: ApiKeyShare[];
 }
 
+export interface BackupKeyShare {
+  bitGoHeldKeyShares?: BitgoHeldBackupKeyShare;
+  userHeldKeyShare?: KeyShare;
+}
+
 /**
  * Common Interface for implementing signature scheme specific
  * util functions
@@ -223,25 +229,29 @@ export interface ITssUtils<KeyShare = EDDSA.KeyShare> {
     bitgoKeychain: Keychain,
     passphrase: string,
     originalPasscodeEncryptionCode: string,
-    recipientIndex?: number
+    isThirdPartyBackup?: boolean
   ): Promise<Keychain>;
   createBackupKeychain(
     userGpgKey: SerializedKeyPair<string>,
     userKeyShare: KeyShare,
     backupKeyShare: KeyShare,
     bitgoKeychain: Keychain,
-    passphrase: string
+    passphrase: string,
+    backupXpubProvider?: string,
+    isThirdPartyBackup?: boolean
   ): Promise<Keychain>;
   createBitgoKeychain(
     userGpgKey: SerializedKeyPair<string>,
     userKeyShare: KeyShare,
     backupKeyShare: KeyShare,
-    enterprise: string
+    enterprise: string,
+    isThirdPartyBackup?: boolean
   ): Promise<Keychain>;
   createKeychains(params: {
     passphrase: string;
     enterprise?: string;
     originalPasscodeEncryptionCode?: string;
+    isThirdPartyBackup?: boolean;
   }): Promise<KeychainsTriplet>;
   signTxRequest(params: { txRequest: string | TxRequest; prv: string; reqId: IRequestTracer }): Promise<TxRequest>;
   signTxRequestForMessage(params: TSSParams): Promise<TxRequest>;

--- a/modules/sdk-core/src/bitgo/wallet/iWallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallets.ts
@@ -21,6 +21,7 @@ export interface GenerateMpcWalletOptions {
   originalPasscodeEncryptionCode?: string;
   enterprise?: string;
   walletVersion?: number;
+  backupProvider?: string;
 }
 
 export interface GenerateWalletOptions {
@@ -29,6 +30,7 @@ export interface GenerateWalletOptions {
   userKey?: string;
   backupXpub?: string;
   backupXpubProvider?: string;
+  backupProvider?: string;
   passcodeEncryptionCode?: string;
   enterprise?: string;
   disableTransactionNotifications?: string;

--- a/modules/sdk-core/src/bitgo/wallet/wallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallets.ts
@@ -163,6 +163,7 @@ export class Wallets implements IWallets {
    * @param params.userKey User xpub
    * @param params.backupXpub Backup xpub
    * @param params.backupXpubProvider
+   * @param params.backupProvider Third party backup provider for TSS
    * @param params.enterprise
    * @param params.disableTransactionNotifications
    * @param params.passcodeEncryptionCode
@@ -226,6 +227,7 @@ export class Wallets implements IWallets {
         originalPasscodeEncryptionCode: params.passcodeEncryptionCode,
         enterprise: params.enterprise,
         walletVersion: params.walletVersion,
+        backupProvider: params.backupProvider,
       });
     }
 
@@ -640,6 +642,7 @@ export class Wallets implements IWallets {
       passphrase: params.passphrase,
       enterprise: params.enterprise,
       originalPasscodeEncryptionCode: params.originalPasscodeEncryptionCode,
+      backupProvider: params.backupProvider,
     });
     const { userKeychain, backupKeychain, bitgoKeychain } = keychains;
     walletParams.keys = [userKeychain.id, backupKeychain.id, bitgoKeychain.id];
@@ -655,7 +658,7 @@ export class Wallets implements IWallets {
       bitgoKeychain,
     };
 
-    if (!_.isUndefined(backupKeychain.prv)) {
+    if (!_.isUndefined(backupKeychain.prv) && !_.isUndefined(params.backupProvider)) {
       result.warning = 'Be sure to backup the backup keychain -- it is not stored anywhere else!';
     }
 


### PR DESCRIPTION
## Description

Ticket: [BG-59055](https://bitgoinc.atlassian.net/browse/BG-59055)

This modifies the ecdsa TSS flow to support third party backup key
providers (for Nike, BitGo is the backup provider) where the backup key
is created via Bitgo (i.e WP->HSM). It involves two additional calls
to the WP, first to create the backup shares, and second time to
update the backup key in WP with the bitgoToBackup shares and verifying
the common keychain. Rest of the flow remains the same.

<!--
Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## Issue Number

<!--
Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.
 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [x] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes