### PR TITLE
fix(bitgo): restrict receive address withdrawals

### DIFF
--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -457,6 +457,21 @@ describe('V2 Wallet:', function () {
       }
     });
 
+    it('should not pass receiveAddress in sendMany when TSS transaction type is transfer or transferToken', async function () {
+      const recipientAddress = '0x7db562c4dd465cc895761c56f83b6af0e32689ba';
+      const recipients = [{
+        address: recipientAddress,
+        amount: 0,
+      }];
+      const sendManyParams = { receiveAddress: 'throw', recipients, type: 'transfer', isTss: true, nonce: '13' };
+
+      try {
+        await ethWallet.sendMany(sendManyParams);
+      } catch (e) {
+        e.message.should.equal('cannot use receive address for TSS transactions of type transfer');
+      }
+    });
+
     it('should use a custom signing function if provided', async function () {
       const customSigningFunction: CustomSigningFunction = sinon.stub();
       const builtInSigningMethod = sinon.spy();

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -1778,6 +1778,12 @@ export class Wallet implements IWallet {
       throw error;
     }
 
+    if (params.recipients && (params.type === 'transfer' || params.type === 'transferToken')) {
+      const error: any = new Error(`cannot use receive address for TSS transactions of type ${params.type}`);
+      error.code = 'receive_address_not_allowed_for_tss_withdrawals';
+      throw error;
+    }
+
     if (params.recipients && (params.type === 'fillNonce' || params.type === 'acceleration')) {
       const error: any = new Error(`cannot provide recipients for transaction type ${params.type}`);
       error.code = 'recipients_not_allowed_for_fillnonce_and_acceleration_tx_type';


### PR DESCRIPTION
the change makes it less confusing and
informs the user that receive address
withdrawals is restricted in case they
attempt to do it

TICKET: BG-71431

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->