### PR TITLE
fix: add test paths to tsconfig.json

### DIFF
--- a/modules/utxo-lib/test/transaction_builder.spec.ts
+++ b/modules/utxo-lib/test/transaction_builder.spec.ts
@@ -8,8 +8,8 @@ import {
   script as bscript,
   Transaction,
   TransactionBuilder,
-} from '..';
-import { ECPair } from '../src/noble_ecc';
+  ECPair,
+} from '../src';
 
 console.warn = (): void => {
   return;

--- a/modules/utxo-lib/tsconfig.json
+++ b/modules/utxo-lib/tsconfig.json
@@ -4,8 +4,9 @@
     "outDir": "./dist",
     "rootDir": ".",
     "esModuleInterop": false,
-    "typeRoots": ["../../types", "./node_modules/@types", "../../node_modules/@types"]
+    "typeRoots": ["../../types", "./node_modules/@types", "../../node_modules/@types"],
+    "resolveJsonModule": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "test/**/*", "test/**/*.json"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Since the tests are written in Typescript, we want `tsconfig.json` to
include them. This enables IntelliJ to work correctly.

The output now includes a new directory `dist/test/`.
However the keys "main" and "files" in `package.json` expliclity
reference `dist/src` paths, so it should not matter.

Issue: BG-47824