### PR TITLE
fix(sdk): fix tss signing

### DIFF
--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
@@ -587,8 +587,15 @@ export class EcdsaUtils extends baseTSSUtils<KeyShare> {
     let signablePayload;
 
     if (requestType === RequestType.tx) {
-      assert(txRequestResolved.transactions, 'Unable to find transactions in txRequest');
-      signablePayload = Buffer.from(txRequestResolved.transactions[0].unsignedTx.signableHex, 'hex');
+      assert(
+        txRequestResolved.transactions || txRequestResolved.unsignedTxs,
+        'Unable to find transactions in txRequest'
+      );
+      const unsignedTx =
+        txRequestResolved.apiVersion === 'full'
+          ? txRequestResolved.transactions![0].unsignedTx
+          : txRequestResolved.unsignedTxs[0];
+      signablePayload = Buffer.from(unsignedTx.signableHex, 'hex');
     } else if (requestType === RequestType.message) {
       const finalMessage = (params as TSSParamsForMessage).messageEncoded;
       assert(finalMessage, 'finalMessage is required');

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
@@ -354,10 +354,10 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
       throw new Error('Invalid user key - missing backupYShare');
     }
 
-    assert(txRequestResolved.transactions, 'Unable to find transactions in txRequest');
+    assert(txRequestResolved.transactions || txRequestResolved.unsignedTxs, 'Unable to find transactions in txRequest');
     const unsignedTx =
       txRequestResolved.apiVersion === 'full'
-        ? txRequestResolved.transactions[0].unsignedTx
+        ? txRequestResolved.transactions![0].unsignedTx
         : txRequestResolved.unsignedTxs[0];
 
     const signingKey = MPC.keyDerive(
@@ -394,10 +394,10 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
       throw new Error('Invalid user key - missing backupYShare');
     }
 
-    assert(txRequestResolved.transactions, 'Unable to find transactions in txRequest');
+    assert(txRequestResolved.transactions || txRequestResolved.unsignedTxs, 'Unable to find transactions in txRequest');
     const unsignedTx =
       txRequestResolved.apiVersion === 'full'
-        ? txRequestResolved.transactions[0].unsignedTx
+        ? txRequestResolved.transactions![0].unsignedTx
         : txRequestResolved.unsignedTxs[0];
 
     const signablePayload = Buffer.from(unsignedTx.signableHex, 'hex');
@@ -475,10 +475,10 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
       throw new Error('Invalid user key - missing backupYShare');
     }
 
-    assert(txRequestResolved.transactions, 'Unable to find transactions in txRequest');
+    assert(txRequestResolved.transactions || txRequestResolved.unsignedTxs, 'Unable to find transactions in txRequest');
     const unsignedTx =
       txRequestResolved.apiVersion === 'full'
-        ? txRequestResolved.transactions[0].unsignedTx
+        ? txRequestResolved.transactions![0].unsignedTx
         : txRequestResolved.unsignedTxs[0];
 
     const signingKey = MPC.keyDerive(


### PR DESCRIPTION
Issue was that `transactions` only exists on txRequest for api version `full`, which was throwing an error for api version `lite`. Added in fix to account for this.

TICKET: [BG-62852](https://bitgoinc.atlassian.net/browse/BG-62852?atlOrigin=eyJpIjoiZTY2ZWNmZTBhNWQ5NDRmYWJmZjk3ZGZmYTgwYTgxOTQiLCJwIjoiaiJ9)