### PR TITLE
feat: move vss proof data to be with signature share

### DIFF
--- a/modules/sdk-core/src/bitgo/tss/common.ts
+++ b/modules/sdk-core/src/bitgo/tss/common.ts
@@ -47,10 +47,7 @@ export async function sendSignatureShare(
   signerShare?: string,
   mpcAlgorithm: 'eddsa' | 'ecdsa' = 'eddsa',
   apiMode: 'full' | 'lite' = 'lite',
-  vssProof?: string,
-  privateShareProof?: string,
-  userPublicGpgKey?: string,
-  publicShare?: string
+  userPublicGpgKey?: string
 ): Promise<SignatureShareRecord> {
   let addendum = '';
   switch (requestType) {
@@ -71,10 +68,7 @@ export async function sendSignatureShare(
     .send({
       signatureShare,
       signerShare,
-      vssProof,
-      privateShareProof,
       userPublicGpgKey,
-      publicShare,
     })
     .result();
 }

--- a/modules/sdk-core/src/bitgo/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/bitgo/tss/ecdsa/ecdsa.ts
@@ -189,6 +189,10 @@ export type MuDShare = { muShare: MUShare; dShare: DShare; i: ShareKeyPosition }
  * @param shareType
  * @param share
  * @param signerShare
+ * @param vssProof - the v value of the share
+ * @param privateShareProof - the uSig of the share
+ * @param publicShare - the y value of the share
+ * @param userPublicGpgKey - the public key of the gpg key used for creating the privateShareProof
  * @returns {Promise<SignatureShareRecord>} - a Signature Share
  */
 export async function sendShareToBitgo(
@@ -201,8 +205,8 @@ export async function sendShareToBitgo(
   signerShare?: string,
   vssProof?: string,
   privateShareProof?: string,
-  userPublicGpgKey?: string,
-  publicShare?: string
+  publicShare?: string,
+  userPublicGpgKey?: string
 ): Promise<SendShareToBitgoRT> {
   if (shareType !== SendShareType.SShare && share.i !== ShareKeyPosition.BITGO) {
     throw new Error('Invalid Share, is not from User to Bitgo');
@@ -215,6 +219,9 @@ export async function sendShareToBitgo(
       assert(signerShare, `signer share must be present`);
       const kShare = share as KShare;
       signatureShare = convertKShare(kShare);
+      signatureShare.vssProof = vssProof;
+      signatureShare.publicShare = publicShare;
+      signatureShare.privateShareProof = privateShareProof;
       await sendSignatureShare(
         bitgo,
         walletId,
@@ -224,10 +231,7 @@ export async function sendShareToBitgo(
         signerShare,
         'ecdsa',
         'full',
-        vssProof,
-        privateShareProof,
-        userPublicGpgKey,
-        publicShare
+        userPublicGpgKey
       );
       responseFromBitgo = await getBitgoToUserLatestShare(
         bitgo,

--- a/modules/sdk-core/src/bitgo/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/bitgo/tss/eddsa/eddsa.ts
@@ -205,6 +205,9 @@ export async function offerUserToBitgoRShare(
     from: SignatureShareType.USER,
     to: SignatureShareType.BITGO,
     share: rShare.r + rShare.R,
+    vssProof,
+    privateShareProof,
+    publicShare,
   };
 
   // TODO (BG-57944): implement message signing for EDDSA
@@ -217,10 +220,7 @@ export async function offerUserToBitgoRShare(
     encryptedSignerShare,
     'eddsa',
     apiMode,
-    vssProof,
-    privateShareProof,
-    userPublicGpgKey,
-    publicShare
+    userPublicGpgKey
   );
 }
 

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -242,6 +242,9 @@ export interface SignatureShareRecord {
   from: SignatureShareType;
   to: SignatureShareType;
   share: string;
+  vssProof?: string;
+  privateShareProof?: string;
+  publicShare?: string;
 }
 
 export type TSSParams = {


### PR DESCRIPTION
The VSS proof data should be with the signature share. The `signatureShare` field will be replaced by `signatureShares` field (an array) in the future and the VSS proof data will be different for each of them.
More info on multiple shares to be signed at once: https://bitgoinc.atlassian.net/browse/BG-52812

Ticket: BG-67907

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->