### PR TITLE
fix(utxo-lib): getSignatureValidationArray throws error for unsigned

### DIFF
--- a/modules/utxo-lib/test/bitgo/psbt/Psbt.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/Psbt.ts
@@ -270,7 +270,7 @@ describe('Psbt from transaction using wallet unspents', function () {
       if (signatureTarget === 'unsigned' && containsP2trInput) {
         assert.throws(
           () => psbt.validateSignaturesOfAllInputs(),
-          (e) => e.message === 'invalid psbt input to validate signature'
+          (e) => e.message === 'No signatures to validate'
         );
       } else {
         assert.deepStrictEqual(psbt.validateSignaturesOfAllInputs(), true);

--- a/modules/utxo-lib/test/bitgo/psbt/signingAndValidation.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/signingAndValidation.ts
@@ -73,6 +73,7 @@ function runTest(scriptType: outputScripts.ScriptType, signerName: KeyName, cosi
         psbt.setMusig2NoncesHD(signer);
         psbt.setMusig2NoncesHD(cosigner);
       }
+      assert.ok(psbt.getSignatureValidationArray(0).every((res) => !res));
       if (scriptType === 'p2shP2pk') {
         psbt.signAllInputs(signer);
       } else {


### PR DESCRIPTION
getSignatureValidationArray should return array of false for unsigned input. Instead it now throws error for missing signature data.

TICKET: BG-74098

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->