### PR TITLE
feat(utxo-lib): function for bitgo psbt parsing

### DIFF
--- a/modules/utxo-lib/src/bitgo/UtxoPsbt.ts
+++ b/modules/utxo-lib/src/bitgo/UtxoPsbt.ts
@@ -64,7 +64,21 @@ export class UtxoPsbt<Tx extends UtxoTransaction<bigint>> extends Psbt {
     return psbt;
   }
 
+  /**
+   * @return true iff PSBT input is finalized
+   */
+  isInputFinalized(inputIndex: number): boolean {
+    const input = checkForInput(this.data.inputs, inputIndex);
+    return Buffer.isBuffer(input.finalScriptSig) || Buffer.isBuffer(input.finalScriptWitness);
+  }
+
+  /**
+   * @return partialSig/tapScriptSig count iff input is not finalized
+   */
   getSignatureCount(inputIndex: number): number {
+    if (this.isInputFinalized(inputIndex)) {
+      throw new Error('Input is already finalized');
+    }
     const input = checkForInput(this.data.inputs, inputIndex);
     return Math.max(
       Array.isArray(input.partialSig) ? input.partialSig.length : 0,

--- a/modules/utxo-lib/src/bitgo/UtxoPsbt.ts
+++ b/modules/utxo-lib/src/bitgo/UtxoPsbt.ts
@@ -8,7 +8,8 @@ import { UtxoTransaction } from './UtxoTransaction';
 import { getOutputIdForInput } from './Unspent';
 import { isSegwit } from './psbt/scriptTypes';
 import { unsign } from './psbt/fromHalfSigned';
-import { parseTaprootScript2of3PubKeys, toXOnlyPublicKey } from './outputScripts';
+import { toXOnlyPublicKey } from './outputScripts';
+import { parsePubScript } from './parseInput';
 
 export interface HDTaprootSigner extends HDSigner {
   /**
@@ -181,7 +182,7 @@ export class UtxoPsbt<Tx extends UtxoTransaction<bigint>> extends Psbt {
     }
     const { controlBlock, script } = input.tapLeafScript[0];
     const witness: Buffer[] = [script, controlBlock];
-    const [pubkey1, pubkey2] = parseTaprootScript2of3PubKeys(script);
+    const [pubkey1, pubkey2] = parsePubScript(script, 'p2tr').publicKeys;
     for (const pk of [pubkey1, pubkey2]) {
       const sig = input.tapScriptSig?.find(({ pubkey }) => pubkey.equals(pk));
       if (!sig) {

--- a/modules/utxo-lib/src/bitgo/outputScripts.ts
+++ b/modules/utxo-lib/src/bitgo/outputScripts.ts
@@ -1,13 +1,11 @@
 import * as assert from 'assert';
 import * as bitcoinjs from 'bitcoinjs-lib';
-import * as opcodes from 'bitcoin-ops';
 
 import { Network, supportsSegwit, supportsTaproot, taproot } from '..';
 
 import { isTriple, Triple, Tuple } from './types';
 
 import { ecc as eccLib } from '../noble_ecc';
-import { script as bscript } from 'bitcoinjs-lib';
 
 export { scriptTypeForChain } from './wallet/chains';
 
@@ -287,23 +285,4 @@ function createTaprootScript2of3(pubkeys: Triple<Buffer>): SpendableScript {
   return {
     scriptPubKey: output,
   };
-}
-
-/**
- * @param script Bitgo taproot script path script
- * @return 2 public keys from the script
- */
-export function parseTaprootScript2of3PubKeys(script: Buffer): [Buffer, Buffer] {
-  const decompiled = bscript.decompile(script);
-  if (!decompiled || decompiled?.length !== 4) {
-    throw new Error('Not a valid bitgo n-of-n script.');
-  }
-  const [pubkey1, op_checksigverify, pubkey2, op_checksig] = decompiled;
-  if (!Buffer.isBuffer(pubkey1) || !Buffer.isBuffer(pubkey2)) {
-    throw new Error('Public Keys are not buffers.');
-  }
-  if (op_checksigverify !== opcodes.OP_CHECKSIGVERIFY || op_checksig !== opcodes.OP_CHECKSIG) {
-    throw new Error('Opcodes do not correspond to a valid bitgo script');
-  }
-  return [pubkey1, pubkey2];
 }

--- a/modules/utxo-lib/src/bitgo/wallet/Psbt.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/Psbt.ts
@@ -3,7 +3,6 @@ import { UtxoTransaction } from '../UtxoTransaction';
 import {
   createOutputScript2of3,
   getLeafHash,
-  parseTaprootScript2of3PubKeys,
   ScriptType2Of3,
   scriptTypeForChain,
   toXOnlyPublicKey,
@@ -44,7 +43,7 @@ interface WalletSigner {
 }
 
 function getTaprootSigners(script: Buffer, walletKeys: DerivedWalletKeys): [WalletSigner, WalletSigner] {
-  const parsedPublicKeys = parseTaprootScript2of3PubKeys(script);
+  const parsedPublicKeys = parsePubScript(script, 'p2tr').publicKeys;
   const walletSigners = parsedPublicKeys.map((publicKey) => {
     const index = walletKeys.publicKeys.findIndex((walletPublicKey) =>
       toXOnlyPublicKey(walletPublicKey).equals(publicKey)

--- a/modules/utxo-lib/src/bitgo/wallet/Psbt.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/Psbt.ts
@@ -4,6 +4,7 @@ import {
   createOutputScript2of3,
   getLeafHash,
   parseTaprootScript2of3PubKeys,
+  ScriptType2Of3,
   scriptTypeForChain,
   toXOnlyPublicKey,
 } from '../outputScripts';
@@ -12,6 +13,30 @@ import { toPrevOutputWithPrevTx } from '../Unspent';
 import { createPsbtFromTransaction } from '../transaction';
 import { BIP32Interface } from 'bip32';
 import { isWalletUnspent, WalletUnspent } from './Unspent';
+import { checkForInput } from 'bip174/src/lib/utils';
+import { PsbtInput } from 'bip174/src/lib/interfaces';
+import {
+  getScriptPathLevel,
+  calculateScriptPathLevel,
+  isValidControlBock,
+  ParsedPubScript2Of3,
+  ParsedPubScriptTaprootScriptPath,
+  parsePubScript,
+} from '../parseInput';
+
+type Signatures = [Buffer] | [Buffer, Buffer] | undefined;
+
+export interface ParsedPsbt2Of3 extends ParsedPubScript2Of3 {
+  signatures: Signatures;
+}
+
+export interface ParsedPsbtP2TR extends ParsedPubScriptTaprootScriptPath {
+  signatures: Signatures;
+  controlBlock: Buffer;
+  leafVersion: number;
+  /** Indicates the level inside the taptree. */
+  scriptPathLevel: number;
+}
 
 interface WalletSigner {
   walletKey: BIP32Interface;
@@ -49,11 +74,11 @@ function updatePsbtInput(
     const input = psbt.data.inputs[inputIndex];
 
     if (!Array.isArray(input.tapLeafScript) || input.tapLeafScript.length === 0) {
-      throw new Error(`Invalid PSBT state. Missing required fields.`);
+      throw new Error('Invalid PSBT state. Missing required fields.');
     }
 
     if (input.tapLeafScript.length > 1) {
-      throw new Error(`Bitgo only supports a single tap leaf script per input`);
+      throw new Error('Bitgo only supports a single tap leaf script per input');
     }
 
     const [signer, cosigner] = getTaprootSigners(input.tapLeafScript[0].script, walletKeys);
@@ -133,4 +158,139 @@ export function signWalletPsbt(
   } else {
     psbt.signInputHD(inputIndex, signer);
   }
+}
+
+function classifyScriptType(input: PsbtInput): ScriptType2Of3 | undefined {
+  let scriptType: ScriptType2Of3 | undefined;
+  if (Buffer.isBuffer(input.redeemScript) && Buffer.isBuffer(input.witnessScript)) {
+    scriptType = 'p2shP2wsh';
+  } else if (Buffer.isBuffer(input.redeemScript)) {
+    scriptType = 'p2sh';
+  } else if (Buffer.isBuffer(input.witnessScript)) {
+    scriptType = 'p2wsh';
+  }
+  if (Array.isArray(input.tapLeafScript) && input.tapLeafScript.length > 0) {
+    if (scriptType) {
+      throw new Error(`Found both ${scriptType} and p2tr PSBT metadata.`);
+    }
+    if (input.tapLeafScript.length > 1) {
+      throw new Error('Bitgo only supports a single tap leaf script per input.');
+    }
+    scriptType = 'p2tr';
+  }
+  return scriptType;
+}
+
+function parseSignatures(input: PsbtInput, scriptType: ScriptType2Of3): Signatures {
+  const validate = (sig: Buffer): Buffer => {
+    if (Buffer.isBuffer(sig)) {
+      return sig;
+    }
+    throw new Error('Invalid signature type');
+  };
+
+  if (scriptType === 'p2tr') {
+    if (input.partialSig && input.partialSig.length > 0) {
+      throw new Error('Invalid PSBT signature state');
+    }
+    if (!input.tapScriptSig || input.tapScriptSig.length === 0) {
+      return undefined;
+    }
+    if (input.tapScriptSig.length > 2) {
+      throw new Error('unexpected signature count');
+    }
+    return input.tapScriptSig.length === 1
+      ? [validate(input.tapScriptSig[0].signature)]
+      : [validate(input.tapScriptSig[0].signature), validate(input.tapScriptSig[1].signature)];
+  }
+  if (input.tapScriptSig && input.tapScriptSig.length > 0) {
+    throw new Error('Invalid PSBT signature state');
+  }
+  if (!input.partialSig || input.partialSig.length === 0) {
+    return undefined;
+  }
+  if (input.partialSig.length > 2) {
+    throw new Error('unexpected signature count');
+  }
+  return input.partialSig.length === 1
+    ? [validate(input.partialSig[0].signature)]
+    : [validate(input.partialSig[0].signature), validate(input.partialSig[1].signature)];
+}
+
+function parseScript(
+  input: PsbtInput,
+  scriptType: ScriptType2Of3
+): ParsedPubScript2Of3 | ParsedPubScriptTaprootScriptPath {
+  let pubScript: Buffer | undefined;
+  if (scriptType === 'p2sh') {
+    pubScript = input.redeemScript;
+  } else if (scriptType === 'p2wsh' || scriptType === 'p2shP2wsh') {
+    pubScript = input.witnessScript;
+  } else {
+    pubScript = input.tapLeafScript ? input.tapLeafScript[0].script : undefined;
+  }
+  if (!pubScript) {
+    throw new Error(`Invalid PSBT state for ${scriptType}. Missing required fields.`);
+  }
+  return parsePubScript(pubScript, scriptType);
+}
+
+function parseInputMetadata(input: PsbtInput, scriptType: ScriptType2Of3): ParsedPsbt2Of3 | ParsedPsbtP2TR {
+  const parsedPubScript = parseScript(input, scriptType);
+  const signatures = parseSignatures(input, scriptType);
+
+  if (parsedPubScript.scriptType === 'p2tr') {
+    if (!input.tapLeafScript) {
+      throw new Error('Invalid PSBT state for p2tr. Missing required fields.');
+    }
+    const controlBlock = input.tapLeafScript[0].controlBlock;
+    if (!isValidControlBock(controlBlock)) {
+      throw new Error('Invalid PSBT p2tr script path controlBlock.');
+    }
+    const scriptPathLevel = calculateScriptPathLevel(controlBlock);
+    const leafVersion = getScriptPathLevel(controlBlock);
+    return {
+      ...parsedPubScript,
+      signatures,
+      controlBlock,
+      scriptPathLevel,
+      leafVersion,
+    };
+  } else {
+    if (parsedPubScript.scriptType === 'p2shP2wsh') {
+      parsedPubScript.redeemScript = input.redeemScript;
+    }
+    return {
+      ...parsedPubScript,
+      signatures,
+    };
+  }
+}
+
+/**
+ * @return psbt metadata are parsed as per below conditions.
+ * redeemScript/witnessScript/tapLeafScript matches BitGo.
+ * signature and public key count matches BitGo.
+ * P2SH => scriptType, redeemScript, public keys, signatures.
+ * PW2SH => scriptType, witnessScript, public keys, signatures.
+ * P2SH-PW2SH => scriptType, redeemScript, witnessScript, public keys, signatures.
+ * P2TR => scriptType, pubScript (witnessScript), controlBlock, scriptPathLevel, leafVersion, public keys, signatures.
+ * Any unsigned PSBT and without required metadata is returned with undefined.
+ */
+export function parsePsbtInput(
+  psbt: UtxoPsbt<UtxoTransaction<bigint>>,
+  inputIndex: number
+): ParsedPsbt2Of3 | ParsedPsbtP2TR | undefined {
+  const input = checkForInput(psbt.data.inputs, inputIndex);
+  if (psbt.isInputFinalized(inputIndex)) {
+    throw new Error('Finalized PSBT parsing is not supported');
+  }
+  const scriptType = classifyScriptType(input);
+  if (!scriptType) {
+    if (psbt.getSignatureCount(inputIndex) > 0) {
+      throw new Error('Invalid PSBT state. Signatures found without scripts.');
+    }
+    return undefined;
+  }
+  return parseInputMetadata(input, scriptType);
 }

--- a/modules/utxo-lib/test/bitgo/psbt/psbtUtil.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/psbtUtil.ts
@@ -1,0 +1,263 @@
+import {
+  addToTransactionBuilder,
+  getScriptPathLevel,
+  calculateScriptPathLevel,
+  createTransactionBuilderForNetwork,
+  getInternalChainCode,
+  getWalletAddress,
+  isPlaceholderSignature,
+  isValidControlBock,
+  isWalletUnspent,
+  outputScripts,
+  ParsedSignatureScript2Of3,
+  ParsedSignatureScriptTaproot,
+  ParsedSignatureScriptTaprootScriptPath,
+  parseSignatureScript2Of3,
+  RootWalletKeys,
+  scriptTypeForChain,
+  signInputWithUnspent,
+  toTNumber,
+  Unspent,
+  unspentSum,
+  UtxoPsbt,
+  UtxoTransaction,
+  UtxoTransactionBuilder,
+  WalletUnspent,
+  WalletUnspentSigner,
+  KeyName,
+} from '../../../src/bitgo';
+import { ParsedPsbt2Of3, ParsedPsbtP2TR, parsePsbtInput, signWalletPsbt } from '../../../src/bitgo/wallet/Psbt';
+import * as assert from 'assert';
+import { SignatureTargetType } from './Psbt';
+import { Network } from '../../../src';
+
+function validateScript(
+  psbtParsed: ParsedPsbt2Of3 | ParsedPsbtP2TR | undefined,
+  txParsed: ParsedSignatureScript2Of3 | ParsedSignatureScriptTaproot | undefined
+) {
+  if (txParsed === undefined) {
+    assert.deepStrictEqual(Buffer.isBuffer(psbtParsed?.pubScript), true);
+
+    if (psbtParsed?.scriptType === 'p2sh') {
+      assert.deepStrictEqual(Buffer.isBuffer(psbtParsed?.redeemScript), true);
+      assert.deepStrictEqual(Buffer.isBuffer(psbtParsed?.witnessScript), false);
+    } else if (psbtParsed?.scriptType === 'p2wsh') {
+      assert.deepStrictEqual(Buffer.isBuffer(psbtParsed?.redeemScript), false);
+      assert.deepStrictEqual(Buffer.isBuffer(psbtParsed?.witnessScript), true);
+    } else if (psbtParsed?.scriptType === 'p2shP2wsh') {
+      assert.deepStrictEqual(Buffer.isBuffer(psbtParsed?.redeemScript), true);
+      assert.deepStrictEqual(Buffer.isBuffer(psbtParsed?.witnessScript), true);
+    } else if (psbtParsed?.scriptType === 'p2tr') {
+      assert.deepStrictEqual(isValidControlBock(psbtParsed?.controlBlock), true);
+      assert.deepStrictEqual(psbtParsed?.scriptPathLevel, calculateScriptPathLevel(psbtParsed?.controlBlock));
+      assert.deepStrictEqual(psbtParsed?.leafVersion, getScriptPathLevel(psbtParsed?.controlBlock));
+    }
+  } else {
+    assert.deepStrictEqual(txParsed.scriptType, psbtParsed?.scriptType);
+    assert.deepStrictEqual(txParsed.pubScript, psbtParsed?.pubScript);
+
+    if (
+      (txParsed.scriptType === 'p2sh' && psbtParsed?.scriptType === 'p2sh') ||
+      (txParsed.scriptType === 'p2wsh' && psbtParsed?.scriptType === 'p2wsh') ||
+      (txParsed.scriptType === 'p2shP2wsh' && psbtParsed?.scriptType === 'p2shP2wsh')
+    ) {
+      assert.deepStrictEqual(txParsed.redeemScript, psbtParsed?.redeemScript);
+      assert.deepStrictEqual(txParsed.witnessScript, psbtParsed?.witnessScript);
+    } else if (txParsed.scriptType === 'p2tr' && psbtParsed?.scriptType === 'p2tr') {
+      // To ensure script path p2tr
+      assert.deepStrictEqual(txParsed.publicKeys, psbtParsed.publicKeys);
+      const txParsedP2trScriptPath = txParsed as ParsedSignatureScriptTaprootScriptPath;
+      assert.deepStrictEqual(txParsedP2trScriptPath.controlBlock, psbtParsed?.controlBlock);
+      assert.deepStrictEqual(txParsedP2trScriptPath.scriptPathLevel, psbtParsed?.scriptPathLevel);
+      assert.deepStrictEqual(txParsedP2trScriptPath.leafVersion, psbtParsed?.leafVersion);
+    }
+  }
+}
+
+function validatePublicKeys(
+  psbtParsed: ParsedPsbt2Of3 | ParsedPsbtP2TR | undefined,
+  txParsed: ParsedSignatureScript2Of3 | ParsedSignatureScriptTaproot | undefined
+) {
+  if (txParsed === undefined) {
+    assert.deepStrictEqual(psbtParsed?.publicKeys.length, 3);
+    psbtParsed?.publicKeys.forEach((publicKey) => {
+      assert.deepStrictEqual(Buffer.isBuffer(publicKey), true);
+    });
+  } else {
+    assert.deepStrictEqual(txParsed.publicKeys.length, psbtParsed?.publicKeys?.length);
+    const pubKeyMatch = txParsed.publicKeys.every((txPubKey) =>
+      psbtParsed?.publicKeys?.some((psbtPubKey) => psbtPubKey.equals(txPubKey))
+    );
+    assert.deepStrictEqual(pubKeyMatch, true);
+  }
+}
+
+function validateSignature(
+  psbtParsed: ParsedPsbt2Of3 | ParsedPsbtP2TR | undefined,
+  txParsed: ParsedSignatureScript2Of3 | ParsedSignatureScriptTaproot | undefined
+) {
+  if (txParsed === undefined) {
+    assert.deepStrictEqual(psbtParsed?.signatures, undefined);
+  } else {
+    const txSignatures = txParsed.signatures.filter(
+      (txSig) => Buffer.isBuffer(txSig) && !isPlaceholderSignature(txSig)
+    );
+    assert.deepStrictEqual(txSignatures.length, psbtParsed?.signatures?.length);
+    if (txSignatures.length < 1) {
+      return;
+    }
+    const sigMatch = txSignatures.every((txSig) =>
+      Buffer.isBuffer(txSig) ? psbtParsed?.signatures?.some((psbtSig) => psbtSig.equals(txSig)) : true
+    );
+    assert.deepStrictEqual(sigMatch, true);
+  }
+}
+
+export function validatePsbtParsing(
+  tx: UtxoTransaction<bigint>,
+  psbt: UtxoPsbt<UtxoTransaction<bigint>>,
+  unspents: WalletUnspent<bigint>[],
+  signatureTarget: SignatureTargetType
+): void {
+  unspents.forEach((u, i) => {
+    if (!isWalletUnspent(u)) {
+      return;
+    }
+    const scriptType = scriptTypeForChain(u.chain);
+    const psbtParsed = parsePsbtInput(psbt, i);
+
+    if (signatureTarget === 'unsigned') {
+      if (scriptType === 'p2tr') {
+        assert.deepStrictEqual(psbtParsed, undefined);
+      } else {
+        assert.ok(psbtParsed);
+        assert.deepStrictEqual(psbtParsed?.scriptType, scriptType);
+        validateScript(psbtParsed, undefined);
+        validatePublicKeys(psbtParsed, undefined);
+        validateSignature(psbtParsed, undefined);
+      }
+    } else {
+      assert.ok(psbtParsed);
+      const txParsed = parseSignatureScript2Of3(tx.ins[i]);
+      assert.deepStrictEqual(psbtParsed?.scriptType, scriptType);
+      validateScript(psbtParsed, txParsed);
+      validatePublicKeys(psbtParsed, txParsed);
+      validateSignature(psbtParsed, txParsed);
+    }
+  });
+}
+
+export function toBigInt<TNumber extends number | bigint>(unspents: Unspent<TNumber>[]): WalletUnspent<bigint>[] {
+  return unspents.map((u) => {
+    if (isWalletUnspent(u)) {
+      return { ...u, value: BigInt(u.value) };
+    }
+    throw new Error('invalid unspent');
+  });
+}
+
+export function signPsbt(
+  psbt: UtxoPsbt<UtxoTransaction<bigint>>,
+  unspents: Unspent<bigint>[],
+  rootWalletKeys: RootWalletKeys,
+  signer: string,
+  cosigner: string,
+  signatureTarget: SignatureTargetType
+): void {
+  unspents.forEach((u, i) => {
+    if (!isWalletUnspent(u)) {
+      throw new Error('invalid unspent');
+    }
+    try {
+      if (signatureTarget === 'unsigned') {
+        signWalletPsbt(psbt, i, rootWalletKeys[signer], u);
+      }
+      signWalletPsbt(psbt, i, rootWalletKeys[cosigner], u);
+
+      // unsigned p2tr does not contain tapLeafScript & tapBip32Derivation.
+      // So it's signing is expected to fail
+      assert.deepStrictEqual(
+        signatureTarget === 'unsigned' && scriptTypeForChain(u.chain) === 'p2tr',
+        false,
+        'unsigned p2tr sign should fail'
+      );
+    } catch (err) {
+      if (err.message === 'unsigned p2tr sign should fail') {
+        throw err;
+      }
+      assert.deepStrictEqual(signatureTarget, 'unsigned');
+      assert.deepStrictEqual(scriptTypeForChain(u.chain), 'p2tr');
+      assert.deepStrictEqual(psbt.data.inputs[i].tapLeafScript, undefined);
+      assert.deepStrictEqual(psbt.data.inputs[i].tapBip32Derivation, undefined);
+      assert.deepStrictEqual(psbt.data.inputs[i].tapScriptSig, undefined);
+      assert.ok(psbt.data.inputs[i].witnessUtxo);
+    }
+  });
+}
+
+export function signTxBuilder<TNumber extends number | bigint>(
+  txb: UtxoTransactionBuilder<TNumber, UtxoTransaction<TNumber>>,
+  unspents: Unspent<TNumber>[],
+  rootWalletKeys: RootWalletKeys,
+  signer: string,
+  cosigner: string,
+  signatureTarget: SignatureTargetType
+): UtxoTransaction<TNumber> {
+  let walletUnspentSigners: WalletUnspentSigner<RootWalletKeys>[] = [];
+
+  if (signatureTarget === 'halfsigned') {
+    walletUnspentSigners = [WalletUnspentSigner.from(rootWalletKeys, rootWalletKeys[signer], rootWalletKeys[cosigner])];
+  } else if (signatureTarget === 'fullsigned') {
+    walletUnspentSigners = [
+      WalletUnspentSigner.from(rootWalletKeys, rootWalletKeys[signer], rootWalletKeys[cosigner]),
+      WalletUnspentSigner.from(rootWalletKeys, rootWalletKeys[cosigner], rootWalletKeys[signer]),
+    ];
+  }
+
+  walletUnspentSigners.forEach((walletSigner, nSignature) => {
+    unspents.forEach((u, i) => {
+      if (isWalletUnspent(u)) {
+        signInputWithUnspent(txb, i, u, walletSigner);
+      } else {
+        throw new Error(`unexpected unspent ${u.id}`);
+      }
+    });
+  });
+
+  return signatureTarget === 'fullsigned' ? txb.build() : txb.buildIncomplete();
+}
+
+export function constructTransactionUsingTxBuilder<TNumber extends number | bigint>(
+  unspents: Unspent<TNumber>[],
+  rootWalletKeys: RootWalletKeys,
+  params: {
+    signer: KeyName;
+    cosigner: KeyName;
+    amountType: 'number' | 'bigint';
+    outputType: outputScripts.ScriptType2Of3;
+    signatureTarget: SignatureTargetType;
+    network: Network;
+    changeIndex: number;
+    fee: bigint;
+  }
+): UtxoTransaction<bigint> {
+  const txb = createTransactionBuilderForNetwork<TNumber>(params.network);
+  const total = BigInt(unspentSum<TNumber>(unspents, params.amountType));
+  // Kinda weird, treating entire value as change, but tests the relevant paths
+  txb.addOutput(
+    getWalletAddress(rootWalletKeys, getInternalChainCode(params.outputType), params.changeIndex, params.network),
+    toTNumber<TNumber>(total - params.fee, params.amountType)
+  );
+  unspents.forEach((u) => {
+    addToTransactionBuilder(txb, u);
+  });
+
+  return signTxBuilder<TNumber>(
+    txb,
+    unspents,
+    rootWalletKeys,
+    params.signer,
+    params.cosigner,
+    params.signatureTarget
+  ).clone<bigint>('bigint');
+}

--- a/modules/utxo-lib/test/bitgo/wallet/util.ts
+++ b/modules/utxo-lib/test/bitgo/wallet/util.ts
@@ -11,6 +11,8 @@ import {
   fromOutputWithPrevTx,
   isSegwit,
   fromOutput,
+  outputScripts,
+  getExternalChainCode,
 } from '../../../src/bitgo';
 
 import {
@@ -26,6 +28,7 @@ import { mockTransactionId } from '../../transaction_util';
 import * as utxolib from '../../../src';
 import * as noble from '@noble/secp256k1';
 import { BIP32Interface } from 'bip32';
+import { InputType } from '../psbt/Psbt';
 
 export function mockOutputId(vout: number): string {
   return formatOutputId({
@@ -123,4 +126,22 @@ export function mockWalletUnspent<TNumber extends number | bigint>(
       value,
     };
   }
+}
+
+export function mockUnspents<TNumber extends number | bigint>(
+  rootWalletKeys: RootWalletKeys,
+  inputScriptTypes: InputType[],
+  testOutputAmount: TNumber,
+  network: Network
+): WalletUnspent<TNumber>[] {
+  return inputScriptTypes.map((t, i): WalletUnspent<TNumber> => {
+    if (outputScripts.isScriptType2Of3(t)) {
+      return mockWalletUnspent(network, testOutputAmount, {
+        keys: rootWalletKeys,
+        chain: getExternalChainCode(t),
+        vout: i,
+      });
+    }
+    throw new Error(`invalid input type ${t}`);
+  });
 }


### PR DESCRIPTION
Currently legacy parsing is done with parseScriptInput. This psbt parser is similar to that.
It works for both unsigned and signed psbt to parse.

TICKET: BG-58455

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->