### PR TITLE
feat(sdk-core): Allow preBuildTransaction to Accept Wallet Id

### DIFF
--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -1297,6 +1297,42 @@ describe('V2 Wallet:', function () {
 
       response.isDone().should.be.true();
     });
+
+    it('should pass walletId parameter through when building transactions in recipient field', async function () {
+      const recipients = [{
+        walletId: 'bbb',
+        amount: '1000',
+      }];
+      const path = `/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/build`;
+      const response = nock(bgUrl)
+        .post(path, _.matches({ recipients }))
+        .reply(200);
+      try {
+        await wallet.prebuildTransaction({ recipients });
+      } catch (e) {
+        // the prebuildTransaction method will probably throw an exception for not having all of the correct nocks
+        // we only care about /tx/build and whether walletId is an allowed parameter in prebuildTransaction
+      }
+      response.isDone().should.be.true();
+    });
+
+    it('should fail when neither address nor walletId is passed in recipient field', async function () {
+      const recipients = [{
+        amount: '1000',
+      }];
+
+      await wallet.prebuildTransaction({ recipients }).should.be.rejectedWith('recipient field must have either an address or walletId');
+    });
+
+    it('should fail when both address and walletId are passed in recipient field', async function () {
+      const recipients = [{
+        address: 'abc',
+        amount: '1000',
+        walletId: 'abc',
+      }];
+
+      await wallet.prebuildTransaction({ recipients }).should.be.rejectedWith('recipient field can only have one of: address or walletId');
+    });
   });
 
   describe('Maximum Spendable', function maximumSpendable() {
@@ -1565,6 +1601,24 @@ describe('V2 Wallet:', function () {
             feeString: '5000',
           },
         });
+      });
+
+      it('should fail when neither address nor walletId is passed in recipient field -- tss wallet', async function () {
+        const recipients = [{
+          amount: '1000',
+        }];
+
+        await tssWallet.prebuildTransaction({ recipients }).should.be.rejectedWith('recipient field must have either an address or walletId');
+      });
+
+      it('should fail when both address and walletId are passed in recipient field -- tss wallet', async function () {
+        const recipients = [{
+          address: 'abc',
+          amount: '1000',
+          walletId: 'abc',
+        }];
+
+        await tssWallet.prebuildTransaction({ recipients }).should.be.rejectedWith('recipient field can only have one of: address or walletId');
       });
 
       it('should build a multiple recipient transfer transaction with memo', async function () {

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -69,7 +69,7 @@ export interface IntentOptionsBase {
 
 export interface PrebuildTransactionWithIntentOptions extends IntentOptionsBase {
   recipients?: {
-    address: string;
+    address?: string;
     amount: string | number;
     tokenName?: string;
     tokenData?: TokenTransferRecipientParams;
@@ -84,7 +84,7 @@ export interface PrebuildTransactionWithIntentOptions extends IntentOptionsBase 
 }
 export interface IntentRecipient {
   address: {
-    address: string;
+    address?: string;
   };
   amount: {
     value: string | number;

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -55,8 +55,9 @@ export interface BuildTokenEnablementOptions extends PrebuildTransactionOptions 
 export interface PrebuildTransactionOptions {
   reqId?: IRequestTracer;
   recipients?: {
-    address: string;
+    address?: string;
     amount: string | number;
+    walletId?: string;
     tokenName?: string;
     tokenData?: TokenTransferRecipientParams;
   }[];
@@ -414,7 +415,7 @@ export interface SendOptions {
 export interface SendManyOptions extends PrebuildAndSignTransactionOptions {
   reqId?: IRequestTracer;
   recipients?: {
-    address: string;
+    address?: string;
     amount: string | number;
     feeLimit?: string;
     data?: string;

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -1441,7 +1441,7 @@ export class Wallet implements IWallet {
    * Fetch a transaction prebuild (unsigned transaction) from BitGo
    *
    * @param {Object} params
-   * @param {{address: string, amount: string}} params.recipients - list of recipients and necessary recipient information
+   * @param {{address: string | walletId: string, amount: string}} params.recipients - list of recipients and necessary recipient information
    * @param {Number} params.numBlocks - Estimates the approximate fee per kilobyte necessary for a transaction confirmation within numBlocks blocks
    * @param {Number} params.feeRate - the desired feeRate for the transaction in base units/kB
    * @param {Number} params.maxFeeRate - upper limit for feeRate in base units/kB
@@ -1472,6 +1472,16 @@ export class Wallet implements IWallet {
    * @returns {*}
    */
   async prebuildTransaction(params: PrebuildTransactionOptions = {}): Promise<PrebuildTransactionResult> {
+    if (params.recipients) {
+      for (const recipient of params.recipients) {
+        if (!recipient.address && !recipient.walletId) {
+          throw new Error('recipient field must have either an address or walletId');
+        } else if (recipient.address && recipient.walletId) {
+          throw new Error('recipient field can only have one of: address or walletId');
+        }
+      }
+    }
+
     if (this._wallet.multisigType === 'tss') {
       return this.prebuildTransactionTss(params);
     }


### PR DESCRIPTION
Ticket: BG-57866

## Description

Allow WalletId to be passed as argument (under `recipient`) when we build txn

<!--
Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## Issue Number

Ticket: BG-57866

<!--
Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.
 -->

## Type of change

- [x] New feature (non-breaking change which adds functionality)