### PR TITLE
fix(bitgo): should skip password validation in external signing

### DIFF
--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -516,6 +516,13 @@ describe('V2 Wallet:', function () {
         e.message.should.equal(errorMessage);
       }
       try {
+        const customSigningFunction = () => {return 'mock'; };
+        // Should not validate passphrase if custom signing function is provided
+        await ethWallet.sendMany( { ...sendManyParamsCorrectPassPhrase, walletPassphrase: 'wrongPassphrase', customSigningFunction } );
+      } catch (e) {
+        e.message.should.not.equal(errorMessage);
+      }
+      try {
         await ethWallet.sendMany( { ...sendManyParamsCorrectPassPhrase } );
       } catch (e) {
         e.message.should.not.equal(errorMessage);

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -1795,8 +1795,10 @@ export class Wallet implements IWallet {
     const keychains = await this.baseCoin.keychains().getKeysForSigning({ wallet: this, reqId: params.reqId });
 
     // Doing a sanity check for password here to avoid doing further work if we know it's wrong
+    // we ignore this check with if customSigningFunction is provided
+    //  which means that the user is handling the signing in external signing mode
     try {
-      if (keychains[0].encryptedPrv) {
+      if (keychains[0].encryptedPrv && !params.customSigningFunction && params.walletPassphrase) {
         this.bitgo.decrypt({ input: keychains[0].encryptedPrv as string, password: params.walletPassphrase });
       }
     } catch (e) {


### PR DESCRIPTION
In external signing mode, we use two express instances where one will initiate the transfer and delegate the signing to the external signer ideally in a air gapped machine. The initiator thus won't have access to wallet passpharse so with this change we are skipping password checks if custom signing function is present

Ticket: BG-000000

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->