### PR TITLE
fix(sdk-api): don't throw a TypeError for errors without request body

### DIFF
--- a/modules/sdk-api/src/api.ts
+++ b/modules/sdk-api/src/api.ts
@@ -68,7 +68,7 @@ function errFromResponse<ResponseBodyType>(res: superagent.Response): ApiRespons
   const status = res.status;
   const result = res.body as ResponseBodyType;
   const invalidToken = _.has(res.header, 'x-auth-required') && res.header['x-auth-required'] === 'true';
-  const needsOtp = res.body.needsOTP !== undefined;
+  const needsOtp = res.body?.needsOTP !== undefined;
   return new ApiResponseError(message, status, result, invalidToken, needsOtp);
 }
 

--- a/modules/sdk-api/test/unit/api.ts
+++ b/modules/sdk-api/test/unit/api.ts
@@ -1,0 +1,76 @@
+import * as assert from 'assert';
+import { handleResponseError } from '../../src';
+
+describe('bitgo:api unit tests', function () {
+  describe('handleResponseError', function () {
+    it('should re-throw an error without response property', function () {
+      const originalError = new Error('Han shot first');
+      assert.throws(() => handleResponseError(originalError), { name: 'Error', message: 'Han shot first' });
+    });
+
+    it('should use the status code if the response has no error text', function () {
+      const originalError: any = new Error();
+      originalError.response = { status: 400 };
+      assert.throws(() => handleResponseError(originalError), {
+        name: 'ApiResponseError',
+        message: '400',
+        invalidToken: false,
+        needsOTP: false,
+        result: undefined,
+        status: 400,
+      });
+    });
+
+    it('should use the response body.error text', function () {
+      const originalError: any = new Error();
+      originalError.response = { status: 400, body: { error: 'Han shot first' } };
+      assert.throws(() => handleResponseError(originalError), {
+        name: 'ApiResponseError',
+        message: 'Han shot first',
+        invalidToken: false,
+        needsOTP: false,
+        result: originalError.response.body,
+        status: 400,
+      });
+    });
+
+    it('should parse HTML code from the response text', function () {
+      const originalError: any = new Error();
+      originalError.response = { status: 400, text: ' <b> Han shot first </b>' };
+      assert.throws(() => handleResponseError(originalError), {
+        name: 'ApiResponseError',
+        message: '400\nHan shot first',
+        invalidToken: false,
+        needsOTP: false,
+        result: undefined,
+        status: 400,
+      });
+    });
+
+    it('should annotate invalidToken property', function () {
+      const originalError: any = new Error();
+      originalError.response = { status: 400, header: { 'x-auth-required': 'true' } };
+      assert.throws(() => handleResponseError(originalError), {
+        name: 'ApiResponseError',
+        message: '400',
+        invalidToken: true,
+        needsOTP: false,
+        result: undefined,
+        status: 400,
+      });
+    });
+
+    it('should annotate needsOTP property', function () {
+      const originalError: any = new Error();
+      originalError.response = { status: 400, body: { needsOTP: true } };
+      assert.throws(() => handleResponseError(originalError), {
+        name: 'ApiResponseError',
+        message: '400',
+        invalidToken: false,
+        needsOTP: true,
+        result: originalError.response.body,
+        status: 400,
+      });
+    });
+  });
+});


### PR DESCRIPTION
If an error occurs on Cloudflare instead at the BitGo API, the response from CF won't have a `body` property. This caused this error to be thrown: `Cannot read properties of null (reading 'needsOTP')`. Making the `body` property optional will re-throw the original error. Adds some basic unit tests for the API error wrapping.

Ticket: BG-63649

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [x] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes