### PR TITLE
feat(sdk-coin-sui): prefix sui addresses with 0x

### DIFF
--- a/modules/sdk-coin-sui/src/lib/transaction.ts
+++ b/modules/sdk-coin-sui/src/lib/transaction.ts
@@ -281,16 +281,19 @@ export class Transaction extends BaseTransaction {
   }
 
   static updateProperTransactionData(k: any): void {
-    // bcs deserializes number into Big Number, needs to convert them back to number
+    // bcs deserializes number into Big Number and removed '0x' prefix from addresses, needs to convert them back
     k.payTx.amounts = k.payTx.amounts.map((amount) => amount.toNumber());
     k.payTx.coins = k.payTx.coins.map((coin): SuiObjectRef => {
       return {
-        objectId: coin.objectId,
+        objectId: utils.normalizeHexId(coin.objectId),
         version: coin.version.toNumber(),
         digest: coin.digest,
       };
     });
+    k.payTx.recipients = k.payTx.recipients.map((recipient) => utils.normalizeHexId(recipient));
+    k.gasPayment.objectId = utils.normalizeHexId(k.gasPayment.objectId);
     k.gasPayment.version = k.gasPayment.version.toNumber();
+    k.sender = utils.normalizeHexId(k.sender);
   }
 
   /**

--- a/modules/sdk-coin-sui/src/lib/utils.ts
+++ b/modules/sdk-coin-sui/src/lib/utils.ts
@@ -122,6 +122,13 @@ export class Utils implements BaseUtils {
     }
     return true;
   }
+
+  /**
+   Normalizes hex ids (addresses, object ids) to always contain the '0x' prefix.
+   **/
+  normalizeHexId(id: string): string {
+    return id.startsWith('0x') ? id : '0x'.concat(id);
+  }
 }
 
 const utils = new Utils();

--- a/modules/sdk-coin-sui/test/resources/sui.ts
+++ b/modules/sdk-coin-sui/test/resources/sui.ts
@@ -1,12 +1,12 @@
 export const addresses = {
   validAddresses: [
-    'cba4a48bb0f8b586c167e5dcefaa1c5e96ab3f08',
-    'c4173a804406a365e69dfb297d4eaaf002546ebd',
-    '111b8a49f67370bc4a58e500b9e64cb6547ee9b4',
+    '0xcba4a48bb0f8b586c167e5dcefaa1c5e96ab3f08',
+    '0xc4173a804406a365e69dfb297d4eaaf002546ebd',
+    '0x111b8a49f67370bc4a58e500b9e64cb6547ee9b4',
   ],
   invalidAddresses: [
     'randomString',
-    'c4173a804406a365e69dfb297ddfgsdcvf',
+    '0xc4173a804406a365e69dfb297ddfgsdcvf',
     '5ne7phA48Jrvpn39AtupB8ZkCCAy8gLTfpGihZPuDqen',
   ],
 };
@@ -19,19 +19,19 @@ export const sender = {
 export const recipients = [addresses.validAddresses[1]];
 
 export const gasPayment = {
-  objectId: '36d6ca08f2081732944d1e5b6b406a4a462e39b8',
+  objectId: '0x36d6ca08f2081732944d1e5b6b406a4a462e39b8',
   version: 3,
   digest: 'uUkO3mMhUmLENOA/YG2XmfO6cEUjztoYSzhtR6of+B8=',
 };
 
 export const coins = [
   {
-    objectId: '111b8a49f67370bc4a58e500b9e64cb6547ee9b4',
+    objectId: '0x111b8a49f67370bc4a58e500b9e64cb6547ee9b4',
     version: 3,
     digest: 'ZLofsvL70pOKNQAV1gH024nNfo4jcNDdmuOsT2NcFYE=',
   },
   {
-    objectId: '111b8a49f67370bc4a58e500b9e64cb6462e39b8',
+    objectId: '0x111b8a49f67370bc4a58e500b9e64cb6462e39b8',
     version: 2,
     digest: 'ZLofsvL70pOKNQAV1gH024nNfo4jcNDdmuOsR6of+B8=',
   },

--- a/modules/sdk-coin-sui/test/unit/utils.ts
+++ b/modules/sdk-coin-sui/test/unit/utils.ts
@@ -30,4 +30,16 @@ describe('Sui util library', function () {
       should.equal(utils.isValidRawTransaction(testData.INVALID_RAW_TX), false);
     });
   });
+
+  describe('normalizeHexId', function () {
+    it('should succeed to normalize hexId with no prefix', function () {
+      const hexId = 'cba4a48bb0f8b586c167e5dcefaa1c5e96ab3f08';
+      const expectedNormalized = '0xcba4a48bb0f8b586c167e5dcefaa1c5e96ab3f08';
+      should.equal(utils.normalizeHexId(hexId), expectedNormalized);
+    });
+    it('should return the hexId with prefix already', function () {
+      const hexId = '0xcba4a48bb0f8b586c167e5dcefaa1c5e96ab3f08';
+      should.equal(utils.normalizeHexId(hexId), hexId);
+    });
+  });
 });


### PR DESCRIPTION
Ticket: BG-59876

bsc deserialization removes '0x' prefix automatically, needs to add the prefix back after bcs deserialization

## Description

<!--
Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## Issue Number

<!--
Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.
 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes