### PR TITLE
feat(sdk-coin-atom): add send tx example for atom

### DIFF
--- a/examples/ts/atom/buildSignSendTx.ts
+++ b/examples/ts/atom/buildSignSendTx.ts
@@ -1,0 +1,89 @@
+/**
+ * Create a TSS atom wallet at BitGo.
+ * This makes use of the convenience function generateWallet
+ *
+ * This tool will help you see how to use the BitGo API to easily create a wallet.
+ * In this form, it creates 2 keys on the host which runs this example.
+ * It is HIGHLY RECOMMENDED that you GENERATE THE KEYS ON SEPARATE MACHINES for real money wallets!
+ *
+ * To perform more advanced features, such as encrypting keys yourself, please look at createWalletAdvanced.js
+ *
+ * Copyright 2023, BitGo, Inc.  All Rights Reserved.
+ */
+const BitGoJS = require('bitgo');
+const bitgo = new BitGoJS.BitGo({
+  env: 'custom',
+  customRootURI: 'https://testnet-16-app.bitgo-dev.com',
+});
+
+// TODO: set your access token here
+// You can get this from User Settings > Developer Options > Add Access Token
+const accessToken = 'v2x04674c296b63dd92e7508f47f098692da3f6d84ac08f1bfac449a76728ed9f4d';
+
+// TODO: get the wallet with this id
+const id = '643f8362242e9e00070172edc8ef57c1';
+
+const coin = 'tatom';
+
+const receiveAddress = 'cosmos1smefkq9yaxgw9c9fhym6qsp746q884czeacn32';
+
+const walletPassphrase = '6PZKSm$oIFa%s1fy';
+
+// Create the wallet
+async function main() {
+  bitgo.authenticateWithAccessToken({ accessToken });
+
+  const wallet = await bitgo.coin(coin).wallets().get({ id });
+
+  console.log(`Wallet label: ${wallet}`);
+
+  const whitelistedParams = {
+    intent: {
+      intentType: 'payment',
+      recipients: [
+        {
+          address: {
+            address: receiveAddress,
+          },
+          amount: {
+            value: '100000',
+            symbol: 'tatom',
+          },
+        },
+      ],
+      memo: "12",
+    },
+    apiVersion: 'full',
+    preview: false,
+  };
+
+  await bitgo.unlock({ otp: '000000', duration: 3600 });
+  const unsignedTx = (await bitgo
+    .post(bitgo.url('/wallet/' + id + '/txrequests', 2))
+    .send(whitelistedParams)
+    .result());
+
+  console.log("Unsigned tx: ");
+  console.log(unsignedTx);
+
+  // sign tx
+  const keychains = await bitgo.coin(coin).keychains().getKeysForSigning({ wallet: wallet });
+  const signedTransaction = await wallet.signTransaction({
+    txPrebuild: unsignedTx,
+    keychain: keychains[0],
+    walletPassphrase: walletPassphrase,
+    pubs: keychains.map((k) => k.pub),
+    reqId: unsignedTx.txRequestId,
+  });
+
+  // submit tx
+  const submittedTx = await bitgo
+    .post(bitgo.url('/wallet/' + id + '/tx/send'))
+    .send({ txRequestId: signedTransaction.txRequestId })
+    .result();
+
+  console.log('New Transaction:', JSON.stringify(submittedTx, null, 4));
+
+}
+
+main().catch((e) => console.error(e));

--- a/examples/ts/atom/sendMany.ts
+++ b/examples/ts/atom/sendMany.ts
@@ -1,0 +1,50 @@
+const BitGoJS = require('bitgo');
+const bitgo = new BitGoJS.BitGo({
+  env: 'custom',
+  customRootURI: 'https://testnet-16-app.bitgo-dev.com',
+});
+
+const accessToken = 'v2x04674c296b63dd92e7508f47f098692da3f6d84ac08f1bfac449a76728ed9f4d';
+
+const WALLET_ID = '643f8362242e9e00070172edc8ef57c1';
+
+const COIN = 'tatom';
+
+const receiveAddress = 'cosmos1smefkq9yaxgw9c9fhym6qsp746q884czeacn32';
+
+const PASS_PHRASE = '6PZKSm$oIFa%s1fy';
+
+async function sendWallet() {
+
+  await bitgo.authenticateWithAccessToken({ accessToken });
+
+  await bitgo.unlock({ otp: '000000', duration: 3600 });
+
+  const walletInstance = await bitgo.coin(COIN).wallets().get({ id: WALLET_ID });
+  try {
+
+    const transaction = await walletInstance.sendMany({
+      recipients: [{
+        amount: '1',
+        address: receiveAddress,
+        //  data: "0x095ea7b30000000000000000000000000e71a7bbd318f2b72b2c296e8983f4569a775c0d00000000000000000000000000000000000000000000000000000000000186a0"
+      }],
+
+      walletPassphrase: PASS_PHRASE,
+      type: 'transfer',
+      // gasPrice: 21000000000,
+      // gasLimit: 31000
+
+    });
+    const { feeInfo, serializedTxHex } = transaction.transactions[0].unsignedTx;
+    const explanation = await bitgo.coin(COIN).explainTransaction({ txHex: serializedTxHex, feeInfo });
+
+    console.log('Wallet ID:', walletInstance.id());
+    console.log('New Transaction:', JSON.stringify(transaction, null, 4));
+    console.log('Transaction Explanation:', JSON.stringify(explanation, null, 4));
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+sendWallet();


### PR DESCRIPTION
Ticket: BG-67328

## Context
This PR adds a small script to send tx using the necessary APIs, which is similar to how an integration test works (?)