### PR TITLE
feat(sdk-coin-xlm): adding txHex to explainTransaction params for xlm

### DIFF
--- a/modules/sdk-coin-xlm/test/unit/xlm.ts
+++ b/modules/sdk-coin-xlm/test/unit/xlm.ts
@@ -171,6 +171,57 @@ describe('XLM:', function () {
     unsignedExplanation.changeAmount.should.equal('0');
   });
 
+  it('Should explain an XLM transaction', async function () {
+    const signedExplanation = await basecoin.explainTransaction({
+      txBase64:
+        'AAAAAMDHAbd3O7B2auR1e+EH/LRKe8IcQBOF+XP2lOxWi1PfAAAB9AAEvJEAAAABAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABAAAAB1RFU1RJTkcAAAAAAQAAAAAAAAABAAAAALgEl4p84728zfXtl/JdOsx3QbI97mcybqcXdfgdv54zAAAAAAAAAAEqBfIAAAAAAAAAAAFWi1PfAAAAQDoqo7juOBZawMlk8znIbYqSKemjgmINosp/P4+0SFGo/xJy1YgD6YEc65aWuyBxucFFBXCSlAxP2Z7nPMyjewM=',
+    });
+    signedExplanation.outputAmount.should.equal('5000000000');
+    signedExplanation.outputAmounts.should.have.property('txlm', '5000000000');
+    signedExplanation.outputs.length.should.equal(1);
+    signedExplanation.outputs[0].address.should.equal('GC4AJF4KPTR33PGN6XWZP4S5HLGHOQNSHXXGOMTOU4LXL6A5X6PDH445');
+    signedExplanation.outputs[0].amount.should.equal('5000000000');
+    signedExplanation.outputs[0].coin.should.equal('txlm');
+    signedExplanation.fee.fee.should.equal('500');
+    signedExplanation.memo.value.should.equal('TESTING');
+    signedExplanation.memo.type.should.equal('text');
+    signedExplanation.changeOutputs.length.should.equal(0);
+    signedExplanation.changeAmount.should.equal('0');
+    const unsignedExplanation = await basecoin.explainTransaction({
+      txBase64:
+        'AAAAAMDHAbd3O7B2auR1e+EH/LRKe8IcQBOF+XP2lOxWi1PfAAAAZAAEvJEAAAACAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAEAAAABAAAAAAAAAAEAAAAAuASXinzjvbzN9e2X8l06zHdBsj3uZzJupxd1+B2/njMAAAAAAAAAAlQL5AAAAAAAAAAAAA==',
+    });
+    unsignedExplanation.outputAmount.should.equal('10000000000');
+    unsignedExplanation.outputAmounts.should.have.property('txlm', '10000000000');
+    unsignedExplanation.outputs.length.should.equal(1);
+    unsignedExplanation.outputs[0].address.should.equal('GC4AJF4KPTR33PGN6XWZP4S5HLGHOQNSHXXGOMTOU4LXL6A5X6PDH445');
+    unsignedExplanation.outputs[0].amount.should.equal('10000000000');
+    unsignedExplanation.outputs[0].coin.should.equal('txlm');
+    unsignedExplanation.fee.fee.should.equal('100');
+    unsignedExplanation.memo.value.should.equal('1');
+    unsignedExplanation.memo.type.should.equal('id');
+    unsignedExplanation.changeOutputs.length.should.equal(0);
+    unsignedExplanation.changeAmount.should.equal('0');
+  });
+
+  it('Should explain an XLM transaction by passing in a hex format', async function () {
+    const signedExplanation = await basecoin.explainTransaction({
+      txHex:
+        '0000000200000000aa0c5c593ed36af12269dc4605dd34da32fdab5c676fa0644f28e598dd57512a0000afc800000000009896810000000100000000000000000000000000000000000000000000000100000000000000010000010000000000000000010a76d14eccfd0072c997b12189beb926473ff0f01c72957432db5678b8feb945000000000000000005f5e1000000000000000000',
+    });
+    signedExplanation.outputAmount.should.equal('100000000');
+    signedExplanation.outputAmounts.should.have.property('txlm', '100000000');
+    signedExplanation.outputs.length.should.equal(1);
+    signedExplanation.outputs[0].address.should.equal(
+      'MAFHNUKOZT6QA4WJS6YSDCN6XETEOP7Q6AOHFFLUGLNVM6FY724UKAAAAAAAAAAAAEJCO'
+    );
+    signedExplanation.outputs[0].amount.should.equal('100000000');
+    signedExplanation.outputs[0].coin.should.equal('txlm');
+    signedExplanation.fee.fee.should.equal('45000');
+    signedExplanation.changeOutputs.length.should.equal(0);
+    signedExplanation.changeAmount.should.equal('0');
+  });
+
   it('Should explain a trustline transaction', async function () {
     const explanation = await basecoin.explainTransaction({
       txBase64:


### PR DESCRIPTION
For the migration to HSMv3, we have a new wallet recovery flow. In BGA we've made changes to the recovery flow for v3 that involve using `explainTransaction` and expect a transaction hex as input. We need to adapt XLM for this reason to accept `txHex` as input in it's coin specific `explainTransaction` method.
<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->