### PR TITLE
feat(utxo-lib): new function getTaprootOutputKey

### DIFF
--- a/modules/utxo-lib/src/bitgo/UtxoPsbt.ts
+++ b/modules/utxo-lib/src/bitgo/UtxoPsbt.ts
@@ -13,7 +13,7 @@ import { UtxoTransaction } from './UtxoTransaction';
 import { getOutputIdForInput } from './Unspent';
 import { isSegwit } from './psbt/scriptTypes';
 import { unsign } from './psbt/fromHalfSigned';
-import { checkPlainPublicKey, createTaprootOutputScript, toXOnlyPublicKey } from './outputScripts';
+import { checkPlainPublicKey, toXOnlyPublicKey } from './outputScripts';
 import { parsePubScript } from './parseInput';
 import { BIP32Factory, BIP32Interface } from 'bip32';
 import * as bs58check from 'bs58check';
@@ -754,12 +754,15 @@ export class UtxoPsbt<Tx extends UtxoTransaction<bigint> = UtxoTransaction<bigin
   private getTaprootOutputScript(inputIndex: number) {
     const input = checkForInput(this.data.inputs, inputIndex);
     if (input.tapLeafScript?.length) {
-      return createTaprootOutputScript({
+      return taproot.createTaprootOutputScript({
         controlBlock: input.tapLeafScript[0].controlBlock,
         leafScript: input.tapLeafScript[0].script,
       });
     } else if (input.tapInternalKey && input.tapMerkleRoot) {
-      return createTaprootOutputScript({ internalPubKey: input.tapInternalKey, taptreeRoot: input.tapMerkleRoot });
+      return taproot.createTaprootOutputScript({
+        internalPubKey: input.tapInternalKey,
+        taptreeRoot: input.tapMerkleRoot,
+      });
     }
     throw new Error('not a taproot input');
   }

--- a/modules/utxo-lib/src/bitgo/outputScripts.ts
+++ b/modules/utxo-lib/src/bitgo/outputScripts.ts
@@ -7,7 +7,6 @@ import { isTriple, Triple, Tuple } from './types';
 
 import { ecc as eccLib } from '../noble_ecc';
 import { getDepthFirstTaptree, getTweakedOutputKey } from '../taproot';
-import { script as bscript } from 'bitcoinjs-lib';
 
 export { scriptTypeForChain } from './wallet/chains';
 
@@ -386,24 +385,4 @@ function createTaprootScript2of3(scriptType: 'p2tr' | 'p2trMusig2', pubkeys: Tri
   return {
     scriptPubKey: output,
   };
-}
-
-/**
- * @returns output script for either script path input controlBlock
- * & leafScript OR key path input internalPubKey & taptreeRoot
- */
-export function createTaprootOutputScript(
-  p2trArgs: { internalPubKey: Buffer; taptreeRoot: Buffer } | { controlBlock: Buffer; leafScript: Buffer }
-): Buffer {
-  let internalPubKey: Buffer | undefined;
-  let taptreeRoot: Buffer | undefined;
-  if ('internalPubKey' in p2trArgs) {
-    internalPubKey = p2trArgs.internalPubKey;
-    taptreeRoot = p2trArgs.taptreeRoot;
-  } else {
-    internalPubKey = taproot.parseControlBlock(eccLib, p2trArgs.controlBlock).internalPubkey;
-    taptreeRoot = taproot.getTaptreeRoot(eccLib, p2trArgs.controlBlock, p2trArgs.leafScript);
-  }
-  const outputKey = taproot.tapTweakPubkey(eccLib, internalPubKey, taptreeRoot).xOnlyPubkey;
-  return bscript.compile([bscript.OPS.OP_1, Buffer.from(outputKey)]);
 }


### PR DESCRIPTION
To get x-only output key from taproot output script

TICKET: BG-66942

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->