### PR TITLE
feat(sdk-core): change third party to backupGpgKey

### DIFF
--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
@@ -322,9 +322,7 @@ export class EcdsaUtils extends baseTSSUtils<KeyShare> {
         },
       ],
       userGPGPublicKey: userGpgKey.publicKey,
-      // BitGo is the only supported third party backup as of now, so the
-      // backup GPG key is the same as bitgo GPG key. Else use the provided backupGpgKey.
-      backupGPGPublicKey: isThirdPartyBackup ? bitgoPublicGpgKey.armor() : backupGpgKey.publicKey,
+      backupGPGPublicKey: backupGpgKey.publicKey,
       enterprise: enterprise,
       algoUsed: 'ecdsa',
     };


### PR DESCRIPTION
Changes the `createBitgoKeychain()` function to use the distinct backup GPG keys that are generated, whether it is a third party backup or not.

BG-62364
## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes