### PR TITLE
chore(commitlint): add WIN to issue prefix

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -50,6 +50,7 @@ module.exports = {
         "STLX-",
         "TRUST-",
         "VL-",
+        "WIN-",
         "WP-",
         '#', // Prefix used by GitHub issues
       ],


### PR DESCRIPTION
Ticket: BG-00000

Since we're using new issue prefixes for onboarding cosmos side chains, our existing commit lint file in SDK cannot recognize it