### PR TITLE
feat(abstract-utxo): support express external signer for musig2 inputs

### DIFF
--- a/modules/bitgo/test/v2/unit/coins/utxo/transaction.ts
+++ b/modules/bitgo/test/v2/unit/coins/utxo/transaction.ts
@@ -22,6 +22,8 @@ import {
   transactionHexToObj,
   createPrebuildTransaction,
   getDefaultWalletKeys,
+  getUtxoCoin,
+  keychainsBase58,
 } from './util';
 
 import {
@@ -40,6 +42,202 @@ type WalletUnspent<TNumber extends number | bigint = number> = bitgo.WalletUnspe
 function getScriptTypes2Of3() {
   return [...bitgo.outputScripts.scriptTypes2Of3, 'taprootKeyPathSpend'] as const;
 }
+
+describe(`UTXO coin signTransaction`, async function () {
+  const bgUrl = common.Environments[TestBitGo.decorate(BitGo, { env: 'mock' }).getEnv()].uri;
+
+  const coin = getUtxoCoin('btc');
+  const wallet = getUtxoWallet(coin, { id: '5b34252f1bf349930e34020a00000000', coin: coin.getChain() });
+  const rootWalletKeys = getDefaultWalletKeys();
+  const userPrv = rootWalletKeys.user.toBase58();
+  const pubs = keychainsBase58.map((v) => v.pub) as Triple<string>;
+
+  function validatePsbt(txHex: string, targetSigCount: 0 | 1, targetNonceCount?: 1 | 2) {
+    const psbt = utxolib.bitgo.createPsbtFromHex(txHex, coin.network);
+    psbt.data.inputs.forEach((input, index) => {
+      const parsed = utxolib.bitgo.parsePsbtInput(input);
+      if (parsed.scriptType === 'taprootKeyPathSpend') {
+        assert.ok(targetNonceCount);
+        const nonce = psbt.getProprietaryKeyVals(index, {
+          identifier: utxolib.bitgo.PSBT_PROPRIETARY_IDENTIFIER,
+          subtype: utxolib.bitgo.ProprietaryKeySubtype.MUSIG2_PUB_NONCE,
+        });
+        assert.strictEqual(nonce.length, targetNonceCount);
+      }
+      const expectedSigCount = parsed.scriptType === 'p2shP2pk' || targetSigCount === 0 ? undefined : 1;
+      assert.strictEqual(parsed.signatures?.length, expectedSigCount);
+    });
+  }
+
+  function validateTx(txHex: string, unspents: Unspent<bigint>[], targetSigCount: 0 | 1) {
+    const tx = utxolib.bitgo.createTransactionFromHex(txHex, coin.network);
+    unspents.forEach((u, i) => {
+      const sigCount = utxolib.bitgo.getStrictSignatureCount(tx.ins[i]);
+      const expectedSigCount = utxolib.bitgo.isWalletUnspent(u) && !!targetSigCount ? 1 : 0;
+      assert.strictEqual(sigCount, expectedSigCount);
+    });
+  }
+
+  async function signTransaction(
+    tx: utxolib.bitgo.UtxoPsbt | utxolib.bitgo.UtxoTransaction<bigint>,
+    useSigningSteps: boolean,
+    unspents?: Unspent<bigint>[]
+  ) {
+    const isPsbt = tx instanceof utxolib.bitgo.UtxoPsbt;
+    const isTxWithTaprootKeyPathSpend = isPsbt && utxolib.bitgo.isTransactionWithKeyPathSpendInput(tx);
+    const txHex = tx.toHex();
+
+    function nockSignPsbt(psbtHex: string): nock.Scope {
+      const psbt = utxolib.bitgo.createPsbtFromHex(psbtHex, coin.network);
+      return nock(bgUrl)
+        .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/signpsbt`, (body) => body.psbt)
+        .reply(200, { psbt: psbt.setAllInputsMusig2NonceHD(rootWalletKeys.bitgo).toHex() });
+    }
+
+    if (!useSigningSteps) {
+      let scope: nock.Scope | undefined;
+      if (tx instanceof utxolib.bitgo.UtxoPsbt && isTxWithTaprootKeyPathSpend) {
+        scope = nockSignPsbt(tx.clone().setAllInputsMusig2NonceHD(rootWalletKeys.bitgo).toHex());
+      }
+      const psbt = await coin.signTransaction({
+        txPrebuild: {
+          txHex,
+          txInfo: isPsbt ? undefined : { unspents },
+          walletId: isTxWithTaprootKeyPathSpend ? wallet.id() : undefined,
+        },
+        prv: userPrv,
+        pubs: isPsbt ? undefined : pubs,
+      });
+      assert.ok('txHex' in psbt);
+      if (isPsbt) {
+        validatePsbt(psbt.txHex, 1, 2);
+      } else {
+        assert(unspents);
+        validateTx(psbt.txHex, unspents, 1);
+      }
+      if (scope) {
+        assert.strictEqual(scope.isDone(), true);
+      }
+      return;
+    }
+
+    const signerNoncePsbt = await coin.signTransaction({
+      txPrebuild: { txHex },
+      prv: userPrv,
+      signingStep: 'signerNonce',
+    });
+    assert.ok('txHex' in signerNoncePsbt);
+    if (isPsbt) {
+      validatePsbt(signerNoncePsbt.txHex, 0, isTxWithTaprootKeyPathSpend ? 1 : undefined);
+    } else {
+      assert(unspents);
+      validateTx(signerNoncePsbt.txHex, unspents, 0);
+    }
+
+    let scope: nock.Scope | undefined;
+    if (isTxWithTaprootKeyPathSpend) {
+      scope = nockSignPsbt(signerNoncePsbt.txHex);
+    }
+
+    const cosignerNoncePsbt = await coin.signTransaction({
+      txPrebuild: { ...signerNoncePsbt, walletId: wallet.id() },
+      signingStep: 'cosignerNonce',
+    });
+    assert.ok('txHex' in cosignerNoncePsbt);
+    if (isPsbt) {
+      validatePsbt(cosignerNoncePsbt.txHex, 0, isTxWithTaprootKeyPathSpend ? 2 : undefined);
+    } else {
+      assert(unspents);
+      validateTx(cosignerNoncePsbt.txHex, unspents, 0);
+    }
+
+    if (scope) {
+      assert.strictEqual(scope.isDone(), true);
+    }
+
+    const signerSigPsbt = await coin.signTransaction({
+      txPrebuild: { ...cosignerNoncePsbt, txInfo: isPsbt ? undefined : { unspents } },
+      prv: userPrv,
+      pubs: isPsbt ? undefined : pubs,
+      signingStep: 'signerSignature',
+    });
+    assert.ok('txHex' in signerSigPsbt);
+    if (isPsbt) {
+      validatePsbt(signerSigPsbt.txHex, 1, isTxWithTaprootKeyPathSpend ? 2 : undefined);
+    } else {
+      assert(unspents);
+      validateTx(signerSigPsbt.txHex, unspents, 1);
+    }
+  }
+
+  it('success when called like customSigningFunction flow - PSBT with taprootKeyPathSpend inputs', async function () {
+    const inputs: testutil.Input[] = testutil.inputScriptTypes.map((scriptType) => ({
+      scriptType,
+      value: BigInt(1000),
+    }));
+    const unspentSum = inputs.reduce((prev: bigint, curr) => prev + curr.value, BigInt(0));
+    const outputs: testutil.Output[] = [{ scriptType: 'p2sh', value: unspentSum - BigInt(1000) }];
+    const psbt = testutil.constructPsbt(inputs, outputs, coin.network, rootWalletKeys, 'unsigned');
+
+    for (const v of [false, true]) {
+      await signTransaction(psbt, v);
+    }
+  });
+
+  it('success when called like customSigningFunction flow - PSBT without taprootKeyPathSpend inputs', async function () {
+    const inputs: testutil.Input[] = testutil.inputScriptTypes
+      .filter((v) => v !== 'taprootKeyPathSpend')
+      .map((scriptType) => ({
+        scriptType,
+        value: BigInt(1000),
+      }));
+    const unspentSum = inputs.reduce((prev: bigint, cur) => prev + cur.value, BigInt(0));
+    const outputs: testutil.Output[] = [{ scriptType: 'p2sh', value: unspentSum - BigInt(1000) }];
+    const psbt = testutil.constructPsbt(inputs, outputs, coin.network, rootWalletKeys, 'unsigned');
+
+    for (const v of [false, true]) {
+      await signTransaction(psbt, v);
+    }
+  });
+
+  it('success when called like customSigningFunction flow - Network Tx', async function () {
+    const inputs: testutil.TxnInput<bigint>[] = testutil.txnInputScriptTypes
+      .filter((v) => v !== 'p2shP2pk')
+      .map((scriptType) => ({
+        scriptType,
+        value: BigInt(1000),
+      }));
+    const unspentSum = inputs.reduce((prev: bigint, curr) => prev + curr.value, BigInt(0));
+    const outputs: testutil.TxnOutput<bigint>[] = [{ scriptType: 'p2sh', value: unspentSum - BigInt(1000) }];
+    const txBuilder = testutil.constructTxnBuilder(inputs, outputs, coin.network, rootWalletKeys, 'unsigned');
+    const unspents = inputs.map((v, i) => testutil.toTxnUnspent(v, i, coin.network, rootWalletKeys));
+
+    for (const v of [false, true]) {
+      await signTransaction(txBuilder.buildIncomplete(), v, unspents);
+    }
+  });
+
+  it('fails when called like customSigningFunction flow - PSBT cache miss', async function () {
+    const inputs: testutil.Input[] = [{ scriptType: 'taprootKeyPathSpend', value: BigInt(1000) }];
+    const unspentSum = inputs.reduce((prev: bigint, curr) => prev + curr.value, BigInt(0));
+    const outputs: testutil.Output[] = [{ scriptType: 'p2sh', value: unspentSum - BigInt(1000) }];
+    const psbt = testutil.constructPsbt(inputs, outputs, coin.network, rootWalletKeys, 'unsigned');
+
+    await assert.rejects(
+      async () => {
+        await coin.signTransaction({
+          txPrebuild: { txHex: psbt.toHex() },
+          prv: userPrv,
+          signingStep: 'signerSignature',
+        });
+      },
+      {
+        message: `Psbt is missing from txCache (cache size 0).
+            This may be due to the request being routed to a different BitGo-Express instance that for signing step 'signerNonce'.`,
+      }
+    );
+  });
+});
 
 function run<TNumber extends number | bigint = number>(
   coin: AbstractUtxoCoin,

--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -435,6 +435,9 @@ export async function handleV2SignTSSWalletTx(req: express.Request) {
   }
 }
 
+/**
+ * This route is used to sign while external express signer is enabled
+ */
 export async function handleV2Sign(req: express.Request) {
   const walletId = req.body.txPrebuild?.walletId;
 

--- a/modules/sdk-coin-doge/src/doge.ts
+++ b/modules/sdk-coin-doge/src/doge.ts
@@ -119,7 +119,7 @@ export class Doge extends AbstractUtxoCoin {
       ...params,
       txPrebuild: {
         ...params.txPrebuild,
-        txInfo: parseTransactionInfo(params.txPrebuild.txInfo),
+        txInfo: params.txPrebuild.txInfo === undefined ? undefined : parseTransactionInfo(params.txPrebuild.txInfo),
       },
     });
   }

--- a/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
@@ -7,7 +7,7 @@ import { IPendingApprovals } from '../pendingApproval';
 import { InitiateRecoveryOptions } from '../recovery';
 import { EcdsaUtils } from '../utils/tss/ecdsa';
 import EddsaUtils from '../utils/tss/eddsa';
-import { IWallet, IWallets, Wallet, WalletData } from '../wallet';
+import { CustomSigningFunction, IWallet, IWallets, Wallet, WalletData } from '../wallet';
 
 import { IWebhooks } from '../webhook/iWebhooks';
 import { BaseTokenConfig } from '@bitgo/statics';
@@ -451,6 +451,10 @@ export interface IBaseCoin {
   getExtraPrebuildParams(buildParams: ExtraPrebuildParamsOptions): Promise<Record<string, unknown>>;
   postProcessPrebuild(prebuildResponse: TransactionPrebuild): Promise<TransactionPrebuild>;
   presignTransaction(params: PresignTransactionOptions): Promise<PresignTransactionOptions>;
+  signWithCustomSigningFunction?(
+    customSigningFunction: CustomSigningFunction,
+    signTransactionParams: { txPrebuild: TransactionPrebuild; pubs?: string[] }
+  ): Promise<SignedTransaction>;
   newWalletObject(walletParams: any): IWallet;
   feeEstimate(params: FeeEstimateOptions): Promise<any>;
   deriveKeyWithSeed(params: DeriveKeyWithSeedOptions): { key: string; derivationPath: string };

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -1624,12 +1624,15 @@ export class Wallet implements IWallet {
 
     const signTransactionParams = {
       ...presign,
-      txPrebuild,
+      txPrebuild: { ...txPrebuild, walletId: this.id() },
       pubs,
       coin: this.baseCoin,
     };
 
     if (_.isFunction(params.customSigningFunction)) {
+      if (typeof this.baseCoin.signWithCustomSigningFunction === 'function') {
+        return this.baseCoin.signWithCustomSigningFunction(params.customSigningFunction, signTransactionParams);
+      }
       return params.customSigningFunction(signTransactionParams);
     }
     return this.baseCoin.signTransaction({


### PR DESCRIPTION
Express external signer requires 2 calls to it for musig2 inputs.
This enables external signer support to consolidate and fanout unspents.

IMPORTANT NOTE this change assumes that external express signer and
its caller maintain sticky sessions.

Ticket: BTC-276

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->