### PR TITLE
fix!: remove final sig construction for message signing

### DIFF
--- a/modules/sdk-coin-eth/src/eth.ts
+++ b/modules/sdk-coin-eth/src/eth.ts
@@ -19,7 +19,6 @@ import {
   common,
   ECDSA,
   Ecdsa,
-  ECDSAMethods,
   ECDSAMethodTypes,
   EthereumLibraryUnavailableError,
   FeeEstimateOptions,
@@ -53,7 +52,7 @@ import type * as EthTxLib from '@ethereumjs/tx';
 import { FeeMarketEIP1559Transaction, Transaction as LegacyTransaction } from '@ethereumjs/tx';
 import type * as EthCommon from '@ethereumjs/common';
 import { calculateForwarderV1Address, getProxyInitcode, KeyPair as KeyPairLib } from './lib';
-import { addHexPrefix, intToHex, stripHexPrefix } from 'ethereumjs-util';
+import { addHexPrefix, stripHexPrefix } from 'ethereumjs-util';
 import BN from 'bn.js';
 import { TypedDataUtils, SignTypedDataVersion } from '@metamask/eth-sig-util';
 
@@ -2119,25 +2118,6 @@ export class Eth extends BaseCoin {
       );
     }
     return Buffer.concat(parts);
-  }
-
-  /**
-   *  Create the final signed message hash from the combine share
-   * @param combineShare
-   */
-  constructFinalSignedMessageHash(combineShare: string): string {
-    const combineSigArray = combineShare.split(ECDSAMethods.delimeter);
-    const signature = {
-      recid: parseInt(combineSigArray[0], 10),
-      r: combineSigArray[1],
-      s: combineSigArray[2],
-      y: combineSigArray[3],
-    };
-    const v = 27 + signature.recid;
-    const vHex = intToHex(v);
-    const vStr = stripHexPrefix(vHex);
-    const finalSig = addHexPrefix(signature.r.concat(signature.s, vStr));
-    return finalSig;
   }
 
   private isETHAddress(address: string): boolean {

--- a/modules/sdk-core/src/bitgo/features/constructFinalSignedMessageHash.ts
+++ b/modules/sdk-core/src/bitgo/features/constructFinalSignedMessageHash.ts
@@ -1,7 +1,0 @@
-export interface CoinThatConstructFinalSignedMessageHash {
-  constructFinalSignedMessageHash(combineShare: string): string;
-}
-
-export function isCoinThatConstructFinalSignedMessageHash(c: unknown): c is CoinThatConstructFinalSignedMessageHash {
-  return typeof (c as any).constructFinalSignedMessageHash === 'function';
-}

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -85,7 +85,6 @@ import { Lightning } from '../lightning';
 import EddsaUtils from '../utils/tss/eddsa';
 import { EcdsaUtils } from '../utils/tss/ecdsa';
 import { getTxRequest } from '../tss';
-import { isCoinThatConstructFinalSignedMessageHash } from '../features/constructFinalSignedMessageHash';
 
 const debug = require('debug')('bitgo:v2:wallet');
 
@@ -2808,10 +2807,7 @@ export class Wallet implements IWallet {
         signedMessageRequest.messages[0].combineSigShare,
         'Unable to find combineSigShare in signedMessageRequest.messages'
       );
-      if (isCoinThatConstructFinalSignedMessageHash(this.baseCoin)) {
-        return this.baseCoin.constructFinalSignedMessageHash(signedMessageRequest.messages[0].combineSigShare);
-      }
-      assert(signedMessageRequest.messages[0].txHash, 'Unable to find txHash in signedMessageRequest.messages');
+      assert(signedMessageRequest.messages[0].txHash, 'Unable to find txHash in signedMessageRequest.mesages');
       return signedMessageRequest.messages[0].txHash;
     } catch (e) {
       throw new Error('failed to sign message ' + e);
@@ -2859,9 +2855,6 @@ export class Wallet implements IWallet {
         signedTypedDataRequest.messages[0].combineSigShare,
         'Unable to find combineSigShare in signedTypedDataRequest.messages'
       );
-      if (isCoinThatConstructFinalSignedMessageHash(this.baseCoin)) {
-        return this.baseCoin.constructFinalSignedMessageHash(signedTypedDataRequest.messages[0].combineSigShare);
-      }
       assert(signedTypedDataRequest.messages[0].txHash, 'Unable to find txHash in signedTypedDataRequest.messages');
       return signedTypedDataRequest.messages[0].txHash;
     } catch (e) {


### PR DESCRIPTION
Recovery ID (v) is required for Ethereum message signing, in addition to the r and s values from the ECDSA standard. Previously this [was being computed and concatenated](https://github.com/BitGo/BitGoJS/blob/master/modules/sdk-coin-eth/src/eth.ts#L1761) inside of SDK, however MMI does not use SDK but still need the final form of the message hash. Hence this computation[ is being moved to WP](https://github.com/BitGo/bitgo-microservices/pull/27035), and being deleted here.

Ticket: BG-64064

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->