### PR TITLE
chore(statics): document fiat naming pattern

### DIFF
--- a/modules/statics/src/account.ts
+++ b/modules/statics/src/account.ts
@@ -1562,7 +1562,7 @@ export function tpolygonErc20(
 /**
  * Factory function for fiat coin instances.
  *
- * @param name unique identifier of the coin, should start with 'fiat' or 'tfiat'
+ * @param name unique identifier of the coin, should start with 'fiat' or 'tfiat' followed by the 3-char ISO-4217 alphabetical code
  * @param fullName Complete human-readable name of the coin
  * @param network Network object for this coin
  * @param decimalPlaces Number of decimal places this coin supports (divisibility exponent)


### PR DESCRIPTION
## Description

fiat currencies should be named following the pattern /^t?fiat([a-z]{3})$/ in which the 3 characters are the ISO currency codes

## Issue Number
Ticket: BG-62244


[BG-62244]: https://bitgoinc.atlassian.net/browse/BG-62244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ