### PR TITLE
fix: used derived keys and use xonly public key for script

### DIFF
--- a/modules/sdk-core/src/account-lib/util/crypto.ts
+++ b/modules/sdk-core/src/account-lib/util/crypto.ts
@@ -7,16 +7,33 @@ import { ExtendedKeys } from '../baseCoin/iface';
 import bs58 from 'bs58';
 
 /**
- * @param {string} xpub - a base-58 encoded extended public key (BIP32)
- * @returns {string} the uncompressed public key in hexadecimal
+ * @param xpub - a base-58 encoded extended public key (BIP32)
+ * @param compressed flag to determine if return key should be compressed/uncompressed
+ * @return a compressed or an uncompresseed public key in hexadecimal
  */
-export function xpubToUncompressedPub(xpub: string): string {
+function xPubToPub(xpub: string, compressed: boolean) {
   if (!isValidXpub(xpub)) {
     throw new Error('invalid xpub');
   }
   return ECPair.fromPublicKey(bip32.fromBase58(xpub, networks.bitcoin).publicKey, {
-    compressed: false,
+    compressed,
   }).publicKey.toString('hex');
+}
+
+/**
+ * @param {string} xpub - a base-58 encoded extended public key (BIP32)
+ * @returns {string} the uncompressed public key in hexadecimal
+ */
+export function xpubToUncompressedPub(xpub: string): string {
+  return xPubToPub(xpub, false);
+}
+
+/**
+ * @param {string} xpub - a base-58 encoded extended public key (BIP32)
+ * @returns {string} the uncompressed public key in hexadecimal
+ */
+export function xpubToCompressedPub(xpub: string): string {
+  return xPubToPub(xpub, true);
 }
 
 /**

--- a/modules/sdk-core/src/bitgo/inscriptionBuilder/iInscriptionBuilder.ts
+++ b/modules/sdk-core/src/bitgo/inscriptionBuilder/iInscriptionBuilder.ts
@@ -75,7 +75,8 @@ export interface IInscriptionBuilder {
     commitAddress: string,
     unsignedCommitTx: Buffer,
     commitTransactionUnspents: utxolib.bitgo.WalletUnspent[],
-    recipientAddress: string
+    recipientAddress: string,
+    inscriptionData: Buffer
   ): Promise<SubmitTransactionResponse>;
 
   signAndSendTransfer(

--- a/modules/utxo-ord/src/inscriptions.ts
+++ b/modules/utxo-ord/src/inscriptions.ts
@@ -58,7 +58,7 @@ function createPaymentForInscription(pubkey: Buffer, contentType: string, inscri
     Buffer.from(contentType, 'ascii'),
     OPS.OP_0,
     ...dataPushBuffers,
-    OPS.ENDIF,
+    OPS.OP_ENDIF,
   ];
 
   const compiledScript = bscript.compile(uncompiledScript);
@@ -118,11 +118,11 @@ function getInscriptionRevealSize(
 }
 
 /**
- * @returns PreparedInscriptionRevealData
  * @param pubkey
  * @param contentType
  * @param inscriptionData
  * @param network
+ * @returns PreparedInscriptionRevealData
  */
 export function createInscriptionRevealData(
   pubkey: Buffer,
@@ -199,7 +199,7 @@ export function signRevealTransaction(
   psbt.addInput({
     hash,
     index: vout,
-    witnessUtxo: { script: commitOutput, value: BigInt(100_000) },
+    witnessUtxo: { script: commitOutput, value: BigInt(unserCommitTxn.outs[vout].value) },
     tapLeafScript: [tapLeafScript],
   });
 

--- a/modules/utxo-ord/test/inscription.ts
+++ b/modules/utxo-ord/test/inscription.ts
@@ -49,8 +49,8 @@ describe('inscriptions', () => {
 
       testInscriptionScript(
         inscriptionData,
-        '5120e0db418d51573f593389816568e86f96b65cf474712d085b1b0461645639f2fb',
-        'tb1purd5rr232ul4jvufs9jk36r0j6m9ear5wyksskcmq3skg43e7tasdjpqs4'
+        '512044d2e55d99b3412c569e3769f4522f9a92cbef8e10ab54f9db1f01421a541574',
+        'tb1pgnfw2hvekdqjc457xa5lg530n2fvhmuwzz44f7wmruq5yxj5z46qenh5sy'
       );
     });
 
@@ -59,8 +59,8 @@ describe('inscriptions', () => {
 
       testInscriptionScript(
         inscriptionData,
-        '51205cc628635e0d8fd0aab0547cc23c0a9e90f47c0c8b3348b0d394a62d2b8b63fb',
-        'tb1ptnrzsc67pk8ap24s237vy0q2n6g0glqv3ve53vxnjjnz62utv0as70jae4'
+        '5120d5092e5a0107db36b1e16044057fd47dd8d3309ff4f878989d8b55bd9823a187',
+        'tb1p65yjukspqldndv0pvpzq2l750hvdxvyl7nu83xya3d2mmxpr5xrsj02kpf'
       );
     });
   });


### PR DESCRIPTION
Inscription minting was failing due to invalid signature. The fix was to use derived keys and use xonly public key when creating the inscription script.

TICKET: BG-71103

Successful transactions:
Reveal: https://mempool.space/testnet/tx/2eb5d353ac3769a9bbcb7f4a363c3699f1e72ca4c79aeffca764b530a61ee2e5
Commit : https://mempool.space/testnet/tx/6d9b07c4dabf6743c435716a6c0b040910dd2fc4ff8d53b9b27315bc3df15231


### Usage

```
 const inscriptinoData = Buffer.from('Its Rick James', 'ascii');
  const { address, tapLeafScript, revealTransactionVSize } = await inscriptionBuilder.prepareReveal(inscriptinoData,'txt/plain;charset=utf-8');
  const feeRateSatPerKb = 1001;
  const sendAmount = new BigNumber( (revealTransactionVSize / 1000) * feeRateSatPerKb).plus(10000);

  const builtTxn = await walletInstance.prebuildTransaction({
    recipients: [{
      amount: sendAmount.decimalPlaces(0,6).toString(),
      address: address,
    }],
  });

  const unsignedCommitTx = builtTxn.txHex;
  const unspents = builtTxn.txInfo.unspents;

  const signedTx = await inscriptionBuilder.signAndSendReveal(walletPassphrase, tapLeafScript, address,
    Buffer.from(unsignedCommitTx, 'hex'),
    unspents,
    '2N8yw7oCh1rdMYmH4rGQVxfA4R2NmsnxzMX',
    inscriptinoData);
```