### PR TITLE
fix(sdk-coin-atom): fix getAddress of KeyPair

### DIFF
--- a/modules/sdk-coin-atom/src/lib/keyPair.ts
+++ b/modules/sdk-coin-atom/src/lib/keyPair.ts
@@ -1,7 +1,3 @@
-import { randomBytes } from 'crypto';
-import { bip32 } from '@bitgo/utxo-lib';
-import { pubkeyToAddress } from '@cosmjs/amino';
-import { toBase64 } from '@cosmjs/encoding';
 import {
   DefaultKeys,
   isPrivateKey,
@@ -10,6 +6,10 @@ import {
   KeyPairOptions,
   Secp256k1ExtendedKeyPair,
 } from '@bitgo/sdk-core';
+import { bip32 } from '@bitgo/utxo-lib';
+import { pubkeyToAddress } from '@cosmjs/amino';
+import { randomBytes } from 'crypto';
+
 import { DEFAULT_SEED_SIZE_BYTES } from './constants';
 
 /**
@@ -54,12 +54,7 @@ export class KeyPair extends Secp256k1ExtendedKeyPair {
 
   /** @inheritdoc */
   getAddress(): string {
-    const PUBLIC_KEY_SIZE = 32;
-    const tmp = new Uint8Array(PUBLIC_KEY_SIZE + 1);
-    const pubBuf = Buffer.from(this.getKeys().pub.slice(0, 64), 'hex');
-    tmp.set(pubBuf, 1);
-    // convert to base64
-    const base64String = toBase64(tmp);
+    const base64String = Buffer.from(this.getKeys().pub.slice(0, 66), 'hex').toString('base64');
     return pubkeyToAddress(
       {
         type: 'tendermint/PubKeySecp256k1',

--- a/modules/sdk-coin-atom/test/unit/keyPair.ts
+++ b/modules/sdk-coin-atom/test/unit/keyPair.ts
@@ -1,8 +1,9 @@
+import { fromBase64, toHex } from '@cosmjs/encoding';
 import assert from 'assert';
 import should from 'should';
 
 import { KeyPair } from '../../src/lib';
-import { TEST_ACCOUNT } from '../resources/atom';
+import { TEST_ACCOUNT, TEST_SEND_TX } from '../resources/atom';
 
 describe('ATOM Key Pair', () => {
   describe('should create a valid KeyPair', () => {
@@ -20,14 +21,14 @@ describe('ATOM Key Pair', () => {
     });
 
     it('from a private key', () => {
-      const privateKey = TEST_ACCOUNT.privateKey;
-      const keyPairObj = new KeyPair({ prv: privateKey });
+      const privateKey = TEST_SEND_TX.privateKey;
+      const keyPairObj = new KeyPair({ prv: toHex(fromBase64(privateKey)) });
       const keys = keyPairObj.getKeys();
       should.exists(keys.prv);
       should.exists(keys.pub);
-      should.equal(keys.prv, TEST_ACCOUNT.privateKey);
-      should.equal(keys.pub, TEST_ACCOUNT.compressedPublicKey);
-      should.equal(keyPairObj.getAddress(), TEST_ACCOUNT.pubAddress);
+      should.equal(keys.prv, toHex(fromBase64(TEST_SEND_TX.privateKey)));
+      should.equal(keys.pub, toHex(fromBase64(TEST_SEND_TX.pubKey)));
+      should.equal(keyPairObj.getAddress(), TEST_SEND_TX.sender);
 
       assert.throws(() => keyPairObj.getExtendedKeys());
     });
@@ -100,13 +101,13 @@ describe('ATOM Key Pair', () => {
 
   describe('get unique address ', () => {
     it('from a private key', () => {
-      const keyPair = new KeyPair({ prv: TEST_ACCOUNT.privateKey });
-      should.equal(keyPair.getAddress(), TEST_ACCOUNT.pubAddress);
+      const keyPair = new KeyPair({ prv: toHex(fromBase64(TEST_SEND_TX.privateKey)) });
+      should.equal(keyPair.getAddress(), TEST_SEND_TX.sender);
     });
 
     it('from a compressed public key', () => {
-      const keyPair = new KeyPair({ pub: TEST_ACCOUNT.compressedPublicKey });
-      should.equal(keyPair.getAddress(), TEST_ACCOUNT.pubAddress);
+      const keyPair = new KeyPair({ pub: toHex(fromBase64(TEST_SEND_TX.pubKey)) });
+      should.equal(keyPair.getAddress(), TEST_SEND_TX.sender);
     });
 
     it('should be different for different public keys', () => {


### PR DESCRIPTION
Atom KeyPair class is creating public key 64 bytes long similar to EDDSA and to match the secp256k1 key size, one extra byte is prepended. This generates wrong address.
Slicing initial 66 bytes from full public key to get the correct compressed key

Ticket: BG-72104

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->