### PR TITLE
fix(sdk-core): use hex toString() verify ecdsa

### DIFF
--- a/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsa.ts
+++ b/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsa.ts
@@ -947,9 +947,9 @@ describe('TSS Ecdsa Utils:', async function () {
 
     const userKeyId = userGpgKeyActual.keyPacket.getFingerprint();
     const backupKeyId = backupGpgKeyActual.keyPacket.getFingerprint();
-    const bitgoToUserPublicU = (ecc.pointFromScalar(Buffer.from(params.bitgoKeyShare.nShares[1].u, 'hex'), false) as Uint8Array).toString()
+    const bitgoToUserPublicU = Buffer.from((ecc.pointFromScalar(Buffer.from(params.bitgoKeyShare.nShares[1].u, 'hex'), true) as Uint8Array)).toString('hex')
       + params.bitgoKeyShare.nShares[1].chaincode;
-    const bitgoToBackupPublicU = (ecc.pointFromScalar(Buffer.from(params.bitgoKeyShare.nShares[2].u, 'hex'), false) as Uint8Array).toString()
+    const bitgoToBackupPublicU = Buffer.from((ecc.pointFromScalar(Buffer.from(params.bitgoKeyShare.nShares[2].u, 'hex'), true) as Uint8Array)).toString('hex')
       + params.bitgoKeyShare.nShares[2].chaincode;
 
     bitgoKeychain.walletHSMGPGPublicKeySigs = await createWalletSignatures(

--- a/modules/sdk-core/src/bitgo/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/bitgo/tss/ecdsa/ecdsa.ts
@@ -755,12 +755,12 @@ export async function verifyWalletSignature(params: {
   const publicUValueRawNotationIndex = 2 + params.verifierIndex;
 
   // Derive public form of u-value
-  const publicUValue = ecc.pointFromScalar(Buffer.from(params.decryptedShare.slice(0, 64), 'hex'), false);
+  const publicUValue = ecc.pointFromScalar(Buffer.from(params.decryptedShare.slice(0, 64), 'hex'), true);
+  assert(publicUValue !== null, 'null public u-value');
   // Verify that the u value + chaincode is equal to the proof retrieved from the raw notations
   assert(
-    publicUValue !== null &&
-      publicUValue.toString() + params.decryptedShare.slice(64) ===
-        Buffer.from(rawNotations[publicUValueRawNotationIndex].value).toString(),
+    Buffer.from(publicUValue).toString('hex') + params.decryptedShare.slice(64) ===
+      Buffer.from(rawNotations[publicUValueRawNotationIndex].value).toString(),
     'bitgo share mismatch'
   );
 }


### PR DESCRIPTION
Passes the `hex` parameter to the `toString()` calls within the ECDSA `verifyWalletSignature()` function.

TICKET: BG-65152
