### PR TITLE
fix(sdk-core): retrieve bitgo modulus for ecdsa signing

### DIFF
--- a/modules/bitgo/test/v2/unit/tss/ecdsa.ts
+++ b/modules/bitgo/test/v2/unit/tss/ecdsa.ts
@@ -512,6 +512,24 @@ describe('Ecdsa tss helper functions tests', function () {
         kShare.should.deepEqual(bitgoKShare);
       });
 
+      it('should successfully parse K share with sigma but no p', function () {
+        const bitgoKShare = {
+          ...mockSignWithPaillierChallengeRT.kShare,
+          p: undefined,
+        };
+        const share = {
+          to: SignatureShareType.BITGO,
+          from: SignatureShareType.USER,
+          share: ECDSAMethods.convertKShare(bitgoKShare).share,
+        } as SignatureShareRecord;
+        const kShare = ECDSAMethods.parseKShare(share);
+        kShare.should.deepEqual({
+          ...bitgoKShare,
+          p: undefined,
+          sigma: undefined,
+        });
+      });
+
       it('should successfully convert K share to signature share record without paillier challenge', function () {
         const bitgoKShare = mockSignRT.kShare;
         const share = {

--- a/modules/sdk-core/src/bitgo/tss/common.ts
+++ b/modules/sdk-core/src/bitgo/tss/common.ts
@@ -1,10 +1,9 @@
 import assert from 'assert';
 import openpgp from 'openpgp';
 
-import { EcdsaTypes } from '@bitgo/sdk-lib-mpc';
-
 import { BitGoBase } from '../bitgoBase';
 import { RequestType, TxRequest, verifyPrimaryUserWrapper, SignatureShareRecord } from '../utils';
+import { TxRequestChallengeResponse } from './types';
 
 /**
  * Gets the latest Tx Request by id
@@ -138,7 +137,7 @@ export async function getTxRequestChallenge(
   index: string,
   requestType: RequestType,
   paillierModulus: string
-): Promise<EcdsaTypes.SerializedEcdsaChallenges> {
+): Promise<TxRequestChallengeResponse> {
   let addendum = '';
   switch (requestType) {
     case RequestType.tx:

--- a/modules/sdk-core/src/bitgo/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/bitgo/tss/ecdsa/ecdsa.ts
@@ -476,14 +476,10 @@ export function parseKShare(share: SignatureShareRecord): KShare {
   // and remove the validateOptionalValues check
   validateSharesLength(shares, 11 + 2, 'K');
   const hasProof = validateOptionalValues(shares, 5, 11, 'K', 'proof');
-  const hasP = validateOptionalValues(shares, 11, 11 + EcdsaPaillierProof.m, 'K', 'p');
-  const hasSigma = validateOptionalValues(
-    shares,
-    11 + EcdsaPaillierProof.m,
-    11 + 2 * EcdsaPaillierProof.m,
-    'K',
-    'sigma'
-  );
+  const hasP = validateOptionalValues(shares, 11, 11 + 1, 'K', 'p');
+  const hasSigma = hasP
+    ? validateOptionalValues(shares, 11 + EcdsaPaillierProof.m, 11 + 2 * EcdsaPaillierProof.m, 'K', 'sigma')
+    : false;
 
   const proof: RangeProofShare | undefined = hasProof
     ? {

--- a/modules/sdk-core/src/bitgo/tss/types.ts
+++ b/modules/sdk-core/src/bitgo/tss/types.ts
@@ -1,5 +1,12 @@
+import { EcdsaTypes } from '@bitgo/sdk-lib-mpc';
+
 export enum ShareKeyPosition {
   USER = 1,
   BACKUP = 2,
   BITGO = 3,
 }
+
+export type TxRequestChallengeResponse = EcdsaTypes.SerializedEcdsaChallenges & {
+  // TODO(BG-78794): make this mandatory
+  n?: string;
+};


### PR DESCRIPTION
## Description

The user signing key currently does not contain an `n` value for bitgo. This PR changes the signing flow to use an `n` value from the create bitgo challenge endpoint for ecdsa tss.

## Issue Number

TICKET: BG-78974

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested against a PR namespace with WP.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [x] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes