### PR TITLE
feat: add psbt and musig2 support to sdk-api

### DIFF
--- a/modules/bitgo/test/v2/unit/coins/utxo/prebuildAndSign.ts
+++ b/modules/bitgo/test/v2/unit/coins/utxo/prebuildAndSign.ts
@@ -1,0 +1,209 @@
+/**
+ * @prettier
+ */
+import * as assert from 'assert';
+
+import { AbstractUtxoCoin, getReplayProtectionAddresses } from '@bitgo/abstract-utxo';
+import * as utxolib from '@bitgo/utxo-lib';
+import * as nock from 'nock';
+
+import { encryptKeychain, getDefaultWalletKeys, getUtxoWallet, keychainsBase58, utxoCoins } from './util';
+import { common, Wallet } from '@bitgo/sdk-core';
+import { getSeed, TestBitGo } from '@bitgo/sdk-test';
+import { BitGo } from '../../../../../src';
+
+const txFormats = ['legacy', 'psbt'] as const;
+export type TxFormat = (typeof txFormats)[number];
+
+type KeyDoc = {
+  id: string;
+  pub: string;
+  source: string;
+  encryptedPrv: string;
+  coinSpecific: any;
+};
+
+const walletPassphrase = 'gabagool';
+
+const scriptTypes = [...utxolib.bitgo.outputScripts.scriptTypes2Of3, 'taprootKeyPathSpend'];
+export type ScriptType = (typeof scriptTypes)[number];
+
+type Input = {
+  scriptType: ScriptType;
+  value: bigint;
+};
+// Build the key objects
+const rootWalletKeys = getDefaultWalletKeys();
+const keyDocumentObjects = rootWalletKeys.triple.map((bip32, keyIdx) => {
+  return {
+    id: getSeed(keychainsBase58[keyIdx].pub).toString('hex'),
+    pub: bip32.neutered().toBase58(),
+    source: ['user', 'backup', 'bitgo'][keyIdx],
+    encryptedPrv: encryptKeychain(walletPassphrase, keychainsBase58[keyIdx]),
+    coinSpecific: {},
+  };
+});
+
+function run(coin: AbstractUtxoCoin, inputScripts: ScriptType[], txFormat: TxFormat): void {
+  function createPrebuildPsbt(inputs: Input[], outputs: { scriptType: 'p2sh'; value: bigint }[]) {
+    return utxolib.testutil.constructPsbt(
+      inputs as utxolib.testutil.Input[],
+      outputs,
+      coin.network,
+      rootWalletKeys,
+      'unsigned'
+    );
+  }
+
+  function createNocks(
+    bgUrl: string,
+    wallet: Wallet,
+    keyDocuments: KeyDoc[],
+    prebuild: string,
+    recipient: { address: string; amount: string },
+    addressInfo: Record<string, any>
+  ): nock.Scope[] {
+    const nocks: nock.Scope[] = [];
+
+    // Nock the prebuild route (/tx/build, blockheight)
+    nocks.push(
+      nock(bgUrl)
+        .post(`/api/v2/${coin.getChain()}/wallet/${wallet.id()}/tx/build`, { recipients: [recipient] })
+        .reply(200, { txHex: prebuild })
+    );
+    nocks.push(nock(bgUrl).get(`/api/v2/${coin.getChain()}/public/block/latest`).reply(200, { height: 1000 }));
+
+    // nock the keychain fetch - 3 times (prebuildAndSign, verifyTransaction, and signTransaction)
+    keyDocuments.forEach((keyDocument) => {
+      nocks.push(nock(bgUrl).get(`/api/v2/${coin.getChain()}/key/${keyDocument.id}`).times(3).reply(200, keyDocument));
+    });
+
+    // nock the address info fetch
+    nocks.push(
+      nock(bgUrl)
+        .get(`/api/v2/${coin.getChain()}/wallet/${wallet.id()}/address/${addressInfo.address}`)
+        .reply(200, addressInfo)
+    );
+
+    // Nock the previous transaction txids
+    const psbt = utxolib.bitgo.createPsbtFromHex(prebuild, coin.network);
+    psbt.getUnsignedTx().ins.forEach((input, inputIndex) => {
+      const unspent = utxolib.testutil.toUnspent(
+        {
+          scriptType: (inputScripts[inputIndex] === 'taprootKeyPathSpend'
+            ? 'p2trMusig2'
+            : inputScripts[inputIndex]) as utxolib.bitgo.outputScripts.ScriptType2Of3,
+          value: BigInt(1e8),
+        },
+        inputIndex,
+        coin.network,
+        rootWalletKeys
+      );
+      // Only thing we care about is that the address and value is at the correct respective previous
+      // output index
+      const outputs = psbt.data.inputs.map((_, ii) =>
+        ii === inputIndex ? { address: unspent.address, value: BigInt(unspent.value).toString() } : {}
+      );
+      const payload = { outputs };
+      const txId = (Buffer.from(input.hash).reverse() as Buffer).toString('hex');
+
+      nocks.push(nock(bgUrl).get(`/api/v2/${coin.getChain()}/public/tx/${txId}`).reply(200, payload));
+    });
+
+    if (inputScripts.includes('p2trMusig2')) {
+      // nock the deterministic nonce response
+      const psbt = utxolib.bitgo.createPsbtFromHex(prebuild, coin.network);
+      psbt.setAllInputsMusig2NonceHD(rootWalletKeys.user);
+      const psbtHex = psbt.toHex();
+      psbt.setAllInputsMusig2NonceHD(rootWalletKeys.bitgo, { deterministic: true });
+      nocks.push(
+        nock(bgUrl)
+          .post(`/api/v2/${coin.getChain()}/wallet/${wallet.id()}/tx/signpsbt`, { psbt: psbtHex })
+          .reply(200, { txHex: psbt.toHex() })
+      );
+    }
+
+    return nocks;
+  }
+
+  describe(`${coin.getFullName()}-prebuildAndSign-txFormat=${txFormat}-inputScripts=${inputScripts.join(
+    ','
+  )}`, function () {
+    const wallet = getUtxoWallet(coin, {
+      coinSpecific: { addressVersion: 'base58' },
+      keys: keyDocumentObjects.map((k) => k.id),
+      id: 'walletId',
+    });
+
+    const bitgo = TestBitGo.decorate(BitGo, { env: 'mock' });
+    // bitgo.initializeTestVars();
+    const bgUrl = common.Environments[bitgo.getEnv()].uri;
+
+    let prebuild: utxolib.bitgo.UtxoPsbt;
+    let recipient: { address: string; amount: string };
+    let addressInfo: Record<string, any>;
+    before(async function () {
+      // Make output address information
+      const outputAmount = BigInt(inputScripts.length) * BigInt(1e8) - BigInt(10000);
+      const outputScriptType: utxolib.bitgo.outputScripts.ScriptType = 'p2sh';
+      const outputChain = utxolib.bitgo.getExternalChainCode(outputScriptType);
+      const outputAddress = utxolib.bitgo.getWalletAddress(rootWalletKeys, outputChain, 0, coin.network);
+
+      recipient = {
+        address: outputAddress,
+        amount: outputAmount.toString(),
+      };
+      addressInfo = {
+        address: outputAddress,
+        chain: outputChain,
+        index: 0,
+        coin: coin.getChain(),
+        wallet: wallet.id(),
+        coinSpecific: {},
+      };
+
+      prebuild = createPrebuildPsbt(
+        inputScripts.map((s) => ({ scriptType: s, value: BigInt(1e8) })),
+        [{ scriptType: outputScriptType, value: outputAmount }]
+      );
+    });
+
+    it('should succeed', async function () {
+      const nocks = createNocks(bgUrl, wallet, keyDocumentObjects, prebuild.toHex(), recipient, addressInfo);
+
+      // call prebuild and sign, nocks should be consumed
+      await wallet.prebuildAndSignTransaction({ recipients: [recipient], walletPassphrase });
+
+      nocks.forEach((nock) => assert.ok(nock.isDone()));
+
+      // Make sure that you can sign with bitgo key and extract the transaction
+    });
+  });
+}
+
+utxoCoins.forEach((coin) => {
+  scriptTypes.forEach((inputScriptType) => {
+    const inputScript = (
+      inputScriptType === 'taprootKeyPathSpend' ? 'p2trMusig2' : inputScriptType
+    ) as utxolib.bitgo.outputScripts.ScriptType2Of3;
+
+    if (!coin.supportsAddressType(inputScript)) {
+      return;
+    }
+    txFormats.forEach((txFormat) => {
+      // TODO BG-77799 should handle this case in the future
+      if (txFormat === 'legacy' && inputScript === 'p2trMusig2') {
+        return;
+      }
+
+      if (txFormat === 'legacy') {
+        return;
+      }
+
+      run(coin, [inputScriptType, inputScriptType], txFormat);
+      if (getReplayProtectionAddresses(coin.network).length) {
+        run(coin, ['p2shP2pk', inputScript], txFormat);
+      }
+    });
+  });
+});

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -114,6 +114,7 @@ export interface PrebuildTransactionOptions {
    * If set to false, sweep all funds including the required minimums for address(es). E.g. Polkadot (DOT) requires 1 DOT minimum.
    */
   keepAlive?: boolean;
+  txFormat?: string;
 }
 
 export interface PrebuildAndSignTransactionOptions extends PrebuildTransactionOptions, WalletSignTransactionOptions {

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -1833,7 +1833,7 @@ export class Wallet implements IWallet {
     // pass our three keys
     const signingParams = {
       ...params,
-      txPrebuild: txPrebuild,
+      txPrebuild,
       wallet: {
         // this is the version of the multisig address at wallet creation time
         addressVersion: this._wallet.coinSpecific.addressVersion,

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -200,6 +200,7 @@ export class Wallet implements IWallet {
       'destinationChain',
       'targetWalletUnspents',
       'trustlines',
+      'txFormat',
       'type',
       'unspents',
       'nonParticipation',

--- a/modules/utxo-lib/src/bitgo/Musig2.ts
+++ b/modules/utxo-lib/src/bitgo/Musig2.ts
@@ -1,3 +1,6 @@
+import { TxInput } from 'bitcoinjs-lib';
+import { SessionKey } from '@brandonblack/musig';
+
 import { PSBT_PROPRIETARY_IDENTIFIER, ProprietaryKeyValue, UtxoPsbt, ProprietaryKeySubtype } from './UtxoPsbt';
 import {
   checkPlainPublicKey,
@@ -9,8 +12,10 @@ import {
 import { ecc, musig } from '../noble_ecc';
 import { Tuple } from './types';
 import { calculateTapTweak, tapTweakPubkey } from '../taproot';
-import { SessionKey } from '@brandonblack/musig';
 import { Transaction } from '../index';
+import { UtxoTransaction } from './UtxoTransaction';
+import { getSignatureCount, parsePsbtInput } from './wallet';
+import { parseSignatureScript } from './parseInput';
 
 /**
  *  Participant key value object.
@@ -475,4 +480,25 @@ export function musig2DeterministicSign(params: PsbtMusig2DeterministicParams): 
     msg: params.hash,
   });
   return { sig: Buffer.from(sig), sessionKey, publicNonce: Buffer.from(publicNonce) };
+}
+
+export function isTransactionWithKeyPathSpendInput(
+  data: UtxoPsbt | UtxoTransaction<bigint | number> | TxInput[]
+): boolean {
+  if (data instanceof UtxoPsbt) {
+    return data.data.inputs.some((_, inputIndex) => {
+      const parsedInput = parsePsbtInput(data, inputIndex);
+      return parsedInput?.scriptType === 'taprootKeyPathSpend';
+    });
+  }
+  const inputs = data instanceof UtxoTransaction ? data.ins : data;
+  return inputs.some((input, inputIndex) => {
+    // If the input is not signed, it cannot be a taprootKeyPathSpend input because you can only
+    // extract a fully signed psbt into a transaction with taprootKeyPathSpend inputs.
+    if (getSignatureCount(data, inputIndex) === 0) {
+      return false;
+    }
+    const parsedInput = parseSignatureScript(input);
+    return parsedInput?.scriptType === 'taprootKeyPathSpend';
+  });
 }

--- a/modules/utxo-lib/src/bitgo/wallet/Psbt.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/Psbt.ts
@@ -445,3 +445,10 @@ export function getSignatureCount(
     .map((index, _) => getInputSignatureCount(constructParam(tx, index)))
     .reduce((prev, curr) => (curr > prev ? curr : prev), 0);
 }
+
+/** @return true iff input starts with magic PSBT byte sequence */
+export function isPsbt(data: Buffer): boolean {
+  // https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#specification
+  // 0x70736274 - ASCII for 'psbt'. 0xff - separator
+  return 5 <= data.length && data.readUInt32BE(0) === 0x70736274 && data.readUInt8(4) === 0xff;
+}

--- a/modules/utxo-lib/test/bitgo/psbt/Musig2.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/Musig2.ts
@@ -14,6 +14,8 @@ import {
   verifySignatureWithUnspent,
 } from '../../../src/bitgo';
 
+import { testutil } from '../../../src';
+
 import { getKeyTriple, verifyFullySignedSignatures } from '../../../src/testutil';
 import {
   createTapInternalKey,
@@ -25,6 +27,7 @@ import {
   musig2PartialSign,
   assertPsbtMusig2Nonces,
   Musig2NonceStore,
+  isTransactionWithKeyPathSpendInput,
 } from '../../../src/bitgo/Musig2';
 import { scriptTypes2Of3, toXOnlyPublicKey } from '../../../src/bitgo/outputScripts';
 import {
@@ -711,6 +714,96 @@ describe('p2trMusig2', function () {
         (e) => e.message === `Invalid nonce keydata tapOutputKey`
       );
       assert.strictEqual(psbt.getProprietaryKeyVals(0).length, 3);
+    });
+
+    describe('isTransactionWithKeyPathSpendInput', function () {
+      describe('transaction input', function () {
+        it('taprootKeyPath inputs successfully triggers', function () {
+          const psbt = testutil.constructPsbt(
+            [
+              { scriptType: 'taprootKeyPathSpend', value: BigInt(1e8) },
+              { scriptType: 'p2sh', value: BigInt(1e8) },
+            ],
+            [{ scriptType: 'p2sh', value: BigInt(2e8 - 10000) }],
+            network,
+            rootWalletKeys,
+            'fullsigned'
+          );
+          assert(psbt.validateSignaturesOfAllInputs());
+          psbt.finalizeAllInputs();
+          const tx = psbt.extractTransaction() as UtxoTransaction<bigint>;
+
+          assert.strictEqual(isTransactionWithKeyPathSpendInput(tx), true);
+          assert.strictEqual(isTransactionWithKeyPathSpendInput(tx.ins), true);
+        });
+
+        it('no taprootKeyPath inputs successfully does not trigger', function () {
+          const psbt = testutil.constructPsbt(
+            [
+              { scriptType: 'p2trMusig2', value: BigInt(1e8) },
+              { scriptType: 'p2sh', value: BigInt(1e8) },
+            ],
+            [{ scriptType: 'p2sh', value: BigInt(2e8 - 10000) }],
+            network,
+            rootWalletKeys,
+            'fullsigned'
+          );
+          assert(psbt.validateSignaturesOfAllInputs());
+          psbt.finalizeAllInputs();
+          const tx = psbt.extractTransaction() as UtxoTransaction<bigint>;
+
+          assert.strictEqual(isTransactionWithKeyPathSpendInput(tx), false);
+          assert.strictEqual(isTransactionWithKeyPathSpendInput(tx.ins), false);
+        });
+
+        it('unsigned inputs successfully fail', function () {
+          const psbt = testutil.constructPsbt(
+            [
+              { scriptType: 'p2wsh', value: BigInt(1e8) },
+              { scriptType: 'p2sh', value: BigInt(1e8) },
+            ],
+            [{ scriptType: 'p2sh', value: BigInt(2e8 - 10000) }],
+            network,
+            rootWalletKeys,
+            'unsigned'
+          );
+          const tx = psbt.getUnsignedTx();
+          assert.strictEqual(isTransactionWithKeyPathSpendInput(tx), false);
+          assert.strictEqual(isTransactionWithKeyPathSpendInput(tx.ins), false);
+        });
+      });
+
+      describe('psbt input', function () {
+        it('psbt with taprootKeyPathInputs successfully triggers', function () {
+          const psbt = testutil.constructPsbt(
+            [
+              { scriptType: 'taprootKeyPathSpend', value: BigInt(1e8) },
+              { scriptType: 'p2sh', value: BigInt(1e8) },
+            ],
+            [{ scriptType: 'p2sh', value: BigInt(2e8 - 10000) }],
+            network,
+            rootWalletKeys,
+            'unsigned'
+          );
+
+          assert.strictEqual(isTransactionWithKeyPathSpendInput(psbt), true);
+        });
+
+        it('psbt without taprootKeyPathInputs successfully does not trigger', function () {
+          const psbt = testutil.constructPsbt(
+            [
+              { scriptType: 'p2wsh', value: BigInt(1e8) },
+              { scriptType: 'p2sh', value: BigInt(1e8) },
+            ],
+            [{ scriptType: 'p2sh', value: BigInt(2e8 - 10000) }],
+            network,
+            rootWalletKeys,
+            'halfsigned'
+          );
+
+          assert.strictEqual(isTransactionWithKeyPathSpendInput(psbt), false);
+        });
+      });
     });
   });
 

--- a/modules/utxo-lib/test/bitgo/psbt/Psbt.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/Psbt.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 
-import { Network, getNetworkName, networks } from '../../../src';
+import { Network, getNetworkName, networks, getNetworkList } from '../../../src';
 import {
   getExternalChainCode,
   outputScripts,
@@ -16,6 +16,7 @@ import {
   getInternalChainCode,
   getSignatureCount,
   UtxoTransaction,
+  isPsbt,
 } from '../../../src/bitgo';
 import { createOutputScript2of3, createOutputScriptP2shP2pk } from '../../../src/bitgo/outputScripts';
 
@@ -269,6 +270,47 @@ describe('Parse PSBT', function () {
       );
     }
   });
+});
+
+describe('isPsbt', function () {
+  function isPsbtForNetwork(n: Network) {
+    describe(`network: ${getNetworkName(n)}`, function () {
+      const psbt = createPsbtForNetwork({ network: n });
+
+      it('should return true for a valid PSBT', function () {
+        assert.strictEqual(isPsbt(psbt.toBuffer()), true);
+      });
+
+      it('should return false for a transaction', function () {
+        assert.strictEqual(isPsbt(psbt.getUnsignedTx().toBuffer()), false);
+      });
+
+      it('should return false for a valid PSBT with an invalid magic', function () {
+        const buffer = psbt.toBuffer();
+        buffer.writeUInt8(0x00, 1);
+        assert.strictEqual(isPsbt(psbt.getUnsignedTx().toBuffer()), false);
+      });
+
+      it('should return false for a valid PSBT with an invalid separator', function () {
+        const buffer = psbt.toBuffer();
+        buffer.writeUInt8(0xfe, 4);
+        assert.strictEqual(isPsbt(psbt.getUnsignedTx().toBuffer()), false);
+      });
+
+      it('should return false for a random buffer', function () {
+        const buffer = Buffer.alloc(64);
+        assert.strictEqual(isPsbt(buffer), false);
+      });
+
+      it('should return true if buffer is changed after the separator', function () {
+        const buffer = psbt.toBuffer();
+        buffer.writeUInt8(0x00, 5);
+        assert.strictEqual(isPsbt(buffer), true);
+      });
+    });
+  }
+
+  getNetworkList().forEach((n) => isPsbtForNetwork(n));
 });
 
 describe('Psbt from transaction using wallet unspents', function () {


### PR DESCRIPTION
Adding sdk-api support for PSBT format and taproot keypath spend inputs for bitcoin transactions.

Added utility functions within utxo-lib as well.


BG-66947
<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->