### PR TITLE
feat(utxo-lib): add functionalities related to v1 safe wallets

### DIFF
--- a/modules/utxo-lib/src/bitgo/legacysafe/index.ts
+++ b/modules/utxo-lib/src/bitgo/legacysafe/index.ts
@@ -1,8 +1,14 @@
+/**
+ * V1 Safe Wallets are the oldest type of wallets that BitGo supports. They were
+ * created back in 2013-14 and don't use HD chains. Instead, they have only one
+ * P2SH address per wallet whose redeem script uses uncompressed public keys.
+ * */
+
 import * as assert from 'assert';
-import { ecc as eccLib /* , bip32 */ } from '../../noble_ecc';
-// import { BIP32Interface } from 'bip32';
-// import { ECPairInterface } from 'ecpair';
-// import { networks } from 'bitcoinjs-lib';
+import { ecc as eccLib } from '../../noble_ecc';
+import { isBitcoin, Network } from '../../networks';
+import { isTriple } from '../types';
+import * as bitcoinjs from 'bitcoinjs-lib';
 
 function getPublicKeyBuffer(publicKey: Buffer, { compressed = true } = {}): Buffer {
   const res = eccLib.pointCompress(publicKey, compressed);
@@ -15,10 +21,47 @@ function getPublicKeyBuffer(publicKey: Buffer, { compressed = true } = {}): Buff
   return buffer;
 }
 
-export function convertToUncompressedPub(compressedPub: Buffer): Buffer {
-  return getPublicKeyBuffer(compressedPub, { compressed: false });
+export function toUncompressedPub(pubkey: Buffer): Buffer {
+  return getPublicKeyBuffer(pubkey, { compressed: false });
 }
 
-export function convertToCompressedPub(compressedPub: Buffer): Buffer {
-  return getPublicKeyBuffer(compressedPub, { compressed: true });
+export function toCompressedPub(pubkey: Buffer): Buffer {
+  return getPublicKeyBuffer(pubkey, { compressed: true });
+}
+
+/** create p2sh scripts with uncompressed pubkeys */
+export function createLegacySafeOutputScript2of3(
+  pubkeys: Buffer[],
+  network?: Network
+): {
+  scriptPubKey: Buffer;
+  redeemScript: Buffer;
+} {
+  if (network) {
+    if (!isBitcoin(network)) {
+      throw new Error(`unsupported network for legacy safe output script: ${network.coin}`);
+    }
+  }
+
+  if (!isTriple(pubkeys)) {
+    throw new Error(`must provide pubkey triple`);
+  }
+
+  pubkeys.forEach((key) => {
+    if (key.length !== 65) {
+      throw new Error(`Unexpected key length ${key.length}. Must use uncompressed keys.`);
+    }
+  });
+
+  const script2of3 = bitcoinjs.payments.p2ms({ m: 2, pubkeys });
+  assert(script2of3.output);
+
+  const scriptPubKey = bitcoinjs.payments.p2sh({ redeem: script2of3 });
+  assert(scriptPubKey);
+  assert(scriptPubKey.output);
+
+  return {
+    scriptPubKey: scriptPubKey.output,
+    redeemScript: script2of3.output,
+  };
 }

--- a/modules/utxo-lib/src/bitgo/legacysafe/index.ts
+++ b/modules/utxo-lib/src/bitgo/legacysafe/index.ts
@@ -1,0 +1,24 @@
+import * as assert from 'assert';
+import { ecc as eccLib /* , bip32 */ } from '../../noble_ecc';
+// import { BIP32Interface } from 'bip32';
+// import { ECPairInterface } from 'ecpair';
+// import { networks } from 'bitcoinjs-lib';
+
+function getPublicKeyBuffer(publicKey: Buffer, { compressed = true } = {}): Buffer {
+  const res = eccLib.pointCompress(publicKey, compressed);
+  if (res === null) {
+    throw new Error('invalid public key');
+  }
+  const buffer = Buffer.from(res);
+
+  assert.strictEqual(buffer.length, compressed ? 33 : 65);
+  return buffer;
+}
+
+export function convertToUncompressedPub(compressedPub: Buffer): Buffer {
+  return getPublicKeyBuffer(compressedPub, { compressed: false });
+}
+
+export function convertToCompressedPub(compressedPub: Buffer): Buffer {
+  return getPublicKeyBuffer(compressedPub, { compressed: true });
+}

--- a/modules/utxo-lib/test/bitgo/legacysafe/index.ts
+++ b/modules/utxo-lib/test/bitgo/legacysafe/index.ts
@@ -1,28 +1,54 @@
-import { convertToUncompressedPub, convertToCompressedPub } from '../../../src/bitgo/legacysafe';
-import { getKey } from '../../../src/testutil';
+import { toUncompressedPub, toCompressedPub, createLegacySafeOutputScript2of3 } from '../../../src/bitgo/legacysafe';
+import { getKey, getKeyTriple } from '../../../src/testutil';
 import * as assert from 'assert';
+import { networks } from '../../../src';
+import { fromOutputScript } from '../../../src/address';
 
-describe('pub key conversion', function () {
+describe('public key conversion', function () {
   const compressedKeyPair = getKey('utxo');
   const uncompressedPublicKeyHex =
     '048b9c36721d4c9d9c46c796039ccab17cb89df246ff991720fb119990cbc049969445c874ae1272aa0d3f94087cd2f210c90036aff09d3bc521b01098f7cce3b5';
 
   it('converts compressed to uncompressed', function () {
-    const uncompressedPub = convertToUncompressedPub(compressedKeyPair.publicKey);
+    const uncompressedPub = toUncompressedPub(compressedKeyPair.publicKey);
     assert.strictEqual(uncompressedPub.length, 65);
     assert.strictEqual(uncompressedPub.toString('hex'), uncompressedPublicKeyHex);
   });
 
   it('keeps compressed as compressed', function () {
-    const compressedPub = convertToCompressedPub(compressedKeyPair.publicKey);
+    const compressedPub = toCompressedPub(compressedKeyPair.publicKey);
     assert.strictEqual(compressedPub.length, 33);
     assert.strictEqual(compressedPub.toString('hex'), compressedKeyPair.publicKey.toString('hex'));
   });
 
   it('converts uncompressed to compressed', function () {
-    const uncompressedPub = convertToUncompressedPub(compressedKeyPair.publicKey);
-    const compressedPub = convertToCompressedPub(uncompressedPub);
+    const uncompressedPub = toUncompressedPub(compressedKeyPair.publicKey);
+    const compressedPub = toCompressedPub(uncompressedPub);
     assert.strictEqual(compressedPub.length, 33);
     assert.strictEqual(compressedPub.toString('hex'), compressedKeyPair.publicKey.toString('hex'));
+  });
+});
+
+describe('legacy safe scripts creation', function () {
+  const compressedKeyPairs = getKeyTriple('utxo');
+  const compressedPubKeys = compressedKeyPairs.map((keyPair) => keyPair.publicKey);
+
+  it('throws error for compressed public keys', function () {
+    assert.throws(
+      () => createLegacySafeOutputScript2of3(compressedPubKeys, networks.bitcoin),
+      /^Error: Unexpected key length 33. Must use uncompressed keys.$/
+    );
+  });
+
+  it('creates output script for legacy safe wallet', function () {
+    const uncompressedKeyPairs = compressedKeyPairs.map((keyPair) => toUncompressedPub(keyPair.publicKey));
+    const uncompressedPubKeysAddress = '3B8ySJRmah2bSFin39kkTz7Fe8soVJx9Vf';
+    const uncompressedPubKeysScriptSize = 201; // bytes;
+
+    const script = createLegacySafeOutputScript2of3(uncompressedKeyPairs, networks.bitcoin);
+
+    assert.strictEqual(script.redeemScript.length, uncompressedPubKeysScriptSize); // bytes
+    assert.strictEqual(script.scriptPubKey.length, 23); // bytes;
+    assert.strictEqual(fromOutputScript(script.scriptPubKey, networks.bitcoin), uncompressedPubKeysAddress);
   });
 });

--- a/modules/utxo-lib/test/bitgo/legacysafe/index.ts
+++ b/modules/utxo-lib/test/bitgo/legacysafe/index.ts
@@ -1,0 +1,28 @@
+import { convertToUncompressedPub, convertToCompressedPub } from '../../../src/bitgo/legacysafe';
+import { getKey } from '../../../src/testutil';
+import * as assert from 'assert';
+
+describe('pub key conversion', function () {
+  const compressedKeyPair = getKey('utxo');
+  const uncompressedPublicKeyHex =
+    '048b9c36721d4c9d9c46c796039ccab17cb89df246ff991720fb119990cbc049969445c874ae1272aa0d3f94087cd2f210c90036aff09d3bc521b01098f7cce3b5';
+
+  it('converts compressed to uncompressed', function () {
+    const uncompressedPub = convertToUncompressedPub(compressedKeyPair.publicKey);
+    assert.strictEqual(uncompressedPub.length, 65);
+    assert.strictEqual(uncompressedPub.toString('hex'), uncompressedPublicKeyHex);
+  });
+
+  it('keeps compressed as compressed', function () {
+    const compressedPub = convertToCompressedPub(compressedKeyPair.publicKey);
+    assert.strictEqual(compressedPub.length, 33);
+    assert.strictEqual(compressedPub.toString('hex'), compressedKeyPair.publicKey.toString('hex'));
+  });
+
+  it('converts uncompressed to compressed', function () {
+    const uncompressedPub = convertToUncompressedPub(compressedKeyPair.publicKey);
+    const compressedPub = convertToCompressedPub(uncompressedPub);
+    assert.strictEqual(compressedPub.length, 33);
+    assert.strictEqual(compressedPub.toString('hex'), compressedKeyPair.publicKey.toString('hex'));
+  });
+});


### PR DESCRIPTION
[BG-63667](https://bitgoinc.atlassian.net/browse/BG-63667)

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->


[BG-63667]: https://bitgoinc.atlassian.net/browse/BG-63667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ