### PR TITLE
feat(utxo-lib): remove dependency on `classify` in parseSignatureScript

### DIFF
--- a/modules/utxo-lib/src/bitgo/index.ts
+++ b/modules/utxo-lib/src/bitgo/index.ts
@@ -3,6 +3,7 @@ export * as keyutil from './keyutil';
 export * as nonStandardHalfSigned from './nonStandardHalfSigned';
 export * as outputScripts from './outputScripts';
 export * from './dash';
+export * from './parseInput';
 export * from './signature';
 export * from './transaction';
 export * from './types';

--- a/modules/utxo-lib/src/bitgo/parseInput.ts
+++ b/modules/utxo-lib/src/bitgo/parseInput.ts
@@ -1,0 +1,418 @@
+import * as opcodes from 'bitcoin-ops';
+import { TxInput, script as bscript } from 'bitcoinjs-lib';
+
+import { ScriptType } from './outputScripts';
+import { isTriple } from './types';
+
+const inputTypes = [
+  'multisig',
+  'nonstandard',
+  'nulldata',
+  'pubkey',
+  'pubkeyhash',
+  'scripthash',
+  'witnesspubkeyhash',
+  'witnessscripthash',
+  'taproot',
+  'taprootnofn',
+  'witnesscommitment',
+] as const;
+
+type InputType = typeof inputTypes[number];
+
+export function isPlaceholderSignature(v: number | Buffer): boolean {
+  if (Buffer.isBuffer(v)) {
+    return v.length === 0;
+  }
+  return v === 0;
+}
+
+export interface ParsedSignatureScript {
+  scriptType: ScriptType | 'p2pkh' | undefined;
+  isSegwitInput: boolean;
+  inputClassification: InputType;
+  p2shOutputClassification?: string;
+}
+
+export interface ParsedSignatureScriptUnknown extends ParsedSignatureScript {
+  scriptType: undefined;
+}
+
+export interface ParsedSignatureScriptP2PK extends ParsedSignatureScript {
+  scriptType: 'p2shP2pk';
+  inputClassification: 'scripthash';
+}
+
+export interface ParsedSignatureScriptP2PKH extends ParsedSignatureScript {
+  scriptType: 'p2pkh';
+  inputClassification: 'pubkeyhash';
+  signatures: [Buffer];
+  publicKeys: [Buffer];
+  pubScript?: Buffer;
+}
+
+export interface ParsedSignatureScript2Of3 extends ParsedSignatureScript {
+  scriptType: 'p2sh' | 'p2shP2wsh' | 'p2wsh';
+  inputClassification: 'scripthash' | 'witnessscripthash';
+  publicKeys: [Buffer, Buffer, Buffer];
+  signatures:
+    | [Buffer, Buffer] // fully-signed transactions with signatures
+    /* Partially signed transactions with placeholder signatures.
+       For p2sh, the placeholder is OP_0 (number 0) */
+    | [Buffer | 0, Buffer | 0, Buffer | 0];
+  pubScript: Buffer;
+}
+
+/**
+ * Keypath spends only have a single pubkey and single signature
+ */
+export interface ParsedSignatureScriptTaprootKeyPath extends ParsedSignatureScript {
+  scriptType: 'p2tr';
+  inputClassification: 'taproot';
+  publicKeys: [Buffer];
+  signatures: [Buffer];
+  pubScript: Buffer;
+}
+
+/**
+ * Taproot Scriptpath spends are more similar to regular p2ms spends and have two public keys and
+ * two signatures
+ */
+export interface ParsedSignatureScriptTaprootScriptPath extends ParsedSignatureScript {
+  scriptType: 'p2tr';
+  inputClassification: 'taproot';
+  publicKeys: [Buffer, Buffer];
+  signatures: [Buffer, Buffer];
+  controlBlock: Buffer;
+  /** Indicates the level inside the taptree. */
+  scriptPathLevel: number;
+  pubScript: Buffer;
+}
+
+export type ParsedSignatureScriptTaproot = ParsedSignatureScriptTaprootKeyPath | ParsedSignatureScriptTaprootScriptPath;
+
+type DecompiledScript = Array<Buffer | number>;
+
+/**
+ * Static script elements
+ */
+type ScriptPatternConstant =
+  | 'OP_0'
+  | 'OP_1'
+  | 'OP_2'
+  | 'OP_3'
+  | 'OP_CHECKMULTISIG'
+  | 'OP_CHECKSIG'
+  | 'OP_CHECKSIGVERIFY';
+
+/**
+ * Script elements that can be captured
+ */
+type ScriptPatternCapture = ':pubkey' | ':signature' | ':buffer' | { ':script': ScriptPatternElement[] };
+
+type ScriptPatternElement = ScriptPatternConstant | ScriptPatternCapture;
+
+/**
+ * Result for a successful script match
+ */
+type MatchResult = {
+  ':pubkey': Buffer[];
+  ':buffer': Buffer[];
+  ':signature': (Buffer | 0)[];
+  ':script': { buffer: Buffer; match: MatchResult }[];
+};
+
+/**
+ * @param script
+ * @param pattern
+ * @return MatchResult if script matches pattern. The result will contain the matched values.
+ */
+function matchScript(script: DecompiledScript, pattern: ScriptPatternElement[]): MatchResult | undefined {
+  /**
+   * Match a single script element with a ScriptPatternElement
+   */
+  function matchElement(e: Buffer | number, p: ScriptPatternElement): boolean | MatchResult {
+    switch (p) {
+      case 'OP_0':
+        return e === opcodes.OP_0 || (Buffer.isBuffer(e) && e.length === 0);
+      case 'OP_1':
+      case 'OP_2':
+      case 'OP_3':
+      case 'OP_CHECKMULTISIG':
+      case 'OP_CHECKSIG':
+      case 'OP_CHECKSIGVERIFY':
+        return e === opcodes[p];
+      case ':pubkey':
+        return Buffer.isBuffer(e) && (e.length === 32 || e.length === 33);
+      case ':signature':
+        return Buffer.isBuffer(e) || isPlaceholderSignature(e);
+      case ':buffer':
+        return Buffer.isBuffer(e);
+      default:
+        throw new Error(`unknown pattern element ${p}`);
+    }
+  }
+
+  if (script.length !== pattern.length) {
+    return;
+  }
+
+  // Go over each pattern element.
+  // Collect captures into a result object.
+  return pattern.reduce(
+    (obj: MatchResult | undefined, p, i): MatchResult | undefined => {
+      // if we had a previous mismatch, short-circuit
+      if (!obj) {
+        return;
+      }
+
+      const e = script[i];
+
+      // for ':script' pattern elements, decompile script element and recurse
+      if (typeof p === 'object' && ':script' in p) {
+        if (!Buffer.isBuffer(e)) {
+          return;
+        }
+        const dec = bscript.decompile(e);
+        const match = dec && matchScript(dec, p[':script']);
+        if (!match) {
+          return;
+        }
+        obj[':script'].push({
+          buffer: e,
+          match,
+        });
+        return obj;
+      }
+
+      const match = matchElement(e, p);
+      if (!match) {
+        return;
+      }
+
+      // if pattern element is a capture, add it to the result obj
+      if (p === ':signature' && e === 0) {
+        obj[p].push(e);
+      } else if (p === ':buffer' || p === ':pubkey' || p === ':signature') {
+        if (!Buffer.isBuffer(e)) {
+          throw new Error(`invalid capture value`);
+        }
+        obj[p].push(e);
+      }
+
+      return obj;
+    },
+    {
+      ':script': [],
+      ':signature': [],
+      ':buffer': [],
+      ':pubkey': [],
+    }
+  );
+}
+
+/**
+ * @param script
+ * @param patterns
+ * @return first match
+ */
+function matchScriptSome(script: DecompiledScript, patterns: ScriptPatternElement[][]): MatchResult | undefined {
+  for (const p of patterns) {
+    const m = matchScript(script, p);
+    if (m) {
+      return m;
+    }
+  }
+}
+
+type InputScripts<TScript, TWitness> = {
+  script: TScript;
+  witness: TWitness;
+};
+
+type InputScriptsLegacy = InputScripts<DecompiledScript, null>;
+type InputScriptsWrappedSegwit = InputScripts<DecompiledScript, Buffer[]>;
+type InputScriptsNativeSegwit = InputScripts<null, Buffer[]>;
+
+type InputScriptsUnknown = InputScripts<DecompiledScript | null, Buffer[] | null>;
+
+type InputParser<
+  T extends
+    | ParsedSignatureScriptP2PKH
+    | ParsedSignatureScriptP2PK
+    | ParsedSignatureScript2Of3
+    | ParsedSignatureScriptTaproot
+> = (p: InputScriptsUnknown) => T | undefined;
+
+function isLegacy(p: InputScriptsUnknown): p is InputScriptsLegacy {
+  return Boolean(p.script && !p.witness);
+}
+
+function isWrappedSegwit(p: InputScriptsUnknown): p is InputScriptsWrappedSegwit {
+  return Boolean(p.script && p.witness);
+}
+
+function isNativeSegwit(p: InputScriptsUnknown): p is InputScriptsNativeSegwit {
+  return Boolean(!p.script && p.witness);
+}
+
+const parseP2PK: InputParser<ParsedSignatureScriptP2PK> = (p) => {
+  if (!isLegacy(p)) {
+    return;
+  }
+  const match = matchScript(p.script, [':signature', { ':script': [':pubkey', 'OP_CHECKSIG'] }]);
+  if (!match) {
+    return;
+  }
+  return {
+    scriptType: 'p2shP2pk',
+    inputClassification: 'scripthash',
+    p2shOutputClassification: 'pubkey',
+    isSegwitInput: false,
+  };
+};
+
+function parseP2ms(
+  decScript: DecompiledScript,
+  params: Pick<
+    ParsedSignatureScript2Of3,
+    'scriptType' | 'inputClassification' | 'p2shOutputClassification' | 'isSegwitInput'
+  >
+): ParsedSignatureScript2Of3 | undefined {
+  const pattern2Of3: ScriptPatternElement[] = ['OP_2', ':pubkey', ':pubkey', ':pubkey', 'OP_3', 'OP_CHECKMULTISIG'];
+
+  const match = matchScriptSome(decScript, [
+    /* full-signed, no placeholder signature */
+    ['OP_0', ':signature', ':signature', { ':script': pattern2Of3 }],
+    /* half-signed, placeholder signatures */
+    ['OP_0', ':signature', ':signature', ':signature', { ':script': pattern2Of3 }],
+  ]);
+  if (!match) {
+    return;
+  }
+
+  const [redeemScript] = match[':script'];
+
+  if (!isTriple(redeemScript.match[':pubkey'])) {
+    throw new Error(`invalid pubkey count`);
+  }
+
+  return {
+    ...params,
+    publicKeys: redeemScript.match[':pubkey'],
+    pubScript: redeemScript.buffer,
+    signatures: match[':signature'] as ParsedSignatureScript2Of3['signatures'],
+  };
+}
+
+const parseP2sh2Of3: InputParser<ParsedSignatureScript2Of3> = (p) => {
+  if (!isLegacy(p)) {
+    return;
+  }
+  return parseP2ms(p.script, {
+    scriptType: 'p2sh',
+    inputClassification: 'scripthash',
+    p2shOutputClassification: 'multisig',
+    isSegwitInput: false,
+  });
+};
+
+const parseP2shP2wsh2Of3: InputParser<ParsedSignatureScript2Of3> = (p) => {
+  if (!isWrappedSegwit(p)) {
+    return undefined;
+  }
+  return parseP2ms(p.witness, {
+    scriptType: 'p2shP2wsh',
+    inputClassification: 'scripthash',
+    p2shOutputClassification: 'multisig',
+    isSegwitInput: true,
+  });
+};
+
+const parseP2wsh2Of3: InputParser<ParsedSignatureScript2Of3> = (p) => {
+  if (!isNativeSegwit(p)) {
+    return;
+  }
+  return parseP2ms(p.witness, {
+    scriptType: 'p2wsh',
+    inputClassification: 'witnessscripthash',
+    p2shOutputClassification: 'multisig',
+    isSegwitInput: true,
+  });
+};
+
+const parseP2tr2Of3: InputParser<ParsedSignatureScriptTaproot> = (p) => {
+  if (!isNativeSegwit(p)) {
+    return;
+  }
+  // assumes no annex
+  const match = matchScript(p.witness, [
+    ':signature',
+    ':signature',
+    { ':script': [':pubkey', 'OP_CHECKSIGVERIFY', ':pubkey', 'OP_CHECKSIG'] },
+    ':buffer',
+  ]);
+  if (!match) {
+    return;
+  }
+  const [controlBlock] = match[':buffer'];
+  const scriptPathLevel = controlBlock.length === 65 ? 1 : controlBlock.length === 97 ? 2 : undefined;
+
+  /* istanbul ignore next */
+  if (scriptPathLevel === undefined) {
+    throw new Error(`unexpected control block length ${controlBlock.length}`);
+  }
+
+  return {
+    scriptType: 'p2tr',
+    isSegwitInput: true,
+    inputClassification: 'taproot',
+    pubScript: match[':script'][0].buffer,
+    publicKeys: match[':script'][0].match[':pubkey'] as [Buffer, Buffer],
+    signatures: match[':signature'] as [Buffer, Buffer],
+    controlBlock,
+    scriptPathLevel,
+  };
+};
+
+/**
+ * Parse a transaction's signature script to obtain public keys, signatures, the sig script,
+ * and other properties.
+ *
+ * Only supports script types used in BitGo transactions.
+ *
+ * @param input
+ * @returns ParsedSignatureScript
+ */
+export function parseSignatureScript(
+  input: TxInput
+): ParsedSignatureScriptP2PK | ParsedSignatureScriptP2PKH | ParsedSignatureScript2Of3 | ParsedSignatureScriptTaproot {
+  const decScript = bscript.decompile(input.script);
+  const parsers = [parseP2PK, parseP2sh2Of3, parseP2shP2wsh2Of3, parseP2wsh2Of3, parseP2tr2Of3] as const;
+  for (const f of parsers) {
+    const parsed = f({
+      script: decScript?.length === 0 ? null : decScript,
+      witness: input.witness.length === 0 ? null : input.witness,
+    });
+    if (parsed) {
+      return parsed;
+    }
+  }
+  throw new Error(`could not parse input`);
+}
+
+export function parseSignatureScript2Of3(input: TxInput): ParsedSignatureScript2Of3 | ParsedSignatureScriptTaproot {
+  const result = parseSignatureScript(input) as ParsedSignatureScript2Of3 | ParsedSignatureScriptTaproot;
+
+  if (!result.signatures) {
+    throw new Error(`missing signatures`);
+  }
+  if (result.publicKeys.length !== 3 && (result.publicKeys.length !== 2 || result.scriptType !== 'p2tr')) {
+    throw new Error(`unexpected pubkey count`);
+  }
+  if (!result.pubScript || result.pubScript.length === 0) {
+    throw new Error(`pubScript missing or empty`);
+  }
+
+  return result;
+}

--- a/modules/utxo-lib/src/bitgo/signature.ts
+++ b/modules/utxo-lib/src/bitgo/signature.ts
@@ -1,7 +1,6 @@
-import * as opcodes from 'bitcoin-ops';
 import { BIP32Interface } from 'bip32';
 
-import { payments, script, Transaction, TxInput, taproot, TxOutput, ScriptSignature } from 'bitcoinjs-lib';
+import { Transaction, taproot, TxOutput, ScriptSignature } from 'bitcoinjs-lib';
 
 import { UtxoTransaction } from './UtxoTransaction';
 import { UtxoTransactionBuilder } from './UtxoTransactionBuilder';
@@ -9,373 +8,14 @@ import {
   createOutputScript2of3,
   createOutputScriptP2shP2pk,
   createSpendScriptP2tr,
-  ScriptType,
   ScriptType2Of3,
   scriptType2Of3AsPrevOutType,
 } from './outputScripts';
-import { isTriple, Triple } from './types';
+import { Triple } from './types';
 import { classify } from '../';
 import { getMainnet, Network, networks } from '../networks';
 import { ecc as eccLib } from '../noble_ecc';
-
-const inputTypes = [
-  'multisig',
-  'nonstandard',
-  'nulldata',
-  'pubkey',
-  'pubkeyhash',
-  'scripthash',
-  'witnesspubkeyhash',
-  'witnessscripthash',
-  'taproot',
-  'taprootnofn',
-  'witnesscommitment',
-] as const;
-
-type InputType = typeof inputTypes[number];
-
-export function isPlaceholderSignature(v: number | Buffer): boolean {
-  if (Buffer.isBuffer(v)) {
-    return v.length === 0;
-  }
-  return v === 0;
-}
-
-export interface ParsedSignatureScript {
-  scriptType: ScriptType | 'p2pkh' | undefined;
-  isSegwitInput: boolean;
-  inputClassification: InputType;
-  p2shOutputClassification?: string;
-}
-
-export interface ParsedSignatureScriptUnknown extends ParsedSignatureScript {
-  scriptType: undefined;
-}
-
-export interface ParsedSignatureScriptP2PK extends ParsedSignatureScript {
-  scriptType: 'p2shP2pk';
-  inputClassification: 'scripthash';
-}
-
-export interface ParsedSignatureScriptP2PKH extends ParsedSignatureScript {
-  scriptType: 'p2pkh';
-  inputClassification: 'pubkeyhash';
-  signatures: [Buffer];
-  publicKeys: [Buffer];
-  pubScript?: Buffer;
-}
-
-export interface ParsedSignatureScript2Of3 extends ParsedSignatureScript {
-  scriptType: 'p2sh' | 'p2shP2wsh' | 'p2wsh';
-  inputClassification: 'scripthash' | 'witnessscripthash';
-  publicKeys: [Buffer, Buffer, Buffer];
-  signatures:
-    | [Buffer, Buffer] // fully-signed transactions with signatures
-    /* Partially signed transactions with placeholder signatures.
-       For p2sh, the placeholder is OP_0 (number 0) */
-    | [Buffer | 0, Buffer | 0, Buffer | 0];
-  pubScript: Buffer;
-}
-
-export interface ParsedSignatureScriptTaproot extends ParsedSignatureScript {
-  scriptType: 'p2tr';
-  inputClassification: 'taproot';
-  // P2TR tapscript spends are for keypath spends or 2-of-2 multisig scripts
-  // A single signature indicates a keypath spend.
-  // Two signatures indicate a scriptPath spend.
-  publicKeys: [Buffer] | [Buffer, Buffer];
-  signatures: [Buffer] | [Buffer, Buffer];
-  // For scriptpath signatures, this contains the control block data. For keypath signatures this is undefined.
-  controlBlock: Buffer | undefined;
-  // For scriptpath signatures, this indicates the level inside the taptree. For keypath signatures this is undefined.
-  scriptPathLevel: number | undefined;
-  pubScript: Buffer;
-}
-
-export function getDefaultSigHash(network: Network, scriptType?: ScriptType2Of3): number {
-  switch (getMainnet(network)) {
-    case networks.bitcoincash:
-    case networks.bitcoinsv:
-    case networks.bitcoingold:
-      return Transaction.SIGHASH_ALL | UtxoTransaction.SIGHASH_FORKID;
-    default:
-      return scriptType === 'p2tr' ? Transaction.SIGHASH_DEFAULT : Transaction.SIGHASH_ALL;
-  }
-}
-
-/**
- * Parse a transaction's signature script to obtain public keys, signatures, the sig script,
- * and other properties.
- *
- * Only supports script types used in BitGo transactions.
- *
- * @param input
- * @returns ParsedSignatureScript
- */
-export function parseSignatureScript(
-  input: TxInput
-):
-  | ParsedSignatureScriptUnknown
-  | ParsedSignatureScriptP2PK
-  | ParsedSignatureScriptP2PKH
-  | ParsedSignatureScript2Of3
-  | ParsedSignatureScriptTaproot {
-  const isSegwitInput = input.witness.length > 0;
-  const isNativeSegwitInput = input.script.length === 0;
-  let decompiledSigScript: Array<Buffer | number> | null;
-  let inputClassification: InputType;
-  if (isSegwitInput) {
-    // The decompiledSigScript is the script containing the signatures, public keys, and the script that was committed
-    // to (pubScript). If this is a segwit input the decompiledSigScript is in the witness, regardless of whether it
-    // is native or not. The inputClassification is determined based on whether or not the input is native to give an
-    // accurate classification. Note that p2shP2wsh inputs will be classified as p2sh and not p2wsh.
-    decompiledSigScript = input.witness;
-    if (isNativeSegwitInput) {
-      inputClassification = classify.witness(decompiledSigScript as Buffer[], true) as InputType;
-    } else {
-      inputClassification = classify.input(input.script, true) as InputType;
-    }
-  } else {
-    inputClassification = classify.input(input.script, true) as InputType;
-    decompiledSigScript = script.decompile(input.script);
-  }
-
-  if (!decompiledSigScript) {
-    return { scriptType: undefined, isSegwitInput, inputClassification };
-  }
-
-  if (inputClassification === 'pubkeyhash') {
-    /* istanbul ignore next */
-    if (!decompiledSigScript || decompiledSigScript.length !== 2) {
-      throw new Error('unexpected signature for p2pkh');
-    }
-    const [signature, publicKey] = decompiledSigScript;
-    /* istanbul ignore next */
-    if (!Buffer.isBuffer(signature) || !Buffer.isBuffer(publicKey)) {
-      throw new Error('unexpected signature for p2pkh');
-    }
-    const publicKeys: [Buffer] = [publicKey];
-    const signatures: [Buffer] = [signature];
-    const pubScript = payments.p2pkh({ pubkey: publicKey }).output;
-
-    return {
-      scriptType: 'p2pkh',
-      isSegwitInput,
-      inputClassification,
-      signatures,
-      publicKeys,
-      pubScript,
-    };
-  }
-
-  if (inputClassification === 'taproot') {
-    // assumes no annex
-    if (input.witness.length !== 4) {
-      throw new Error(`unrecognized taproot input`);
-    }
-    const [sig1, sig2, tapscript, controlBlock] = input.witness;
-    const tapscriptClassification = classify.output(tapscript);
-    if (tapscriptClassification !== 'taprootnofn') {
-      throw new Error(`tapscript must be n of n multisig`);
-    }
-
-    const publicKeys = payments.p2tr_ns({ output: tapscript }, { eccLib }).pubkeys;
-    if (!publicKeys || publicKeys.length !== 2) {
-      throw new Error('expected 2 pubkeys');
-    }
-
-    const signatures = [sig1, sig2].map((b) => {
-      if (Buffer.isBuffer(b)) {
-        return b;
-      }
-      throw new Error(`unexpected signature element ${b}`);
-    }) as [Buffer, Buffer];
-
-    const scriptPathLevel = controlBlock.length === 65 ? 1 : controlBlock.length === 97 ? 2 : undefined;
-
-    /* istanbul ignore next */
-    if (scriptPathLevel === undefined) {
-      throw new Error(`unexpected control block length ${controlBlock.length}`);
-    }
-
-    return {
-      scriptType: 'p2tr',
-      isSegwitInput,
-      inputClassification,
-      publicKeys: publicKeys as [Buffer, Buffer],
-      signatures,
-      pubScript: tapscript,
-      controlBlock,
-      scriptPathLevel,
-    };
-  }
-
-  // Note the assumption here that if we have a p2sh or p2wsh input it will be multisig (appropriate because the
-  // BitGo platform only supports multisig within these types of inputs, with the exception of replay protection inputs,
-  // which are single signature p2sh). Signatures are all but the last entry in the decompiledSigScript.
-  // The redeemScript/witnessScript (depending on which type of input this is) is the last entry in
-  // the decompiledSigScript (denoted here as the pubScript). The public keys are the second through
-  // antepenultimate entries in the decompiledPubScript. See below for a visual representation of the typical 2-of-3
-  // multisig setup:
-  //
-  //   decompiledSigScript = 0 <sig1> <sig2> [<sig3>] <pubScript>
-  //   decompiledPubScript = 2 <pub1> <pub2> <pub3> 3 OP_CHECKMULTISIG
-  //
-  // Transactions built with `.build()` only have two signatures `<sig1>` and `<sig2>` in _decompiledSigScript_.
-  // Transactions built with `.buildIncomplete()` have three signatures, where missing signatures are substituted with `OP_0`.
-  if (inputClassification !== 'scripthash' && inputClassification !== 'witnessscripthash') {
-    return { scriptType: undefined, isSegwitInput, inputClassification };
-  }
-
-  const pubScript = decompiledSigScript[decompiledSigScript.length - 1];
-  /* istanbul ignore next */
-  if (!Buffer.isBuffer(pubScript)) {
-    throw new Error(`invalid pubScript`);
-  }
-
-  const p2shOutputClassification = classify.output(pubScript);
-
-  if (inputClassification === 'scripthash' && p2shOutputClassification === 'pubkey') {
-    return {
-      scriptType: 'p2shP2pk',
-      isSegwitInput,
-      inputClassification,
-      p2shOutputClassification,
-    };
-  }
-
-  if (p2shOutputClassification !== 'multisig') {
-    return {
-      scriptType: undefined,
-      isSegwitInput,
-      inputClassification,
-      p2shOutputClassification,
-    };
-  }
-
-  const decompiledPubScript = script.decompile(pubScript);
-  if (decompiledPubScript === null) {
-    /* istanbul ignore next */
-    throw new Error(`could not decompile pubScript`);
-  }
-
-  const expectedScriptLength =
-    // complete transactions with 2 signatures
-    decompiledSigScript.length === 4 ||
-    // incomplete transaction with 3 signatures or signature placeholders
-    decompiledSigScript.length === 5;
-
-  if (!expectedScriptLength) {
-    return { scriptType: undefined, isSegwitInput, inputClassification };
-  }
-
-  if (isSegwitInput) {
-    /* istanbul ignore next */
-    if (!Buffer.isBuffer(decompiledSigScript[0])) {
-      throw new Error(`expected decompiledSigScript[0] to be a buffer for segwit inputs`);
-    }
-    /* istanbul ignore next */
-    if (decompiledSigScript[0].length !== 0) {
-      throw new Error(`witness stack expected to start with empty buffer`);
-    }
-  } else if (decompiledSigScript[0] !== opcodes.OP_0) {
-    throw new Error(`sigScript expected to start with OP_0`);
-  }
-
-  const signatures = decompiledSigScript.slice(1 /* ignore leading OP_0 */, -1 /* ignore trailing pubScript */);
-  /* istanbul ignore next */
-  if (signatures.length !== 2 && signatures.length !== 3) {
-    throw new Error(`expected 2 or 3 signatures, got ${signatures.length}`);
-  }
-
-  /* istanbul ignore next */
-  if (decompiledPubScript.length !== 6) {
-    throw new Error(`unexpected decompiledPubScript length`);
-  }
-  const publicKeys = decompiledPubScript.slice(1, -2) as Buffer[];
-  publicKeys.forEach((b) => {
-    /* istanbul ignore next */
-    if (!Buffer.isBuffer(b)) {
-      throw new Error();
-    }
-  });
-  if (!isTriple(publicKeys)) {
-    /* istanbul ignore next */
-    throw new Error(`expected 3 public keys, got ${publicKeys.length}`);
-  }
-
-  // Op codes 81 through 96 represent numbers 1 through 16 (see https://en.bitcoin.it/wiki/Script#Opcodes), which is
-  // why we subtract by 80 to get the number of signatures (n) and the number of public keys (m) in an n-of-m setup.
-  const len = decompiledPubScript.length;
-  const signatureThreshold = (decompiledPubScript[0] as number) - 80;
-  /* istanbul ignore next */
-  if (signatureThreshold !== 2) {
-    throw new Error(`expected signatureThreshold 2, got ${signatureThreshold}`);
-  }
-  const nPubKeys = (decompiledPubScript[len - 2] as number) - 80;
-  /* istanbul ignore next */
-  if (nPubKeys !== 3) {
-    throw new Error(`expected nPubKeys 3, got ${nPubKeys}`);
-  }
-
-  const lastOpCode = decompiledPubScript[len - 1];
-  /* istanbul ignore next */
-  if (lastOpCode !== opcodes.OP_CHECKMULTISIG) {
-    throw new Error(`expected opcode #${opcodes.OP_CHECKMULTISIG}, got opcode #${lastOpCode}`);
-  }
-
-  const scriptType = input.witness.length
-    ? input.script.length
-      ? 'p2shP2wsh'
-      : 'p2wsh'
-    : input.script.length
-    ? 'p2sh'
-    : undefined;
-  if (scriptType === undefined) {
-    throw new Error('illegal state');
-  }
-
-  return {
-    scriptType,
-    isSegwitInput,
-    inputClassification,
-    p2shOutputClassification,
-    signatures: signatures.map((b) => {
-      if (Buffer.isBuffer(b) || b === 0) {
-        return b;
-      }
-      throw new Error(`unexpected signature element ${b}`);
-    }) as [Buffer, Buffer] | [Buffer, Buffer, Buffer],
-    publicKeys,
-    pubScript,
-  };
-}
-
-export function parseSignatureScript2Of3(input: TxInput): ParsedSignatureScript2Of3 | ParsedSignatureScriptTaproot {
-  const result = parseSignatureScript(input) as ParsedSignatureScript2Of3;
-
-  if (
-    ![classify.types.P2WSH, classify.types.P2SH, classify.types.P2PKH, classify.types.P2TR].includes(
-      result.inputClassification
-    )
-  ) {
-    throw new Error(`unexpected inputClassification ${result.inputClassification}`);
-  }
-  if (!result.signatures) {
-    throw new Error(`missing signatures`);
-  }
-  if (
-    result.publicKeys.length !== 3 &&
-    (result.publicKeys.length !== 2 || result.inputClassification !== classify.types.P2TR)
-  ) {
-    throw new Error(`unexpected pubkey count`);
-  }
-  if (!result.pubScript || result.pubScript.length === 0) {
-    throw new Error(`pubScript missing or empty`);
-  }
-
-  return result;
-}
+import { parseSignatureScript2Of3 } from './parseInput';
 
 /**
  * Constraints for signature verifications.
@@ -472,10 +112,10 @@ export function getSignatureVerifications<TNumber extends number | bigint>(
         throw new Error(`prevOutputs length ${prevOutputs.length}, expected ${transaction.ins.length}`);
       }
 
-      const { controlBlock, pubScript } = parsedScript as ParsedSignatureScriptTaproot;
-      if (!controlBlock) {
+      if (!('controlBlock' in parsedScript)) {
         throw new Error('expected controlBlock');
       }
+      const { controlBlock, pubScript } = parsedScript;
       const leafHash = taproot.getTapleafHash(eccLib, controlBlock, pubScript);
       const signatureHash = transaction.hashForWitnessV1(
         inputIndex,
@@ -619,6 +259,17 @@ export function verifySignatureWithPublicKey<TNumber extends number | bigint>(
   publicKey: Buffer
 ): boolean {
   return verifySignatureWithPublicKeys(transaction, inputIndex, prevOutputs, [publicKey])[0];
+}
+
+export function getDefaultSigHash(network: Network, scriptType?: ScriptType2Of3): number {
+  switch (getMainnet(network)) {
+    case networks.bitcoincash:
+    case networks.bitcoinsv:
+    case networks.bitcoingold:
+      return Transaction.SIGHASH_ALL | UtxoTransaction.SIGHASH_FORKID;
+    default:
+      return scriptType === 'p2tr' ? Transaction.SIGHASH_DEFAULT : Transaction.SIGHASH_ALL;
+  }
 }
 
 export function signInputP2shP2pk<TNumber extends number | bigint>(

--- a/modules/utxo-lib/test/bitgo/signature.ts
+++ b/modules/utxo-lib/test/bitgo/signature.ts
@@ -289,8 +289,9 @@ function runTestCheckSignatureVerify<TNumber extends number | bigint = number>(
   amountType: 'number' | 'bigint' = 'number'
 ) {
   if (k1 && k2) {
-    describe(`verifySignature
-${getNetworkName(network)} ${scriptType} ${keyName(k1)} ${keyName(k2)} ${amountType}`, function () {
+    describe(`verifySignature ${getNetworkName(network)} ${scriptType} ${keyName(k1)} ${keyName(
+      k2
+    )} ${amountType}`, function () {
       it(`verifies half-signed`, function () {
         checkSignTransaction(
           getHalfSignedTransaction2Of3<TNumber>(fixtureKeys, k1, k2, scriptType, network, amountType),


### PR DESCRIPTION
Our current script parsing code consists of

- decompiling a script
- checking the classification
- checking the length
- picking certain parts and validating them
- potential recursion for nested scripts

Doing this manually with hand-written conditionals and destructuring
is hard to read and error prone. Further we do not want to depend on
the `classify` methods any longer.

This change introduces a simple recursive pattern matching
implementation that can deal with the handful of scripts we need to
work with. It only depends on `opcodes` and `script.decompile`.

As a side benefit, the new implementation reduced the execution time
by ~5s on my machine.

Issue: BG-57748


<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->