### PR TITLE
feat(abstract-utxo): add psbt and musig2 support for sdk-api

### DIFF
--- a/modules/abstract-utxo/src/sign.ts
+++ b/modules/abstract-utxo/src/sign.ts
@@ -12,15 +12,27 @@ import { isReplayProtectionUnspent } from './replayProtection';
 
 const debug = debugLib('bitgo:v2:utxo');
 
+type PsbtParsedScriptTypes =
+  | 'p2sh'
+  | 'p2wsh'
+  | 'p2shP2wsh'
+  | 'p2shP2pk'
+  | 'taprootKeyPathSpend'
+  | 'taprootScriptPathSpend';
+
 export class InputSigningError<TNumber extends number | bigint = number> extends Error {
   static expectedWalletUnspent<TNumber extends number | bigint>(
     inputIndex: number,
-    unspent: Unspent<TNumber>
+    unspent: Unspent<TNumber> | { id: string }
   ): InputSigningError<TNumber> {
     return new InputSigningError(inputIndex, unspent, `not a wallet unspent, not a replay protection unspent`);
   }
 
-  constructor(public inputIndex: number, public unspent: Unspent<TNumber>, public reason: Error | string) {
+  constructor(
+    public inputIndex: number,
+    public unspent: Unspent<TNumber> | { id: string },
+    public reason: Error | string
+  ) {
     super(`signing error at input ${inputIndex}: unspentId=${unspent.id}: ${reason}`);
   }
 }
@@ -32,6 +44,95 @@ export class TransactionSigningError<TNumber extends number | bigint = number> e
         `verify errors at inputs: [${verifyError.join(',')}], see log for details`
     );
   }
+}
+
+/**
+ * Sign all inputs of a psbt and verify signatures after signing.
+ * Collects and logs signing errors and verification errors, throws error in the end if any of them
+ * failed.
+ *
+ * If it is the last signature, finalize and extract the transaction from the psbt.
+ *
+ * This function mirrors signAndVerifyWalletTransaction, but is used for signing PSBTs instead of
+ * using TransactionBuilder
+ *
+ * @param psbt
+ * @param signerKeychain
+ * @param isLastSignature
+ */
+export function signAndVerifyPsbt(
+  psbt: utxolib.bitgo.UtxoPsbt,
+  signerKeychain: utxolib.BIP32Interface,
+  { isLastSignature }: { isLastSignature: boolean }
+): utxolib.bitgo.UtxoPsbt | utxolib.bitgo.UtxoTransaction<bigint> {
+  const txInputs = psbt.txInputs;
+  const outputIds: string[] = [];
+  const parsedInputs: (PsbtParsedScriptTypes | undefined)[] = [];
+
+  const signErrors: InputSigningError<bigint>[] = psbt.data.inputs
+    .map((input, inputIndex: number) => {
+      const outputId = utxolib.bitgo.formatOutputId(utxolib.bitgo.getOutputIdForInput(txInputs[inputIndex]));
+      outputIds.push(outputId);
+
+      const parsedInput = utxolib.bitgo.parsePsbtInput(psbt, inputIndex);
+      parsedInputs.push(parsedInput?.scriptType);
+
+      if (!parsedInput) {
+        return new InputSigningError<bigint>(inputIndex, { id: outputId }, 'could not parse input');
+      }
+
+      if (parsedInput.scriptType === 'p2shP2pk') {
+        debug('Skipping signature for input %d of %d (RP input?)', inputIndex + 1, psbt.data.inputs.length);
+        return;
+      }
+
+      try {
+        psbt.signInputHD(inputIndex, signerKeychain);
+        debug('Successfully signed input %d of %d', inputIndex + 1, psbt.data.inputs.length);
+      } catch (e) {
+        return new InputSigningError<bigint>(inputIndex, { id: outputId }, e);
+      }
+    })
+    .filter((e): e is InputSigningError<bigint> => e !== undefined);
+
+  const verifyErrors: InputSigningError<bigint>[] = psbt.data.inputs
+    .map((input, inputIndex) => {
+      const outputId = outputIds[inputIndex];
+
+      const parsedInput = parsedInputs[inputIndex];
+      if (!parsedInput) {
+        return new InputSigningError<bigint>(inputIndex, { id: outputId }, 'could not parse input');
+      }
+      if (parsedInput === 'p2shP2pk') {
+        debug(
+          'Skipping input signature %d of %d (unspent from replay protection address which is platform signed only)',
+          inputIndex + 1,
+          psbt.data.inputs.length
+        );
+        return;
+      }
+
+      try {
+        if (!psbt.validateSignaturesOfInputHD(inputIndex, signerKeychain)) {
+          return new InputSigningError(inputIndex, { id: outputId }, new Error(`invalid signature`));
+        }
+      } catch (e) {
+        debug('Invalid signature');
+        return new InputSigningError<bigint>(inputIndex, { id: outputId }, e);
+      }
+    })
+    .filter((e): e is InputSigningError<bigint> => e !== undefined);
+
+  if (signErrors.length || verifyErrors.length) {
+    throw new TransactionSigningError(signErrors, verifyErrors);
+  }
+
+  if (isLastSignature) {
+    psbt.finalizeAllInputs();
+    return psbt.extractTransaction() as utxolib.bitgo.UtxoTransaction<bigint>;
+  }
+
+  return psbt;
 }
 
 /**

--- a/modules/bitgo/test/v2/unit/coins/utxo/prebuildAndSign.ts
+++ b/modules/bitgo/test/v2/unit/coins/utxo/prebuildAndSign.ts
@@ -1,0 +1,220 @@
+/**
+ * @prettier
+ */
+import * as assert from 'assert';
+
+import { AbstractUtxoCoin, getReplayProtectionAddresses } from '@bitgo/abstract-utxo';
+import * as utxolib from '@bitgo/utxo-lib';
+import * as nock from 'nock';
+
+import { encryptKeychain, getDefaultWalletKeys, getUtxoWallet, keychainsBase58, utxoCoins } from './util';
+import { common, HalfSignedUtxoTransaction, Wallet } from '@bitgo/sdk-core';
+import { getSeed, TestBitGo } from '@bitgo/sdk-test';
+import { BitGo } from '../../../../../src';
+
+const txFormats = ['legacy', 'psbt'] as const;
+export type TxFormat = (typeof txFormats)[number];
+
+type KeyDoc = {
+  id: string;
+  pub: string;
+  source: string;
+  encryptedPrv: string;
+  coinSpecific: any;
+};
+
+const walletPassphrase = 'gabagool';
+
+const scriptTypes = [...utxolib.bitgo.outputScripts.scriptTypes2Of3, 'taprootKeyPathSpend', 'p2shP2pk'] as const;
+export type ScriptType = (typeof scriptTypes)[number];
+
+type Input = {
+  scriptType: ScriptType;
+  value: bigint;
+};
+
+// Build the key objects
+const rootWalletKeys = getDefaultWalletKeys();
+const keyDocumentObjects = rootWalletKeys.triple.map((bip32, keyIdx) => {
+  return {
+    id: getSeed(keychainsBase58[keyIdx].pub).toString('hex'),
+    pub: bip32.neutered().toBase58(),
+    source: ['user', 'backup', 'bitgo'][keyIdx],
+    encryptedPrv: encryptKeychain(walletPassphrase, keychainsBase58[keyIdx]),
+    coinSpecific: {},
+  };
+});
+
+function run(coin: AbstractUtxoCoin, inputScripts: ScriptType[], txFormat: TxFormat): void {
+  function createPrebuildPsbt(inputs: Input[], outputs: { scriptType: 'p2sh'; value: bigint }[]) {
+    return utxolib.testutil.constructPsbt(
+      inputs as utxolib.testutil.Input[],
+      outputs,
+      coin.network,
+      rootWalletKeys,
+      'unsigned'
+    );
+  }
+
+  function createNocks(params: {
+    bgUrl: string;
+    wallet: Wallet;
+    keyDocuments: KeyDoc[];
+    prebuild: utxolib.bitgo.UtxoPsbt;
+    recipient: { address: string; amount: string };
+    addressInfo: Record<string, any>;
+  }): nock.Scope[] {
+    const nocks: nock.Scope[] = [];
+
+    // Nock the prebuild route (/tx/build, blockheight)
+    nocks.push(
+      nock(params.bgUrl)
+        .post(`/api/v2/${coin.getChain()}/wallet/${params.wallet.id()}/tx/build`, { recipients: [params.recipient] })
+        .reply(200, { txHex: params.prebuild.toHex(), txInfo: {} })
+    );
+    nocks.push(nock(params.bgUrl).get(`/api/v2/${coin.getChain()}/public/block/latest`).reply(200, { height: 1000 }));
+
+    // nock the keychain fetch - 3 times (prebuildAndSign, verifyTransaction, and signTransaction)
+    params.keyDocuments.forEach((keyDocument) => {
+      nocks.push(
+        nock(params.bgUrl).get(`/api/v2/${coin.getChain()}/key/${keyDocument.id}`).times(3).reply(200, keyDocument)
+      );
+    });
+
+    // nock the address info fetch
+    nocks.push(
+      nock(params.bgUrl)
+        .get(`/api/v2/${coin.getChain()}/wallet/${params.wallet.id()}/address/${params.addressInfo.address}`)
+        .reply(200, params.addressInfo)
+    );
+
+    // Nock the previous transaction txids
+    params.prebuild.getUnsignedTx().ins.forEach((input, inputIndex) => {
+      const unspent = utxolib.testutil.toUnspent(
+        {
+          scriptType: inputScripts[inputIndex],
+          value: BigInt(1e8),
+        },
+        inputIndex,
+        coin.network,
+        rootWalletKeys
+      );
+      // Only thing we care about is that the address and value is at the correct respective previous
+      // output index
+      const payload = {
+        outputs: params.prebuild.data.inputs.map((_, ii) =>
+          ii === inputIndex
+            ? {
+                address: unspent.address,
+                value: BigInt(unspent.value).toString(),
+                valueString: BigInt(unspent.value).toString(),
+              }
+            : {}
+        ),
+      };
+      const txId = (Buffer.from(input.hash).reverse() as Buffer).toString('hex');
+
+      nocks.push(nock(params.bgUrl).get(`/api/v2/${coin.getChain()}/public/tx/${txId}`).reply(200, payload));
+    });
+
+    // nock the deterministic nonce response
+    if (inputScripts.includes('taprootKeyPathSpend')) {
+      const psbt = params.prebuild.clone();
+      psbt.setAllInputsMusig2NonceHD(rootWalletKeys.user);
+      psbt.setAllInputsMusig2NonceHD(rootWalletKeys.bitgo);
+      nocks.push(
+        nock(params.bgUrl)
+          .post(`/api/v2/${coin.getChain()}/wallet/${params.wallet.id()}/tx/signpsbt`, (body) => body.psbt)
+          .reply(200, { psbt: psbt.toHex() })
+      );
+    }
+
+    return nocks;
+  }
+
+  describe(`${coin.getFullName()}-prebuildAndSign-txFormat=${txFormat}-inputScripts=${inputScripts.join(
+    ','
+  )}`, function () {
+    const wallet = getUtxoWallet(coin, {
+      coinSpecific: { addressVersion: 'base58' },
+      keys: keyDocumentObjects.map((k) => k.id),
+      id: 'walletId',
+    });
+
+    const bitgo = TestBitGo.decorate(BitGo, { env: 'mock' });
+    const bgUrl = common.Environments[bitgo.getEnv()].uri;
+    let prebuild: utxolib.bitgo.UtxoPsbt;
+    let recipient: { address: string; amount: string };
+    let addressInfo: Record<string, any>;
+    before(async function () {
+      // Make output address information
+      const outputAmount = BigInt(inputScripts.length) * BigInt(1e8) - BigInt(10000);
+      const outputScriptType: utxolib.bitgo.outputScripts.ScriptType = 'p2sh';
+      const outputChain = utxolib.bitgo.getExternalChainCode(outputScriptType);
+      const outputAddress = utxolib.bitgo.getWalletAddress(rootWalletKeys, outputChain, 0, coin.network);
+
+      recipient = {
+        address: outputAddress,
+        amount: outputAmount.toString(),
+      };
+      addressInfo = {
+        address: outputAddress,
+        chain: outputChain,
+        index: 0,
+        coin: coin.getChain(),
+        wallet: wallet.id(),
+        coinSpecific: {},
+      };
+
+      prebuild = createPrebuildPsbt(
+        inputScripts.map((s) => ({ scriptType: s, value: BigInt(1e8) })),
+        [{ scriptType: outputScriptType, value: outputAmount }]
+      );
+    });
+
+    afterEach(nock.cleanAll);
+
+    it('should succeed', async function () {
+      const nocks = createNocks({ bgUrl, wallet, keyDocuments: keyDocumentObjects, prebuild, recipient, addressInfo });
+
+      // call prebuild and sign, nocks should be consumed
+      const res = (await wallet.prebuildAndSignTransaction({
+        recipients: [recipient],
+        walletPassphrase,
+      })) as HalfSignedUtxoTransaction;
+      nocks.forEach((nock) => assert.ok(nock.isDone()));
+
+      // Make sure that you can sign with bitgo key and extract the transaction
+      const psbt = utxolib.bitgo.createPsbtFromHex(res.txHex, coin.network);
+
+      // No signatures should be present if it's a p2shP2pk input
+      if (!inputScripts.includes('p2shP2pk')) {
+        const key = inputScripts.includes('p2trMusig2') ? rootWalletKeys.backup : rootWalletKeys.bitgo;
+        psbt.signAllInputsHD(key, { deterministic: true });
+        psbt.validateSignaturesOfAllInputs();
+        psbt.finalizeAllInputs();
+        const tx = psbt.extractTransaction();
+        assert.ok(tx);
+      }
+    });
+  });
+}
+
+utxoCoins
+  .filter((coin) => utxolib.getMainnet(coin.network) !== utxolib.networks.bitcoinsv)
+  .forEach((coin) => {
+    scriptTypes.forEach((inputScript) => {
+      const inputScriptCleaned = (
+        inputScript === 'taprootKeyPathSpend' ? 'p2trMusig2' : inputScript
+      ) as utxolib.bitgo.outputScripts.ScriptType2Of3;
+
+      if (!coin.supportsAddressType(inputScriptCleaned)) {
+        return;
+      }
+
+      run(coin, [inputScript, inputScript], 'psbt');
+      if (getReplayProtectionAddresses(coin.network).length) {
+        run(coin, ['p2shP2pk', inputScript], 'psbt');
+      }
+    });
+  });

--- a/modules/bitgo/test/v2/unit/coins/utxo/transaction.ts
+++ b/modules/bitgo/test/v2/unit/coins/utxo/transaction.ts
@@ -1,10 +1,12 @@
 /**
  * @prettier
  */
+import 'mocha';
 import * as _ from 'lodash';
 import * as assert from 'assert';
 import * as utxolib from '@bitgo/utxo-lib';
-import { BIP32Interface, bitgo } from '@bitgo/utxo-lib';
+import * as nock from 'nock';
+import { BIP32Interface, bitgo, testutil } from '@bitgo/utxo-lib';
 
 import { AbstractUtxoCoin, getReplayProtectionAddresses } from '@bitgo/abstract-utxo';
 
@@ -23,34 +25,62 @@ import {
 } from './util';
 
 import {
+  common,
   FullySignedTransaction,
   HalfSignedUtxoTransaction,
   Triple,
   WalletSignTransactionOptions,
 } from '@bitgo/sdk-core';
+import { TestBitGo } from '@bitgo/sdk-test';
+import { BitGo } from '../../../../../src';
 
 type Unspent<TNumber extends number | bigint = number> = bitgo.Unspent<TNumber>;
 type WalletUnspent<TNumber extends number | bigint = number> = bitgo.WalletUnspent<TNumber>;
 
 function getScriptTypes2Of3() {
-  // FIXME(BG-66941): p2trMusig2 signing does not work in this test suite yet
-  //  because the test suite is written with TransactionBuilder
-  return utxolib.bitgo.outputScripts.scriptTypes2Of3.filter((scriptType) => scriptType !== 'p2trMusig2');
+  return [...bitgo.outputScripts.scriptTypes2Of3, 'taprootKeyPathSpend'] as const;
 }
 
 function run<TNumber extends number | bigint = number>(
   coin: AbstractUtxoCoin,
-  inputScripts: InputScriptType[],
+  inputScripts: testutil.InputScriptType[],
+  txFormat: 'legacy' | 'psbt',
   amountType: 'number' | 'bigint' = 'number'
 ) {
-  describe(`Transaction Stages ${coin.getChain()} (${amountType}) scripts=${inputScripts.join(',')}`, function () {
-    const wallet = getUtxoWallet(coin);
-    const walletKeys = getDefaultWalletKeys();
+  describe(`Transaction Stages ${coin.getChain()} (${amountType}) scripts=${inputScripts.join(
+    ','
+  )} txFormat=${txFormat}`, function () {
+    const bgUrl = common.Environments[TestBitGo.decorate(BitGo, { env: 'mock' }).getEnv()].uri;
+
+    const isTransactionWithKeyPathSpend = inputScripts.some((s) => s === 'taprootKeyPathSpend');
+    const isTransactionWithReplayProtection = inputScripts.some((s) => s === 'p2shP2pk');
+
     const value = (amountType === 'bigint' ? BigInt('10999999800000001') : 1e8) as TNumber;
-    const fullSign = !inputScripts.some((s) => s === 'replayProtection');
+    const wallet = getUtxoWallet(coin, { id: '5b34252f1bf349930e34020a00000000', coin: coin.getChain() });
+    const walletKeys = getDefaultWalletKeys();
+
+    // once full psbt support is added to abstract-utxo module, below txFormat check can be removed.
+    const fullSign = !(txFormat === 'psbt' || isTransactionWithReplayProtection);
+
+    function getUnspentsForPsbt(): Unspent<bigint>[] {
+      return inputScripts.map((t, index) => {
+        return testutil.toUnspent(
+          { scriptType: t, value: t === 'p2shP2pk' ? BigInt(1000) : BigInt(value) },
+          index,
+          coin.network,
+          walletKeys
+        );
+      });
+    }
+
+    function toTxnInputScriptType(type: testutil.InputScriptType): InputScriptType {
+      return type === 'p2shP2pk' ? 'replayProtection' : type === 'taprootKeyPathSpend' ? 'p2trMusig2' : type;
+    }
 
     function getUnspents(): Unspent<TNumber>[] {
-      return inputScripts.map((type, i) => mockUnspent<TNumber>(coin.network, walletKeys, type, i, value));
+      return inputScripts.map((type, i) =>
+        mockUnspent<TNumber>(coin.network, walletKeys, toTxnInputScriptType(type), i, value)
+      );
     }
 
     function getOutputAddress(): string {
@@ -65,28 +95,43 @@ function run<TNumber extends number | bigint = number>(
       cosigner: BIP32Interface
     ): WalletSignTransactionOptions {
       const txInfo = {
-        unspents: getUnspents(),
+        unspents: txFormat === 'psbt' ? undefined : getUnspents(),
       };
       return {
         txPrebuild: {
+          walletId: wallet.id(),
           txHex: prebuildHex,
           txInfo,
         },
         prv: signer.toBase58(),
         pubs: walletKeys.triple.map((k) => k.neutered().toBase58()),
         cosignerPub: cosigner.neutered().toBase58(),
-      };
+      } as WalletSignTransactionOptions;
     }
 
-    function createHalfSignedTransaction(
-      prebuild: utxolib.bitgo.UtxoTransaction<TNumber>,
+    async function createHalfSignedTransaction(
+      prebuild: utxolib.bitgo.UtxoTransaction<TNumber> | utxolib.bitgo.UtxoPsbt,
       signer: BIP32Interface,
       cosigner: BIP32Interface
     ): Promise<HalfSignedUtxoTransaction> {
+      let scope: nock.Scope | undefined;
+      if (prebuild instanceof utxolib.bitgo.UtxoPsbt && isTransactionWithKeyPathSpend) {
+        const psbt = prebuild.clone().setAllInputsMusig2NonceHD(cosigner);
+        scope = nock(bgUrl)
+          .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/signpsbt`, (body) => body.psbt)
+          .reply(200, { psbt: psbt.toHex() });
+      }
+
       // half-sign with the user key
-      return wallet.signTransaction(
+      const result = (await wallet.signTransaction(
         getSignParams(prebuild.toBuffer().toString('hex'), signer, cosigner)
-      ) as Promise<HalfSignedUtxoTransaction>;
+      )) as Promise<HalfSignedUtxoTransaction>;
+
+      if (scope) {
+        assert.strictEqual(scope.isDone(), true);
+      }
+
+      return result;
     }
 
     async function createFullSignedTransaction(
@@ -101,8 +146,8 @@ function run<TNumber extends number | bigint = number>(
     }
 
     type TransactionStages = {
-      prebuild: utxolib.bitgo.UtxoTransaction<TNumber>;
-      halfSignedUserBackup: HalfSignedUtxoTransaction;
+      prebuild: utxolib.bitgo.UtxoTransaction<TNumber> | utxolib.bitgo.UtxoPsbt;
+      halfSignedUserBackup?: HalfSignedUtxoTransaction;
       halfSignedUserBitGo: HalfSignedUtxoTransaction;
       fullSignedUserBackup?: FullySignedTransaction;
       fullSignedUserBitGo?: FullySignedTransaction;
@@ -110,16 +155,36 @@ function run<TNumber extends number | bigint = number>(
 
     type TransactionObjStages = Record<keyof TransactionStages, TransactionObj>;
 
+    function createPrebuildPsbt() {
+      const inputs = inputScripts.map(
+        (t): testutil.Input => ({
+          scriptType: t,
+          value: t === 'p2shP2pk' ? BigInt(1000) : BigInt(value),
+        })
+      );
+      const unspentSum = inputs.reduce((prev: bigint, curr) => prev + curr.value, BigInt(0));
+      const outputs: testutil.Output[] = [{ scriptType: 'p2sh', value: unspentSum - BigInt(1000) }];
+      return testutil.constructPsbt(inputs, outputs, coin.network, walletKeys, 'unsigned');
+    }
+
     async function getTransactionStages(): Promise<TransactionStages> {
-      const prebuild = createPrebuildTransaction<TNumber>(coin.network, getUnspents(), getOutputAddress());
-      const halfSignedUserBackup = await createHalfSignedTransaction(prebuild, walletKeys.user, walletKeys.backup);
-      const fullSignedUserBackup = fullSign
-        ? await createFullSignedTransaction(halfSignedUserBackup, walletKeys.backup, walletKeys.user)
-        : undefined;
+      const prebuild =
+        txFormat === 'psbt'
+          ? createPrebuildPsbt()
+          : createPrebuildTransaction<TNumber>(coin.network, getUnspents(), getOutputAddress());
+
       const halfSignedUserBitGo = await createHalfSignedTransaction(prebuild, walletKeys.user, walletKeys.bitgo);
       const fullSignedUserBitGo = fullSign
         ? await createFullSignedTransaction(halfSignedUserBitGo, walletKeys.bitgo, walletKeys.user)
         : undefined;
+
+      const halfSignedUserBackup = isTransactionWithKeyPathSpend
+        ? undefined
+        : await createHalfSignedTransaction(prebuild, walletKeys.user, walletKeys.backup);
+      const fullSignedUserBackup =
+        fullSign && halfSignedUserBackup
+          ? await createFullSignedTransaction(halfSignedUserBackup, walletKeys.backup, walletKeys.user)
+          : undefined;
 
       return {
         prebuild,
@@ -136,10 +201,19 @@ function run<TNumber extends number | bigint = number>(
       transactionStages = await getTransactionStages();
     });
 
-    it('match fixtures', async function () {
+    afterEach(nock.cleanAll);
+
+    it('match fixtures', async function (this: Mocha.Context) {
+      if (txFormat === 'psbt') {
+        // TODO (maybe) - once full PSBT support is added to abstract-utxo module, custom JSON representation of PSBT can be created and tested here.
+        // signatures of taprootKeyPathSpends are random since random nature of MuSig2 nonce, so psbt hex comparison also wont work.
+
+        return this.skip();
+      }
+
       function toTransactionStagesObj(stages: TransactionStages): TransactionObjStages {
         return _.mapValues(stages, (v) =>
-          v === undefined
+          v === undefined || v instanceof utxolib.bitgo.UtxoPsbt
             ? undefined
             : v instanceof utxolib.bitgo.UtxoTransaction
             ? transactionToObj<TNumber>(v)
@@ -149,11 +223,37 @@ function run<TNumber extends number | bigint = number>(
 
       shouldEqualJSON(
         toTransactionStagesObj(transactionStages),
-        await getFixture(coin, `transactions-${inputScripts.join('-')}`, toTransactionStagesObj(transactionStages))
+        await getFixture(
+          coin,
+          `transactions-${inputScripts.map((t) => toTxnInputScriptType(t)).join('-')}`,
+          toTransactionStagesObj(transactionStages)
+        )
       );
     });
 
+    function testPsbtValidSignatures(tx: HalfSignedUtxoTransaction, signedBy: BIP32Interface[]) {
+      const psbt = utxolib.bitgo.createPsbtFromHex(tx.txHex, coin.network);
+      const unspents = getUnspentsForPsbt();
+      psbt.data.inputs.forEach((input, index) => {
+        const parsedInput = utxolib.bitgo.parsePsbtInput(psbt, index);
+        assert.ok(parsedInput);
+        const unspent = unspents[index];
+        if (!utxolib.bitgo.isWalletUnspent(unspent)) {
+          assert.ok(parsedInput.scriptType, 'p2shP2pk');
+          return;
+        }
+        const pubkeys = walletKeys.deriveForChainAndIndex(unspent.chain, unspent.index).publicKeys;
+        pubkeys.forEach((pk, pkIndex) => {
+          psbt.validateSignaturesOfInputCommon(index, pk).should.eql(signedBy.includes(walletKeys.triple[pkIndex]));
+        });
+      });
+    }
+
     function testValidSignatures(tx: HalfSignedUtxoTransaction | FullySignedTransaction, signedBy: BIP32Interface[]) {
+      if (txFormat === 'psbt') {
+        testPsbtValidSignatures(tx, signedBy);
+        return;
+      }
       const unspents = getUnspents();
       const prevOutputs = unspents.map(
         (u): utxolib.TxOutput<TNumber> => ({
@@ -168,7 +268,7 @@ function run<TNumber extends number | bigint = number>(
         { amountType }
       );
       transaction.ins.forEach((input, index) => {
-        if (inputScripts[index] === 'replayProtection') {
+        if (inputScripts[index] === 'p2shP2pk') {
           assert(coin.isBitGoTaintedUnspent(unspents[index]));
           return;
         }
@@ -195,7 +295,7 @@ function run<TNumber extends number | bigint = number>(
     async function testExplainTx(
       stageName: string,
       txHex: string,
-      unspents: utxolib.bitgo.Unspent<TNumber>[],
+      unspents?: utxolib.bitgo.Unspent<TNumber>[],
       pubs?: Triple<string>
     ): Promise<void> {
       const explanation = await coin.explainTransaction<TNumber>({
@@ -228,13 +328,14 @@ function run<TNumber extends number | bigint = number>(
 
       explanation.inputSignatures.should.eql(
         // FIXME(BG-35154): implement signature verification for replay protection inputs
-        inputScripts.map((type) => (type === 'replayProtection' ? 0 : expectedSignatureCount))
+        inputScripts.map((type) => (type === 'p2shP2pk' ? 0 : expectedSignatureCount))
       );
       explanation.signatures.should.eql(expectedSignatureCount);
       explanation.changeAmount.should.eql('0'); // no change addresses given
-      let expectedOutputAmount = BigInt(getUnspents().length) * BigInt(value);
+      let expectedOutputAmount =
+        BigInt((txFormat === 'psbt' ? getUnspentsForPsbt() : getUnspents()).length) * BigInt(value);
       inputScripts.forEach((type) => {
-        if (type === 'replayProtection') {
+        if (type === 'p2shP2pk') {
           // replayProtection unspents have value 1000
           expectedOutputAmount -= BigInt(value);
           expectedOutputAmount += BigInt(1000);
@@ -245,13 +346,14 @@ function run<TNumber extends number | bigint = number>(
     }
 
     it('have valid signature for half-signed transaction', function () {
-      testValidSignatures(transactionStages.halfSignedUserBackup, [walletKeys.user]);
+      if (transactionStages.halfSignedUserBackup) {
+        testValidSignatures(transactionStages.halfSignedUserBackup, [walletKeys.user]);
+      }
       testValidSignatures(transactionStages.halfSignedUserBitGo, [walletKeys.user]);
     });
 
     it('have valid signatures for full-signed transaction', function () {
       if (!fullSign) {
-        // @ts-expect-error - no implicit this
         return this.skip();
       }
       assert(transactionStages.fullSignedUserBackup && transactionStages.fullSignedUserBitGo);
@@ -261,19 +363,22 @@ function run<TNumber extends number | bigint = number>(
 
     it('have correct results for explainTransaction', async function () {
       for (const [stageName, stageTx] of Object.entries(transactionStages)) {
-        if (!stageTx) {
+        // once psbt support is added to explainTransaction function, the below prebuild can be removed.
+        if (!stageTx || (txFormat === 'psbt' && stageName !== 'prebuild')) {
           continue;
         }
 
-        let txHex;
-        if (stageTx instanceof utxolib.bitgo.UtxoTransaction) {
-          txHex = stageTx.toBuffer().toString('hex');
-        } else {
-          txHex = stageTx.txHex;
-        }
+        const txHex =
+          stageTx instanceof utxolib.bitgo.UtxoPsbt
+            ? stageTx.getUnsignedTx().toBuffer().toString('hex')
+            : stageTx instanceof utxolib.bitgo.UtxoTransaction
+            ? stageTx.toBuffer().toString('hex')
+            : utxolib.bitgo.isPsbt(stageTx.txHex)
+            ? utxolib.bitgo.createPsbtFromHex(stageTx.txHex, coin.network).getUnsignedTx().toBuffer().toString('hex')
+            : stageTx.txHex;
 
         const pubs = walletKeys.triple.map((k) => k.neutered().toBase58()) as Triple<string>;
-        const unspents = getUnspents();
+        const unspents = txFormat === 'psbt' ? undefined : getUnspents();
         await testExplainTx(stageName, txHex, unspents, pubs);
         await testExplainTx(stageName, txHex, unspents);
       }
@@ -281,23 +386,32 @@ function run<TNumber extends number | bigint = number>(
   });
 }
 
-function runWithAmountType(coin: AbstractUtxoCoin, inputScripts: InputScriptType[]) {
+function runWithAmountType(
+  coin: AbstractUtxoCoin,
+  inputScripts: testutil.InputScriptType[],
+  txFormat: 'legacy' | 'psbt'
+) {
   const amountType = coin.amountType;
   if (amountType === 'bigint') {
-    run<bigint>(coin, inputScripts, amountType);
+    run<bigint>(coin, inputScripts, txFormat, amountType);
   } else {
-    run(coin, inputScripts, amountType);
+    run(coin, inputScripts, txFormat, amountType);
   }
 }
 
 utxoCoins.forEach((coin) =>
   getScriptTypes2Of3().forEach((type) => {
-    if (coin.supportsAddressType(type)) {
-      runWithAmountType(coin, [type, type]);
-
-      if (getReplayProtectionAddresses(coin.network).length) {
-        runWithAmountType(coin, ['replayProtection', type]);
+    (['legacy', 'psbt'] as const).forEach((txFormat) => {
+      if ((type === 'taprootKeyPathSpend' || type === 'p2trMusig2') && txFormat !== 'psbt') {
+        return;
       }
-    }
+      if (coin.supportsAddressType(type === 'taprootKeyPathSpend' ? 'p2trMusig2' : type)) {
+        runWithAmountType(coin, [type, type], txFormat);
+
+        if (getReplayProtectionAddresses(coin.network).length) {
+          runWithAmountType(coin, ['p2shP2pk', type], txFormat);
+        }
+      }
+    });
   })
 );

--- a/modules/sdk-coin-doge/src/doge.ts
+++ b/modules/sdk-coin-doge/src/doge.ts
@@ -40,7 +40,10 @@ function parseUnspents<TNumber extends number | bigint>(
 function parseTransactionInfo<TNumber extends number | bigint>(
   txInfo: TransactionInfo<TNumber> | TransactionInfoJSON
 ): TransactionInfo<bigint> {
-  return { ...txInfo, unspents: parseUnspents(txInfo.unspents) };
+  if (txInfo.unspents) {
+    return { ...txInfo, unspents: parseUnspents(txInfo.unspents) };
+  }
+  return { ...txInfo, unspents: undefined };
 }
 
 function parseTransactionPrebuild<TNumber extends number | bigint>(

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -114,6 +114,11 @@ export interface PrebuildTransactionOptions {
    * If set to false, sweep all funds including the required minimums for address(es). E.g. Polkadot (DOT) requires 1 DOT minimum.
    */
   keepAlive?: boolean;
+  /**
+   * This comment applies to UTXO coins. It's asking which transaction format to use:
+   * the legacy format defined by bitcoinjs-lib, or the 'psbt' format, which follows the BIP-174.
+   */
+  txFormat?: 'legacy' | 'psbt';
 }
 
 export interface PrebuildAndSignTransactionOptions extends PrebuildTransactionOptions, WalletSignTransactionOptions {

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -200,6 +200,7 @@ export class Wallet implements IWallet {
       'destinationChain',
       'targetWalletUnspents',
       'trustlines',
+      'txFormat',
       'type',
       'unspents',
       'nonParticipation',
@@ -1832,7 +1833,7 @@ export class Wallet implements IWallet {
     // pass our three keys
     const signingParams = {
       ...params,
-      txPrebuild: txPrebuild,
+      txPrebuild,
       wallet: {
         // this is the version of the multisig address at wallet creation time
         addressVersion: this._wallet.coinSpecific.addressVersion,

--- a/modules/utxo-lib/src/bitgo/wallet/Psbt.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/Psbt.ts
@@ -445,3 +445,19 @@ export function getSignatureCount(
     .map((index, _) => getInputSignatureCount(constructParam(tx, index)))
     .reduce((prev, curr) => (curr > prev ? curr : prev), 0);
 }
+
+/**
+ * @return true iff data starts with magic PSBT byte sequence
+ * @param data byte array or hex string
+ * */
+export function isPsbt(data: Buffer | string): boolean {
+  // https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#specification
+  // 0x70736274 - ASCII for 'psbt'. 0xff - separator
+  if (typeof data === 'string') {
+    if (data.length < 10) {
+      return false;
+    }
+    data = Buffer.from(data.slice(0, 10), 'hex');
+  }
+  return 5 <= data.length && data.readUInt32BE(0) === 0x70736274 && data.readUInt8(4) === 0xff;
+}

--- a/modules/utxo-lib/test/bitgo/psbt/Musig2.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/Musig2.ts
@@ -14,6 +14,8 @@ import {
   verifySignatureWithUnspent,
 } from '../../../src/bitgo';
 
+import { testutil } from '../../../src';
+
 import { getKeyTriple, verifyFullySignedSignatures } from '../../../src/testutil';
 import {
   createTapInternalKey,
@@ -25,6 +27,7 @@ import {
   musig2PartialSign,
   assertPsbtMusig2Nonces,
   Musig2NonceStore,
+  isTransactionWithKeyPathSpendInput,
 } from '../../../src/bitgo/Musig2';
 import { scriptTypes2Of3, toXOnlyPublicKey } from '../../../src/bitgo/outputScripts';
 import {
@@ -711,6 +714,96 @@ describe('p2trMusig2', function () {
         (e) => e.message === `Invalid nonce keydata tapOutputKey`
       );
       assert.strictEqual(psbt.getProprietaryKeyVals(0).length, 3);
+    });
+
+    describe('isTransactionWithKeyPathSpendInput', function () {
+      describe('transaction input', function () {
+        it('taprootKeyPath inputs successfully triggers', function () {
+          const psbt = testutil.constructPsbt(
+            [
+              { scriptType: 'taprootKeyPathSpend', value: BigInt(1e8) },
+              { scriptType: 'p2sh', value: BigInt(1e8) },
+            ],
+            [{ scriptType: 'p2sh', value: BigInt(2e8 - 10000) }],
+            network,
+            rootWalletKeys,
+            'fullsigned'
+          );
+          assert(psbt.validateSignaturesOfAllInputs());
+          psbt.finalizeAllInputs();
+          const tx = psbt.extractTransaction() as UtxoTransaction<bigint>;
+
+          assert.strictEqual(isTransactionWithKeyPathSpendInput(tx), true);
+          assert.strictEqual(isTransactionWithKeyPathSpendInput(tx.ins), true);
+        });
+
+        it('no taprootKeyPath inputs successfully does not trigger', function () {
+          const psbt = testutil.constructPsbt(
+            [
+              { scriptType: 'p2trMusig2', value: BigInt(1e8) },
+              { scriptType: 'p2sh', value: BigInt(1e8) },
+            ],
+            [{ scriptType: 'p2sh', value: BigInt(2e8 - 10000) }],
+            network,
+            rootWalletKeys,
+            'fullsigned'
+          );
+          assert(psbt.validateSignaturesOfAllInputs());
+          psbt.finalizeAllInputs();
+          const tx = psbt.extractTransaction() as UtxoTransaction<bigint>;
+
+          assert.strictEqual(isTransactionWithKeyPathSpendInput(tx), false);
+          assert.strictEqual(isTransactionWithKeyPathSpendInput(tx.ins), false);
+        });
+
+        it('unsigned inputs successfully fail', function () {
+          const psbt = testutil.constructPsbt(
+            [
+              { scriptType: 'p2wsh', value: BigInt(1e8) },
+              { scriptType: 'p2sh', value: BigInt(1e8) },
+            ],
+            [{ scriptType: 'p2sh', value: BigInt(2e8 - 10000) }],
+            network,
+            rootWalletKeys,
+            'unsigned'
+          );
+          const tx = psbt.getUnsignedTx();
+          assert.strictEqual(isTransactionWithKeyPathSpendInput(tx), false);
+          assert.strictEqual(isTransactionWithKeyPathSpendInput(tx.ins), false);
+        });
+      });
+
+      describe('psbt input', function () {
+        it('psbt with taprootKeyPathInputs successfully triggers', function () {
+          const psbt = testutil.constructPsbt(
+            [
+              { scriptType: 'taprootKeyPathSpend', value: BigInt(1e8) },
+              { scriptType: 'p2sh', value: BigInt(1e8) },
+            ],
+            [{ scriptType: 'p2sh', value: BigInt(2e8 - 10000) }],
+            network,
+            rootWalletKeys,
+            'unsigned'
+          );
+
+          assert.strictEqual(isTransactionWithKeyPathSpendInput(psbt), true);
+        });
+
+        it('psbt without taprootKeyPathInputs successfully does not trigger', function () {
+          const psbt = testutil.constructPsbt(
+            [
+              { scriptType: 'p2wsh', value: BigInt(1e8) },
+              { scriptType: 'p2sh', value: BigInt(1e8) },
+            ],
+            [{ scriptType: 'p2sh', value: BigInt(2e8 - 10000) }],
+            network,
+            rootWalletKeys,
+            'halfsigned'
+          );
+
+          assert.strictEqual(isTransactionWithKeyPathSpendInput(psbt), false);
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Adding PSBT and taproot key path spend support for the `prebuildAndSign` method.

Added a unit test for the `prebuildAndSign` method as well as unit tests in `utxo-lib` for the utility methods that we implemented there

BG-66947

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->