### PR TITLE
feat(eth): add support for tss recoveries

### DIFF
--- a/modules/sdk-coin-eth/src/eth.ts
+++ b/modules/sdk-coin-eth/src/eth.ts
@@ -17,38 +17,43 @@ import {
   BitGoBase,
   checkKrsProvider,
   common,
+  ECDSA,
+  Ecdsa,
+  ECDSAMethods,
+  ECDSAMethodTypes,
   EthereumLibraryUnavailableError,
   FeeEstimateOptions,
+  FullySignedTransaction,
   getIsKrsRecovery,
   getIsUnsignedSweep,
+  HalfSignedTransaction,
   InvalidAddressError,
   InvalidAddressVerificationObjectPropertyError,
   IWallet,
   KeyPair,
+  MPCAlgorithm,
   ParsedTransaction,
   ParseTransactionOptions,
-  UnexpectedAddressError,
   PresignTransactionOptions as BasePresignTransactionOptions,
+  Recipient,
   SignTransactionOptions as BaseSignTransactionOptions,
   TransactionParams,
   TransactionPrebuild as BaseTransactionPrebuild,
   TransactionRecipient,
+  UnexpectedAddressError,
   Util,
   VerifyAddressOptions as BaseVerifyAddressOptions,
   VerifyTransactionOptions,
   Wallet,
-  Recipient,
-  HalfSignedTransaction,
-  FullySignedTransaction,
-  MPCAlgorithm,
-  ECDSAMethods,
 } from '@bitgo/sdk-core';
 
 import { BaseCoin as StaticsBaseCoin, EthereumNetwork, ethGasConfigs } from '@bitgo/statics';
 import type * as EthTxLib from '@ethereumjs/tx';
+import { FeeMarketEIP1559Transaction, Transaction as LegacyTransaction } from '@ethereumjs/tx';
 import type * as EthCommon from '@ethereumjs/common';
-import { calculateForwarderV1Address, getProxyInitcode } from './lib';
-import { intToHex, stripHexPrefix, addHexPrefix } from 'ethereumjs-util';
+import { calculateForwarderV1Address, getProxyInitcode, KeyPair as KeyPairLib } from './lib';
+import { addHexPrefix, intToHex, stripHexPrefix } from 'ethereumjs-util';
+import BN from 'bn.js';
 
 export { Recipient, HalfSignedTransaction, FullySignedTransaction };
 
@@ -205,13 +210,15 @@ export interface RecoverOptions {
   userKey: string;
   backupKey: string;
   walletPassphrase?: string;
-  walletContractAddress: string;
+  walletContractAddress: string; // use this as walletBaseAddress for TSS
+  // walletBaseAddress?: string;
   recoveryDestination: string;
   krsProvider?: string;
   gasPrice?: number;
   gasLimit?: number;
   eip1559?: EIP1559;
   replayProtectionOptions?: ReplayProtectionOptions;
+  isTss?: boolean;
 }
 
 export interface BuildTransactionParams {
@@ -345,7 +352,7 @@ export class Eth extends BaseCoin {
     return new Eth(bitgo, staticsCoin);
   }
 
-  static buildTransaction(params: BuildTransactionParams): EthTxLib.FeeMarketEIP1559Transaction | EthTxLib.Transaction {
+  private static getEthCommon(params: RecoverOptions | BuildTransactionParams) {
     // if eip1559 params are specified, default to london hardfork, otherwise,
     // default to tangerine whistle to avoid replay protection issues
     const defaultHardfork = !!params.eip1559 ? 'london' : optionalDeps.EthCommon.Hardfork.TangerineWhistle;
@@ -368,6 +375,13 @@ export class Eth extends BaseCoin {
             defaultHardfork: params.replayProtectionOptions.hardfork,
           })
       : defaultCommon;
+    return ethCommon;
+  }
+
+  static buildTransaction(params: BuildTransactionParams): EthTxLib.FeeMarketEIP1559Transaction | EthTxLib.Transaction {
+    // if eip1559 params are specified, default to london hardfork, otherwise,
+    // default to tangerine whistle to avoid replay protection issues
+    const ethCommon = Eth.getEthCommon(params);
 
     const baseParams = {
       to: params.to,
@@ -865,6 +879,7 @@ export class Eth extends BaseCoin {
     const backupSigningKey = backupHDNode.publicKey;
     const response: OfflineVaultTxInfo = {
       tx: ethTx.serialize().toString('hex'),
+      txHex: ethTx.getMessageToSign(false).toString('hex'),
       userKey,
       backupKey,
       coin: this.getChain(),
@@ -881,6 +896,52 @@ export class Eth extends BaseCoin {
     };
     _.extend(response, txInfo);
     response.nextContractSequenceId = response.contractSequenceId;
+    return response;
+  }
+
+  /**
+   * Helper function for recover()
+   * This transforms the unsigned transaction information into a format the BitGo offline vault expects
+   * @param txInfo
+   * @param ethTx
+   * @param userKey
+   * @param backupKey
+   * @param gasPrice
+   * @param gasLimit
+   * @param eip1559
+   * @param replayProtectionOptions
+   * @returns {Promise<OfflineVaultTxInfo>}
+   */
+  async formatForOfflineVaultTSS(
+    txInfo: UnformattedTxInfo,
+    ethTx: EthTxLib.Transaction | EthTxLib.FeeMarketEIP1559Transaction,
+    userKey: string,
+    backupKey: string,
+    gasPrice: Buffer,
+    gasLimit: number,
+    backupKeyNonce: number,
+    eip1559?: EIP1559,
+    replayProtectionOptions?: ReplayProtectionOptions
+  ): Promise<OfflineVaultTxInfo> {
+    if (!ethTx.to) {
+      throw new Error('Eth tx must have a `to` address');
+    }
+    const response: OfflineVaultTxInfo = {
+      tx: ethTx.serialize().toString('hex'),
+      txHex: ethTx.getMessageToSign(false).toString('hex'),
+      userKey,
+      backupKey,
+      coin: this.getChain(),
+      gasPrice: optionalDeps.ethUtil.bufferToInt(gasPrice).toFixed(),
+      gasLimit,
+      recipients: [txInfo.recipient],
+      walletContractAddress: ethTx.to.toString(),
+      amount: txInfo.recipient.amount,
+      backupKeyNonce: backupKeyNonce,
+      eip1559,
+      replayProtectionOptions,
+    };
+    _.extend(response, txInfo);
     return response;
   }
 
@@ -942,6 +1003,239 @@ export class Eth extends BaseCoin {
     }
   }
 
+  private signRecoveryTSS(
+    userKeyCombined: ECDSA.KeyCombined,
+    backupKeyCombined: ECDSA.KeyCombined,
+    txHex: string
+  ): ECDSAMethodTypes.Signature {
+    const MPC = new Ecdsa();
+
+    const signerOneIndex = userKeyCombined.xShare.i;
+    const signerTwoIndex = backupKeyCombined.xShare.i;
+    const signShares: ECDSA.SignShareRT = MPC.signShare(
+      userKeyCombined.xShare,
+      userKeyCombined.yShares[signerTwoIndex]
+    );
+
+    let signConvertS21: ECDSA.SignConvertRT = MPC.signConvert({
+      xShare: backupKeyCombined.xShare,
+      yShare: backupKeyCombined.yShares[signerOneIndex], // YShare corresponding to the other participant signerOne
+      kShare: signShares.kShare,
+    });
+
+    const signConvertS12: ECDSA.SignConvertRT = MPC.signConvert({
+      aShare: signConvertS21.aShare,
+      wShare: signShares.wShare,
+    });
+
+    signConvertS21 = MPC.signConvert({
+      muShare: signConvertS12.muShare,
+      bShare: signConvertS21.bShare,
+    });
+
+    const [signCombineOne, signCombineTwo] = [
+      MPC.signCombine({
+        gShare: signConvertS12.gShare as ECDSA.GShare,
+        signIndex: {
+          i: (signConvertS12.muShare as ECDSA.MUShare).i,
+          j: (signConvertS12.muShare as ECDSA.MUShare).j,
+        },
+      }),
+      MPC.signCombine({
+        gShare: signConvertS21.gShare as ECDSA.GShare,
+        signIndex: {
+          i: (signConvertS21.muShare as ECDSA.MUShare).i,
+          j: (signConvertS21.muShare as ECDSA.MUShare).j,
+        },
+      }),
+    ];
+
+    const MESSAGE = Buffer.from(txHex);
+
+    // const hashGenerator = (hashType?: string): Hash | undefined => {
+    //   return hashType === 'keccak256' ? createKeccakHash('keccak256') : undefined;
+    // };
+
+    const [signA, signB] = [
+      MPC.sign(MESSAGE, signCombineOne.oShare, signCombineTwo.dShare),
+      MPC.sign(MESSAGE, signCombineTwo.oShare, signCombineOne.dShare),
+    ];
+
+    const signature = MPC.constructSignature([signA, signB]);
+
+    return signature;
+  }
+
+  async recoverTSS(params: RecoverOptions): Promise<RecoveryInfo | OfflineVaultTxInfo> {
+    // this.validateRecoveryParams(params);
+    const isUnsignedSweep = getIsUnsignedSweep(params);
+
+    // Clean up whitespace from entered values
+    const userKey = params.userKey.replace(/\s/g, '');
+    const backupKey = params.backupKey.replace(/\s/g, '');
+
+    // Set new eth tx fees (using default config values from platform)
+    const gasLimit = new optionalDeps.ethUtil.BN(this.setGasLimit(params.gasLimit));
+    const gasPrice = params.eip1559
+      ? new optionalDeps.ethUtil.BN(params.eip1559.maxFeePerGas)
+      : new optionalDeps.ethUtil.BN(this.setGasPrice(params.gasPrice));
+
+    let backupKeyAddress;
+    let userKeyCombined;
+    let backupKeyCombined;
+
+    if (isUnsignedSweep) {
+      const backupKeyPair = new KeyPairLib({ pub: backupKey });
+      backupKeyAddress = backupKeyPair.getAddress();
+    } else {
+      let backupPrv;
+      let userPrv;
+      try {
+        backupPrv = this.bitgo.decrypt({
+          input: backupKey,
+          password: params.walletPassphrase,
+        });
+        userPrv = this.bitgo.decrypt({
+          input: userKey,
+          password: params.walletPassphrase,
+        });
+      } catch (e) {
+        throw new Error(`Error decrypting backup keychain: ${e.message}`);
+      }
+
+      const userSigningMaterial = JSON.parse(userPrv) as ECDSAMethodTypes.SigningMaterial;
+      const backupSigningMaterial = JSON.parse(backupPrv) as ECDSAMethodTypes.SigningMaterial;
+
+      if (!userSigningMaterial.backupNShare) {
+        throw new Error('Invalid user key - missing backupNShare');
+      }
+
+      if (!backupSigningMaterial.userNShare) {
+        throw new Error('Invalid backup key - missing userNShare');
+      }
+
+      const MPC = new Ecdsa();
+
+      userKeyCombined = MPC.keyCombine(userSigningMaterial.pShare, [
+        userSigningMaterial.bitgoNShare,
+        userSigningMaterial.backupNShare,
+      ]);
+      backupKeyCombined = MPC.keyCombine(backupSigningMaterial.pShare, [
+        backupSigningMaterial.bitgoNShare,
+        backupSigningMaterial.userNShare,
+      ]);
+
+      const backupKeyPair = new KeyPairLib({ pub: backupKeyCombined.xShare.y });
+
+      backupKeyAddress = backupKeyPair.getAddress();
+    }
+
+    const backupKeyNonce = await this.getAddressNonce(backupKeyAddress);
+
+    // get balance of backupKey to ensure funds are available to pay fees
+    const backupKeyBalance = await this.queryAddressBalance(backupKeyAddress);
+
+    const totalGasNeeded = gasPrice.mul(gasLimit);
+    const weiToGwei = 10 ** 9;
+    if (backupKeyBalance.lt(totalGasNeeded)) {
+      throw new Error(
+        `Backup key address ${backupKeyAddress} has balance ${(backupKeyBalance / weiToGwei).toString()} Gwei.` +
+          `This address must have a balance of at least ${(totalGasNeeded / weiToGwei).toString()}` +
+          ` Gwei to perform recoveries. Try sending some ETH to this address then retry.`
+      );
+    }
+
+    // get balance of wallet and deduct fees to get transaction amount, wallet contract address acts as base address for tss?
+    const txAmount = backupKeyBalance.sub(totalGasNeeded);
+
+    // build recipients object
+    const recipients = [
+      {
+        address: params.recoveryDestination,
+        amount: txAmount.toString(10),
+      },
+    ];
+
+    const txInfo = {
+      recipient: recipients[0],
+      expireTime: this.getDefaultExpireTime(),
+      gasLimit: gasLimit.toString(10),
+    };
+
+    const txParams = {
+      to: params.recoveryDestination, // no contract address, so this field should not be used anyways
+      nonce: backupKeyNonce,
+      value: txAmount,
+      gasPrice: gasPrice,
+      gasLimit: gasLimit,
+      data: Buffer.from('0x'), // no contract call, so no call data?
+      eip1559: params.eip1559,
+      replayProtectionOptions: params.replayProtectionOptions,
+    };
+
+    let tx = Eth.buildTransaction(txParams);
+
+    if (isUnsignedSweep) {
+      return this.formatForOfflineVaultTSS(
+        txInfo,
+        tx,
+        userKey,
+        backupKey,
+        gasPrice,
+        gasLimit,
+        backupKeyNonce,
+        params.eip1559,
+        params.replayProtectionOptions
+      );
+    }
+
+    const signableHex = tx.getMessageToSign(false).toString('hex');
+
+    const signature = this.signRecoveryTSS(userKeyCombined, backupKeyCombined, signableHex);
+
+    // get signed Tx from signature
+    const txData = tx.toJSON();
+    const yParity = signature.recid;
+    const baseParams = {
+      to: txData.to,
+      nonce: new BN(stripHexPrefix(txData.nonce!), 'hex'),
+      value: new BN(stripHexPrefix(txData.value!), 'hex'),
+      gasLimit: new BN(stripHexPrefix(txData.gasLimit!), 'hex'),
+      data: txData.data,
+      r: addHexPrefix(signature.r),
+      s: addHexPrefix(signature.s),
+    };
+
+    const ethCommon = Eth.getEthCommon(params);
+
+    if (txData.maxFeePerGas && txData.maxPriorityFeePerGas) {
+      tx = FeeMarketEIP1559Transaction.fromTxData(
+        {
+          ...baseParams,
+          maxPriorityFeePerGas: new BN(stripHexPrefix(txData.maxPriorityFeePerGas!), 'hex'),
+          maxFeePerGas: new BN(stripHexPrefix(txData.maxFeePerGas!), 'hex'),
+          v: new BN(yParity.toString()),
+        },
+        { common: ethCommon }
+      );
+    } else if (txData.gasPrice) {
+      const v = BigInt(35) + BigInt(yParity) + BigInt(ethCommon.chainIdBN().toNumber()) * BigInt(2);
+      tx = LegacyTransaction.fromTxData(
+        {
+          ...baseParams,
+          v: new BN(v.toString()),
+          gasPrice: new BN(stripHexPrefix(txData.gasPrice!.toString()), 'hex'),
+        },
+        { common: ethCommon }
+      );
+    }
+
+    return {
+      id: addHexPrefix(tx.hash().toString('hex')),
+      tx: addHexPrefix(tx.serialize().toString('hex')),
+    };
+  }
+
   /**
    * Builds a funds recovery transaction without BitGo
    * @param params
@@ -952,7 +1246,14 @@ export class Eth extends BaseCoin {
    * @param params.krsProvider {String} necessary if backup key is held by KRS
    * @param params.recoveryDestination {String} target address to send recovered funds to
    */
-  async recover(params: RecoverOptions): Promise<RecoveryInfo | OfflineVaultTxInfo> {
+  async recover(params: RecoverOptions): Promise<RecoveryInfo | OfflineVaultTxInfo | ECDSAMethodTypes.Signature> {
+    if (params.isTss) {
+      return this.recoverTSS(params);
+    }
+    return this.recoverEth(params);
+  }
+
+  async recoverEth(params: RecoverOptions): Promise<RecoveryInfo | OfflineVaultTxInfo> {
     this.validateRecoveryParams(params);
     const isKrsRecovery = getIsKrsRecovery(params);
     const isUnsignedSweep = getIsUnsignedSweep(params);
@@ -1080,8 +1381,7 @@ export class Eth extends BaseCoin {
       replayProtectionOptions: params.replayProtectionOptions,
     };
 
-    // Build contract call and sign it
-    let tx = Eth.buildTransaction(txParams);
+    const tx = Eth.buildTransaction(txParams);
 
     if (isUnsignedSweep) {
       return this.formatForOfflineVault(
@@ -1096,19 +1396,10 @@ export class Eth extends BaseCoin {
       );
     }
 
-    if (!isKrsRecovery) {
-      tx = tx.sign(backupSigningKey);
-    }
-
     const signedTx: RecoveryInfo = {
       id: optionalDeps.ethUtil.bufferToHex(tx.hash()),
       tx: tx.serialize().toString('hex'),
     };
-
-    if (isKrsRecovery) {
-      signedTx.backupKey = backupKey;
-      signedTx.coin = this.getChain();
-    }
 
     return signedTx;
   }

--- a/modules/sdk-coin-eth/src/eth.ts
+++ b/modules/sdk-coin-eth/src/eth.ts
@@ -913,7 +913,7 @@ export class Eth extends BaseCoin {
    * @param replayProtectionOptions
    * @returns {Promise<OfflineVaultTxInfo>}
    */
-  async formatForOfflineVaultTSS(
+  formatForOfflineVaultTSS(
     txInfo: UnformattedTxInfo,
     ethTx: EthTxLib.Transaction | EthTxLib.FeeMarketEIP1559Transaction,
     userKey: string,
@@ -923,7 +923,7 @@ export class Eth extends BaseCoin {
     backupKeyNonce: number,
     eip1559?: EIP1559,
     replayProtectionOptions?: ReplayProtectionOptions
-  ): Promise<OfflineVaultTxInfo> {
+  ): OfflineVaultTxInfo {
     if (!ethTx.to) {
       throw new Error('Eth tx must have a `to` address');
     }
@@ -1175,7 +1175,7 @@ export class Eth extends BaseCoin {
    * @param params.krsProvider {String} necessary if backup key is held by KRS
    * @param params.recoveryDestination {String} target address to send recovered funds to
    */
-  async recover(params: RecoverOptions): Promise<RecoveryInfo | OfflineVaultTxInfo | ECDSAMethodTypes.Signature> {
+  async recover(params: RecoverOptions): Promise<RecoveryInfo | OfflineVaultTxInfo> {
     if (params.isTss) {
       return this.recoverTSS(params);
     }

--- a/modules/sdk-core/src/bitgo/recovery/initiate.ts
+++ b/modules/sdk-core/src/bitgo/recovery/initiate.ts
@@ -68,7 +68,22 @@ export function getIsKrsRecovery({ backupKey, userKey }: { backupKey: string; us
   return backupKey.startsWith('xpub') && !userKey.startsWith('xpub');
 }
 
-export function getIsUnsignedSweep({ backupKey, userKey }: { backupKey: string; userKey: string }): boolean {
+export function getIsUnsignedSweep({
+  backupKey,
+  userKey,
+  isTss,
+}: {
+  backupKey: string;
+  userKey: string;
+  isTss?: boolean;
+}): boolean {
+  if (isTss) {
+    try {
+      return typeof JSON.parse(backupKey) === 'string' && typeof JSON.parse(userKey) === 'string';
+    } catch (e) {
+      return true;
+    }
+  }
   return backupKey.startsWith('xpub') && userKey.startsWith('xpub');
 }
 


### PR DESCRIPTION
Ticket: BG-61005

This change supports building/signing a recovery transaction with TSS. It expects the user/backup key shares to perform TSS signing. A couple unit tests were added to test building an unsigned tx and to fully build/sign a recovery tx.

More work needs to be done on the WRW side to actually allow for an end user to perform the recovery flow like other coins. 

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->