### PR TITLE
chore(sdk-core): export ecdsa and bip32 classes

### DIFF
--- a/modules/sdk-core/src/account-lib/mpc/index.ts
+++ b/modules/sdk-core/src/account-lib/mpc/index.ts
@@ -1,4 +1,4 @@
-import HDTree, { Ed25519BIP32 } from './hdTree';
+import HDTree, { Ed25519BIP32, BIP32 } from './hdTree';
 import { EDDSA } from './tss';
 import ShamirSecret from './shamir';
 
@@ -9,4 +9,4 @@ export * from './util';
 
 type KeyShare = EDDSA.KeyShare;
 
-export { Ed25519BIP32, HDTree, KeyShare, ShamirSecret };
+export { Ed25519BIP32, HDTree, KeyShare, ShamirSecret, BIP32 };


### PR DESCRIPTION
Exporting ecdsa and bip32 classes to use in WP.

TICKET: BG-69708