### PR TITLE
feat: add base factor for individual cosmos side chains

### DIFF
--- a/modules/abstract-cosmos/src/cosmosCoin.ts
+++ b/modules/abstract-cosmos/src/cosmosCoin.ts
@@ -68,7 +68,7 @@ export class CosmosCoin extends BaseCoin {
 
   /** @inheritDoc **/
   getBaseFactor(): string | number {
-    return 1e6;
+    throw new Error('Method not implemented');
   }
 
   /** @inheritDoc **/

--- a/modules/sdk-coin-bld/src/bld.ts
+++ b/modules/sdk-coin-bld/src/bld.ts
@@ -27,6 +27,11 @@ export class Bld extends CosmosCoin {
   }
 
   /** @inheritDoc **/
+  getBaseFactor(): string | number {
+    return 1e6;
+  }
+
+  /** @inheritDoc **/
   isValidAddress(address: string): boolean {
     return utils.isValidAddress(address) || utils.isValidValidatorAddress(address);
   }

--- a/modules/sdk-coin-hash/src/hash.ts
+++ b/modules/sdk-coin-hash/src/hash.ts
@@ -27,6 +27,11 @@ export class Hash extends CosmosCoin {
   }
 
   /** @inheritDoc **/
+  getBaseFactor(): string | number {
+    return 1e9;
+  }
+
+  /** @inheritDoc **/
   isValidAddress(address: string): boolean {
     return utils.isValidAddress(address) || utils.isValidValidatorAddress(address);
   }

--- a/modules/sdk-coin-hash/test/unit/hash.ts
+++ b/modules/sdk-coin-hash/test/unit/hash.ts
@@ -32,12 +32,12 @@ describe('HASH', function () {
     hash.getChain().should.equal('hash');
     hash.getFamily().should.equal('hash');
     hash.getFullName().should.equal('Provenance');
-    hash.getBaseFactor().should.equal(1e6);
+    hash.getBaseFactor().should.equal(1e9);
 
     thash.getChain().should.equal('thash');
     thash.getFamily().should.equal('hash');
     thash.getFullName().should.equal('Testnet Provenance');
-    thash.getBaseFactor().should.equal(1e6);
+    thash.getBaseFactor().should.equal(1e9);
   });
 
   describe('Address Validation', () => {

--- a/modules/sdk-coin-injective/src/injective.ts
+++ b/modules/sdk-coin-injective/src/injective.ts
@@ -27,6 +27,11 @@ export class Injective extends CosmosCoin {
   }
 
   /** @inheritDoc **/
+  getBaseFactor(): string | number {
+    return 1e18;
+  }
+
+  /** @inheritDoc **/
   isValidAddress(address: string): boolean {
     return utils.isValidAddress(address) || utils.isValidValidatorAddress(address);
   }

--- a/modules/sdk-coin-injective/test/unit/injective.ts
+++ b/modules/sdk-coin-injective/test/unit/injective.ts
@@ -32,12 +32,12 @@ describe('INJ', function () {
     injective.getChain().should.equal('injective');
     injective.getFamily().should.equal('injective');
     injective.getFullName().should.equal('Injective');
-    injective.getBaseFactor().should.equal(1e6);
+    injective.getBaseFactor().should.equal(1e18);
 
     tinjective.getChain().should.equal('tinjective');
     tinjective.getFamily().should.equal('injective');
     tinjective.getFullName().should.equal('Testnet Injective');
-    tinjective.getBaseFactor().should.equal(1e6);
+    tinjective.getBaseFactor().should.equal(1e18);
   });
 
   describe('Address Validation', () => {

--- a/modules/sdk-coin-osmo/src/osmo.ts
+++ b/modules/sdk-coin-osmo/src/osmo.ts
@@ -27,6 +27,11 @@ export class Osmo extends CosmosCoin {
   }
 
   /** @inheritDoc **/
+  getBaseFactor(): string | number {
+    return 1e6;
+  }
+
+  /** @inheritDoc **/
   isValidAddress(address: string): boolean {
     return (
       utils.isValidAddress(address) || utils.isValidValidatorAddress(address) || utils.isValidContractAddress(address)

--- a/modules/sdk-coin-sei/src/sei.ts
+++ b/modules/sdk-coin-sei/src/sei.ts
@@ -27,6 +27,11 @@ export class Sei extends CosmosCoin {
   }
 
   /** @inheritDoc **/
+  getBaseFactor(): string | number {
+    return 1e6;
+  }
+
+  /** @inheritDoc **/
   isValidAddress(address: string): boolean {
     return utils.isValidAddress(address) || utils.isValidValidatorAddress(address);
   }

--- a/modules/sdk-coin-tia/src/tia.ts
+++ b/modules/sdk-coin-tia/src/tia.ts
@@ -27,6 +27,11 @@ export class Tia extends CosmosCoin {
   }
 
   /** @inheritDoc **/
+  getBaseFactor(): string | number {
+    return 1e6;
+  }
+
+  /** @inheritDoc **/
   isValidAddress(address: string): boolean {
     return utils.isValidAddress(address) || utils.isValidValidatorAddress(address);
   }


### PR DESCRIPTION
Ticket: [WIN-124](https://bitgoinc.atlassian.net/browse/WIN-124)

### Context:

- We recently observed that the the decimal factor used in WP and SDK for amount was different from what the UI was passing along and that caused some confusion on a test [transaction](https://testnet.explorer.injective.network/transaction/5EAAF21229E8379F51892A70B5E559F4E952ADD5461AB8AF1AA5799D0BAD1FA8/) for injective
- Turns out there's a method in the SDK called `getBaseFactor`, which is being referenced to populate the amount in the respective token denomination in the UI
- This method was incorrectly using `1e6` for all the cosmos side chains, while injective needed `1e18` instead
- This PR fixes that issue for injective as well as adds the respective base factor in the individual SDK classes for all the cosmos side chains

[WIN-124]: https://bitgoinc.atlassian.net/browse/WIN-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ