### PR TITLE
fix: pass custodianId to prebuildTxWithIntent

### DIFF
--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -82,6 +82,7 @@ export interface PrebuildTransactionWithIntentOptions extends IntentOptionsBase 
   feeOptions?: FeeOption | EIP1559FeeOptions;
   hopParams?: HopParams;
   lowFeeTxid?: string;
+  custodianTransactionId?: string;
 }
 export interface IntentRecipient {
   address: {

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -2537,6 +2537,7 @@ export class Wallet implements IWallet {
             memo: params.memo,
             nonce: params.nonce,
             feeOptions,
+            custodianTransactionId: params.custodianTransactionId,
           },
           apiVersion,
           params.preview


### PR DESCRIPTION
Pass custodianTransactionId to prebuildTxWithIntent so it gets included inside the payment intent

Tested E2E with MMI Transactions