### PR TITLE
feat: add units functions to sdk core

### DIFF
--- a/modules/statics/src/index.ts
+++ b/modules/statics/src/index.ts
@@ -1,5 +1,6 @@
 export * from './base';
 export * from './coins';
+export * from './units';
 export * from './networks';
 export * from './errors';
 export * from './tokenConfig';

--- a/modules/statics/src/units.ts
+++ b/modules/statics/src/units.ts
@@ -1,0 +1,51 @@
+import BigNumber from 'bignumber.js';
+
+import { coins } from './';
+
+/**
+ * Converts an amount of coin in base units (such as satoshis, cents, or wei) to full units (such as bitcoin, dollars, or ether)
+ * @param baseUnits number of base units
+ * @param coin coin ticker
+ */
+export function toFullUnits(baseUnits: number | string | BigNumber, coin: string): string {
+  return new BigNumber(baseUnits).div(10 ** coins.get(coin).decimalPlaces).toString();
+}
+
+/**
+ * Converts an amount of coin in base units (such as satoshis, cents, or wei) to full units (such as bitcoin, dollars, or ether) fixed amount
+ * @param baseUnits number of base units
+ * @param coin coin ticker
+ */
+export function toFullUnitsFixed(baseUnits: number | string | BigNumber, coin: string): string {
+  const decimalPlaces = coins.get(coin).decimalPlaces;
+  return new BigNumber(baseUnits).div(10 ** decimalPlaces).toFixed(decimalPlaces);
+}
+
+/**
+ * Converts an amount of coin in full units (such as bitcoin, dollars, or ether) to base units (such as satoshis, cents, or wei)
+ * @param fullUnits number of full units
+ * @param coin coin ticker
+ */
+export function toBaseUnits(fullUnits: number | string | BigNumber, coin: string): string {
+  return new BigNumber(fullUnits).times(10 ** coins.get(coin).decimalPlaces).toString();
+}
+
+/**
+ * Converts price and quantity for a coin into base units market value
+ * (note, price might be 2 decimal places longer than priceIn decimal places for base units)
+ * @param coin - which coin to calculate for
+ * @param price - price of a unit of the coin specified
+ * @param quantity - number of coins
+ * @param priceIn - numerator of trading pair, for example USD of BTC/USD
+ */
+export function toMarketValueBaseUnits(
+  coin: string,
+  price: number | string | BigNumber,
+  quantity: string | number | bigint,
+  priceIn = 'tsusd'
+): bigint {
+  const roundFactor = BigInt(1000000);
+  const priceInBaseUnitsBy100 = Math.round(Number(toBaseUnits(price, priceIn)) * 100);
+  const decimalPlacesCoinBy100 = BigInt(toBaseUnits(1, coin)) * BigInt(100);
+  return (roundFactor * BigInt(quantity) * BigInt(priceInBaseUnitsBy100)) / (decimalPlacesCoinBy100 * roundFactor);
+}

--- a/modules/statics/test/unit/units.ts
+++ b/modules/statics/test/unit/units.ts
@@ -1,0 +1,97 @@
+import BigNumber from 'bignumber.js';
+import 'should';
+import { toFullUnits, toFullUnitsFixed, toBaseUnits, toMarketValueBaseUnits } from '../../src';
+
+describe('units', function () {
+  describe('toFullUnits', function () {
+    it('should convert numbers into full units', () => {
+      toFullUnits(0, 'susd').should.equal('0');
+      toFullUnits(75, 'susd').should.equal('0.75');
+      toFullUnits(-100, 'susd').should.equal('-1');
+      toFullUnits(0, 'btc').should.equal('0');
+      toFullUnits(75, 'btc').should.equal('7.5e-7');
+      toFullUnits(750000, 'btc').should.equal('0.0075');
+      toFullUnits(-7500000, 'btc').should.equal('-0.075');
+    });
+
+    it('should convert big numbers into full units', () => {
+      toFullUnits(BigNumber(0), 'susd').should.equal('0');
+      toFullUnits(BigNumber(75), 'susd').should.equal('0.75');
+      toFullUnits(BigNumber('7500000000000'), 'susd').should.equal('75000000000');
+      toFullUnits(BigNumber('750000000000000000000000000'), 'susd').should.equal('7.5e+24');
+      toFullUnits(BigNumber(-100), 'susd').should.equal('-1');
+      toFullUnits(BigNumber(0), 'btc').should.equal('0');
+      toFullUnits(BigNumber(75), 'btc').should.equal('7.5e-7');
+      toFullUnits(BigNumber(750000), 'btc').should.equal('0.0075');
+      toFullUnits(BigNumber(-7500000), 'btc').should.equal('-0.075');
+      toFullUnits(BigNumber('75000000000000000000000000'), 'btc').should.equal('750000000000000000');
+    });
+  });
+
+  describe('toFullUnitsFixed', function () {
+    it('should convert numbers into full fixed units', () => {
+      toFullUnitsFixed(0, 'susd').should.equal('0.00');
+      toFullUnitsFixed(75, 'susd').should.equal('0.75');
+      toFullUnitsFixed(-100, 'susd').should.equal('-1.00');
+      toFullUnitsFixed(0, 'btc').should.equal('0.00000000');
+      toFullUnitsFixed(75, 'btc').should.equal('0.00000075');
+      toFullUnitsFixed(750000, 'btc').should.equal('0.00750000');
+      toFullUnitsFixed(-7500000, 'btc').should.equal('-0.07500000');
+    });
+
+    it('should convert big numbers into full fixed units', () => {
+      toFullUnitsFixed(BigNumber(0), 'susd').should.equal('0.00');
+      toFullUnitsFixed(BigNumber(75), 'susd').should.equal('0.75');
+      toFullUnitsFixed(BigNumber('7500000000000'), 'susd').should.equal('75000000000.00');
+      toFullUnitsFixed(BigNumber('750000000000000000000000000'), 'susd').should.equal('7500000000000000000000000.00');
+      toFullUnitsFixed(BigNumber(-100), 'susd').should.equal('-1.00');
+      toFullUnitsFixed(BigNumber(0), 'btc').should.equal('0.00000000');
+      toFullUnitsFixed(BigNumber(75), 'btc').should.equal('0.00000075');
+      toFullUnitsFixed(BigNumber(750000), 'btc').should.equal('0.00750000');
+      toFullUnitsFixed(BigNumber(-7500000), 'btc').should.equal('-0.07500000');
+      toFullUnitsFixed(BigNumber('75000000000000000000000000'), 'btc').should.equal('750000000000000000.00000000');
+    });
+  });
+
+  describe('toBaseUnits', function () {
+    it('should convert into base units', () => {
+      toBaseUnits(0, 'susd').should.equal('0');
+      toBaseUnits('0.75', 'susd').should.equal('75');
+      toBaseUnits('-1.00', 'susd').should.equal('-100');
+      toBaseUnits('0', 'btc').should.equal('0');
+      toBaseUnits('0.000000000', 'btc').should.equal('0');
+      toBaseUnits('0.00000075', 'btc').should.equal('75');
+      toBaseUnits('0.00750000', 'btc').should.equal('750000');
+      toBaseUnits('-0.07500000', 'btc').should.equal('-7500000');
+    });
+
+    it('should convert big numbers into base units', () => {
+      toBaseUnits(BigNumber(0), 'susd').should.equal('0');
+      toBaseUnits(BigNumber(75), 'susd').should.equal('7500');
+      toBaseUnits(BigNumber('7500000000000'), 'susd').should.equal('750000000000000');
+      toBaseUnits(BigNumber('750000000000000000000000000'), 'susd').should.equal('7.5e+28');
+      toBaseUnits(BigNumber(-100), 'susd').should.equal('-10000');
+      toBaseUnits(BigNumber(0), 'btc').should.equal('0');
+      toBaseUnits(BigNumber(75), 'btc').should.equal('7500000000');
+      toBaseUnits(BigNumber(750000), 'btc').should.equal('75000000000000');
+      toBaseUnits(BigNumber(-7500000), 'btc').should.equal('-750000000000000');
+      toBaseUnits(BigNumber('75000000000000000000000000'), 'btc').should.equal('7.5e+33');
+    });
+  });
+
+  describe('toMarketValueBaseUnits', function () {
+    it('should convert into market value base units', () => {
+      toMarketValueBaseUnits('susd', 1, 0).should.equal(BigInt(0));
+      toMarketValueBaseUnits('susd', 1, 10).should.equal(BigInt(10));
+      toMarketValueBaseUnits('susd', 70000000, 0).should.equal(BigInt(0));
+      toMarketValueBaseUnits('susd', 70000000, 10).should.equal(BigInt(700000000));
+      toMarketValueBaseUnits('btc', 1, 0).should.equal(BigInt(0));
+      toMarketValueBaseUnits('btc', 1, 10).should.equal(BigInt(0));
+      toMarketValueBaseUnits('btc', 70000000, 0).should.equal(BigInt(0));
+      toMarketValueBaseUnits('btc', 70000000, 10).should.equal(BigInt(700));
+      toMarketValueBaseUnits('btc', BigNumber('7000000000000000000000000'), 10).should.equal(
+        BigInt('69999999999999999280')
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Description

This PR introduces units conversion functions that are based on the `statics` part of the SDK. These functions are tightly coupled with the map of coins in `statics`, so it makes sense for the utility functions to live in the SDK.


## Issue Number

BG-61910

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I mainly tested by adding unit tests. I'm not a domain expert here, so please let me know if you want other boundary conditions to be tested.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [x] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes