### PR TITLE
feat(utxo-lib): parse p2trMusig2 key path witness

### DIFF
--- a/modules/unspents/src/dimensions.ts
+++ b/modules/unspents/src/dimensions.ts
@@ -190,6 +190,7 @@ export class Dimensions {
     switch (scriptTypeForChain(chain)) {
       case 'p2wsh':
       case 'p2tr':
+      case 'p2trMusig2':
         return 34;
       default:
         return 23;
@@ -234,6 +235,7 @@ export class Dimensions {
         return Dimensions.SingleInput[scriptType];
       case 'p2tr':
       case 'p2trMusig2':
+      case 'taprootKeyPathSpend':
       case 'taprootScriptPathSpend':
         switch (params.scriptPathLevel) {
           case undefined:
@@ -266,9 +268,7 @@ export class Dimensions {
   static fromInput(input: utxolib.TxInput, params: FromInputParams = {}): Dimensions {
     if (input.script?.length || input.witness?.length) {
       const parsed = utxolib.bitgo.parseSignatureScript(input);
-      if (parsed.scriptType) {
-        return Dimensions.fromScriptType(parsed.scriptType, parsed as { scriptPathLevel?: number });
-      }
+      return Dimensions.fromScriptType(parsed.scriptType, parsed as { scriptPathLevel?: number });
     }
 
     const { assumeUnsigned } = params;

--- a/modules/utxo-bin/src/InputOutputParser.ts
+++ b/modules/utxo-bin/src/InputOutputParser.ts
@@ -177,7 +177,8 @@ export class InputOutputParser extends Parser {
     if (
       parsed.scriptType &&
       (utxolib.bitgo.outputScripts.isScriptType2Of3(parsed.scriptType) ||
-        parsed.scriptType === 'taprootScriptPathSpend')
+        parsed.scriptType === 'taprootScriptPathSpend' ||
+        parsed.scriptType === 'taprootKeyPathSpend')
     ) {
       const parsed2Of3 = parsed.scriptType === 'taprootScriptPathSpend' ? { ...parsed, scriptType: 'p2tr' } : parsed;
       return this.node('sigScript', parsed2Of3.scriptType, [

--- a/modules/utxo-lib/src/bitgo/signature.ts
+++ b/modules/utxo-lib/src/bitgo/signature.ts
@@ -1,3 +1,4 @@
+import * as assert from 'assert';
 import { BIP32Interface } from 'bip32';
 
 import { Transaction, taproot, TxOutput, ScriptSignature } from 'bitcoinjs-lib';
@@ -78,6 +79,7 @@ export function getSignatureVerifications<TNumber extends number | bigint>(
   }
 
   const parsedScript = parseSignatureScript2Of3(input);
+  assert.ok(parsedScript.scriptType !== 'taprootKeyPathSpend');
 
   const signatures = parsedScript.signatures
     .filter((s) => s && s.length)

--- a/modules/utxo-lib/test/bitgo/psbt/psbtUtil.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/psbtUtil.ts
@@ -84,6 +84,7 @@ function validatePublicKeys(
       assert.deepStrictEqual(Buffer.isBuffer(publicKey), true);
     });
   } else {
+    assert.ok(txParsed.scriptType !== 'taprootKeyPathSpend');
     assert.deepStrictEqual(txParsed.publicKeys.length, psbtParsed.publicKeys?.length);
     const pubKeyMatch = txParsed.publicKeys.every((txPubKey) =>
       psbtParsed.publicKeys?.some((psbtPubKey) => psbtPubKey.equals(txPubKey))

--- a/modules/utxo-lib/test/integration_local_rpc/parse.ts
+++ b/modules/utxo-lib/test/integration_local_rpc/parse.ts
@@ -215,18 +215,19 @@ function runTestParse<TNumber extends number | bigint>(
     it(`verifySignatures for original transaction`, function () {
       parsedTx.ins.forEach((input, i) => {
         const prevOutValue = getPrevOutputValue(input);
-        const { publicKeys } = parseSignatureScript2Of3(input);
-        if (!publicKeys) {
+        const result = parseSignatureScript2Of3(input);
+        assert.ok(result.scriptType !== 'taprootKeyPathSpend');
+        if (!result.publicKeys) {
           throw new Error(`expected publicKeys`);
         }
-        assert.strictEqual(publicKeys.length, scriptType === 'p2tr' ? 2 : 3);
+        assert.strictEqual(result.publicKeys.length, scriptType === 'p2tr' ? 2 : 3);
 
         if (scriptType === 'p2tr') {
           // TODO implement verifySignature for p2tr
           this.skip();
         }
 
-        publicKeys.forEach((publicKey, publicKeyIndex) => {
+        result.publicKeys.forEach((publicKey, publicKeyIndex) => {
           assert.strictEqual(
             verifySignature(parsedTx, i, prevOutValue, {
               publicKey,

--- a/modules/utxo-ord/test/psbt.ts
+++ b/modules/utxo-ord/test/psbt.ts
@@ -136,9 +136,9 @@ describe('OutputLayout to PSBT conversion', function () {
 
   testWithUnspents(u20k, [], [u20k], {
     firstChangeOutput: BigInt(0),
-    inscriptionOutput: BigInt(19659),
+    inscriptionOutput: BigInt(19648),
     secondChangeOutput: BigInt(0),
-    feeOutput: BigInt(341),
+    feeOutput: BigInt(352),
   });
   testWithUnspents(u1k, [], [u1k], undefined);
   testWithUnspents(
@@ -148,15 +148,15 @@ describe('OutputLayout to PSBT conversion', function () {
     {
       firstChangeOutput: BigInt(0),
       inscriptionOutput: BigInt(10_000),
-      secondChangeOutput: BigInt(199990031),
-      feeOutput: BigInt(969),
+      secondChangeOutput: BigInt(199990009),
+      feeOutput: BigInt(991),
     },
     { minimizeInputs: false }
   );
   testWithUnspents(u1k, [u5k1, u5k2, u10k], [u1k, u10k], {
     firstChangeOutput: BigInt(0),
-    inscriptionOutput: BigInt(10_361),
+    inscriptionOutput: BigInt(10_350),
     secondChangeOutput: BigInt(0),
-    feeOutput: BigInt(639),
+    feeOutput: BigInt(650),
   });
 });


### PR DESCRIPTION
taprootKeyPathSpend type is used to parse p2trMusig2 key path witness

TICKET: BG-66942

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->