### PR TITLE
feat(statics): add EVM_WALLET coin feature

### DIFF
--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -63,6 +63,10 @@ export enum CoinFamily {
  */
 export enum CoinFeature {
   /*
+   * This coin supports creating wallets on different networks with the same keys. Only works for TSS account-base coins
+   */
+  EVM_WALLET = 'evm-wallet',
+  /*
    * This coin supports creating an EVM transaction using Metamask Institutional (MMI).
    */
   METAMASK_INSTITUTIONAL = 'metamask-institutional',

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -150,6 +150,7 @@ export const coins = CoinMap.fromCoins([
   account('eth', 'Ethereum', Networks.main.ethereum, 18, UnderlyingAsset.ETH, BaseUnit.ETH, [
     ...ETH_FEATURES_WITH_STAKING_AND_MMI,
     CoinFeature.TSS,
+    CoinFeature.EVM_WALLET,
   ]), // we should probably refactor this into a eth() method
   account('teth', 'Kovan Testnet Ethereum (Deprecated)', Networks.test.kovan, 18, UnderlyingAsset.ETH, BaseUnit.ETH, [
     ...ETH_FEATURES,
@@ -158,6 +159,7 @@ export const coins = CoinMap.fromCoins([
   account('gteth', 'Goerli Testnet Ethereum', Networks.test.goerli, 18, UnderlyingAsset.ETH, BaseUnit.ETH, [
     ...ETH_FEATURES_WITH_STAKING_AND_MMI,
     CoinFeature.TSS,
+    CoinFeature.EVM_WALLET,
   ]),
   account(
     'eth2',
@@ -276,18 +278,22 @@ export const coins = CoinMap.fromCoins([
   account('bsc', 'Binance Smart Chain', Networks.main.bsc, 18, UnderlyingAsset.BSC, BaseUnit.BSC, [
     ...ETH_FEATURES_WITH_MMI,
     CoinFeature.TSS,
+    CoinFeature.EVM_WALLET,
   ]),
   account('tbsc', 'Testnet Binance Smart Chain', Networks.test.bsc, 18, UnderlyingAsset.BSC, BaseUnit.BSC, [
     ...ETH_FEATURES_WITH_MMI,
     CoinFeature.TSS,
+    CoinFeature.EVM_WALLET,
   ]),
   account('polygon', 'Polygon', Networks.main.polygon, 18, UnderlyingAsset.POLYGON, BaseUnit.ETH, [
     ...ETH_FEATURES_WITH_STAKING_AND_MMI,
     CoinFeature.TSS,
+    CoinFeature.EVM_WALLET,
   ]),
   account('tpolygon', 'Testnet Polygon', Networks.test.polygon, 18, UnderlyingAsset.POLYGON, BaseUnit.ETH, [
     ...ETH_FEATURES_WITH_STAKING_AND_MMI,
     CoinFeature.TSS,
+    CoinFeature.EVM_WALLET,
   ]),
   erc20CompatibleAccountCoin(
     'celo',


### PR DESCRIPTION
This PR creates a new CoinFeature that will be used on TSS account based coins. This will be used in SDK-Core and WP to track which coin-specific wallets should be created with the same set of keys.