### PR TITLE
fix(utxo-lib): implement toHex for ZcashPsbt

### DIFF
--- a/modules/utxo-lib/src/bitgo/UtxoPsbt.ts
+++ b/modules/utxo-lib/src/bitgo/UtxoPsbt.ts
@@ -65,6 +65,10 @@ export class UtxoPsbt<Tx extends UtxoTransaction<bigint>> extends Psbt {
     return psbt;
   }
 
+  toHex(): string {
+    return this.toBuffer().toString('hex');
+  }
+
   /**
    * @return true iff PSBT input is finalized
    */

--- a/modules/utxo-lib/test/bitgo/psbt/ZcashPsbt.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/ZcashPsbt.ts
@@ -1,0 +1,33 @@
+import * as assert from 'assert';
+
+import { networks } from '../../../src';
+import * as utxolib from '../../../src';
+import { mockUnspents } from '../wallet/util';
+import { getDefaultWalletKeys } from '../../testutil';
+import { addWalletOutputToPsbt, getInternalChainCode } from '../../../src/bitgo';
+
+const network = networks.zcash;
+const rootWalletKeys = getDefaultWalletKeys();
+
+describe('Zcash PSBT', function () {
+  let psbt: utxolib.bitgo.ZcashPsbt;
+  before(async function () {
+    const unspents = mockUnspents(rootWalletKeys, ['p2sh'], BigInt('10000000000000000'), network);
+    psbt = await utxolib.bitgo.ZcashPsbt.createPsbt({ network });
+
+    unspents.forEach((unspent) => {
+      utxolib.bitgo.addWalletUnspentToPsbt(psbt, unspent, rootWalletKeys, 'user', 'bitgo', network);
+    });
+    addWalletOutputToPsbt(psbt, rootWalletKeys, getInternalChainCode('p2sh'), 0, BigInt('1000000000000000'));
+  });
+
+  describe('txHex should serialize psbt', function () {
+    function testToHexForVersion(version: number) {
+      it(`version ${version} should serialize properly`, async function () {
+        psbt.setDefaultsForVersion(network, version);
+        assert.deepStrictEqual(psbt.toHex(), psbt.toBuffer().toString('hex'));
+      });
+    }
+    [400, 450, 500].forEach((version) => testToHexForVersion(version));
+  });
+});


### PR DESCRIPTION
Currently, the `ZcashPsbt.toHex` method uses the [BIP174 `toHex`](https://github.com/BitGo/bitcoinjs-lib/blob/master/ts_src/psbt.ts#L704) method, which does not correctly incorporate the `consensusBranchId` and is therefore not serializing properly. 

This (simple) PR fixes this and adds a test file for Zcash.

[BG-65050](https://bitgoinc.atlassian.net/browse/BG-65050)

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->

[BG-65050]: https://bitgoinc.atlassian.net/browse/BG-65050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BG-65050]: https://bitgoinc.atlassian.net/browse/BG-65050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ