### PR TITLE
feat(express): consolidate account support in external signer

### DIFF
--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -607,7 +607,11 @@ export async function handleV2ConsolidateAccount(req: express.Request) {
 
   let result: any;
   try {
-    result = await wallet.sendAccountConsolidations(req.body);
+    if (coin.supportsTss()) {
+      result = await wallet.sendAccountConsolidations(createTSSSendParams(req));
+    } else {
+      result = await wallet.sendAccountConsolidations(createSendParams(req));
+    }
   } catch (err) {
     err.status = 400;
     throw err;

--- a/modules/express/test/unit/clientRoutes/consolidateAccount.ts
+++ b/modules/express/test/unit/clientRoutes/consolidateAccount.ts
@@ -68,10 +68,11 @@ describe('Consolidate account', () => {
       .should.be.rejectedWith('consolidate address must be an array of addresses');
   });
 
-  function createConsolidateMocks(res, allowsAccountConsolidations = false) {
+  function createConsolidateMocks(res, allowsAccountConsolidations = false, supportsTss = false) {
     const consolidationStub = sinon.stub().returns(res);
     const walletStub = { sendAccountConsolidations: consolidationStub };
     const coinStub = {
+      supportsTss: () => supportsTss,
       allowsAccountConsolidations: () => allowsAccountConsolidations,
       wallets: () => ({ get: () => Promise.resolve(walletStub) }),
     };

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -2637,21 +2637,26 @@ export class Wallet implements IWallet {
     params: WalletSignTransactionOptions = {},
     coin: IBaseCoin
   ): Promise<TxRequest> {
-    if (!params.txRequestId) {
-      throw new Error('txRequestId required to sign transactions with TSS');
+    let txRequestId = '';
+    if (params.txRequestId) {
+      txRequestId = params.txRequestId;
+    } else if (params.txPrebuild && params.txPrebuild.txRequestId) {
+      txRequestId = params.txPrebuild.txRequestId;
+    } else {
+      throw new Error('TxRequestId required to sign TSS transactions with External Signer.');
     }
 
     if (!params.customRShareGeneratingFunction) {
-      throw new Error('Generator function for R share required to sign transactions with External Signer');
+      throw new Error('Generator function for R share required to sign transactions with External Signer.');
     }
 
     if (!params.customGShareGeneratingFunction) {
-      throw new Error('Generator function for G share required to sign transactions with External Signer');
+      throw new Error('Generator function for G share required to sign transactions with External Signer.');
     }
 
     try {
       const signedTxRequest = await this.tssUtils!.signUsingExternalSigner(
-        params.txRequestId,
+        txRequestId,
         params.customRShareGeneratingFunction,
         params.customGShareGeneratingFunction
       );


### PR DESCRIPTION
<!--
# Please be aware of the following when making your pull request:

## Description

This change is to support using the external signer for signing the transaction built in the consolidate account endpoint.

## Issue Number

BG-62277

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested with a test wallet of Algo and express setup in external signing mode locally. I created three receive addresses in testnet and then consolidated funds using the external signer to one receive address.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->