### PR TITLE
feat(utxo-lib): add sorted musig2 participant pub keys in PSBT

### DIFF
--- a/modules/utxo-lib/src/bitgo/Musig2.ts
+++ b/modules/utxo-lib/src/bitgo/Musig2.ts
@@ -215,6 +215,10 @@ export function decodePsbtMusig2PartialSig(kv: ProprietaryKeyValue): PsbtMusig2P
   return { participantPubKey: key.subarray(0, 33), tapOutputKey: key.subarray(33), partialSig: value };
 }
 
+export function sortMusig2ParticipantPubKeys(plainPubKeys: Buffer[]): Buffer[] {
+  return musig.keySort(plainPubKeys).map((pk) => Buffer.from(pk));
+}
+
 export function createTapInternalKey(plainPubKeys: Buffer[]): Buffer {
   return Buffer.from(musig.getXOnlyPubkey(musig.keyAgg(musig.keySort(plainPubKeys))));
 }

--- a/modules/utxo-lib/src/bitgo/wallet/Unspent.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/Unspent.ts
@@ -13,11 +13,11 @@ import { signInput2Of3, verifySignatureWithPublicKeys } from '../signature';
 import { WalletUnspentSigner } from './WalletUnspentSigner';
 import { KeyName, RootWalletKeys } from './WalletKeys';
 import { UtxoTransaction } from '../UtxoTransaction';
-import { Triple, Tuple } from '../types';
+import { Triple } from '../types';
 import { toOutput, UnspentWithPrevTx, Unspent, isUnspentWithPrevTx, toPrevOutput } from '../Unspent';
 import { ChainCode, isSegwit } from './chains';
 import { UtxoPsbt } from '../UtxoPsbt';
-import { encodePsbtMusig2Participants } from '../Musig2';
+import { encodePsbtMusig2Participants, sortMusig2ParticipantPubKeys } from '../Musig2';
 
 export interface WalletUnspent<TNumber extends number | bigint = number> extends Unspent<TNumber> {
   chain: ChainCode;
@@ -189,11 +189,11 @@ export function addWalletUnspentToPsbt(
       outputPubkey: tapOutputKey,
       taptreeRoot,
     } = createKeyPathP2trMusig2(walletKeys.publicKeys);
-    const participantPubKeys: Tuple<Buffer> = [walletKeys.user.publicKey, walletKeys.bitgo.publicKey];
+    const participantPubKeys = sortMusig2ParticipantPubKeys([walletKeys.user.publicKey, walletKeys.bitgo.publicKey]);
     const participantsKeyValData = encodePsbtMusig2Participants({
       tapOutputKey,
       tapInternalKey,
-      participantPubKeys,
+      participantPubKeys: [participantPubKeys[0], participantPubKeys[1]],
     });
     psbt.addProprietaryKeyValToInput(inputIndex, participantsKeyValData);
     psbt.updateInput(inputIndex, {


### PR DESCRIPTION
HSM or any other user of the PSBT created by SDK can skip sorting.

TICKET: BG-73442

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->