### PR TITLE
feat(sdk-core): utxo build routes set txFormat='psbt' when not returning the build result

### DIFF
--- a/modules/bitgo/test/v2/unit/unspents.ts
+++ b/modules/bitgo/test/v2/unit/unspents.ts
@@ -117,7 +117,7 @@ describe('Verify string type is used for value of unspent', function () {
 
       await wallet.sendMany(params);
 
-      prebuildAndSignTransactionStub.should.calledOnce();
+      prebuildAndSignTransactionStub.should.be.calledOnceWith({ ...params, txFormat: 'psbt' });
       sendScope.done();
     });
 

--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -1364,7 +1364,7 @@ describe('V2 Wallet:', function () {
     it('should pass maxFeeRate parameter when calling sweep wallets', async function () {
       const path = `/api/v2/${wallet.coin()}/wallet/${wallet.id()}/sweepWallet`;
       const response = nock(bgUrl)
-        .post(path, _.matches({ address, maxFeeRate })) // use _.matches to do a partial match on request body object instead of strict matching
+        .post(path, _.matches({ address, maxFeeRate, txFormat: 'psbt' })) // use _.matches to do a partial match on request body object instead of strict matching
         .reply(200);
 
       try {
@@ -1413,7 +1413,7 @@ describe('V2 Wallet:', function () {
     it('should pass allowPartialSweep parameter when calling sweep wallets', async function () {
       const path = `/api/v2/${wallet.coin()}/wallet/${wallet.id()}/sweepWallet`;
       const response = nock(bgUrl)
-        .post(path, _.matches({ address, allowPartialSweep })) // use _.matches to do a partial match on request body object instead of strict matching
+        .post(path, _.matches({ address, allowPartialSweep, txFormat: 'psbt' })) // use _.matches to do a partial match on request body object instead of strict matching
         .reply(200);
 
       try {

--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -1323,8 +1323,9 @@ describe('V2 Wallet:', function () {
 
     it('should pass maxFeeRate parameter when consolidating unspents', async function () {
       const path = `/api/v2/${wallet.coin()}/wallet/${wallet.id()}/consolidateUnspents`;
+      // When doing option=BUILD_SIGN_SEND, we automatically set txFormat='psbt'
       const response = nock(bgUrl)
-        .post(path, _.matches({ maxFeeRate })) // use _.matches to do a partial match on request body object instead of strict matching
+        .post(path, _.matches({ maxFeeRate, txFormat: 'psbt' })) // use _.matches to do a partial match on request body object instead of strict matching
         .reply(200);
 
       nock(bgUrl)
@@ -1379,7 +1380,7 @@ describe('V2 Wallet:', function () {
     it('should pass maxFeeRate parameter when calling fanout unspents', async function () {
       const path = `/api/v2/${wallet.coin()}/wallet/${wallet.id()}/fanoutUnspents`;
       const response = nock(bgUrl)
-        .post(path, _.matches({ maxFeeRate })) // use _.matches to do a partial match on request body object instead of strict matching
+        .post(path, _.matches({ maxFeeRate, txFormat: 'psbt' })) // use _.matches to do a partial match on request body object instead of strict matching
         .reply(200);
 
       try {

--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -1230,6 +1230,7 @@ describe('V2 Wallet:', function () {
         maxFee: 1,
       };
 
+      // Should always pass through txFormat='psbt'
       const prebuildReturn = Object.assign({ txHex: '123' }, params);
       const prebuildStub = sinon.stub(wallet, 'prebuildAndSignTransaction').resolves(prebuildReturn);
 
@@ -1238,9 +1239,9 @@ describe('V2 Wallet:', function () {
         .post(path, _.matches(prebuildReturn))
         .reply(200);
 
-      await wallet.accelerateTransaction(params);
-
-      prebuildStub.should.have.been.calledOnceWith(params);
+      // Make a deep copy of the params because the function mutates the object
+      await wallet.accelerateTransaction(JSON.parse(JSON.stringify(params)));
+      prebuildStub.should.be.calledOnceWith({ ...params, txFormat: 'psbt', recipients: [] });
 
       sinon.restore();
     });

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -629,7 +629,7 @@ export class Wallet implements IWallet {
     common.validateParams(params, [], ['walletPassphrase', 'xprv']);
 
     const reqId = new RequestTracer();
-    const filteredParams = _.pick(params, [
+    let filteredParams = _.pick(params, [
       'feeRate',
       'maxFeeRate',
       'maxFeePercentage',
@@ -646,6 +646,12 @@ export class Wallet implements IWallet {
       routeName === 'consolidate' ? 'limit' : 'maxNumInputsToUse',
       'numUnspentsToMake',
     ]);
+
+    // If we are not returning the txPrebuild, we can force the txFormat='psbt'
+    if (option === ManageUnspentsOptions.BUILD_SIGN_SEND) {
+      filteredParams = { ...filteredParams, txFormat: 'psbt' };
+    }
+
     this.bitgo.setRequestTracer(reqId);
     const response = await this.bitgo
       .post(this.url(`/${routeName}Unspents`))

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -832,7 +832,6 @@ export class Wallet implements IWallet {
     common.validateParams(params, ['address'], ['walletPassphrase', 'xprv', 'otp']);
 
     // The sweep API endpoint is only available to utxo-based coins
-
     if (!this.baseCoin.sweepWithSendMany()) {
       if (this.confirmedBalanceString() !== this.balanceString()) {
         throw new Error(
@@ -2065,8 +2064,7 @@ export class Wallet implements IWallet {
       Object.assign(selectParams, extraParams);
       return await this.bitgo.post(this.url('/tx/initiate')).send(selectParams).result();
     }
-
-    const halfSignedTransaction = await this.prebuildAndSignTransaction(params);
+    const halfSignedTransaction = await this.prebuildAndSignTransaction({ ...params, txFormat: 'psbt' });
     const finalTxParams = _.extend({}, halfSignedTransaction, selectParams);
 
     return this.bitgo.post(this.url('/tx/send')).send(finalTxParams).result();

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -869,7 +869,10 @@ export class Wallet implements IWallet {
       'allowPartialSweep',
     ]);
     this.bitgo.setRequestTracer(reqId);
-    const response = await this.bitgo.post(this.url('/sweepWallet')).send(filteredParams).result();
+    const response = await this.bitgo
+      .post(this.url('/sweepWallet'))
+      .send({ ...filteredParams, txFormat: 'psbt' })
+      .result();
 
     // TODO(BG-3588): add txHex validation to protect man in the middle attacks replacing the txHex
 

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -1923,7 +1923,7 @@ export class Wallet implements IWallet {
     params.recipients = [];
 
     // We must pass the build params through to submit in case the CPFP tx ever has to be rebuilt.
-    const submitParams = Object.assign(params, await this.prebuildAndSignTransaction(params));
+    const submitParams = Object.assign(params, await this.prebuildAndSignTransaction({ ...params, txFormat: 'psbt' }));
     delete (submitParams as any).wallet;
     return await this.submitTransaction(submitParams);
   }


### PR DESCRIPTION
When we are not returning the build result, use `txFormat='psbt'` when building UTXO transactions.

Done for:
- `accelerateTransaction`
- `sweepWallet`
- `fanoutUnspents`
- `consolidateUnspents`
- `sendMany`

All of these routes have PSBT support in WP

[BG-79255](https://bitgoinc.atlassian.net/browse/BG-79255)
<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->

[BG-79255]: https://bitgoinc.atlassian.net/browse/BG-79255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ