### PR TITLE
fix: accept apiKey for recoverFromWrongChain

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -228,6 +228,7 @@ export interface RecoverFromWrongChainOptions {
   wallet: string;
   walletPassphrase?: string;
   xprv?: string;
+  apiKey?: string;
   /** @deprecated */
   coin?: AbstractUtxoCoin;
   recoveryCoin?: AbstractUtxoCoin;
@@ -1269,12 +1270,13 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
    * @param params.signed return a half-signed transaction (default=true)
    * @param params.walletPassphrase the wallet passphrase
    * @param params.xprv the unencrypted xprv (used instead of wallet passphrase)
+   * @param params.apiKey for utxo coins other than [BTC,TBTC] this is a Block Chair api key
    * @returns {*}
    */
   async recoverFromWrongChain<TNumber extends number | bigint = number>(
     params: RecoverFromWrongChainOptions
   ): Promise<CrossChainRecoverySigned<TNumber> | CrossChainRecoveryUnsigned<TNumber>> {
-    const { txid, recoveryAddress, wallet, walletPassphrase, xprv } = params;
+    const { txid, recoveryAddress, wallet, walletPassphrase, xprv, apiKey } = params;
 
     // params.recoveryCoin used to be params.coin, backwards compatibility
     const recoveryCoin = params.coin || params.recoveryCoin;
@@ -1300,6 +1302,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       recoveryAddress,
       walletPassphrase: signed ? walletPassphrase : undefined,
       xprv: signed ? xprv : undefined,
+      apiKey,
     });
   }
 


### PR DESCRIPTION
## Description

This PR adds `apiKey` as an optional parameter to abstractUtxoCoin. recoverFromWrongChain. This is needed to facilitate wrong chain recoveries for source coins other than BTC. With the abcense of a blockchair api key, the code path for recoverFromWrongChain will result in IP blacklists from blockchair.  

## Issue Number

TICKET: BG-67619

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [x] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
