### PR TITLE
feat(utxo-lib): zcash non-segwit unspents can be signed

### DIFF
--- a/modules/utxo-lib/src/bitgo/zcash/ZcashPsbt.ts
+++ b/modules/utxo-lib/src/bitgo/zcash/ZcashPsbt.ts
@@ -4,7 +4,7 @@ import {
   getDefaultVersionGroupIdForVersion,
   ZcashTransaction,
 } from './ZcashTransaction';
-import { Network, PsbtTransaction } from '../../';
+import { Network, PsbtTransaction, Signer } from '../../';
 import { Psbt as PsbtBase } from 'bip174';
 import * as types from 'bitcoinjs-lib/src/types';
 import { UtxoTransaction } from '../UtxoTransaction';
@@ -126,6 +126,15 @@ export class ZcashPsbt extends UtxoPsbt<ZcashTransaction<bigint>> {
 
     this.tx.versionGroupId = getDefaultVersionGroupIdForVersion(version);
     this.tx.consensusBranchId = getDefaultConsensusBranchIdForVersion(network, version);
+  }
+
+  signInput(inputIndex: number, keyPair: Signer, sighashTypes?: number[]): this {
+    (this as any).__CACHE.__UNSAFE_SIGN_NONSEGWIT = true;
+    try {
+      return super.signInput(inputIndex, keyPair, sighashTypes);
+    } finally {
+      (this as any).__CACHE.__UNSAFE_SIGN_NONSEGWIT = false;
+    }
   }
 
   private setPropertyCheckSignatures(propName: keyof ZcashTransaction<bigint>, value: unknown) {

--- a/modules/utxo-lib/test/bitgo/psbt/fromHalfSigned.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/fromHalfSigned.ts
@@ -45,7 +45,7 @@ function runTest(
     before('create transaction', function () {
       prevOutputs = getPrevOutputs(scriptType, BigInt(1e8), network, {
         keys: walletKeys.triple,
-        prevTx: scriptType === 'p2sh' || scriptType === 'p2shP2pk',
+        prevTx: (scriptType === 'p2sh' || scriptType === 'p2shP2pk') && getNetworkName(network) !== 'zcash',
       });
       ({ unsigned, halfSigned, fullSigned } = getTransactionStages(
         walletKeys.triple,


### PR DESCRIPTION
Zcash non-segwit unspents can be signed without a nonWitnessUtxo

[BG-66488](https://bitgoinc.atlassian.net/browse/BG-66488)

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->

[BG-66488]: https://bitgoinc.atlassian.net/browse/BG-66488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ