### PR TITLE
fix(statics): update BTC/TBTC block explorer

### DIFF
--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -228,14 +228,14 @@ class Bitcoin extends Mainnet implements UtxoNetwork {
   name = 'Bitcoin';
   family = CoinFamily.BTC;
   utxolibName = 'bitcoin';
-  explorerUrl = 'https://blockstream.info/tx/';
+  explorerUrl = 'https://mempool.space/tx/';
 }
 
 class BitcoinTestnet extends Testnet implements UtxoNetwork {
   name = 'BitcoinTestnet';
   family = CoinFamily.BTC;
   utxolibName = 'testnet';
-  explorerUrl = 'https://blockstream.info/testnet/tx/';
+  explorerUrl = 'https://mempool.space/testnet/tx/';
 }
 
 class BitcoinCash extends Mainnet implements UtxoNetwork {


### PR DESCRIPTION
- update explorer url for BTC and TBTC

Ticket: [CE-398](https://bitgoinc.atlassian.net/browse/CE-398)

[CE-398]: https://bitgoinc.atlassian.net/browse/CE-398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ