### PR TITLE
feat(utxo-ord): add support for additional inputs

### DIFF
--- a/modules/utxo-ord/src/OutputLayout.ts
+++ b/modules/utxo-ord/src/OutputLayout.ts
@@ -272,7 +272,7 @@ export function findOutputLayout(
   search: Omit<Constraints, 'satPos' | 'total'>
 ): OutputLayout | undefined {
   if (inscriptionInput.ordinals.length !== 1) {
-    throw new Error(`unexpected ordinal count`);
+    throw new Error(`unexpected ordinal count ${inscriptionInput.ordinals.length}`);
   }
   if (inscriptionInput.ordinals[0].size() !== ONE) {
     throw new Error(`only single-satoshi inscriptions are supported`);

--- a/modules/utxo-ord/src/combinations.ts
+++ b/modules/utxo-ord/src/combinations.ts
@@ -1,0 +1,8 @@
+export function powerset<T>(arr: T[]): T[][] {
+  if (arr.length === 0) {
+    return [[]];
+  } else {
+    const [a, ...rest] = arr;
+    return powerset(rest).flatMap((s) => [[a, ...s], s]);
+  }
+}

--- a/modules/utxo-ord/test/combinations.ts
+++ b/modules/utxo-ord/test/combinations.ts
@@ -1,0 +1,8 @@
+import * as assert from 'assert';
+
+import { powerset } from '../src/combinations';
+describe('powerset', function () {
+  it('has expected results', function () {
+    assert.deepStrictEqual(powerset([1, 2, 3]), [[1, 2, 3], [2, 3], [1, 3], [3], [1, 2], [2], [1], []]);
+  });
+});

--- a/modules/utxo-ord/test/psbt.ts
+++ b/modules/utxo-ord/test/psbt.ts
@@ -1,11 +1,12 @@
 import * as assert from 'assert';
 import {
-  InscriptionOutputs,
+  InscriptionTransactionOutputs,
   createPsbtForSingleInscriptionPassingTransaction,
   createPsbtFromOutputLayout,
   findOutputLayoutForWalletUnspents,
   WalletInputBuilder,
-} from '../src/psbt';
+  toArray,
+} from '../src';
 import { isSatPoint, OutputLayout, toParameters } from '../src';
 import { bitgo, networks, testutil } from '@bitgo/utxo-lib';
 
@@ -36,7 +37,7 @@ describe('OutputLayout to PSBT conversion', function () {
     signer: 'user',
     cosigner: 'bitgo',
   };
-  const outputs: InscriptionOutputs = {
+  const outputs: InscriptionTransactionOutputs = {
     changeOutputs: [
       { chain: 40, index: 0 },
       { chain: 40, index: 1 },
@@ -69,34 +70,54 @@ describe('OutputLayout to PSBT conversion', function () {
     testInscriptionTxWithLayout(toParameters(BigInt(1_000), BigInt(17_800), BigInt(1_000), BigInt(200)), 3);
   });
 
-  it('finds layout with WalletUnspent with SatRange', function () {
-    const satPoint = walletUnspent.id + ':0';
-    assert(isSatPoint(satPoint));
-    const layout = findOutputLayoutForWalletUnspents([walletUnspent], satPoint, outputs, {
-      feeRateSatKB: 1000,
-    });
-    assert.deepStrictEqual(layout, {
-      firstChangeOutput: BigInt(0),
-      inscriptionOutput: BigInt(19659),
-      secondChangeOutput: BigInt(0),
-      feeOutput: BigInt(341),
-    });
-    const psbt = createPsbtFromOutputLayout(network, inputBuilder, [walletUnspent], outputs, layout);
-    assertValidPsbt(psbt, signer, 1, BigInt(341));
-    const psbt1 = createPsbtForSingleInscriptionPassingTransaction(
-      network,
-      inputBuilder,
-      [walletUnspent],
-      satPoint,
-      outputs,
-      {
+  function testWithUnspents(unspents: bitgo.WalletUnspent<bigint>[], expectedResult: OutputLayout | undefined) {
+    const values = unspents.map((u) => u.value);
+    it(`finds layout for unspents [${values}]`, function () {
+      const satPoint = unspents[0].id + ':0';
+      assert(isSatPoint(satPoint));
+      const layout = findOutputLayoutForWalletUnspents(unspents, satPoint, outputs, {
         feeRateSatKB: 1000,
+      });
+      assert.deepStrictEqual(layout, expectedResult);
+      if (!layout) {
+        return;
       }
-    );
-    assertValidPsbt(psbt1, signer, 1, BigInt(341));
-    assert.strictEqual(
-      psbt.extractTransaction().toBuffer().toString('hex'),
-      psbt1.extractTransaction().toBuffer().toString('hex')
-    );
+      assert(expectedResult);
+      const expectedOutputs = toArray(expectedResult).filter((v) => v !== BigInt(0)).length - 1;
+      const psbt = createPsbtFromOutputLayout(network, inputBuilder, unspents, outputs, layout);
+      assertValidPsbt(psbt, signer, expectedOutputs, expectedResult.feeOutput);
+      const psbt1 = createPsbtForSingleInscriptionPassingTransaction(
+        network,
+        inputBuilder,
+        unspents,
+        satPoint,
+        outputs,
+        {
+          feeRateSatKB: 1000,
+        }
+      );
+      assertValidPsbt(psbt1, signer, expectedOutputs, expectedResult.feeOutput);
+      assert.strictEqual(
+        psbt.extractTransaction().toBuffer().toString('hex'),
+        psbt1.extractTransaction().toBuffer().toString('hex')
+      );
+    });
+  }
+
+  testWithUnspents([testutil.mockWalletUnspent(network, BigInt(20_000))], {
+    firstChangeOutput: BigInt(0),
+    inscriptionOutput: BigInt(19659),
+    secondChangeOutput: BigInt(0),
+    feeOutput: BigInt(341),
   });
+  testWithUnspents([testutil.mockWalletUnspent(network, BigInt(1_000))], undefined);
+  testWithUnspents(
+    [testutil.mockWalletUnspent(network, BigInt(1_000)), testutil.mockWalletUnspent(network, BigInt(100_000_000))],
+    {
+      firstChangeOutput: BigInt(0),
+      inscriptionOutput: BigInt(10_000),
+      secondChangeOutput: BigInt(99990329),
+      feeOutput: BigInt(671),
+    }
+  );
 });


### PR DESCRIPTION
A single input might be too small to allow building an inscription
passing transaction

Issue: BG-68315


<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->