### PR TITLE
chore(sdk-core): sui pass gas limit param in prebuild

### DIFF
--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -1300,6 +1300,22 @@ describe('V2 Wallet:', function () {
 
       response.isDone().should.be.true();
     });
+
+    it('should pass gas limit parameter through when building transaction for sui', async function () {
+      const params = { gasLimit: 100 };
+      const path = `/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/build`;
+      const response = nock(bgUrl)
+        .post(path, _.matches(params)) // use _.matches to do a partial match on request body object instead of strict matching
+        .reply(200);
+      try {
+        await wallet.prebuildTransaction(params);
+      } catch (e) {
+        // the prebuildTransaction method will probably throw an exception for not having all of the correct nocks
+        // we only care about /tx/build and whether reservation is an allowed parameter
+      }
+
+      response.isDone().should.be.true();
+    });
   });
 
   describe('Maximum Spendable', function maximumSpendable() {

--- a/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
@@ -161,6 +161,16 @@ export abstract class MpcUtils {
       }
     }
 
+    if (params.feeOptions !== undefined) {
+      return {
+        ...baseIntent,
+        memo: params.memo?.value,
+        token: params.tokenName,
+        enableTokens: params.enableTokens,
+        feeOptions: params.feeOptions,
+      };
+    }
+
     return {
       ...baseIntent,
       memo: params.memo?.value,

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -2554,6 +2554,8 @@ export class Wallet implements IWallet {
               maxPriorityFeePerGas: Number(params.eip1559?.maxPriorityFeePerGas),
               gasLimit: params.gasLimit,
             };
+    } else if (params.gasLimit !== undefined) {
+      feeOptions = { gasLimit: params.gasLimit };
     } else {
       feeOptions = undefined;
     }


### PR DESCRIPTION
Ticket: BG-63034

Sui requires a `gasBudget` input, so this PR is to support passing `gasLimit` parameter in prebuild

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->