### PR TITLE
fix(dot): update DOT transferAll value to zero

### DIFF
--- a/modules/sdk-coin-dot/src/lib/transaction.ts
+++ b/modules/sdk-coin-dot/src/lib/transaction.ts
@@ -415,7 +415,7 @@ export class Transaction extends BaseTransaction {
         pub: Buffer.from(decodeAddress(txMethod.dest.id)).toString('hex'),
       });
       to = keypairDest.getAddress(utils.getAddressFormat(this._coinConfig.name as DotAssetTypes));
-      value = 'sweep';
+      value = '0'; // DOT transferAll's do not deserialize amounts
       from = decodedTx.address;
     } else if (utils.isTransfer(txMethod)) {
       const keypairDest = new KeyPair({

--- a/modules/sdk-coin-dot/test/unit/transactionBuilder/transferBuilder.ts
+++ b/modules/sdk-coin-dot/test/unit/transactionBuilder/transferBuilder.ts
@@ -14,6 +14,9 @@ describe('Dot Transfer Builder', () => {
   const sender = accounts.account1;
   const receiver = accounts.account2;
 
+  // Consolidation/sweep tx's do not deseialize amounts.
+  const consolidationValue = '0';
+
   beforeEach(() => {
     const config = buildTestConfig();
     builder = new TransferBuilder(config).material(utils.getMaterial(config));
@@ -344,11 +347,11 @@ describe('Dot Transfer Builder', () => {
 
       const inputs = tx.inputs[0];
       should.deepEqual(inputs.address, sender.address);
-      should.deepEqual(inputs.value, 'sweep');
+      should.deepEqual(inputs.value, consolidationValue);
 
       const outputs = tx.outputs[0];
       should.deepEqual(outputs.address, receiver.address);
-      should.deepEqual(outputs.value, 'sweep');
+      should.deepEqual(outputs.value, consolidationValue);
     });
 
     it('should build an unsigned sweep transaction', async () => {
@@ -376,11 +379,11 @@ describe('Dot Transfer Builder', () => {
 
       const inputs = tx.inputs[0];
       should.deepEqual(inputs.address, sender.address);
-      should.deepEqual(inputs.value, 'sweep');
+      should.deepEqual(inputs.value, consolidationValue);
 
       const outputs = tx.outputs[0];
       should.deepEqual(outputs.address, receiver.address);
-      should.deepEqual(outputs.value, 'sweep');
+      should.deepEqual(outputs.value, consolidationValue);
     });
 
     it('should build from raw signed sweep transaction', async () => {
@@ -403,11 +406,11 @@ describe('Dot Transfer Builder', () => {
 
       const inputs = tx.inputs[0];
       should.deepEqual(inputs.address, sender.address);
-      should.deepEqual(inputs.value, 'sweep');
+      should.deepEqual(inputs.value, consolidationValue);
 
       const outputs = tx.outputs[0];
       should.deepEqual(outputs.address, receiver.address);
-      should.deepEqual(outputs.value, 'sweep');
+      should.deepEqual(outputs.value, consolidationValue);
     });
 
     it('should build from an unsigned sweep transaction', async () => {
@@ -432,11 +435,11 @@ describe('Dot Transfer Builder', () => {
 
       const inputs = tx.inputs[0];
       should.deepEqual(inputs.address, sender.address);
-      should.deepEqual(inputs.value, 'sweep');
+      should.deepEqual(inputs.value, consolidationValue);
 
       const outputs = tx.outputs[0];
       should.deepEqual(outputs.address, receiver.address);
-      should.deepEqual(outputs.value, 'sweep');
+      should.deepEqual(outputs.value, consolidationValue);
     });
   });
 });


### PR DESCRIPTION
## Description

Polkadot transferAll transactions (used in consolidation) do not deserialize amounts. Set the value of the transaction to zero.

Currently the value is 'sweep', but this string does not merge well with the Amount type when parsing the tx internally.

## Issue Number

TICKET: BG-62062

Internal Users - BG-62062
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
