### PR TITLE
fix(wrw): fix uploading unsigned sweep tx for sol, dot and ada

### DIFF
--- a/modules/sdk-coin-ada/src/ada.ts
+++ b/modules/sdk-coin-ada/src/ada.ts
@@ -55,6 +55,7 @@ interface RecoveryOptions {
 interface AdaTx {
   serializedTx: string;
   scanIndex: number;
+  coin?: string;
 }
 
 export type AdaTransactionExplanation = TransactionExplanation;
@@ -381,6 +382,8 @@ export class Ada extends BaseCoin {
         txBuilder.addSignature({ pub: adaKeyPair.getKeys().pub }, signatureHex);
         const signedTransaction = await txBuilder.build();
         serializedTx = signedTransaction.toBroadcastFormat();
+      } else {
+        return { serializedTx: serializedTx, scanIndex: i, coin: this.getChain() };
       }
       return { serializedTx: serializedTx, scanIndex: i };
     }

--- a/modules/sdk-coin-dot/src/dot.ts
+++ b/modules/sdk-coin-dot/src/dot.ts
@@ -62,6 +62,7 @@ interface RecoveryOptions {
 interface DotTx {
   serializedTx: string;
   scanIndex: number;
+  coin?: string;
 }
 
 const dotUtils = Utils.default;
@@ -441,6 +442,8 @@ export class Dot extends BaseCoin {
         txnBuilder.addSignature({ pub: dotKeyPair.getKeys().pub }, signatureHex);
         const signedTransaction = await txnBuilder.build();
         serializedTx = signedTransaction.toBroadcastFormat();
+      } else {
+        return { serializedTx: serializedTx, scanIndex: i, coin: this.getChain() };
       }
       return { serializedTx: serializedTx, scanIndex: i };
     }

--- a/modules/sdk-coin-sol/src/sol.ts
+++ b/modules/sdk-coin-sol/src/sol.ts
@@ -104,6 +104,7 @@ export interface SolParseTransactionOptions extends BaseParseTransactionOptions 
 interface SolTx {
   serializedTx: string;
   scanIndex: number;
+  coin?: string;
 }
 
 interface SolDurableNonceFromNode {
@@ -709,6 +710,13 @@ export class Sol extends BaseCoin {
 
     const completedTransaction = await txBuilder.build();
     const serializedTx = completedTransaction.toBroadcastFormat();
+    if (isUnsignedSweep) {
+      return {
+        serializedTx: serializedTx,
+        scanIndex: scanIndex,
+        coin: this.getChain(),
+      };
+    }
     return {
       serializedTx: serializedTx,
       scanIndex: scanIndex,


### PR DESCRIPTION
Added in missing coin field needed by ovc to upload unsigned sweep transactions for signing.

TICKET: WP-155