### PR TITLE
Add EdDSA commitments

### DIFF
--- a/modules/sdk-coin-dot/test/unit/transactionBuilder/base.ts
+++ b/modules/sdk-coin-dot/test/unit/transactionBuilder/base.ts
@@ -207,16 +207,26 @@ describe('Dot Transfer Builder Base', () => {
       const unsignedTransaction = await transferBuilder.build();
       const signablePayload = unsignedTransaction.signablePayload;
 
-      // signing with 3-3 signatures
-      let A_sign_share = MPC.signShare(signablePayload, A_combine.pShare, [A_combine.jShares[2], A_combine.jShares[3]]);
-      let B_sign_share = MPC.signShare(signablePayload, B_combine.pShare, [B_combine.jShares[1], B_combine.jShares[3]]);
-      let C_sign_share = MPC.signShare(signablePayload, C_combine.pShare, [C_combine.jShares[1], C_combine.jShares[2]]);
-      let A_sign = MPC.sign(signablePayload, A_sign_share.xShare, [B_sign_share.rShares[1], C_sign_share.rShares[1]]);
-      let B_sign = MPC.sign(signablePayload, B_sign_share.xShare, [A_sign_share.rShares[2], C_sign_share.rShares[2]]);
-      let C_sign = MPC.sign(signablePayload, C_sign_share.xShare, [A_sign_share.rShares[3], B_sign_share.rShares[3]]);
-      let signature = MPC.signCombine([A_sign, B_sign, C_sign]);
+      // signing with A and B
+      let A_sign_share = MPC.signShare(signablePayload, A_combine.pShare, A_combine.jShares[2]);
+      let B_sign_share = MPC.signShare(signablePayload, B_combine.pShare, B_combine.jShares[1]);
+      let A_sign = MPC.sign(
+        signablePayload,
+        A_sign_share.xShare,
+        B_sign_share.commitment,
+        B_sign_share.rShare,
+        C.yShares[1]
+      );
+      let B_sign = MPC.sign(
+        signablePayload,
+        B_sign_share.xShare,
+        A_sign_share.commitment,
+        A_sign_share.rShare,
+        C.yShares[2]
+      );
+      // sign the message_buffer (unsigned txHex)
+      let signature = MPC.signCombine([A_sign, B_sign]);
       let rawSignature = Buffer.concat([Buffer.from(signature.R, 'hex'), Buffer.from(signature.sigma, 'hex')]);
-
       transferBuilder = factory
         .getTransferBuilder()
         .amount('90034235235322')
@@ -232,34 +242,23 @@ describe('Dot Transfer Builder Base', () => {
       signedTransaction.signature.length.should.equal(1);
       signedTransaction.signature[0].should.equal(rawSignature.toString('hex'));
 
-      // signing with A and B
-      A_sign_share = MPC.signShare(signablePayload, A_combine.pShare, [A_combine.jShares[2]]);
-      B_sign_share = MPC.signShare(signablePayload, B_combine.pShare, [B_combine.jShares[1]]);
-      A_sign = MPC.sign(signablePayload, A_sign_share.xShare, [B_sign_share.rShares[1]], [C.yShares[1]]);
-      B_sign = MPC.sign(signablePayload, B_sign_share.xShare, [A_sign_share.rShares[2]], [C.yShares[2]]);
-      // sign the message_buffer (unsigned txHex)
-      signature = MPC.signCombine([A_sign, B_sign]);
-      rawSignature = Buffer.concat([Buffer.from(signature.R, 'hex'), Buffer.from(signature.sigma, 'hex')]);
-      transferBuilder = factory
-        .getTransferBuilder()
-        .amount('90034235235322')
-        .to({ address: '5Ffp1wJCPu4hzVDTo7XaMLqZSvSadyUQmxWPDw74CBjECSoq' })
-        .sender({ address: sender })
-        .to({ address: receiver.address })
-        .validity({ firstValid: 3933, maxDuration: 64 })
-        .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
-        .sequenceId({ name: 'Nonce', keyword: 'nonce', value: 200 })
-        .fee({ amount: 0, type: 'tip' });
-      transferBuilder.addSignature({ pub: dotKeyPair.getKeys().pub }, rawSignature);
-      signedTransaction = await transferBuilder.build();
-      signedTransaction.signature.length.should.equal(1);
-      signedTransaction.signature[0].should.equal(rawSignature.toString('hex'));
-
       // signing with A and C
-      A_sign_share = MPC.signShare(signablePayload, A_combine.pShare, [A_combine.jShares[3]]);
-      C_sign_share = MPC.signShare(signablePayload, C_combine.pShare, [C_combine.jShares[1]]);
-      A_sign = MPC.sign(signablePayload, A_sign_share.xShare, [C_sign_share.rShares[1]], [B.yShares[1]]);
-      C_sign = MPC.sign(signablePayload, C_sign_share.xShare, [A_sign_share.rShares[3]], [B.yShares[3]]);
+      A_sign_share = MPC.signShare(signablePayload, A_combine.pShare, A_combine.jShares[3]);
+      let C_sign_share = MPC.signShare(signablePayload, C_combine.pShare, C_combine.jShares[1]);
+      A_sign = MPC.sign(
+        signablePayload,
+        A_sign_share.xShare,
+        C_sign_share.commitment,
+        C_sign_share.rShare,
+        B.yShares[1]
+      );
+      let C_sign = MPC.sign(
+        signablePayload,
+        C_sign_share.xShare,
+        A_sign_share.commitment,
+        A_sign_share.rShare,
+        B.yShares[3]
+      );
       signature = MPC.signCombine([A_sign, C_sign]);
       rawSignature = Buffer.concat([Buffer.from(signature.R, 'hex'), Buffer.from(signature.sigma, 'hex')]);
       transferBuilder = factory
@@ -278,10 +277,22 @@ describe('Dot Transfer Builder Base', () => {
       signedTransaction.signature[0].should.equal(rawSignature.toString('hex'));
 
       // signing with B and C
-      B_sign_share = MPC.signShare(signablePayload, B_combine.pShare, [B_combine.jShares[3]]);
-      C_sign_share = MPC.signShare(signablePayload, C_combine.pShare, [C_combine.jShares[2]]);
-      B_sign = MPC.sign(signablePayload, B_sign_share.xShare, [C_sign_share.rShares[2]], [A.yShares[2]]);
-      C_sign = MPC.sign(signablePayload, C_sign_share.xShare, [B_sign_share.rShares[3]], [A.yShares[3]]);
+      B_sign_share = MPC.signShare(signablePayload, B_combine.pShare, B_combine.jShares[3]);
+      C_sign_share = MPC.signShare(signablePayload, C_combine.pShare, C_combine.jShares[2]);
+      B_sign = MPC.sign(
+        signablePayload,
+        B_sign_share.xShare,
+        C_sign_share.commitment,
+        C_sign_share.rShare,
+        A.yShares[2]
+      );
+      C_sign = MPC.sign(
+        signablePayload,
+        C_sign_share.xShare,
+        B_sign_share.commitment,
+        B_sign_share.rShare,
+        A.yShares[3]
+      );
       signature = MPC.signCombine([B_sign, C_sign]);
       rawSignature = Buffer.concat([Buffer.from(signature.R, 'hex'), Buffer.from(signature.sigma, 'hex')]);
       transferBuilder = factory

--- a/modules/sdk-coin-sol/test/unit/transactionBuilder/transactionBuilder.ts
+++ b/modules/sdk-coin-sol/test/unit/transactionBuilder/transactionBuilder.ts
@@ -392,14 +392,24 @@ describe('Sol Transaction Builder', async () => {
       const unsignedTransaction = await transferBuilder.build();
       const signablePayload = unsignedTransaction.signablePayload;
 
-      // signing with 3-3 signatures
-      let A_sign_share = MPC.signShare(signablePayload, A_combine.pShare, [A_combine.jShares[2], A_combine.jShares[3]]);
-      let B_sign_share = MPC.signShare(signablePayload, B_combine.pShare, [B_combine.jShares[1], B_combine.jShares[3]]);
-      let C_sign_share = MPC.signShare(signablePayload, C_combine.pShare, [C_combine.jShares[1], C_combine.jShares[2]]);
-      let A_sign = MPC.sign(signablePayload, A_sign_share.xShare, [B_sign_share.rShares[1], C_sign_share.rShares[1]]);
-      let B_sign = MPC.sign(signablePayload, B_sign_share.xShare, [A_sign_share.rShares[2], C_sign_share.rShares[2]]);
-      let C_sign = MPC.sign(signablePayload, C_sign_share.xShare, [A_sign_share.rShares[3], B_sign_share.rShares[3]]);
-      let signature = MPC.signCombine([A_sign, B_sign, C_sign]);
+      // signing with A and B
+      let A_sign_share = MPC.signShare(signablePayload, A_combine.pShare, A_combine.jShares[2]);
+      let B_sign_share = MPC.signShare(signablePayload, B_combine.pShare, B_combine.jShares[1]);
+      let A_sign = MPC.sign(
+        signablePayload,
+        A_sign_share.xShare,
+        B_sign_share.commitment,
+        B_sign_share.rShare,
+        C.yShares[1]
+      );
+      let B_sign = MPC.sign(
+        signablePayload,
+        B_sign_share.xShare,
+        A_sign_share.commitment,
+        A_sign_share.rShare,
+        C.yShares[2]
+      );
+      let signature = MPC.signCombine([A_sign, B_sign]);
       let rawSignature = Buffer.concat([Buffer.from(signature.R, 'hex'), Buffer.from(signature.sigma, 'hex')]);
 
       transferBuilder = factory
@@ -409,37 +419,28 @@ describe('Sol Transaction Builder', async () => {
         .fee({ amount: 5000 })
         .send({ address: nonceAccount.pub, amount: '1000' });
       transferBuilder.addSignature({ pub: sender }, rawSignature);
-
       let signedTransaction = await transferBuilder.build();
       signedTransaction.signature.length.should.equal(1);
       signedTransaction.signature[0].should.equal(bs58.encode(rawSignature));
       signedTransaction.id.should.equal(bs58.encode(rawSignature));
 
-      // signing with A and B
-      A_sign_share = MPC.signShare(signablePayload, A_combine.pShare, [A_combine.jShares[2]]);
-      B_sign_share = MPC.signShare(signablePayload, B_combine.pShare, [B_combine.jShares[1]]);
-      A_sign = MPC.sign(signablePayload, A_sign_share.xShare, [B_sign_share.rShares[1]], [C.yShares[1]]);
-      B_sign = MPC.sign(signablePayload, B_sign_share.xShare, [A_sign_share.rShares[2]], [C.yShares[2]]);
-      signature = MPC.signCombine([A_sign, B_sign]);
-      rawSignature = Buffer.concat([Buffer.from(signature.R, 'hex'), Buffer.from(signature.sigma, 'hex')]);
-
-      transferBuilder = factory
-        .getTransferBuilder()
-        .sender(sender)
-        .nonce(validBlockhash)
-        .fee({ amount: 5000 })
-        .send({ address: nonceAccount.pub, amount: '1000' });
-      transferBuilder.addSignature({ pub: sender }, rawSignature);
-      signedTransaction = await transferBuilder.build();
-      signedTransaction.signature.length.should.equal(1);
-      signedTransaction.signature[0].should.equal(bs58.encode(rawSignature));
-      signedTransaction.id.should.equal(bs58.encode(rawSignature));
-
       // signing with A and C
-      A_sign_share = MPC.signShare(signablePayload, A_combine.pShare, [A_combine.jShares[3]]);
-      C_sign_share = MPC.signShare(signablePayload, C_combine.pShare, [C_combine.jShares[1]]);
-      A_sign = MPC.sign(signablePayload, A_sign_share.xShare, [C_sign_share.rShares[1]], [B.yShares[1]]);
-      C_sign = MPC.sign(signablePayload, C_sign_share.xShare, [A_sign_share.rShares[3]], [B.yShares[3]]);
+      A_sign_share = MPC.signShare(signablePayload, A_combine.pShare, A_combine.jShares[3]);
+      let C_sign_share = MPC.signShare(signablePayload, C_combine.pShare, C_combine.jShares[1]);
+      A_sign = MPC.sign(
+        signablePayload,
+        A_sign_share.xShare,
+        C_sign_share.commitment,
+        C_sign_share.rShare,
+        B.yShares[1]
+      );
+      let C_sign = MPC.sign(
+        signablePayload,
+        C_sign_share.xShare,
+        A_sign_share.commitment,
+        A_sign_share.rShare,
+        B.yShares[3]
+      );
       signature = MPC.signCombine([A_sign, C_sign]);
       rawSignature = Buffer.concat([Buffer.from(signature.R, 'hex'), Buffer.from(signature.sigma, 'hex')]);
 
@@ -456,10 +457,22 @@ describe('Sol Transaction Builder', async () => {
       signedTransaction.id.should.equal(bs58.encode(rawSignature));
 
       // signing with B and C
-      B_sign_share = MPC.signShare(signablePayload, B_combine.pShare, [B_combine.jShares[3]]);
-      C_sign_share = MPC.signShare(signablePayload, C_combine.pShare, [C_combine.jShares[2]]);
-      B_sign = MPC.sign(signablePayload, B_sign_share.xShare, [C_sign_share.rShares[2]], [A.yShares[2]]);
-      C_sign = MPC.sign(signablePayload, C_sign_share.xShare, [B_sign_share.rShares[3]], [A.yShares[3]]);
+      B_sign_share = MPC.signShare(signablePayload, B_combine.pShare, B_combine.jShares[3]);
+      C_sign_share = MPC.signShare(signablePayload, C_combine.pShare, C_combine.jShares[2]);
+      B_sign = MPC.sign(
+        signablePayload,
+        B_sign_share.xShare,
+        C_sign_share.commitment,
+        C_sign_share.rShare,
+        A.yShares[2]
+      );
+      C_sign = MPC.sign(
+        signablePayload,
+        C_sign_share.xShare,
+        B_sign_share.commitment,
+        B_sign_share.rShare,
+        A.yShares[3]
+      );
       signature = MPC.signCombine([B_sign, C_sign]);
       rawSignature = Buffer.concat([Buffer.from(signature.R, 'hex'), Buffer.from(signature.sigma, 'hex')]);
 
@@ -507,10 +520,22 @@ describe('Sol Transaction Builder', async () => {
         const unsignedTransaction = await transferBuilder.build();
         const signablePayload = unsignedTransaction.signablePayload;
 
-        const A_sign_share = MPC.signShare(signablePayload, A_subkey.pShare, [A_combine.jShares[2]]);
-        const B_sign_share = MPC.signShare(signablePayload, B_subkey.pShare, [B_combine.jShares[1]]);
-        const A_sign = MPC.sign(signablePayload, A_sign_share.xShare, [B_sign_share.rShares[1]], [C.yShares[1]]);
-        const B_sign = MPC.sign(signablePayload, B_sign_share.xShare, [A_sign_share.rShares[2]], [C.yShares[2]]);
+        const A_sign_share = MPC.signShare(signablePayload, A_subkey.pShare, A_combine.jShares[2]);
+        const B_sign_share = MPC.signShare(signablePayload, B_subkey.pShare, B_combine.jShares[1]);
+        const A_sign = MPC.sign(
+          signablePayload,
+          A_sign_share.xShare,
+          B_sign_share.commitment,
+          B_sign_share.rShare,
+          C.yShares[1]
+        );
+        const B_sign = MPC.sign(
+          signablePayload,
+          B_sign_share.xShare,
+          A_sign_share.commitment,
+          A_sign_share.rShare,
+          C.yShares[2]
+        );
 
         const signature = MPC.signCombine([A_sign, B_sign]);
         const rawSignature = Buffer.concat([Buffer.from(signature.R, 'hex'), Buffer.from(signature.sigma, 'hex')]);

--- a/modules/sdk-core/src/account-lib/mpc/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/account-lib/mpc/tss/eddsa/eddsa.ts
@@ -34,7 +34,6 @@ import { Ed25519Curve } from '../../curves';
 import Shamir from '../../shamir';
 import HDTree from '../../hdTree';
 import { bigIntFromBufferLE, bigIntToBufferLE, bigIntFromBufferBE, bigIntToBufferBE, clamp } from '../../util';
-import { hexToBigInt } from '../../../util/crypto';
 import {
   KeyShare,
   UShare,
@@ -313,8 +312,8 @@ export default class Eddsa {
     otherPlayerRShare: RShare,
     yShare: YShare
   ): GShare {
-    const c = Eddsa.curve.basePointMult(hexToBigInt(otherPlayerRShare.r));
-    if (c !== hexToBigInt(otherPlayerCommitment.c)) {
+    const c = Eddsa.curve.basePointMult(bigIntFromBufferLE(Buffer.from(otherPlayerRShare.r, 'hex')));
+    if (c !== bigIntFromBufferLE(Buffer.from(otherPlayerCommitment.c, 'hex'))) {
       throw new Error('Could not verify other player share');
     }
 

--- a/modules/sdk-core/src/account-lib/mpc/tss/eddsa/types.ts
+++ b/modules/sdk-core/src/account-lib/mpc/tss/eddsa/types.ts
@@ -63,9 +63,15 @@ export interface RShare {
   R: string;
 }
 
+export interface Commitment {
+  c: string; // A commitment of $r_j$, where $c = r_j G$.
+  z: string; // A commitment of the message being signed, $m$, where $z = H(m)$ and $H$ is a hash.
+}
+
 export interface SignShare {
   xShare: XShare;
-  rShares: Record<number, RShare>;
+  commitment: Commitment;
+  rShare: RShare;
 }
 
 export interface GShare {

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
@@ -25,7 +25,7 @@ import {
   PopulatedIntentForTypedDataSigning,
   CreateBitGoKeychainParamsBase,
 } from './baseTypes';
-import { GShare, SignShare, YShare } from '../../../account-lib/mpc/tss';
+import { Commitment, GShare, SignShare, YShare } from '../../../account-lib/mpc/tss';
 
 /**
  * BaseTssUtil class which different signature schemes have to extend
@@ -141,6 +141,7 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
    *
    * @param {TxRequest} txRequest - transaction request with unsigned transaction
    * @param {string} prv - user signing material
+   * @param {Commitment} bitgoToUserCommitment - BitGo to User Commitment
    * @param {SignatureShareRecord} bitgoToUserRShare - BitGo to User R Share
    * @param {SignShare} userToBitgoRShare - User to BitGo R Share
    * @returns {Promise<GShare>} - GShare from User to BitGo
@@ -148,6 +149,7 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
   createGShareFromTxRequest(params: {
     txRequest: TxRequest;
     prv: string;
+    bitgoToUserCommitment: Commitment;
     bitgoToUserRShare: SignatureShareRecord;
     userToBitgoRShare: SignShare;
   }): Promise<GShare> {

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
@@ -25,7 +25,7 @@ import {
   TSSParams,
   TxRequest,
 } from '../baseTypes';
-import { CreateEddsaBitGoKeychainParams, CreateEddsaKeychainParams, KeyShare, YShare } from './types';
+import { CreateEddsaBitGoKeychainParams, CreateEddsaKeychainParams, KeyShare, YShare, Commitment } from './types';
 import baseTSSUtils from '../baseTSSUtils';
 import { KeychainsTriplet } from '../../../baseCoin';
 
@@ -395,12 +395,13 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
   async createGShareFromTxRequest(params: {
     txRequest: string | TxRequest;
     prv: string;
+    bitgoToUserCommitment: Commitment;
     bitgoToUserRShare: SignatureShareRecord;
     userToBitgoRShare: SignShare;
   }): Promise<GShare> {
     let txRequestResolved: TxRequest;
 
-    const { txRequest, prv, bitgoToUserRShare, userToBitgoRShare } = params;
+    const { txRequest, prv, bitgoToUserCommitment, bitgoToUserRShare, userToBitgoRShare } = params;
 
     if (typeof txRequest === 'string') {
       txRequestResolved = await getTxRequest(this.bitgo, this.wallet.id(), txRequest);
@@ -423,6 +424,7 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
 
     const userToBitGoGShare = await createUserToBitGoGShare(
       userToBitgoRShare,
+      bitgoToUserCommitment,
       bitgoToUserRShare,
       userSigningMaterial.backupYShare,
       userSigningMaterial.bitgoYShare,
@@ -534,10 +536,12 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
       publicShare
     );
 
+    const bitgoToUserCommitment = {} as Commitment; // TODO: Not sure where to source this from -JD
     const bitgoToUserRShare = await getBitgoToUserRShare(this.bitgo, this.wallet.id(), txRequestId);
 
     const userToBitGoGShare = await createUserToBitGoGShare(
       userSignShare,
+      bitgoToUserCommitment,
       bitgoToUserRShare,
       userSigningMaterial.backupYShare,
       userSigningMaterial.bitgoYShare,

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/types.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/types.ts
@@ -5,6 +5,7 @@ import { SerializedKeyPair } from 'openpgp';
 
 export type KeyShare = EDDSA.KeyShare;
 export type YShare = EDDSA.YShare;
+export type Commitment = EDDSA.Commitment;
 /** @deprected use UnsignedTransactionTss from baseTypes */
 export type EddsaUnsignedTransaction = UnsignedTransactionTss;
 


### PR DESCRIPTION
Ticket: BG-69663

Both signers must commit to their `RShare.r` values before exchanging them. These commitments will be produced via `signShare` as the `commitment` property on the returned `SignShare` type. Signers then exchange these commitments before proceeding to exchange their `SignShare.rShare`.

BREAKING CHANGES:
* `commitment` is now a required parameter to `sign`.
* `jShares` parameter to `signShare` is now `jShare` as we only support 2-of-3 signing.
* `rShares` parameter to `signShare` is now `rShare` as we only support 2-of-3 signing.

Please see TODO, as we still need some WP work and plumbing to store commitments.