### PR TITLE
feat(sdk-coin-dot): add keepAlive flag to DOT sweep constructor

### DIFF
--- a/modules/sdk-coin-dot/src/lib/nativeTransferBuilder.ts
+++ b/modules/sdk-coin-dot/src/lib/nativeTransferBuilder.ts
@@ -13,6 +13,7 @@ import utils from './utils';
 
 export abstract class NativeTransferBuilder extends TransactionBuilder {
   protected _sweepFreeBalance = false;
+  protected _keepAddressAlive = true;
   protected _amount: string;
   protected _to: string;
   protected _owner: string;
@@ -37,7 +38,7 @@ export abstract class NativeTransferBuilder extends TransactionBuilder {
       transferTx = methods.balances.transferAll(
         {
           dest: this._to,
-          keepAlive: false,
+          keepAlive: this._keepAddressAlive,
         },
         baseTxInfo.baseTxInfo,
         baseTxInfo.options
@@ -73,14 +74,19 @@ export abstract class NativeTransferBuilder extends TransactionBuilder {
 
   /**
    *
-   * Set this to be a sweep transaction, using TransferAll with keepAlive set to false
+   * Set this to be a sweep transaction, using TransferAll with keepAlive set to true by default.
+   * If keepAlive is false, the entire address will be swept (including the 1 DOT minimum).
    *
+   * @param {boolean} keepAlive - keep the address alive after this sweep
    * @returns {TransferBuilder} This transfer builder.
    *
    * @see https://github.com/paritytech/txwrapper-core/blob/main/docs/modules/txwrapper_substrate_src.methods.balances.md#transferall
    */
-  sweep(): this {
+  sweep(keepAlive?: boolean): this {
     this._sweepFreeBalance = true;
+    if (keepAlive) {
+      this._keepAddressAlive = keepAlive;
+    }
     return this;
   }
 

--- a/modules/sdk-coin-dot/test/unit/transactionBuilder/transferBuilder.ts
+++ b/modules/sdk-coin-dot/test/unit/transactionBuilder/transferBuilder.ts
@@ -386,6 +386,38 @@ describe('Dot Transfer Builder', () => {
       should.deepEqual(outputs.value, consolidationValue);
     });
 
+    it('should build an unsigned sweep transaction with keepAlive as false', async () => {
+      builder
+        .sweep(false)
+        .to({ address: receiver.address })
+        .amount('90034235235322')
+        .sender({ address: sender.address })
+        .validity({ firstValid: 3933, maxDuration: 64 })
+        .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
+        .sequenceId({ name: 'Nonce', keyword: 'nonce', value: 200 })
+        .fee({ amount: 0, type: 'tip' });
+      const tx = await builder.build();
+      const txJson = tx.toJson();
+      should.deepEqual(txJson.sender, sender.address);
+      should.deepEqual(txJson.blockNumber, 3933);
+      should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
+      should.deepEqual(txJson.genesisHash, genesisHash);
+      should.deepEqual(txJson.specVersion, specVersion);
+      should.deepEqual(txJson.nonce, 200);
+      should.deepEqual(txJson.tip, 0);
+      should.deepEqual(txJson.transactionVersion, txVersion);
+      should.deepEqual(txJson.chainName, chainName);
+      should.deepEqual(txJson.eraPeriod, 64);
+
+      const inputs = tx.inputs[0];
+      should.deepEqual(inputs.address, sender.address);
+      should.deepEqual(inputs.value, consolidationValue);
+
+      const outputs = tx.outputs[0];
+      should.deepEqual(outputs.address, receiver.address);
+      should.deepEqual(outputs.value, consolidationValue);
+    });
+
     it('should build from raw signed sweep transaction', async () => {
       builder.from(rawTx.transferAll.signed);
       builder


### PR DESCRIPTION
Adds the keepAlive flag as an optional parameter to the sweep() constructor used when building DOT transactions.

TICKET: BG-62062

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->