### PR TITLE
fix(sdk-coin-sui): fix unstaking again

### DIFF
--- a/modules/sdk-coin-sui/src/lib/mystenlab/builder/Inputs.ts
+++ b/modules/sdk-coin-sui/src/lib/mystenlab/builder/Inputs.ts
@@ -35,7 +35,7 @@ export const Inputs = {
   },
 };
 
-export function getIdFromCallArg(arg: ObjectId | ObjectCallArg) {
+export function getIdFromCallArg(arg: ObjectId | ObjectCallArg): string {
   if (typeof arg === 'string') {
     return normalizeSuiAddress(arg);
   }

--- a/modules/sdk-coin-sui/src/lib/utils.ts
+++ b/modules/sdk-coin-sui/src/lib/utils.ts
@@ -26,9 +26,18 @@ import {
   SuiJsonValue,
   SuiObjectRef,
 } from './mystenlab/types';
-import { builder, TransactionBlockInput, TransactionType as TransactionCommandType } from './mystenlab/builder';
+import {
+  builder,
+  ObjectCallArg,
+  TransactionBlockInput,
+  TransactionType as TransactionCommandType,
+} from './mystenlab/builder';
 import { SIGNATURE_SCHEME_TO_FLAG } from './keyPair';
 import blake2b from '@bitgo/blake2b';
+
+export function isImmOrOwnedObj(obj: ObjectCallArg['Object']): obj is { ImmOrOwned: SuiObjectRef } {
+  return 'ImmOrOwned' in obj;
+}
 
 export class Utils implements BaseUtils {
   /** @inheritdoc */

--- a/modules/sdk-coin-sui/test/local_fullnode/transactions.ts
+++ b/modules/sdk-coin-sui/test/local_fullnode/transactions.ts
@@ -96,7 +96,7 @@ async function getStakes(
   if (result.length) {
     return result;
   }
-  const { attempts = 10, sleepMs = 1000 } = params;
+  const { attempts = 60, sleepMs = 1000 } = params;
   if (0 < attempts) {
     await new Promise((resolve) => setTimeout(resolve, sleepMs));
     return await getStakes(conn, owner, { ...params, attempts: attempts - 1, sleepMs });

--- a/modules/sdk-coin-sui/test/resources/sui.ts
+++ b/modules/sdk-coin-sui/test/resources/sui.ts
@@ -261,8 +261,8 @@ export const txInputWithdrawStaked = [
     value: {
       Object: {
         ImmOrOwned: {
-          objectId: 'ee6dfc3da32e21541a2aeadfcd250f8a0a23bb7abda9c8988407fc32068c3746',
-          version: '1121',
+          objectId: '0xee6dfc3da32e21541a2aeadfcd250f8a0a23bb7abda9c8988407fc32068c3746',
+          version: 1121,
           digest: 'EZ5yqap5XJJy9KhnW3dsbE73UmC5bd1KBEx7eQ5k4HNT',
         },
       },
@@ -295,8 +295,8 @@ export const txTransactionsWithdrawStaked = [
         value: {
           Object: {
             ImmOrOwned: {
-              objectId: 'ee6dfc3da32e21541a2aeadfcd250f8a0a23bb7abda9c8988407fc32068c3746',
-              version: '1121',
+              objectId: '0xee6dfc3da32e21541a2aeadfcd250f8a0a23bb7abda9c8988407fc32068c3746',
+              version: 1121,
               digest: 'EZ5yqap5XJJy9KhnW3dsbE73UmC5bd1KBEx7eQ5k4HNT',
             },
           },


### PR DESCRIPTION
We need to be able to rebuild the unstaking transaction from some intermediary
format. Implement this feature and add tests.

Issue: BG-78857


<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->