### PR TITLE
feat(statics): Add Custody BitGo Trust Coin Feature For Avax-p

### DIFF
--- a/modules/statics/src/avaxp.ts
+++ b/modules/statics/src/avaxp.ts
@@ -13,7 +13,7 @@ export interface AVAXPConstructorOptions {
 }
 
 export class AVAXPCoin extends BaseCoin {
-  public static readonly DEFAULT_FEATURES = [CoinFeature.UNSPENT_MODEL];
+  public static readonly DEFAULT_FEATURES = [CoinFeature.UNSPENT_MODEL, CoinFeature.CUSTODY_BITGO_TRUST];
 
   /**
    * Additional fields for utxo coins


### PR DESCRIPTION
We recently introduced new custody coin features where every coin has a feature for all the BitGo entities it belongs to. We're now enforcing these features in the Wallet Platform, and during this change, it came about that Avax-p is currently missing any of the custody flags. As part of this PR, we're adding the default BitGo Trust custody flag for the Avax-p coin.

[BG-66028](https://bitgoinc.atlassian.net/browse/BG-66028)

## Changes
- Modified: modules/statics/src/avaxp.ts

[BG-66028]: https://bitgoinc.atlassian.net/browse/BG-66028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ