### PR TITLE
feat(wp): migrate deterministic signing into utxopsbt

### DIFF
--- a/modules/utxo-lib/src/bitgo/UtxoPsbt.ts
+++ b/modules/utxo-lib/src/bitgo/UtxoPsbt.ts
@@ -35,6 +35,8 @@ import {
   musig2PartialSigVerify,
   musig2AggregateSigs,
   getSigHashTypeFromSigs,
+  musig2DeterministicSign,
+  createMusig2DeterministicNonce,
 } from './Musig2';
 import { isTuple, Tuple } from './types';
 
@@ -45,6 +47,25 @@ export enum ProprietaryKeySubtype {
   MUSIG2_PARTICIPANT_PUB_KEYS = 0x01,
   MUSIG2_PUB_NONCE = 0x02,
   MUSIG2_PARTIAL_SIG = 0x03,
+}
+
+type SignatureParams = {
+  /** When true, and add the second (last) nonce and signature for a taproot key
+   * path spend deterministically. Throws an error if done for the first nonce/signature
+   * of a taproot keypath spend. Ignore for all other input types.
+   */
+  deterministic: boolean;
+  /** Allowed sighash types */
+  sighashTypes: number[];
+};
+
+const defaultSignatureParams = {
+  deterministic: false,
+  sighashTypes: [Transaction.SIGHASH_DEFAULT, Transaction.SIGHASH_ALL],
+};
+
+function toSignatureParams(v: Partial<SignatureParams> | number[]): SignatureParams {
+  return Array.isArray(v) ? toSignatureParams({ sighashTypes: v }) : { ...defaultSignatureParams, ...v };
 }
 
 export interface HDTaprootSigner extends HDSigner {
@@ -536,7 +557,7 @@ export class UtxoPsbt<Tx extends UtxoTransaction<bigint> = UtxoTransaction<bigin
       const { hash } = this.getTaprootHashForSig(inputIndex, [sigHashType], leafHash);
       results.push(eccLib.verifySchnorr(hash, pubkey, sig));
     }
-    return results.every((res) => res === true);
+    return results.every((res) => res);
   }
 
   /**
@@ -581,22 +602,23 @@ export class UtxoPsbt<Tx extends UtxoTransaction<bigint> = UtxoTransaction<bigin
    */
   signAllInputsHD(
     hdKeyPair: HDTaprootSigner | HDTaprootMusig2Signer,
-    sighashTypes: number[] = [Transaction.SIGHASH_DEFAULT, Transaction.SIGHASH_ALL]
+    params: number[] | Partial<SignatureParams> = defaultSignatureParams
   ): this {
     if (!hdKeyPair || !hdKeyPair.publicKey || !hdKeyPair.fingerprint) {
       throw new Error('Need HDSigner to sign input');
     }
+    const { sighashTypes, deterministic } = toSignatureParams(params);
 
     const results: boolean[] = [];
     for (let i = 0; i < this.data.inputs.length; i++) {
       try {
-        this.signInputHD(i, hdKeyPair, sighashTypes);
+        this.signInputHD(i, hdKeyPair, { sighashTypes, deterministic });
         results.push(true);
       } catch (err) {
         results.push(false);
       }
     }
-    if (results.every((v) => v === false)) {
+    if (results.every((v) => !v)) {
       throw new Error('No inputs were signed');
     }
     return this;
@@ -608,7 +630,7 @@ export class UtxoPsbt<Tx extends UtxoTransaction<bigint> = UtxoTransaction<bigin
   signTaprootInputHD(
     inputIndex: number,
     hdKeyPair: HDTaprootSigner | HDTaprootMusig2Signer,
-    sighashTypes: number[] = [Transaction.SIGHASH_DEFAULT, Transaction.SIGHASH_ALL]
+    { sighashTypes = [Transaction.SIGHASH_DEFAULT, Transaction.SIGHASH_ALL], deterministic = false } = {}
   ): this {
     if (!hdKeyPair || !hdKeyPair.publicKey || !hdKeyPair.fingerprint) {
       throw new Error('Need HDSigner to sign input');
@@ -653,15 +675,20 @@ export class UtxoPsbt<Tx extends UtxoTransaction<bigint> = UtxoTransaction<bigin
         }
         return signer;
       });
-      signers.forEach((signer) => this.signTaprootMusig2Input(inputIndex, signer, sighashTypes));
+      signers.forEach((signer) => this.signTaprootMusig2Input(inputIndex, signer, { sighashTypes, deterministic }));
     }
     return this;
   }
 
-  signInputHD(inputIndex: number, hdKeyPair: HDTaprootSigner | HDTaprootMusig2Signer, sighashTypes?: number[]): this {
+  signInputHD(
+    inputIndex: number,
+    hdKeyPair: HDTaprootSigner | HDTaprootMusig2Signer,
+    params: number[] | Partial<SignatureParams> = defaultSignatureParams
+  ): this {
+    const { sighashTypes, deterministic } = toSignatureParams(params);
     const input = checkForInput(this.data.inputs, inputIndex);
     if (input.tapBip32Derivation?.length) {
-      return this.signTaprootInputHD(inputIndex, hdKeyPair, sighashTypes);
+      return this.signTaprootInputHD(inputIndex, hdKeyPair, { sighashTypes, deterministic });
     } else {
       return super.signInputHD(inputIndex, hdKeyPair, sighashTypes);
     }
@@ -689,14 +716,17 @@ export class UtxoPsbt<Tx extends UtxoTransaction<bigint> = UtxoTransaction<bigin
 
   /**
    * Signs p2tr musig2 key path input with 2 aggregated keys.
+   *
+   * Note: Only can sign deterministically as the cosigner
    * @param inputIndex
    * @param signer - XY public key and private key are required
    * @param sighashTypes
+   * @param deterministic If true, sign the musig input deterministically
    */
   signTaprootMusig2Input(
     inputIndex: number,
     signer: Musig2Signer,
-    sighashTypes: number[] = [Transaction.SIGHASH_DEFAULT, Transaction.SIGHASH_ALL]
+    { sighashTypes = [Transaction.SIGHASH_DEFAULT, Transaction.SIGHASH_ALL], deterministic = false } = {}
   ): this {
     const input = checkForInput(this.data.inputs, inputIndex);
 
@@ -707,6 +737,7 @@ export class UtxoPsbt<Tx extends UtxoTransaction<bigint> = UtxoTransaction<bigin
       throw new Error('tapMerkleRoot is required for p2tr musig2 key path signing');
     }
 
+    // Retrieve and check that we have two participant nonces
     const participants = this.getMusig2Participants(inputIndex, input.tapInternalKey, input.tapMerkleRoot);
     const { tapOutputKey, participantPubKeys } = participants;
     const signerPubKey = participantPubKeys.find((pubKey) => pubKey.equals(signer.publicKey));
@@ -717,19 +748,40 @@ export class UtxoPsbt<Tx extends UtxoTransaction<bigint> = UtxoTransaction<bigin
     const nonces = this.getMusig2Nonces(inputIndex, participants);
     const { hash, sighashType } = this.getTaprootHashForSig(inputIndex, sighashTypes);
 
-    const sessionKey = createMusig2SigningSession({
-      pubNonces: [nonces[0].pubNonce, nonces[1].pubNonce],
-      pubKeys: participantPubKeys,
-      txHash: hash,
-      internalPubKey: input.tapInternalKey,
-      tapTreeRoot: input.tapMerkleRoot,
-    });
+    let partialSig: Buffer;
+    if (deterministic) {
+      if (!signerPubKey.equals(participantPubKeys[1])) {
+        throw new Error('can only add a deterministic signature on the cosigner');
+      }
 
-    const signerNonce = nonces.find((kv) => kv.participantPubKey.equals(signerPubKey));
-    if (!signerNonce) {
-      throw new Error('pubNonce is missing. retry signing process');
+      const firstSignerNonce = nonces.find((n) => n.participantPubKey.equals(participantPubKeys[0]));
+      if (!firstSignerNonce) {
+        throw new Error('could not find the user nonce');
+      }
+
+      partialSig = musig2DeterministicSign({
+        privateKey: signer.privateKey,
+        otherNonce: firstSignerNonce.pubNonce,
+        publicKeys: participantPubKeys,
+        internalPubKey: input.tapInternalKey,
+        tapTreeRoot: input.tapMerkleRoot,
+        hash,
+      }).sig;
+    } else {
+      const sessionKey = createMusig2SigningSession({
+        pubNonces: [nonces[0].pubNonce, nonces[1].pubNonce],
+        pubKeys: participantPubKeys,
+        txHash: hash,
+        internalPubKey: input.tapInternalKey,
+        tapTreeRoot: input.tapMerkleRoot,
+      });
+
+      const signerNonce = nonces.find((kv) => kv.participantPubKey.equals(signerPubKey));
+      if (!signerNonce) {
+        throw new Error('pubNonce is missing. retry signing process');
+      }
+      partialSig = musig2PartialSign(signer.privateKey, signerNonce.pubNonce, sessionKey, this.nonceStore);
     }
-    let partialSig = musig2PartialSign(signer.privateKey, signerNonce.pubNonce, sessionKey, this.nonceStore);
 
     if (sighashType !== Transaction.SIGHASH_DEFAULT) {
       partialSig = Buffer.concat([partialSig, Buffer.of(sighashType)]);
@@ -802,7 +854,7 @@ export class UtxoPsbt<Tx extends UtxoTransaction<bigint> = UtxoTransaction<bigin
     throw new Error('not a taproot input');
   }
 
-  getTaprootHashForSig(
+  private getTaprootHashForSig(
     inputIndex: number,
     sighashTypes?: number[],
     leafHash?: Buffer
@@ -944,7 +996,7 @@ export class UtxoPsbt<Tx extends UtxoTransaction<bigint> = UtxoTransaction<bigin
     inputIndex: number,
     keyPair: BIP32Interface,
     keyType: 'root' | 'derived',
-    sessionId?: Buffer
+    params: { sessionId?: Buffer; deterministic?: boolean } = { deterministic: false }
   ): PsbtMusig2PubNonce {
     const input = this.data.inputs[inputIndex];
     if (!input.tapInternalKey) {
@@ -981,36 +1033,70 @@ export class UtxoPsbt<Tx extends UtxoTransaction<bigint> = UtxoTransaction<bigin
 
     const { hash } = this.getTaprootHashForSig(inputIndex);
 
-    const pubNonce = this.nonceStore.createMusig2Nonce(
-      derivedKeyPair.privateKey,
-      participantPubKey,
-      tapOutputKey,
-      hash,
-      sessionId
-    );
+    let pubNonce: Buffer;
+    if (params.deterministic) {
+      if (params.sessionId) {
+        throw new Error('Cannot add extra entropy when generating a deterministic nonce');
+      }
+      // There must be only 2 participant pubKeys if it got to this point
+      if (!participantPubKey.equals(participantPubKeys[1])) {
+        throw new Error(`Only the cosigner's nonce can be set deterministically`);
+      }
+      const nonces = parsePsbtMusig2Nonces(this, inputIndex);
+      if (!nonces) {
+        throw new Error(`No nonces found on input #${inputIndex}`);
+      }
+      if (nonces.length > 2) {
+        throw new Error(`Cannot have more than 2 nonces`);
+      }
+      const firstSignerNonce = nonces.find((kv) => kv.participantPubKey.equals(participantPubKeys[0]));
+      if (!firstSignerNonce) {
+        throw new Error('signer nonce must be set if cosigner nonce is to be derived deterministically');
+      }
 
-    return { tapOutputKey, participantPubKey, pubNonce: Buffer.from(pubNonce) };
+      pubNonce = createMusig2DeterministicNonce({
+        privateKey: derivedKeyPair.privateKey,
+        otherNonce: firstSignerNonce.pubNonce,
+        publicKeys: participantPubKeys,
+        internalPubKey: input.tapInternalKey,
+        tapTreeRoot: input.tapMerkleRoot,
+        hash,
+      });
+    } else {
+      pubNonce = Buffer.from(
+        this.nonceStore.createMusig2Nonce(
+          derivedKeyPair.privateKey,
+          participantPubKey,
+          tapOutputKey,
+          hash,
+          params.sessionId
+        )
+      );
+    }
+
+    return { tapOutputKey, participantPubKey, pubNonce };
   }
 
   private setMusig2NoncesInner(
     keyPair: BIP32Interface,
     keyType: 'root' | 'derived',
-    sessionId?: Buffer,
-    inputIndex?: number
+    inputIndex?: number,
+    params: { sessionId?: Buffer; deterministic?: boolean } = { deterministic: false }
   ): this {
     if (keyPair.isNeutered()) {
       throw new Error('private key is required to generate nonce');
     }
-    if (Buffer.isBuffer(sessionId) && sessionId.length !== 32) {
-      throw new Error(`Invalid sessionId size ${sessionId.length}`);
+    if (Buffer.isBuffer(params.sessionId) && params.sessionId.length !== 32) {
+      throw new Error(`Invalid sessionId size ${params.sessionId.length}`);
     }
-    const inputs = inputIndex === undefined ? this.data.inputs : [this.data.inputs[inputIndex]];
+
+    const inputs = inputIndex === undefined ? this.data.inputs : [checkForInput(this.data.inputs, inputIndex)];
     inputs.forEach((input, index) => {
       if (!input.tapInternalKey) {
         // Not a p2trMusig2 key path input, so skip it.
         return;
       }
-      const nonce = this.createMusig2NonceForInput(index, keyPair, keyType, sessionId);
+      const nonce = this.createMusig2NonceForInput(index, keyPair, keyType, params);
       this.addOrUpdateProprietaryKeyValToInput(index, encodePsbtMusig2PubNonce(nonce));
     });
     return this;
@@ -1024,10 +1110,15 @@ export class UtxoPsbt<Tx extends UtxoTransaction<bigint> = UtxoTransaction<bigin
    * @param keyPair derived key pair
    * @param sessionId Optional extra entropy. If provided it must either be a counter unique to this secret key,
    * (converted to an array of 32 bytes), or 32 uniformly random bytes.
+   * @param deterministic If true, set the cosigner nonce deterministically
    */
-  setInputMusig2Nonce(inputIndex: number, keyPair: BIP32Interface, sessionId?: Buffer): this {
-    checkForInput(this.data.inputs, inputIndex);
-    return this.setMusig2NoncesInner(keyPair, 'derived', sessionId, inputIndex);
+  setInputMusig2Nonce(
+    inputIndex: number,
+    derivedKeyPair: BIP32Interface,
+    params: { sessionId?: Buffer; deterministic?: boolean } = { deterministic: false }
+  ): this {
+    // TODO: This should take an inputIndex and only apply to that input with this derived key.
+    return this.setMusig2NoncesInner(derivedKeyPair, 'derived', inputIndex, params);
   }
 
   /**
@@ -1038,10 +1129,15 @@ export class UtxoPsbt<Tx extends UtxoTransaction<bigint> = UtxoTransaction<bigin
    * @param keyPair HD root key pair
    * @param sessionId Optional extra entropy. If provided it must either be a counter unique to this secret key,
    * (converted to an array of 32 bytes), or 32 uniformly random bytes.
+   * @param deterministic If true, set the cosigner nonce deterministically
    */
-  setInputMusig2NonceHD(inputIndex: number, keyPair: BIP32Interface, sessionId?: Buffer): this {
+  setInputMusig2NonceHD(
+    inputIndex: number,
+    keyPair: BIP32Interface,
+    params: { sessionId?: Buffer; deterministic?: boolean } = { deterministic: false }
+  ): this {
     checkForInput(this.data.inputs, inputIndex);
-    return this.setMusig2NoncesInner(keyPair, 'root', sessionId, inputIndex);
+    return this.setMusig2NoncesInner(keyPair, 'root', inputIndex, params);
   }
 
   /**
@@ -1052,8 +1148,11 @@ export class UtxoPsbt<Tx extends UtxoTransaction<bigint> = UtxoTransaction<bigin
    * @param sessionId Optional extra entropy. If provided it must either be a counter unique to this secret key,
    * (converted to an array of 32 bytes), or 32 uniformly random bytes.
    */
-  setAllInputsMusig2Nonce(keyPair: BIP32Interface, sessionId?: Buffer): this {
-    return this.setMusig2NoncesInner(keyPair, 'derived', sessionId);
+  setAllInputsMusig2Nonce(
+    keyPair: BIP32Interface,
+    params: { sessionId?: Buffer; deterministic?: boolean } = { deterministic: false }
+  ): this {
+    return this.setMusig2NoncesInner(keyPair, 'derived', undefined, params);
   }
 
   /**
@@ -1064,8 +1163,11 @@ export class UtxoPsbt<Tx extends UtxoTransaction<bigint> = UtxoTransaction<bigin
    * @param sessionId Optional extra entropy. If provided it must either be a counter unique to this secret key,
    * (converted to an array of 32 bytes), or 32 uniformly random bytes.
    */
-  setAllInputsMusig2NonceHD(keyPair: BIP32Interface, sessionId?: Buffer): this {
-    return this.setMusig2NoncesInner(keyPair, 'root', sessionId);
+  setAllInputsMusig2NonceHD(
+    keyPair: BIP32Interface,
+    params: { sessionId?: Buffer; deterministic?: boolean } = { deterministic: false }
+  ): this {
+    return this.setMusig2NoncesInner(keyPair, 'root', undefined, params);
   }
 
   clone(): this {

--- a/modules/utxo-lib/src/testutil/psbt.ts
+++ b/modules/utxo-lib/src/testutil/psbt.ts
@@ -1,10 +1,5 @@
 import * as assert from 'assert';
 
-import { Transaction } from 'bitcoinjs-lib';
-import { BIP32Interface } from 'bip32';
-import { checkForInput } from 'bip174/src/lib/utils';
-import { TapBip32Derivation } from 'bip174/src/lib/interfaces';
-
 import {
   createOutputScriptP2shP2pk,
   ScriptType,
@@ -12,7 +7,6 @@ import {
   scriptTypeP2shP2pk,
   scriptTypes2Of3,
 } from '../bitgo/outputScripts';
-import * as musig2 from '../bitgo/Musig2';
 import {
   addReplayProtectionUnspentToPsbt,
   addWalletOutputToPsbt,
@@ -24,9 +18,6 @@ import {
   KeyName,
   parseSignatureScript2Of3,
   getInternalChainCode,
-  HDTaprootMusig2Signer,
-  HDTaprootSigner,
-  Musig2Signer,
   RootWalletKeys,
   toOutput,
   Unspent,
@@ -230,156 +221,4 @@ export function verifyFullySignedSignatures(
       }
     }
   });
-}
-
-export function getTaprootSigners(
-  psbt: UtxoPsbt,
-  inputIndex: number,
-  keypair: BIP32Interface
-): HDTaprootSigner[] | HDTaprootMusig2Signer[] {
-  const input = checkForInput(psbt.data.inputs, inputIndex);
-  if (!input.tapBip32Derivation || input.tapBip32Derivation.length === 0) {
-    throw new Error('Need tapBip32Derivation to sign Taproot with HD');
-  }
-  const myDerivations = input.tapBip32Derivation
-    .map((bipDv) => {
-      if (bipDv.masterFingerprint.equals(keypair.fingerprint)) {
-        return bipDv;
-      }
-    })
-    .filter((v) => !!v) as TapBip32Derivation[];
-  if (myDerivations.length === 0) {
-    throw new Error('Need one tapBip32Derivation masterFingerprint to match the HDSigner fingerprint');
-  }
-
-  function getDerivedNode(bipDv: TapBip32Derivation): HDTaprootMusig2Signer | HDTaprootSigner {
-    const node = keypair.derivePath(bipDv.path);
-    if (!bipDv.pubkey.equals(node.publicKey.slice(1))) {
-      throw new Error('pubkey did not match tapBip32Derivation');
-    }
-    return node;
-  }
-
-  if (input.tapLeafScript?.length) {
-    return myDerivations.map((bipDv) => {
-      const signer = getDerivedNode(bipDv);
-      if (!('signSchnorr' in signer)) {
-        throw new Error('signSchnorr function is required to sign p2tr');
-      }
-      return signer;
-    });
-  } else if (input.tapInternalKey?.length) {
-    return myDerivations.map((bipDv) => {
-      const signer = getDerivedNode(bipDv);
-      if (!('privateKey' in signer) || !signer.privateKey) {
-        throw new Error('privateKey is required to sign p2tr musig2');
-      }
-      return signer;
-    });
-  }
-  throw new Error(`taproot input #${inputIndex} failed to get signers`);
-}
-
-export function addDeterministicNoncesToPsbt(psbt: UtxoPsbt, keypair: BIP32Interface): UtxoPsbt {
-  psbt.data.inputs.forEach((input, inputIndex) => {
-    if (!input.tapMerkleRoot || !input.tapInternalKey) {
-      return;
-    }
-    const derivedKey = input.tapBip32Derivation ? UtxoPsbt.deriveKeyPair(keypair, input.tapBip32Derivation) : keypair;
-    assert.ok(derivedKey);
-    assert.ok(derivedKey.privateKey);
-
-    const participants = musig2.parsePsbtMusig2Participants(psbt, inputIndex);
-    assert.ok(participants);
-    musig2.assertPsbtMusig2Participants(participants, input.tapInternalKey, input.tapMerkleRoot);
-    const { tapOutputKey, participantPubKeys } = participants;
-    const participantPubKey = participantPubKeys.find((pubKey) => pubKey.equals(derivedKey.publicKey));
-
-    // If the bitgo pubkey is not within the participants, then this musig2 input doesnt use this key. Skip
-    if (!participantPubKey) {
-      return;
-    }
-    assert.ok(participantPubKeys[1].equals(derivedKey.publicKey));
-
-    const { hash } = psbt.getTaprootHashForSig(inputIndex);
-
-    const musigNonces = musig2.parsePsbtMusig2Nonces(psbt, inputIndex);
-    assert.ok(musigNonces);
-    const userNonce = musigNonces.find((kv) => kv.participantPubKey.equals(participantPubKeys[0]));
-    assert.ok(userNonce);
-
-    const pubNonce = musig2.createMusig2DeterministicNonce({
-      privateKey: derivedKey.privateKey,
-      otherNonce: userNonce.pubNonce,
-      publicKeys: participantPubKeys,
-      internalPubKey: input.tapInternalKey,
-      tapTreeRoot: input.tapMerkleRoot,
-      hash,
-    });
-    const nonce = { tapOutputKey, participantPubKey, pubNonce };
-    psbt.addOrUpdateProprietaryKeyValToInput(inputIndex, musig2.encodePsbtMusig2PubNonce(nonce));
-  });
-  return psbt;
-}
-
-/**
- * General flow is copied from UtxoPsbt.signAllInputsHD going into UtxoPsbt.signTaprootMusig2Input.
- *
- * This only adds signatures to musig2 inputs
- * @param psbt
- * @param keypair
- */
-export function addDeterministicMusig2SignaturesToPsbt(
-  psbt: UtxoPsbt,
-  inputIndex: number,
-  signer: Musig2Signer,
-  sighashTypes: number[] = [Transaction.SIGHASH_DEFAULT, Transaction.SIGHASH_ALL]
-): void {
-  const input = checkForInput(psbt.data.inputs, inputIndex);
-
-  if (!input.tapBip32Derivation?.length) {
-    return;
-  }
-
-  if (!input.tapInternalKey || !input.tapMerkleRoot) {
-    return;
-  }
-  assert.ok(input.tapInternalKey);
-  assert.ok(input.tapMerkleRoot);
-
-  const participants = musig2.parsePsbtMusig2Participants(psbt, inputIndex);
-  assert.ok(participants);
-  const { tapOutputKey, participantPubKeys } = participants;
-  const signerPubKey = participantPubKeys.find((pubKey) => pubKey.equals(signer.publicKey));
-  assert.ok(signerPubKey);
-  if (!participantPubKeys[1].equals(signer.publicKey)) {
-    return;
-  }
-
-  const nonces = musig2.parsePsbtMusig2Nonces(psbt, inputIndex);
-  assert.ok(nonces);
-  const userNonce = nonces.find((n) => !n.participantPubKey.equals(signerPubKey));
-  assert.ok(userNonce);
-
-  const { hash, sighashType } = psbt.getTaprootHashForSig(inputIndex, sighashTypes);
-
-  let partialSig = musig2.musig2DeterministicSign({
-    privateKey: signer.privateKey,
-    otherNonce: userNonce.pubNonce,
-    publicKeys: participantPubKeys,
-    internalPubKey: input.tapInternalKey,
-    tapTreeRoot: input.tapMerkleRoot,
-    hash,
-  }).sig;
-
-  if (sighashType !== Transaction.SIGHASH_DEFAULT) {
-    partialSig = Buffer.concat([partialSig, Buffer.of(sighashType)]);
-  }
-
-  const sig = musig2.encodePsbtMusig2PartialSig({
-    participantPubKey: signerPubKey,
-    tapOutputKey,
-    partialSig: partialSig,
-  });
-  psbt.addProprietaryKeyValToInput(inputIndex, sig);
 }

--- a/modules/utxo-lib/test/bitgo/psbt/Musig2.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/Musig2.ts
@@ -1,7 +1,5 @@
 import * as assert from 'assert';
 
-import { BIP32Interface } from 'bip32';
-
 import {
   createPsbtFromHex,
   getExternalChainCode,
@@ -12,18 +10,10 @@ import {
   PSBT_PROPRIETARY_IDENTIFIER,
   RootWalletKeys,
   scriptTypeForChain,
-  UtxoPsbt,
   UtxoTransaction,
 } from '../../../src/bitgo';
 
-import {
-  getDefaultWalletKeys,
-  getKeyTriple,
-  addDeterministicNoncesToPsbt,
-  addDeterministicMusig2SignaturesToPsbt,
-  getTaprootSigners,
-  verifyFullySignedSignatures,
-} from '../../../src/testutil';
+import { getDefaultWalletKeys, getKeyTriple, verifyFullySignedSignatures } from '../../../src/testutil';
 import {
   createTapInternalKey,
   createTapOutputKey,
@@ -69,27 +59,6 @@ const p2trMusig2Unspent = getUnspents(['p2trMusig2'], rootWalletKeys);
 const outputType = 'p2trMusig2';
 const CHANGE_INDEX = 100;
 
-/**
- * Add signatures to psbt. This is broken out like this so that we can add a
- * deterministic signature for the bitgo key
- * @param psbt
- * @param keypair
- */
-function signTxLocal(psbt: UtxoPsbt, keypair: BIP32Interface): void {
-  psbt.data.inputs.forEach((input, inputIndex) => {
-    if (input.tapBip32Derivation?.length) {
-      if (input.tapInternalKey?.length) {
-        const signers = getTaprootSigners(psbt, inputIndex, keypair);
-        signers.forEach((signer) => addDeterministicMusig2SignaturesToPsbt(psbt, inputIndex, signer));
-      } else if (input.tapLeafScript?.length) {
-        psbt.signTaprootInputHD(inputIndex, keypair);
-      }
-    } else {
-      psbt.signInputHD(inputIndex, keypair);
-    }
-  });
-}
-
 describe('p2trMusig2', function () {
   describe('p2trMusig2 key path', function () {
     it(`create psbt, nonces, sign (internal verify) - success`, function () {
@@ -108,7 +77,8 @@ describe('p2trMusig2', function () {
       const userPsbtSer = userPsbt.toHex();
 
       // HSM deserializes the user psbt, adds the deterministic bitgo nonce, and sends that back to the user
-      const bitgoPsbt = addDeterministicNoncesToPsbt(createPsbtFromHex(userPsbtSer, network), rootWalletKeys.bitgo);
+      const bitgoPsbt = createPsbtFromHex(userPsbtSer, network);
+      bitgoPsbt.setAllInputsMusig2NonceHD(rootWalletKeys.bitgo, { deterministic: true });
       const bitgoPsbtSer = bitgoPsbt.toHex();
 
       // User combines the psbt with the bitgo nonce, adds user signature, and sends half-signed to hsm
@@ -123,7 +93,7 @@ describe('p2trMusig2', function () {
 
       // WP sends to hsm for signature and returns a fully signed psbt
       const psbt = createPsbtFromHex(userPsbtHalfSignedHex, network);
-      signTxLocal(psbt, rootWalletKeys.bitgo);
+      psbt.signAllInputsHD(rootWalletKeys.bitgo, { deterministic: true });
 
       unspents.forEach((unspent, index) => {
         if (scriptTypeForChain(unspent.chain) !== 'p2trMusig2') {
@@ -235,6 +205,76 @@ describe('p2trMusig2', function () {
         assert.strictEqual(participantKeyVals.length, 1);
       });
 
+      it('Cosigner can create a deterministic nonce', function () {
+        const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
+        psbt.setAllInputsMusig2NonceHD(rootWalletKeys.user);
+        psbt.setAllInputsMusig2NonceHD(rootWalletKeys.bitgo, { deterministic: true });
+
+        const noncesKeyVals = psbt.getProprietaryKeyVals(0, {
+          identifier: PSBT_PROPRIETARY_IDENTIFIER,
+          subtype: ProprietaryKeySubtype.MUSIG2_PUB_NONCE,
+        });
+        assert.strictEqual(noncesKeyVals.length, 2);
+      });
+
+      it('Cosigner cannot create a deterministic nonce if there is no signer nonce', function () {
+        const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
+
+        assert.throws(
+          () => psbt.setAllInputsMusig2NonceHD(rootWalletKeys.bitgo, { deterministic: true }),
+          (e) => e.message === 'No nonces found on input #0'
+        );
+
+        let noncesKeyVals = psbt.getProprietaryKeyVals(0, {
+          identifier: PSBT_PROPRIETARY_IDENTIFIER,
+          subtype: ProprietaryKeySubtype.MUSIG2_PUB_NONCE,
+        });
+        assert.strictEqual(noncesKeyVals.length, 0);
+
+        psbt.setAllInputsMusig2NonceHD(rootWalletKeys.bitgo);
+        assert.throws(
+          () => psbt.setAllInputsMusig2NonceHD(rootWalletKeys.bitgo, { deterministic: true }),
+          (e) => e.message === 'signer nonce must be set if cosigner nonce is to be derived deterministically'
+        );
+
+        noncesKeyVals = psbt.getProprietaryKeyVals(0, {
+          identifier: PSBT_PROPRIETARY_IDENTIFIER,
+          subtype: ProprietaryKeySubtype.MUSIG2_PUB_NONCE,
+        });
+        assert.strictEqual(noncesKeyVals.length, 1);
+      });
+
+      it('Cosigner cannot add entropy to deterministic nonce creation', function () {
+        const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
+        psbt.setAllInputsMusig2NonceHD(rootWalletKeys.user);
+        assert.throws(
+          () =>
+            psbt.setAllInputsMusig2NonceHD(rootWalletKeys.bitgo, {
+              deterministic: true,
+              sessionId: Buffer.allocUnsafe(32),
+            }),
+          (e) => e.message === 'Cannot add extra entropy when generating a deterministic nonce'
+        );
+        const noncesKeyVals = psbt.getProprietaryKeyVals(0, {
+          identifier: PSBT_PROPRIETARY_IDENTIFIER,
+          subtype: ProprietaryKeySubtype.MUSIG2_PUB_NONCE,
+        });
+        assert.strictEqual(noncesKeyVals.length, 1);
+      });
+
+      it('Signer cannot create a deterministic nonce', function () {
+        const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
+        assert.throws(
+          () => psbt.setAllInputsMusig2NonceHD(rootWalletKeys.user, { deterministic: true }),
+          (e) => e.message === `Only the cosigner's nonce can be set deterministically`
+        );
+        const noncesKeyVals = psbt.getProprietaryKeyVals(0, {
+          identifier: PSBT_PROPRIETARY_IDENTIFIER,
+          subtype: ProprietaryKeySubtype.MUSIG2_PUB_NONCE,
+        });
+        assert.strictEqual(noncesKeyVals.length, 0);
+      });
+
       it(`skipped if tapInternalKey doesn't match participant pub keys agg`, function () {
         const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
         psbt.data.inputs[0].tapInternalKey = dummyTapInternalKey;
@@ -248,7 +288,7 @@ describe('p2trMusig2', function () {
       it(`fails if sessionId size is invalid`, function () {
         const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
         assert.throws(
-          () => psbt.setAllInputsMusig2NonceHD(rootWalletKeys.user, Buffer.allocUnsafe(33)),
+          () => psbt.setAllInputsMusig2NonceHD(rootWalletKeys.user, { sessionId: Buffer.allocUnsafe(33) }),
           (e) => e.message === 'Invalid sessionId size 33'
         );
         assert.strictEqual(psbt.getProprietaryKeyVals(0).length, 1);
@@ -477,6 +517,36 @@ describe('p2trMusig2', function () {
           (e) => e.message === 'tapInternalKey is required for p2tr musig2 key path signing'
         );
         assert.strictEqual(psbt.getProprietaryKeyVals(0).length, 3);
+      });
+
+      it('only the cosigner can add a deterministic signature', function () {
+        const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
+        psbt.setAllInputsMusig2NonceHD(rootWalletKeys.user);
+        psbt.setAllInputsMusig2NonceHD(rootWalletKeys.bitgo, { deterministic: true });
+        assert.throws(
+          () => psbt.signInputHD(0, rootWalletKeys.user, { deterministic: true }),
+          (e) => e.message === 'can only add a deterministic signature on the cosigner'
+        );
+      });
+
+      it('cosigner can sign deterministically', function () {
+        const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
+        psbt.setAllInputsMusig2NonceHD(rootWalletKeys.user);
+        psbt.setAllInputsMusig2NonceHD(rootWalletKeys.bitgo, { deterministic: true });
+        psbt.signAllInputsHD(rootWalletKeys.user);
+        psbt.signAllInputsHD(rootWalletKeys.bitgo, { deterministic: true });
+        assert.ok(psbt.validateSignaturesOfAllInputs());
+        assert.ok(psbt.finalizeAllInputs());
+      });
+
+      it('cosigner can sign non-deterministically', function () {
+        const psbt = constructPsbt(p2trMusig2Unspent, rootWalletKeys, 'user', 'bitgo', 'p2sh');
+        psbt.setAllInputsMusig2NonceHD(rootWalletKeys.user);
+        psbt.setAllInputsMusig2NonceHD(rootWalletKeys.bitgo, { deterministic: false });
+        psbt.signAllInputsHD(rootWalletKeys.user);
+        psbt.signAllInputsHD(rootWalletKeys.bitgo, { deterministic: false });
+        assert.ok(psbt.validateSignaturesOfAllInputs());
+        assert.ok(psbt.finalizeAllInputs());
       });
     });
 


### PR DESCRIPTION
BREAKING CHANGE

Move deterministic signing functionality within UtxoPsbt
and out of testutils.

Set deterministic signing and nonce generation as an optional flag that defaults to non-deterministic signing for the cosigner. 

BG-74624

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->