### PR TITLE
feat(statics): Add Custody Coin Features For Switzerland To Polygon

### DIFF
--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -118,6 +118,7 @@ const POLYGON_FEATURES = [
   CoinFeature.TSS,
   CoinFeature.EVM_WALLET,
   CoinFeature.CUSTODY_BITGO_GERMANY,
+  CoinFeature.CUSTODY_BITGO_SWITZERLAND,
 ];
 const SOL_FEATURES = [
   ...AccountCoin.DEFAULT_FEATURES,

--- a/modules/statics/test/unit/coins.ts
+++ b/modules/statics/test/unit/coins.ts
@@ -52,7 +52,7 @@ const custodyFeatures: Record<string, { features: CoinFeature[] }> = {
     features: [CoinFeature.CUSTODY_BITGO_GERMANY, CoinFeature.CUSTODY_BITGO_NEW_YORK],
   },
   matic: { features: [CoinFeature.CUSTODY_BITGO_SWITZERLAND] },
-  polygon: { features: [CoinFeature.CUSTODY_BITGO_GERMANY] },
+  polygon: { features: [CoinFeature.CUSTODY_BITGO_GERMANY, CoinFeature.CUSTODY_BITGO_SWITZERLAND] },
   xrp: {
     features: [CoinFeature.CUSTODY_BITGO_GERMANY, CoinFeature.CUSTODY_BITGO_NEW_YORK],
   },
@@ -95,7 +95,7 @@ const custodyFeatures: Record<string, { features: CoinFeature[] }> = {
     features: [CoinFeature.CUSTODY_BITGO_GERMANY, CoinFeature.CUSTODY_BITGO_NEW_YORK],
   },
   tmatic: { features: [CoinFeature.CUSTODY_BITGO_SWITZERLAND] },
-  tpolygon: { features: [CoinFeature.CUSTODY_BITGO_GERMANY] },
+  tpolygon: { features: [CoinFeature.CUSTODY_BITGO_GERMANY, CoinFeature.CUSTODY_BITGO_SWITZERLAND] },
   txrp: {
     features: [CoinFeature.CUSTODY_BITGO_GERMANY, CoinFeature.CUSTODY_BITGO_NEW_YORK],
   },


### PR DESCRIPTION
We have gotten approval to create custodial wallets for `POLYGON` coin within the BitGo Switzerland entity. As part of this PR, we're updating the coin features on this coin to support custodial wallets in Switzerland

BG-69987

## Changes
- Modified: modules/statics/src/coins.ts
- Modified: modules/statics/test/unit/coins.ts