### PR TITLE
fix(statics): updated ADA block explorer url

### DIFF
--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -120,7 +120,7 @@ class Ada extends Mainnet implements AdaNetwork {
   utxolibName = 'cardano';
   poolDeposit = 500000000;
   stakeKeyDeposit = 2000000;
-  explorerUrl = 'https://explorer.cardano.org/en';
+  explorerUrl = 'https://explorer.cardano.org/en/';
   coinsPerUtxoWord = 34482;
   maxTransactionSize = 8000;
   maxValueSize = 4000;


### PR DESCRIPTION
- missing trailing slash on ADA block explorer url

[CE-985]: https://bitgoinc.atlassian.net/browse/CE-985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Ticket: [CE-985](https://bitgoinc.atlassian.net/browse/CE-985)