### PR TITLE
feat: express route for signing arbitrary payloads

### DIFF
--- a/modules/express/test/unit/clientRoutes/signPayload.ts
+++ b/modules/express/test/unit/clientRoutes/signPayload.ts
@@ -1,0 +1,71 @@
+import * as sinon from 'sinon';
+
+import 'should-http';
+import 'should-sinon';
+import '../../lib/asserts';
+
+import { Request } from 'express';
+import { handleV2OFCSignPayload } from '../../../src/clientRoutes';
+
+import { BitGo, BaseCoin, Wallet, Wallets } from 'bitgo';
+
+describe('Sign an arbitrary payload with trading account key', function () {
+  const coin = 'ofc';
+  const payload = {
+    this: {
+      is: {
+        a: 'payload',
+      },
+    },
+  };
+  const signature = 'signedPayload123';
+  const walletId = 'myWalletId';
+
+  const walletStub = sinon.createStubInstance(
+    Wallet as any,
+    {
+      id: walletId,
+      coin: sinon.stub().returns(coin),
+      toTradingAccount: sinon.stub().returns({
+        signPayload: sinon.stub().returns(signature),
+      }),
+    },
+  );
+
+  const walletsStub = sinon.createStubInstance(
+    Wallets as any,
+    {
+      get: sinon.stub().resolves(walletStub),
+    }
+  );
+
+  const coinStub = sinon.createStubInstance(
+    BaseCoin as any,
+    ({ wallets: sinon.stub().returns(walletsStub) })
+  );
+
+  const bitGoStub = sinon.createStubInstance(
+    BitGo as any,
+    { coin: sinon.stub().returns(coinStub) }
+  );
+
+  before(() => {
+    process.env['WALLET_myWalletId_PASSPHRASE'] = 'mypass';
+  });
+
+  it('should return a signed payload', async function () {
+    const expectedResponse = {
+      payload: JSON.stringify(payload),
+      signature,
+    };
+    const req = {
+      bitgo: bitGoStub,
+      body: {
+        payload,
+        walletId,
+      },
+      query: {},
+    } as unknown as Request;
+    await handleV2OFCSignPayload(req).should.be.resolvedWith(expectedResponse);
+  });
+});

--- a/modules/sdk-core/src/bitgo/trading/iTradingAccount.ts
+++ b/modules/sdk-core/src/bitgo/trading/iTradingAccount.ts
@@ -16,7 +16,7 @@ export interface BuildPayloadAmounts {
 }
 
 export interface SignPayloadParameters {
-  payload: Payload;
+  payload: string | Record<string, unknown>;
   walletPassphrase: string;
 }
 

--- a/modules/sdk-core/src/bitgo/trading/tradingAccount.ts
+++ b/modules/sdk-core/src/bitgo/trading/tradingAccount.ts
@@ -142,9 +142,9 @@ export class TradingAccount implements ITradingAccount {
   }
 
   /**
-   * Signs a pre-built trade payload with the user key on this trading account
+   * Signs an arbitrary payload with the user key on this trading account
    * @param params
-   * @param params.payload trade payload object from TradingAccount::buildPayload()
+   * @param params.payload arbitrary payload object (string | Record<string, unknown>)
    * @param params.walletPassphrase passphrase on this trading account, used to unlock the account user key
    * @returns hex-encoded signature of the payload
    */
@@ -154,7 +154,7 @@ export class TradingAccount implements ITradingAccount {
       input: key.encryptedPrv,
       password: params.walletPassphrase,
     });
-    const payload = JSON.stringify(params.payload);
+    const payload = typeof params.payload === 'string' ? params.payload : JSON.stringify(params.payload);
     return ((await this.wallet.baseCoin.signMessage({ prv }, payload)) as any).toString('hex');
   }
 


### PR DESCRIPTION
This endpoint will enable our Clients and Partners to leverage
BitGo Express to sign arbitrary http post request payloads, with
their trading account key, in order to integrate with our systems.

Ticket: BG-66430

![image](https://user-images.githubusercontent.com/102554090/223590218-b9040eb8-bb91-48b2-838b-01fd99b73af3.png)
