### PR TITLE
chore: add narrow types for backupProvider

### DIFF
--- a/modules/sdk-core/src/bitgo/keychain/iKeychains.ts
+++ b/modules/sdk-core/src/bitgo/keychain/iKeychains.ts
@@ -1,6 +1,6 @@
 import { IRequestTracer } from '../../api';
 import { KeyPair, KeychainsTriplet } from '../baseCoin';
-import { IWallet } from '../wallet';
+import { BackupProvider, IWallet } from '../wallet';
 
 export type KeyType = 'tss' | 'independent' | 'blsdkg';
 
@@ -107,7 +107,7 @@ export interface CreateMpcOptions {
   passphrase?: string;
   originalPasscodeEncryptionCode?: string;
   enterprise?: string;
-  backupProvider?: string;
+  backupProvider?: BackupProvider;
 }
 
 export interface GetKeysForSigningOptions {

--- a/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
@@ -6,6 +6,7 @@ import { decrypt, readMessage, readPrivateKey, SerializedKeyPair } from 'openpgp
 import { IBaseCoin, KeychainsTriplet } from '../baseCoin';
 import { BitGoBase } from '../bitgoBase';
 import { AddKeychainOptions, Keychain, KeyType } from '../keychain';
+import { BackupProvider } from '../wallet';
 import { encryptText, getBitgoGpgPubKey } from './opengpgUtils';
 import { IntentRecipient, PopulatedIntent, PrebuildTransactionWithIntentOptions } from './tss/baseTypes';
 
@@ -94,6 +95,7 @@ export abstract class MpcUtils {
     passphrase: string;
     enterprise?: string;
     originalPasscodeEncryptionCode?: string;
+    backupProvider?: BackupProvider;
   }): Promise<KeychainsTriplet>;
 
   /**

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
@@ -4,7 +4,7 @@ import { IBaseCoin, KeychainsTriplet } from '../../baseCoin';
 import { BitGoBase } from '../../bitgoBase';
 import { Keychain } from '../../keychain';
 import { getTxRequest } from '../../tss';
-import { IWallet } from '../../wallet';
+import { IWallet, BackupProvider } from '../../wallet';
 import { MpcUtils } from '../mpcUtils';
 import * as _ from 'lodash';
 import {
@@ -89,6 +89,7 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
     enterprise?: string | undefined;
     originalPasscodeEncryptionCode?: string | undefined;
     isThirdPartyBackup?: boolean;
+    backupProvider?: BackupProvider;
   }): Promise<KeychainsTriplet> {
     throw new Error('Method not implemented.');
   }
@@ -314,7 +315,9 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
    * Checks whether the third party backup provider is valid/supported
    * @param backupProvider - the backup provider client selected
    */
-  isValidThirdPartyBackupProvider(backupProvider: string | undefined): boolean {
+  isValidThirdPartyBackupProvider(
+    backupProvider: BackupProvider | string | undefined
+  ): backupProvider is BackupProvider {
     // As of now, BitGo is the only supported KRS provider for TSS
     return !!(backupProvider && backupProvider === 'BitGoTrustAsKrs');
   }

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
@@ -19,7 +19,7 @@ import { getTxRequest } from '../../../tss';
 import { AShare, DShare, EncryptedNShare, SendShareType } from '../../../tss/ecdsa/types';
 import { generateGPGKeyPair, getBitgoGpgPubKey } from '../../opengpgUtils';
 import { BitGoBase } from '../../../bitgoBase';
-import { IWallet } from '../../../wallet';
+import { BackupProvider, IWallet } from '../../../wallet';
 import assert from 'assert';
 import { bip32 } from '@bitgo/utxo-lib';
 import { buildNShareFromAPIKeyShare, getParticipantFromIndex, verifyWalletSignature } from '../../../tss/ecdsa/ecdsa';
@@ -115,7 +115,7 @@ export class EcdsaUtils extends baseTSSUtils<KeyShare> {
     passphrase: string;
     enterprise?: string | undefined;
     originalPasscodeEncryptionCode?: string | undefined;
-    backupProvider?: string;
+    backupProvider?: BackupProvider;
   }): Promise<KeychainsTriplet> {
     const MPC = new Ecdsa();
     const m = 2;

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/types.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/types.ts
@@ -2,6 +2,7 @@ import { ECDSA } from '../../../../account-lib/mpc/tss';
 import { ECDSAMethodTypes } from '../../../tss/ecdsa';
 import { BackupKeyShare, CreateKeychainParamsBase } from '../baseTypes';
 import { Key, SerializedKeyPair } from 'openpgp';
+import { BackupProvider } from '../../../wallet';
 
 export type KeyShare = ECDSA.KeyShare;
 export type DecryptableNShare = ECDSAMethodTypes.DecryptableNShare;
@@ -11,7 +12,7 @@ export type CreateEcdsaKeychainParams = CreateKeychainParamsBase & {
   backupGpgKey: SerializedKeyPair<string>;
   backupKeyShare: BackupKeyShare;
   isThirdPartyBackup?: boolean;
-  backupProvider?: string;
+  backupProvider?: BackupProvider;
   bitgoPublicGpgKey: Key;
 };
 

--- a/modules/sdk-core/src/bitgo/wallet/iWallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallets.ts
@@ -21,16 +21,17 @@ export interface GenerateMpcWalletOptions {
   originalPasscodeEncryptionCode?: string;
   enterprise?: string;
   walletVersion?: number;
-  backupProvider?: string;
+  backupProvider?: BackupProvider;
 }
-
+export const backupProviders = ['BitGoTrustAsKrs'] as const;
+export type BackupProvider = typeof backupProviders[number];
 export interface GenerateWalletOptions {
   label?: string;
   passphrase?: string;
   userKey?: string;
   backupXpub?: string;
   backupXpubProvider?: string;
-  backupProvider?: string;
+  backupProvider?: BackupProvider;
   passcodeEncryptionCode?: string;
   enterprise?: string;
   disableTransactionNotifications?: string;


### PR DESCRIPTION
## Description

This PR adds a narrow type for BackupProvider to make it easier to understand all the valid values it can hold.

## Issue Number

TICKET: BG-66601

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This PR does not change any existing functionality. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [x] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes