### PR TITLE
Bg 62806 eip712 encoding

### DIFF
--- a/modules/sdk-coin-eth/package.json
+++ b/modules/sdk-coin-eth/package.json
@@ -53,6 +53,7 @@
     "ethers": "^5.1.3",
     "keccak": "^3.0.2",
     "lodash": "^4.17.14",
+    "@metamask/eth-sig-util": "^5.0.2",
     "secp256k1": "4.0.2",
     "superagent": "^3.8.3"
   },

--- a/modules/sdk-core/src/bitgo/baseCoin/baseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/baseCoin.ts
@@ -285,6 +285,14 @@ export abstract class BaseCoin implements IBaseCoin {
   }
 
   /**
+   * Check whether a coin supports signing of Typed data
+   * @returns {boolean}
+   */
+  supportsSigningTypedData(): boolean {
+    return false;
+  }
+
+  /**
    * Hook to add additional parameters to the wallet generation
    * @param walletParams
    * @param keychains

--- a/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
@@ -258,6 +258,57 @@ export interface Message extends BaseSignable {
   messageEncoded?: string;
 }
 
+export interface MessageTypeProperty {
+  name: string;
+  type: string;
+}
+export interface MessageTypes {
+  EIP712Domain: MessageTypeProperty[];
+  [additionalProperties: string]: MessageTypeProperty[];
+}
+
+export enum SignTypedDataVersion {
+  V1 = 'V1',
+  V3 = 'V3',
+  V4 = 'V4',
+}
+
+/**
+ * This is the message format used for `signTypeData`, for all versions
+ * except `V1`.
+ *
+ * @template T - The custom types used by this message.
+ * @property types - The custom types used by this message.
+ * @property primaryType - The type of the message.
+ * @property domain - Signing domain metadata. The signing domain is the intended context for the
+ * signature (e.g. the dapp, protocol, etc. that it's intended for). This data is used to
+ * construct the domain seperator of the message.
+ * @property domain.name - The name of the signing domain.
+ * @property domain.version - The current major version of the signing domain.
+ * @property domain.chainId - The chain ID of the signing domain.
+ * @property domain.verifyingContract - The address of the contract that can verify the signature.
+ * @property domain.salt - A disambiguating salt for the protocol.
+ * @property message - The message to be signed.
+ */
+export interface TypedMessage<T extends MessageTypes> {
+  types: T;
+  primaryType: keyof T;
+  domain: {
+    name?: string;
+    version?: string;
+    chainId?: number;
+    verifyingContract?: string;
+    salt?: ArrayBuffer;
+  };
+  message: Record<string, unknown>;
+}
+
+export interface TypedData<T extends MessageTypes> extends BaseSignable {
+  typedDataRaw: TypedMessage<T>;
+  version: SignTypedDataVersion;
+  typedDataEncoded?: Buffer;
+}
+
 export interface AddressCoinSpecific {
   outputScript?: string;
   redeemScript?: string;
@@ -388,6 +439,7 @@ export interface IBaseCoin {
   supportsBlockTarget(): boolean;
   supportsLightning(): boolean;
   supportsMessageSigning(): boolean;
+  supportsSigningTypedData(): boolean;
   supplementGenerateWallet(walletParams: SupplementGenerateWalletOptions, keychains: KeychainsTriplet): Promise<any>;
   getExtraPrebuildParams(buildParams: ExtraPrebuildParamsOptions): Promise<Record<string, unknown>>;
   postProcessPrebuild(prebuildResponse: TransactionPrebuild): Promise<TransactionPrebuild>;

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
@@ -20,6 +20,8 @@ import {
   BackupKeyShare,
   IntentOptionsForMessage,
   PopulatedIntentForMessageSigning,
+  IntentOptionsForTypedData,
+  PopulatedIntentForTypedDataSigning,
 } from './baseTypes';
 import { SignShare, YShare, GShare } from '../../../account-lib/mpc/tss/eddsa/types';
 
@@ -219,6 +221,45 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
       messageEncoded: params.messageEncoded ?? '',
     };
 
+    return this.createTxRequestBase(intentOptions, apiVersion, preview);
+  }
+
+  /**
+   * Create a tx request from params for type data signing
+   *
+   * @param params
+   * @param apiVersion
+   * @param preview
+   */
+  async createTxRequestWithIntentForTypedDataSigning(
+    params: IntentOptionsForTypedData,
+    apiVersion: TxRequestVersion = 'full',
+    preview?: boolean
+  ): Promise<TxRequest> {
+    const intentOptions: PopulatedIntentForTypedDataSigning<any> = {
+      custodianMessageId: params.custodianMessageId,
+      intentType: params.intentType,
+      sequenceId: params.sequenceId,
+      comment: params.comment,
+      memo: params.memo?.value,
+      isTss: params.isTss,
+      messageRaw: params.typedDataRaw,
+      messageEncoded: params.typedDataEncoded ?? '',
+    };
+
+    return this.createTxRequestBase(intentOptions, apiVersion, preview);
+  }
+
+  /**
+   * Calls Bitgo API to create tx request.
+   *
+   * @private
+   */
+  private async createTxRequestBase(
+    intentOptions: PopulatedIntentForTypedDataSigning<any> | PopulatedIntentForMessageSigning,
+    apiVersion: TxRequestVersion,
+    preview?: boolean
+  ): Promise<TxRequest> {
     const whitelistedParams = {
       intent: {
         ...intentOptions,

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -1,6 +1,6 @@
 import { SerializedKeyPair } from 'openpgp';
 import { IRequestTracer } from '../../../api';
-import { KeychainsTriplet } from '../../baseCoin';
+import { KeychainsTriplet, TypedMessage, MessageTypes } from '../../baseCoin';
 import { ApiKeyShare, Keychain } from '../../keychain';
 import { ApiVersion, Memo, WalletType } from '../../wallet';
 import { EDDSA, GShare, SignShare, YShare } from '../../../account-lib/mpc/tss';
@@ -72,6 +72,11 @@ export interface IntentOptionsForMessage extends IntentOptionsBase {
   messageEncoded?: string;
 }
 
+export interface IntentOptionsForTypedData extends IntentOptionsBase {
+  typedDataRaw: TypedMessage<any>;
+  typedDataEncoded?: string;
+}
+
 export interface PrebuildTransactionWithIntentOptions extends IntentOptionsBase {
   recipients?: {
     address: string;
@@ -110,6 +115,12 @@ interface PopulatedIntentBase {
 
 export interface PopulatedIntentForMessageSigning extends PopulatedIntentBase {
   messageRaw: string;
+  messageEncoded: string;
+  custodianMessageId?: string;
+}
+
+export interface PopulatedIntentForTypedDataSigning<T extends MessageTypes> extends PopulatedIntentBase {
+  messageRaw: TypedMessage<T>;
   messageEncoded: string;
   custodianMessageId?: string;
 }
@@ -231,7 +242,7 @@ export type TSSParams = {
 };
 
 export type TSSParamsForMessage = TSSParams & {
-  messageRaw: string;
+  messageRaw: string | TypedMessage<any>;
   messageEncoded?: string;
 };
 

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -6,6 +6,7 @@ import {
   SignedTransaction,
   TransactionPrebuild,
   VerificationOptions,
+  TypedData,
 } from '../baseCoin';
 import { BitGoBase } from '../bitgoBase';
 import { Keychain } from '../keychain';
@@ -156,6 +157,11 @@ export interface WalletSignTransactionOptions extends WalletSignBaseOptions {
 
 export interface WalletSignMessageOptions extends WalletSignBaseOptions {
   message?: Message;
+  custodianMessageId?: string;
+}
+
+export interface WalletSignTypedDataOptions extends WalletSignMessageOptions {
+  typedData: TypedData<any>;
   custodianMessageId?: string;
 }
 
@@ -633,5 +639,6 @@ export interface IWallet {
   sendTokenEnablements(params?: BuildTokenEnablementOptions): Promise<any>;
   lightning(): ILightning;
   signMessage(params: WalletSignMessageOptions): Promise<SignedMessage>;
+  signTypedData(params: WalletSignTypedDataOptions): Promise<SignedMessage>;
   fetchCrossChainUTXOs(params: FetchCrossChainUTXOsOptions): Promise<CrossChainUTXO[]>;
 }

--- a/webpack/bitgojs.config.js
+++ b/webpack/bitgojs.config.js
@@ -17,6 +17,7 @@ module.exports = {
       'superagent-proxy': false,
       // use the default version here since we're webpacking ourselves
       '@bitgo/sdk-api': path.resolve('../sdk-api/dist/src/index.js'),
+      async: path.resolve('../../node_modules/async/index.js'),
     },
     fallback: {
       constants: false,
@@ -34,6 +35,7 @@ module.exports = {
       url: require.resolve('url/'),
       vm: false,
       zlib: false,
+      async: require.resolve('async'),
     },
   },
   externals: ['morgan', 'superagent-proxy'],
@@ -44,7 +46,7 @@ module.exports = {
     }),
 
     new webpack.NormalModuleReplacementPlugin(/\@emurgo\/cardano-serialization-lib-nodejs/, '@emurgo/cardano-serialization-lib-browser'),
- 
+
     new webpack.ContextReplacementPlugin(/cardano-serialization-lib-browser/),
   ],
   node: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2955,6 +2955,18 @@
     npmlog "^6.0.2"
     write-file-atomic "^4.0.1"
 
+"@metamask/eth-sig-util@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@metamask/eth-sig-util/-/eth-sig-util-5.0.2.tgz#c518279a6e17a88135a13d53a0b970f145ff8bce"
+  integrity sha512-RU6fG/H6/UlBol221uBkq5C7w3TwLK611nEZliO2u+kO0vHKGBXnIPlhI0tzKUigjhUeOd9mhCNbNvhh0LKt9Q==
+  dependencies:
+    "@ethereumjs/util" "^8.0.0"
+    bn.js "^4.11.8"
+    ethereum-cryptography "^1.1.2"
+    ethjs-util "^0.1.6"
+    tweetnacl "^1.0.3"
+    tweetnacl-util "^0.15.1"
+
 "@mysten/bcs@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@mysten/bcs/-/bcs-0.4.0.tgz#d0c9deb91918fcd37a2f1eb30621ac5a58ef6381"


### PR DESCRIPTION
[EIP-712 standard](https://eips.ethereum.org/EIPS/eip-712) describe how to encode the data before hashing. This is usually handled by the `@metamask/eth-sig-util` library. Normally we would just call the `eip712hash` function of that library, however that function applies the `keccak` transformation to the encoded data. In our case, we just needed the raw encoding, so we ended up doing everything shy of the `keccak`

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->