### PR TITLE
refactor: tweak names of some Unspent types

### DIFF
--- a/modules/utxo-lib/src/bitgo/Unspent.ts
+++ b/modules/utxo-lib/src/bitgo/Unspent.ts
@@ -27,14 +27,14 @@ export interface Unspent<TNumber extends number | bigint = number> {
   value: TNumber;
 }
 
-export interface NonWitnessUnspent<TNumber extends number | bigint = number> extends Unspent<TNumber> {
+export interface UnspentWithPrevTx<TNumber extends number | bigint = number> extends Unspent<TNumber> {
   prevTx: Buffer;
 }
 
-export function isNonWitnessUnspent<TNumber extends number | bigint = number>(
+export function isUnspentWithPrevTx<TNumber extends number | bigint, TUnspent extends Unspent<TNumber>>(
   u: Unspent<TNumber>
-): u is NonWitnessUnspent<TNumber> {
-  return Buffer.isBuffer((u as NonWitnessUnspent<TNumber>).prevTx);
+): u is TUnspent & { prevTx: Buffer } {
+  return Buffer.isBuffer((u as UnspentWithPrevTx<TNumber>).prevTx);
 }
 
 /**
@@ -212,7 +212,7 @@ export function addToPsbt(
   });
   const inputIndex = psbt.inputCount - 1;
   if (!isSegwit(u.chain)) {
-    if (!isNonWitnessUnspent(u)) {
+    if (!isUnspentWithPrevTx(u)) {
       throw new Error('Error, require previous tx to add to PSBT');
     }
     psbt.updateInput(inputIndex, { nonWitnessUtxo: u.prevTx });

--- a/modules/utxo-lib/src/bitgo/wallet/Unspent.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/Unspent.ts
@@ -7,7 +7,7 @@ import { WalletUnspentSigner } from './WalletUnspentSigner';
 import { RootWalletKeys } from './WalletKeys';
 import { UtxoTransaction } from '../UtxoTransaction';
 import { Triple } from '../types';
-import { toOutput, NonWitnessUnspent, Unspent } from '../Unspent';
+import { toOutput, UnspentWithPrevTx, Unspent } from '../Unspent';
 import { ChainCode } from './chains';
 
 export interface WalletUnspent<TNumber extends number | bigint = number> extends Unspent<TNumber> {
@@ -16,7 +16,7 @@ export interface WalletUnspent<TNumber extends number | bigint = number> extends
 }
 
 export interface NonWitnessWalletUnspent<TNumber extends number | bigint = number>
-  extends NonWitnessUnspent<TNumber>,
+  extends UnspentWithPrevTx<TNumber>,
     WalletUnspent<TNumber> {}
 
 export function isWalletUnspent<TNumber extends number | bigint>(u: Unspent<TNumber>): u is WalletUnspent<TNumber> {

--- a/modules/utxo-lib/test/bitgo/wallet/WalletUnspent.ts
+++ b/modules/utxo-lib/test/bitgo/wallet/WalletUnspent.ts
@@ -3,7 +3,7 @@ import * as assert from 'assert';
 import { Transaction, networks } from '../../../src';
 import {
   isWalletUnspent,
-  isNonWitnessUnspent,
+  isUnspentWithPrevTx,
   formatOutputId,
   getOutputIdForInput,
   parseOutputId,
@@ -20,7 +20,7 @@ import {
   getWalletAddress,
   verifySignatureWithUnspent,
   toTNumber,
-  NonWitnessUnspent,
+  UnspentWithPrevTx,
   WalletUnspent,
   UtxoTransaction,
   createPsbtForNetwork,
@@ -155,7 +155,9 @@ describe('WalletUnspent', function () {
       tx,
       unspents.map((u) => toPrevOutput<bigint>(u, network))
     );
-    const nonWitnessUnspents = unspents.filter((u) => isNonWitnessUnspent(u)) as unknown as NonWitnessUnspent<bigint>[];
+    const nonWitnessUnspents = unspents.filter((u): u is WalletUnspent<bigint> & UnspentWithPrevTx =>
+      isUnspentWithPrevTx(u)
+    );
     const txBufs = Object.fromEntries(
       psbt2.getNonWitnessPreviousTxids().map((txid) => {
         const u = nonWitnessUnspents.find((u) => parseOutputId(u.id).txid === txid);


### PR DESCRIPTION
Change NonWitnessUnspent to UnspentWithPrevTx, reflecting the
structure a little bit better. This cleans up a double negation in the
code.

Issue: BG-47824