### PR TITLE
feat(sdk-core): expect txid response for lightning withdrawal

### DIFF
--- a/modules/bitgo/test/v2/fixtures/lightning/lightning.ts
+++ b/modules/bitgo/test/v2/fixtures/lightning/lightning.ts
@@ -111,39 +111,7 @@ export default {
   },
 
   withdraw: {
-    transfer: {
-      entries: [
-        {
-          address: '2NCDoKg3j3TrkiRa17npwnenbpadEaw3aFS',
-          wallet: '62acd3e4d1d77600074c70829a0940d8',
-          value: -30000,
-          valueString: '-30000',
-        },
-      ],
-      id: '62f428a4a8fe2800087908e901f26ae9',
-      coin: 'tbtc',
-      wallet: '62acd3e4d1d77600074c70829a0940d8',
-      heightId: '999999999-62f428a4a8fe2800087908e901f26ae9',
-      date: '2022-08-10T21:52:36.147Z',
-      type: 'send',
-      value: -30000,
-      valueString: '-30000',
-      baseValue: -30000,
-      baseValueString: '-30000',
-      payGoFee: 0,
-      payGoFeeString: '0',
-      state: 'pendingApproval',
-      instant: false,
-      isReward: false,
-      isFee: false,
-      tags: ['62acd3e4d1d77600074c70829a0940d8'],
-      history: [{ date: '2022-08-10T21:52:36.147Z', action: 'created' }],
-      coinSpecific: { lightning: true },
-      sequenceId: '3578',
-      createdTime: '2022-08-10T21:52:36.147Z',
-      sendAccounting: [],
-    },
-    status: 'unconfirmed',
+    txid: 'f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16',
   },
 
   deposit: {

--- a/modules/sdk-core/src/bitgo/lightning/iLightning.ts
+++ b/modules/sdk-core/src/bitgo/lightning/iLightning.ts
@@ -68,8 +68,7 @@ export type WPTransfer = t.TypeOf<typeof WPTransfer>;
 
 export const WithdrawResponse = t.strict(
   {
-    status: t.string,
-    transfer: WPTransfer,
+    txid: t.string,
   },
   'CreateWithdrawalResponse'
 );


### PR DESCRIPTION
## Description

This updates the SDK code to expect the new response format used for lightning withdrawal requests, which specifies a `txid` in the body rather than a `transfer` and `status`.

## Issue Number

Ticket: BG-59192

## Type of change

This does not break or change any of the SDK APIs, but rather brings it up to date with a breaking change on the BitGo API side. 

## How Has This Been Tested?

Direct requests against the BitGo API in test confirm that the response body for this call only contains `txid`.