### PR TITLE
fix(sdk-core): sign typed data json stringify

### DIFF
--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -160,7 +160,7 @@ export interface WalletSignMessageOptions extends WalletSignBaseOptions {
   custodianMessageId?: string;
 }
 
-export interface WalletSignTypedDataOptions extends WalletSignMessageOptions {
+export interface WalletSignTypedDataOptions extends WalletSignBaseOptions {
   typedData: TypedData;
   custodianMessageId?: string;
 }

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -1609,6 +1609,9 @@ export class Wallet implements IWallet {
     if (this._wallet.multisigType !== 'tss') {
       throw new Error('Message signing only supported for TSS wallets');
     }
+    if (_.isFunction(params.typedData.typedDataRaw)) {
+      throw new Error('typedData.typedDataRaw must be JSON string');
+    }
     if (_.isFunction((this.baseCoin as any).encodeTypedData)) {
       params.typedData.typedDataEncoded = (this.baseCoin as any).encodeTypedData(params.typedData);
     }
@@ -2848,7 +2851,7 @@ export class Wallet implements IWallet {
           reqId: params.reqId,
           intentType: 'signTypedStructuredData',
           isTss: true,
-          typedDataRaw: JSON.stringify(params.typedData.typedDataRaw),
+          typedDataRaw: params.typedData.typedDataRaw,
           typedDataEncoded: params.typedData.typedDataEncoded!.toString('hex'),
         };
         txRequest = await this.tssUtils!.createTxRequestWithIntentForTypedDataSigning(intentOptions);


### PR DESCRIPTION
TypedDataRaw is already `stringify` and that was causing an issue in `hsm` where this could not be parsed properly.

Ticket: BG-67362

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->