### PR TITLE
feat(sdk-coin-atom): add function to load inputs and outputs of a txn

### DIFF
--- a/modules/sdk-coin-atom/src/lib/transactionBuilder.ts
+++ b/modules/sdk-coin-atom/src/lib/transactionBuilder.ts
@@ -143,7 +143,7 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
 
   /** @inheritdoc */
   protected async buildImplementation(): Promise<Transaction> {
-    this.transaction.transactionType(this.transactionType);
+    this.transaction.transactionType = this.transactionType;
     if (this._accountNumber) {
       this.transaction.accountNumber = this._accountNumber;
     }
@@ -176,6 +176,7 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
         this._signature
       );
     }
+    this.transaction.loadInputsAndOutputs();
     return this.transaction;
   }
 

--- a/modules/sdk-coin-atom/test/unit/keyPair.ts
+++ b/modules/sdk-coin-atom/test/unit/keyPair.ts
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import should from 'should';
+
 import { KeyPair } from '../../src/lib';
 import { TEST_ACCOUNT } from '../resources/atom';
 

--- a/modules/sdk-coin-atom/test/unit/transaction.ts
+++ b/modules/sdk-coin-atom/test/unit/transaction.ts
@@ -1,10 +1,11 @@
 import { toHex, TransactionType } from '@bitgo/sdk-core';
 import { coins } from '@bitgo/statics';
-import { DelegateOrUndelegeteMessage, SendMessage, WithdrawDelegatorRewardsMessage } from '../../src/lib/iface';
-import should from 'should';
-import { Transaction } from '../../src';
-import * as testData from '../resources/atom';
 import { fromBase64 } from '@cosmjs/encoding';
+import should from 'should';
+
+import { Transaction } from '../../src';
+import { DelegateOrUndelegeteMessage, SendMessage, WithdrawDelegatorRewardsMessage } from '../../src/lib/iface';
+import * as testData from '../resources/atom';
 
 describe('Atom Transaction', () => {
   let tx: Transaction;
@@ -38,6 +39,21 @@ describe('Atom Transaction', () => {
       );
       should.equal(Buffer.from(json.signature as any).toString('base64'), testData.TEST_SEND_TX.signature);
       should.equal(tx.type, TransactionType.Send);
+      tx.loadInputsAndOutputs();
+      should.deepEqual(tx.inputs, [
+        {
+          address: testData.TEST_SEND_TX.sender,
+          value: testData.TEST_SEND_TX.sendMessage.value.amount[0].amount,
+          coin: 'tatom',
+        },
+      ]);
+      should.deepEqual(tx.outputs, [
+        {
+          address: testData.TEST_SEND_TX.sendMessage.value.toAddress,
+          value: testData.TEST_SEND_TX.sendMessage.value.amount[0].amount,
+          coin: 'tatom',
+        },
+      ]);
     });
 
     it('should build a transfer from raw signed hex', function () {
@@ -56,6 +72,21 @@ describe('Atom Transaction', () => {
       );
       should.equal(Buffer.from(json.signature as any).toString('base64'), testData.TEST_SEND_TX.signature);
       should.equal(tx.type, TransactionType.Send);
+      tx.loadInputsAndOutputs();
+      should.deepEqual(tx.inputs, [
+        {
+          address: testData.TEST_SEND_TX.sender,
+          value: testData.TEST_SEND_TX.sendMessage.value.amount[0].amount,
+          coin: 'tatom',
+        },
+      ]);
+      should.deepEqual(tx.outputs, [
+        {
+          address: testData.TEST_SEND_TX.sendMessage.value.toAddress,
+          value: testData.TEST_SEND_TX.sendMessage.value.amount[0].amount,
+          coin: 'tatom',
+        },
+      ]);
     });
 
     it('should build a delegate txn from raw signed base64', function () {
@@ -74,6 +105,21 @@ describe('Atom Transaction', () => {
       );
       should.equal(Buffer.from(json.signature as any).toString('base64'), testData.TEST_DELEGATE_TX.signature);
       should.equal(tx.type, TransactionType.StakingActivate);
+      tx.loadInputsAndOutputs();
+      should.deepEqual(tx.inputs, [
+        {
+          address: testData.TEST_DELEGATE_TX.delegator,
+          value: testData.TEST_DELEGATE_TX.sendMessage.value.amount.amount,
+          coin: 'tatom',
+        },
+      ]);
+      should.deepEqual(tx.outputs, [
+        {
+          address: testData.TEST_DELEGATE_TX.validator,
+          value: testData.TEST_DELEGATE_TX.sendMessage.value.amount.amount,
+          coin: 'tatom',
+        },
+      ]);
     });
 
     it('should build a undelegate txn from raw signed base64', function () {
@@ -92,6 +138,21 @@ describe('Atom Transaction', () => {
       );
       should.equal(Buffer.from(json.signature as any).toString('base64'), testData.TEST_UNDELEGATE_TX.signature);
       should.equal(tx.type, TransactionType.StakingDeactivate);
+      tx.loadInputsAndOutputs();
+      should.deepEqual(tx.inputs, [
+        {
+          address: testData.TEST_UNDELEGATE_TX.delegator,
+          value: testData.TEST_UNDELEGATE_TX.sendMessage.value.amount.amount,
+          coin: 'tatom',
+        },
+      ]);
+      should.deepEqual(tx.outputs, [
+        {
+          address: testData.TEST_UNDELEGATE_TX.validator,
+          value: testData.TEST_UNDELEGATE_TX.sendMessage.value.amount.amount,
+          coin: 'tatom',
+        },
+      ]);
     });
 
     it('should build a withdraw rewards from raw signed base64', function () {
@@ -109,6 +170,22 @@ describe('Atom Transaction', () => {
       );
       should.equal(Buffer.from(json.signature as any).toString('base64'), testData.TEST_WITHDRAW_REWARDS_TX.signature);
       should.equal(tx.type, TransactionType.StakingWithdraw);
+
+      tx.loadInputsAndOutputs();
+      should.deepEqual(tx.inputs, [
+        {
+          address: testData.TEST_WITHDRAW_REWARDS_TX.delegator,
+          value: 'UNAVAILABLE',
+          coin: 'tatom',
+        },
+      ]);
+      should.deepEqual(tx.outputs, [
+        {
+          address: testData.TEST_WITHDRAW_REWARDS_TX.validator,
+          value: 'UNAVAILABLE',
+          coin: 'tatom',
+        },
+      ]);
     });
     it('should fail to build a transfer from incorrect raw hex', function () {
       should.throws(

--- a/modules/sdk-coin-atom/test/unit/transactionBuilder/StakingDeactivateBuilder.ts
+++ b/modules/sdk-coin-atom/test/unit/transactionBuilder/StakingDeactivateBuilder.ts
@@ -23,6 +23,20 @@ describe('Atom Undelegate txn Builder', () => {
     should.deepEqual(json.sequence, testTx.sequence);
     const rawTx = tx.toBroadcastFormat();
     should.equal(rawTx, testTx.signedTxBase64);
+    should.deepEqual(tx.inputs, [
+      {
+        address: testTx.delegator,
+        value: testTx.sendMessage.value.amount.amount,
+        coin: 'tatom',
+      },
+    ]);
+    should.deepEqual(tx.outputs, [
+      {
+        address: testTx.validator,
+        value: testTx.sendMessage.value.amount.amount,
+        coin: 'tatom',
+      },
+    ]);
   });
 
   it('should build undelegate tx without signature', async function () {
@@ -39,6 +53,20 @@ describe('Atom Undelegate txn Builder', () => {
     should.deepEqual(json.publicKey, toHex(fromBase64(testTx.pubKey)));
     should.deepEqual(json.sequence, testTx.sequence);
     tx.toBroadcastFormat();
+    should.deepEqual(tx.inputs, [
+      {
+        address: testTx.delegator,
+        value: testTx.sendMessage.value.amount.amount,
+        coin: 'tatom',
+      },
+    ]);
+    should.deepEqual(tx.outputs, [
+      {
+        address: testTx.validator,
+        value: testTx.sendMessage.value.amount.amount,
+        coin: 'tatom',
+      },
+    ]);
   });
 
   it('should sign undelegate tx', async function () {
@@ -59,5 +87,19 @@ describe('Atom Undelegate txn Builder', () => {
     const rawTx = tx.toBroadcastFormat();
     should.equal(tx.signature[0], toHex(fromBase64(testTx.signature)));
     should.equal(rawTx, testTx.signedTxBase64);
+    should.deepEqual(tx.inputs, [
+      {
+        address: testTx.delegator,
+        value: testTx.sendMessage.value.amount.amount,
+        coin: 'tatom',
+      },
+    ]);
+    should.deepEqual(tx.outputs, [
+      {
+        address: testTx.validator,
+        value: testTx.sendMessage.value.amount.amount,
+        coin: 'tatom',
+      },
+    ]);
   });
 });

--- a/modules/sdk-coin-atom/test/unit/transactionBuilder/StakingWithdrawRewardsBuilder.ts
+++ b/modules/sdk-coin-atom/test/unit/transactionBuilder/StakingWithdrawRewardsBuilder.ts
@@ -2,7 +2,6 @@ import { toHex, TransactionType } from '@bitgo/sdk-core';
 import { fromBase64 } from '@cosmjs/encoding';
 import should from 'should';
 
-import { Transaction as AtomTransaction } from '../../../src/lib/transaction';
 import * as testData from '../../resources/atom';
 import { getBuilderFactory } from '../getBuilderFactory';
 
@@ -18,10 +17,28 @@ describe('Atom WithdrawRewards txn Builder', () => {
     txBuilder.addSignature({ pub: toHex(fromBase64(testTx.pubKey)) }, Buffer.from(testTx.signature, 'base64'));
 
     const tx = await txBuilder.build();
+    const json = await (await txBuilder.build()).toJson();
     should.equal(tx.type, TransactionType.StakingWithdraw);
-    (tx as AtomTransaction).atomTransaction.gasBudget.should.deepEqual(testTx.gasBudget);
+    should.deepEqual(json.gasBudget, testTx.gasBudget);
+    should.deepEqual(json.sendMessages, [testTx.sendMessage]);
+    should.deepEqual(json.publicKey, toHex(fromBase64(testTx.pubKey)));
+    should.deepEqual(json.sequence, testTx.sequence);
     const rawTx = tx.toBroadcastFormat();
     should.equal(rawTx, testTx.signedTxBase64);
+    should.deepEqual(tx.inputs, [
+      {
+        address: testData.TEST_WITHDRAW_REWARDS_TX.delegator,
+        value: 'UNAVAILABLE',
+        coin: 'tatom',
+      },
+    ]);
+    should.deepEqual(tx.outputs, [
+      {
+        address: testData.TEST_WITHDRAW_REWARDS_TX.validator,
+        value: 'UNAVAILABLE',
+        coin: 'tatom',
+      },
+    ]);
   });
 
   it('should build a WithdrawRewards tx without signature', async function () {
@@ -38,6 +55,20 @@ describe('Atom WithdrawRewards txn Builder', () => {
     should.deepEqual(json.publicKey, toHex(fromBase64(testTx.pubKey)));
     should.deepEqual(json.sequence, testTx.sequence);
     tx.toBroadcastFormat();
+    should.deepEqual(tx.inputs, [
+      {
+        address: testData.TEST_WITHDRAW_REWARDS_TX.delegator,
+        value: 'UNAVAILABLE',
+        coin: 'tatom',
+      },
+    ]);
+    should.deepEqual(tx.outputs, [
+      {
+        address: testData.TEST_WITHDRAW_REWARDS_TX.validator,
+        value: 'UNAVAILABLE',
+        coin: 'tatom',
+      },
+    ]);
   });
 
   it('should sign a WithdrawRewards tx', async function () {
@@ -58,5 +89,19 @@ describe('Atom WithdrawRewards txn Builder', () => {
     const rawTx = tx.toBroadcastFormat();
     should.equal(tx.signature[0], toHex(fromBase64(testTx.signature)));
     should.equal(rawTx, testTx.signedTxBase64);
+    should.deepEqual(tx.inputs, [
+      {
+        address: testData.TEST_WITHDRAW_REWARDS_TX.delegator,
+        value: 'UNAVAILABLE',
+        coin: 'tatom',
+      },
+    ]);
+    should.deepEqual(tx.outputs, [
+      {
+        address: testData.TEST_WITHDRAW_REWARDS_TX.validator,
+        value: 'UNAVAILABLE',
+        coin: 'tatom',
+      },
+    ]);
   });
 });


### PR DESCRIPTION
BaseTransaction has five properties: id, type, inputs, outputs and signature. There is coin specific txn object is also present in extended transaction classes, AtomTransaction in this case. This PR adds a function to transaction class to load inputs and outputs from AtomTransaction. This PR also makes sure that `loadInputsAndOutputs` is called while building the transaction in TransactionBuilder

Ticket: BG-70311

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->