### PR TITLE
fix(utxo-lib): unwrap parseSignatureScript from try/catch

### DIFF
--- a/modules/utxo-lib/src/bitgo/wallet/Unspent.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/Unspent.ts
@@ -78,28 +78,27 @@ export function verifySignatureWithUnspent<TNumber extends number | bigint>(
   if (tx.ins.length !== unspents.length) {
     throw new Error(`input length must match unspents length`);
   }
+
+  const input = tx.ins[inputIndex];
+  /* istanbul ignore next */
+  if (!input) {
+    throw new Error(`no input at index ${inputIndex}`);
+  }
+
   const unspent = unspents[inputIndex];
-  if (!isWalletUnspent(unspent)) {
+  if (!isWalletUnspent(unspent) || (!input.script?.length && !input.witness?.length)) {
     return [false, false, false];
   }
 
+  const parsedInput = parseSignatureScript(input);
   const prevOutputs = unspents.map((u) => toOutput(u, tx.network));
-  try {
-    // If this fails to parse, that means there is no signature on the input and we can skip
-    // taprootKeyPathSpend verification
-    const parsedInput = parseSignatureScript(tx.ins[inputIndex]);
 
-    // If it is a taproot keyPathSpend input, the only valid signature combinations is user-bitgo. We can
-    // only verify that the aggregated signature is valid, not that the individual partial-signature is valid.
-    // Therefore, we can only say that either all partial signatures are valid, or none are.
-    if (parsedInput.scriptType === 'taprootKeyPathSpend') {
-      const result = getSignatureVerifications(tx, inputIndex, unspent.value, undefined, prevOutputs);
-      return result.length === 1 && result[0].signature ? [true, false, true] : [false, false, false];
-    }
-  } catch (e) {
-    if (e.message !== 'could not parse input') {
-      throw e;
-    }
+  // If it is a taproot keyPathSpend input, the only valid signature combinations is user-bitgo. We can
+  // only verify that the aggregated signature is valid, not that the individual partial-signature is valid.
+  // Therefore, we can only say that either all partial signatures are valid, or none are.
+  if (parsedInput.scriptType === 'taprootKeyPathSpend') {
+    const result = getSignatureVerifications(tx, inputIndex, unspent.value, undefined, prevOutputs);
+    return result.length === 1 && result[0].signature ? [true, false, true] : [false, false, false];
   }
 
   return verifySignatureWithPublicKeys(


### PR DESCRIPTION
unwrapping less reliable try catch block validation with arguement validation.

Ticket: BG-76314

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->