### PR TITLE
fix(sdk-coin-sui): add support for partial unstaking

### DIFF
--- a/modules/sdk-coin-sui/src/lib/compareTransactionBlocks.ts
+++ b/modules/sdk-coin-sui/src/lib/compareTransactionBlocks.ts
@@ -1,0 +1,10 @@
+import assert from 'assert';
+import { SuiTransaction } from './iface';
+
+export function assertEqualTransactionBlocks(
+  a: { inputs: SuiTransaction['tx']['inputs']; transactions: unknown[] },
+  b: { inputs: SuiTransaction['tx']['inputs']; transactions: unknown[] }
+): void {
+  assert.deepStrictEqual(a.inputs, b.inputs, 'Different inputs');
+  assert.deepStrictEqual(a.transactions, b.transactions, 'Different transactions');
+}

--- a/modules/sdk-coin-sui/src/lib/constants.ts
+++ b/modules/sdk-coin-sui/src/lib/constants.ts
@@ -10,3 +10,5 @@ export const SER_BUFFER_SIZE = 8192;
 export const SUI_INTENT_BYTES = Buffer.from([0, 0, 0]);
 
 export const SIGNATURE_SCHEME_BYTES = [0x00];
+
+export const MIN_STAKING_THRESHOLD = 1_000_000_000; // 1 SUI

--- a/modules/sdk-coin-sui/src/lib/iface.ts
+++ b/modules/sdk-coin-sui/src/lib/iface.ts
@@ -65,6 +65,7 @@ export interface RequestAddStake {
 }
 
 export interface RequestWithdrawStakedSui {
+  amount?: number;
   stakedSui: SuiObjectRef;
 }
 

--- a/modules/sdk-coin-sui/src/lib/mystenlab/framework/sui-system-state.ts
+++ b/modules/sdk-coin-sui/src/lib/mystenlab/framework/sui-system-state.ts
@@ -16,3 +16,7 @@ export const SUI_SYSTEM_MODULE_NAME = 'sui_system';
 export const ADD_STAKE_FUN_NAME = 'request_add_stake';
 export const ADD_STAKE_LOCKED_COIN_FUN_NAME = 'request_add_stake_with_locked_coin';
 export const WITHDRAW_STAKE_FUN_NAME = 'request_withdraw_stake';
+
+// https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/staking_pool.md
+export const SUI_STAKING_POOL_MODULE_NAME = 'staking_pool';
+export const SUI_STAKING_POOL_SPLIT_FUN_NAME = 'split';

--- a/modules/sdk-coin-sui/test/local_fullnode/transactions.ts
+++ b/modules/sdk-coin-sui/test/local_fullnode/transactions.ts
@@ -1,9 +1,12 @@
+import { StakeObject } from '../../src/lib/mystenlab/types/validator';
+
 process.env.DEBUG = 'RpcClient,SuiTransactionTypes';
 
 import assert from 'assert';
 import util from 'util';
 import { Faucet } from './faucet';
 import buildDebug from 'debug';
+import { createHash } from 'crypto';
 
 import {
   KeyPair,
@@ -18,7 +21,7 @@ import { RpcClient } from './RpcClient';
 import { getBuilderFactory } from '../unit/getBuilderFactory';
 import { SuiTransactionType } from '../../src/lib/iface';
 import { GasData, SuiObjectRef } from '../../src/lib/mystenlab/types';
-import { DUMMY_SUI_GAS_PRICE } from '../../src/lib/constants';
+import { DUMMY_SUI_GAS_PRICE, MIN_STAKING_THRESHOLD } from '../../src/lib/constants';
 
 const debug = buildDebug('SuiTransactionTypes');
 
@@ -32,13 +35,83 @@ async function getAllCoins(conn: RpcClient, address: string): Promise<SuiObjectR
   });
 }
 
-async function getAllActiveStakedSuis(conn: RpcClient, owner: string): Promise<SuiObjectRef[]> {
+/**
+ * @returns The stakes array with the stakedSui amount reduced by amount. If amount is undefined, the stakedSui is removed.
+ */
+function subtractStake(stakes: StakeObject[], stakedSui: StakeObject, amount: number | undefined): StakeObject[] {
+  return stakes.flatMap((s): StakeObject[] => {
+    if (s.stakedSuiId === stakedSui.stakedSuiId) {
+      if (amount === undefined) {
+        // remove the stake
+        return [];
+      } else {
+        // reduce the stake by amount
+        return [{ ...s, principal: Number(s.principal) - amount }];
+      }
+    } else {
+      // keep the stake unchanged
+      return [s];
+    }
+  });
+}
+
+/**
+ * Asserts that the stakesAfter array is the same as the stakesBefore array with the stakedSui amount reduced by amount.
+ */
+function assertReducedStake(
+  stakesBefore: StakeObject[],
+  stakesAfter: StakeObject[],
+  stakedSui: StakeObject,
+  amount: number | undefined
+) {
+  /*
+   * Normalize the stake objects by converting the principal to a number and removing the estimatedReward.
+   */
+  function normStake(s: StakeObject): StakeObject {
+    return { ...s, principal: Number(s.principal), estimatedReward: undefined };
+  }
+  stakesBefore = stakesBefore.map(normStake);
+  stakesAfter = stakesAfter.map(normStake);
+  assert.deepStrictEqual(stakesAfter, subtractStake(stakesBefore, stakedSui, amount));
+}
+
+async function getStakes(
+  conn: RpcClient,
+  owner: string,
+  params: {
+    filterStatus?: StakeObject['status'];
+    filterMinValue?: number;
+    attempts?: number;
+    sleepMs?: number;
+  } = {}
+): Promise<StakeObject[]> {
   const all = await conn.getStakes(owner);
-  return Promise.all(
-    all
-      .flatMap((s) => s.stakes.flatMap((v) => (v.status === 'Active' ? [v.stakedSuiId] : [])))
-      .map(async (id) => (await conn.getObject(id)).data)
+  const result = await Promise.all(
+    all.flatMap((s) =>
+      s.stakes
+        .filter((v) => params.filterStatus === undefined || v.status === params.filterStatus)
+        .filter((v) => params.filterMinValue === undefined || params.filterMinValue <= Number(v.principal))
+    )
   );
+  if (result.length) {
+    return result;
+  }
+  const { attempts = 10, sleepMs = 1000 } = params;
+  if (0 < attempts) {
+    await new Promise((resolve) => setTimeout(resolve, sleepMs));
+    return await getStakes(conn, owner, { ...params, attempts: attempts - 1, sleepMs });
+  } else {
+    throw new Error('getAllActiveStakedSuis: no active staked suis found');
+  }
+}
+
+async function resolveStakedSui(conn: RpcClient, stake: StakeObject): Promise<SuiObjectRef> {
+  return (await conn.getObject(stake.stakedSuiId)).data;
+}
+
+function getKeyPair(seed: string): KeyPair {
+  const seedBuf = createHash('sha256').update(seed).digest();
+  return new KeyPair({ seed: seedBuf });
 }
 
 async function signAndSubmit(
@@ -57,23 +130,30 @@ async function signAndSubmit(
   }
 }
 
+async function fundFromFaucet(url: string, v: KeyPair | string, amount = 100e9): Promise<void> {
+  if (typeof v !== 'string') {
+    v = v.getAddress();
+  }
+  await new Faucet(url).getCoins(v, 10e9);
+}
+
 describe('Sui Transaction Types', function () {
   if (process.env.DRONE) {
     console.log('skipping local_fullnode/transactions.ts on drone');
     return;
   }
 
-  const keyPair = new KeyPair({ seed: Buffer.alloc(32).fill(1) });
+  const keyPair = getKeyPair('test');
   const address = keyPair.getAddress();
   debug('address', address);
 
   const fullnodeUrl = process.env.SUI_FULLNODE_URL || 'http://127.0.0.1:9000';
   const faucetUrl = process.env.SUI_FAUCET_URL || 'http://127.0.0.1:9123';
 
-  async function getDefaultGasData(): Promise<GasData> {
+  async function getDefaultGasData(keyPair: KeyPair): Promise<GasData> {
     return {
-      owner: address,
-      payment: await getAllCoins(conn, address),
+      owner: keyPair.getAddress(),
+      payment: await getAllCoins(conn, keyPair.getAddress()),
       budget: 100_000_000,
       price: DUMMY_SUI_GAS_PRICE,
     };
@@ -89,7 +169,7 @@ describe('Sui Transaction Types', function () {
 
   before('fund via faucet', async function () {
     if (faucetUrl) {
-      await new Faucet(faucetUrl).getCoins(address, 10e9);
+      await fundFromFaucet(faucetUrl, address);
     }
   });
 
@@ -104,35 +184,60 @@ describe('Sui Transaction Types', function () {
       .type(SuiTransactionType.Transfer)
       .sender(address)
       .send([{ address, amount: (111_111).toString() }])
-      .gasData(await getDefaultGasData());
+      .gasData(await getDefaultGasData(keyPair));
 
     await signAndSubmit(conn, keyPair, txb);
   });
 
-  it('can stake coins', async function () {
+  async function stakeAmount(keyPair: KeyPair, amount: number): Promise<void> {
     const builder = getBuilderFactory('tsui').getStakingBuilder();
     const txb = builder
       .type(SuiTransactionType.AddStake)
-      .sender(address)
-      .stake({ amount: 1e9, validatorAddress: validator })
-      .gasData(await getDefaultGasData());
+      .sender(keyPair.getAddress())
+      .stake({ amount, validatorAddress: validator })
+      .gasData(await getDefaultGasData(keyPair));
 
     await signAndSubmit(conn, keyPair, txb);
+  }
+
+  it('can stake coins', async function () {
+    await stakeAmount(keyPair, 1e9);
   });
 
-  it('can unstake all coins', async function () {
-    const activeStakedSui = await getAllActiveStakedSuis(conn, address);
-    assert(activeStakedSui.length > 0, 'No staked coins found');
+  function testUnstake(amount: number | undefined) {
+    describe(`unstake (amount=${amount})`, function () {
+      const keyPairStakeTest = getKeyPair(`stake-test-amount-${amount !== undefined}`);
+      const address = keyPairStakeTest.getAddress();
 
-    for (const stakedSui of activeStakedSui) {
-      const builder = getBuilderFactory('tsui').getUnstakingBuilder();
-      const txb = builder
-        .type(SuiTransactionType.WithdrawStake)
-        .sender(address)
-        .unstake({ stakedSui })
-        .gasData(await getDefaultGasData());
+      before('stake coins', async function () {
+        await fundFromFaucet(faucetUrl, address);
+        await stakeAmount(keyPairStakeTest, 10e9);
+      });
 
-      await signAndSubmit(conn, keyPair, txb);
-    }
-  });
+      it(`can unstake`, async function () {
+        const activeStakedSui = await getStakes(conn, address, {
+          filterStatus: 'Active',
+          filterMinValue: MIN_STAKING_THRESHOLD + (amount || 0),
+        });
+        assert(activeStakedSui.length > 0, 'No staked coins found');
+
+        for (const stakedSui of activeStakedSui.slice(0, 3)) {
+          debug('unstaking', stakedSui);
+          const builder = getBuilderFactory('tsui').getUnstakingBuilder();
+          const stakedBefore = await getStakes(conn, address);
+          const txb = builder
+            .type(SuiTransactionType.WithdrawStake)
+            .sender(address)
+            .unstake({ stakedSui: await resolveStakedSui(conn, stakedSui), amount })
+            .gasData(await getDefaultGasData(keyPairStakeTest));
+          await signAndSubmit(conn, keyPairStakeTest, txb);
+
+          assertReducedStake(stakedBefore, await getStakes(conn, address), stakedSui, amount);
+        }
+      });
+    });
+  }
+
+  testUnstake(undefined);
+  testUnstake(1e9);
 });

--- a/modules/sdk-coin-sui/test/resources/sui.ts
+++ b/modules/sdk-coin-sui/test/resources/sui.ts
@@ -363,6 +363,9 @@ export const ADD_STAKE =
 export const WITHDRAW_STAKED_SUI =
   'AAACAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQEAAAAAAAAAAQEA7m38PaMuIVQaKurfzSUPigoju3q9qciYhAf8MgaMN0ZhBAAAAAAAACDJYCWUFis6HawzxGyErvRT03pYayRliLki0kYsV0XCBAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMKc3VpX3N5c3RlbRZyZXF1ZXN0X3dpdGhkcmF3X3N0YWtlAAIBAAABAQCYghiLo+gHCpuwaulEbPYHkU7o7ljtgwaj46//Whu7cQIJxAUirtVLzs+kg2BcXaWCGxcawaobYVlx+43+J+0T/VEEAAAAAAAAILZEZ8lcLtxXB9dIMp0rBAH+s8LT/e12XMNKiaW4bnuyJ90A5/zNyHtNlbY4S3ORGbkfKoGha67ep/TgBo5SlDfZAAAAAAAAACC+KT7TKlmOYLySRsTgG25Ck38WiZCIOmogUHrCwU0nJ5iCGIuj6AcKm7Bq6URs9geRTujuWO2DBqPjr/9aG7tx6AMAAAAAAAAALTEBAAAAAAA=';
 
+export const WITHDRAW_STAKED_SUI_WITH_AMOUNT =
+  'AAADAQDubfw9oy4hVBoq6t/NJQ+KCiO7er2pyJiEB/wyBow3RmEEAAAAAAAAIMlgJZQWKzodrDPEbISu9FPTelhrJGWIuSLSRixXRcIEAAgAypo7AAAAAAEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUBAAAAAAAAAAECAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADDHN0YWtpbmdfcG9vbAVzcGxpdAACAQAAAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADCnN1aV9zeXN0ZW0WcmVxdWVzdF93aXRoZHJhd19zdGFrZQACAQIAAwAAAACYghiLo+gHCpuwaulEbPYHkU7o7ljtgwaj46//Whu7cQIJxAUirtVLzs+kg2BcXaWCGxcawaobYVlx+43+J+0T/VEEAAAAAAAAILZEZ8lcLtxXB9dIMp0rBAH+s8LT/e12XMNKiaW4bnuyJ90A5/zNyHtNlbY4S3ORGbkfKoGha67ep/TgBo5SlDfZAAAAAAAAACC+KT7TKlmOYLySRsTgG25Ck38WiZCIOmogUHrCwU0nJ5iCGIuj6AcKm7Bq6URs9geRTujuWO2DBqPjr/9aG7tx6AMAAAAAAAAALTEBAAAAAAA=';
+
 export const invalidRecipients: Recipient[] = [
   {
     address: addresses.invalidAddresses[0],
@@ -389,4 +392,154 @@ export const requestWithdrawStakedSui: RequestWithdrawStakedSui = {
     version: 1121,
     digest: 'EZ5yqap5XJJy9KhnW3dsbE73UmC5bd1KBEx7eQ5k4HNT',
   },
+};
+
+export const txBlockUnstakeNoAmount = {
+  inputs: [
+    {
+      kind: 'Input',
+      value: {
+        Object: {
+          Shared: {
+            objectId: '0x0000000000000000000000000000000000000000000000000000000000000005',
+            initialSharedVersion: 1,
+            mutable: true,
+          },
+        },
+      },
+      index: 0,
+      type: 'object',
+    },
+    {
+      kind: 'Input',
+      value: {
+        Object: {
+          ImmOrOwned: {
+            objectId: '0xee6dfc3da32e21541a2aeadfcd250f8a0a23bb7abda9c8988407fc32068c3746',
+            version: 1121,
+            digest: 'EZ5yqap5XJJy9KhnW3dsbE73UmC5bd1KBEx7eQ5k4HNT',
+          },
+        },
+      },
+      index: 1,
+      type: 'pure',
+    },
+  ],
+  transactions: [
+    {
+      kind: 'MoveCall',
+      target: '0x3::sui_system::request_withdraw_stake',
+      arguments: [
+        {
+          kind: 'Input',
+          value: {
+            Object: {
+              Shared: {
+                objectId: '0x0000000000000000000000000000000000000000000000000000000000000005',
+                initialSharedVersion: 1,
+                mutable: true,
+              },
+            },
+          },
+          index: 0,
+          type: 'object',
+        },
+        {
+          kind: 'Input',
+          value: {
+            Object: {
+              ImmOrOwned: {
+                objectId: '0xee6dfc3da32e21541a2aeadfcd250f8a0a23bb7abda9c8988407fc32068c3746',
+                version: 1121,
+                digest: 'EZ5yqap5XJJy9KhnW3dsbE73UmC5bd1KBEx7eQ5k4HNT',
+              },
+            },
+          },
+          index: 1,
+          type: 'pure',
+        },
+      ],
+      typeArguments: [],
+    },
+  ],
+};
+
+export const txBlockUnstakeWithAmount = {
+  inputs: [
+    {
+      kind: 'Input',
+      value: {
+        Object: {
+          ImmOrOwned: {
+            objectId: '0xee6dfc3da32e21541a2aeadfcd250f8a0a23bb7abda9c8988407fc32068c3746',
+            version: 1121,
+            digest: 'EZ5yqap5XJJy9KhnW3dsbE73UmC5bd1KBEx7eQ5k4HNT',
+          },
+        },
+      },
+      index: 0,
+      type: 'object',
+    },
+    { kind: 'Input', value: '1000000000', index: 1, type: 'pure' },
+    {
+      kind: 'Input',
+      value: {
+        Object: {
+          Shared: {
+            objectId: '0x0000000000000000000000000000000000000000000000000000000000000005',
+            initialSharedVersion: 1,
+            mutable: true,
+          },
+        },
+      },
+      index: 2,
+      type: 'object',
+    },
+  ],
+  transactions: [
+    {
+      kind: 'MoveCall',
+      target: '0x3::staking_pool::split',
+      arguments: [
+        {
+          kind: 'Input',
+          value: {
+            Object: {
+              ImmOrOwned: {
+                objectId: '0xee6dfc3da32e21541a2aeadfcd250f8a0a23bb7abda9c8988407fc32068c3746',
+                version: 1121,
+                digest: 'EZ5yqap5XJJy9KhnW3dsbE73UmC5bd1KBEx7eQ5k4HNT',
+              },
+            },
+          },
+          index: 0,
+          type: 'object',
+        },
+        { kind: 'Input', value: '1000000000', index: 1, type: 'pure' },
+      ],
+      typeArguments: [],
+    },
+    {
+      kind: 'MoveCall',
+      target: '0x3::sui_system::request_withdraw_stake',
+      arguments: [
+        {
+          kind: 'Input',
+          value: {
+            Object: {
+              Shared: {
+                objectId: '0x0000000000000000000000000000000000000000000000000000000000000005',
+                initialSharedVersion: 1,
+                mutable: true,
+              },
+            },
+          },
+          index: 2,
+          type: 'object',
+        },
+        { kind: 'NestedResult', index: 0, resultIndex: 0 },
+      ],
+      typeArguments: [],
+    },
+  ],
 };

--- a/modules/sdk-coin-sui/test/unit/compareTransactionBlocks.ts
+++ b/modules/sdk-coin-sui/test/unit/compareTransactionBlocks.ts
@@ -1,0 +1,36 @@
+import assert from 'assert';
+import { assertEqualTransactionBlocks } from '../../src/lib/compareTransactionBlocks';
+import { UnstakingBuilder } from '../../src';
+import * as testData from '../resources/sui';
+import { SuiObjectRef } from '../../src/lib/mystenlab/types';
+
+describe('compareTransactionBlocks', function () {
+  function runTest(tag: string, objRef: SuiObjectRef, amount: bigint, expectedError: string | null) {
+    it(`compares two transaction blocks: ${tag}`, function () {
+      const f = () => {
+        assertEqualTransactionBlocks(
+          UnstakingBuilder.getTransactionBlockData(testData.requestWithdrawStakedSui.stakedSui, BigInt(100)),
+          UnstakingBuilder.getTransactionBlockData(objRef, amount)
+        );
+      };
+
+      if (expectedError === null) {
+        f();
+      } else {
+        assert.throws(f, new RegExp(expectedError));
+      }
+    });
+  }
+
+  runTest('equal', testData.requestWithdrawStakedSui.stakedSui, BigInt(100), null);
+  runTest('different amount', testData.requestWithdrawStakedSui.stakedSui, BigInt(101), 'Different inputs');
+  runTest(
+    'different objRef',
+    {
+      ...testData.requestWithdrawStakedSui.stakedSui,
+      objectId: '0x' + Buffer.alloc(32, 0xff).toString('hex'),
+    },
+    BigInt(101),
+    'Different inputs'
+  );
+});


### PR DESCRIPTION
- The UnstakingBuilder.unstake() method now accepts an optional `amount`
  parameter.
- When the `amount` parameter is provided, the transaction block
  will contain two transactions:
  - The first transaction will split the staked amount into two
    staked amounts, one with the `amount` and the other with the
    remaining amount.
  - The second transaction will use the result of the first
    transaction as input and will unstake the `amount` from the
    staked amount.
- Improve tests

Issue: BG-78857


<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->