### PR TITLE
fix(sdk-core): Use PrebuiltTx with Tss Full SendMany

### DIFF
--- a/examples/ts/list-wallets.ts
+++ b/examples/ts/list-wallets.ts
@@ -7,18 +7,17 @@
  *
  * Copyright 2022, BitGo, Inc.  All Rights Reserved.
  */
-import { BitGoAPI } from "../BitGoJS/modules/sdk-api";
-import { Gteth } from "../BitGoJS/modules/sdk-coin-eth";
-// import { Tbtc } from '@bitgo/sdk-coin-btc';
-// require('dotenv').config({ path: '../../.env' });
+import { BitGoAPI } from '@bitgo/sdk-api';
+import { Tbtc } from '@bitgo/sdk-coin-btc';
+require('dotenv').config({ path: '../../.env' });
 
 const bitgo = new BitGoAPI({
   accessToken: process.env.TESTNET_ACCESS_TOKEN,
   env: 'test',
 });
 
-const coin = 'gteth';
-bitgo.register(coin, Gteth.createInstance);
+const coin = 'tbtc';
+bitgo.register(coin, Tbtc.createInstance);
 
 async function main() {
   const wallets = await bitgo.coin(coin).wallets().list({});

--- a/examples/ts/list-wallets.ts
+++ b/examples/ts/list-wallets.ts
@@ -7,17 +7,18 @@
  *
  * Copyright 2022, BitGo, Inc.  All Rights Reserved.
  */
-import { BitGoAPI } from '@bitgo/sdk-api';
-import { Tbtc } from '@bitgo/sdk-coin-btc';
-require('dotenv').config({ path: '../../.env' });
+import { BitGoAPI } from "../BitGoJS/modules/sdk-api";
+import { Gteth } from "../BitGoJS/modules/sdk-coin-eth";
+// import { Tbtc } from '@bitgo/sdk-coin-btc';
+// require('dotenv').config({ path: '../../.env' });
 
 const bitgo = new BitGoAPI({
   accessToken: process.env.TESTNET_ACCESS_TOKEN,
   env: 'test',
 });
 
-const coin = 'tbtc';
-bitgo.register(coin, Tbtc.createInstance);
+const coin = 'gteth';
+bitgo.register(coin, Gteth.createInstance);
 
 async function main() {
   const wallets = await bitgo.coin(coin).wallets().list({});

--- a/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
@@ -242,9 +242,14 @@ export interface KeychainsTriplet {
   bitgoKeychain: Keychain;
 }
 
+interface BuildParams {
+  preview?: boolean;
+  recipients?: ITransactionRecipient[];
+}
+
 interface BaseSignable {
   wallet?: IWallet;
-  buildParams?: any;
+  buildParams?: BuildParams & Partial<any>;
   consolidateId?: string;
   txRequestId?: string;
 }

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
@@ -396,4 +396,22 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
     const bitgoPublicKeyStr = response.publicKey as string;
     return readKey({ armoredKey: bitgoPublicKeyStr });
   }
+
+  /**
+   * Returns supported TxRequest versions for this wallet
+   */
+  public supportedTxRequestVersions(): TxRequestVersion[] {
+    const walletType = this._wallet?.type();
+    const supportedWalletTypes = ['custodial', 'cold', 'hot'];
+    if (!walletType || this._wallet?.multisigType() !== 'tss' || !supportedWalletTypes.includes(walletType)) {
+      return [];
+    } else if (this._wallet?.baseCoin.getMPCAlgorithm() === 'ecdsa') {
+      return ['full'];
+    } else if (walletType === 'custodial' || walletType === 'cold') {
+      return ['full'];
+    } else if (this._wallet?.baseCoin.getMPCAlgorithm() === 'eddsa' && walletType === 'hot') {
+      return ['lite', 'full'];
+    }
+    return [];
+  }
 }

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -442,4 +442,5 @@ export interface ITssUtils<KeyShare = EDDSA.KeyShare> {
   sendTxRequest(txRequestId: string): Promise<any>;
   recreateTxRequest(txRequestId: string, decryptedPrv: string, reqId: IRequestTracer): Promise<TxRequest>;
   getTxRequest(txRequestId: string): Promise<TxRequest>;
+  supportedTxRequestVersions(): TxRequestVersion[];
 }

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -627,6 +627,8 @@ export interface IWallet {
   confirmedBalanceString(): string;
   spendableBalanceString(): string;
   coin(): string;
+  type(): WalletType | undefined;
+  multisigType(): 'onchain' | 'tss';
   label(): string;
   keyIds(): string[];
   receiveAddress(): string;

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -84,6 +84,7 @@ import {
   WalletSignMessageOptions,
   WalletSignTransactionOptions,
   WalletSignTypedDataOptions,
+  WalletType,
 } from './iWallet';
 import { StakingWallet } from '../staking/stakingWallet';
 import { Lightning } from '../lightning';
@@ -102,6 +103,15 @@ export enum ManageUnspentsOptions {
   BUILD_SIGN_SEND,
 }
 
+function isPrebuildTransactionResult(
+  prebuildTx: string | PrebuildTransactionResult | undefined
+): prebuildTx is PrebuildTransactionResult {
+  if (!prebuildTx || typeof prebuildTx === 'string') {
+    return false;
+  }
+  return (prebuildTx as PrebuildTransactionResult).walletId !== undefined;
+}
+
 export class Wallet implements IWallet {
   public readonly bitgo: BitGoBase;
   public readonly baseCoin: IBaseCoin;
@@ -118,7 +128,7 @@ export class Wallet implements IWallet {
       const userDetails = _.find(walletData.users, { user: userId });
       this._permissions = _.get(userDetails, 'permissions');
     }
-    if (baseCoin?.supportsTss()) {
+    if (baseCoin?.supportsTss() && this._wallet.multisigType === 'tss') {
       switch (baseCoin.getMPCAlgorithm()) {
         case 'ecdsa':
           this.tssUtils = new EcdsaUtils(bitgo, baseCoin, this);
@@ -283,6 +293,14 @@ export class Wallet implements IWallet {
    */
   coin(): string {
     return this._wallet.coin;
+  }
+
+  type(): WalletType | undefined {
+    return this._wallet.type;
+  }
+
+  multisigType(): 'onchain' | 'tss' {
+    return this._wallet.multisigType;
   }
 
   /**
@@ -1829,15 +1847,15 @@ export class Wallet implements IWallet {
       throw error;
     }
 
-    let txPrebuildQuery;
+    let txPrebuildQuery: Promise<PrebuildTransactionResult | string>;
+    const supportedTxRequestVersions = this.tssUtils?.supportedTxRequestVersions() || [];
+    const mustUseTxRequestFull = supportedTxRequestVersions.length === 1 && supportedTxRequestVersions.includes('full');
+
     if (
-      // verify if wallet is tssFull and has prebuiltTx that can be used to send the actual transaction
-      this._wallet.multisigType === 'tss' &&
-      (this._wallet.type === 'custodial' || this.baseCoin.getMPCAlgorithm() === 'ecdsa') &&
-      params.prebuildTx &&
-      !(typeof params.prebuildTx === 'string' || params.prebuildTx instanceof String) &&
-      'preview' in params.prebuildTx.buildParams &&
-      params.prebuildTx.buildParams.preview
+      // verify the wallet must use txRequest Full api and must rebuild the tx before submitting
+      mustUseTxRequestFull &&
+      isPrebuildTransactionResult(params.prebuildTx) &&
+      params.prebuildTx.buildParams?.preview
     ) {
       txPrebuildQuery = this.prebuildTransaction({
         ...params,
@@ -3055,6 +3073,14 @@ export class Wallet implements IWallet {
    * @param params send options
    */
   private async sendManyTss(params: SendManyOptions = {}): Promise<any> {
+    const { apiVersion } = params;
+    const supportedTxRequestVersions = this.tssUtils?.supportedTxRequestVersions() ?? [];
+    const onlySupportsTxRequestFull =
+      supportedTxRequestVersions.length === 1 && supportedTxRequestVersions.includes('full');
+    if (apiVersion === 'lite' && onlySupportsTxRequestFull) {
+      throw new Error('TxRequest Lite API is not supported for this wallet');
+    }
+
     const signedTransaction = (await this.prebuildAndSignTransaction(params)) as SignedTransactionRequest;
     if (!signedTransaction.txRequestId) {
       throw new Error('txRequestId missing from signed transaction');
@@ -3073,7 +3099,7 @@ export class Wallet implements IWallet {
     }
 
     // ECDSA TSS uses TxRequestFull
-    if (this.baseCoin.getMPCAlgorithm() === 'ecdsa' || params.apiVersion === 'full' || this._wallet.type === 'cold') {
+    if (apiVersion === 'full' || onlySupportsTxRequestFull) {
       return getTxRequest(this.bitgo, this.id(), signedTransaction.txRequestId);
     }
 


### PR DESCRIPTION
This pr enables rebuilding a prebuiltTx when used with SendMany on TSS Full wallets. Previously this method would not work because the SDK would be looking for a non-existent txRequestID from the prebuiltTx.

Ticket: WP-139

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
