### PR TITLE
feat(utxo-lib): do not require previous transactions for zcash

### DIFF
--- a/modules/utxo-lib/src/bitgo/psbt/fromHalfSigned.ts
+++ b/modules/utxo-lib/src/bitgo/psbt/fromHalfSigned.ts
@@ -1,5 +1,5 @@
 import { PsbtInputUpdate, PartialSig } from 'bip174/src/lib/interfaces';
-import { ecc as eccLib, TxOutput, taproot } from '../..';
+import { ecc as eccLib, TxOutput, taproot, getMainnet, networks } from '../..';
 import { UtxoTransaction } from '../UtxoTransaction';
 import { parseSignatureScript } from '../parseInput';
 import { getSignaturesWithPublicKeys } from '../signature';
@@ -34,8 +34,10 @@ export function getInputUpdate(
         : []
     );
   }
-
-  if (!hasWitnessData(parsedInput.scriptType) && !nonWitnessUtxo) {
+  // Because Zcash directly hashes the value for non-segwit transactions, we do not need to check indirectly
+  // with the previous transaction. Therefore, we can treat Zcash non-segwit transactions as Bitcoin
+  // segwit transactions
+  if (!hasWitnessData(parsedInput.scriptType) && !nonWitnessUtxo && getMainnet(tx.network) !== networks.zcash) {
     throw new Error(`scriptType ${parsedInput.scriptType} requires prevTx Buffer`);
   }
 

--- a/modules/utxo-lib/test/bitgo/wallet/util.ts
+++ b/modules/utxo-lib/test/bitgo/wallet/util.ts
@@ -1,4 +1,4 @@
-import { Network } from '../../../src';
+import { getMainnet, Network, networks } from '../../../src';
 import {
   formatOutputId,
   WalletUnspent,
@@ -118,7 +118,10 @@ export function mockWalletUnspent<TNumber extends number | bigint>(
       BigInt(value),
       network
     );
-    const unspent = isSegwit(chain) ? fromOutput(prevTransaction, vout) : fromOutputWithPrevTx(prevTransaction, vout);
+    const unspent =
+      isSegwit(chain) || getMainnet(network) === networks.zcash
+        ? fromOutput(prevTransaction, vout)
+        : fromOutputWithPrevTx(prevTransaction, vout);
     return {
       ...unspent,
       chain,


### PR DESCRIPTION
Treat Zcash transactions as Bitcoin Segwit transactions to not using previous transactions because the value is hashed in non-segwit transactions

BG-65554

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->