### PR TITLE
fix: use half signed commit txn when signing reveal

### DIFF
--- a/modules/sdk-coin-btc/src/inscriptionBuilder.ts
+++ b/modules/sdk-coin-btc/src/inscriptionBuilder.ts
@@ -63,7 +63,7 @@ export class InscriptionBuilder implements IInscriptionBuilder {
       tapLeafScript,
       commitAddress,
       recipientAddress,
-      unsignedCommitTx,
+      Buffer.from(halfSignedCommitTransaction.txHex, 'hex'),
       this.coin.network
     );
 


### PR DESCRIPTION
Fixes the error where child transaction input did not have the same hash as the parent transaction.

TICKET: BG-70918