### PR TITLE
fix: disable vss verification

### DIFF
--- a/modules/bitgo/test/v2/unit/tss/eddsa.ts
+++ b/modules/bitgo/test/v2/unit/tss/eddsa.ts
@@ -398,7 +398,8 @@ describe('test tss helper functions', function () {
 
     describe('offerUserToBitgoRShare:', async function() {
       it('should succeed to send Signature Share', async function() {
-        const signatureShare = { from: 'user', to: 'bitgo', share: validUserSignShare.rShares[3].v + validUserSignShare.rShares[3].r + validUserSignShare.rShares[3].R } as SignatureShareRecord;
+        // TODO(BG-61037): add back v when VSS signing is fixed
+        const signatureShare = { from: 'user', to: 'bitgo', share: /* validUserSignShare.rShares[3].v + */ validUserSignShare.rShares[3].r + validUserSignShare.rShares[3].R } as SignatureShareRecord;
         const nock = await nockSendSignatureShare({ walletId: wallet.id(), txRequestId: txRequest.txRequestId, signatureShare, signerShare: 'signerShare' });
         await offerUserToBitgoRShare(bitgo, wallet.id(), txRequest.txRequestId, validUserSignShare, 'signerShare').should.be.fulfilled();
         nock.isDone().should.equal(true);

--- a/modules/sdk-core/src/account-lib/mpc/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/account-lib/mpc/tss/eddsa/eddsa.ts
@@ -135,7 +135,8 @@ export default class Eddsa {
             uShare.i
           );
         } catch (err) {
-          throw new Error(`Could not verify share from participant ${share.j}. Verification error: ${err}`);
+          // TODO(BG-61036): Fix Verification
+          // throw new Error(`Could not verify share from participant ${share.j}. Verification error: ${err}`);
         }
       }
     }

--- a/modules/sdk-core/src/bitgo/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/bitgo/tss/eddsa/eddsa.ts
@@ -197,7 +197,8 @@ export async function offerUserToBitgoRShare(
   const signatureShare: SignatureShareRecord = {
     from: SignatureShareType.USER,
     to: SignatureShareType.BITGO,
-    share: rShare.v + rShare.r + rShare.R,
+    // TODO(BG-61037): Fix signing with VSS
+    share: /* rShare.v + */ rShare.r + rShare.R,
   };
 
   // TODO (BG-57944): implement message signing for EDDSA


### PR DESCRIPTION
VSS verification does not currently work with current APIs. Will need to make changes before re-enabling.

Ticket: BG-61040

## Description

<!--
Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## Issue Number

<!--
Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.
 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes