### PR TITLE
fix: convert addr to canonical addr during wrongChainRecovery

### DIFF
--- a/modules/abstract-utxo/src/recovery/crossChainRecovery.ts
+++ b/modules/abstract-utxo/src/recovery/crossChainRecovery.ts
@@ -116,9 +116,12 @@ async function getAllRecoveryOutputs<TNumber extends number | bigint = number>(
   const tx = await api.getTransactionIO(txid);
   const addresses = tx.outputs.map((output) => output.address);
   const unspents = await api.getUnspentsForAddresses(addresses);
+  // the api may return cashaddr's instead of legacy for BCH and BCHA
+  // downstream processes's only expect legacy addresses
   return unspents.map((recoveryOutput) => {
     return {
       ...recoveryOutput,
+      address: coin.canonicalAddress(recoveryOutput.address),
       value: utxolib.bitgo.toTNumber<TNumber>(BigInt(recoveryOutput.value), amountType),
     };
   });

--- a/modules/sdk-coin-bch/src/bch.ts
+++ b/modules/sdk-coin-bch/src/bch.ts
@@ -35,11 +35,11 @@ export class Bch extends AbstractUtxoCoin {
    * https://www.bitcoinabc.org/cashaddr. We're sticking with the old base58 format because
    * migrating over to the new format will be laborious, and we want to see how the space evolves
    *
-   * @param address
+   * @param address may or may not be prefixed with the network, example bitcoincash:pppkt7q2axpsm2cajyjtu6x8fsh6ywauzgxmsru962 or pppkt7q2axpsm2cajyjtu6x8fsh6ywauzgxmsru962
    * @param version the version of the desired address, 'base58' or 'cashaddr', defaulting to 'base58'
    * @returns {*} address string
    */
-  canonicalAddress(address, version = 'base58') {
+  canonicalAddress(address: string, version: unknown = 'base58'): string {
     if (version === 'base58') {
       return utxolib.addressFormat.toCanonicalFormat(address, this.network);
     }

--- a/modules/sdk-coin-bch/test/unit/bch.ts
+++ b/modules/sdk-coin-bch/test/unit/bch.ts
@@ -21,6 +21,9 @@ describe('Custom BCH Tests', function () {
     bch
       .canonicalAddress('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a', 'cashaddr')
       .should.equal('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a');
+    bch
+      .canonicalAddress('qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a', 'cashaddr')
+      .should.equal('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a');
 
     // P2PKH base58 -> cashaddr
     bch
@@ -30,6 +33,9 @@ describe('Custom BCH Tests', function () {
     // P2SH cashaddr -> cashaddr
     bch
       .canonicalAddress('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq', 'cashaddr')
+      .should.equal('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq');
+    bch
+      .canonicalAddress('ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq', 'cashaddr')
       .should.equal('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq');
 
     // P2SH base58 -> cashaddr
@@ -46,6 +52,9 @@ describe('Custom BCH Tests', function () {
     bch
       .canonicalAddress('bitcoincash:qqq3728yw0y47sqn6l2na30mcw6zm78dzqre909m2r', 'base58')
       .should.equal('16w1D5WRVKJuZUsSRzdLp9w3YGcgoxDXb');
+    bch
+      .canonicalAddress('qqq3728yw0y47sqn6l2na30mcw6zm78dzqre909m2r', 'base58')
+      .should.equal('16w1D5WRVKJuZUsSRzdLp9w3YGcgoxDXb');
 
     // P2PKH base58 -> base58
     bch
@@ -55,6 +64,9 @@ describe('Custom BCH Tests', function () {
     // P2SH cashaddr -> base58
     bch
       .canonicalAddress('bitcoincash:pr95sy3j9xwd2ap32xkykttr4cvcu7as4yc93ky28e', 'base58')
+      .should.equal('3LDsS579y7sruadqu11beEJoTjdFiFCdX4');
+    bch
+      .canonicalAddress('pr95sy3j9xwd2ap32xkykttr4cvcu7as4yc93ky28e', 'base58')
       .should.equal('3LDsS579y7sruadqu11beEJoTjdFiFCdX4');
 
     // P2SH base58 -> base58
@@ -66,10 +78,16 @@ describe('Custom BCH Tests', function () {
     bch
       .canonicalAddress('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq')
       .should.equal('3CWFddi6m4ndiGyKqzYvsFYagqDLPVMTzC');
+    bch
+      .canonicalAddress('ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq')
+      .should.equal('3CWFddi6m4ndiGyKqzYvsFYagqDLPVMTzC');
 
     // all capitalized
     bch
       .canonicalAddress('BITCOINCASH:QQQ3728YW0Y47SQN6L2NA30MCW6ZM78DZQRE909M2R', 'base58')
+      .should.equal('16w1D5WRVKJuZUsSRzdLp9w3YGcgoxDXb');
+    bch
+      .canonicalAddress('QQQ3728YW0Y47SQN6L2NA30MCW6ZM78DZQRE909M2R', 'base58')
       .should.equal('16w1D5WRVKJuZUsSRzdLp9w3YGcgoxDXb');
 
     // testnet addresses
@@ -83,7 +101,10 @@ describe('Custom BCH Tests', function () {
       .canonicalAddress('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'cashaddr')
       .should.equal('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f');
     tbch
-      .canonicalAddress('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'base58')
+      .canonicalAddress('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'cashaddr')
+      .should.equal('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f');
+    tbch
+      .canonicalAddress('prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'base58')
       .should.equal('2NCEDmmKNNnqKvnWw7pE3RLzuFe5aHHVy1X');
     tbch
       .canonicalAddress('prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'base58')


### PR DESCRIPTION
## Description

This PR fixes a bug in the wrongChainRecovery flow where `getAllRecoveryOutputs` propagates cashaddr formatted addresses in the return value. Downstream processes only expect legacy address formats.

This is only a recent issue as we have changed the api provider. Previously it was BitGo indexer api, which always returned legacy address formats. 

## Issue Number

TICKET: BG-67646

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Existing tests have been updated to mock cashaddr, while keeping the expected outputs the same.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [x] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
