### PR TITLE
fix(sdk-core): change testnet ada node url in config

### DIFF
--- a/modules/sdk-core/src/bitgo/environments.ts
+++ b/modules/sdk-core/src/bitgo/environments.ts
@@ -123,7 +123,7 @@ const testnetBase: EnvironmentTemplate = {
   eosNodeUrls: ['https://kylin.eosn.io', 'https://api.kylin.alohaeos.com'],
   nearNodeUrls: ['https://rpc.testnet.near.org'],
   solNodeUrl: 'https://api.devnet.solana.com',
-  adaNodeUrl: 'https://testnet.koios.rest/api/v0',
+  adaNodeUrl: 'https://preprod.koios.rest/api/v0',
   dotNodeUrls: ['wss://westend-rpc.polkadot.io'],
   tronNodes: {
     full: 'http://47.252.81.135:8090',


### PR DESCRIPTION
Previous testnet ada node url was deprecated and had to be updated with the new one.

TICKET: [BG-69958](https://bitgoinc.atlassian.net/browse/BG-69958?atlOrigin=eyJpIjoiMjFlMDBkYzgzNjJhNGY4ZWJlZGY4YzRhOTc5ZWMwNDIiLCJwIjoiaiJ9)

[BG-69958]: https://bitgoinc.atlassian.net/browse/BG-69958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ