### PR TITLE
fix(sdk-coin-sui): fix explainTransaction when amounts is empty

### DIFF
--- a/modules/sdk-coin-sui/src/lib/transaction.ts
+++ b/modules/sdk-coin-sui/src/lib/transaction.ts
@@ -368,7 +368,7 @@ export class Transaction extends BaseTransaction {
 
     const outputs: TransactionRecipient[] = recipients.map((recipient, index) => ({
       address: recipient,
-      amount: amounts[index].toString(),
+      amount: amounts.length === 0 ? '' : amounts[index].toString(),
     }));
     const outputAmount = amounts.reduce((accumulator, current) => accumulator + current, 0);
 

--- a/modules/sdk-coin-sui/test/unit/transaction.ts
+++ b/modules/sdk-coin-sui/test/unit/transaction.ts
@@ -30,7 +30,7 @@ describe('Sui Transaction', () => {
   });
 
   describe('Explain transaction', () => {
-    it('should explain a transfer transaction', function () {
+    it('should explain a transfer pay transaction', function () {
       tx.fromRawTransaction(testData.TRANSFER_PAY_TX);
       const explainedTransaction = tx.explainTransaction();
       explainedTransaction.should.deepEqual({
@@ -43,6 +43,26 @@ describe('Sui Transaction', () => {
           },
         ],
         outputAmount: testData.AMOUNT,
+        changeOutputs: [],
+        changeAmount: '0',
+        fee: { fee: testData.GAS_BUDGET.toString() },
+        type: 0,
+      });
+    });
+
+    it('should explain a transfer payAll transaction', function () {
+      tx.fromRawTransaction(testData.TRANSFER_PAY_ALL_SUI_TX);
+      const explainedTransaction = tx.explainTransaction();
+      explainedTransaction.should.deepEqual({
+        displayOrder: ['id', 'outputs', 'outputAmount', 'changeOutputs', 'changeAmount', 'fee', 'type'],
+        id: 'UNAVAILABLE',
+        outputs: [
+          {
+            address: testData.recipients[0],
+            amount: '', // deserialize doesn't return amount for PayAllSui
+          },
+        ],
+        outputAmount: 0,
         changeOutputs: [],
         changeAmount: '0',
         fee: { fee: testData.GAS_BUDGET.toString() },


### PR DESCRIPTION
Ticket: BG-64130

Fix explainTransaction when `amounts` is empty

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->