### PR TITLE
feat(utxo-ord): use stepwise solution algorithm for inscription tx

### DIFF
--- a/modules/utxo-ord/src/psbt.ts
+++ b/modules/utxo-ord/src/psbt.ts
@@ -1,17 +1,10 @@
 import { Network, bitgo, address } from '@bitgo/utxo-lib';
 import { Dimensions, VirtualSizes } from '@bitgo/unspents';
 
-import {
-  getOrdOutputsForLayout,
-  OrdOutput,
-  OutputLayout,
-  toArray,
-  SatPoint,
-  findOutputLayout,
-  Constraint,
-  parseSatPoint,
-  SatRange,
-} from './index';
+import { OrdOutput } from './OrdOutput';
+import { parseSatPoint, SatPoint } from './SatPoint';
+import { SatRange } from './SatRange';
+import { getOrdOutputsForLayout, OutputLayout, toArray, findOutputLayout } from './OutputLayout';
 
 export type WalletOutputPath = {
   chain: bitgo.ChainCode;
@@ -118,7 +111,6 @@ export function findOutputLayoutForWalletUnspents(
 
   const {
     minChangeOutput = BigInt(10_000),
-    maxChangeOutput = Constraint.MAXSAT,
     minInscriptionOutput = BigInt(10_000),
     maxInscriptionOutput = BigInt(20_000),
   } = constraints;
@@ -127,7 +119,6 @@ export function findOutputLayoutForWalletUnspents(
   const inscriptionOutput = new OrdOutput(input.value, [toSatRange(satPoint)]);
   return findOutputLayout(inscriptionOutput, {
     minChangeOutput,
-    maxChangeOutput,
     minInscriptionOutput,
     maxInscriptionOutput,
     feeFixed: getFee(

--- a/modules/utxo-ord/test/OutputLayout.ts
+++ b/modules/utxo-ord/test/OutputLayout.ts
@@ -1,13 +1,26 @@
 import * as assert from 'assert';
 
-import { SatRange, Constraint, findOutputLayout, SearchParams, OutputLayout, getOrdOutputsForLayout } from '../src';
+import { SatRange, findOutputLayout, OutputLayout, getOrdOutputsForLayout, toParameters, toArray } from '../src';
 
 import { output, range } from './util';
 
+function layout(
+  firstChangeOutput: number | bigint,
+  inscriptionOutput: number | bigint,
+  secondChangeOutput: number | bigint,
+  feeOutput: number | bigint
+) {
+  return toParameters(
+    BigInt(firstChangeOutput),
+    BigInt(inscriptionOutput),
+    BigInt(secondChangeOutput),
+    BigInt(feeOutput)
+  );
+}
+
 describe('Ordinal Transaction Layout', function () {
-  const params: SearchParams = {
+  const constraints = {
     minChangeOutput: BigInt(10),
-    maxChangeOutput: Constraint.MAXSAT,
     minInscriptionOutput: BigInt(10),
     maxInscriptionOutput: BigInt(20),
     feeFixed: BigInt(10),
@@ -16,8 +29,8 @@ describe('Ordinal Transaction Layout', function () {
 
   describe('findOrdOutputs', function () {
     function testNoPadding(r: SatRange, expectedResult: OutputLayout | undefined) {
-      it(`finds solution for simple inscription input without padding (SatRange=${r})`, function () {
-        assert.deepStrictEqual(findOutputLayout(output(30, r), params), expectedResult);
+      it(`has expectedResult for simple inscription input without padding (SatRange=${r} expectedResult=${expectedResult})`, function () {
+        assert.deepStrictEqual(findOutputLayout(output(30, r), constraints), expectedResult);
       });
     }
 
@@ -28,39 +41,51 @@ describe('Ordinal Transaction Layout', function () {
           If the input inscription is within maxInscriptionOutput and leaves enough room for fees,
           we can find a result.
          */
-        i < 15
-          ? {
-              firstChangeOutput: BigInt(0),
-              inscriptionOutput: BigInt(15),
-              secondChangeOutput: BigInt(0),
-              feeOutput: BigInt(15),
-            }
-          : undefined
+
+        /* inscriptionOutput has always 10 sats */
+        i < 15 ? layout(0, 15, 0, 15) : /* If there is no room for fees we do not have a result */ undefined
       );
     }
 
     function testEndPadding(r: SatRange, expectedResult: OutputLayout | undefined) {
-      it(`finds solution for simple inscription input with end padding (SatRange=${r})`, function () {
-        const result = findOutputLayout(output(1000, r), params);
+      it(`has expectedResult for inscription input with end padding (SatRange=${r}, expectedResult=${
+        expectedResult ? toArray(expectedResult) : undefined
+      })`, function () {
+        const result = findOutputLayout(output(1000, r), constraints);
         assert.deepStrictEqual(result, expectedResult);
       });
     }
 
-    for (let i = 0; i < 30; i++) {
-      testEndPadding(
-        range(i),
-        /* if the inscription is within maxInscriptionOutput there will always be solution */
-        i < 20
-          ? {
-              firstChangeOutput: BigInt(0),
-              /* if the inscription is below minInscriptionOutput we prefer that branch */
-              inscriptionOutput: i < 10 ? BigInt(10) : BigInt(20),
-              secondChangeOutput: i < 10 ? BigInt(970) : BigInt(960),
-              feeOutput: BigInt(20),
-            }
-          : undefined
-      );
+    function values(r: SatRange): number[] {
+      return Array.from({ length: Number(r.size()) }).map((_, i) => i + Number(r.start));
     }
+
+    [...values(range(0, 30)), ...values(range(500, 530)), ...values(range(950, 999))].forEach((i) => {
+      let expectedResult;
+      if (i < 10) {
+        // inscriptions at the very start of the range are put into inscriptionOutput with a minimal size
+        expectedResult = layout(0, 10, 1000 - 10 - 20, 20);
+      } else if (i < 20) {
+        // the inscription output grows as needed
+        expectedResult = layout(0, i + 1, 1000 - (i + 1) - 20, 20);
+      } else if (i <= 955) {
+        // if the inscription is outside the maxInscription size, we insert a leading change output that ends just before
+        // the inscription and a second change output to pad the nd
+        expectedResult = layout(i, 10, 1000 - i - 10 - 25, 25);
+      } else if (i <= 960) {
+        // If the inscription is close to the end of the input, we omit the secondChangeOutput and
+        // grow the inscriptionOutput instead. If it is maxed out, we grow the feeOutput.
+        expectedResult = layout(i, 20, 0, 1000 - 20 - i);
+      } else if (i <= 970) {
+        expectedResult = layout(i, 1000 - 20 - i, 0, 20);
+      } else if (970 < i) {
+        // if the inscription is at the very far end, we cannot construct a layout
+        expectedResult = undefined;
+      } else {
+        throw new Error(`i=${i}`);
+      }
+      testEndPadding(range(i), expectedResult);
+    });
   });
 
   describe('getOutputsForResult', function () {


### PR DESCRIPTION
Replace incomplete constraint resolution algorithm with a more
hand-crafted solution.

This now correctly builds transactions for inscriptions that are in
the middle or close to the end of an input.

Also remove the `maxChangeOutput` parameter since practically we don't
care much about the maximum size of change outputs for inscription
passing transactions.

Issue: BG-68315


<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->