### PR TITLE
chore: don't throw exception when re-registering coin

### DIFF
--- a/modules/sdk-core/src/bitgo/coinFactory.ts
+++ b/modules/sdk-core/src/bitgo/coinFactory.ts
@@ -38,7 +38,7 @@ export class CoinFactory {
    */
   public register(name: string, coin: CoinConstructor): void {
     if (this.coinConstructors.has(name)) {
-      throw new Error(`coin '${name}' is already defined`);
+      return;
     }
     this.coinConstructors.set(name, coin);
   }


### PR DESCRIPTION
## Description

Instead of throwing an exception when reregistering a coin, return early.

## Issue Number

TICKET: BG-62974

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [x] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes