### PR TITLE
feat(key-card): add basic code to generate key cards

### DIFF
--- a/modules/key-card/package.json
+++ b/modules/key-card/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@bitgo/sdk-api": "^1.9.7",
     "@bitgo/sdk-core": "^5.2.0",
-    "@bitgo/statics": "^14.1.0"
+    "@bitgo/statics": "^14.1.0",
+    "jspdf": "^2.5.1"
   }
 }

--- a/modules/key-card/src/drawKeycard.ts
+++ b/modules/key-card/src/drawKeycard.ts
@@ -1,0 +1,201 @@
+import { jsPDF } from 'jspdf';
+import { FAQ } from './faq';
+import { QrData } from './generateQrData';
+
+// Max for Binary/Byte Data https://en.wikipedia.org/wiki/QR_code#Standards
+// keys for TSS wallets aren't alphanumeric, so qrcode.react falls back to binary/byte encoding
+export const QRBinaryMaxLength = 2953;
+
+const font = {
+  header: 24,
+  subheader: 15,
+  body: 12,
+};
+
+const color = {
+  black: '#000000',
+  darkgray: '#4c4c4c',
+  gray: '#9b9b9b',
+  red: '#e21e1e',
+};
+
+const margin = 30;
+
+export function drawKeycard({ activationCode, questions, keyCardImage, qrData, walletLabel }: {
+  activationCode?: string;
+  keyCardImage?: HTMLImageElement;
+  qrData: QrData;
+  questions: FAQ[];
+  walletLabel: string;
+}): jsPDF {
+  // document details
+  const width = 8.5 * 72;
+  let y = 0;
+
+  // Helpers for data formatting / positioning on the paper
+  const left = (x: number) => margin + x;
+  const moveDown = (ydelta: number) => (y += ydelta);
+
+  // Create the PDF instance
+
+  const doc = new jsPDF('portrait', 'pt', 'letter'); // jshint ignore:line
+  doc.setFont('helvetica');
+
+  // PDF Header Area - includes the logo and company name
+  // This is data for the BitGo logo in the top left of the PDF
+  moveDown(30);
+
+  if (keyCardImage) {
+    doc.addImage(keyCardImage, left(0), y, 303, 40);
+  }
+
+  // Activation Code
+  if (activationCode) {
+    moveDown(8);
+    doc.setFontSize(font.body).setTextColor(color.gray);
+    doc.text('Activation Code', left(460), y);
+  }
+  doc.setFontSize(font.header).setTextColor(color.black);
+  moveDown(25);
+  doc.text('KeyCard', left(325), y - 1);
+  if (activationCode) {
+    doc.setFontSize(font.header).setTextColor(color.gray);
+    doc.text(activationCode, left(460), y);
+  }
+
+  // Subheader
+  // titles
+  const date = new Date().toDateString();
+  moveDown(margin);
+  doc.setFontSize(font.body).setTextColor(color.gray);
+  doc.text('Created on ' + date + ' for wallet named:', left(0), y);
+  // copy
+  moveDown(25);
+  doc.setFontSize(font.subheader).setTextColor(color.black);
+  doc.text(walletLabel, left(0), y);
+  // Red Bar
+  moveDown(20);
+  doc.setFillColor(255, 230, 230);
+  doc.rect(left(0), y, width - 2 * margin, 32, 'F');
+
+  // warning message
+  moveDown(20);
+  doc.setFontSize(font.body).setTextColor(color.red);
+  doc.text('Print this document, or keep it securely offline. See below for FAQ.', left(75), y);
+
+  // Generate the first page's data for the backup PDF
+  moveDown(35);
+  const qrSize = 130;
+
+  const qrKeys = ['user', 'passcode', 'backup', 'bitgo'];
+  qrKeys.forEach(function (name, index) {
+    if (index === 2) {
+      // Add 2nd Page
+      doc.addPage();
+
+      // 2nd page title
+      y = 30;
+    }
+
+    const qr = qrData[name];
+    let topY = y;
+    const textLeft = left(qrSize + 15);
+    let textHeight = 0;
+
+    doc.setFontSize(font.subheader).setTextColor(color.black);
+    moveDown(10);
+    textHeight += 10;
+    doc.text(qr.title, textLeft, y);
+    textHeight += doc.getLineHeight();
+    moveDown(15);
+    textHeight += 15;
+    doc.setFontSize(font.body).setTextColor(color.darkgray);
+    doc.text(qr.description, textLeft, y);
+    textHeight += doc.getLineHeight();
+    doc.setFontSize(font.body - 2);
+    if (qr?.data?.length > QRBinaryMaxLength) {
+      moveDown(30);
+      textHeight += 30;
+      doc.text('Note: you will need to put Part 1 and Part 2 together for the full key', textLeft, y);
+    }
+    moveDown(30);
+    textHeight += 30;
+    doc.text('Data:', textLeft, y);
+    textHeight += doc.getLineHeight();
+    moveDown(15);
+    textHeight += 15;
+    const width = 72 * 8.5 - textLeft - 30;
+    doc.setFont('courier').setFontSize(9).setTextColor(color.black);
+    const lines = doc.splitTextToSize(qr.data, width);
+    const buffer = 10;
+    for (let line = 0; line < lines.length; line++) {
+      // add new page if data does not fit on one page
+      if (y + buffer >= doc.internal.pageSize.getHeight()) {
+        doc.addPage();
+        textHeight = 0;
+        y = 30;
+        topY = y;
+      }
+      doc.text(lines[line], textLeft, y);
+      if (line !== lines.length - 1) {
+        moveDown(buffer);
+        textHeight += buffer;
+      }
+    }
+
+    // Add public key if exists
+    if (qr.publicMasterKey) {
+      const text = 'Key Id: ' + qr.publicMasterKey;
+
+      // Gray bar
+      moveDown(20);
+      textHeight += 20;
+      doc.setFillColor(247, 249, 249); // Gray background
+      doc.setDrawColor(0, 0, 0); // Border
+
+      // Leave a bit of space for the side of the rectangle.
+      const splitKeyId = doc.splitTextToSize(text, width - 10);
+
+      // The height of the box must be at least 15 px (for single line case), or
+      // a multiple of 13 for each line.  This allows for proper padding.
+      doc.rect(textLeft, y, width, Math.max(12 * splitKeyId.length, 15), 'FD');
+      textHeight += splitKeyId.length * doc.getLineHeight();
+      doc.text(splitKeyId, textLeft + 5, y + 10);
+    }
+
+    doc.setFont('helvetica');
+    // Move down the size of the QR code minus accumulated height on the right side, plus margin
+    // if we have a key that spans multiple pages, then exclude QR code size
+    let rowHeight = Math.max(qrSize, textHeight);
+    if (qr?.data?.length > QRBinaryMaxLength) {
+      rowHeight = textHeight;
+    }
+    const marginBottom = 15;
+    moveDown(rowHeight - (y - topY) + marginBottom);
+  });
+
+  // Add next Page
+  doc.addPage();
+
+  // next pages title
+  y = 0;
+  moveDown(55);
+  doc.setFontSize(font.header).setTextColor(color.black);
+  doc.text('BitGo KeyCard FAQ', left(0), y);
+
+  // Generate the second page's data for the backup PDF
+  moveDown(30);
+  questions.forEach(function (q) {
+    doc.setFontSize(font.subheader).setTextColor(color.black);
+    doc.text(q.question, left(0), y);
+    moveDown(20);
+    doc.setFontSize(font.body).setTextColor(color.darkgray);
+    q.answer.forEach(function (line) {
+      doc.text(line, left(0), y);
+      moveDown(font.body + 3);
+    });
+    moveDown(22);
+  });
+
+  return doc;
+}

--- a/modules/key-card/src/index.ts
+++ b/modules/key-card/src/index.ts
@@ -1,1 +1,22 @@
+import { generateQrData, GenerateQrDataParams } from './generateQrData';
+import { generateFaq } from './faq';
+import { drawKeycard } from './drawKeycard';
+
+export * from './drawKeycard';
+export * from './faq';
+export * from './generateQrData';
 export * from './utils';
+
+export interface GenerateKeycardParams extends GenerateQrDataParams {
+  activationCode?: string;
+  keyCardImage?: HTMLImageElement;
+  walletLabel: string;
+}
+
+export function generateKeycard(params: GenerateKeycardParams): void {
+  const questions = generateFaq(params.coin.fullName);
+  const qrData = generateQrData(params);
+  const keycard = drawKeycard({ ...params, questions, qrData });
+  // Save the PDF on the user's browser
+  keycard.save(`BitGo Keycard for ${params.walletLabel}.pdf`);
+}

--- a/modules/web-demo/package.json
+++ b/modules/web-demo/package.json
@@ -24,6 +24,7 @@
     "precommit": "yarn lint-staged"
   },
   "dependencies": {
+    "@bitgo/key-card": "^0.0.0",
     "@bitgo/sdk-api": "^1.9.7",
     "@bitgo/sdk-coin-ada": "^2.3.7",
     "@bitgo/sdk-coin-algo": "^1.3.12",
@@ -59,6 +60,7 @@
     "@bitgo/sdk-coin-xtz": "^1.4.12",
     "@bitgo/sdk-coin-zec": "^1.3.12",
     "@bitgo/sdk-core": "^5.2.0",
+    "@bitgo/statics": "^14.1.0",
     "bitgo": "^16.4.0",
     "lodash": "^4.17.15",
     "react": "^17.0.2",
@@ -92,10 +94,15 @@
     "webpack-dev-server": "^4.9.0"
   },
   "lint-staged": {
-    "*.{js,ts,tsx}": ["yarn prettier --write", "yarn eslint --fix"]
+    "*.{js,ts,tsx}": [
+      "yarn prettier --write",
+      "yarn eslint --fix"
+    ]
   },
   "nyc": {
-    "extension": [".ts"]
+    "extension": [
+      ".ts"
+    ]
   },
   "resolutions": {
     "@types/react": "17.0.24",

--- a/modules/web-demo/src/App.tsx
+++ b/modules/web-demo/src/App.tsx
@@ -6,6 +6,7 @@ const Home = lazy(() => import('@components/Home'));
 const BGComponent = lazy(() => import('@components/BitGoJS'));
 const BGApiComponent = lazy(() => import('@components/BitGoAPI'));
 const CoinsComponent = lazy(() => import('@components/Coins'));
+const KeyCardComponent = lazy(() => import('@components/KeyCard'));
 
 const Loading = () => <div>Loading route...</div>;
 
@@ -19,6 +20,7 @@ const App = () => {
             <Route path="/bitgo-js" element={<BGComponent />} />
             <Route path="/bitgo-api" element={<BGApiComponent />} />
             <Route path="/coins" element={<CoinsComponent />} />
+            <Route path="/keycard" element={<KeyCardComponent />} />
           </Routes>
         </Suspense>
       </Layout>

--- a/modules/web-demo/src/components/KeyCard/index.tsx
+++ b/modules/web-demo/src/components/KeyCard/index.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { coins } from '@bitgo/statics';
+import { generateKeycard } from '@bitgo/key-card';
+import { Keychain } from '@bitgo/sdk-core';
+
+function downloadKeycard() {
+  const userKeychain: Keychain = {
+    id: '63e107b5ef7bba0007145e41065b26a6',
+    pub: 'xpub661MyMwAqRbcFXFJ8wZhWjEiFg9wM89UamPyP3XsnEHg2VJ4m7wE7ALLszakPiEEy5cH9FCAvCrx1cL6rLE6jewaa1ubP8DjqsDtP4R7w5g',
+    encryptedPrv:
+      '{"iv":"pivw5c3fmgc0/1LP3SX7rA==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"XKtQHasaidc=","ct":"wXbSW115VD4e+r1pxX/wB1/2g332c4thdLkk91Fr+hrRzuoDzWyhYcaxndIP5Nzc5z0Q9HGc+cZ4Zb2Ij7O3cPoIyrsXv84NaHfVNN7rY2UopmxS4Xg05x1S936kxfZjDjlgNfj7lkrY9LzVh3wC8YGSxx960Vw="}',
+    prv: 'xprv9s21ZrQH143K33Aq2v2h9bHyheKSwfRdDYUNaf8GDtkh9gxvDacyZN1s2gpDb4QLwAK4DzxoQpDAneJTNL7vgvnneTBAKptkKLYTVCNhya6',
+    type: 'independent',
+  };
+  const backupKeychain: Keychain = {
+    id: '63e107b51af424000794ea5e39db15c6',
+    pub: 'xpub661MyMwAqRbcF7DseJgApbN9DtRXeUT3H41id4eSNCL9VDK7rDJ7kZNGS3Zz49a9XXH52qZ5KTQqQht9uciMZvaAJ7wy69a4hyKb94YMYqm',
+    type: 'independent',
+    prv: 'xprv9s21ZrQH143K2d9QYH9ATTRQfrb3F1jBuq67pgEporoAcQyyJfysCm3nanTyUvDhAhEQAHyooZsNaMFF6nYHd2sYb5nNRervxwsedLYfafh',
+  };
+  const bitgoKeychain: Keychain = {
+    id: '63e107b5ca60390007008767278e5fc4',
+    pub: 'xpub661MyMwAqRbcGWXcaHWYPH8Bz9qg6K3zSFac4hv8JZvKCorehqS8xVToEGXt7zJUfsT5aUaH1ZzjEYruXdgDRgFpAwfWxQyEuU9fpQzaPAE',
+    type: 'independent',
+  };
+
+  generateKeycard({
+    activationCode: '123456',
+    backupKeychain,
+    bitgoKeychain,
+    coin: coins.get('tsol'),
+    passcodeEncryptionCode: '654321',
+    passphrase: 'test_wallet_passphrase',
+    userKeychain,
+    walletLabel: 'Hello World',
+  });
+}
+
+const KeyCard = () => {
+  return (
+    <React.Fragment>
+      <h3>Key Card</h3>
+      <br />
+      <button onClick={downloadKeycard}>Download</button>
+    </React.Fragment>
+  );
+};
+
+export default KeyCard;

--- a/modules/web-demo/src/components/Navbar/index.tsx
+++ b/modules/web-demo/src/components/Navbar/index.tsx
@@ -32,6 +32,12 @@ const Navbar = () => {
       >
         Coins
       </NavItem>
+      <NavItem
+        activeRoute={pathname === '/keycard'}
+        onClick={() => navigate('/keycard')}
+      >
+        Key Card
+      </NavItem>
     </NavbarContainer>
   );
 };

--- a/modules/web-demo/tsconfig.json
+++ b/modules/web-demo/tsconfig.json
@@ -37,6 +37,9 @@
       "path": "../bitgo"
     },
     {
+      "path": "../key-card"
+    },
+    {
       "path": "../sdk-api"
     },
     {

--- a/modules/web-demo/webpack/base.config.js
+++ b/modules/web-demo/webpack/base.config.js
@@ -152,6 +152,10 @@ const prodPlugins = [
   }),
 ];
 
+const resolveFallback = {
+  'process/browser': require.resolve('process/browser'),
+};
+
 module.exports = {
   aliasItems,
   copyPluginPatterns,
@@ -165,4 +169,5 @@ module.exports = {
   prodRules,
   devPlugins,
   prodPlugins,
+  resolveFallback,
 };

--- a/modules/web-demo/webpack/dev.config.js
+++ b/modules/web-demo/webpack/dev.config.js
@@ -7,6 +7,7 @@ const {
   outputConfig,
   devRules,
   devPlugins,
+  resolveFallback,
 } = require('./base.config');
 const { mergeWith } = require('lodash');
 const bitgoConfig = require('../../../webpack/bitgojs.config');
@@ -28,6 +29,7 @@ module.exports = (env, options) => {
       resolve: {
         extensions: ['.tsx', '.ts', '.js'],
         alias: aliasItems,
+        fallback: resolveFallback,
       },
       output: {
         filename: 'js/[name].bundle.js',

--- a/modules/web-demo/webpack/prod.config.js
+++ b/modules/web-demo/webpack/prod.config.js
@@ -9,6 +9,7 @@ const {
   prodRules,
   prodPlugins,
   mergeCustomizer,
+  resolveFallback,
 } = require('./base.config');
 const { mergeWith } = require('lodash');
 const bitgoConfig = require('./bitgojs.config');
@@ -24,6 +25,7 @@ module.exports = (env, options) => {
       resolve: {
         extensions: ['.tsx', '.ts', '.js'],
         alias: aliasItems,
+        fallback: resolveFallback,
       },
       output: {
         filename: 'js/[name].bundle.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -885,6 +885,13 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+"@babel/runtime@^7.14.0":
+  version "7.20.13"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.13.tgz#7055ab8a7cff2b8f6058bf6ae45ff84ad2aded4b"
+  integrity sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/template@^7.18.10":
   version "7.18.10"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.10.tgz#6f9134835970d1dbf0835c0d100c9f38de0c5e71"
@@ -4747,6 +4754,11 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
+"@types/raf@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@types/raf/-/raf-3.4.0.tgz#2b72cbd55405e071f1c4d29992638e022b20acc2"
+  integrity sha512-taW5/WYqo36N7V39oYyHP9Ipfd5pNFvGTIQsNGj86xV88YQ7GnI30/yMfKDF7Zgin0m3e+ikX88FvImnK4RjGw==
+
 "@types/randombytes@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/randombytes/-/randombytes-2.0.0.tgz#0087ff5e60ae68023b9bc4398b406fea7ad18304"
@@ -5988,6 +6000,11 @@ base64-arraybuffer@0.1.4:
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz#9818c79e059b1355f97e0428a017c838e90ba812"
   integrity sha512-a1eIFi4R9ySrbiMuyTGx5e92uRH5tQY6kArNcFaKBUleIoLjdjBg7Zxm3Mqm3Kmkf27HLR/1fnxX9q8GQ7Iavg==
 
+base64-arraybuffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz#1c37589a7c4b0746e34bd1feb951da2df01c1bdc"
+  integrity sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==
+
 base64-js@^1.3.0, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -6570,6 +6587,11 @@ bs58check@<3.0.0, bs58check@^2.1.1, bs58check@^2.1.2:
     create-hash "^1.1.0"
     safe-buffer "^5.1.2"
 
+btoa@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/btoa/-/btoa-1.2.1.tgz#01a9909f8b2c93f6bf680ba26131eb30f7fa3d73"
+  integrity sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==
+
 buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
@@ -6797,6 +6819,20 @@ caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001426:
   version "1.0.30001436"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001436.tgz#22d7cbdbbbb60cdc4ca1030ccd6dea9f5de4848b"
   integrity sha512-ZmWkKsnC2ifEPoWUvSAIGyOYwT+keAaaWPHiQ9DfMqS1t6tfuyFYoWR78TeZtznkEQ64+vGXH9cZrElwR2Mrxg==
+
+canvg@^3.0.6:
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/canvg/-/canvg-3.0.10.tgz#8e52a2d088b6ffa23ac78970b2a9eebfae0ef4b3"
+  integrity sha512-qwR2FRNO9NlzTeKIPIKpnTY6fqwuYSequ8Ru8c0YkYU7U0oW+hLUvWadLvAu1Rl72OMNiFhoLu4f8eUjQ7l/+Q==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/raf" "^3.4.0"
+    core-js "^3.8.3"
+    raf "^3.4.1"
+    regenerator-runtime "^0.13.7"
+    rgbcolor "^1.0.1"
+    stackblur-canvas "^2.0.0"
+    svg-pathdata "^6.0.3"
 
 capability@^0.2.5:
   version "0.2.5"
@@ -7527,6 +7563,11 @@ core-js@^2.4.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
+core-js@^3.6.0, core-js@^3.8.3:
+  version "3.27.2"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.27.2.tgz#85b35453a424abdcacb97474797815f4d62ebbf7"
+  integrity sha512-9ashVQskuh5AZEZ1JdQWp1GqSoC1e1G87MzRqg2gIfVAQ7Qn9K+uFj8EcniUFA4P2NLZfV+TOlX1SzoKfo+s7w==
+
 core-js@^3.6.1:
   version "3.26.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.26.1.tgz#7a9816dabd9ee846c1c0fe0e8fcad68f3709134e"
@@ -7717,6 +7758,13 @@ css-has-pseudo@^3.0.4:
   integrity sha512-Vse0xpR1K9MNlp2j5w1pgWIJtm1a8qS0JwS9goFYcImjlHEmywP9VUF05aGBXzGpDJF86QXk4L0ypBmwPhGArw==
   dependencies:
     postcss-selector-parser "^6.0.9"
+
+css-line-break@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/css-line-break/-/css-line-break-2.1.0.tgz#bfef660dfa6f5397ea54116bb3cb4873edbc4fa0"
+  integrity sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==
+  dependencies:
+    utrie "^1.0.2"
 
 css-loader@^5.2.4:
   version "5.2.7"
@@ -8376,6 +8424,11 @@ domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.1:
   integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
   dependencies:
     domelementtype "^2.2.0"
+
+dompurify@^2.2.0:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.4.3.tgz#f4133af0e6a50297fc8874e2eaedc13a3c308c03"
+  integrity sha512-q6QaLcakcRjebxjg8/+NP+h0rPfatOgOzc46Fst9VAA3jF2ApfKBNKMzdP4DYTqtUMXSCd5pRS/8Po/OmoCHZQ==
 
 domutils@^2.0.0, domutils@^2.5.2, domutils@^2.8.0:
   version "2.8.0"
@@ -9608,6 +9661,11 @@ fetch-blob@^3.1.2, fetch-blob@^3.1.4:
     node-domexception "^1.0.0"
     web-streams-polyfill "^3.0.3"
 
+fflate@^0.4.8:
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.4.8.tgz#f90b82aefbd8ac174213abb338bd7ef848f0f5ae"
+  integrity sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==
+
 figures@3.2.0, figures@^3.0.0, figures@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
@@ -10622,6 +10680,14 @@ html-webpack-plugin@^5.5.0:
     lodash "^4.17.21"
     pretty-error "^4.0.0"
     tapable "^2.0.0"
+
+html2canvas@^1.0.0-rc.5:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/html2canvas/-/html2canvas-1.4.1.tgz#7cef1888311b5011d507794a066041b14669a543"
+  integrity sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==
+  dependencies:
+    css-line-break "^2.1.0"
+    text-segmentation "^1.0.3"
 
 htmlescape@^1.1.0:
   version "1.1.1"
@@ -11828,6 +11894,21 @@ jsonschema@1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.2.2.tgz#83ab9c63d65bf4d596f91d81195e78772f6452bc"
   integrity sha512-iX5OFQ6yx9NgbHCwse51ohhKgLuLL7Z5cNOeZOPIlDUtAMrxlruHLzVZxbltdHE5mEDXN+75oFOwq6Gn0MZwsA==
+
+jspdf@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/jspdf/-/jspdf-2.5.1.tgz#00c85250abf5447a05f3b32ab9935ab4a56592cc"
+  integrity sha512-hXObxz7ZqoyhxET78+XR34Xu2qFGrJJ2I2bE5w4SM8eFaFEkW2xcGRVUss360fYelwRSid/jT078kbNvmoW0QA==
+  dependencies:
+    "@babel/runtime" "^7.14.0"
+    atob "^2.1.2"
+    btoa "^1.2.1"
+    fflate "^0.4.8"
+  optionalDependencies:
+    canvg "^3.0.6"
+    core-js "^3.6.0"
+    dompurify "^2.2.0"
+    html2canvas "^1.0.0-rc.5"
 
 jsprim@^1.2.2:
   version "1.4.2"
@@ -14818,6 +14899,13 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
+raf@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
+  integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
+  dependencies:
+    performance-now "^2.1.0"
+
 ramda@0.26.1:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
@@ -15119,7 +15207,7 @@ regenerator-runtime@^0.11.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
-regenerator-runtime@^0.13.11, regenerator-runtime@^0.13.2:
+regenerator-runtime@^0.13.11, regenerator-runtime@^0.13.2, regenerator-runtime@^0.13.7:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
@@ -15391,6 +15479,11 @@ rfdc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
   integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
+
+rgbcolor@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/rgbcolor/-/rgbcolor-1.0.1.tgz#d6505ecdb304a6595da26fa4b43307306775945d"
+  integrity sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==
 
 rimraf@^2.6.1, rimraf@^2.6.3:
   version "2.7.1"
@@ -16356,6 +16449,11 @@ ssri@^9.0.0, ssri@^9.0.1:
   dependencies:
     minipass "^3.1.1"
 
+stackblur-canvas@^2.0.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/stackblur-canvas/-/stackblur-canvas-2.5.0.tgz#aa87bbed1560fdcd3138fff344fc6a1c413ebac4"
+  integrity sha512-EeNzTVfj+1In7aSLPKDD03F/ly4RxEuF/EX0YcOG0cKoPXs+SLZxDawQbexQDBzwROs4VKLWTOaZQlZkGBFEIQ==
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -16766,6 +16864,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+svg-pathdata@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/svg-pathdata/-/svg-pathdata-6.0.3.tgz#80b0e0283b652ccbafb69ad4f8f73e8d3fbf2cac"
+  integrity sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==
+
 swarm-js@^0.1.40:
   version "0.1.42"
   resolved "https://registry.yarnpkg.com/swarm-js/-/swarm-js-0.1.42.tgz#497995c62df6696f6e22372f457120e43e727979"
@@ -16917,6 +17020,13 @@ text-extensions@^1.0.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.9.0.tgz#1853e45fee39c945ce6f6c36b2d659b5aabc2a26"
   integrity sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==
+
+text-segmentation@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/text-segmentation/-/text-segmentation-1.0.3.tgz#52a388159efffe746b24a63ba311b6ac9f2d7943"
+  integrity sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==
+  dependencies:
+    utrie "^1.0.2"
 
 text-table@^0.2.0:
   version "0.2.0"
@@ -17582,6 +17692,13 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
+
+utrie@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/utrie/-/utrie-1.0.2.tgz#d42fe44de9bc0119c25de7f564a6ed1b2c87a645"
+  integrity sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==
+  dependencies:
+    base64-arraybuffer "^1.0.2"
 
 uuid@3.3.2:
   version "3.3.2"


### PR DESCRIPTION
* adds code in the key-card module that creates the key cards
* skips the QR codes on the key-cards for now, will come in a
  followup
* adds some sample code in the web-demo module that allows creation
  of a sample key card

Ticket: BG-64432

## Test Instructions

* check out the PR branch locally
* run the following commands
```
yarn install
cd modules/web-demo
yarn dev
```
Open `localhost:8080/keycard` in your browser and click on the Download button. This should generate and download a key card, compare it against the one attached to this PR:
[BitGo Keycard for Hello World.pdf](https://github.com/BitGo/BitGoJS/files/10675748/BitGo.Keycard.for.Hello.World.pdf)