### PR TITLE
feat(utxo-bin): add support for base64

### DIFF
--- a/modules/utxo-bin/src/parseString.ts
+++ b/modules/utxo-bin/src/parseString.ts
@@ -1,0 +1,27 @@
+type Format = 'hex' | 'base64';
+export function stringToBuffer(data: string, format: Format | Format[]): Buffer {
+  if (typeof format !== 'string') {
+    for (const f of format) {
+      try {
+        return stringToBuffer(data, f);
+      } catch (err) {
+        // ignore, try next
+      }
+    }
+    throw new Error(`could not parse data, formats: ${format}`);
+  }
+
+  // strip all whitespace
+  data = data.replace(/\s*/g, '');
+
+  if (format === 'hex') {
+    data = data.toLowerCase();
+  }
+
+  const buf = Buffer.from(data, format);
+  // make sure there were no decoding errors
+  if (buf.toString(format) !== data) {
+    throw new Error(`invalid ${format}`);
+  }
+  return buf;
+}

--- a/modules/utxo-bin/test/stringToBuffer.ts
+++ b/modules/utxo-bin/test/stringToBuffer.ts
@@ -1,0 +1,16 @@
+import * as assert from 'assert';
+
+import { stringToBuffer } from '../src/parseString';
+
+describe('stringToBuffer', function () {
+  const bytes = Buffer.alloc(32, 42);
+  it('converts hex and base64', function () {
+    for (const e of ['hex', 'base64']) {
+      const str = bytes.toString(e);
+      assert.deepStrictEqual(stringToBuffer(str, ['hex', 'base64']), bytes);
+
+      const strNl = [str.slice(0, 4), str.slice(4)].join('\n');
+      assert.deepStrictEqual(stringToBuffer(strNl, ['hex', 'base64']), bytes);
+    }
+  });
+});


### PR DESCRIPTION
Add `--data` option to `parseTx` command (alias `--hex` for backwards
compatibility).

We now attempt to parse the input as hex, and if that fails, as base64.

Issue: BTC-0


<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->