### PR TITLE
fix(sdk-coin-osmo): allow zero amount on contract call

### DIFF
--- a/modules/abstract-cosmos/src/lib/ContractCallBuilder.ts
+++ b/modules/abstract-cosmos/src/lib/ContractCallBuilder.ts
@@ -21,7 +21,7 @@ export class ContractCallBuilder extends CosmosTransactionBuilder {
   /** @inheritdoc */
   messages(messages: ExecuteContractMessage[]): this {
     this._messages = messages.map((executeContractMessage) => {
-      this._utils.validateExecuteContractMessage(executeContractMessage);
+      this._utils.validateExecuteContractMessage(executeContractMessage, this.transactionType);
       return {
         typeUrl: constants.executeContractMsgTypeUrl,
         value: executeContractMessage,

--- a/modules/abstract-cosmos/src/lib/utils.ts
+++ b/modules/abstract-cosmos/src/lib/utils.ts
@@ -646,10 +646,11 @@ export class CosmosUtils implements BaseUtils {
   /**
    * Validates an array of coin amounts.
    * @param {Coin[]} amountArray - The array of coin amounts to validate.
+   * @param {TransactionType} transactionType - optional field for transaction type
    */
-  validateAmountData(amountArray: Coin[]): void {
+  validateAmountData(amountArray: Coin[], transactionType?: TransactionType): void {
     amountArray.forEach((coinAmount) => {
-      this.validateAmount(coinAmount);
+      this.validateAmount(coinAmount, transactionType);
     });
   }
 
@@ -683,9 +684,10 @@ export class CosmosUtils implements BaseUtils {
   /**
    * Validates a coin amount.
    * @param {Coin} amount - The coin amount to validate.
+   * @param {TransactionType} transactionType - optional field for transaction type
    * @throws {InvalidTransactionError} Throws an error if the coin amount is invalid.
    */
-  validateAmount(amount: Coin): void {
+  validateAmount(amount: Coin, transactionType?: TransactionType): void {
     throw new NotImplementedError('validateAmount not implemented');
   }
 
@@ -719,9 +721,10 @@ export class CosmosUtils implements BaseUtils {
   /**
    * Validates a execute contract message
    * @param {ExecuteContractMessage} message - The execute contract message to validate
+   * @param {TransactionType} transactionType - optional field for transaction type
    * @throws {InvalidTransactionError} Throws an error if the message is invalid
    */
-  validateExecuteContractMessage(message: ExecuteContractMessage) {
+  validateExecuteContractMessage(message: ExecuteContractMessage, transactionType?: TransactionType) {
     if (!message.contract || !this.isValidContractAddress(message.contract)) {
       throw new InvalidTransactionError(`Invalid ExecuteContractMessage contract address: ` + message.contract);
     }
@@ -732,7 +735,7 @@ export class CosmosUtils implements BaseUtils {
       throw new InvalidTransactionError(`Invalid ExecuteContractMessage msg: ` + message.msg);
     }
     if (message.funds) {
-      this.validateAmountData(message.funds);
+      this.validateAmountData(message.funds, transactionType);
     }
   }
 }

--- a/modules/sdk-coin-osmo/src/lib/utils.ts
+++ b/modules/sdk-coin-osmo/src/lib/utils.ts
@@ -1,7 +1,6 @@
-import { InvalidTransactionError } from '@bitgo/sdk-core';
+import { InvalidTransactionError, TransactionType } from '@bitgo/sdk-core';
 import { Coin } from '@cosmjs/stargate';
 import BigNumber from 'bignumber.js';
-
 import { CosmosUtils } from '@bitgo/abstract-cosmos';
 import * as constants from './constants';
 
@@ -22,9 +21,9 @@ export class OsmoUtils extends CosmosUtils {
   }
 
   /** @inheritdoc */
-  validateAmount(amount: Coin): void {
+  validateAmount(amount: Coin, transactionType?: TransactionType): void {
     const amountBig = BigNumber(amount.amount);
-    if (amountBig.isLessThanOrEqualTo(0)) {
+    if (amountBig.isLessThanOrEqualTo(0) && transactionType !== TransactionType.ContractCall) {
       throw new InvalidTransactionError('transactionBuilder: validateAmount: Invalid amount: ' + amount.amount);
     }
     if (!constants.validDenoms.find((denom) => denom === amount.denom)) {

--- a/modules/sdk-coin-osmo/test/resources/osmo.ts
+++ b/modules/sdk-coin-osmo/test/resources/osmo.ts
@@ -257,4 +257,5 @@ export const coinAmounts = {
   amount3: { amount: '100000000000', denom: 'nosmo' },
   amount4: { amount: '-1', denom: 'uosmo' },
   amount5: { amount: '1000', denom: 'hosmo' },
+  amount6: { amount: '0', denom: 'uosmo' },
 };

--- a/modules/sdk-coin-osmo/test/unit/utils.ts
+++ b/modules/sdk-coin-osmo/test/unit/utils.ts
@@ -3,6 +3,7 @@ import should from 'should';
 import utils from '../../src/lib/utils';
 import { blockHash, txIds } from '../resources/osmo';
 import * as testData from '../resources/osmo';
+import { TransactionType } from '@bitgo/sdk-core';
 
 describe('utils', () => {
   it('should validate block hash correctly', () => {
@@ -37,8 +38,12 @@ describe('utils', () => {
     should.doesNotThrow(() => utils.validateAmountData([testData.coinAmounts.amount1]));
     should.doesNotThrow(() => utils.validateAmountData([testData.coinAmounts.amount2]));
     should.doesNotThrow(() => utils.validateAmountData([testData.coinAmounts.amount3]));
+    should.doesNotThrow(() => utils.validateAmountData([testData.coinAmounts.amount6], TransactionType.ContractCall));
     should(() => utils.validateAmountData([testData.coinAmounts.amount4])).throwError(
       'transactionBuilder: validateAmount: Invalid amount: ' + testData.coinAmounts.amount4.amount
+    );
+    should(() => utils.validateAmountData([testData.coinAmounts.amount6])).throwError(
+      'transactionBuilder: validateAmount: Invalid amount: ' + testData.coinAmounts.amount6.amount
     );
     should(() => utils.validateAmountData([testData.coinAmounts.amount5])).throwError(
       'transactionBuilder: validateAmount: Invalid denom: ' + testData.coinAmounts.amount5.denom


### PR DESCRIPTION
Ticket: WIN-155

### Context:

We observed during testing that - for contract call execution, we were throwing an error for 0 amount, which is not what we want. Because we still want to execute contract without any amount. This PR amends the validation flow for amount, so that we can account for 0 amount to be passed in the respective contract call builder.
<p align="center">
<img src="https://github.com/BitGo/BitGoJS/assets/119414331/fd22684e-fee5-4f6f-be3f-5d64a40f011f" width="500">
</p>


