### PR TITLE
refactor(utxo-lib): introduce ParsedScriptType

### DIFF
--- a/modules/unspents/src/dimensions.ts
+++ b/modules/unspents/src/dimensions.ts
@@ -221,7 +221,7 @@ export class Dimensions {
    * @return
    */
   static fromScriptType(
-    scriptType: utxolib.bitgo.outputScripts.ScriptType | 'p2pkh',
+    scriptType: utxolib.bitgo.outputScripts.ScriptType | utxolib.bitgo.ParsedScriptType | 'p2pkh',
     params: {
       scriptPathLevel?: number;
     } = {}
@@ -234,6 +234,7 @@ export class Dimensions {
         return Dimensions.SingleInput[scriptType];
       case 'p2tr':
       case 'p2trMusig2':
+      case 'taprootScriptPathSpend':
         switch (params.scriptPathLevel) {
           case undefined:
             return Dimensions.SingleInput.p2trKeypath;
@@ -244,6 +245,8 @@ export class Dimensions {
           default:
             throw new Error(`unexpected script path level`);
         }
+      case 'taprootKeyPathSpend':
+        throw new Error('TODO');
       default:
         throw new Error(`unexpected scriptType ${scriptType}`);
     }

--- a/modules/utxo-lib/src/bitgo/UtxoPsbt.ts
+++ b/modules/utxo-lib/src/bitgo/UtxoPsbt.ts
@@ -306,7 +306,7 @@ export class UtxoPsbt<Tx extends UtxoTransaction<bigint> = UtxoTransaction<bigin
     }
     const { controlBlock, script } = input.tapLeafScript[0];
     const witness: Buffer[] = [script, controlBlock];
-    const [pubkey1, pubkey2] = parsePubScript(script, 'p2tr').publicKeys;
+    const [pubkey1, pubkey2] = parsePubScript(script, 'taprootScriptPathSpend').publicKeys;
     for (const pk of [pubkey1, pubkey2]) {
       const sig = input.tapScriptSig?.find(({ pubkey }) => pubkey.equals(pk));
       if (!sig) {

--- a/modules/utxo-lib/src/bitgo/parseInput.ts
+++ b/modules/utxo-lib/src/bitgo/parseInput.ts
@@ -38,7 +38,7 @@ export function calculateScriptPathLevel(controlBlock: Buffer): number {
 /**
  * @return leaf version for P2TR control block.
  */
-export function getScriptPathLevel(controlBlock: Buffer): number {
+export function getLeafVersion(controlBlock: Buffer): number {
   if (Buffer.isBuffer(controlBlock) && controlBlock.length > 0) {
     return controlBlock[0] & 0xfe;
   }
@@ -395,7 +395,7 @@ const parseP2tr2Of3: InputParser<ParsedSignatureScriptTaproot> = (p) => {
   const [controlBlock] = match[':control-block'];
   const scriptPathLevel = calculateScriptPathLevel(controlBlock);
 
-  const leafVersion = getScriptPathLevel(controlBlock);
+  const leafVersion = getLeafVersion(controlBlock);
 
   return {
     scriptType: 'p2tr',

--- a/modules/utxo-lib/src/bitgo/psbt/fromHalfSigned.ts
+++ b/modules/utxo-lib/src/bitgo/psbt/fromHalfSigned.ts
@@ -37,7 +37,13 @@ export function getInputUpdate(
   // Because Zcash directly hashes the value for non-segwit transactions, we do not need to check indirectly
   // with the previous transaction. Therefore, we can treat Zcash non-segwit transactions as Bitcoin
   // segwit transactions
-  if (!hasWitnessData(parsedInput.scriptType) && !nonWitnessUtxo && getMainnet(tx.network) !== networks.zcash) {
+  if (
+    parsedInput.scriptType !== 'taprootScriptPathSpend' &&
+    parsedInput.scriptType !== 'taprootKeyPathSpend' &&
+    !hasWitnessData(parsedInput.scriptType) &&
+    !nonWitnessUtxo &&
+    getMainnet(tx.network) !== networks.zcash
+  ) {
     throw new Error(`scriptType ${parsedInput.scriptType} requires prevTx Buffer`);
   }
 
@@ -56,7 +62,7 @@ export function getInputUpdate(
         redeemScript: parsedInput.redeemScript,
         witnessScript: parsedInput.witnessScript,
       });
-    case 'p2tr':
+    case 'taprootScriptPathSpend':
       if (!('controlBlock' in parsedInput)) {
         throw new Error(`keypath not implemented`);
       }
@@ -71,6 +77,8 @@ export function getInputUpdate(
         ],
         tapScriptSig: getPartialSigs().map((obj) => ({ ...obj, leafHash })),
       };
+    default:
+      throw new Error(`parsedInput.scriptType not supported ${parsedInput.scriptType}`);
   }
 }
 

--- a/modules/utxo-lib/src/bitgo/signature.ts
+++ b/modules/utxo-lib/src/bitgo/signature.ts
@@ -102,7 +102,7 @@ export function getSignatureVerifications<TNumber extends number | bigint>(
       signatureBuffer = signatureBuffer.slice(0, -1);
     }
 
-    if (parsedScript.scriptType === 'p2tr') {
+    if (parsedScript.scriptType === 'taprootScriptPathSpend') {
       if (verificationSettings.signatureIndex !== undefined) {
         throw new Error(`signatureIndex parameter not supported for p2tr`);
       }

--- a/modules/utxo-lib/src/bitgo/wallet/Psbt.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/Psbt.ts
@@ -15,7 +15,7 @@ import { isWalletUnspent, WalletUnspent } from './Unspent';
 import { checkForInput } from 'bip174/src/lib/utils';
 import { PsbtInput } from 'bip174/src/lib/interfaces';
 import {
-  getScriptPathLevel,
+  getLeafVersion,
   calculateScriptPathLevel,
   isValidControlBock,
   ParsedPubScript2Of3,
@@ -247,7 +247,7 @@ function parseInputMetadata(input: PsbtInput, scriptType: ScriptType2Of3): Parse
       throw new Error('Invalid PSBT p2tr script path controlBlock.');
     }
     const scriptPathLevel = calculateScriptPathLevel(controlBlock);
-    const leafVersion = getScriptPathLevel(controlBlock);
+    const leafVersion = getLeafVersion(controlBlock);
     return {
       ...parsedPubScript,
       signatures,

--- a/modules/utxo-lib/src/bitgo/wallet/Psbt.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/Psbt.ts
@@ -1,12 +1,6 @@
 import { UtxoPsbt } from '../UtxoPsbt';
 import { UtxoTransaction } from '../UtxoTransaction';
-import {
-  createOutputScript2of3,
-  getLeafHash,
-  ScriptType2Of3,
-  scriptTypeForChain,
-  toXOnlyPublicKey,
-} from '../outputScripts';
+import { createOutputScript2of3, getLeafHash, scriptTypeForChain, toXOnlyPublicKey } from '../outputScripts';
 import { DerivedWalletKeys, RootWalletKeys } from './WalletKeys';
 import { toPrevOutputWithPrevTx } from '../Unspent';
 import { createPsbtFromTransaction } from '../transaction';
@@ -21,6 +15,7 @@ import {
   ParsedPubScript2Of3,
   ParsedPubScriptTaprootScriptPath,
   parsePubScript,
+  ParsedScriptType,
 } from '../parseInput';
 
 type Signatures = [Buffer] | [Buffer, Buffer] | undefined;
@@ -43,7 +38,7 @@ interface WalletSigner {
 }
 
 function getTaprootSigners(script: Buffer, walletKeys: DerivedWalletKeys): [WalletSigner, WalletSigner] {
-  const parsedPublicKeys = parsePubScript(script, 'p2tr').publicKeys;
+  const parsedPublicKeys = parsePubScript(script, 'taprootScriptPathSpend').publicKeys;
   const walletSigners = parsedPublicKeys.map((publicKey) => {
     const index = walletKeys.publicKeys.findIndex((walletPublicKey) =>
       toXOnlyPublicKey(walletPublicKey).equals(publicKey)
@@ -159,8 +154,8 @@ export function signWalletPsbt(
   }
 }
 
-function classifyScriptType(input: PsbtInput): ScriptType2Of3 | undefined {
-  let scriptType: ScriptType2Of3 | undefined;
+function classifyScriptType(input: PsbtInput): ParsedScriptType | undefined {
+  let scriptType: ParsedScriptType | undefined;
   if (Buffer.isBuffer(input.redeemScript) && Buffer.isBuffer(input.witnessScript)) {
     scriptType = 'p2shP2wsh';
   } else if (Buffer.isBuffer(input.redeemScript)) {
@@ -175,12 +170,12 @@ function classifyScriptType(input: PsbtInput): ScriptType2Of3 | undefined {
     if (input.tapLeafScript.length > 1) {
       throw new Error('Bitgo only supports a single tap leaf script per input.');
     }
-    scriptType = 'p2tr';
+    scriptType = 'taprootScriptPathSpend';
   }
   return scriptType;
 }
 
-function parseSignatures(input: PsbtInput, scriptType: ScriptType2Of3): Signatures {
+function parseSignatures(input: PsbtInput, scriptType: ParsedScriptType): Signatures {
   const validate = (sig: Buffer): Buffer => {
     if (Buffer.isBuffer(sig)) {
       return sig;
@@ -188,7 +183,7 @@ function parseSignatures(input: PsbtInput, scriptType: ScriptType2Of3): Signatur
     throw new Error('Invalid signature type');
   };
 
-  if (scriptType === 'p2tr') {
+  if (scriptType === 'taprootScriptPathSpend') {
     if (input.partialSig && input.partialSig.length > 0) {
       throw new Error('Invalid PSBT signature state');
     }
@@ -218,7 +213,7 @@ function parseSignatures(input: PsbtInput, scriptType: ScriptType2Of3): Signatur
 
 function parseScript(
   input: PsbtInput,
-  scriptType: ScriptType2Of3
+  scriptType: ParsedScriptType
 ): ParsedPubScript2Of3 | ParsedPubScriptTaprootScriptPath {
   let pubScript: Buffer | undefined;
   if (scriptType === 'p2sh') {
@@ -234,11 +229,11 @@ function parseScript(
   return parsePubScript(pubScript, scriptType);
 }
 
-function parseInputMetadata(input: PsbtInput, scriptType: ScriptType2Of3): ParsedPsbt2Of3 | ParsedPsbtP2TR {
+function parseInputMetadata(input: PsbtInput, scriptType: ParsedScriptType): ParsedPsbt2Of3 | ParsedPsbtP2TR {
   const parsedPubScript = parseScript(input, scriptType);
   const signatures = parseSignatures(input, scriptType);
 
-  if (parsedPubScript.scriptType === 'p2tr') {
+  if (parsedPubScript.scriptType === 'taprootScriptPathSpend') {
     if (!input.tapLeafScript) {
       throw new Error('Invalid PSBT state for p2tr. Missing required fields.');
     }

--- a/modules/utxo-lib/test/bitgo/psbt/psbtUtil.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/psbtUtil.ts
@@ -32,82 +32,82 @@ import { SignatureTargetType } from './Psbt';
 import { Network } from '../../../src';
 
 function validateScript(
-  psbtParsed: ParsedPsbt2Of3 | ParsedPsbtP2TR | undefined,
+  psbtParsed: ParsedPsbt2Of3 | ParsedPsbtP2TR,
   txParsed: ParsedSignatureScript2Of3 | ParsedSignatureScriptTaproot | undefined
 ) {
   if (txParsed === undefined) {
-    assert.deepStrictEqual(Buffer.isBuffer(psbtParsed?.pubScript), true);
+    assert.deepStrictEqual(Buffer.isBuffer(psbtParsed.pubScript), true);
 
-    if (psbtParsed?.scriptType === 'p2sh') {
-      assert.deepStrictEqual(Buffer.isBuffer(psbtParsed?.redeemScript), true);
-      assert.deepStrictEqual(Buffer.isBuffer(psbtParsed?.witnessScript), false);
-    } else if (psbtParsed?.scriptType === 'p2wsh') {
-      assert.deepStrictEqual(Buffer.isBuffer(psbtParsed?.redeemScript), false);
-      assert.deepStrictEqual(Buffer.isBuffer(psbtParsed?.witnessScript), true);
-    } else if (psbtParsed?.scriptType === 'p2shP2wsh') {
-      assert.deepStrictEqual(Buffer.isBuffer(psbtParsed?.redeemScript), true);
-      assert.deepStrictEqual(Buffer.isBuffer(psbtParsed?.witnessScript), true);
-    } else if (psbtParsed?.scriptType === 'p2tr') {
-      assert.deepStrictEqual(isValidControlBock(psbtParsed?.controlBlock), true);
-      assert.deepStrictEqual(psbtParsed?.scriptPathLevel, calculateScriptPathLevel(psbtParsed?.controlBlock));
-      assert.deepStrictEqual(psbtParsed?.leafVersion, getLeafVersion(psbtParsed?.controlBlock));
+    if (psbtParsed.scriptType === 'p2sh') {
+      assert.deepStrictEqual(Buffer.isBuffer(psbtParsed.redeemScript), true);
+      assert.deepStrictEqual(Buffer.isBuffer(psbtParsed.witnessScript), false);
+    } else if (psbtParsed.scriptType === 'p2wsh') {
+      assert.deepStrictEqual(Buffer.isBuffer(psbtParsed.redeemScript), false);
+      assert.deepStrictEqual(Buffer.isBuffer(psbtParsed.witnessScript), true);
+    } else if (psbtParsed.scriptType === 'p2shP2wsh') {
+      assert.deepStrictEqual(Buffer.isBuffer(psbtParsed.redeemScript), true);
+      assert.deepStrictEqual(Buffer.isBuffer(psbtParsed.witnessScript), true);
+    } else if (psbtParsed.scriptType === 'p2tr') {
+      assert.deepStrictEqual(isValidControlBock(psbtParsed.controlBlock), true);
+      assert.deepStrictEqual(psbtParsed.scriptPathLevel, calculateScriptPathLevel(psbtParsed.controlBlock));
+      assert.deepStrictEqual(psbtParsed.leafVersion, getLeafVersion(psbtParsed.controlBlock));
     }
   } else {
-    assert.deepStrictEqual(txParsed.scriptType, psbtParsed?.scriptType);
-    assert.deepStrictEqual(txParsed.pubScript, psbtParsed?.pubScript);
+    assert.deepStrictEqual(txParsed.scriptType, psbtParsed.scriptType);
+    assert.deepStrictEqual(txParsed.pubScript, psbtParsed.pubScript);
 
     if (
-      (txParsed.scriptType === 'p2sh' && psbtParsed?.scriptType === 'p2sh') ||
-      (txParsed.scriptType === 'p2wsh' && psbtParsed?.scriptType === 'p2wsh') ||
-      (txParsed.scriptType === 'p2shP2wsh' && psbtParsed?.scriptType === 'p2shP2wsh')
+      (txParsed.scriptType === 'p2sh' && psbtParsed.scriptType === 'p2sh') ||
+      (txParsed.scriptType === 'p2wsh' && psbtParsed.scriptType === 'p2wsh') ||
+      (txParsed.scriptType === 'p2shP2wsh' && psbtParsed.scriptType === 'p2shP2wsh')
     ) {
-      assert.deepStrictEqual(txParsed.redeemScript, psbtParsed?.redeemScript);
-      assert.deepStrictEqual(txParsed.witnessScript, psbtParsed?.witnessScript);
-    } else if (txParsed.scriptType === 'p2tr' && psbtParsed?.scriptType === 'p2tr') {
+      assert.deepStrictEqual(txParsed.redeemScript, psbtParsed.redeemScript);
+      assert.deepStrictEqual(txParsed.witnessScript, psbtParsed.witnessScript);
+    } else if (txParsed.scriptType === 'p2tr' && psbtParsed.scriptType === 'p2tr') {
       // To ensure script path p2tr
       assert.deepStrictEqual(txParsed.publicKeys, psbtParsed.publicKeys);
       const txParsedP2trScriptPath = txParsed as ParsedSignatureScriptTaprootScriptPath;
-      assert.deepStrictEqual(txParsedP2trScriptPath.controlBlock, psbtParsed?.controlBlock);
-      assert.deepStrictEqual(txParsedP2trScriptPath.scriptPathLevel, psbtParsed?.scriptPathLevel);
-      assert.deepStrictEqual(txParsedP2trScriptPath.leafVersion, psbtParsed?.leafVersion);
+      assert.deepStrictEqual(txParsedP2trScriptPath.controlBlock, psbtParsed.controlBlock);
+      assert.deepStrictEqual(txParsedP2trScriptPath.scriptPathLevel, psbtParsed.scriptPathLevel);
+      assert.deepStrictEqual(txParsedP2trScriptPath.leafVersion, psbtParsed.leafVersion);
     }
   }
 }
 
 function validatePublicKeys(
-  psbtParsed: ParsedPsbt2Of3 | ParsedPsbtP2TR | undefined,
+  psbtParsed: ParsedPsbt2Of3 | ParsedPsbtP2TR,
   txParsed: ParsedSignatureScript2Of3 | ParsedSignatureScriptTaproot | undefined
 ) {
   if (txParsed === undefined) {
-    assert.deepStrictEqual(psbtParsed?.publicKeys.length, 3);
-    psbtParsed?.publicKeys.forEach((publicKey) => {
+    assert.deepStrictEqual(psbtParsed.publicKeys.length, 3);
+    psbtParsed.publicKeys.forEach((publicKey) => {
       assert.deepStrictEqual(Buffer.isBuffer(publicKey), true);
     });
   } else {
-    assert.deepStrictEqual(txParsed.publicKeys.length, psbtParsed?.publicKeys?.length);
+    assert.deepStrictEqual(txParsed.publicKeys.length, psbtParsed.publicKeys?.length);
     const pubKeyMatch = txParsed.publicKeys.every((txPubKey) =>
-      psbtParsed?.publicKeys?.some((psbtPubKey) => psbtPubKey.equals(txPubKey))
+      psbtParsed.publicKeys?.some((psbtPubKey) => psbtPubKey.equals(txPubKey))
     );
     assert.deepStrictEqual(pubKeyMatch, true);
   }
 }
 
 function validateSignature(
-  psbtParsed: ParsedPsbt2Of3 | ParsedPsbtP2TR | undefined,
+  psbtParsed: ParsedPsbt2Of3 | ParsedPsbtP2TR,
   txParsed: ParsedSignatureScript2Of3 | ParsedSignatureScriptTaproot | undefined
 ) {
   if (txParsed === undefined) {
-    assert.deepStrictEqual(psbtParsed?.signatures, undefined);
+    assert.deepStrictEqual(psbtParsed.signatures, undefined);
   } else {
     const txSignatures = txParsed.signatures.filter(
       (txSig) => Buffer.isBuffer(txSig) && !isPlaceholderSignature(txSig)
     );
-    assert.deepStrictEqual(txSignatures.length, psbtParsed?.signatures?.length);
+    assert.deepStrictEqual(txSignatures.length, psbtParsed.signatures?.length);
     if (txSignatures.length < 1) {
       return;
     }
     const sigMatch = txSignatures.every((txSig) =>
-      Buffer.isBuffer(txSig) ? psbtParsed?.signatures?.some((psbtSig) => psbtSig.equals(txSig)) : true
+      Buffer.isBuffer(txSig) ? psbtParsed.signatures?.some((psbtSig) => psbtSig.equals(txSig)) : true
     );
     assert.deepStrictEqual(sigMatch, true);
   }
@@ -131,7 +131,7 @@ export function validatePsbtParsing(
         assert.deepStrictEqual(psbtParsed, undefined);
       } else {
         assert.ok(psbtParsed);
-        assert.deepStrictEqual(psbtParsed?.scriptType, scriptType);
+        assert.deepStrictEqual(psbtParsed.scriptType, scriptType);
         validateScript(psbtParsed, undefined);
         validatePublicKeys(psbtParsed, undefined);
         validateSignature(psbtParsed, undefined);
@@ -139,7 +139,7 @@ export function validatePsbtParsing(
     } else {
       assert.ok(psbtParsed);
       const txParsed = parseSignatureScript2Of3(tx.ins[i]);
-      assert.deepStrictEqual(psbtParsed?.scriptType, scriptType);
+      assert.deepStrictEqual(psbtParsed.scriptType, scriptType);
       validateScript(psbtParsed, txParsed);
       validatePublicKeys(psbtParsed, txParsed);
       validateSignature(psbtParsed, txParsed);

--- a/modules/utxo-lib/test/bitgo/psbt/psbtUtil.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/psbtUtil.ts
@@ -47,7 +47,7 @@ function validateScript(
     } else if (psbtParsed.scriptType === 'p2shP2wsh') {
       assert.deepStrictEqual(Buffer.isBuffer(psbtParsed.redeemScript), true);
       assert.deepStrictEqual(Buffer.isBuffer(psbtParsed.witnessScript), true);
-    } else if (psbtParsed.scriptType === 'p2tr') {
+    } else if (psbtParsed.scriptType === 'taprootScriptPathSpend') {
       assert.deepStrictEqual(isValidControlBock(psbtParsed.controlBlock), true);
       assert.deepStrictEqual(psbtParsed.scriptPathLevel, calculateScriptPathLevel(psbtParsed.controlBlock));
       assert.deepStrictEqual(psbtParsed.leafVersion, getLeafVersion(psbtParsed.controlBlock));
@@ -63,7 +63,7 @@ function validateScript(
     ) {
       assert.deepStrictEqual(txParsed.redeemScript, psbtParsed.redeemScript);
       assert.deepStrictEqual(txParsed.witnessScript, psbtParsed.witnessScript);
-    } else if (txParsed.scriptType === 'p2tr' && psbtParsed.scriptType === 'p2tr') {
+    } else if (txParsed.scriptType === 'taprootScriptPathSpend' && psbtParsed.scriptType === 'taprootScriptPathSpend') {
       // To ensure script path p2tr
       assert.deepStrictEqual(txParsed.publicKeys, psbtParsed.publicKeys);
       const txParsedP2trScriptPath = txParsed as ParsedSignatureScriptTaprootScriptPath;

--- a/modules/utxo-lib/test/bitgo/psbt/psbtUtil.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/psbtUtil.ts
@@ -1,6 +1,6 @@
 import {
   addToTransactionBuilder,
-  getScriptPathLevel,
+  getLeafVersion,
   calculateScriptPathLevel,
   createTransactionBuilderForNetwork,
   getInternalChainCode,
@@ -50,7 +50,7 @@ function validateScript(
     } else if (psbtParsed?.scriptType === 'p2tr') {
       assert.deepStrictEqual(isValidControlBock(psbtParsed?.controlBlock), true);
       assert.deepStrictEqual(psbtParsed?.scriptPathLevel, calculateScriptPathLevel(psbtParsed?.controlBlock));
-      assert.deepStrictEqual(psbtParsed?.leafVersion, getScriptPathLevel(psbtParsed?.controlBlock));
+      assert.deepStrictEqual(psbtParsed?.leafVersion, getLeafVersion(psbtParsed?.controlBlock));
     }
   } else {
     assert.deepStrictEqual(txParsed.scriptType, psbtParsed?.scriptType);

--- a/modules/utxo-lib/test/bitgo/signature.ts
+++ b/modules/utxo-lib/test/bitgo/signature.ts
@@ -158,7 +158,7 @@ function runTestParseScript<TNumber extends number | bigint = number>(
       case 'p2sh':
       case 'p2shP2wsh':
       case 'p2wsh':
-      case 'p2tr':
+      case 'taprootScriptPathSpend':
         assert.strictEqual(
           parsed.signatures.filter((s) => isPlaceholderSignature(s)).length,
           expectedPlaceholderSignatures


### PR DESCRIPTION
When parsing inputs, we cannot always map the parsed script type to a 
single outputScript.

We introduce a new type to represent the parse result.

Issue: BG-66942

7a420d823
refactor(utxo-lib): tighten constraints in validateScript

We don't need to consider the `| undefined` case for `psbtParsed`

Issue: BG-66942