### PR TITLE
feat(sdk-core): include keyShares in third party backup tss keychain

### DIFF
--- a/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsa.ts
+++ b/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsa.ts
@@ -349,6 +349,23 @@ describe('TSS Ecdsa Utils:', async function () {
       userKeychain.should.deepEqual(nockedUserKeychain);
       backupKeychain.id.should.equal('2');
       backupKeychain.provider?.should.equal(backupProvider);
+
+      // verify that all four key shares are included on the response of the backup keychain
+      assert(backupKeychain.keyShares);
+      backupKeychain.keyShares.length.should.equal(4);
+      for (const keyShare of bitgoHeldBackupShares.keyShares) {
+        backupKeychain.keyShares.should.matchAny(keyShare);
+      }
+      const bitgoToBackupShare = bitgoKeychain.keyShares?.find((keyShare) => keyShare.from === 'bitgo' && keyShare.to === 'backup');
+      assert(bitgoToBackupShare);
+      backupKeychain.keyShares.should.matchAny(bitgoToBackupShare);
+
+      const userToBackupShare = backupKeychain.keyShares.find((keyShare) => keyShare.from === 'user' && keyShare.to === 'backup');
+      assert(userToBackupShare);
+      userToBackupShare.publicShare.should.equal(Buffer.concat([
+        Buffer.from(userKeyShare.nShares[2].y, 'hex'),
+        Buffer.from(userKeyShare.nShares[2].chaincode, 'hex'),
+      ]).toString('hex'));
     });
 
     it('should generate TSS key chains with optional params', async function () {

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
@@ -282,7 +282,9 @@ export class EcdsaUtils extends baseTSSUtils<KeyShare> {
         commonKeychain: finalizedBackupKeyShare.commonKeychain,
         provider: backupProvider ?? 'BitGoTrustAsKrs',
       };
-      return await this.baseCoin.keychains().createBackup(backupKeyParams);
+      const backupKeychain = await this.baseCoin.keychains().createBackup(backupKeyParams);
+      backupKeychain.keyShares = finalizedBackupKeyShare.keyShares;
+      return backupKeychain;
     }
     assert(backupKeyShare.userHeldKeyShare);
     assert(passphrase);


### PR DESCRIPTION
This way the keyShares will be included on the backup keychain and can later easily be put on the keycard.

Ticket: BG-64432

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->