### PR TITLE
feat(utxo-lib): refactor validation and fix sig val array

### DIFF
--- a/modules/utxo-lib/src/bitgo/wallet/Unspent.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/Unspent.ts
@@ -112,7 +112,7 @@ export function addReplayProtectionUnspentToPsbt(
     throw new Error(`network parameter does not match psbt.network`);
   }
   const { txid, vout } = toPrevOutput(u, psbt.network);
-  const isZcash = getMainnet(psbt.network) !== networks.zcash;
+  const isZcash = getMainnet(psbt.network) === networks.zcash;
 
   // Because Zcash directly hashes the value for non-segwit transactions, we do not need to check indirectly
   // with the previous transaction. Therefore, we can treat Zcash non-segwit transactions as Bitcoin

--- a/modules/utxo-lib/test/bitgo/psbt/Musig2.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/Musig2.ts
@@ -357,7 +357,7 @@ describe('p2trMusig2', function () {
         psbt.data.inputs[0].tapBip32Derivation?.forEach((bv) => (bv.masterFingerprint = Buffer.allocUnsafe(4)));
         assert.throws(
           () => psbt.setMusig2Nonces(rootWalletKeys.user),
-          (e) => e.message === 'Need one bip32Derivation masterFingerprint to match the rootWalletKey fingerprint'
+          (e) => e.message === 'No bip32Derivation masterFingerprint matched the rootWalletKey fingerprint'
         );
         assert.strictEqual(psbt.getProprietaryKeyVals(0).length, 1);
       });

--- a/modules/utxo-lib/test/bitgo/psbt/signingAndValidation.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/signingAndValidation.ts
@@ -1,0 +1,94 @@
+import * as assert from 'assert';
+import { describe, it } from 'mocha';
+import * as bs58check from 'bs58check';
+
+import { getDefaultWalletKeys, mockReplayProtectionUnspent, mockUnspents } from '../../../src/testutil';
+import {
+  addReplayProtectionUnspentToPsbt,
+  addWalletOutputToPsbt,
+  addWalletUnspentToPsbt,
+  createPsbtForNetwork,
+  getInternalChainCode,
+  KeyName,
+  outputScripts,
+  UtxoPsbt,
+} from '../../../src/bitgo';
+import { getNetworkName, Network, networks } from '../../../src';
+import { createOutputScriptP2shP2pk } from '../../../src/bitgo/outputScripts';
+
+function getScriptTypes(): outputScripts.ScriptType[] {
+  return [...outputScripts.scriptTypes2Of3, 'p2shP2pk'];
+}
+
+const walletKeys = getDefaultWalletKeys();
+function runTest(scriptType: outputScripts.ScriptType, signerName: KeyName, cosignerName: KeyName, network: Network) {
+  const signer = walletKeys[signerName];
+  const cosigner = walletKeys[cosignerName];
+
+  const networkName = getNetworkName(network);
+  const signingKeys = [
+    signerName === 'user' || (cosignerName === 'user' && scriptType !== 'p2shP2pk'),
+    signerName === 'backup' || (cosignerName === 'backup' && scriptType !== 'p2shP2pk'),
+    signerName === 'bitgo' || (cosignerName === 'bitgo' && scriptType !== 'p2shP2pk'),
+  ];
+
+  describe(`UtxoPsbt ${[
+    `scriptType=${scriptType}`,
+    `network=${networkName}`,
+    `signer=${signerName}`,
+    `cosigner=${cosignerName}`,
+  ].join(',')}`, function () {
+    let psbt: UtxoPsbt;
+    before('create transaction', async function () {
+      // Build a fully hydrated UtxoPsbt
+      psbt = createPsbtForNetwork({ network });
+      psbt.updateGlobal({
+        globalXpub: walletKeys.triple.map((bip32) => {
+          const extendedPubkey = bip32.neutered().toBase58();
+          return {
+            extendedPubkey: bs58check.decode(extendedPubkey),
+            masterFingerprint: bip32.fingerprint,
+            path: 'm',
+          };
+        }),
+      });
+
+      // Add the inputs
+      if (scriptType === 'p2shP2pk') {
+        const unspent = mockReplayProtectionUnspent(network, BigInt(1e8), { key: signer });
+        const { redeemScript } = createOutputScriptP2shP2pk(signer.publicKey);
+        assert(redeemScript);
+        addReplayProtectionUnspentToPsbt(psbt, unspent, redeemScript);
+      } else {
+        const unspents = mockUnspents(walletKeys, [scriptType], BigInt(1e8), network);
+        unspents.forEach((unspent) => addWalletUnspentToPsbt(psbt, unspent, walletKeys, signerName, cosignerName));
+      }
+
+      // Add the outputs
+      addWalletOutputToPsbt(psbt, walletKeys, getInternalChainCode('p2sh'), 0, BigInt(1e8 - 10000));
+    });
+
+    it('can go from unsigned to fully signed', async function () {
+      if (scriptType === 'p2trMusig2' && signerName === 'user' && cosignerName === 'bitgo') {
+        psbt.setMusig2Nonces(signer);
+        psbt.setMusig2Nonces(cosigner);
+      }
+      if (scriptType === 'p2shP2pk') {
+        psbt.signAllInputs(signer);
+      } else {
+        psbt.signAllInputsHD(signer);
+        psbt.signAllInputsHD(cosigner);
+      }
+      assert(psbt.validateSignaturesOfAllInputs());
+      assert.deepStrictEqual(psbt.getSignatureValidationArray(0), signingKeys);
+      psbt.finalizeAllInputs();
+      const tx = psbt.extractTransaction();
+      assert(tx);
+    });
+  });
+}
+
+getScriptTypes().forEach((t) => {
+  runTest(t, 'user', 'bitgo', networks.bitcoin);
+  runTest(t, 'backup', 'user', networks.bitcoin);
+});


### PR DESCRIPTION
Fix `getSignatureValidationArray` so it correctly uses HD keys and so that it includes `validateTaprootMusig2SignaturesOfInput`

BG-68722

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->