### PR TITLE
fix(utxo-ord): match `ord` decoder bug in reveal script

### DIFF
--- a/modules/utxo-ord/src/inscriptions.ts
+++ b/modules/utxo-ord/src/inscriptions.ts
@@ -54,7 +54,8 @@ function createPaymentForInscription(pubkey: Buffer, contentType: string, inscri
     OPS.OP_FALSE,
     OPS.OP_IF,
     Buffer.from('ord', 'ascii'),
-    OPS.OP_1,
+    1, // these two lines should be combined as a single OPS.OP_1,
+    1, // but `ord`'s decoder has a bug so it has to be like this
     Buffer.from(contentType, 'ascii'),
     OPS.OP_0,
     ...dataPushBuffers,

--- a/modules/utxo-ord/test/inscription.ts
+++ b/modules/utxo-ord/test/inscription.ts
@@ -49,8 +49,8 @@ describe('inscriptions', () => {
 
       testInscriptionScript(
         inscriptionData,
-        '512044d2e55d99b3412c569e3769f4522f9a92cbef8e10ab54f9db1f01421a541574',
-        'tb1pgnfw2hvekdqjc457xa5lg530n2fvhmuwzz44f7wmruq5yxj5z46qenh5sy'
+        '5120dc8b12eec336e7215fd1213acf66fb0d5dd962813c0616988a12c08493831109',
+        'tb1pmj939mkrxmnjzh73yyav7ehmp4wajc5p8srpdxy2ztqgfyurzyys4sg9zx'
       );
     });
 
@@ -59,8 +59,8 @@ describe('inscriptions', () => {
 
       testInscriptionScript(
         inscriptionData,
-        '5120d5092e5a0107db36b1e16044057fd47dd8d3309ff4f878989d8b55bd9823a187',
-        'tb1p65yjukspqldndv0pvpzq2l750hvdxvyl7nu83xya3d2mmxpr5xrsj02kpf'
+        '5120ec90ba87f3e7c5462eb2173afdc50e00cea6fc69166677171d70f45dfb3a31b8',
+        'tb1pajgt4plnulz5vt4jzua0m3gwqr82dlrfzen8w9cawr69m7e6xxuq7dzypl'
       );
     });
   });


### PR DESCRIPTION
Thanks to @arik-so for immediately seeing the issue with our inscriptions

Note: our decoder accepts either style

Issue: BG-68089

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->