### PR TITLE
chore(utxo-lib): wrap verifySignature checks for zcash as unsafe

### DIFF
--- a/modules/utxo-lib/src/bitgo/zcash/ZcashPsbt.ts
+++ b/modules/utxo-lib/src/bitgo/zcash/ZcashPsbt.ts
@@ -8,6 +8,7 @@ import { Network, PsbtTransaction, Signer } from '../../';
 import { Psbt as PsbtBase } from 'bip174';
 import * as types from 'bitcoinjs-lib/src/types';
 import { UtxoTransaction } from '../UtxoTransaction';
+import { ValidateSigFunction } from 'bitcoinjs-lib/src/psbt';
 const typeforce = require('typeforce');
 
 enum Subtype {
@@ -128,9 +129,17 @@ export class ZcashPsbt extends UtxoPsbt<ZcashTransaction<bigint>> {
   // transactions because zcash hashes the value directly. Thus, it is unnecessary to have
   // the previous transaction hash on the unspent.
   signInput(inputIndex: number, keyPair: Signer, sighashTypes?: number[]): this {
+    return this.withUnsafeSignNonSegwitTrue(super.signInput.bind(this, inputIndex, keyPair, sighashTypes));
+  }
+
+  validateSignaturesOfInput(inputIndex: number, validator: ValidateSigFunction, pubkey?: Buffer): boolean {
+    return this.withUnsafeSignNonSegwitTrue(super.validateSignaturesOfInput.bind(this, inputIndex, validator, pubkey));
+  }
+
+  private withUnsafeSignNonSegwitTrue<T>(fn: () => T): T {
     (this as any).__CACHE.__UNSAFE_SIGN_NONSEGWIT = true;
     try {
-      return super.signInput(inputIndex, keyPair, sighashTypes);
+      return fn();
     } finally {
       (this as any).__CACHE.__UNSAFE_SIGN_NONSEGWIT = false;
     }

--- a/modules/utxo-lib/test/bitgo/psbt/ZcashPsbt.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/ZcashPsbt.ts
@@ -40,4 +40,23 @@ describe('Zcash PSBT', function () {
     }
     [400, 450, 500].forEach((version) => testFromHexForVersion(version));
   });
+
+  describe('should be able to sign the transaction', function () {
+    it('can sign the inputs', async function () {
+      psbt.signAllInputsHD(rootWalletKeys.user);
+      assert(!(psbt as any).__CACHE.__UNSAFE_SIGN_NONSEGWIT);
+      psbt.signAllInputsHD(rootWalletKeys.bitgo);
+      assert(!(psbt as any).__CACHE.__UNSAFE_SIGN_NONSEGWIT);
+    });
+
+    it('can validate the signatures on the unspents', async function () {
+      psbt.validateSignaturesOfAllInputs();
+      assert(!(psbt as any).__CACHE.__UNSAFE_SIGN_NONSEGWIT);
+    });
+
+    it('can finalize and extract the transaction', async function () {
+      psbt.finalizeAllInputs();
+      psbt.extractTransaction(true);
+    });
+  });
 });


### PR DESCRIPTION
For Zcash transactions, we do not have to have non-witness UTXO data for non-segwit transactions because zcash hashes the value directly. Thus, it is unnecessary to have the previous transaction hash on the unspent. We did this for signing inputs and we need to do it for validating inputs as well.

BG-66521

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->