### PR TITLE
fix(sdk-core): verifyWalletSignatures support in offline settings

### DIFF
--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
@@ -768,18 +768,20 @@ export class EcdsaUtils extends baseTSSUtils<KeyShare> {
    * @param bitgoKeychain previously created BitGo keychain; must be compatible with user and backup key shares
    * @param decryptedShare The decrypted bitgo-to-user/backup private share retrieved from the keychain
    * @param verifierIndex The index of the party to verify: 1 = user, 2 = backup
+   * @param bitgoGpgPub Bitgo's public GPG key for encryption between bitgo/backup or user
    */
   async verifyWalletSignatures(
     userGpgPub: string,
     backupGpgPub: string,
     bitgoKeychain: Keychain,
     decryptedShare: string,
-    verifierIndex: 1 | 2
+    verifierIndex: 1 | 2,
+    bitgoGpgPub?: openpgp.Key
   ): Promise<void> {
     assert(bitgoKeychain.commonKeychain);
     assert(bitgoKeychain.walletHSMGPGPublicKeySigs);
-
-    const bitgoGpgKey = await getBitgoGpgPubKey(this.bitgo);
+    // Allow config of bitgo's gpg key in settings where the sdk is being used offline.
+    const bitgoGpgKey = bitgoGpgPub ?? (await getBitgoGpgPubKey(this.bitgo));
     const userKeyPub = await openpgp.readKey({ armoredKey: userGpgPub });
     const userKeyId = userKeyPub.keyPacket.getFingerprint();
     const backupKeyPub = await openpgp.readKey({ armoredKey: backupGpgPub });

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
@@ -39,12 +39,14 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
     backupGpgPub: string,
     bitgoKeychain: Keychain,
     decryptedShare: string,
-    verifierIndex: 1 | 2
+    verifierIndex: 1 | 2,
+    bitgoGpgPub?: openpgp.Key
   ): Promise<void> {
     assert(bitgoKeychain.commonKeychain);
     assert(bitgoKeychain.walletHSMGPGPublicKeySigs);
 
-    const bitgoGpgKey = await getBitgoGpgPubKey(this.bitgo);
+    // Allow config of bitgo's gpg key in settings where the sdk is being used offline.
+    const bitgoGpgKey = bitgoGpgPub ?? (await getBitgoGpgPubKey(this.bitgo));
 
     const userKeyPub = await openpgp.readKey({ armoredKey: userGpgPub });
     const userKeyId = userKeyPub.keyPacket.getFingerprint();


### PR DESCRIPTION
Ticket: BG-58578

verifyWalletSignatures is fetching Bitgo's GPG Pub key from WP, however in some settings where the sdk is being used offline that call would not be possible. Since this is a public facing function, i.e. someone can import sdk-core and use this function, it makes sense to also allow verifying wallet signatures coming from HSM in a way where bitgo's public gpg key is baked in an offline setting.

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->