### PR TITLE
feat(sdk-core): allow passing a list of delegations for eth

### DIFF
--- a/modules/sdk-core/src/bitgo/staking/iStakingWallet.ts
+++ b/modules/sdk-core/src/bitgo/staking/iStakingWallet.ts
@@ -31,6 +31,11 @@ export interface UnstakeOptions {
   delegationId?: string;
 }
 
+export interface EthUnstakeOptions {
+  clientId?: string;
+  delegationIds?: string[];
+}
+
 export interface SwitchValidatorOptions {
   amount: string;
   clientId?: string;
@@ -112,7 +117,7 @@ export interface IStakingWallet {
   readonly walletId: string;
   readonly coin: string;
   stake(options: StakeOptions): Promise<StakingRequest>;
-  unstake(options: UnstakeOptions): Promise<StakingRequest>;
+  unstake(options: UnstakeOptions | EthUnstakeOptions): Promise<StakingRequest>;
   switchValidator(options: SwitchValidatorOptions): Promise<StakingRequest>;
   getStakingRequest(stakingRequestId: string): Promise<StakingRequest>;
   getTransactionsReadyToSign(stakingRequestId: string): Promise<TransactionsReadyToSign>;

--- a/modules/sdk-core/src/bitgo/staking/stakingWallet.ts
+++ b/modules/sdk-core/src/bitgo/staking/stakingWallet.ts
@@ -14,6 +14,7 @@ import {
   SwitchValidatorOptions,
   TransactionsReadyToSign,
   UnstakeOptions,
+  EthUnstakeOptions,
 } from './iStakingWallet';
 import { BitGoBase } from '../bitgoBase';
 import { IWallet } from '../wallet';
@@ -56,7 +57,7 @@ export class StakingWallet implements IStakingWallet {
    * @param options - unstake options
    * @return StakingRequest
    */
-  async unstake(options: UnstakeOptions): Promise<StakingRequest> {
+  async unstake(options: UnstakeOptions | EthUnstakeOptions): Promise<StakingRequest> {
     return await this.createStakingRequest(options, 'UNSTAKE');
   }
 
@@ -224,7 +225,7 @@ export class StakingWallet implements IStakingWallet {
   }
 
   private async createStakingRequest(
-    options: StakeOptions | UnstakeOptions | SwitchValidatorOptions,
+    options: StakeOptions | UnstakeOptions | EthUnstakeOptions | SwitchValidatorOptions,
     type: string
   ): Promise<StakingRequest> {
     return await this.bitgo


### PR DESCRIPTION
BG-71114

currently only ETH unstaking endpoint supports a list of delegations 

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->