### PR TITLE
feat(utxo-lib): use chronological musig2 key order

### DIFF
--- a/modules/utxo-bin/test/fixtures/formatAddress_bitcoin_default_bc1p5xqvqger0zdpcq6s3jznfz352exhk356p9hml6c69matmggrve9scdgsyg.txt
+++ b/modules/utxo-bin/test/fixtures/formatAddress_bitcoin_default_bc1p5xqvqger0zdpcq6s3jznfz352exhk356p9hml6c69matmggrve9scdgsyg.txt
@@ -1,0 +1,12 @@
+address: bc1p5xqvqger0zdpcq6s3jznfz352exhk356p9hml6c69matmggrve9scdgsyg
+├─┬ bech32m
+│ ├── prefix: bc
+│ ├── words: 011406000c000819030f020d0118001a1011120213090211140a1906171611141a0105171b1f1a181a051b1d0b1b0808030c190510
+│ └── bytes: 0d0c0601191bc4d0e01a846429a451a2b26bda34d04b7dff58d177d5ed081b3258
+├── format: default
+├─┬ outputScript: 5120a180c02323789a1c03508c85348a34564d7b469a096fbfeb1a2efabda103664b
+│ └─┬ scriptPubKey: [34byte]
+│   ├── type: taproot
+│   ├── hex: 5120a180c02323789a1c03508c85348a34564d7b469a096fbfeb1a2efabda103664b
+│   └── asm: OP_1 a180c02323789a1c03508c85348a34564d7b469a096fbfeb1a2efabda103664b
+└── network: bitcoin

--- a/modules/utxo-bin/test/fixtures/formatAddress_testnet_default_tb1p5xqvqger0zdpcq6s3jznfz352exhk356p9hml6c69matmggrve9s097l78.txt
+++ b/modules/utxo-bin/test/fixtures/formatAddress_testnet_default_tb1p5xqvqger0zdpcq6s3jznfz352exhk356p9hml6c69matmggrve9s097l78.txt
@@ -1,0 +1,12 @@
+address: tb1p5xqvqger0zdpcq6s3jznfz352exhk356p9hml6c69matmggrve9s097l78
+├─┬ bech32m
+│ ├── prefix: tb
+│ ├── words: 011406000c000819030f020d0118001a1011120213090211140a1906171611141a0105171b1f1a181a051b1d0b1b0808030c190510
+│ └── bytes: 0d0c0601191bc4d0e01a846429a451a2b26bda34d04b7dff58d177d5ed081b3258
+├── format: default
+├─┬ outputScript: 5120a180c02323789a1c03508c85348a34564d7b469a096fbfeb1a2efabda103664b
+│ └─┬ scriptPubKey: [34byte]
+│   ├── type: taproot
+│   ├── hex: 5120a180c02323789a1c03508c85348a34564d7b469a096fbfeb1a2efabda103664b
+│   └── asm: OP_1 a180c02323789a1c03508c85348a34564d7b469a096fbfeb1a2efabda103664b
+└── network: testnet

--- a/modules/utxo-lib/src/bitgo/Musig2.ts
+++ b/modules/utxo-lib/src/bitgo/Musig2.ts
@@ -215,12 +215,8 @@ export function decodePsbtMusig2PartialSig(kv: ProprietaryKeyValue): PsbtMusig2P
   return { participantPubKey: key.subarray(0, 33), tapOutputKey: key.subarray(33), partialSig: value };
 }
 
-export function sortMusig2ParticipantPubKeys(plainPubKeys: Buffer[]): Buffer[] {
-  return musig.keySort(plainPubKeys).map((pk) => Buffer.from(pk));
-}
-
 export function createTapInternalKey(plainPubKeys: Buffer[]): Buffer {
-  return Buffer.from(musig.getXOnlyPubkey(musig.keyAgg(musig.keySort(plainPubKeys))));
+  return Buffer.from(musig.getXOnlyPubkey(musig.keyAgg(plainPubKeys)));
 }
 
 export function createTapOutputKey(internalPubKey: Buffer, tapTreeRoot: Buffer): Buffer {
@@ -243,7 +239,7 @@ function startMusig2SigningSession(
   publicKeys: Tuple<Buffer>,
   tweak: Buffer
 ): SessionKey {
-  return musig.startSigningSession(aggNonce, hash, musig.keySort(publicKeys), { tweak, xOnly: true });
+  return musig.startSigningSession(aggNonce, hash, publicKeys, { tweak, xOnly: true });
 }
 
 export function musig2PartialSign(

--- a/modules/utxo-lib/src/bitgo/wallet/Unspent.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/Unspent.ts
@@ -17,7 +17,7 @@ import { Triple } from '../types';
 import { toOutput, UnspentWithPrevTx, Unspent, isUnspentWithPrevTx, toPrevOutput } from '../Unspent';
 import { ChainCode, isSegwit } from './chains';
 import { UtxoPsbt } from '../UtxoPsbt';
-import { encodePsbtMusig2Participants, sortMusig2ParticipantPubKeys } from '../Musig2';
+import { encodePsbtMusig2Participants } from '../Musig2';
 import { createTransactionFromBuffer } from '../transaction';
 
 export interface WalletUnspent<TNumber extends number | bigint = number> extends Unspent<TNumber> {
@@ -194,11 +194,10 @@ export function addWalletUnspentToPsbt(
       outputPubkey: tapOutputKey,
       taptreeRoot,
     } = createKeyPathP2trMusig2(walletKeys.publicKeys);
-    const participantPubKeys = sortMusig2ParticipantPubKeys([walletKeys.user.publicKey, walletKeys.bitgo.publicKey]);
     const participantsKeyValData = encodePsbtMusig2Participants({
       tapOutputKey,
       tapInternalKey,
-      participantPubKeys: [participantPubKeys[0], participantPubKeys[1]],
+      participantPubKeys: [walletKeys.user.publicKey, walletKeys.bitgo.publicKey],
     });
     psbt.addProprietaryKeyValToInput(inputIndex, participantsKeyValData);
     psbt.updateInput(inputIndex, {

--- a/modules/utxo-lib/src/payments/p2tr.ts
+++ b/modules/utxo-lib/src/payments/p2tr.ts
@@ -133,7 +133,7 @@ export function p2tr(a: Payment, opts?: PaymentOpts): Payment {
     } else if (a.pubkeys && a.pubkeys.length > 1) {
       // multiple pubkeys
       if (isPlainPubkeys(a.pubkeys)) {
-        return Buffer.from(musig.getXOnlyPubkey(musig.keyAgg(musig.keySort(a.pubkeys))));
+        return Buffer.from(musig.getXOnlyPubkey(musig.keyAgg(a.pubkeys)));
       }
 
       return Buffer.from(taproot.aggregateMuSigPubkeys(ecc, a.pubkeys));

--- a/modules/utxo-lib/test/bitgo/outputScripts.ts
+++ b/modules/utxo-lib/test/bitgo/outputScripts.ts
@@ -63,7 +63,7 @@ describe('createOutputScript2of3()', function () {
     'a020478d8f208753ae';
   const p2wsh = '002095ecaacb606b9ece3821c0111c0a1208dd1d35192809bf8cf6cbad4bbeaca67f';
   const p2tr = '5120a4ce7d122bdc05224b27415228728e5d5bf485961a07493d068ddbb4d4569059';
-  const p2trMusig2 = '5120d5e2a42a42d34aab295ba6b05bba335aca40a1cf8ac789244d3f949c2b5b8d01';
+  const p2trMusig2 = '51207cd79799a4cf6183b018a29960ffe8351e90afdb2383b9b9dcd3ec07929c72e3';
 
   scriptTypes2Of3.forEach((scriptType) => {
     it(`creates output script (type=${scriptType})`, function () {


### PR DESCRIPTION
Previously user and bitgo musig2 keys are lexicographically sorted. Now its changed to user and bitgo key order to save hsm resources.

Ticket: BG-74843

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->