### PR TITLE
fix(sdk-coin-ada): cosmetic signature array might duplicate

### DIFF
--- a/modules/sdk-coin-ada/src/lib/transactionBuilder.ts
+++ b/modules/sdk-coin-ada/src/lib/transactionBuilder.ts
@@ -291,6 +291,9 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
       );
       vkeyWitnesses.add(vkeyWitness);
     });
+
+    // Clear the cosmetic signature array in native txn wrapper to prevent duplicate when builder is inited from a partially witnessed txn
+    this._transaction.signature.length = 0;
     this.getAllSignatures().forEach((signature) => {
       const vkey = CardanoWasm.Vkey.new(CardanoWasm.PublicKey.from_bytes(Buffer.from(signature.publicKey.pub, 'hex')));
       const ed255Sig = CardanoWasm.Ed25519Signature.from_bytes(signature.signature);

--- a/modules/sdk-coin-ada/test/unit/stakingPledgeBuilder.ts
+++ b/modules/sdk-coin-ada/test/unit/stakingPledgeBuilder.ts
@@ -78,11 +78,12 @@ describe('ADA Staking Pledge Transaction Builder', async () => {
     rebuiltTx.toBroadcastFormat().should.not.equal(rawTx.unsignedUpdatePledgeTx);
   });
 
-  it('should init partially signed txn hex and preserver the signature', async () => {
+  it('should init from partially signed txn hex and preserve the signature', async () => {
     const txnBuilderFactory = new TransactionBuilderFactory(coins.get('tada'));
     const txnBuilder = txnBuilderFactory.from(rawTx.partiallySignedPledgeTx);
     let tx = (await txnBuilder.build()) as Transaction;
     tx.type.should.equal(TransactionType.StakingPledge);
+    tx.signature.length.should.equal(1);
     let txData = tx.toJson();
     txData.witnesses.length.should.equal(1);
     txData.witnesses[0].publicKey.should.equal(rawTx.pledgeNodeKeyPubkey);
@@ -97,5 +98,22 @@ describe('ADA Staking Pledge Transaction Builder', async () => {
     txData.witnesses[0].signature.should.equal(rawTx.pledgeNodeWitnessSignature);
     txData.witnesses[1].publicKey.should.equal(rawTx.pledgeNodeKeyPubkey);
     txData.witnesses[1].signature.should.equal(rawTx.pledgeNodeWitnessSignature);
+  });
+
+  it('should init from partially signed txn object and preserve the signature', async () => {
+    const prebuiltTx = new Transaction(coins.get('tada'));
+    prebuiltTx.fromRawTransaction(rawTx.partiallySignedPledgeTx);
+    prebuiltTx.toBroadcastFormat().should.equal(rawTx.partiallySignedPledgeTx);
+    prebuiltTx.signature.length.should.equal(1);
+    const txBuilder = factory.getStakingPledgeBuilder();
+    txBuilder.initBuilder(prebuiltTx);
+    const tx = (await txBuilder.build()) as Transaction;
+    tx.type.should.equal(TransactionType.StakingPledge);
+    tx.toBroadcastFormat().should.equal(rawTx.partiallySignedPledgeTx);
+    tx.signature.length.should.equal(1);
+    const txData = tx.toJson();
+    txData.witnesses.length.should.equal(1);
+    txData.witnesses[0].publicKey.should.equal(rawTx.pledgeNodeKeyPubkey);
+    txData.witnesses[0].signature.should.equal(rawTx.pledgeNodeWitnessSignature);
   });
 });


### PR DESCRIPTION
The signature array of native txn wrapper might duplicate in certain cases. This does not affect the broadcast HEX since the HEX is calculated from native txn.

EA-621

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->