### PR TITLE
feat(sdk-core): add `switchValidator` for stakingWallet

### DIFF
--- a/modules/bitgo/test/v2/unit/staking/stakingWalletCommon.ts
+++ b/modules/bitgo/test/v2/unit/staking/stakingWalletCommon.ts
@@ -119,6 +119,37 @@ describe('Staking Wallet Common', function () {
 
   });
 
+  describe('switch validator', function () {
+    it('should call staking-service to switch validator', async function () {
+      const expected = fixtures.stakingRequest(
+        [
+          fixtures.transaction('NEW'),
+        ]);
+      const msScope = nock(microservicesUri)
+        .post(`/api/staking/v1/${stakingWallet.coin}/wallets/${stakingWallet.walletId}/requests`, {
+          amount: '1',
+          clientId: 'clientId',
+          validator: 'validator',
+          delegationId: 'delegation',
+          type: 'SWITCH_VALIDATOR',
+        })
+        .reply(201, expected);
+
+      const stakingRequest = await stakingWallet.switchValidator({
+        amount: '1',
+        clientId: 'clientId',
+        validator: 'validator',
+        delegationId: 'delegation',
+      });
+
+      should.exist(stakingRequest);
+
+      stakingRequest.should.deepEqual(expected);
+      msScope.isDone().should.be.True();
+    });
+
+  });
+
   describe('cancelStakingRequest', function () {
     it('should call staking-service to cancel staking request', async function () {
       const stakingRequestId = '8638284a-dab2-46b9-b07f-21109a6e7220';

--- a/modules/sdk-core/src/bitgo/staking/iStakingWallet.ts
+++ b/modules/sdk-core/src/bitgo/staking/iStakingWallet.ts
@@ -31,6 +31,13 @@ export interface UnstakeOptions {
   delegationId?: string;
 }
 
+export interface SwitchValidatorOptions {
+  amount: string;
+  clientId?: string;
+  delegationId: string;
+  validator: string;
+}
+
 export interface DelegationOptions {
   delegationStatus?: DelegationStatus;
   delegationIds?: Set<string>;
@@ -106,6 +113,7 @@ export interface IStakingWallet {
   readonly coin: string;
   stake(options: StakeOptions): Promise<StakingRequest>;
   unstake(options: UnstakeOptions): Promise<StakingRequest>;
+  switchValidator(options: SwitchValidatorOptions): Promise<StakingRequest>;
   getStakingRequest(stakingRequestId: string): Promise<StakingRequest>;
   getTransactionsReadyToSign(stakingRequestId: string): Promise<TransactionsReadyToSign>;
   build(transaction: StakingTransaction): Promise<StakingPrebuildTransactionResult>;

--- a/modules/sdk-core/src/bitgo/staking/stakingWallet.ts
+++ b/modules/sdk-core/src/bitgo/staking/stakingWallet.ts
@@ -11,6 +11,7 @@ import {
   StakingSignedTransaction,
   StakingSignOptions,
   StakingTransaction,
+  SwitchValidatorOptions,
   TransactionsReadyToSign,
   UnstakeOptions,
 } from './iStakingWallet';
@@ -57,6 +58,16 @@ export class StakingWallet implements IStakingWallet {
    */
   async unstake(options: UnstakeOptions): Promise<StakingRequest> {
     return await this.createStakingRequest(options, 'UNSTAKE');
+  }
+
+  /**
+   * Submit a request to switch the validator used for a specific delegation
+   * This will create a new delegation with the new validator address and mark the old delegation as inactive
+   * @param options - switch validator options
+   * @return StakingRequest
+   */
+  async switchValidator(options: SwitchValidatorOptions): Promise<StakingRequest> {
+    return await this.createStakingRequest(options, 'SWITCH_VALIDATOR');
   }
 
   /**
@@ -212,7 +223,10 @@ export class StakingWallet implements IStakingWallet {
       .result();
   }
 
-  private async createStakingRequest(options: StakeOptions | UnstakeOptions, type: string): Promise<StakingRequest> {
+  private async createStakingRequest(
+    options: StakeOptions | UnstakeOptions | SwitchValidatorOptions,
+    type: string
+  ): Promise<StakingRequest> {
     return await this.bitgo
       .post(this.bitgo.microservicesUrl(this.stakingRequestsURL()))
       .send({


### PR DESCRIPTION
add support for `SWITCH_VALIDATOR` staking request.
currently only SUI will be using the new type