### PR TITLE
feat: use UtxoApi to facilitate cross chain recoveries

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -10,7 +10,13 @@ import * as _ from 'lodash';
 import BigNumber from 'bignumber.js';
 
 import { backupKeyRecovery, RecoverParams } from './recovery/backupKeyRecovery';
-import { CrossChainRecoverySigned, CrossChainRecoveryUnsigned, recoverCrossChain } from './recovery';
+import {
+  CrossChainRecoverySigned,
+  CrossChainRecoveryUnsigned,
+  forCoin,
+  recoverCrossChain,
+  RecoveryProvider,
+} from './recovery';
 
 import {
   AddressCoinSpecific,
@@ -1342,5 +1348,9 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
 
   valuelessTransferAllowed(): boolean {
     return false;
+  }
+
+  getRecoveryProvider(apiToken?: string): RecoveryProvider {
+    return forCoin(this.getChain(), apiToken);
   }
 }

--- a/modules/abstract-utxo/src/recovery/RecoveryProvider.ts
+++ b/modules/abstract-utxo/src/recovery/RecoveryProvider.ts
@@ -1,5 +1,8 @@
-import { AddressApi, UtxoApi, BlockchairApi, BlockstreamApi } from '@bitgo/blockapis';
+import { BlockchairApi, BlockstreamApi, AddressInfo, TransactionInfo } from '@bitgo/blockapis';
 import { ApiNotImplementedError } from './baseApi';
+import { bitgo } from '@bitgo/utxo-lib';
+
+type Unspent<TNumber extends number | bigint = number> = bitgo.Unspent<TNumber>;
 
 /**
  * An account with bear minimum information required for recoveries.
@@ -12,9 +15,14 @@ export interface RecoveryAccountData {
 /**
  * Factory for AddressApi & UtxoApi
  */
-export type RecoveryProvider = AddressApi & UtxoApi;
+export interface RecoveryProvider<TNumber extends number | bigint = number> {
+  getUnspentsForAddresses(addresses: string[]): Promise<Unspent<TNumber>[]>;
+  getAddressInfo(address: string): Promise<AddressInfo>;
+  getTransactionHex(txid: string): Promise<string>;
+  getTransactionInfo(txid: string): Promise<TransactionInfo>;
+}
 
-export function forCoin(coinName: string, apiToken?: string): RecoveryProvider {
+export function forCoin(coinName: string, apiToken?: string): RecoveryProvider<number> {
   switch (coinName) {
     case 'btc':
     case 'tbtc':

--- a/modules/abstract-utxo/src/recovery/RecoveryProvider.ts
+++ b/modules/abstract-utxo/src/recovery/RecoveryProvider.ts
@@ -1,7 +1,4 @@
-import { AddressInfo, BlockchairApi, BlockstreamApi } from '@bitgo/blockapis';
-import { bitgo } from '@bitgo/utxo-lib';
-type Unspent = bitgo.Unspent;
-
+import { AddressApi, UtxoApi, BlockchairApi, BlockstreamApi } from '@bitgo/blockapis';
 import { ApiNotImplementedError } from './baseApi';
 
 /**
@@ -15,11 +12,7 @@ export interface RecoveryAccountData {
 /**
  * Factory for AddressApi & UtxoApi
  */
-export interface RecoveryProvider {
-  getUnspentsForAddresses(addresses: string[]): Promise<Unspent[]>;
-  getAddressInfo(address: string): Promise<AddressInfo>;
-  getTransactionHex(txid: string): Promise<string>;
-}
+export type RecoveryProvider = AddressApi & UtxoApi;
 
 export function forCoin(coinName: string, apiToken?: string): RecoveryProvider {
   switch (coinName) {

--- a/modules/abstract-utxo/src/recovery/RecoveryProvider.ts
+++ b/modules/abstract-utxo/src/recovery/RecoveryProvider.ts
@@ -1,4 +1,4 @@
-import { BlockchairApi, BlockstreamApi, AddressInfo, TransactionInfo } from '@bitgo/blockapis';
+import { BlockchairApi, BlockstreamApi, AddressInfo, TransactionIO } from '@bitgo/blockapis';
 import { ApiNotImplementedError } from './baseApi';
 import { bitgo } from '@bitgo/utxo-lib';
 
@@ -19,7 +19,7 @@ export interface RecoveryProvider<TNumber extends number | bigint = number> {
   getUnspentsForAddresses(addresses: string[]): Promise<Unspent<TNumber>[]>;
   getAddressInfo(address: string): Promise<AddressInfo>;
   getTransactionHex(txid: string): Promise<string>;
-  getTransactionInfo(txid: string): Promise<TransactionInfo>;
+  getTransactionIO(txid: string): Promise<TransactionIO>;
 }
 
 export function forCoin(coinName: string, apiToken?: string): RecoveryProvider<number> {

--- a/modules/abstract-utxo/src/recovery/crossChainRecovery.ts
+++ b/modules/abstract-utxo/src/recovery/crossChainRecovery.ts
@@ -18,7 +18,6 @@ import { AbstractUtxoCoin, TransactionInfo } from '../abstractUtxoCoin';
 
 import { decrypt } from '@bitgo/sdk-api';
 import { signAndVerifyWalletTransaction } from '../sign';
-import { forCoin } from './RecoveryProvider';
 export interface BuildRecoveryTransactionOptions {
   wallet: string;
   faultyTxId: string;
@@ -54,7 +53,7 @@ export interface CrossChainRecoverySigned<TNumber extends number | bigint = numb
 
 type WalletV1 = {
   keychains: { xpub: string }[];
-  address({ address: string }): Promise<{ chain: number; index: number }>;
+  address({ address }: { address: string }): Promise<{ chain: number; index: number }>;
   getEncryptedUserKeychain(): Promise<{ encryptedXprv: string }>;
 };
 
@@ -111,7 +110,7 @@ async function getAllRecoveryOutputs<TNumber extends number | bigint = number>(
   txid: string,
   amountType: 'number' | 'bigint' = 'number'
 ): Promise<Unspent<TNumber>[]> {
-  const api = forCoin(coin.getChain());
+  const api = coin.getRecoveryProvider();
   const tx = await api.getTransactionInfo(txid);
   const addresses = tx.outputs.map((output) => output.address);
   const unspents = await api.getUnspentsForAddresses(addresses);

--- a/modules/abstract-utxo/src/recovery/crossChainRecovery.ts
+++ b/modules/abstract-utxo/src/recovery/crossChainRecovery.ts
@@ -111,7 +111,7 @@ async function getAllRecoveryOutputs<TNumber extends number | bigint = number>(
   amountType: 'number' | 'bigint' = 'number'
 ): Promise<Unspent<TNumber>[]> {
   const api = coin.getRecoveryProvider();
-  const tx = await api.getTransactionInfo(txid);
+  const tx = await api.getTransactionIO(txid);
   const addresses = tx.outputs.map((output) => output.address);
   const unspents = await api.getUnspentsForAddresses(addresses);
   return unspents.map((recoveryOutput) => {

--- a/modules/bitgo/test/v2/unit/coins/utxo/recovery/backupKeyRecovery.ts
+++ b/modules/bitgo/test/v2/unit/coins/utxo/recovery/backupKeyRecovery.ts
@@ -159,7 +159,7 @@ function run(
         userKeyPath: params.userKeyPath,
         krsProvider: params.krsProvider,
         ...params.keys,
-        recoveryProvider: new MockRecoveryProvider(coin, recoverUnspents),
+        recoveryProvider: new MockRecoveryProvider(recoverUnspents),
       });
       const txHex =
         (recovery as BackupKeyRecoveryTransansaction).transactionHex ?? (recovery as FormattedOfflineVaultTxInfo).txHex;

--- a/modules/bitgo/test/v2/unit/coins/utxo/recovery/backupKeyRecovery.ts
+++ b/modules/bitgo/test/v2/unit/coins/utxo/recovery/backupKeyRecovery.ts
@@ -159,7 +159,7 @@ function run(
         userKeyPath: params.userKeyPath,
         krsProvider: params.krsProvider,
         ...params.keys,
-        recoveryProvider: new MockRecoveryProvider(recoverUnspents),
+        recoveryProvider: new MockRecoveryProvider(coin, recoverUnspents),
       });
       const txHex =
         (recovery as BackupKeyRecoveryTransansaction).transactionHex ?? (recovery as FormattedOfflineVaultTxInfo).txHex;

--- a/modules/bitgo/test/v2/unit/coins/utxo/recovery/crossChainRecovery.ts
+++ b/modules/bitgo/test/v2/unit/coins/utxo/recovery/crossChainRecovery.ts
@@ -1,21 +1,11 @@
 /**
  * @prettier
  */
-import * as _ from 'lodash';
 import * as assert from 'assert';
 import * as should from 'should';
 import * as nock from 'nock';
 import * as utxolib from '@bitgo/utxo-lib';
 import { Triple } from '@bitgo/sdk-core';
-import {
-  AbstractUtxoCoin,
-  BitgoPublicApi,
-  CrossChainRecoverySigned,
-  CrossChainRecoveryUnsigned,
-  getWallet,
-  supportedCrossChainRecoveries,
-} from '@bitgo/abstract-utxo';
-
 import {
   getFixture,
   keychainsBase58,
@@ -30,11 +20,18 @@ import {
 } from '../util';
 import { getSeed } from '@bitgo/sdk-test';
 import { nockBitGo } from '../util/nockBitGo';
-import { nockBitGoPublicAddressUnspents, nockBitGoPublicTransaction } from '../util/nockIndexerAPI';
 import { createFullSignedTransaction } from '../util/transaction';
 import { getDefaultWalletUnspentSigner } from '../util/keychains';
+import { MockRecoveryProvider } from './mock';
+import {
+  AbstractUtxoCoin,
+  CrossChainRecoverySigned,
+  CrossChainRecoveryUnsigned,
+  getWallet,
+  supportedCrossChainRecoveries,
+} from '@bitgo/abstract-utxo';
+import * as sinon from 'sinon';
 
-type Unspent<TNumber extends number | bigint = number> = utxolib.bitgo.Unspent<TNumber>;
 type WalletUnspent<TNumber extends number | bigint = number> = utxolib.bitgo.WalletUnspent<TNumber>;
 
 function getKeyId(k: KeychainBase58): string {
@@ -61,58 +58,6 @@ function nockWallet(coin: AbstractUtxoCoin, walletId: string, walletKeys: Triple
   ];
 }
 
-type Address = {
-  address: string;
-  chain: number;
-  index: number;
-  coinSpecific: unknown;
-};
-
-function nockWalletAddress(coin: AbstractUtxoCoin, walletId: string, address: Address): nock.Scope {
-  return nockBitGo()
-    .get(`/api/v2/${coin.getChain()}/wallet/${walletId}/address/${address.address}`)
-    .reply(200, {
-      address: address.address,
-      chain: address.chain,
-      index: address.index,
-      coin: coin.getChain(),
-      wallet: walletId,
-      coinSpecific: address.coinSpecific,
-    })
-    .persist();
-}
-
-function nockAddressWithUnspents<TNumber extends number | bigint = number>(
-  coin: AbstractUtxoCoin,
-  address: string,
-  unspents: Unspent<TNumber>[]
-): nock.Scope {
-  const payload = unspents.map((u) => {
-    return {
-      ...u,
-      value: Number(u.value),
-      valueString: coin.amountType === 'bigint' ? u.value.toString() : undefined,
-    };
-  });
-  return nockBitGo().get(`/api/v2/${coin.getChain()}/public/addressUnspents/${address}`).reply(200, payload).persist();
-}
-
-function nockAddressWithoutUnspents(coin: AbstractUtxoCoin, address: string): nock.Scope {
-  return nockBitGo().get(`/api/v2/${coin.getChain()}/public/addressUnspents/${address}`).reply(404).persist();
-}
-
-function nockBitGoPublicTransactionInfo<TNumber extends number | bigint = number>(
-  coin: AbstractUtxoCoin,
-  depositTx: utxolib.bitgo.UtxoTransaction<TNumber>,
-  depositUnspents: Unspent<TNumber>[],
-  depositAddress: string
-): nock.Scope[] {
-  return [
-    nockBitGoPublicTransaction(coin, depositTx, depositUnspents).persist(),
-    nockBitGoPublicAddressUnspents<TNumber>(coin, depositTx.getId(), depositAddress, depositTx.outs).persist(),
-  ];
-}
-
 /**
  * Setup test for cross-chain recovery.
  *
@@ -133,7 +78,7 @@ function run<TNumber extends number | bigint = number>(sourceCoin: AbstractUtxoC
     const walletKeys = getDefaultWalletKeys();
     const recoveryWalletId = '5abacebe28d72fbd07e0b8cbba0ff39e';
     // the address the accidental deposit went to, in both sourceCoin and addressCoin formats
-    const [depositAddressSourceCoin, depositAddressRecoveryCoin] = [sourceCoin, recoveryCoin].map((coin) =>
+    const [depositAddressSourceCoin] = [sourceCoin, recoveryCoin].map((coin) =>
       coin.generateAddress({ keychains: keychainsBase58, index: 0 })
     );
     // the address where we want to recover our funds to
@@ -142,7 +87,7 @@ function run<TNumber extends number | bigint = number>(sourceCoin: AbstractUtxoC
 
     let depositTx: utxolib.bitgo.UtxoTransaction<TNumber>;
 
-    function getDepositUnspents() {
+    function getDepositUnspents(): utxolib.bitgo.Unspent<TNumber>[] {
       return [
         mockUnspent<TNumber>(
           sourceCoin.network,
@@ -181,10 +126,6 @@ function run<TNumber extends number | bigint = number>(sourceCoin: AbstractUtxoC
 
     before('setup nocks', function () {
       nocks.push(...nockWallet(recoveryCoin, recoveryWalletId, keychainsBase58));
-      nocks.push(nockWalletAddress(recoveryCoin, recoveryWalletId, depositAddressRecoveryCoin));
-      nocks.push(
-        ...nockBitGoPublicTransactionInfo(sourceCoin, depositTx, getDepositUnspents(), depositAddressSourceCoin.address)
-      );
     });
 
     after(function () {
@@ -195,26 +136,8 @@ function run<TNumber extends number | bigint = number>(sourceCoin: AbstractUtxoC
       nock.cleanAll();
     });
 
-    let signedRecovery: CrossChainRecoverySigned<TNumber>;
-    let unsignedRecovery: CrossChainRecoveryUnsigned<TNumber>;
-
-    before('create recovery transaction', async function () {
-      const params = {
-        recoveryCoin,
-        txid: depositTx.getId(),
-        recoveryAddress,
-        wallet: recoveryWalletId,
-      };
-
-      signedRecovery = (await sourceCoin.recoverFromWrongChain<TNumber>({
-        ...params,
-        xprv: keychainsBase58[0].prv,
-      })) as CrossChainRecoverySigned<TNumber>;
-
-      unsignedRecovery = (await sourceCoin.recoverFromWrongChain<TNumber>({
-        ...params,
-        signed: false,
-      })) as CrossChainRecoveryUnsigned<TNumber>;
+    afterEach(function () {
+      sinon.restore();
     });
 
     function testMatchFixture(
@@ -245,9 +168,6 @@ function run<TNumber extends number | bigint = number>(sourceCoin: AbstractUtxoC
       });
     }
 
-    testMatchFixture('signed', () => signedRecovery);
-    testMatchFixture('unsigned', () => unsignedRecovery);
-
     function checkRecoveryTransactionSignature(tx: string | utxolib.bitgo.UtxoTransaction<TNumber>) {
       if (typeof tx === 'string') {
         tx = utxolib.bitgo.createTransactionFromBuffer<TNumber>(
@@ -267,17 +187,55 @@ function run<TNumber extends number | bigint = number>(sourceCoin: AbstractUtxoC
       });
     }
 
-    it('should have valid signatures for signed recovery', function () {
-      checkRecoveryTransactionSignature(signedRecovery.txHex as string);
+    it('should test signed cross chain recovery', async () => {
+      const getRecoveryProviderStub = sinon
+        .stub(AbstractUtxoCoin.prototype, 'getRecoveryProvider')
+        .returns(new MockRecoveryProvider<TNumber>(recoveryCoin, getDepositUnspents(), depositTx));
+      const params = {
+        recoveryCoin,
+        txid: depositTx.getId(),
+        recoveryAddress,
+        wallet: recoveryWalletId,
+      };
+      const signedRecovery = (await sourceCoin.recoverFromWrongChain<TNumber>({
+        ...params,
+        xprv: keychainsBase58[0].prv,
+      })) as CrossChainRecoverySigned<TNumber>;
+      should.equal(getRecoveryProviderStub.callCount, 1);
+
+      testMatchFixture('signed', () => signedRecovery);
+
+      it('should have valid signatures for signed recovery', function () {
+        checkRecoveryTransactionSignature(signedRecovery.txHex as string);
+      });
     });
 
-    it('should be signable for unsigned recovery', async function () {
-      const signedTx = await sourceCoin.signTransaction<TNumber>({
-        txPrebuild: unsignedRecovery,
-        prv: keychainsBase58[0].prv,
-        pubs: keychainsBase58.map((k) => k.pub) as Triple<string>,
+    it('should test unsigned cross chain recovery', async () => {
+      const getRecoveryProviderStub = sinon
+        .stub(AbstractUtxoCoin.prototype, 'getRecoveryProvider')
+        .returns(new MockRecoveryProvider(recoveryCoin, getDepositUnspents(), depositTx));
+      const params = {
+        recoveryCoin,
+        txid: depositTx.getId(),
+        recoveryAddress,
+        wallet: recoveryWalletId,
+      };
+      const unsignedRecovery = (await sourceCoin.recoverFromWrongChain<TNumber>({
+        ...params,
+        signed: false,
+      })) as CrossChainRecoveryUnsigned<TNumber>;
+      should.equal(getRecoveryProviderStub.callCount, 1);
+
+      testMatchFixture('unsigned', () => unsignedRecovery);
+
+      it('should be signable for unsigned recovery', async function () {
+        const signedTx = await sourceCoin.signTransaction<TNumber>({
+          txPrebuild: unsignedRecovery,
+          prv: keychainsBase58[0].prv,
+          pubs: keychainsBase58.map((k) => k.pub) as Triple<string>,
+        });
+        checkRecoveryTransactionSignature((signedTx as { txHex: string }).txHex);
       });
-      checkRecoveryTransactionSignature((signedTx as { txHex: string }).txHex);
     });
   });
 }
@@ -341,85 +299,5 @@ describe(`Cross-Chain Recovery getWallet`, async function () {
       });
       nockV2Wallet.done();
     }
-  });
-});
-
-describe(`Cross-Chain Recovery BitgoPublicApi.getUnspentInfo`, async function () {
-  const coin = getUtxoCoin('btc');
-  const bigintCoin = getUtxoCoin('doge');
-  const numberValue = 1000;
-  const bigintValue = '10999999800000001';
-
-  const withUnspent1 = 'addresswithUnspent1';
-  const unspent1: Unspent = {
-    id: 'txid1',
-    address: withUnspent1,
-    value: numberValue,
-  };
-  const bigintUnspent1: Unspent<bigint> = _.assign(_.clone(unspent1), {
-    value: BigInt(bigintValue),
-    valueString: bigintValue,
-  });
-  const withUnspent2 = 'addresswithUnspent2';
-  const unspent2: Unspent = {
-    id: 'txid2',
-    address: withUnspent2,
-    value: numberValue,
-  };
-  const bigintUnspent2: Unspent<bigint> = _.assign(_.clone(unspent2), {
-    value: BigInt(bigintValue),
-    valueString: bigintValue,
-  });
-  const withoutUnspent = 'addressWithoutUnspent';
-  const nocks: nock.Scope[] = [];
-
-  afterEach(function () {
-    nocks.forEach((n) => n.done());
-    nock.cleanAll();
-  });
-
-  const api = new BitgoPublicApi(coin);
-  const bigintApi = new BitgoPublicApi(bigintCoin);
-
-  it('should first attempt a single batched address call to the addressUnspents api', async function () {
-    const addresses = [withUnspent1, withUnspent2];
-    nocks.push(nockAddressWithUnspents(coin, _.uniq(addresses).join(','), [unspent1, unspent2]));
-    (await api.getUnspentInfo(addresses)).should.eql([unspent1, unspent2]);
-  });
-
-  it('[bigint] should first attempt a single batched address call to the addressUnspents api', async function () {
-    const addresses = [withUnspent1, withUnspent2];
-    nocks.push(nockAddressWithUnspents(bigintCoin, _.uniq(addresses).join(','), [bigintUnspent1, bigintUnspent2]));
-    (await bigintApi.getUnspentInfo<bigint>(addresses, bigintCoin.amountType)).should.eql([
-      bigintUnspent1,
-      bigintUnspent2,
-    ]);
-  });
-
-  it('should ignore duplicate addresses and those which have missing (already spent) unspents', async function () {
-    const addresses = [withUnspent1, withUnspent1, withoutUnspent, withUnspent2];
-    nocks.push(nockAddressWithoutUnspents(coin, _.uniq(addresses).join(',')));
-    nocks.push(nockAddressWithUnspents(coin, withUnspent1, [unspent1]));
-    nocks.push(nockAddressWithUnspents(coin, withUnspent2, [unspent2]));
-    nocks.push(nockAddressWithoutUnspents(coin, withoutUnspent));
-    (await api.getUnspentInfo(addresses)).should.eql([unspent1, unspent2]);
-  });
-
-  it('[bigint] should ignore duplicate addresses and those which have missing (already spent) unspents', async function () {
-    const addresses = [withUnspent1, withUnspent1, withoutUnspent, withUnspent2];
-    nocks.push(nockAddressWithoutUnspents(bigintCoin, _.uniq(addresses).join(',')));
-    nocks.push(nockAddressWithUnspents(bigintCoin, withUnspent1, [bigintUnspent1]));
-    nocks.push(nockAddressWithUnspents(bigintCoin, withUnspent2, [bigintUnspent2]));
-    nocks.push(nockAddressWithoutUnspents(bigintCoin, withoutUnspent));
-    (await bigintApi.getUnspentInfo<bigint>(addresses, bigintCoin.amountType)).should.eql([
-      bigintUnspent1,
-      bigintUnspent2,
-    ]);
-  });
-
-  it('should throw an error if no unspents are found', async function () {
-    const addresses = [withoutUnspent];
-    nocks.push(nockAddressWithoutUnspents(coin, withoutUnspent));
-    await api.getUnspentInfo(addresses).should.be.rejectedWith(`no unspents found for addresses: ${addresses}`);
   });
 });

--- a/modules/bitgo/test/v2/unit/coins/utxo/recovery/mock.ts
+++ b/modules/bitgo/test/v2/unit/coins/utxo/recovery/mock.ts
@@ -2,7 +2,7 @@
  * @prettier
  */
 import { bitgo } from '@bitgo/utxo-lib';
-import { AddressInfo, TransactionInfo } from '@bitgo/blockapis';
+import { AddressInfo, TransactionIO } from '@bitgo/blockapis';
 import { AbstractUtxoCoin, RecoveryProvider } from '@bitgo/abstract-utxo';
 import * as utxolib from '@bitgo/utxo-lib';
 
@@ -62,8 +62,8 @@ export class MockRecoveryProvider<TNumber extends number | bigint> implements Re
     throw new Error(`not implemented`);
   }
 
-  async getTransactionInfo(txid: string): Promise<TransactionInfo> {
-    const payload: TransactionInfo = {
+  async getTransactionIO(txid: string): Promise<TransactionIO> {
+    const payload: TransactionIO = {
       inputs: this.unspents.map((u) => ({ address: u.address })),
       outputs:
         this.tx?.outs.map((o) => ({ address: utxolib.address.fromOutputScript(o.script, this.coin.network) })) ?? [],

--- a/modules/bitgo/test/v2/unit/coins/utxo/util/nockIndexerAPI.ts
+++ b/modules/bitgo/test/v2/unit/coins/utxo/util/nockIndexerAPI.ts
@@ -3,7 +3,7 @@
  */
 import * as nock from 'nock';
 import * as utxolib from '@bitgo/utxo-lib';
-import { AbstractUtxoCoin, ExplorerTxInfo } from '@bitgo/abstract-utxo';
+import { AbstractUtxoCoin } from '@bitgo/abstract-utxo';
 import { nockBitGo } from './nockBitGo';
 
 interface ImsUnspent {
@@ -18,7 +18,7 @@ export function nockBitGoPublicTransaction<TNumber extends number | bigint = num
   tx: utxolib.bitgo.UtxoTransaction<TNumber>,
   unspents: { address: string }[]
 ): nock.Scope {
-  const payload: ExplorerTxInfo = {
+  const payload = {
     input: unspents.map((u) => ({ address: u.address })),
     outputs: tx.outs.map((o) => ({ address: utxolib.address.fromOutputScript(o.script, coin.network) })),
   };

--- a/modules/blockapis/src/UtxoApi.ts
+++ b/modules/blockapis/src/UtxoApi.ts
@@ -9,7 +9,7 @@ export type OutputSpend =
     }
   | { txid: undefined; vin: undefined };
 
-export type TransactionInfo = {
+export type TransactionIO = {
   inputs: { address: string }[];
   outputs: { address: string }[];
 };
@@ -28,7 +28,7 @@ export interface UtxoApi extends TransactionApi {
    * @param txid
    * @return transaction input and output addresses
    */
-  getTransactionInfo(txid: string): Promise<TransactionInfo>;
+  getTransactionIO(txid: string): Promise<TransactionIO>;
 
   /**
    * @param txid

--- a/modules/blockapis/src/UtxoApi.ts
+++ b/modules/blockapis/src/UtxoApi.ts
@@ -9,6 +9,11 @@ export type OutputSpend =
     }
   | { txid: undefined; vin: undefined };
 
+export type TransactionInfo = {
+  inputs: { address: string }[];
+  outputs: { address: string }[];
+};
+
 /**
  * Methods specific to UTXO-based blockchains
  */
@@ -18,6 +23,12 @@ export interface UtxoApi extends TransactionApi {
    * @return transaction inputs
    */
   getTransactionInputs(txid: string): Promise<utxolib.bitgo.Unspent[]>;
+
+  /**
+   * @param txid
+   * @return transaction input and output addresses
+   */
+  getTransactionInfo(txid: string): Promise<TransactionInfo>;
 
   /**
    * @param txid

--- a/modules/blockapis/src/impl/BlockchairApi.ts
+++ b/modules/blockapis/src/impl/BlockchairApi.ts
@@ -2,7 +2,7 @@ import { bitgo } from '@bitgo/utxo-lib';
 import { BaseHttpClient, HttpClient, Response } from '../BaseHttpClient';
 import { ApiNotImplementedError } from '../ApiBuilder';
 import { AddressApi, AddressInfo } from '../AddressApi';
-import { OutputSpend, UtxoApi } from '../UtxoApi';
+import { OutputSpend, TransactionInfo, UtxoApi } from '../UtxoApi';
 import { TransactionStatus } from '../TransactionApi';
 
 type Unspent = bitgo.Unspent;
@@ -198,6 +198,24 @@ export class BlockchairApi implements AddressApi, UtxoApi {
         value: i.value,
       };
     });
+  }
+
+  async getTransactionInfo(txid: string): Promise<TransactionInfo> {
+    const tx = await this.getTransaction(txid);
+    const inputs = tx.inputs.map((input) => {
+      return {
+        address: input.recipient,
+      };
+    });
+    const outputs = tx.outputs.map((output) => {
+      return {
+        address: output.recipient,
+      };
+    });
+    return {
+      inputs,
+      outputs,
+    };
   }
 
   async getTransactionSpends(txid: string): Promise<OutputSpend[]> {

--- a/modules/blockapis/src/impl/BlockchairApi.ts
+++ b/modules/blockapis/src/impl/BlockchairApi.ts
@@ -2,7 +2,7 @@ import { bitgo } from '@bitgo/utxo-lib';
 import { BaseHttpClient, HttpClient, Response } from '../BaseHttpClient';
 import { ApiNotImplementedError } from '../ApiBuilder';
 import { AddressApi, AddressInfo } from '../AddressApi';
-import { OutputSpend, TransactionInfo, UtxoApi } from '../UtxoApi';
+import { OutputSpend, TransactionIO, UtxoApi } from '../UtxoApi';
 import { TransactionStatus } from '../TransactionApi';
 
 type Unspent = bitgo.Unspent;
@@ -200,7 +200,7 @@ export class BlockchairApi implements AddressApi, UtxoApi {
     });
   }
 
-  async getTransactionInfo(txid: string): Promise<TransactionInfo> {
+  async getTransactionIO(txid: string): Promise<TransactionIO> {
     const tx = await this.getTransaction(txid);
     const inputs = tx.inputs.map((input) => {
       return {

--- a/modules/blockapis/src/impl/BlockstreamApi.ts
+++ b/modules/blockapis/src/impl/BlockstreamApi.ts
@@ -1,6 +1,6 @@
 import { bitgo } from '@bitgo/utxo-lib';
 import { AddressApi, AddressInfo } from '../AddressApi';
-import { OutputSpend, TransactionInfo, UtxoApi } from '../UtxoApi';
+import { OutputSpend, TransactionIO, UtxoApi } from '../UtxoApi';
 import { ApiRequestError, BaseHttpClient, HttpClient, mapSeries } from '../BaseHttpClient';
 import { ApiNotImplementedError } from '../ApiBuilder';
 import { TransactionStatus } from '../TransactionApi';
@@ -136,7 +136,7 @@ export class BlockstreamApi implements AddressApi, UtxoApi {
     );
   }
 
-  async getTransactionInfo(txid: string): Promise<TransactionInfo> {
+  async getTransactionIO(txid: string): Promise<TransactionIO> {
     const tx = await this.client.get<EsploraTransaction>(`/tx/${txid}`);
     const inputs = tx.map((body) =>
       body.vin.map((u) => {

--- a/modules/blockapis/src/impl/BlockstreamApi.ts
+++ b/modules/blockapis/src/impl/BlockstreamApi.ts
@@ -1,6 +1,6 @@
 import { bitgo } from '@bitgo/utxo-lib';
 import { AddressApi, AddressInfo } from '../AddressApi';
-import { OutputSpend, UtxoApi } from '../UtxoApi';
+import { OutputSpend, TransactionInfo, UtxoApi } from '../UtxoApi';
 import { ApiRequestError, BaseHttpClient, HttpClient, mapSeries } from '../BaseHttpClient';
 import { ApiNotImplementedError } from '../ApiBuilder';
 import { TransactionStatus } from '../TransactionApi';
@@ -67,6 +67,7 @@ type EsploraStatus =
 type EsploraTransaction = {
   txid: string;
   vin: EsploraVin[];
+  vout: EsploraVout[];
   status: EsploraStatus;
 };
 
@@ -133,6 +134,28 @@ export class BlockstreamApi implements AddressApi, UtxoApi {
     return (await this.client.get<EsploraTransaction>(`/tx/${txid}`)).map((body) =>
       body.vin.map((u) => toBitGoUnspent(u, u.prevout.scriptpubkey_address, u.prevout.value))
     );
+  }
+
+  async getTransactionInfo(txid: string): Promise<TransactionInfo> {
+    const tx = await this.client.get<EsploraTransaction>(`/tx/${txid}`);
+    const inputs = tx.map((body) =>
+      body.vin.map((u) => {
+        return {
+          address: u.prevout.scriptpubkey_address,
+        };
+      })
+    );
+    const outputs = tx.map((body) =>
+      body.vout.map((u) => {
+        return {
+          address: u.scriptpubkey_address,
+        };
+      })
+    );
+    return {
+      inputs,
+      outputs,
+    };
   }
 
   async getTransactionSpends(txid: string): Promise<OutputSpend[]> {

--- a/modules/blockapis/test/UtxoApi.ts
+++ b/modules/blockapis/test/UtxoApi.ts
@@ -106,6 +106,7 @@ function getTestCases(coinName: string): TestCase<unknown>[] {
     switch (methodName) {
       case 'getTransactionHex':
       case 'getTransactionInputs':
+      case 'getTransactionIO':
       case 'getTransactionSpends':
       case 'getTransactionStatus':
         return getTestTransactionIds(coinName).map((v) => [v]);
@@ -118,6 +119,7 @@ function getTestCases(coinName: string): TestCase<unknown>[] {
   const methods: (keyof UtxoApi)[] = [
     'getTransactionHex',
     'getTransactionInputs',
+    'getTransactionIO',
     'getTransactionStatus',
     'getTransactionSpends',
     'getUnspentsForAddresses',

--- a/modules/blockapis/test/fixtures/UtxoApi.BlockchairApi.tbtc.getTransactionIO.19c6cd6b7b8a91e1a63d759eedd2818877a624771d38e00c3ffcedfdd09afc50.json
+++ b/modules/blockapis/test/fixtures/UtxoApi.BlockchairApi.tbtc.getTransactionIO.19c6cd6b7b8a91e1a63d759eedd2818877a624771d38e00c3ffcedfdd09afc50.json
@@ -1,0 +1,15 @@
+{
+  "inputs": [
+    {
+      "address": "tb1q2ajf7llsxvff7r0fpm42tmd5nz43cr8mg85f3788rm4cy7uwajdsusr2mg"
+    }
+  ],
+  "outputs": [
+    {
+      "address": "2NEhVzd2Lom5g7ZF5K1qYrgZLpXecniqHcE"
+    },
+    {
+      "address": "tb1q2wqmwu89mh5ztajnvasj8nr32szq6mfwxzvgvqyydzv8xpnvdpvq34wgpv"
+    }
+  ]
+}

--- a/modules/blockapis/test/fixtures/UtxoApi.BlockchairApi.tbtc.getTransactionIO.87f4cf756eef9979f0fb6a03db2ab2e0fd46060cf97714a990623093fe227a87.json
+++ b/modules/blockapis/test/fixtures/UtxoApi.BlockchairApi.tbtc.getTransactionIO.87f4cf756eef9979f0fb6a03db2ab2e0fd46060cf97714a990623093fe227a87.json
@@ -1,0 +1,15 @@
+{
+  "inputs": [
+    {
+      "address": "2NCgafDsUvFi6tg5bHED6C6Q4shmH7n8jkR"
+    }
+  ],
+  "outputs": [
+    {
+      "address": "2My1QBzpW7sPdRLeUab7ta1adeKpWferNbs"
+    },
+    {
+      "address": "2NFxDVK4y8KjMRsurZHZuyjtcMtH6hLVhPi"
+    }
+  ]
+}

--- a/modules/blockapis/test/fixtures/UtxoApi.BlockchairApi.tbtc.getTransactionIO.fe38c68afcdd60dc0af11b692f81f512b886132b26165e404c0d0a30d7d6dc54.json
+++ b/modules/blockapis/test/fixtures/UtxoApi.BlockchairApi.tbtc.getTransactionIO.fe38c68afcdd60dc0af11b692f81f512b886132b26165e404c0d0a30d7d6dc54.json
@@ -1,0 +1,15 @@
+{
+  "inputs": [
+    {
+      "address": "tb1qy9xagxksmqjz6rwqh4kn03x8gp96sv8gjhkenu"
+    }
+  ],
+  "outputs": [
+    {
+      "address": "tb1qwgm0d5esj57wx34jsvy32avtrx5tw7ehs0xgr3"
+    },
+    {
+      "address": "tb1qr8j845m2ue6py8g9v9nx0vjqtz6ndfyy4yk3a2"
+    }
+  ]
+}

--- a/modules/blockapis/test/fixtures/UtxoApi.BlockstreamApi.tbtc.getTransactionIO.19c6cd6b7b8a91e1a63d759eedd2818877a624771d38e00c3ffcedfdd09afc50.json
+++ b/modules/blockapis/test/fixtures/UtxoApi.BlockstreamApi.tbtc.getTransactionIO.19c6cd6b7b8a91e1a63d759eedd2818877a624771d38e00c3ffcedfdd09afc50.json
@@ -1,0 +1,15 @@
+{
+  "inputs": [
+    {
+      "address": "tb1q2ajf7llsxvff7r0fpm42tmd5nz43cr8mg85f3788rm4cy7uwajdsusr2mg"
+    }
+  ],
+  "outputs": [
+    {
+      "address": "2NEhVzd2Lom5g7ZF5K1qYrgZLpXecniqHcE"
+    },
+    {
+      "address": "tb1q2wqmwu89mh5ztajnvasj8nr32szq6mfwxzvgvqyydzv8xpnvdpvq34wgpv"
+    }
+  ]
+}

--- a/modules/blockapis/test/fixtures/UtxoApi.BlockstreamApi.tbtc.getTransactionIO.87f4cf756eef9979f0fb6a03db2ab2e0fd46060cf97714a990623093fe227a87.json
+++ b/modules/blockapis/test/fixtures/UtxoApi.BlockstreamApi.tbtc.getTransactionIO.87f4cf756eef9979f0fb6a03db2ab2e0fd46060cf97714a990623093fe227a87.json
@@ -1,0 +1,15 @@
+{
+  "inputs": [
+    {
+      "address": "2NCgafDsUvFi6tg5bHED6C6Q4shmH7n8jkR"
+    }
+  ],
+  "outputs": [
+    {
+      "address": "2My1QBzpW7sPdRLeUab7ta1adeKpWferNbs"
+    },
+    {
+      "address": "2NFxDVK4y8KjMRsurZHZuyjtcMtH6hLVhPi"
+    }
+  ]
+}

--- a/modules/blockapis/test/fixtures/UtxoApi.BlockstreamApi.tbtc.getTransactionIO.fe38c68afcdd60dc0af11b692f81f512b886132b26165e404c0d0a30d7d6dc54.json
+++ b/modules/blockapis/test/fixtures/UtxoApi.BlockstreamApi.tbtc.getTransactionIO.fe38c68afcdd60dc0af11b692f81f512b886132b26165e404c0d0a30d7d6dc54.json
@@ -1,0 +1,15 @@
+{
+  "inputs": [
+    {
+      "address": "tb1qy9xagxksmqjz6rwqh4kn03x8gp96sv8gjhkenu"
+    }
+  ],
+  "outputs": [
+    {
+      "address": "tb1qwgm0d5esj57wx34jsvy32avtrx5tw7ehs0xgr3"
+    },
+    {
+      "address": "tb1qr8j845m2ue6py8g9v9nx0vjqtz6ndfyy4yk3a2"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

This PR changes `getAllRecoveryOutputs` to use the UtxoApi opposed to the BitGo Public Api. This is to add support for BCHA cross chain recoveries, in which BitGo does not support BCHA in its public api. 

To make use of UtxoApi in `getAllRecoveryOutputs`, a new interface method in the utxo api is introduced to fetch all input and output addresses of a transaction.

## Issue Number

Ticket: BG-66081

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

##  How Has This Been Tested?

Existing tests where updated in `modules/bitgo/test/v2/unit/coins/utxo/recovery/crossChainRecovery.ts`.
New tests for blockapis where added in `modules/blockapis/test/UtxoApi.ts`

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [x] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
