### PR TITLE
refactor(utxo-lib): deprecate `network` parameter in some psbt methods

### DIFF
--- a/modules/utxo-lib/src/bitgo/wallet/Unspent.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/Unspent.ts
@@ -93,10 +93,16 @@ export function addReplayProtectionUnspentToPsbt(
   psbt: UtxoPsbt,
   u: Unspent<bigint>,
   redeemScript: Buffer,
-  network: Network
+  /**
+   * @deprecated
+   */
+  network: Network = psbt.network
 ): void {
-  const { txid, vout } = toPrevOutput(u, network);
-  const isZcash = getMainnet(network) !== networks.zcash;
+  if (network !== psbt.network) {
+    throw new Error(`network parameter does not match psbt.network`);
+  }
+  const { txid, vout } = toPrevOutput(u, psbt.network);
+  const isZcash = getMainnet(psbt.network) !== networks.zcash;
 
   // Because Zcash directly hashes the value for non-segwit transactions, we do not need to check indirectly
   // with the previous transaction. Therefore, we can treat Zcash non-segwit transactions as Bitcoin
@@ -120,9 +126,15 @@ export function addWalletUnspentToPsbt(
   rootWalletKeys: RootWalletKeys,
   signer: KeyName,
   cosigner: KeyName,
-  network: Network
+  /**
+   * @deprecated
+   */
+  network: Network = psbt.network
 ): void {
-  const { txid, vout, script, value } = toPrevOutput(u, network);
+  if (network !== psbt.network) {
+    throw new Error(`network parameter does not match psbt.network`);
+  }
+  const { txid, vout, script, value } = toPrevOutput(u, psbt.network);
   const walletKeys = rootWalletKeys.deriveForChainAndIndex(u.chain, u.index);
   const scriptType = scriptTypeForChain(u.chain);
   psbt.addInput({
@@ -137,7 +149,7 @@ export function addWalletUnspentToPsbt(
   // Because Zcash directly hashes the value for non-segwit transactions, we do not need to check indirectly
   // with the previous transaction. Therefore, we can treat Zcash non-segwit transactions as Bitcoin
   // segwit transactions
-  if (!isSegwit(u.chain) && getMainnet(network) !== networks.zcash) {
+  if (!isSegwit(u.chain) && getMainnet(psbt.network) !== networks.zcash) {
     if (!isUnspentWithPrevTx(u)) {
       throw new Error('Error, require previous tx to add to PSBT');
     }

--- a/modules/utxo-lib/test/bitgo/psbt/ZcashPsbt.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/ZcashPsbt.ts
@@ -16,7 +16,7 @@ describe('Zcash PSBT', function () {
     psbt = await utxolib.bitgo.ZcashPsbt.createPsbt({ network });
 
     unspents.forEach((unspent) => {
-      utxolib.bitgo.addWalletUnspentToPsbt(psbt, unspent, rootWalletKeys, 'user', 'bitgo', network);
+      utxolib.bitgo.addWalletUnspentToPsbt(psbt, unspent, rootWalletKeys, 'user', 'bitgo');
     });
     addWalletOutputToPsbt(psbt, rootWalletKeys, getInternalChainCode('p2sh'), 0, BigInt('1000000000000000'));
   });

--- a/modules/utxo-lib/test/bitgo/wallet/WalletUnspent.ts
+++ b/modules/utxo-lib/test/bitgo/wallet/WalletUnspent.ts
@@ -91,7 +91,7 @@ describe('WalletUnspent', function () {
 
     unspents.forEach((u) => {
       if (isWalletUnspent(u)) {
-        addWalletUnspentToPsbt(psbt, u, walletKeys, signer, cosigner, network);
+        addWalletUnspentToPsbt(psbt, u, walletKeys, signer, cosigner);
       } else {
         throw new Error(`invalid unspent`);
       }


### PR DESCRIPTION
We do have a `psbt.network` property so let's use it

Issue: BG-68315


<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->