### PR TITLE
feat(utxo-lib): add methods for creating PSBTs for inscription txs

### DIFF
--- a/modules/utxo-ord/package.json
+++ b/modules/utxo-ord/package.json
@@ -26,7 +26,8 @@
     "directory": "modules/utxo-ord"
   },
   "dependencies": {
-    "@bitgo/utxo-lib": "^7.7.0"
+    "@bitgo/utxo-lib": "^7.7.0",
+    "@bitgo/unspents": "^0.11.12"
   },
   "lint-staged": {
     "*.{js,ts}": [

--- a/modules/utxo-ord/src/OutputLayout.ts
+++ b/modules/utxo-ord/src/OutputLayout.ts
@@ -242,8 +242,8 @@ function toOutputLayout(total: bigint, p: Parameters<Constraint>): OutputLayout 
  * High-level constraints for output layout
  */
 export type SearchParams = {
-  minChange: bigint;
-  maxChange: bigint;
+  minChangeOutput: bigint;
+  maxChangeOutput: bigint;
   minInscriptionOutput: bigint;
   maxInscriptionOutput: bigint;
   feeFixed: bigint;
@@ -252,8 +252,8 @@ export type SearchParams = {
 
 /**
  * @param inscriptionInput
- * @param minChange
- * @param maxChange
+ * @param minChangeOutput
+ * @param maxChangeOutput
  * @param minInscriptionOutput
  * @param maxInscriptionOutput
  * @param feeFixed
@@ -262,14 +262,7 @@ export type SearchParams = {
  */
 export function findOutputLayout(
   inscriptionInput: OrdOutput,
-  {
-    minChange = BigInt(10_000),
-    maxChange = Constraint.MAXSAT,
-    minInscriptionOutput = BigInt(10_000),
-    maxInscriptionOutput = BigInt(20_000),
-    feeFixed,
-    feePerOutput,
-  }: SearchParams
+  { minChangeOutput, maxChangeOutput, minInscriptionOutput, maxInscriptionOutput, feeFixed, feePerOutput }: SearchParams
 ): OutputLayout | undefined {
   if (inscriptionInput.ordinals.length !== 1) {
     throw new Error(`unexpected ordinal count`);
@@ -283,7 +276,7 @@ export function findOutputLayout(
   }
 
   const fixedZero = Constraint.ZERO;
-  const expandableChangePadding = new Constraint(minChange, maxChange);
+  const expandableChangePadding = new Constraint(minChangeOutput, maxChangeOutput);
   const expandableInscriptionConstraint = new Constraint(minInscriptionOutput, maxInscriptionOutput);
   const fixedMinInscriptionConstraint = new Constraint(minInscriptionOutput, minInscriptionOutput);
   const fixedMaxInscriptionConstraint = new Constraint(maxInscriptionOutput, maxInscriptionOutput);

--- a/modules/utxo-ord/src/index.ts
+++ b/modules/utxo-ord/src/index.ts
@@ -6,3 +6,4 @@ export * from './SatRange';
 export * from './OrdOutput';
 export * from './OutputLayout';
 export * from './SatPoint';
+export * from './psbt';

--- a/modules/utxo-ord/src/psbt.ts
+++ b/modules/utxo-ord/src/psbt.ts
@@ -1,0 +1,157 @@
+import { Network, bitgo, address } from '@bitgo/utxo-lib';
+import { Dimensions, VirtualSizes } from '@bitgo/unspents';
+
+import {
+  getOrdOutputsForLayout,
+  OrdOutput,
+  OutputLayout,
+  toArray,
+  SatPoint,
+  findOutputLayout,
+  Constraint,
+  parseSatPoint,
+  SatRange,
+} from './index';
+
+export type WalletOutputPath = {
+  chain: bitgo.ChainCode;
+  index: number;
+};
+
+export type WalletInputBuilder = {
+  walletKeys: bitgo.RootWalletKeys;
+  signer: bitgo.KeyName;
+  cosigner: bitgo.KeyName;
+};
+
+export type InscriptionOutputs = {
+  inscriptionRecipient: string | Buffer;
+  changeOutputs: [WalletOutputPath, WalletOutputPath];
+};
+
+export type InscriptionTransactionConstraints = {
+  feeRateSatKB: number;
+  minChangeOutput?: bigint;
+  maxChangeOutput?: bigint;
+  minInscriptionOutput?: bigint;
+  maxInscriptionOutput?: bigint;
+};
+
+export function createPsbtFromOutputLayout(
+  network: Network,
+  inputBuilder: WalletInputBuilder,
+  unspents: bitgo.WalletUnspent<bigint>[],
+  outputs: InscriptionOutputs,
+  outputLayout: OutputLayout
+): bitgo.UtxoPsbt {
+  const psbt = bitgo.createPsbtForNetwork({ network: network });
+  if (unspents.length !== 1) {
+    throw new Error(`multiple unspents not supported yet`);
+  }
+  unspents.forEach((u) =>
+    bitgo.addWalletUnspentToPsbt(
+      psbt,
+      u,
+      inputBuilder.walletKeys,
+      inputBuilder.signer,
+      inputBuilder.cosigner,
+      psbt.network
+    )
+  );
+  const [input] = unspents;
+  const ordOutputs = getOrdOutputsForLayout(new OrdOutput(input.value), outputLayout);
+  toArray(ordOutputs).forEach((ordOutput) => {
+    if (ordOutput === null) {
+      return;
+    }
+    switch (ordOutput) {
+      // skip padding outputs and fee output (virtual)
+      case null:
+      case ordOutputs.feeOutput:
+        return;
+      // add padding outputs
+      case ordOutputs.firstChangeOutput:
+      case ordOutputs.secondChangeOutput:
+        const { chain, index } =
+          ordOutput === ordOutputs.firstChangeOutput ? outputs.changeOutputs[0] : outputs.changeOutputs[1];
+        bitgo.addWalletOutputToPsbt(psbt, inputBuilder.walletKeys, chain, index, ordOutput.value);
+        break;
+      // add actual inscription output
+      case ordOutputs.inscriptionOutput:
+        let { inscriptionRecipient } = outputs;
+        if (typeof inscriptionRecipient === 'string') {
+          inscriptionRecipient = address.toOutputScript(inscriptionRecipient, network);
+        }
+        psbt.addOutput({
+          script: inscriptionRecipient,
+          value: ordOutput.value,
+        });
+        break;
+    }
+  });
+  return psbt;
+}
+
+function toSatRange(p: SatPoint) {
+  const { offset } = parseSatPoint(p);
+  return new SatRange(offset, offset);
+}
+
+function getFee(vsize: number, rateSatPerKB: number): bigint {
+  return BigInt(Math.ceil((vsize * rateSatPerKB) / 1000));
+}
+
+export function findOutputLayoutForWalletUnspents(
+  inputs: bitgo.WalletUnspent<bigint>[],
+  satPoint: SatPoint,
+  outputs: InscriptionOutputs,
+  constraints: InscriptionTransactionConstraints
+): OutputLayout | undefined {
+  if (inputs.length !== 1) {
+    throw new Error(`only single input supported currently`);
+  }
+
+  if (outputs.changeOutputs[0].chain !== outputs.changeOutputs[1].chain) {
+    // otherwise our fee calc is too complicated
+    throw new Error(`wallet outputs must be on same chain`);
+  }
+
+  const {
+    minChangeOutput = BigInt(10_000),
+    maxChangeOutput = Constraint.MAXSAT,
+    minInscriptionOutput = BigInt(10_000),
+    maxInscriptionOutput = BigInt(20_000),
+  } = constraints;
+
+  const [input] = inputs;
+  const inscriptionOutput = new OrdOutput(input.value, [toSatRange(satPoint)]);
+  return findOutputLayout(inscriptionOutput, {
+    minChangeOutput,
+    maxChangeOutput,
+    minInscriptionOutput,
+    maxInscriptionOutput,
+    feeFixed: getFee(
+      VirtualSizes.txSegOverheadVSize + Dimensions.fromUnspents(inputs).getInputsVSize(),
+      constraints.feeRateSatKB
+    ),
+    feePerOutput: getFee(
+      Dimensions.fromOutputOnChain(outputs.changeOutputs[0].chain).getOutputsVSize(),
+      constraints.feeRateSatKB
+    ),
+  });
+}
+
+export function createPsbtForSingleInscriptionPassingTransaction(
+  network: Network,
+  inputBuilder: WalletInputBuilder,
+  unspents: bitgo.WalletUnspent<bigint>[],
+  satPoint: SatPoint,
+  outputs: InscriptionOutputs,
+  constraints: InscriptionTransactionConstraints
+): bitgo.UtxoPsbt {
+  const layout = findOutputLayoutForWalletUnspents(unspents, satPoint, outputs, constraints);
+  if (!layout) {
+    throw new Error(`could not output layout for inscription passing transaction`);
+  }
+  return createPsbtFromOutputLayout(network, inputBuilder, unspents, outputs, layout);
+}

--- a/modules/utxo-ord/test/OutputLayout.ts
+++ b/modules/utxo-ord/test/OutputLayout.ts
@@ -6,8 +6,8 @@ import { output, range } from './util';
 
 describe('Ordinal Transaction Layout', function () {
   const params: SearchParams = {
-    minChange: BigInt(10),
-    maxChange: Constraint.MAXSAT,
+    minChangeOutput: BigInt(10),
+    maxChangeOutput: Constraint.MAXSAT,
     minInscriptionOutput: BigInt(10),
     maxInscriptionOutput: BigInt(20),
     feeFixed: BigInt(10),

--- a/modules/utxo-ord/test/psbt.ts
+++ b/modules/utxo-ord/test/psbt.ts
@@ -1,0 +1,102 @@
+import * as assert from 'assert';
+import {
+  InscriptionOutputs,
+  createPsbtForSingleInscriptionPassingTransaction,
+  createPsbtFromOutputLayout,
+  findOutputLayoutForWalletUnspents,
+  WalletInputBuilder,
+} from '../src/psbt';
+import { isSatPoint, OutputLayout, toParameters } from '../src';
+import { bitgo, networks, testutil } from '@bitgo/utxo-lib';
+
+function assertValidPsbt(
+  psbt: bitgo.UtxoPsbt,
+  s: bitgo.WalletUnspentSigner<bitgo.RootWalletKeys>,
+  expectedOutputs: number,
+  expectedFee: bigint
+) {
+  psbt.signAllInputsHD(s.signer);
+  psbt.signAllInputsHD(s.cosigner);
+  psbt.finalizeAllInputs();
+  assert.strictEqual(psbt.txOutputs.length, expectedOutputs);
+  assert.strictEqual(psbt.getFee(), expectedFee);
+}
+
+describe('OutputLayout to PSBT conversion', function () {
+  const network = networks.bitcoin;
+  const walletKeys = testutil.getDefaultWalletKeys();
+  const signer = bitgo.WalletUnspentSigner.from(walletKeys, walletKeys.user, walletKeys.bitgo);
+  const inscriptionRecipient = bitgo.outputScripts.createOutputScript2of3(
+    walletKeys.deriveForChainAndIndex(0, 0).publicKeys,
+    'p2sh'
+  ).scriptPubKey;
+  const walletUnspent = testutil.mockWalletUnspent(network, BigInt(20_000), { keys: walletKeys });
+  const inputBuilder: WalletInputBuilder = {
+    walletKeys,
+    signer: 'user',
+    cosigner: 'bitgo',
+  };
+  const outputs: InscriptionOutputs = {
+    changeOutputs: [
+      { chain: 40, index: 0 },
+      { chain: 40, index: 1 },
+    ],
+    inscriptionRecipient,
+  };
+
+  function testInscriptionTxWithLayout(layout: OutputLayout, expectedOutputs: number) {
+    assertValidPsbt(
+      createPsbtFromOutputLayout(network, inputBuilder, [walletUnspent], outputs, layout),
+      signer,
+      expectedOutputs,
+      layout.feeOutput
+    );
+  }
+
+  it('can convert zero-padding layout to psbt', function () {
+    testInscriptionTxWithLayout(toParameters(BigInt(0), BigInt(19_800), BigInt(0), BigInt(200)), 1);
+  });
+
+  it('can convert start-padding layout to psbt', function () {
+    testInscriptionTxWithLayout(toParameters(BigInt(1_000), BigInt(18_800), BigInt(0), BigInt(200)), 2);
+  });
+
+  it('can convert end-padding layout to psbt', function () {
+    testInscriptionTxWithLayout(toParameters(BigInt(0), BigInt(18_800), BigInt(1_000), BigInt(200)), 2);
+  });
+
+  it('can convert double-padding layout to psbt', function () {
+    testInscriptionTxWithLayout(toParameters(BigInt(1_000), BigInt(17_800), BigInt(1_000), BigInt(200)), 3);
+  });
+
+  it('finds layout with WalletUnspent with SatRange', function () {
+    const satPoint = walletUnspent.id + ':0';
+    assert(isSatPoint(satPoint));
+    const layout = findOutputLayoutForWalletUnspents([walletUnspent], satPoint, outputs, {
+      feeRateSatKB: 1000,
+    });
+    assert.deepStrictEqual(layout, {
+      firstChangeOutput: BigInt(0),
+      inscriptionOutput: BigInt(19659),
+      secondChangeOutput: BigInt(0),
+      feeOutput: BigInt(341),
+    });
+    const psbt = createPsbtFromOutputLayout(network, inputBuilder, [walletUnspent], outputs, layout);
+    assertValidPsbt(psbt, signer, 1, BigInt(341));
+    const psbt1 = createPsbtForSingleInscriptionPassingTransaction(
+      network,
+      inputBuilder,
+      [walletUnspent],
+      satPoint,
+      outputs,
+      {
+        feeRateSatKB: 1000,
+      }
+    );
+    assertValidPsbt(psbt1, signer, 1, BigInt(341));
+    assert.strictEqual(
+      psbt.extractTransaction().toBuffer().toString('hex'),
+      psbt1.extractTransaction().toBuffer().toString('hex')
+    );
+  });
+});


### PR DESCRIPTION
These are wrappers around the layout methods that do some fee calculation
and psbt construction.

Issue: BG-68315