### PR TITLE
fix(utxo-lib): specify tapTweaks as xOnly for deterministic

### DIFF
--- a/modules/utxo-lib/src/bitgo/Musig2.ts
+++ b/modules/utxo-lib/src/bitgo/Musig2.ts
@@ -456,7 +456,7 @@ export function createMusig2DeterministicNonce(params: PsbtMusig2DeterministicPa
       secretKey: params.privateKey,
       aggOtherNonce: musig.nonceAgg([params.otherNonce]),
       publicKeys: params.publicKeys,
-      tweaks: [createTapTweak(params.internalPubKey, params.tapTreeRoot)],
+      tweaks: [{ tweak: createTapTweak(params.internalPubKey, params.tapTreeRoot), xOnly: true }],
       msg: params.hash,
     }).publicNonce
   );
@@ -471,7 +471,7 @@ export function musig2DeterministicSign(params: PsbtMusig2DeterministicParams): 
     secretKey: params.privateKey,
     aggOtherNonce: musig.nonceAgg([params.otherNonce]),
     publicKeys: params.publicKeys,
-    tweaks: [createTapTweak(params.internalPubKey, params.tapTreeRoot)],
+    tweaks: [{ tweak: createTapTweak(params.internalPubKey, params.tapTreeRoot), xOnly: true }],
     msg: params.hash,
   });
   return { sig: Buffer.from(sig), sessionKey, publicNonce: Buffer.from(publicNonce) };

--- a/modules/utxo-lib/test/bitgo/psbt/Musig2.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/Musig2.ts
@@ -13,7 +13,7 @@ import {
   UtxoTransaction,
 } from '../../../src/bitgo';
 
-import { getDefaultWalletKeys, getKeyTriple, verifyFullySignedSignatures } from '../../../src/testutil';
+import { getKeyTriple, verifyFullySignedSignatures } from '../../../src/testutil';
 import {
   createTapInternalKey,
   createTapOutputKey,
@@ -52,9 +52,9 @@ import {
   validateParsedTaprootScriptPathTxInput,
   validateParsedTaprootKeyPathPsbt,
   validateParsedTaprootScriptPathPsbt,
+  rootWalletKeys,
 } from './Musig2Util';
 
-const rootWalletKeys = getDefaultWalletKeys();
 const p2trMusig2Unspent = getUnspents(['p2trMusig2'], rootWalletKeys);
 const outputType = 'p2trMusig2';
 const CHANGE_INDEX = 100;

--- a/modules/utxo-lib/test/bitgo/psbt/Musig2Util.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/Musig2Util.ts
@@ -28,14 +28,18 @@ import {
   ScriptType2Of3,
   toXOnlyPublicKey,
 } from '../../../src/bitgo/outputScripts';
-import { getDefaultWalletKeys, mockWalletUnspent } from '../../../src/testutil';
-import { networks } from '../../../src';
+import { mockWalletUnspent } from '../../../src/testutil';
+import { bip32, networks } from '../../../src';
+import { BIP32Interface } from 'bip32';
 
 export const network = networks.bitcoin;
 const outputType = 'p2trMusig2';
 const CHANGE_INDEX = 100;
 const FEE = BigInt(100);
-const rootWalletKeys = getDefaultWalletKeys();
+
+const keys = [1, 2, 3].map((v) => bip32.fromSeed(Buffer.alloc(16, `test/2/${v}`), network)) as BIP32Interface[];
+export const rootWalletKeys = new RootWalletKeys([keys[0], keys[1], keys[2]]);
+
 const dummyKey1 = rootWalletKeys.deriveForChainAndIndex(50, 200);
 const dummyKey2 = rootWalletKeys.deriveForChainAndIndex(60, 201);
 


### PR DESCRIPTION
BG-76314

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->