### PR TITLE
fix(core): properly translate tx type to transferToken intent BG-60250

### DIFF
--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -2176,7 +2176,7 @@ describe('V2 Wallet:', function () {
       };
 
       it('calling prebuildxTransaction should execute prebuildTxWithIntent with proper params', async function () {
-        const txRequestFullTokenTransfer = { ...txRequestFull, intent: 'tokenTransfer' };
+        const txRequestFullTokenTransfer = { ...txRequestFull, intent: 'transferToken' };
         const prebuildTxWithIntent = sandbox.stub(ECDSAUtils.EcdsaUtils.prototype, 'prebuildTxWithIntent');
         prebuildTxWithIntent.resolves(txRequestFullTokenTransfer);
         // TODO(BG-59686): this is not doing anything if we don't check the return value, we should also move this check to happen after we invoke prebuildTransaction
@@ -2215,7 +2215,7 @@ describe('V2 Wallet:', function () {
         const mpcUtils = new ECDSAUtils.EcdsaUtils(bitgo, bitgo.coin('tpolygon'));
         // @ts-expect-error only pass in params being tested
         const intent = mpcUtils.populateIntent(bitgo.coin('tpolygon'), {
-          intentType: 'tokenTransfer',
+          intentType: 'transferToken',
           recipients,
           feeOptions,
         });
@@ -2251,7 +2251,7 @@ describe('V2 Wallet:', function () {
         let intent;
         try {
           intent = mpcUtils.populateIntent(bitgo.coin('tpolygon'), {
-            intentType: 'tokenTransfer',
+            intentType: 'transferToken',
             // @ts-expect-error only pass in params be tested for
             recipients,
             feeOptions,

--- a/modules/sdk-coin-eth/src/eth.ts
+++ b/modules/sdk-coin-eth/src/eth.ts
@@ -1626,7 +1626,10 @@ export class Eth extends BaseCoin {
 
   verifyTssTransaction(params: VerifyEthTransactionOptions): boolean {
     const { txParams, txPrebuild, wallet } = params;
-    if (!txParams?.recipients && !(txParams.type && ['acceleration', 'fillNonce'].includes(txParams.type))) {
+    if (
+      !txParams?.recipients &&
+      !(txParams.type && ['acceleration', 'fillNonce', 'transferToken'].includes(txParams.type))
+    ) {
       throw new Error(`missing txParams`);
     }
     if (!wallet || !txPrebuild) {

--- a/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
@@ -102,7 +102,7 @@ export abstract class MpcUtils {
   populateIntent(baseCoin: IBaseCoin, params: PrebuildTransactionWithIntentOptions): PopulatedIntent {
     const chain = this.baseCoin.getChain();
 
-    if (!['acceleration', 'fillNonce'].includes(params.intentType)) {
+    if (!['acceleration', 'fillNonce', 'transferToken'].includes(params.intentType)) {
       assert(params.recipients, `'recipients' is a required parameter for ${params.intentType} intent`);
     }
     const intentRecipients = params.recipients?.map((recipient) => {
@@ -134,7 +134,7 @@ export abstract class MpcUtils {
     if (baseCoin.getFamily() === 'eth' || baseCoin.getFamily() === 'polygon') {
       switch (params.intentType) {
         case 'payment':
-        case 'tokenTransfer':
+        case 'transferToken':
         case 'fillNonce':
           return {
             ...baseIntent,


### PR DESCRIPTION
## Description
This PR fixes the tests and the switch/case statement that check for the intent type set when the tx type is `transfertoken`.