### PR TITLE
feat: pass custodianTransaction and messageId

### DIFF
--- a/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
@@ -143,6 +143,7 @@ export abstract class MpcUtils {
             hopParams: params.hopParams,
             isTss: params.isTss,
             nonce: params.nonce,
+            custodianTransactionId: params.custodianTransactionId,
           };
         case 'acceleration':
           return {

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -63,7 +63,10 @@ export interface IntentOptionsBase {
   isTss?: boolean;
   comment?: string;
   memo?: Memo;
+  custodianTransactionId?: string;
+  custodianMessageId?: string;
 }
+
 export interface PrebuildTransactionWithIntentOptions extends IntentOptionsBase {
   recipients?: {
     address: string;
@@ -107,6 +110,8 @@ export interface PopulatedIntent extends PopulatedIntentBase {
   feeOptions?: FeeOption | EIP1559FeeOptions;
   hopParams?: HopParams;
   txid?: string;
+  custodianTransactionId?: string;
+  custodianMessageId?: string;
 }
 
 export type TxRequestState =

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -103,6 +103,7 @@ export interface PrebuildTransactionOptions {
   gasLimit?: number;
   lowFeeTxid?: string;
   isTss?: boolean;
+  custodianTransactionId?: string;
 }
 
 export interface PrebuildAndSignTransactionOptions extends PrebuildTransactionOptions, WalletSignTransactionOptions {
@@ -147,6 +148,7 @@ export interface WalletSignTransactionOptions extends WalletSignBaseOptions {
 
 export interface WalletSignMessageOptions extends WalletSignBaseOptions {
   messagePrebuild?: MessagePrebuild;
+  custodianMessageId?: string;
 }
 
 export interface GetUserPrvOptions {
@@ -441,6 +443,7 @@ export interface SendManyOptions extends PrebuildAndSignTransactionOptions {
   [index: string]: unknown;
   eip1559?: EIP1559;
   gasLimit?: number;
+  custodianTransactionId?: string;
 }
 
 export type WalletType = 'backing' | 'cold' | 'custodial' | 'custodialPaired' | 'hot' | 'trading';

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -1568,7 +1568,7 @@ export class Wallet implements IWallet {
   }
 
   /**
-   *  Sign a message using TSS (not implemented for hot wallets)
+   *  Sign a message using TSS
    * @param params
    * - messagePrebuild
    * - [keychain / key] (object) or prv (string)
@@ -2684,6 +2684,7 @@ export class Wallet implements IWallet {
       assert(params.messagePrebuild);
       if (!params.messagePrebuild.txRequestId) {
         const intentOption: IntentOptionsBase = {
+          custodianMessageId: params.custodianMessageId,
           reqId: params.reqId,
           intentType: 'signmessage',
           isTss: true,


### PR DESCRIPTION
Add support for MMI transactions and message signing.

Transactions
- Pass custodianTransactionId into the intent in txRequest

Messages
- Pass custodianMessageId into intent in txRequest