### PR TITLE
feat(abstract-utxo): make walletId param optional for signtx

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -202,7 +202,7 @@ export interface AddressDetails {
 export interface SignTransactionOptions<TNumber extends number | bigint = number> extends BaseSignTransactionOptions {
   /** Transaction prebuild from bitgo server */
   txPrebuild: {
-    walletId: string;
+    walletId?: string;
     txHex: string;
     txInfo: TransactionInfo<TNumber>;
   };
@@ -1108,6 +1108,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
     const cosignerKeychain = bip32.fromBase58(cosignerPub);
 
     if (tx instanceof bitgo.UtxoPsbt && isTransactionWithKeyPathSpendInput) {
+      assert(txPrebuild.walletId, 'walletId is required for MuSig2 nonce');
       tx.setAllInputsMusig2NonceHD(signerKeychain);
       const response = await this.signPsbt(tx.toHex(), txPrebuild.walletId);
       const psbt = bitgo.createPsbtFromHex(response.psbt, this.network);

--- a/modules/bitgo/test/v2/unit/coins/utxo/transaction.ts
+++ b/modules/bitgo/test/v2/unit/coins/utxo/transaction.ts
@@ -100,7 +100,7 @@ function run<TNumber extends number | bigint = number>(
       };
       return {
         txPrebuild: {
-          walletId: wallet.id(),
+          walletId: isTransactionWithKeyPathSpend ? wallet.id() : undefined,
           txHex: prebuildHex,
           txInfo,
         },


### PR DESCRIPTION
walletId is required only for signPsbt api call.
Backup signers does not require to pass it since MuSig2 is not supported.

Ticket: BTC-214

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->