### PR TITLE
feat(statics): Add Custody Coin Features For AVAX-P Coin

### DIFF
--- a/modules/statics/src/avaxp.ts
+++ b/modules/statics/src/avaxp.ts
@@ -13,7 +13,11 @@ export interface AVAXPConstructorOptions {
 }
 
 export class AVAXPCoin extends BaseCoin {
-  public static readonly DEFAULT_FEATURES = [CoinFeature.UNSPENT_MODEL];
+  public static readonly DEFAULT_FEATURES = [
+    CoinFeature.UNSPENT_MODEL,
+    CoinFeature.CUSTODY_BITGO_TRUST,
+    CoinFeature.CUSTODY_BITGO_GERMANY,
+  ];
 
   /**
    * Additional fields for utxo coins

--- a/modules/statics/test/unit/coins.ts
+++ b/modules/statics/test/unit/coins.ts
@@ -11,6 +11,7 @@ const custodyFeatures: Record<string, { features: CoinFeature[] }> = {
     features: [CoinFeature.CUSTODY_BITGO_SWITZERLAND, CoinFeature.CUSTODY_BITGO_GERMANY],
   },
   avaxc: { features: [CoinFeature.CUSTODY_BITGO_GERMANY] },
+  avaxp: { features: [CoinFeature.CUSTODY_BITGO_GERMANY] },
   btc: {
     features: [CoinFeature.CUSTODY_BITGO_GERMANY, CoinFeature.CUSTODY_BITGO_NEW_YORK],
   },
@@ -48,6 +49,7 @@ const custodyFeatures: Record<string, { features: CoinFeature[] }> = {
     features: [CoinFeature.CUSTODY_BITGO_SWITZERLAND, CoinFeature.CUSTODY_BITGO_GERMANY],
   },
   tavaxc: { features: [CoinFeature.CUSTODY_BITGO_GERMANY] },
+  tavaxp: { features: [CoinFeature.CUSTODY_BITGO_GERMANY] },
   tbtc: {
     features: [CoinFeature.CUSTODY_BITGO_GERMANY, CoinFeature.CUSTODY_BITGO_NEW_YORK],
   },
@@ -126,11 +128,7 @@ coins.forEach((coin, coinName) => {
       it(`should return true for CUSTODY_BITGO_TRUST ${coin.family} coin feature`, () => {
         coin.features.includes(CoinFeature.CUSTODY_BITGO_TRUST).should.eql(true);
       });
-    } else if (
-      coin.family === CoinFamily.XTZ ||
-      coin.family === CoinFamily.AVAXP ||
-      coin.features.includes(CoinFeature.GENERIC_TOKEN)
-    ) {
+    } else if (coin.family === CoinFamily.XTZ || coin.features.includes(CoinFeature.GENERIC_TOKEN)) {
       it(`should return false for all custody ${coin.family} coin feature`, () => {
         coin.features.includes(CoinFeature.CUSTODY).should.eql(false);
         coin.features.includes(CoinFeature.CUSTODY_BITGO_TRUST).should.eql(false);


### PR DESCRIPTION
We recently introduced new custody coin features where every coin has a feature for all the `BitGo` entities it belongs to. We're now enforcing these features in the `Wallet Platform`, and during this change, it came about that `Avax-P` is currently missing all the custody flags. As part of this PR, we're adding the `BitGo Trust` and `BitGo Germany` custody flag for `Avax-P` coin.

The list of BitGo entities for `Avax-P` was confirmed by the `Altcoin` team!

[BG-66028](https://bitgoinc.atlassian.net/browse/BG-66028)

## Changes
- Modified: modules/statics/src/avaxp.ts
- Modified: modules/statics/test/unit/coins.ts

[BG-66028]: https://bitgoinc.atlassian.net/browse/BG-66028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ