### PR TITLE
refactor(utxo-lib): move unspentSum test to better place

### DIFF
--- a/modules/utxo-lib/src/bitgo/Unspent.ts
+++ b/modules/utxo-lib/src/bitgo/Unspent.ts
@@ -128,7 +128,7 @@ export function addToTransactionBuilder<TNumber extends number | bigint>(
  * @return unspentSum - type matches amountType
  */
 export function unspentSum<TNumber extends number | bigint>(
-  unspents: Unspent<TNumber>[],
+  unspents: { value: TNumber }[],
   amountType: 'number' | 'bigint' = 'number'
 ): TNumber {
   if (amountType === 'bigint') {

--- a/modules/utxo-lib/test/bitgo/Unspent.ts
+++ b/modules/utxo-lib/test/bitgo/Unspent.ts
@@ -1,0 +1,42 @@
+import assert = require('assert');
+import { unspentSum } from '../../src/bitgo';
+
+function mockUnspent<TNumber extends number | bigint>(value: TNumber) {
+  return { value };
+}
+describe('unspentSum', function () {
+  const unspents = [mockUnspent(123), mockUnspent(98765)];
+  const bigUnspents = [mockUnspent(Number.MAX_SAFE_INTEGER)];
+  const unspentsBig = [mockUnspent(BigInt(123)), mockUnspent(BigInt(98765))];
+  it('sums number', function () {
+    assert.strictEqual(unspentSum(unspents, 'number'), 123 + 98765);
+  });
+  it('sums bigint', function () {
+    assert.strictEqual(unspentSum(unspentsBig, 'bigint'), BigInt(123 + 98765));
+  });
+  it('sums zero', function () {
+    assert.strictEqual(unspentSum([], 'number'), 0);
+    assert.strictEqual(unspentSum([], 'number'), 0);
+  });
+  it('throws on mixing number and bigint', function () {
+    assert.throws(() => {
+      unspentSum((unspentsBig as unknown as { value: number }[]).concat(unspents), 'number');
+    });
+    assert.throws(() => {
+      unspentSum((unspents as unknown as { value: bigint }[]).concat(unspentsBig), 'bigint');
+    });
+  });
+  it('throws on unsafe integer number', function () {
+    assert.throws(() => {
+      unspentSum(bigUnspents.concat(unspents), 'number');
+    });
+  });
+  it('throws on mismatch between unspent and amountType', function () {
+    assert.throws(() => {
+      unspentSum(unspents, 'bigint');
+    });
+    assert.throws(() => {
+      unspentSum(unspentsBig, 'number');
+    });
+  });
+});

--- a/modules/utxo-lib/test/bitgo/wallet/WalletUnspent.ts
+++ b/modules/utxo-lib/test/bitgo/wallet/WalletUnspent.ts
@@ -68,66 +68,6 @@ describe('WalletUnspent', function () {
     assert.strictEqual(isWalletUnspent({ ...unspent, chain: 0, index: 0 } as Unspent), true);
   });
 
-  describe('unspentSum', function () {
-    const unspents = [
-      mockWalletUnspent(network, 123, {
-        keys: walletKeys,
-        vout: 0,
-      }),
-      mockWalletUnspent(network, 98765, {
-        keys: walletKeys,
-        vout: 1,
-      }),
-    ];
-    const bigUnspents = [
-      mockWalletUnspent(network, Number.MAX_SAFE_INTEGER, {
-        keys: walletKeys,
-        vout: 1,
-      }),
-    ];
-    const unspentsBig = [
-      mockWalletUnspent(network, BigInt(123), {
-        keys: walletKeys,
-        vout: 0,
-      }),
-      mockWalletUnspent(network, BigInt(98765), {
-        keys: walletKeys,
-        vout: 1,
-      }),
-    ];
-    it('sums number', function () {
-      assert.strictEqual(unspentSum(unspents, 'number'), 123 + 98765);
-    });
-    it('sums bigint', function () {
-      assert.strictEqual(unspentSum(unspentsBig, 'bigint'), BigInt(123 + 98765));
-    });
-    it('sums zero', function () {
-      assert.strictEqual(unspentSum([], 'number'), 0);
-      assert.strictEqual(unspentSum([], 'number'), 0);
-    });
-    it('throws on mixing number and bigint', function () {
-      assert.throws(() => {
-        unspentSum((unspentsBig as unknown as Unspent<number>[]).concat(unspents), 'number');
-      });
-      assert.throws(() => {
-        unspentSum((unspents as unknown as Unspent<bigint>[]).concat(unspentsBig), 'bigint');
-      });
-    });
-    it('throws on unsafe integer number', function () {
-      assert.throws(() => {
-        unspentSum(bigUnspents.concat(unspents), 'number');
-      });
-    });
-    it('throws on mismatch between unspent and amountType', function () {
-      assert.throws(() => {
-        unspentSum(unspents, 'bigint');
-      });
-      assert.throws(() => {
-        unspentSum(unspentsBig, 'number');
-      });
-    });
-  });
-
   function constructAndSignTransactionUsingPsbt(
     unspents: WalletUnspent<bigint>[],
     signer: KeyName,


### PR DESCRIPTION
They don't need to be defined on WalletUnspent (or even Unspent)
either.

Issue: BG-47824