### PR TITLE
feat(sdk-lib-mpc): use implementation of paillier-blum for paillier proof

### DIFF
--- a/modules/sdk-lib-mpc/src/tss/ecdsa/generatepaillierkey.ts
+++ b/modules/sdk-lib-mpc/src/tss/ecdsa/generatepaillierkey.ts
@@ -1,0 +1,28 @@
+import * as bcu from 'bigint-crypto-utils';
+import { PublicKey, PrivateKey, KeyPair } from 'paillier-bigint';
+import { proveBlum } from './paillierproof';
+
+export interface KeyPairWithProof {
+  keyPair: KeyPair;
+  w: bigint;
+  x: Array<bigint>;
+  z: Array<bigint>;
+}
+
+// Implementation based on paillier-bigint's generateRandomKeys
+export async function generatePaillierKey(bitlength = 3072): Promise<KeyPairWithProof> {
+  let p, q, n;
+  do {
+    p = await bcu.prime(Math.floor(bitlength / 2) + 1);
+    q = await bcu.prime(Math.floor(bitlength / 2));
+    n = p * q;
+  } while (q === p || q % BigInt(4) !== BigInt(3) || p % BigInt(4) !== BigInt(3) || bcu.bitLength(n) !== bitlength);
+  const { w, x, z } = await proveBlum(p, q);
+  const g = n + BigInt(1);
+  const lambda = (p - BigInt(1)) * (q - BigInt(1));
+  const mu = bcu.modInv(lambda, n);
+  const publicKey = new PublicKey(n, g);
+  const privateKey = new PrivateKey(lambda, mu, publicKey, p, q);
+  const keyPair: KeyPair = { publicKey, privateKey };
+  return { keyPair, w, x, z };
+}

--- a/modules/sdk-lib-mpc/src/tss/ecdsa/paillierproof.ts
+++ b/modules/sdk-lib-mpc/src/tss/ecdsa/paillierproof.ts
@@ -1,16 +1,14 @@
-import { bitLength } from 'bigint-crypto-utils';
+import { createHmac } from 'crypto';
+import { bitLength, randBits, isProbablyPrime } from 'bigint-crypto-utils';
 import { modInv, modPow } from 'bigint-mod-arith';
-
-import { randomPositiveCoPrimeLessThan } from '../../util';
-import { minModulusBitLength } from './index';
+import { bigIntFromBufferBE, bigIntToBufferBE, randomPositiveCoPrimeLessThan } from '../../util';
 import { primesSmallerThan319567 } from './primes';
+import { minModulusBitLength } from './index';
 
-// Security parameters.
-const k = 128;
-// eprint.iacr.org/2018/057.pdf#page6 section 5
-// https://github.com/BitGo/BitGoJS/pull/3502#discussion_r1203070392
-export const alpha = 319567;
-export const m = Math.ceil(k / Math.log2(alpha));
+// Security parameter.
+const blumM = 80;
+
+const m = 7;
 
 /**
  * Generate a set of challenges $p$ for a given paillier public key modulus $n$.
@@ -61,9 +59,6 @@ export function verify(n: bigint, p: Array<bigint>, sigma: Array<bigint>): boole
   if (n <= 0) {
     return false;
   }
-  if (alpha !== 319567) {
-    throw new Error('unsupported alpha value');
-  }
   for (const prime of primesSmallerThan319567) {
     if (n % BigInt(prime) === BigInt(0)) {
       return false;
@@ -80,6 +75,125 @@ export function verify(n: bigint, p: Array<bigint>, sigma: Array<bigint>): boole
   for (let i = 0; i < m; i++) {
     if (p[i] !== modPow(sigma[i], n, n)) {
       return false;
+    }
+  }
+  return true;
+}
+
+// Generate psuedo-random quadratic residue for (N, w, i).
+function generateY(N, w) {
+  const NBuf = bigIntToBufferBE(N);
+  const wBuf = bigIntToBufferBE(w, NBuf.length);
+  return Array(blumM)
+    .fill(null)
+    .map((_, i) => {
+      const h = bigIntFromBufferBE(
+        createHmac('sha256', Buffer.from([i]))
+          .update(NBuf)
+          .update(wBuf)
+          .digest()
+      );
+      return h * h;
+    });
+}
+
+// https://en.wikipedia.org/wiki/Jacobi_symbol#Implementation_in_C++
+function jacobi(a, n) {
+  // a/n is represented as (a,n)
+  if (n <= BigInt(0)) {
+    throw new Error('n must greater than 0');
+  }
+  if (n % BigInt(2) != BigInt(1)) {
+    throw new Error('n must be odd');
+  }
+  // step 1
+  a = a % n;
+  let t = BigInt(1);
+  let r;
+  // step 3
+  while (a != BigInt(0)) {
+    // step 2
+    while (a % BigInt(2) == BigInt(0)) {
+      a /= BigInt(2);
+      r = n % BigInt(8);
+      if (r == BigInt(3) || r == BigInt(5)) {
+        t = -t;
+      }
+    }
+    // step 4
+    r = n;
+    n = a;
+    a = r;
+    if (a % BigInt(4) == BigInt(3) && n % BigInt(4) == BigInt(3)) {
+      t = -t;
+    }
+    a = a % n;
+  }
+  if (n == BigInt(1)) {
+    return t;
+  }
+  return BigInt(0);
+}
+
+/**
+ * Prove that a modulus is the product of two large safe primes.
+ * @param {bigint} p The larger prime factor of the modulus
+ * @param {bigint} q The smaller prime factor of the modulus.
+ */
+export async function proveBlum(p, q) {
+  // Prover selects random w with Jacobi symbol 1 wrt N.
+  const N = p * q;
+  const l = (p - BigInt(1)) * (q - BigInt(1));
+  const d = modInv(N, l);
+  let w;
+  while (true) {
+    w = bigIntFromBufferBE(Buffer.from(await randBits(bitLength(N))));
+    if (jacobi(w, N) == BigInt(-1)) {
+      break;
+    }
+  }
+  // Prover generates y_i.
+  const y = generateY(N, w);
+  // Prover calculates z_i = y_i ^ d mod N
+  const z = y.map((y_i) => modPow(y_i, d, N));
+  // Prover calculates x_i = y_i ^ 1/4 mod N using [HOC - Fact 2.160]
+  const e = ((l + BigInt(4)) / BigInt(8)) ** BigInt(2);
+  const x = y.map((y_i) => modPow(y_i, e, N));
+  return { w, x, z };
+}
+
+/**
+ * Verify that N is the product of two large primes.
+ * @param {bigint} N The modulus.
+ * @param proof The proof to verify.
+ */
+export async function verifyBlum(N, { w, x, z }) {
+  // Verifier checks N > 1.
+  if (N <= 1) {
+    throw new Error('N must be greater than 1');
+  }
+  // Verifier checks N is odd.
+  if (N % BigInt(2) != BigInt(1)) {
+    throw new Error('N must be an odd number');
+  }
+  // Verifier checks N is not prime.
+  if (await isProbablyPrime(N, 24)) {
+    throw new Error('N must be a composite number');
+  }
+  // Verifier checks that the Jacobi symbol for w is 1 wrt N.
+  if (jacobi(w, N) != BigInt(-1)) {
+    throw new Error('Jacobi symbol of w must be -1 wrt to N');
+  }
+  // Verifier generates y_i.
+  const y = generateY(N, w);
+  for (let i = 0; i < blumM; i++) {
+    // Verifier checks z_i ^ N mod N == y_i.
+    if (modPow(z[i], N, N) != y[i]) {
+      throw new Error(`Paillier verification of y[${i}] failed`);
+    }
+    // Verifier checks x_i ^ 4 mod N == y_i.
+    if (modPow(x[i], 4, N) != y[i]) {
+      throw new Error(`Paillier verification of x[${i}] failed`);
     }
   }
   return true;


### PR DESCRIPTION
Issue: HSM-102

BREAKING CHANGE: paillierProof interface is not backwards compatible

The protocol is described here: https://eprint.iacr.org/2021/060.pdf

This PR changes only the paillierProof module and adds EcdsaGeneratePaillierKey.

**TODO:**
* The share types and the Ecdsa library will need updating.
* `rangeProof.generateModulus` must call `paillierProof.prove` and return `w, x, z` as proof of the ntilde's correctness.
* sdk-core tss Ecdsa code will need to call `EcdsaGeneratePaillierKey` instead of paillier-bigint`s `generateRandomKeys`.
* sdk-core tss Ecdsa code will need to verify paillier-blum proofs of bitgo's paillier key and ntilde.