### PR TITLE
feat(root): use utxolib toOutputScriptTryFormats in isValidAddress

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -293,71 +293,20 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
   }
 
   /**
-   * Helper to get the version number for an address
-   */
-  protected getAddressVersion(address: string): number | undefined {
-    // try decoding as base58 first
-    try {
-      const { version } = utxolib.address.fromBase58Check(address, this.network);
-      return version;
-    } catch (e) {
-      // try next format
-    }
-
-    // if coin does not support script types with bech32 encoding, do not attempt to parse
-    if (!this.supportsAddressType('p2wsh') && !this.supportsAddressType('p2tr')) {
-      return;
-    }
-
-    // otherwise, try decoding as bech32
-    try {
-      const { version, prefix } = utxolib.address.fromBech32(address);
-      if (_.isString(this.network.bech32) && prefix === this.network.bech32) {
-        return version;
-      }
-    } catch (e) {
-      // ignore errors, just fall through and return undefined
-    }
-  }
-
-  /**
-   * Helper to get the bech32 prefix for an address
-   */
-  protected getAddressPrefix(address: string): string | undefined {
-    // otherwise, try decoding as bech32
-    try {
-      const { prefix } = utxolib.address.fromBech32(address);
-      return prefix;
-    } catch (e) {
-      // ignore errors, just fall through and return undefined
-    }
-  }
-
-  /**
    * Check if an address is valid
    * @param address
    * @param forceAltScriptSupport
    */
   isValidAddress(address: string, forceAltScriptSupport = false): boolean {
-    const validVersions: number[] = [this.network.pubKeyHash, this.network.scriptHash];
-    if (this.altScriptHash && (forceAltScriptSupport || this.supportAltScriptDestination)) {
-      validVersions.push(this.altScriptHash);
+    if (forceAltScriptSupport) {
+      throw new Error(`deprecated`);
     }
-
-    const addressVersion = this.getAddressVersion(address);
-
-    // the address version needs to be among the valid ones
-    const addressVersionValid = _.isNumber(addressVersion) && validVersions.includes(addressVersion);
-    const addressPrefix = this.getAddressPrefix(address);
-
-    if (!this.supportsAddressType('p2wsh') || _.isUndefined(addressPrefix)) {
-      return addressVersionValid;
+    try {
+      utxolib.addressFormat.toOutputScriptTryFormats(address, this.network);
+      return true;
+    } catch (e) {
+      return false;
     }
-
-    // address has a potential bech32 prefix, validate that
-    return (
-      _.isString(this.network.bech32) && this.network.bech32 === addressPrefix && address === address.toLowerCase()
-    );
   }
 
   /**

--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -295,14 +295,16 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
   /**
    * Check if an address is valid
    * @param address
-   * @param forceAltScriptSupport
+   * @param param
    */
-  isValidAddress(address: string, forceAltScriptSupport = false): boolean {
-    if (forceAltScriptSupport) {
-      throw new Error(`deprecated`);
+  isValidAddress(address: string, param?: { anyFormat: boolean } | /* legacy parameter */ boolean): boolean {
+    if (typeof param === 'boolean' && param) {
+      throw new Error('deprecated');
     }
+
+    const formats = param && param.anyFormat ? undefined : ['default' as const];
     try {
-      utxolib.addressFormat.toOutputScriptTryFormats(address, this.network);
+      utxolib.addressFormat.toOutputScriptTryFormats(address, this.network, formats);
       return true;
     } catch (e) {
       return false;

--- a/modules/abstract-utxo/src/recovery/backupKeyRecovery.ts
+++ b/modules/abstract-utxo/src/recovery/backupKeyRecovery.ts
@@ -258,7 +258,10 @@ export async function backupKeyRecovery<TNumber extends number | bigint = number
     throw new Error('missing backupKey');
   }
 
-  if (_.isUndefined(params.recoveryDestination) || !coin.isValidAddress(params.recoveryDestination)) {
+  if (
+    _.isUndefined(params.recoveryDestination) ||
+    !coin.isValidAddress(params.recoveryDestination, { anyFormat: true })
+  ) {
     throw new Error('invalid recoveryDestination');
   }
 

--- a/modules/sdk-coin-bch/src/bch.ts
+++ b/modules/sdk-coin-bch/src/bch.ts
@@ -23,10 +23,6 @@ export class Bch extends AbstractUtxoCoin {
     return 'Bitcoin Cash';
   }
 
-  getAddressPrefix() {
-    return 'bitcoincash';
-  }
-
   supportsBlockTarget() {
     return false;
   }

--- a/modules/sdk-coin-bch/src/tbch.ts
+++ b/modules/sdk-coin-bch/src/tbch.ts
@@ -21,8 +21,4 @@ export class Tbch extends Bch {
   getFullName() {
     return 'Testnet Bitcoin Cash';
   }
-
-  getAddressPrefix() {
-    return 'bchtest';
-  }
 }

--- a/modules/sdk-coin-bsv/src/tbsv.ts
+++ b/modules/sdk-coin-bsv/src/tbsv.ts
@@ -21,8 +21,4 @@ export class Tbsv extends Bsv {
   getFullName(): string {
     return 'Testnet Bitcoin SV';
   }
-
-  getAddressPrefix(): string {
-    return 'bchtest';
-  }
 }

--- a/modules/sdk-coin-ltc/src/ltc.ts
+++ b/modules/sdk-coin-ltc/src/ltc.ts
@@ -1,5 +1,5 @@
 import { AbstractUtxoCoin, UtxoNetwork } from '@bitgo/abstract-utxo';
-import { BitGoBase, BaseCoin, InvalidAddressError } from '@bitgo/sdk-core';
+import { BitGoBase, BaseCoin } from '@bitgo/sdk-core';
 import * as utxolib from '@bitgo/utxo-lib';
 
 export class Ltc extends AbstractUtxoCoin {
@@ -29,46 +29,5 @@ export class Ltc extends AbstractUtxoCoin {
 
   supportsBlockTarget(): boolean {
     return false;
-  }
-
-  /**
-   * Canonicalize a Litecoin address for a specific scriptHash version
-   * @param address
-   * @param scriptHashVersion 1 or 2, where 1 is the old version and 2 is the new version
-   * @returns {*} address string
-   */
-  canonicalAddress(address: string, scriptHashVersion = 2): string {
-    if (!this.isValidAddress(address, true)) {
-      throw new InvalidAddressError();
-    }
-    try {
-      // try deserializing as bech32
-      utxolib.address.fromBech32(address);
-      // address may be all uppercase, but canonical bech32 addresses are all lowercase
-      return address.toLowerCase();
-    } catch (e) {
-      // not a valid bech32, try to decode as base58
-    }
-    const addressDetails = utxolib.address.fromBase58Check(address, this.network);
-    if (addressDetails.version === this.network.pubKeyHash) {
-      // the pub keys never changed
-      return address;
-    }
-    if ([1, 2].indexOf(scriptHashVersion) === -1) {
-      throw new Error('scriptHashVersion needs to be either 1 or 2');
-    }
-    const scriptHashMap = {
-      // altScriptHash is the old one
-      1: this.altScriptHash,
-      // by default we're using the new one
-      2: this.network.scriptHash,
-    };
-    const newScriptHash = scriptHashMap[scriptHashVersion];
-    return utxolib.address.toBase58Check(addressDetails.hash, newScriptHash, this.network);
-  }
-
-  calculateRecoveryAddress(scriptHashScript: Buffer): string {
-    const bitgoAddress = utxolib.address.fromOutputScript(scriptHashScript, this.network);
-    return this.canonicalAddress(bitgoAddress, 1);
   }
 }

--- a/modules/sdk-coin-ltc/test/unit/index.ts
+++ b/modules/sdk-coin-ltc/test/unit/index.ts
@@ -14,68 +14,6 @@ describe('Litecoin:', function () {
   const ltc = bitgo.coin('ltc') as Ltc;
   const tltc = bitgo.coin('tltc') as Tltc;
 
-  describe('Canonicalize address', function () {
-    it('base58 mainnet address', function () {
-      const standardBase58Address = '3GBygsGPvTdfKMbq4AKZZRu1sPMWPEsBfd';
-      const litecoinBase58Address = 'MNQ7zkgMsaV67rsjA3JuP59RC5wxRXpwgE';
-      // convert from new format to old
-      const downgradedAddress = ltc.canonicalAddress(litecoinBase58Address, 1);
-      downgradedAddress.should.equal(standardBase58Address);
-      // convert from new format to new (no-op)
-      const unmodifiedAddress = ltc.canonicalAddress(litecoinBase58Address, 2);
-      unmodifiedAddress.should.equal(litecoinBase58Address);
-      // convert from old format to new
-      const upgradedAddress = ltc.canonicalAddress(standardBase58Address, 2);
-      upgradedAddress.should.equal(litecoinBase58Address);
-    });
-    it('base58 testnet address', function () {
-      const standardBase58Address = '2MsFGJvxH1kCoRp3XEYvKduAjY6eYz9PJHz';
-      const litecoinBase58Address = 'QLc2RwpX2rFtZzoZrexLibcAgV6Nsg74Jn';
-      // convert from new format to old
-      const downgradedAddress = tltc.canonicalAddress(litecoinBase58Address, 1);
-      downgradedAddress.should.equal(standardBase58Address);
-      // convert from new format to new (no-op)
-      const unmodifiedAddress = tltc.canonicalAddress(litecoinBase58Address, 2);
-      unmodifiedAddress.should.equal(litecoinBase58Address);
-      // convert from old format to new
-      const upgradedAddress = tltc.canonicalAddress(standardBase58Address, 2);
-      upgradedAddress.should.equal(litecoinBase58Address);
-    });
-    it('lower case bech32 mainnet address', function () {
-      // canonicalAddress will only accept lower case bech32 addresses - they are already
-      // in canonical format, and the script hash version is not relevant
-      const bech32Address = 'ltc1qgrl8zpndsklaa9swgd5vevyxmx5x63vcrl7dk4';
-      const version1Address = ltc.canonicalAddress(bech32Address, 1);
-      version1Address.should.equal(bech32Address);
-      const version2Address = ltc.canonicalAddress(bech32Address, 2);
-      version2Address.should.equal(bech32Address);
-    });
-    it('uppercase bech32 mainnet address should fail', function () {
-      // canonicalAddress only accepts lower case bech32 addresses, uppercase addresses
-      // are valid according to the spec but will be treated as invalid
-      const bech32Address = 'LTC1QGRL8ZPNDSKLAA9SWGD5VEVYXMX5X63VCRL7DK4';
-      (() => ltc.canonicalAddress(bech32Address)).should.throw('invalid address');
-    });
-    it('mixed-case bech32 mainnet address should fail', function () {
-      const bech32Address = 'ltc1QGRL8ZPNDSKLAA9SWGD5VEVYXMX5X63VCRL7DK4';
-      (() => ltc.canonicalAddress(bech32Address)).should.throw('invalid address');
-    });
-    it('lower case bech32 testnet address', function () {
-      const bech32Address = 'tltc1qu78xur5xnq6fjy83amy0qcjfau8m367defyhms';
-      const version1Address = tltc.canonicalAddress(bech32Address, 1);
-      version1Address.should.equal(bech32Address);
-      const version2Address = tltc.canonicalAddress(bech32Address, 2);
-      version2Address.should.equal(bech32Address);
-    });
-    it('uppercase bech32 testnet address should fail', function () {
-      const bech32Address = 'TLTC1QU78XUR5XNQ6FJY83AMY0QCJFAU8M367DEFYHMS';
-      (() => ltc.canonicalAddress(bech32Address)).should.throw('invalid address');
-    });
-    it('mixed case bech32 testnet address should fail', function () {
-      const bech32Address = 'tltc1QU78XUR5XNQ6FJY83AMY0QCJFAU8M367DEFYHMS';
-      (() => ltc.canonicalAddress(bech32Address)).should.throw('invalid address');
-    });
-  });
   describe('should validate addresses', () => {
     it('should validate base58 addresses', () => {
       // known valid main and testnet base58 address are valid
@@ -89,9 +27,9 @@ describe('Litecoin:', function () {
       // all lower case is valid
       ltc.isValidAddress('ltc1qq7fzt3ek5ege3v92wh0q6wzcjr39pqswlpe36mu28f6yufark3wspfryg7').should.be.true();
       tltc.isValidAddress('tltc1qq7fzt3ek5ege3v92wh0q6wzcjr39pqswlpe36mu28f6yufark3ws2x86ht').should.be.true();
-      // all upper case is invalid
-      ltc.isValidAddress('LTC1QQ7FZT3EK5EGE3V92WH0Q6WZCJR39PQSWLPE36MU28F6YUFARK3WSPFRYG7').should.be.false();
-      tltc.isValidAddress('TLTC1QQ7FZT3EK5EGE3V92WH0Q6WZCJR39PQSWLPE36MU28F6YUFARK3WS2X86HT').should.be.false();
+      // all upper case is valid
+      ltc.isValidAddress('LTC1QQ7FZT3EK5EGE3V92WH0Q6WZCJR39PQSWLPE36MU28F6YUFARK3WSPFRYG7').should.be.true();
+      tltc.isValidAddress('TLTC1QQ7FZT3EK5EGE3V92WH0Q6WZCJR39PQSWLPE36MU28F6YUFARK3WS2X86HT').should.be.true();
       // mixed case is invalid
       ltc.isValidAddress('LTC1QQ7FZT3EK5EGE3V92WH0Q6WZCJR39PQSWLPE36MU28F6YUFARK3WSPFRYg7').should.be.false();
       tltc.isValidAddress('TLTC1QQ7FZT3EK5EGE3V92WH0Q6WZCJR39PQSWLPE36MU28F6YUFARK3WS2X86Ht').should.be.false();


### PR DESCRIPTION
BG-60666

BREAKING CHANGE: this drops support for the legacy Litecoin format.
Litecoin addresses starting with 3 will not be supported anymore.

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->