### PR TITLE
feat(utxo-lib): create p2trMusig2 nonce using derived key

### DIFF
--- a/modules/unspents/test/testutils.ts
+++ b/modules/unspents/test/testutils.ts
@@ -151,8 +151,8 @@ export function constructPsbt(
     return psbt;
   }
 
-  psbt.setMusig2Nonces(keys['user']);
-  psbt.setMusig2Nonces(keys['bitgo']);
+  psbt.setMusig2NoncesHD(keys['user']);
+  psbt.setMusig2NoncesHD(keys['bitgo']);
 
   inputTypes.forEach((t, i) => {
     const signerNames = getDefaultSignerNames(t, signers);

--- a/modules/utxo-lib/test/bitgo/psbt/Musig2.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/Musig2.ts
@@ -70,7 +70,7 @@ describe('p2trMusig2', function () {
       );
       // WP creates PSBT during build API and adds bitgo nonce
       const bitgoPsbt = constructPsbt(unspents, rootWalletKeys, 'bitgo', 'user', outputType);
-      bitgoPsbt.setMusig2Nonces(rootWalletKeys.bitgo, Buffer.allocUnsafe(32));
+      bitgoPsbt.setMusig2NoncesHD(rootWalletKeys.bitgo, Buffer.allocUnsafe(32));
 
       // WP serialises it and sends to user
       const bitgoPsbtSer = bitgoPsbt.toHex();
@@ -79,7 +79,7 @@ describe('p2trMusig2', function () {
       const userPsbt = createPsbtFromHex(bitgoPsbtSer, network);
 
       // User adds user nonce and signs with user key
-      userPsbt.setMusig2Nonces(rootWalletKeys.user);
+      userPsbt.setMusig2NoncesHD(rootWalletKeys.user);
       userPsbt.signAllInputsHD(rootWalletKeys.user);
 
       // User serialises it and sends to WP
@@ -121,8 +121,8 @@ describe('p2trMusig2', function () {
       const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'bitgo', 'user', outputType);
       validateParsedTaprootKeyPathPsbt(psbt, 0, 'unsigned');
 
-      psbt.setMusig2Nonces(rootWalletKeys.user);
-      psbt.setMusig2Nonces(rootWalletKeys.bitgo);
+      psbt.setMusig2NoncesHD(rootWalletKeys.user);
+      psbt.setMusig2NoncesHD(rootWalletKeys.bitgo);
       psbt.signAllInputsHD(rootWalletKeys.user);
       validateParsedTaprootKeyPathPsbt(psbt, 0, 'halfsigned');
 
@@ -143,7 +143,7 @@ describe('p2trMusig2', function () {
       it(`update with new nonce should be allowed`, function () {
         const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
 
-        psbt.setMusig2Nonces(rootWalletKeys.user);
+        psbt.setMusig2NoncesHD(rootWalletKeys.user);
 
         let noncesKeyVals = psbt.getProprietaryKeyVals(0, {
           identifier: PSBT_PROPRIETARY_IDENTIFIER,
@@ -153,8 +153,8 @@ describe('p2trMusig2', function () {
         const userNonceKey = noncesKeyVals[0].key.keydata;
         const userNonceValue = noncesKeyVals[0].value;
 
-        psbt.setMusig2Nonces(rootWalletKeys.bitgo);
-        psbt.setMusig2Nonces(rootWalletKeys.user);
+        psbt.setMusig2NoncesHD(rootWalletKeys.bitgo);
+        psbt.setMusig2NoncesHD(rootWalletKeys.user);
 
         noncesKeyVals = psbt.getProprietaryKeyVals(0, {
           identifier: PSBT_PROPRIETARY_IDENTIFIER,
@@ -170,19 +170,19 @@ describe('p2trMusig2', function () {
       it(`Cosigner nonce creation fail should not enforce the signer to recreate nonce`, function () {
         const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
 
-        psbt.setMusig2Nonces(rootWalletKeys.user);
+        psbt.setMusig2NoncesHD(rootWalletKeys.user);
 
         const tapMerkleRoot = psbt.data.inputs[0].tapMerkleRoot;
         psbt.data.inputs[0].tapMerkleRoot = undefined;
 
         assert.throws(
-          () => psbt.setMusig2Nonces(rootWalletKeys.bitgo),
+          () => psbt.setMusig2NoncesHD(rootWalletKeys.bitgo),
           (e) => e.message === 'tapMerkleRoot is required to create nonce'
         );
 
         psbt.data.inputs[0].tapMerkleRoot = tapMerkleRoot;
 
-        psbt.setMusig2Nonces(rootWalletKeys.bitgo);
+        psbt.setMusig2NoncesHD(rootWalletKeys.bitgo);
 
         psbt.signAllInputsHD(rootWalletKeys.user);
         psbt.signAllInputsHD(rootWalletKeys.bitgo);
@@ -210,7 +210,7 @@ describe('p2trMusig2', function () {
         const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
         psbt.data.inputs[0].tapInternalKey = dummyTapInternalKey;
         assert.throws(
-          () => psbt.setMusig2Nonces(rootWalletKeys.user),
+          () => psbt.setMusig2NoncesHD(rootWalletKeys.user),
           (e) => e.message === 'tapInternalKey and aggregated participant pub keys does not match'
         );
         assert.strictEqual(psbt.getProprietaryKeyVals(0).length, 1);
@@ -219,7 +219,7 @@ describe('p2trMusig2', function () {
       it(`fails if sessionId size is invalid`, function () {
         const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
         assert.throws(
-          () => psbt.setMusig2Nonces(rootWalletKeys.user, Buffer.allocUnsafe(33)),
+          () => psbt.setMusig2NoncesHD(rootWalletKeys.user, Buffer.allocUnsafe(33)),
           (e) => e.message === 'Invalid sessionId size 33'
         );
         assert.strictEqual(psbt.getProprietaryKeyVals(0).length, 1);
@@ -228,7 +228,7 @@ describe('p2trMusig2', function () {
       it(`fails if private key is missing`, function () {
         const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
         assert.throws(
-          () => psbt.setMusig2Nonces(rootWalletKeys.user.neutered()),
+          () => psbt.setMusig2NoncesHD(rootWalletKeys.user.neutered()),
           (e) => e.message === 'private key is required to generate nonce'
         );
         assert.strictEqual(psbt.getProprietaryKeyVals(0).length, 1);
@@ -238,7 +238,7 @@ describe('p2trMusig2', function () {
         const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
         psbt.data.inputs[0].tapBip32Derivation = [];
         assert.throws(
-          () => psbt.setMusig2Nonces(rootWalletKeys.user),
+          () => psbt.setMusig2NoncesHD(rootWalletKeys.user),
           (e) => e.message === 'tapBip32Derivation is required to create nonce'
         );
         assert.strictEqual(psbt.getProprietaryKeyVals(0).length, 1);
@@ -248,7 +248,7 @@ describe('p2trMusig2', function () {
         const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
         psbt.data.inputs[0].unknownKeyVals = [];
         assert.throws(
-          () => psbt.setMusig2Nonces(rootWalletKeys.user),
+          () => psbt.setMusig2NoncesHD(rootWalletKeys.user),
           (e) => e.message === 'Found 0 matching participant key value instead of 1'
         );
         assert.strictEqual(psbt.getProprietaryKeyVals(0).length, 0);
@@ -261,7 +261,7 @@ describe('p2trMusig2', function () {
         psbt.data.inputs[0].unknownKeyVals = [];
         psbt.addProprietaryKeyValToInput(0, keyVals[0]);
         assert.throws(
-          () => psbt.setMusig2Nonces(rootWalletKeys.user),
+          () => psbt.setMusig2NoncesHD(rootWalletKeys.user),
           (e) => e.message === `Invalid keydata size ${keyVals[0].key.keydata.length} for participant pub keys`
         );
         assert.strictEqual(psbt.getProprietaryKeyVals(0).length, 1);
@@ -274,7 +274,7 @@ describe('p2trMusig2', function () {
         psbt.data.inputs[0].unknownKeyVals = [];
         psbt.addProprietaryKeyValToInput(0, keyVals[0]);
         assert.throws(
-          () => psbt.setMusig2Nonces(rootWalletKeys.user),
+          () => psbt.setMusig2NoncesHD(rootWalletKeys.user),
           (e) => e.message === `Invalid participants keydata tapOutputKey`
         );
         assert.strictEqual(psbt.getProprietaryKeyVals(0).length, 1);
@@ -287,7 +287,7 @@ describe('p2trMusig2', function () {
         psbt.data.inputs[0].unknownKeyVals = [];
         psbt.addProprietaryKeyValToInput(0, keyVals[0]);
         assert.throws(
-          () => psbt.setMusig2Nonces(rootWalletKeys.user),
+          () => psbt.setMusig2NoncesHD(rootWalletKeys.user),
           (e) => e.message === `Invalid participants keydata tapInternalKey`
         );
         assert.strictEqual(psbt.getProprietaryKeyVals(0).length, 1);
@@ -307,7 +307,7 @@ describe('p2trMusig2', function () {
         psbt.data.inputs[0].unknownKeyVals = [];
         psbt.addProprietaryKeyValToInput(0, keyVals[0]);
         assert.throws(
-          () => psbt.setMusig2Nonces(rootWalletKeys.user),
+          () => psbt.setMusig2NoncesHD(rootWalletKeys.user),
           (e) => e.message === `tapInternalKey and aggregated participant pub keys does not match`
         );
         assert.strictEqual(psbt.getProprietaryKeyVals(0).length, 1);
@@ -320,7 +320,7 @@ describe('p2trMusig2', function () {
         psbt.data.inputs[0].unknownKeyVals = [];
         psbt.addProprietaryKeyValToInput(0, keyVals[0]);
         assert.throws(
-          () => psbt.setMusig2Nonces(rootWalletKeys.user),
+          () => psbt.setMusig2NoncesHD(rootWalletKeys.user),
           (e) => e.message === `Invalid keydata size 65 for participant pub keys`
         );
         assert.strictEqual(psbt.getProprietaryKeyVals(0).length, 1);
@@ -333,7 +333,7 @@ describe('p2trMusig2', function () {
         psbt.data.inputs[0].unknownKeyVals = [];
         psbt.addProprietaryKeyValToInput(0, keyVals[0]);
         assert.throws(
-          () => psbt.setMusig2Nonces(rootWalletKeys.user),
+          () => psbt.setMusig2NoncesHD(rootWalletKeys.user),
           (e) => e.message === `Invalid valuedata size 67 for participant pub keys`
         );
         assert.strictEqual(psbt.getProprietaryKeyVals(0).length, 1);
@@ -346,7 +346,7 @@ describe('p2trMusig2', function () {
         psbt.data.inputs[0].unknownKeyVals = [];
         psbt.addProprietaryKeyValToInput(0, keyVals[0]);
         assert.throws(
-          () => psbt.setMusig2Nonces(rootWalletKeys.user),
+          () => psbt.setMusig2NoncesHD(rootWalletKeys.user),
           (e) => e.message === `Duplicate participant pub keys found`
         );
         assert.strictEqual(psbt.getProprietaryKeyVals(0).length, 1);
@@ -356,8 +356,8 @@ describe('p2trMusig2', function () {
         const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
         psbt.data.inputs[0].tapBip32Derivation?.forEach((bv) => (bv.masterFingerprint = Buffer.allocUnsafe(4)));
         assert.throws(
-          () => psbt.setMusig2Nonces(rootWalletKeys.user),
-          (e) => e.message === 'No bip32Derivation masterFingerprint matched the rootWalletKey fingerprint'
+          () => psbt.setMusig2NoncesHD(rootWalletKeys.user),
+          (e) => e.message === 'No bip32Derivation masterFingerprint matched the HD keyPair fingerprint'
         );
         assert.strictEqual(psbt.getProprietaryKeyVals(0).length, 1);
       });
@@ -369,7 +369,7 @@ describe('p2trMusig2', function () {
           bv.path = walletKeys.paths[2];
         });
         assert.throws(
-          () => psbt.setMusig2Nonces(rootWalletKeys.user),
+          () => psbt.setMusig2NoncesHD(rootWalletKeys.user),
           (e) => e.message === 'pubkey did not match bip32Derivation'
         );
         assert.strictEqual(psbt.getProprietaryKeyVals(0).length, 1);
@@ -387,8 +387,8 @@ describe('p2trMusig2', function () {
           bv.masterFingerprint = rootWalletKeys.user.fingerprint;
         });
         assert.throws(
-          () => psbt.setMusig2Nonces(rootWalletKeys.user),
-          (e) => e.message === 'root wallet key should derive one bip32Derivation'
+          () => psbt.setMusig2NoncesHD(rootWalletKeys.user),
+          (e) => e.message === 'hd key pair should derive one bip32Derivation'
         );
         assert.strictEqual(psbt.getProprietaryKeyVals(0).length, 1);
       });
@@ -408,7 +408,7 @@ describe('p2trMusig2', function () {
         psbt.addProprietaryKeyValToInput(0, keyVals[0]);
 
         assert.throws(
-          () => psbt.setMusig2Nonces(rootWalletKeys.user),
+          () => psbt.setMusig2NoncesHD(rootWalletKeys.user),
           (e) => e.message === `participant plain pub key should match one bip32Derivation plain pub key`
         );
         assert.strictEqual(psbt.getProprietaryKeyVals(0).length, 1);
@@ -418,8 +418,8 @@ describe('p2trMusig2', function () {
     describe('sign', function () {
       it(`fails if privateKey is missing`, function () {
         const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
-        psbt.setMusig2Nonces(rootWalletKeys.user);
-        psbt.setMusig2Nonces(rootWalletKeys.bitgo);
+        psbt.setMusig2NoncesHD(rootWalletKeys.user);
+        psbt.setMusig2NoncesHD(rootWalletKeys.bitgo);
         assert.throws(
           () => psbt.signTaprootInputHD(0, rootWalletKeys.user.neutered()),
           (e) => e.message === 'privateKey is required to sign p2tr musig2'
@@ -435,8 +435,8 @@ describe('p2trMusig2', function () {
           p2trMusig2Unspent[0].index
         );
 
-        psbt.setMusig2Nonces(rootWalletKeys.user);
-        psbt.setMusig2Nonces(rootWalletKeys.bitgo);
+        psbt.setMusig2NoncesHD(rootWalletKeys.user);
+        psbt.setMusig2NoncesHD(rootWalletKeys.bitgo);
 
         psbt.data.inputs[0].tapInternalKey = undefined;
         assert.throws(
@@ -456,8 +456,8 @@ describe('p2trMusig2', function () {
 
       const walletKeys = rootWalletKeys.deriveForChainAndIndex(p2trMusig2Unspent[0].chain, p2trMusig2Unspent[0].index);
 
-      psbt.setMusig2Nonces(rootWalletKeys.user);
-      psbt.setMusig2Nonces(rootWalletKeys.bitgo);
+      psbt.setMusig2NoncesHD(rootWalletKeys.user);
+      psbt.setMusig2NoncesHD(rootWalletKeys.bitgo);
 
       psbt.data.inputs[0].tapMerkleRoot = undefined;
       assert.throws(
@@ -473,8 +473,8 @@ describe('p2trMusig2', function () {
 
     it(`fails if participant pub keys is missing`, function () {
       const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
-      psbt.setMusig2Nonces(rootWalletKeys.user);
-      psbt.setMusig2Nonces(rootWalletKeys.bitgo);
+      psbt.setMusig2NoncesHD(rootWalletKeys.user);
+      psbt.setMusig2NoncesHD(rootWalletKeys.bitgo);
       psbt.data.inputs[0].unknownKeyVals = [];
       assert.throws(
         () => psbt.signTaprootInputHD(0, rootWalletKeys.user),
@@ -485,8 +485,8 @@ describe('p2trMusig2', function () {
 
     it(`fails if signer pub key is not matching any participant pub keys`, function () {
       const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
-      psbt.setMusig2Nonces(rootWalletKeys.user);
-      psbt.setMusig2Nonces(rootWalletKeys.bitgo);
+      psbt.setMusig2NoncesHD(rootWalletKeys.user);
+      psbt.setMusig2NoncesHD(rootWalletKeys.bitgo);
       assert.throws(
         () =>
           psbt.signTaprootMusig2Input(0, {
@@ -500,8 +500,8 @@ describe('p2trMusig2', function () {
 
     it(`fails if more than 2 nonce key value exists`, function () {
       const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
-      psbt.setMusig2Nonces(rootWalletKeys.user);
-      psbt.setMusig2Nonces(rootWalletKeys.bitgo);
+      psbt.setMusig2NoncesHD(rootWalletKeys.user);
+      psbt.setMusig2NoncesHD(rootWalletKeys.bitgo);
       psbt.data.inputs[0].unknownKeyVals?.push(psbt.data.inputs[0].unknownKeyVals[2]);
       assert.throws(
         () => psbt.signTaprootInputHD(0, rootWalletKeys.user),
@@ -512,8 +512,8 @@ describe('p2trMusig2', function () {
 
     it(`fails if 2 nonce key value do not exist`, function () {
       const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
-      psbt.setMusig2Nonces(rootWalletKeys.user);
-      psbt.setMusig2Nonces(rootWalletKeys.bitgo);
+      psbt.setMusig2NoncesHD(rootWalletKeys.user);
+      psbt.setMusig2NoncesHD(rootWalletKeys.bitgo);
       psbt.data.inputs[0].unknownKeyVals?.splice(2);
       assert.throws(
         () => psbt.signTaprootInputHD(0, rootWalletKeys.user),
@@ -524,8 +524,8 @@ describe('p2trMusig2', function () {
 
     it(`fails if nonce keydata size is invalid`, function () {
       const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
-      psbt.setMusig2Nonces(rootWalletKeys.user);
-      psbt.setMusig2Nonces(rootWalletKeys.bitgo);
+      psbt.setMusig2NoncesHD(rootWalletKeys.user);
+      psbt.setMusig2NoncesHD(rootWalletKeys.bitgo);
 
       const keyVals = psbt.getProprietaryKeyVals(0, {
         identifier: PSBT_PROPRIETARY_IDENTIFIER,
@@ -543,8 +543,8 @@ describe('p2trMusig2', function () {
 
     it(`fails if nonce valuedata size is invalid`, function () {
       const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
-      psbt.setMusig2Nonces(rootWalletKeys.user);
-      psbt.setMusig2Nonces(rootWalletKeys.bitgo);
+      psbt.setMusig2NoncesHD(rootWalletKeys.user);
+      psbt.setMusig2NoncesHD(rootWalletKeys.bitgo);
 
       const keyVals = psbt.getProprietaryKeyVals(0, {
         identifier: PSBT_PROPRIETARY_IDENTIFIER,
@@ -562,14 +562,14 @@ describe('p2trMusig2', function () {
 
     it(`fails if nonce keydata is invalid`, function () {
       const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
-      psbt.setMusig2Nonces(rootWalletKeys.user);
-      psbt.setMusig2Nonces(rootWalletKeys.bitgo);
+      psbt.setMusig2NoncesHD(rootWalletKeys.user);
+      psbt.setMusig2NoncesHD(rootWalletKeys.bitgo);
 
       const dummyRootWalletKeys = new RootWalletKeys(getKeyTriple('dummy'));
       const dummyP2trMusig2Unspent = getUnspents(['p2trMusig2'], dummyRootWalletKeys);
       const dummyPsbt = constructPsbt(dummyP2trMusig2Unspent, dummyRootWalletKeys, 'user', 'bitgo', 'p2sh');
-      dummyPsbt.setMusig2Nonces(dummyRootWalletKeys.user);
-      dummyPsbt.setMusig2Nonces(dummyRootWalletKeys.bitgo);
+      dummyPsbt.setMusig2NoncesHD(dummyRootWalletKeys.user);
+      dummyPsbt.setMusig2NoncesHD(dummyRootWalletKeys.bitgo);
 
       const dummyKeyVals = dummyPsbt.getProprietaryKeyVals(0, {
         identifier: PSBT_PROPRIETARY_IDENTIFIER,
@@ -587,8 +587,8 @@ describe('p2trMusig2', function () {
 
     it(`fails if nonce keydata tapOutputKey is invalid`, function () {
       const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
-      psbt.setMusig2Nonces(rootWalletKeys.user);
-      psbt.setMusig2Nonces(rootWalletKeys.bitgo);
+      psbt.setMusig2NoncesHD(rootWalletKeys.user);
+      psbt.setMusig2NoncesHD(rootWalletKeys.bitgo);
 
       const keyVals = psbt.getProprietaryKeyVals(0, {
         identifier: PSBT_PROPRIETARY_IDENTIFIER,
@@ -610,8 +610,8 @@ describe('p2trMusig2', function () {
   describe('p2trMusig2 script path', function () {
     it(`psbt creation success and musig2 skips`, function () {
       let psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'backup', outputType);
-      psbt.setMusig2Nonces(rootWalletKeys.user);
-      psbt.setMusig2Nonces(rootWalletKeys.backup);
+      psbt.setMusig2NoncesHD(rootWalletKeys.user);
+      psbt.setMusig2NoncesHD(rootWalletKeys.backup);
       assert.strictEqual(psbt.getProprietaryKeyVals(0).length, 0);
       psbt.signAllInputsHD(rootWalletKeys.user);
       psbt.signAllInputsHD(rootWalletKeys.backup);
@@ -623,8 +623,8 @@ describe('p2trMusig2', function () {
       psbt.extractTransaction();
 
       psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'bitgo', 'backup', outputType);
-      psbt.setMusig2Nonces(rootWalletKeys.bitgo);
-      psbt.setMusig2Nonces(rootWalletKeys.backup);
+      psbt.setMusig2NoncesHD(rootWalletKeys.bitgo);
+      psbt.setMusig2NoncesHD(rootWalletKeys.backup);
       psbt.signAllInputsHD(rootWalletKeys.bitgo);
       psbt.signAllInputsHD(rootWalletKeys.backup);
       assert.strictEqual(psbt.getProprietaryKeyVals(0).length, 0);
@@ -658,14 +658,14 @@ describe('p2trMusig2', function () {
     it(`validate with pubkey`, function () {
       const walletKeys = rootWalletKeys.deriveForChainAndIndex(p2trMusig2Unspent[0].chain, p2trMusig2Unspent[0].index);
       let psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', outputType);
-      psbt.setMusig2Nonces(rootWalletKeys.user);
-      psbt.setMusig2Nonces(rootWalletKeys.bitgo);
+      psbt.setMusig2Nonces(walletKeys.user);
+      psbt.setMusig2Nonces(walletKeys.bitgo);
       psbt.signAllInputsHD(rootWalletKeys.user);
       assert.ok(psbt.validateTaprootMusig2SignaturesOfInput(0, walletKeys.user.publicKey));
 
       psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', outputType);
-      psbt.setMusig2Nonces(rootWalletKeys.user);
-      psbt.setMusig2Nonces(rootWalletKeys.bitgo);
+      psbt.setMusig2Nonces(walletKeys.user);
+      psbt.setMusig2Nonces(walletKeys.bitgo);
       psbt.signAllInputsHD(rootWalletKeys.user);
       assert.ok(psbt.validateTaprootMusig2SignaturesOfInput(0, walletKeys.user.publicKey));
       psbt.signAllInputsHD(rootWalletKeys.bitgo);
@@ -680,8 +680,8 @@ describe('p2trMusig2', function () {
         (e) => e.message === `No signatures to validate`
       );
 
-      psbt.setMusig2Nonces(rootWalletKeys.user);
-      psbt.setMusig2Nonces(rootWalletKeys.bitgo);
+      psbt.setMusig2NoncesHD(rootWalletKeys.user);
+      psbt.setMusig2NoncesHD(rootWalletKeys.bitgo);
 
       psbt.signAllInputsHD(rootWalletKeys.user);
 
@@ -694,8 +694,8 @@ describe('p2trMusig2', function () {
     it(`fails if no tapInternalKey and tapMerkleRoot`, function () {
       const walletKeys = rootWalletKeys.deriveForChainAndIndex(p2trMusig2Unspent[0].chain, p2trMusig2Unspent[0].index);
       const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', outputType);
-      psbt.setMusig2Nonces(rootWalletKeys.user);
-      psbt.setMusig2Nonces(rootWalletKeys.bitgo);
+      psbt.setMusig2NoncesHD(rootWalletKeys.user);
+      psbt.setMusig2NoncesHD(rootWalletKeys.bitgo);
       psbt.signAllInputsHD(rootWalletKeys.user);
       psbt.signAllInputsHD(rootWalletKeys.bitgo);
 
@@ -716,8 +716,8 @@ describe('p2trMusig2', function () {
 
     it(`fails if no nonce and sig pub key match`, function () {
       let psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', outputType);
-      psbt.setMusig2Nonces(rootWalletKeys.user);
-      psbt.setMusig2Nonces(rootWalletKeys.bitgo);
+      psbt.setMusig2NoncesHD(rootWalletKeys.user);
+      psbt.setMusig2NoncesHD(rootWalletKeys.bitgo);
       psbt.signAllInputsHD(rootWalletKeys.user);
       psbt.signAllInputsHD(rootWalletKeys.bitgo);
 
@@ -729,8 +729,8 @@ describe('p2trMusig2', function () {
       const myRootWalletKeys = new RootWalletKeys(getKeyTriple('dummy'));
       const myUnspents = getUnspents(['p2trMusig2'], myRootWalletKeys);
       psbt = constructPsbt(myUnspents, myRootWalletKeys, 'user', 'bitgo', outputType);
-      psbt.setMusig2Nonces(myRootWalletKeys.user);
-      psbt.setMusig2Nonces(myRootWalletKeys.bitgo);
+      psbt.setMusig2NoncesHD(myRootWalletKeys.user);
+      psbt.setMusig2NoncesHD(myRootWalletKeys.bitgo);
       psbt.signAllInputsHD(myRootWalletKeys.user);
       psbt.signAllInputsHD(myRootWalletKeys.bitgo);
 
@@ -759,8 +759,8 @@ describe('p2trMusig2', function () {
 
     it(`fails if no valid sig`, function () {
       const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', outputType);
-      psbt.setMusig2Nonces(rootWalletKeys.user);
-      psbt.setMusig2Nonces(rootWalletKeys.bitgo);
+      psbt.setMusig2NoncesHD(rootWalletKeys.user);
+      psbt.setMusig2NoncesHD(rootWalletKeys.bitgo);
       psbt.signAllInputsHD(rootWalletKeys.user);
       psbt.signAllInputsHD(rootWalletKeys.bitgo);
 
@@ -779,8 +779,8 @@ describe('p2trMusig2', function () {
   describe('finalizeTaprootMusig2Input', function () {
     it('fails if invalid number for sigs', function () {
       const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', outputType);
-      psbt.setMusig2Nonces(rootWalletKeys.user);
-      psbt.setMusig2Nonces(rootWalletKeys.bitgo);
+      psbt.setMusig2NoncesHD(rootWalletKeys.user);
+      psbt.setMusig2NoncesHD(rootWalletKeys.bitgo);
       psbt.signAllInputsHD(rootWalletKeys.user);
 
       assert.throws(
@@ -804,7 +804,7 @@ describe('p2trMusig2', function () {
         assert.throws(
           () =>
             scriptType === 'p2trMusig2'
-              ? psbt.setMusig2Nonces(rootWalletKeys.user)
+              ? psbt.setMusig2NoncesHD(rootWalletKeys.user)
               : scriptType === 'p2tr'
               ? psbt.signTaprootInputHD(index, rootWalletKeys.user)
               : psbt.signInputHD(index, rootWalletKeys.user),
@@ -950,8 +950,8 @@ describe('p2trMusig2', function () {
 
     it(`deleteProprietaryKeyVals`, function () {
       const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', outputType);
-      psbt.setMusig2Nonces(rootWalletKeys.user);
-      psbt.setMusig2Nonces(rootWalletKeys.bitgo);
+      psbt.setMusig2NoncesHD(rootWalletKeys.user);
+      psbt.setMusig2NoncesHD(rootWalletKeys.bitgo);
       const key = {
         identifier: 'DUMMY',
         subtype: 100,

--- a/modules/utxo-lib/test/bitgo/psbt/signingAndValidation.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/signingAndValidation.ts
@@ -70,8 +70,8 @@ function runTest(scriptType: outputScripts.ScriptType, signerName: KeyName, cosi
 
     it('can go from unsigned to fully signed', async function () {
       if (scriptType === 'p2trMusig2' && signerName === 'user' && cosignerName === 'bitgo') {
-        psbt.setMusig2Nonces(signer);
-        psbt.setMusig2Nonces(cosigner);
+        psbt.setMusig2NoncesHD(signer);
+        psbt.setMusig2NoncesHD(cosigner);
       }
       if (scriptType === 'p2shP2pk') {
         psbt.signAllInputs(signer);

--- a/modules/utxo-lib/test/integration_local_rpc/generate/outputScripts.util.ts
+++ b/modules/utxo-lib/test/integration_local_rpc/generate/outputScripts.util.ts
@@ -189,7 +189,7 @@ export function createPsbtSpendTransactionFromPrevTx(
   addWalletOutputToPsbt(psbt, rootWalletKeys, unspents[0].chain, unspents[0].index, outputValue);
 
   signers.forEach((keyName) => {
-    psbt.setMusig2Nonces(rootWalletKeys[keyName]);
+    psbt.setMusig2NoncesHD(rootWalletKeys[keyName]);
   });
 
   signers.forEach((keyName) => {


### PR DESCRIPTION
Add a function to create p2trMusig2 nonce directly using derived key. It is done to make it consistent with other sign functions.

TICKET: BG-73060

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->