### PR TITLE
feat(utxo-lib): add deterministic nonce gen and signing for UtxoPsbt

### DIFF
--- a/modules/utxo-lib/test/bitgo/psbt/Musig2Util.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/Musig2Util.ts
@@ -1,12 +1,19 @@
 import * as assert from 'assert';
+import { BIP32Interface } from 'bip32';
+import { TapBip32Derivation } from 'bip174/src/lib/interfaces';
+import { Transaction } from 'bitcoinjs-lib';
+
 import {
   addWalletOutputToPsbt,
   addWalletUnspentToPsbt,
   createPsbtForNetwork,
   getExternalChainCode,
   getInternalChainCode,
+  HDTaprootMusig2Signer,
+  HDTaprootSigner,
   isWalletUnspent,
   KeyName,
+  Musig2Signer,
   outputScripts,
   parsePsbtInput,
   parseSignatureScript2Of3,
@@ -29,6 +36,9 @@ import {
 } from '../../../src/bitgo/outputScripts';
 import { getDefaultWalletKeys, mockWalletUnspent } from '../../../src/testutil';
 import { networks } from '../../../src';
+import * as musig2 from '../../../src/bitgo/Musig2';
+import { musig2DeterministicSign } from '../../../src/bitgo/Musig2';
+import { checkForInput } from 'bip174/src/lib/utils';
 
 export const network = networks.bitcoin;
 const outputType = 'p2trMusig2';
@@ -316,4 +326,156 @@ export function validateParsedTaprootScriptPathTxInput(
   parsedTxInput.signatures.forEach((sig) => {
     assert.strictEqual(sig.length, 64);
   });
+}
+
+export function getTaprootSigners(
+  psbt: UtxoPsbt,
+  inputIndex: number,
+  keypair: BIP32Interface
+): HDTaprootSigner[] | HDTaprootMusig2Signer[] {
+  const input = checkForInput(psbt.data.inputs, inputIndex);
+  if (!input.tapBip32Derivation || input.tapBip32Derivation.length === 0) {
+    throw new Error('Need tapBip32Derivation to sign Taproot with HD');
+  }
+  const myDerivations = input.tapBip32Derivation
+    .map((bipDv) => {
+      if (bipDv.masterFingerprint.equals(keypair.fingerprint)) {
+        return bipDv;
+      }
+    })
+    .filter((v) => !!v) as TapBip32Derivation[];
+  if (myDerivations.length === 0) {
+    throw new Error('Need one tapBip32Derivation masterFingerprint to match the HDSigner fingerprint');
+  }
+
+  function getDerivedNode(bipDv: TapBip32Derivation): HDTaprootMusig2Signer | HDTaprootSigner {
+    const node = keypair.derivePath(bipDv.path);
+    if (!bipDv.pubkey.equals(node.publicKey.slice(1))) {
+      throw new Error('pubkey did not match tapBip32Derivation');
+    }
+    return node;
+  }
+
+  if (input.tapLeafScript?.length) {
+    return myDerivations.map((bipDv) => {
+      const signer = getDerivedNode(bipDv);
+      if (!('signSchnorr' in signer)) {
+        throw new Error('signSchnorr function is required to sign p2tr');
+      }
+      return signer;
+    });
+  } else if (input.tapInternalKey?.length) {
+    return myDerivations.map((bipDv) => {
+      const signer = getDerivedNode(bipDv);
+      if (!('privateKey' in signer) || !signer.privateKey) {
+        throw new Error('privateKey is required to sign p2tr musig2');
+      }
+      return signer;
+    });
+  }
+  throw new Error(`taproot input #${inputIndex} failed to get signers`);
+}
+
+export function addDeterministicNoncesToPsbt(psbt: UtxoPsbt, keypair: BIP32Interface): UtxoPsbt {
+  psbt.data.inputs.forEach((input, inputIndex) => {
+    if (!input.tapMerkleRoot || !input.tapInternalKey) {
+      return;
+    }
+    const derivedKey = input.tapBip32Derivation ? UtxoPsbt.deriveKeyPair(keypair, input.tapBip32Derivation) : keypair;
+    assert.ok(derivedKey);
+    assert.ok(derivedKey.privateKey);
+
+    const participants = musig2.parsePsbtMusig2Participants(psbt, inputIndex);
+    assert.ok(participants);
+    musig2.assertPsbtMusig2Participants(participants, input.tapInternalKey, input.tapMerkleRoot);
+    const { tapOutputKey, participantPubKeys } = participants;
+    const participantPubKey = participantPubKeys.find((pubKey) => pubKey.equals(derivedKey.publicKey));
+
+    // If the bitgo pubkey is not within the participants, then this musig2 input doesnt use this key. Skip
+    if (!participantPubKey) {
+      return;
+    }
+    assert.ok(participantPubKeys[1].equals(derivedKey.publicKey));
+
+    const { hash } = psbt.getTaprootHashForSig(inputIndex);
+
+    const musigNonces = musig2.parsePsbtMusig2Nonces(psbt, inputIndex);
+    assert.ok(musigNonces);
+    const userNonce = musigNonces.find((kv) => kv.participantPubKey.equals(participantPubKeys[0]));
+    assert.ok(userNonce);
+
+    const pubNonce = musig2.createMusig2DeterministicNonce({
+      privateKey: derivedKey.privateKey,
+      otherNonce: userNonce.pubNonce,
+      publicKeys: participantPubKeys,
+      internalPubKey: input.tapInternalKey,
+      tapTreeRoot: input.tapMerkleRoot,
+      hash,
+    });
+    const nonce = { tapOutputKey, participantPubKey, pubNonce };
+    psbt.addOrUpdateProprietaryKeyValToInput(inputIndex, musig2.encodePsbtMusig2PubNonce(nonce));
+  });
+  return psbt;
+}
+
+/**
+ * General flow is copied from UtxoPsbt.signAllInputsHD going into UtxoPsbt.signTaprootMusig2Input.
+ *
+ * This only adds signatures to musig2 inputs
+ * @param psbt
+ * @param keypair
+ */
+export function addDerterministicMusig2SignaturesToPsbt(
+  psbt: UtxoPsbt,
+  inputIndex: number,
+  signer: Musig2Signer,
+  sighashTypes: number[] = [Transaction.SIGHASH_DEFAULT, Transaction.SIGHASH_ALL]
+): void {
+  const input = checkForInput(psbt.data.inputs, inputIndex);
+
+  if (!input.tapBip32Derivation?.length) {
+    return;
+  }
+
+  if (!input.tapInternalKey || !input.tapMerkleRoot) {
+    return;
+  }
+  assert.ok(input.tapInternalKey);
+  assert.ok(input.tapMerkleRoot);
+
+  const participants = musig2.parsePsbtMusig2Participants(psbt, inputIndex);
+  assert.ok(participants);
+  const { tapOutputKey, participantPubKeys } = participants;
+  const signerPubKey = participantPubKeys.find((pubKey) => pubKey.equals(signer.publicKey));
+  assert.ok(signerPubKey);
+  if (!participantPubKeys[1].equals(signer.publicKey)) {
+    return;
+  }
+
+  const nonces = musig2.parsePsbtMusig2Nonces(psbt, inputIndex);
+  assert.ok(nonces);
+  const userNonce = nonces.find((n) => !n.participantPubKey.equals(signerPubKey));
+  assert.ok(userNonce);
+
+  const { hash, sighashType } = psbt.getTaprootHashForSig(inputIndex, sighashTypes);
+
+  let partialSig = musig2DeterministicSign({
+    privateKey: signer.privateKey,
+    otherNonce: userNonce.pubNonce,
+    publicKeys: participantPubKeys,
+    internalPubKey: input.tapInternalKey,
+    tapTreeRoot: input.tapMerkleRoot,
+    hash,
+  }).sig;
+
+  if (sighashType !== Transaction.SIGHASH_DEFAULT) {
+    partialSig = Buffer.concat([partialSig, Buffer.of(sighashType)]);
+  }
+
+  const sig = musig2.encodePsbtMusig2PartialSig({
+    participantPubKey: signerPubKey,
+    tapOutputKey,
+    partialSig: partialSig,
+  });
+  psbt.addProprietaryKeyValToInput(inputIndex, sig);
 }


### PR DESCRIPTION
Add deterministic nonce generation and signing for PSBTs with `p2trMusig2` inputs.

BG-74624

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->