### PR TITLE
chore(root): remove 14.x from unit-test-all

### DIFF
--- a/.github/workflows/test_package_updates.yml
+++ b/.github/workflows/test_package_updates.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Description

One of our Solana dependencies make use of `||=` which is not supported by node 14. As a result the `unit-test-all` will consistently fail for node `14.x`. Node 14 is also end-of-life, as such this test is not adding any value.

## Issue Number

TICKET: BG-78094

## Type of change
- [x] CI