### PR TITLE
feat(statics): Add Custody Coin Features Switzerland

### DIFF
--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -96,6 +96,7 @@ const CSPR_FEATURES = [
   ...AccountCoin.DEFAULT_FEATURES,
   CoinFeature.REQUIRES_RESERVE,
   CoinFeature.CUSTODY_BITGO_GERMANY,
+  CoinFeature.CUSTODY_BITGO_SWITZERLAND,
 ];
 const ALGO_FEATURES = [
   ...AccountCoin.DEFAULT_FEATURES,
@@ -128,7 +129,12 @@ const SOL_FEATURES = [
 ];
 const STX_FEATURES = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.CUSTODY_BITGO_GERMANY];
 const NEAR_FEATURES = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.TSS, CoinFeature.STAKING];
-const MATIC_FEATURES = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.STAKING, CoinFeature.METAMASK_INSTITUTIONAL];
+const MATIC_FEATURES = [
+  ...AccountCoin.DEFAULT_FEATURES,
+  CoinFeature.STAKING,
+  CoinFeature.METAMASK_INSTITUTIONAL,
+  CoinFeature.CUSTODY_BITGO_SWITZERLAND,
+];
 const SUI_FEATURES = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.TSS];
 const TRX_FEATURES = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.CUSTODY_BITGO_GERMANY];
 const ATOM_FEATURES = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.TSS, CoinFeature.STAKING];
@@ -396,6 +402,7 @@ export const coins = CoinMap.fromCoins([
       CoinFeature.EVM_WALLET,
       CoinFeature.CUSTODY_BITGO_GERMANY,
       CoinFeature.CUSTODY_BITGO_NEW_YORK,
+      CoinFeature.CUSTODY_BITGO_SWITZERLAND,
     ]
   ), // we should probably refactor this into a eth() method
   account(
@@ -422,6 +429,7 @@ export const coins = CoinMap.fromCoins([
       CoinFeature.EVM_WALLET,
       CoinFeature.CUSTODY_BITGO_GERMANY,
       CoinFeature.CUSTODY_BITGO_NEW_YORK,
+      CoinFeature.CUSTODY_BITGO_SWITZERLAND,
     ]
   ),
   account(

--- a/modules/statics/test/unit/coins.ts
+++ b/modules/statics/test/unit/coins.ts
@@ -33,12 +33,16 @@ const custodyFeatures: Record<string, { features: CoinFeature[] }> = {
     features: [CoinFeature.CUSTODY_BITGO_GERMANY, CoinFeature.CUSTODY_BITGO_NEW_YORK],
   },
   btg: { features: [CoinFeature.CUSTODY_BITGO_GERMANY] },
-  cspr: { features: [CoinFeature.CUSTODY_BITGO_GERMANY] },
+  cspr: { features: [CoinFeature.CUSTODY_BITGO_GERMANY, CoinFeature.CUSTODY_BITGO_SWITZERLAND] },
   celo: { features: [CoinFeature.CUSTODY_BITGO_GERMANY] },
   doge: { features: [CoinFeature.CUSTODY_BITGO_GERMANY] },
   eos: { features: [CoinFeature.CUSTODY_BITGO_GERMANY] },
   eth: {
-    features: [CoinFeature.CUSTODY_BITGO_GERMANY, CoinFeature.CUSTODY_BITGO_NEW_YORK],
+    features: [
+      CoinFeature.CUSTODY_BITGO_GERMANY,
+      CoinFeature.CUSTODY_BITGO_NEW_YORK,
+      CoinFeature.CUSTODY_BITGO_SWITZERLAND,
+    ],
   },
   etc: {
     features: [CoinFeature.CUSTODY_BITGO_GERMANY, CoinFeature.CUSTODY_BITGO_NEW_YORK],
@@ -47,6 +51,7 @@ const custodyFeatures: Record<string, { features: CoinFeature[] }> = {
   ltc: {
     features: [CoinFeature.CUSTODY_BITGO_GERMANY, CoinFeature.CUSTODY_BITGO_NEW_YORK],
   },
+  matic: { features: [CoinFeature.CUSTODY_BITGO_SWITZERLAND] },
   polygon: { features: [CoinFeature.CUSTODY_BITGO_GERMANY] },
   xrp: {
     features: [CoinFeature.CUSTODY_BITGO_GERMANY, CoinFeature.CUSTODY_BITGO_NEW_YORK],
@@ -71,12 +76,16 @@ const custodyFeatures: Record<string, { features: CoinFeature[] }> = {
     features: [CoinFeature.CUSTODY_BITGO_GERMANY, CoinFeature.CUSTODY_BITGO_NEW_YORK],
   },
   tbtg: { features: [CoinFeature.CUSTODY_BITGO_GERMANY] },
-  tcspr: { features: [CoinFeature.CUSTODY_BITGO_GERMANY] },
+  tcspr: { features: [CoinFeature.CUSTODY_BITGO_GERMANY, CoinFeature.CUSTODY_BITGO_SWITZERLAND] },
   tcelo: { features: [CoinFeature.CUSTODY_BITGO_GERMANY] },
   tdoge: { features: [CoinFeature.CUSTODY_BITGO_GERMANY] },
   teos: { features: [CoinFeature.CUSTODY_BITGO_GERMANY] },
   gteth: {
-    features: [CoinFeature.CUSTODY_BITGO_GERMANY, CoinFeature.CUSTODY_BITGO_NEW_YORK],
+    features: [
+      CoinFeature.CUSTODY_BITGO_GERMANY,
+      CoinFeature.CUSTODY_BITGO_NEW_YORK,
+      CoinFeature.CUSTODY_BITGO_SWITZERLAND,
+    ],
   },
   tetc: {
     features: [CoinFeature.CUSTODY_BITGO_GERMANY, CoinFeature.CUSTODY_BITGO_NEW_YORK],
@@ -85,6 +94,7 @@ const custodyFeatures: Record<string, { features: CoinFeature[] }> = {
   tltc: {
     features: [CoinFeature.CUSTODY_BITGO_GERMANY, CoinFeature.CUSTODY_BITGO_NEW_YORK],
   },
+  tmatic: { features: [CoinFeature.CUSTODY_BITGO_SWITZERLAND] },
   tpolygon: { features: [CoinFeature.CUSTODY_BITGO_GERMANY] },
   txrp: {
     features: [CoinFeature.CUSTODY_BITGO_GERMANY, CoinFeature.CUSTODY_BITGO_NEW_YORK],


### PR DESCRIPTION
We have gotten approval to create custodial wallets for `CSPR`, `MATIC` and `ETH` coins within the BitGo Switzerland entity. As part of this PR, we're updating the coin features on these coins to support custodial wallets in Switzerland.

[BG-69987](https://bitgoinc.atlassian.net/browse/BG-69987)

## Changes
- Modified: modules/statics/src/coins.ts
- Modified: modules/statics/test/unit/coins.ts

[BG-69987]: https://bitgoinc.atlassian.net/browse/BG-69987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ