### PR TITLE
feat(uxto-lib): fix "Argument must be a Buffer" bug in the frontend

### DIFF
--- a/modules/utxo-lib/src/payments/p2tr.ts
+++ b/modules/utxo-lib/src/payments/p2tr.ts
@@ -6,6 +6,7 @@ import { script as bscript, Payment, PaymentOpts, lazy } from 'bitcoinjs-lib';
 import * as taproot from '../taproot';
 import { musig } from '../noble_ecc';
 import * as necc from '@noble/secp256k1';
+
 const typef = require('typeforce');
 const OPS = bscript.OPS;
 
@@ -297,13 +298,15 @@ export function p2tr(a: Payment, opts?: PaymentOpts): Payment {
         throw new TypeError('mismatch between address & output');
       }
 
-      if (taprootPubkey && _outputPubkey && !_outputPubkey()?.equals(taprootPubkey.xOnlyPubkey)) {
+      // Wrapping `taprootPubkey.xOnlyPubkey` in Buffer because of a peculiar issue in the frontend
+      // where a polyfill for Buffer is used. Refer: https://bitgoinc.atlassian.net/browse/BG-61420
+      if (taprootPubkey && _outputPubkey && !_outputPubkey()?.equals(Buffer.from(taprootPubkey.xOnlyPubkey))) {
         throw new TypeError('mismatch between output and taproot pubkey');
       }
     }
 
     if (a.address) {
-      if (taprootPubkey && !_address()?.data.equals(taprootPubkey.xOnlyPubkey)) {
+      if (taprootPubkey && !_address()?.data.equals(Buffer.from(taprootPubkey.xOnlyPubkey))) {
         throw new TypeError('mismatch between address and taproot pubkey');
       }
     }


### PR DESCRIPTION
when spending from Taproot addresses.

Core issue is the Buffer polyfill in the frontend has a different implementation for `equals()` method than the one in NodeJS.

BG-61420

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->