### PR TITLE
fix(sdk-core): fix pending approval for consolidation

### DIFF
--- a/modules/sdk-core/src/bitgo/pendingApproval/pendingApproval.ts
+++ b/modules/sdk-core/src/bitgo/pendingApproval/pendingApproval.ts
@@ -178,6 +178,13 @@ export class PendingApproval implements IPendingApproval {
       canRecreateTransaction = false;
     }
 
+    // If there are no recipients, then the transaction cannot be recreated
+    const recipients = this.info()?.transactionRequest?.buildParams?.recipients || [];
+    const type = this.info()?.transactionRequest?.buildParams?.type;
+    if (recipients.length === 0 && type !== 'consolidate') {
+      canRecreateTransaction = false;
+    }
+
     const reqId = new RequestTracer();
 
     /*


### PR DESCRIPTION
When doing an unspent consolidation, there are no recipients in the `buildParams` because they are generated within WP. This causes errors reconstructing the consolidation transaction during pending approval. This new check sets the `canRecreateTransaction=false` if there are no recipients. Instead, it will use the txHex of the transaction passed into `/send` and use that. 

This should unblock customers who have policies on BTC wallets that want to consolidate.

BG-78492

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->