### PR TITLE
feat: express route to sign payloads in external signing mode

### DIFF
--- a/modules/express/test/unit/clientRoutes/signPayload.ts
+++ b/modules/express/test/unit/clientRoutes/signPayload.ts
@@ -1,13 +1,13 @@
 import * as sinon from 'sinon';
-
 import 'should-http';
 import 'should-sinon';
-import '../../lib/asserts';
-
+import 'should';
+import * as fs from 'fs';
 import { Request } from 'express';
-import { handleV2OFCSignPayload } from '../../../src/clientRoutes';
+import { BitGo, Coin, BaseCoin, Wallet, Wallets } from 'bitgo';
 
-import { BitGo, BaseCoin, Wallet, Wallets } from 'bitgo';
+import '../../lib/asserts';
+import { handleV2OFCSignPayload, handleV2OFCSignPayloadInExtSigningMode } from '../../../src/clientRoutes';
 
 describe('Sign an arbitrary payload with trading account key', function () {
   const coin = 'ofc';
@@ -67,5 +67,146 @@ describe('Sign an arbitrary payload with trading account key', function () {
       query: {},
     } as unknown as Request;
     await handleV2OFCSignPayload(req).should.be.resolvedWith(expectedResponse);
+  });
+});
+
+describe('With the handler to sign an arbitrary payload in external signing mode', () => {
+  let bitgo: BitGo;
+
+  const walletId = '61f039aad587c2000745c687373e0fa9';
+  const walletPassword = 'wDX058%c4plL1@pP';
+  const secret =
+    'xprv9s21ZrQH143K3EuPWCBuqnWxydaQV6et9htQige4EswvcHKEzNmkVmwTwKoadyHzJYppuADB7Us7AbaNLToNvoFoSxuWqndQRYtnNy5DUY2';
+  const validPrv =
+  '{"61f039aad587c2000745c687373e0fa9":"{\\"iv\\":\\"+1u1Y9cvsYuRMeyH2slnXQ==\\",\\"v\\":1,\\"iter\\":10000,\\"ks\\":256,\\"ts\\":64,\\"mode\\":\\"ccm\\",\\"adata\\":\\"\\",\\"cipher\\":\\"aes\\",\\"salt\\":\\"54kOXTqJ9mc=\\",\\"ct\\":\\"JF5wQ82wa1dYyFxFlbHCvK4a+A6MTHdhOqc5uXsz2icWhkY2Lin/3Ab8ZwvwDaR1JYKmC/g1gXIGwVZEOl1M/bRHY420h7sDtmTS6Ebse5NWbF0ItfUJlk6HVATGa+C6mkbaVxJ4kQW/ehnT3riqzU069ATPz8E=\\"}"}';
+
+  const payload = {
+    this: {
+      is: {
+        a: 'payload',
+      },
+    },
+  };
+
+  before(() => {
+    bitgo = new BitGo({ env: 'test' });
+  });
+
+  it('should return a payload signed with trading account key read from the local file system', async () => {
+    const stubbedSignature = Buffer.from('mysign');
+    const readFileStub = sinon.stub(fs.promises, 'readFile').resolves(validPrv);
+    const envStub = sinon.stub(process, 'env')
+      .value({ WALLET_61f039aad587c2000745c687373e0fa9_PASSPHRASE: walletPassword });
+    
+    const signMessageStub = sinon
+      .stub(Coin.Ofc.prototype, 'signMessage')
+      .resolves(stubbedSignature);
+
+    const stubbedSigHex = stubbedSignature.toString('hex');
+
+    const expectedResponse = {
+      payload: JSON.stringify(payload),
+      signature: stubbedSigHex,
+    };
+
+    const req = {
+      bitgo,
+      body: {
+        walletId,
+        payload,
+      },
+      config: {
+        signerFileSystemPath: 'signerFileSystemPath',
+      },
+    } as unknown as Request;
+
+    await handleV2OFCSignPayloadInExtSigningMode(req).should.be.resolvedWith(expectedResponse);
+    readFileStub.should.be.calledOnceWith('signerFileSystemPath');
+    signMessageStub.should.be.calledOnceWith(
+      sinon.match({
+        prv: secret,
+      })
+    );
+    readFileStub.restore();
+    envStub.restore();
+  });
+
+  describe('With invalid setup', () => {
+    const invalidPrv = '{"61f039aad587c2000745c687373e0fa9":"invalid"}';
+  
+    it('should throw an error with missing wallet passphrase in env', async () => {
+      const req = {
+        bitgo,
+        body: {
+          walletId,
+          payload,
+        },
+      } as unknown as Request;
+
+      await handleV2OFCSignPayloadInExtSigningMode(req).should.be.rejectedWith('Could not find wallet passphrase WALLET_61f039aad587c2000745c687373e0fa9_PASSPHRASE in environment');
+    });
+
+    it('should throw an error with undefined signerFileSystemPath in env', async () => {
+      const envStub = sinon.stub(process, 'env')
+        .value({ WALLET_61f039aad587c2000745c687373e0fa9_PASSPHRASE: walletPassword });
+
+      const req = {
+        bitgo,
+        body: {
+          walletId,
+          payload,
+        },
+        config: {
+          signerFileSystemPath: undefined,
+        },
+      } as unknown as Request;
+
+      await handleV2OFCSignPayloadInExtSigningMode(req).should.be.rejectedWith('Missing required configuration: signerFileSystemPath');
+      envStub.restore();
+    });
+
+    it('should throw error when trying to decrypt with invalid private key', async () => {
+      const readFileStub = sinon.stub(fs.promises, 'readFile').resolves(invalidPrv);
+      const envStub = sinon.stub(process, 'env')
+        .value({ WALLET_61f039aad587c2000745c687373e0fa9_PASSPHRASE: walletPassword });
+
+      const req = {
+        bitgo,
+        body: {
+          walletId,
+          payload,
+        },
+        config: {
+          signerFileSystemPath: 'signerFileSystemPath',
+        },
+      } as unknown as Request;
+      
+      await handleV2OFCSignPayloadInExtSigningMode(req).should.be.rejectedWith('Error when trying to decrypt private key: INVALID: json decode: this isn\'t json!');
+
+      readFileStub.restore();
+      envStub.restore();
+    });
+
+    it('should throw error when trying to decrypt with invalid wallet passphrase key', async () => {
+      const readFileStub = sinon.stub(fs.promises, 'readFile').resolves(validPrv);
+      const envStub = sinon.stub(process, 'env')
+        .value({ WALLET_61f039aad587c2000745c687373e0fa9_PASSPHRASE: 'invalidPassphrase' });
+
+      const req = {
+        bitgo,
+        body: {
+          walletId,
+          payload,
+        },
+        config: {
+          signerFileSystemPath: 'signerFileSystemPath',
+        },
+      } as unknown as Request;
+
+      await handleV2OFCSignPayloadInExtSigningMode(req).should.be.rejectedWith('Error when trying to decrypt private key: CORRUPT: password error - ccm: tag doesn\'t match');
+      
+      readFileStub.restore();
+      envStub.restore();
+    });
   });
 });


### PR DESCRIPTION
## Description

This route will enable our Clients and Partners to leverage BitGo Express in External Signing mode to sign arbitrary http post request payloads, with their trading account key, in order to integrate with our systems.

## Issue Number

Ticket: BG-74347. 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

### Manual testing using TEST data:
I stood up two local instances of the express server; one in external signing mode and the other not. 
My external signing mode server was running on port 4000. Whereas the other one (not in ext signing mode) was on port 3000. 
On the server running on 3000:
1. Set `BITGO_DISABLE_SSL=true` in `.env`
2. Set `BITGO_EXTERNAL_SIGNER_URL=localhost:4000` in `.env`
3. Start the server

Server running on 4000: 
1. Choose a trading account wallet from one of your enterprises. Copy its walletID. This is the trading account whose key will be used to sign the payload. 
5. Populate `BITGO_EXTERNAL_SIGNER_ACCESS_TOKEN` and `BITGO_EXTERNAL_SIGNER_WALLET_IDS` env vars.
6. Use `fetchEncryptedKeys.ts` to fetch the encrypted private key for that walletID to update the `encryptedPrivKeys.json` file. 
7. Set `BITGO_SIGNER_MODE=true` 
8. Set `BITGO_SIGNER_FILE_SYSTEM_PATH` to the path to the `encryptedPrivKeys.json` file. 
9. Start the server

In postman: 

POST `http://localhost:3000/api/v2/ofc/signPayload` with the following payload: `payload` can be any arbitrary payload. 
```
{
    "walletId": "<WALLET_ID chosen above>",
    "payload": {
        "this": {
            "is": {
                "a": "payload"
            }
        }
    }
}
```

### Added unit tests to cover the new handler

### Manual E2E testing in DEV:

- Created an enterprise along with its trading account.
- Added the walletId (trading account ID) and other required info (local encrypted keys in a json + passphrase for that walletID) on to a local express server set up in external signing mode (port 4000).
- Started up a local express server not in ext signing mode (port 3000) with externalSigningURL set to the server running on port 4000. 
- Signed an arbitrary payload for the walletID using the express server that is running on port 3000. This server proxies the request to localhost:4000. 
- Added the payload, signature on to DAS entries in develop by port-forwarding DAS and using the `POST /entries` endpoint. 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
