### PR TITLE
feat(sdk-core): enable fillNonce and acceleration tx for receive address

### DIFF
--- a/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
@@ -155,11 +155,13 @@ export abstract class MpcUtils {
             isTss: params.isTss,
             nonce: params.nonce,
             custodianTransactionId: params.custodianTransactionId,
+            receiveAddress: params.receiveAddress,
           };
         case 'acceleration':
           return {
             ...baseIntent,
             txid: params.lowFeeTxid,
+            receiveAddress: params.receiveAddress,
             feeOptions: params.feeOptions,
           };
         default:

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -93,6 +93,7 @@ export interface PrebuildTransactionWithIntentOptions extends IntentOptionsBase 
   hopParams?: HopParams;
   lowFeeTxid?: string;
   custodianTransactionId?: string;
+  receiveAddress?: string;
 }
 export interface IntentRecipient {
   address: {
@@ -135,6 +136,7 @@ export interface PopulatedIntent extends PopulatedIntentBase {
   feeOptions?: FeeOption | EIP1559FeeOptions;
   hopParams?: HopParams;
   txid?: string;
+  receiveAddress?: string;
   custodianTransactionId?: string;
   custodianMessageId?: string;
 }

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -105,6 +105,7 @@ export interface PrebuildTransactionOptions {
   eip1559?: EIP1559;
   gasLimit?: number;
   lowFeeTxid?: string;
+  receiveAddress?: string;
   isTss?: boolean;
   custodianTransactionId?: string;
   apiVersion?: ApiVersion;

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -188,6 +188,7 @@ export class Wallet implements IWallet {
       'numBlocks',
       'nonce',
       'preview',
+      'receiveAddress',
       'recipients',
       'reservation',
       'sequenceId',
@@ -1758,6 +1759,12 @@ export class Wallet implements IWallet {
       throw error;
     }
 
+    if (params.recipients && (params.type === 'fillNonce' || params.type === 'acceleration')) {
+      const error: any = new Error(`cannot provide recipients for transaction type ${params.type}`);
+      error.code = 'recipients_not_allowed_for_fillnonce_and_acceleration_tx_type';
+      throw error;
+    }
+
     // call prebuildTransaction and keychains-get in parallel
     // the prebuild can be overridden by providing an explicit tx
     const txPrebuildQuery = params.prebuildTx ? Promise.resolve(params.prebuildTx) : this.prebuildTransaction(params);
@@ -2690,6 +2697,7 @@ export class Wallet implements IWallet {
             intentType: 'acceleration',
             comment: params.comment,
             lowFeeTxid: params.lowFeeTxid,
+            receiveAddress: params.receiveAddress,
             feeOptions,
           },
           apiVersion,
@@ -2703,6 +2711,7 @@ export class Wallet implements IWallet {
             intentType: 'fillNonce',
             comment: params.comment,
             nonce: params.nonce,
+            receiveAddress: params.receiveAddress,
             feeOptions,
           },
           apiVersion,


### PR DESCRIPTION
This PR adds support for nonce hole filling and consolidation accelerations on an ETH TSS receive address

BG-69374
BG-69376

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->