### PR TITLE
build(root): node verison was not specified

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,10 +105,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Setup node:${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+      - name: Setup node 16
+        uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 16 # this just needs to pass our lock file requirement for compilation
 
       - name: Build Info
         run: |


### PR DESCRIPTION
Even browser-test does not need Node.js to run, `yarn install` still checks the Node version in package.json files. Since the CI is picking up version `18` as default, which is not what we support, specifying Node version in `brower-test` step.

This will unblock various the build issues we have in `origin/master` right now

Ticket: BG-0