### PR TITLE
fix(sdk-core): update user gpg API param name to create backup keys

### DIFF
--- a/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsa.ts
+++ b/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsa.ts
@@ -630,7 +630,7 @@ describe('TSS Ecdsa Utils:', async function () {
     const keyShare = await createIncompleteBitgoHeldBackupKeyShare(userGpgKey, backupKeyShare, bitgoGpgKey);
 
     nock(bgUrl)
-      .post(`/api/v2/${coin}/krs/backupkeys`, _.matches({ userPub: userGpgKey.publicKey }))
+      .post(`/api/v2/${coin}/krs/backupkeys`, _.matches({ userGPGPublicKey: userGpgKey.publicKey }))
       .reply(201, keyShare);
 
     return keyShare;

--- a/modules/bitgo/test/v2/unit/wallets.ts
+++ b/modules/bitgo/test/v2/unit/wallets.ts
@@ -4,7 +4,7 @@
 
 import 'should';
 import * as nock from 'nock';
-import { BlsUtils, common, TssUtils, Wallets } from '@bitgo/sdk-core';
+import { BlsUtils, common, TssUtils, Wallets, ECDSAUtils } from '@bitgo/sdk-core';
 import * as _ from 'lodash';
 import { TestBitGo } from '@bitgo/sdk-test';
 import { BitGo } from '../../../src/bitgo';
@@ -380,7 +380,8 @@ describe('V2 Wallets:', function () {
       sandbox.verifyAndRestore();
     });
 
-    it('should create a new TSS wallet with BitGoKRS as backup provider', async function () {
+    it('should create a new ECDSA TSS wallet with BitGoKRS as backup provider', async function () {
+      const tpolygon = bitgo.coin('tpolygon');
       const sandbox = sinon.createSandbox();
       const stubbedKeychainsTriplet = {
         userKeychain: {
@@ -396,13 +397,13 @@ describe('V2 Wallets:', function () {
           pub: 'userPub',
         },
       };
-      sandbox.stub(TssUtils.prototype, 'createKeychains').resolves(stubbedKeychainsTriplet);
+      sandbox.stub(ECDSAUtils.EcdsaUtils.prototype, 'createKeychains').resolves(stubbedKeychainsTriplet);
 
       const walletNock = nock('https://bitgo.fakeurl')
-        .post('/api/v2/tsol/wallet')
+        .post('/api/v2/tpolygon/wallet')
         .reply(200);
 
-      const wallets = new Wallets(bitgo, tsol);
+      const wallets = new Wallets(bitgo, tpolygon);
 
       await wallets.generateWallet({
         label: 'tss wallet',
@@ -411,6 +412,7 @@ describe('V2 Wallets:', function () {
         enterprise: 'enterprise',
         passcodeEncryptionCode: 'originalPasscodeEncryptionCode',
         backupProvider: 'BitGoKRS',
+        walletVersion: 3,
       });
 
       walletNock.isDone().should.be.true();

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
@@ -45,7 +45,7 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
     return await this.bitgo
       .post(this.baseCoin.url('/krs/backupkeys'))
       .send({
-        userPub: userGpgKey.publicKey,
+        userGPGPublicKey: userGpgKey.publicKey,
       })
       .result();
   }


### PR DESCRIPTION
## Description

The SDK currently uses `userPub` for the user gpg key, but the API accepts it as `userGPGPublicKey`. This fixes the api param.

<!--
Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## Issue Number

<!--
Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.
 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes