### PR TITLE
chore(sdk-coin-eth): deprecate isTss for eth sends

### DIFF
--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -1735,7 +1735,6 @@ describe('V2 Wallet:', function () {
           reqId,
           recipients,
           type: 'transfer',
-          isTss: true,
           feeOptions,
         });
 
@@ -1743,7 +1742,6 @@ describe('V2 Wallet:', function () {
         const args = prebuildTxWithIntent.args[0];
         args[0]!.recipients!.should.deepEqual(recipients);
         args[0]!.feeOptions!.should.deepEqual(feeOptions);
-        args[0]!.isTss!.should.equal(true);
         args[0]!.intentType.should.equal('payment');
         args[1]!.should.equal('full');
       });
@@ -1831,7 +1829,6 @@ describe('V2 Wallet:', function () {
           type: 'fillNonce',
           feeOptions,
           nonce,
-          isTss: true,
           comment,
         });
 
@@ -1842,7 +1839,6 @@ describe('V2 Wallet:', function () {
         args[0]!.nonce!.should.equal(nonce);
         args[0]!.intentType.should.equal('fillNonce');
         args[0]!.comment!.should.equal(comment);
-        args[0]!.isTss!.should.equal(true);
         args[1]!.should.equal('full');
       });
 
@@ -1865,7 +1861,6 @@ describe('V2 Wallet:', function () {
           reqId,
           recipients,
           type: 'transfer',
-          isTss: true,
           eip1559: {
             maxFeePerGas: expectedFeeOptions.maxFeePerGas.toString(),
             maxPriorityFeePerGas: expectedFeeOptions.maxPriorityFeePerGas.toString(),
@@ -1912,13 +1907,11 @@ describe('V2 Wallet:', function () {
           intentType: 'fillNonce',
           nonce,
           feeOptions,
-          isTss: true,
         });
 
         intent.should.have.property('recipients', undefined);
         intent.feeOptions!.should.deepEqual(feeOptions);
         intent.nonce!.should.equal(nonce);
-        intent.isTss!.should.equal(true);
         intent.intentType.should.equal('fillNonce');
       });
     });

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -2511,7 +2511,6 @@ export class Wallet implements IWallet {
             memo: params.memo,
             nonce: params.nonce,
             feeOptions,
-            isTss: params.isTss,
           },
           apiVersion,
           params.preview
@@ -2552,7 +2551,6 @@ export class Wallet implements IWallet {
             comment: params.comment,
             lowFeeTxid: params.lowFeeTxid,
             feeOptions,
-            isTss: params.isTss,
           },
           apiVersion,
           params.preview
@@ -2565,7 +2563,6 @@ export class Wallet implements IWallet {
             intentType: 'fillNonce',
             comment: params.comment,
             nonce: params.nonce,
-            isTss: params.isTss,
             feeOptions,
           },
           apiVersion,


### PR DESCRIPTION
## Description

<!--
Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Remove logic to pass in 'isTss' to eth tx request builds. This flag is being deprecated in WP in https://github.com/BitGo/bitgo-microservices/pull/25007 (please do not merge this until 25007 is merged).

## Issue Number

<!--
Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.
 -->

Ticket: bg-60332


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes