### PR TITLE
fix(sdk-core): fix generate wallets isCold param

### DIFF
--- a/modules/bitgo/test/v2/unit/wallets.ts
+++ b/modules/bitgo/test/v2/unit/wallets.ts
@@ -132,6 +132,19 @@ describe('V2 Wallets:', function () {
         .reply(200, {});
       await ethWallets.add({ label: 'label', enterprise: 'enterprise', type: 'custodial', walletVersion: 1 } as any);
     });
+
+    it('creates a new hot wallet with userKey', async function () {
+      nock(bgUrl)
+        .post('/api/v2/tbtc/wallet', function (body) {
+          body.type.should.equal('hot');
+          body.should.have.property('keys');
+          body.should.have.property('m');
+          body.should.have.property('n');
+          return true;
+        })
+        .reply(200, {});
+      await wallets.add({ label: 'label', enterprise: 'enterprise', type: 'hot', keys: [], m: 2, n: 3, userKey: 'test123' });
+    });
   });
 
   describe('Generate wallet:', function () {

--- a/modules/sdk-core/src/bitgo/wallet/wallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallets.ts
@@ -184,7 +184,7 @@ export class Wallets implements IWallets {
     const label = params.label;
     const passphrase = params.passphrase;
     const canEncrypt = !!passphrase && typeof passphrase === 'string';
-    const isCold = !!params.userKey;
+    const isCold = !!params.userKey && params.multisigType !== 'onchain';
     const walletParams: SupplementGenerateWalletOptions = {
       label: label,
       m: 2,


### PR DESCRIPTION

## Description

Fix generateWallet which  incorrectly sets isCold as long as the userKey is present. This should only happen if the wallet type is tss - the result is hot wallet creation via the /generateWallet endpoint with Express is broken & only creates hot wallets.

## Issue Number

https://bitgoinc.atlassian.net/browse/BG-63468

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ x] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ x] My code compiles correctly for both Node and Browser environments
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x ] The ticket or github issue was included in the commit message as a reference
- [ x] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
