### PR TITLE
fix(utxo-lib): allow uncompressed pubkeys in utxo-lib

### DIFF
--- a/modules/utxo-lib/src/bitgo/parseInput.ts
+++ b/modules/utxo-lib/src/bitgo/parseInput.ts
@@ -220,7 +220,7 @@ function matchScript(script: DecompiledScript, pattern: ScriptPatternElement[]):
       case 'OP_CHECKSIGVERIFY':
         return e === opcodes[p];
       case ':pubkey':
-        return Buffer.isBuffer(e) && e.length === 33;
+        return Buffer.isBuffer(e) && (e.length === 33 || e.length === 65);
       case ':pubkey-xonly':
         return Buffer.isBuffer(e) && e.length === 32;
       case ':signature':


### PR DESCRIPTION
There are some transactions built by very old versions of utxo-lib that contain
uncompressed pubkeys. Currently those cannot be parsed. This commit fixes that.

Issue: BTC-0


<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->