### PR TITLE
feat(sdk-core): add proof of paillier correctness

### DIFF
--- a/modules/sdk-core/src/account-lib/mpc/tss/ecdsa/paillierproof.ts
+++ b/modules/sdk-core/src/account-lib/mpc/tss/ecdsa/paillierproof.ts
@@ -1,0 +1,67 @@
+import { bitLength, randBits } from 'bigint-crypto-utils';
+import { bigIntFromBufferBE } from '../../util';
+import { gcd, modInv, modPow } from 'bigint-mod-arith';
+
+// Security parameters.
+const k = 128;
+const alpha = 2;
+
+// Generate a random coprime less than x with the same bit depth.
+async function randomCoPrimeLessThan(x: bigint): Promise<bigint> {
+  while (true) {
+    const y = bigIntFromBufferBE(Buffer.from(await randBits(bitLength(x), true)));
+    if (y > BigInt(0) && y < x && gcd(x, y) === BigInt(1)) {
+      return y;
+    }
+  }
+}
+
+export async function generateP(n: bigint): Promise<Array<bigint>> {
+  const m = k / Math.log2(alpha);
+  return Promise.all(
+    Array(m)
+      .fill(null)
+      .map(() => randomCoPrimeLessThan(n))
+  );
+}
+
+export async function prove(n: bigint, lambda: bigint, p: Array<bigint>): Promise<Array<bigint>> {
+  return new Promise(function (resolve) {
+    setTimeout(() => {
+      const n_inv = modInv(n, lambda);
+      resolve(p.map((p_i) => modPow(p_i, n_inv, n)));
+    });
+  });
+}
+
+export async function verify(n: bigint, p: Array<bigint>, sigma: Array<bigint>): Promise<boolean> {
+  // a) Check that $N$ is a positive integer and is not divisible by all
+  // the primes less than $\alpha$.
+  // (Since is $\alpha = 2$, we only check that $N$ is positive.
+  if (n <= 0) {
+    return false;
+  }
+  if (alpha > 2) {
+    throw new Error('unsupported alpha value');
+  }
+  // b) Check that $\sigma_i$ is a positive integer $i = 1...m$.
+  const m = k / Math.log2(alpha);
+  if (sigma.length != m) {
+    return false;
+  }
+  if (!sigma.every((sigma_i) => sigma_i > 0)) {
+    return false;
+  }
+  // c) Verify that $p_i = \sigma_i^N \mod N$ for $i = 1...m$.
+  return new Promise(function (resolve) {
+    setTimeout(() => {
+      for (let i = 0; i < m; i++) {
+        if (p[i] != modPow(sigma[i], n, n)) {
+          resolve(false);
+          return;
+        }
+      }
+      resolve(true);
+    });
+  });
+}

--- a/modules/sdk-core/src/account-lib/mpc/tss/ecdsa/types.ts
+++ b/modules/sdk-core/src/account-lib/mpc/tss/ecdsa/types.ts
@@ -103,6 +103,7 @@ export interface XShare {
   y: string; // combined public key
   x: string; // combined secret
   chaincode: string;
+  p?: string[]; // paillier proof of correctness challenge
 }
 
 export type XShareWithNtilde = XShare & SerializedNtilde;
@@ -112,6 +113,7 @@ export interface YShare {
   i: number;
   j: number;
   n: string;
+  p?: string[]; // paillier proof of correctness challenge
 }
 
 export type YShareWithNtilde = YShare & SerializedNtilde;
@@ -140,6 +142,7 @@ export interface WShare {
   ntilde: string;
   h1: string;
   h2: string;
+  p: Array<string>;
   ck: string;
   k: string;
   w: string;
@@ -162,6 +165,8 @@ export interface KShare {
   ntilde: string;
   h1: string;
   h2: string;
+  p: Array<string>;
+  sigma: Array<string>;
   k: string;
   proof: RangeProofShare;
 }
@@ -193,6 +198,7 @@ export interface AShare {
   ntilde: string;
   h1: string;
   h2: string;
+  sigma: Array<string>;
   k: string;
   alpha: string;
   mu: string;

--- a/modules/sdk-core/src/bitgo/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/bitgo/tss/ecdsa/ecdsa.ts
@@ -469,8 +469,8 @@ function validateOptionalValues(shares: string[], start: number, end: number, sh
 export function parseKShare(share: SignatureShareRecord): KShare {
   const shares = share.share.split(delimeter);
 
-  validateSharesLength(shares, 11, 'K');
-  const hasProof = validateOptionalValues(shares, 5, 11, 'K', 'proof');
+  validateSharesLength(shares, 11 + 2 * 128, 'K');
+  const hasProof = validateOptionalValues(shares, 5, 11 + 2 * 128, 'K', 'proof');
 
   let proof;
   if (hasProof) {
@@ -492,6 +492,8 @@ export function parseKShare(share: SignatureShareRecord): KShare {
     ntilde: shares[2],
     h1: shares[3],
     h2: shares[4],
+    p: shares.slice(11, 11 + 128),
+    sigma: shares.slice(11 + 128),
     proof,
   };
 }
@@ -509,7 +511,9 @@ export function convertKShare(share: KShare): SignatureShareRecord {
       share.h2
     }${delimeter}${share.proof?.z || ''}${delimeter}${share.proof?.u || ''}${delimeter}${
       share.proof?.w || ''
-    }${delimeter}${share.proof?.s || ''}${delimeter}${share.proof?.s1 || ''}${delimeter}${share.proof?.s2 || ''}`,
+    }${delimeter}${share.proof?.s || ''}${delimeter}${share.proof?.s1 || ''}${delimeter}${
+      share.proof?.s2 || ''
+    }${delimeter}${share.p.join(delimeter)}${delimeter}{share.sigma.join(delimeter)}`,
   };
 }
 
@@ -520,7 +524,7 @@ export function convertKShare(share: KShare): SignatureShareRecord {
  */
 export function parseAShare(share: SignatureShareRecord): AShare {
   const shares = share.share.split(delimeter);
-  validateSharesLength(shares, 37, 'A');
+  validateSharesLength(shares, 37 + 128, 'A');
   const hasProof = validateOptionalValues(shares, 7, 13, 'A', 'proof');
   const hasGammaProof = validateOptionalValues(shares, 13, 25, 'A', 'gammaProof');
   const hasWProof = validateOptionalValues(shares, 25, 37, 'A', 'wProof');
@@ -583,6 +587,7 @@ export function parseAShare(share: SignatureShareRecord): AShare {
     ntilde: shares[4],
     h1: shares[5],
     h2: shares[6],
+    sigma: shares.slice(38),
     proof,
     gammaProof,
     wProof,
@@ -620,7 +625,7 @@ export function convertAShare(share: AShare): SignatureShareRecord {
       share.wProof?.s2 || ''
     }${delimeter}${share.wProof?.t1 || ''}${delimeter}${share.wProof?.t2 || ''}${delimeter}${
       share.wProof?.u || ''
-    }${delimeter}${share.wProof?.x || ''}`,
+    }${delimeter}${share.wProof?.x || ''}${delimeter}${share.sigma.join(delimeter)}`,
   };
 }
 
@@ -837,7 +842,7 @@ export function convertBShare(share: BShare): SignatureShareRecord {
   return {
     to: SignatureShareType.BITGO,
     from: getParticipantFromIndex(share.i),
-    share: `${share.beta}${delimeter}${share.gamma}${delimeter}${share.k}${delimeter}${share.nu}${delimeter}${share.w}${delimeter}${share.y}${delimeter}${share.l}${delimeter}${share.m}${delimeter}${share.n}${delimeter}${share.ntilde}${delimeter}${share.h1}${delimeter}${share.h2}${delimeter}${share.ck}`,
+    share: `${share.beta}${delimeter}${share.gamma}${delimeter}${share.k}${delimeter}${share.nu}${delimeter}${share.w}${delimeter}${share.y}${delimeter}${share.l}${delimeter}${share.m}${delimeter}${share.n}${delimeter}${share.ntilde}${delimeter}${share.h1}${delimeter}${share.h2}${delimeter}${share.ck}${delimeter}{share.p.join(delimeter)}`,
   };
 }
 
@@ -848,7 +853,7 @@ export function convertBShare(share: BShare): SignatureShareRecord {
  */
 export function parseBShare(share: SignatureShareRecord): BShare {
   const shares = share.share.split(delimeter);
-  validateSharesLength(shares, 13, 'B');
+  validateSharesLength(shares, 13 + 128, 'B');
 
   return {
     i: getParticipantIndex(share.to),
@@ -864,6 +869,7 @@ export function parseBShare(share: SignatureShareRecord): BShare {
     ntilde: shares[9],
     h1: shares[10],
     h2: shares[11],
+    p: shares.slice(13),
     ck: shares[12],
   };
 }

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
@@ -670,6 +670,7 @@ export class EcdsaUtils extends baseTSSUtils<KeyShare> {
       ntilde: challenges.bitgoChallenge.ntilde,
       h1: challenges.bitgoChallenge.h1,
       h2: challenges.bitgoChallenge.h2,
+      p: [], // TODO: Need to fill this value in with Paillier challenge values from BitGo.
     });
     const u = signingKey.nShares[bitgoIndex].u;
 


### PR DESCRIPTION
Ticket: BG-74325

This is an implementation of the protocol found in [Efficient Noninteractive Certification of RSA Moduli and Beyond](https://eprint.iacr.org/2018/057.pdf#page6) Section 3.2.

This is needed to ensure the Paillier key used during share conversion isn't a spoofed value that allows extraction of signing material.

BREAKING CHANGES: new required fields for ECDSA share types
