### PR TITLE
fix(sdk-coin-atom): fix get address method to generate unique address

### DIFF
--- a/modules/sdk-coin-atom/src/lib/keyPair.ts
+++ b/modules/sdk-coin-atom/src/lib/keyPair.ts
@@ -58,7 +58,7 @@ export class KeyPair extends Secp256k1ExtendedKeyPair {
   getAddress(): string {
     const PUBLIC_KEY_SIZE = 32;
     const tmp = new Uint8Array(PUBLIC_KEY_SIZE + 1);
-    const pubBuf = Buffer.from(this.getPublicKey({ compressed: false }).toString(), 'hex');
+    const pubBuf = Buffer.from(this.getKeys().pub.slice(0, 64), 'hex');
     tmp.set(pubBuf, 1);
     // convert to base64
     const base64String = toBase64(tmp);

--- a/modules/sdk-coin-atom/test/resources/atom.ts
+++ b/modules/sdk-coin-atom/test/resources/atom.ts
@@ -1,6 +1,7 @@
 export const TEST_ACCOUNT = {
-  pubAddress: 'cosmos1988uvdmz2kncg50wkjcjnmvw4nl69lh0jfl8v6',
+  pubAddress: 'cosmos1ctwlqlm4lgnyxz5430ar4nvn43gv8t9mwejyf6',
   compressedPublicKey: '02001fda4568760a99e58ee295b4a51edcc6a689297a71f7d1571cf4e1253baf30',
+  compressedPublicKeyTwo: '02001fda4568760a99e58ee295b4a51edcc6a689297a71f7d1571cf4e1253abcde',
   uncompressedPublicKey:
     '04001fda4568760a99e58ee295b4a51edcc6a689297a71f7d1571cf4e1253baf3036cc7d5af7ade45e189834f19730438f8ca10f3d2a7520f7405ebd29d66c4588',
   privateKey: '2904281770077a37148834686b5931376b8c78842c9fd25c90d7f012f459a5ea',

--- a/modules/sdk-coin-atom/test/unit/keyPair.ts
+++ b/modules/sdk-coin-atom/test/unit/keyPair.ts
@@ -97,7 +97,7 @@ describe('ATOM Key Pair', () => {
     });
   });
 
-  describe('should get address ', () => {
+  describe('get unique address ', () => {
     it('from a private key', () => {
       const keyPair = new KeyPair({ prv: TEST_ACCOUNT.privateKey });
       should.equal(keyPair.getAddress(), TEST_ACCOUNT.pubAddress);
@@ -106,6 +106,12 @@ describe('ATOM Key Pair', () => {
     it('from a compressed public key', () => {
       const keyPair = new KeyPair({ pub: TEST_ACCOUNT.compressedPublicKey });
       should.equal(keyPair.getAddress(), TEST_ACCOUNT.pubAddress);
+    });
+
+    it('should be different for different public keys', () => {
+      const keyPairOne = new KeyPair({ pub: TEST_ACCOUNT.compressedPublicKey });
+      const keyPairTwo = new KeyPair({ pub: TEST_ACCOUNT.compressedPublicKeyTwo });
+      should.notEqual(keyPairOne.getAddress(), keyPairTwo.getAddress());
     });
   });
 });


### PR DESCRIPTION
Ticket: [BG-68083](https://bitgoinc.atlassian.net/browse/BG-68083)


### Context

Wallet creation workflow does not seem to create unique root address and instead creates same root address for different public keys. This seems to be happening since the SDK key pair changes were [incorporated into WP](https://github.com/BitGo/bitgo-microservices/pull/28855).

On looking further, the `getAddress()` method inside the atom sdk module was computing the same base64 string, from an empty usigned int array. This base64 string was always `AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA` and therefore, returned the same cosmos root address, when the corresponding cosmjs libraries were called to convert the base 64 string to a cosmos specific address.



[BG-68083]: https://bitgoinc.atlassian.net/browse/BG-68083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ