### PR TITLE
chore: dont require recipient in both txParam and preBuild

### DIFF
--- a/modules/sdk-coin-avaxc/test/unit/avaxc.ts
+++ b/modules/sdk-coin-avaxc/test/unit/avaxc.ts
@@ -510,8 +510,7 @@ describe('Avalanche C-Chain', function () {
     });
 
     it('should reject when client txParams are missing', async function () {
-      const coin = bitgo.coin('teth');
-      const wallet = new Wallet(bitgo, coin, {});
+      const wallet = new Wallet(bitgo, tavaxCoin, {});
 
       const txParams = null;
 
@@ -528,7 +527,7 @@ describe('Avalanche C-Chain', function () {
 
       const verification = {};
 
-      await coin
+      await tavaxCoin
         .verifyTransaction({ txParams: txParams as any, txPrebuild: txPrebuild as any, wallet, verification })
         .should.be.rejectedWith('missing params');
     });

--- a/modules/sdk-coin-polygon/test/unit/polygon.ts
+++ b/modules/sdk-coin-polygon/test/unit/polygon.ts
@@ -290,7 +290,7 @@ describe('Polygon', function () {
       isTransactionVerified.should.equal(true);
     });
 
-    it('should reject when client txParams are missing', async function () {
+    it('should not reject when client txParams are missing', async function () {
       const wallet = new Wallet(bitgo, basecoin, {});
 
       const txParams = null;
@@ -308,9 +308,7 @@ describe('Polygon', function () {
 
       const verification = {};
 
-      await basecoin
-        .verifyTransaction({ txParams, txPrebuild, wallet, verification })
-        .should.be.rejectedWith('missing params');
+      (await basecoin.verifyTransaction({ txParams, txPrebuild, wallet, verification })).should.be.true();
     });
 
     it('should reject txPrebuild that is both batch and hop', async function () {


### PR DESCRIPTION
While working on the nonce hole UI work I encountered an issue when trying to submit a prebuilt transaction via sendMany:

` fromWallet.sendMany({
      prebuildTx: prebuiltTransaction,
      walletPassphrase: walletPassphrase,
    }),`

When trying to submit the transaction via sendMany **with** a `prebuildTx` present  and no recipients field I got  'missing params' error and realized it was because eth verify transaction excepts that **both** txParams & prebuildTx to have `recipients`. However, when I try to pass recipients as part of the params (see below), I ran into this [error](https://github.com/BitGo/BitGoJS/blob/5f9ec7274eb8313697ce1295933d2e2acd2526ab/modules/sdk-core/src/bitgo/wallet/wallet.ts#L1743-L1747). 


` fromWallet.sendMany({
      prebuildTx: prebuiltTransaction,
      walletPassphrase: walletPassphrase,
      recipients: prebuiltTransaction.recipients
    }),`


Seems like a bug to me