### PR TITLE
feat(utxo-bin): add `--format tree` option

### DIFF
--- a/modules/utxo-bin/src/commands.ts
+++ b/modules/utxo-bin/src/commands.ts
@@ -24,7 +24,13 @@ import { parseUnknown } from './parseUnknown';
 import { getParserTxProperties } from './ParserTx';
 import { ScriptParser } from './ScriptParser';
 import { stringToBuffer } from './parseString';
-import { generateAddress, getAddressPlaceholderDescription, parseIndexRange } from './generateAddress';
+import {
+  formatAddressTree,
+  formatAddressWithFormatString,
+  generateAddress,
+  getAddressPlaceholderDescription,
+  parseIndexRange,
+} from './generateAddress';
 
 type OutputFormat = 'tree' | 'json';
 
@@ -342,7 +348,11 @@ export const cmdGenerateAddress = {
       index: parseIndexRange(argv.index),
       network: getNetworkForName(argv.network ?? 'bitcoin'),
     })) {
-      console.log(address);
+      if (argv.format === 'tree') {
+        console.log(formatAddressTree(address));
+      } else {
+        console.log(formatAddressWithFormatString(address, argv.format));
+      }
     }
   },
 };

--- a/modules/utxo-bin/src/commands.ts
+++ b/modules/utxo-bin/src/commands.ts
@@ -24,7 +24,7 @@ import { parseUnknown } from './parseUnknown';
 import { getParserTxProperties } from './ParserTx';
 import { ScriptParser } from './ScriptParser';
 import { stringToBuffer } from './parseString';
-import { generateAddress, getAddressPlaceholderDescription } from './generateAddress';
+import { generateAddress, getAddressPlaceholderDescription, parseIndexRange } from './generateAddress';
 
 type OutputFormat = 'tree' | 'json';
 
@@ -70,7 +70,7 @@ export type ArgsGenerateAddress = {
   bitgoKey: string;
   chain?: number[];
   format: string;
-  limit: number;
+  index: string;
 };
 
 async function getClient({ cache }: { cache: boolean }): Promise<HttpClient> {
@@ -334,12 +334,12 @@ export const cmdGenerateAddress = {
         description: `Format string. Placeholders: ${getAddressPlaceholderDescription()}`,
       })
       .array('chain')
-      .option('limit', { type: 'number', default: 100 });
+      .option('index', { type: 'string', default: '0-99' });
   },
   handler(argv: yargs.Arguments<ArgsGenerateAddress>): void {
-    console.log('generating addresses..');
     for (const address of generateAddress({
       ...argv,
+      index: parseIndexRange(argv.index),
       network: getNetworkForName(argv.network ?? 'bitcoin'),
     })) {
       console.log(address);

--- a/modules/utxo-bin/src/commands.ts
+++ b/modules/utxo-bin/src/commands.ts
@@ -24,7 +24,7 @@ import { parseUnknown } from './parseUnknown';
 import { getParserTxProperties } from './ParserTx';
 import { ScriptParser } from './ScriptParser';
 import { stringToBuffer } from './parseString';
-import { generateAddress } from './generateAddress';
+import { generateAddress, getAddressPlaceholderDescription } from './generateAddress';
 
 type OutputFormat = 'tree' | 'json';
 
@@ -69,7 +69,7 @@ export type ArgsGenerateAddress = {
   backupKey: string;
   bitgoKey: string;
   chain?: number[];
-  showDerivationPath?: boolean;
+  format: string;
   limit: number;
 };
 
@@ -328,7 +328,11 @@ export const cmdGenerateAddress = {
       .option('backupKey', { type: 'string', demandOption: true })
       .option('bitgoKey', { type: 'string', demandOption: true })
       .option('chain', { type: 'number' })
-      .option('showDerivationPath', { type: 'boolean', default: true })
+      .option('format', {
+        type: 'string',
+        default: '%p0\t%a',
+        description: `Format string. Placeholders: ${getAddressPlaceholderDescription()}`,
+      })
       .array('chain')
       .option('limit', { type: 'number', default: 100 });
   },

--- a/modules/utxo-bin/src/generateAddress.ts
+++ b/modules/utxo-bin/src/generateAddress.ts
@@ -94,6 +94,17 @@ function formatAddress(
   });
 }
 
+export function parseIndexRange(indexRange: string): number[] {
+  const ranges = indexRange.split(',');
+  return ranges.flatMap((range) => {
+    const [start, end] = range.split('-');
+    if (end) {
+      return Array.from({ length: Number(end) - Number(start) + 1 }, (_, i) => Number(start) + i);
+    }
+    return [Number(start)];
+  });
+}
+
 export function* generateAddress(argv: {
   network?: utxolib.Network;
   userKey: string;
@@ -101,13 +112,13 @@ export function* generateAddress(argv: {
   bitgoKey: string;
   chain?: number[];
   format: string;
-  limit: number;
+  index: number[];
 }): Generator<string> {
   const xpubs = [argv.userKey, argv.backupKey, argv.bitgoKey].map((k) => utxolib.bip32.fromBase58(k));
   assert(utxolib.bitgo.isTriple(xpubs));
   const rootXpubs = new utxolib.bitgo.RootWalletKeys(xpubs);
   const chains = argv.chain ?? getDefaultChainCodes();
-  for (let i = 0; i < argv.limit; i++) {
+  for (const i of argv.index) {
     for (const chain of chains) {
       assert(utxolib.bitgo.isChainCode(chain));
       yield formatAddress(rootXpubs, chain, i, argv.network ?? utxolib.networks.bitcoin, argv.format);

--- a/modules/utxo-bin/src/generateAddress.ts
+++ b/modules/utxo-bin/src/generateAddress.ts
@@ -1,35 +1,116 @@
 import * as assert from 'assert';
 import * as utxolib from '@bitgo/utxo-lib';
 
+function getDefaultChainCodes(): number[] {
+  return utxolib.bitgo.chainCodes.filter(
+    // these are rare and show an annoying warning in stderr
+    (c) => utxolib.bitgo.scriptTypeForChain(c) !== 'p2tr' && utxolib.bitgo.scriptTypeForChain(c) !== 'p2trMusig2'
+  );
+}
+
+type AddressProperties = {
+  chain: utxolib.bitgo.ChainCode;
+  index: number;
+  type: utxolib.bitgo.outputScripts.ScriptType;
+  userPath: string;
+  backupPath: string;
+  bitgoPath: string;
+  userKey: string;
+  backupKey: string;
+  bitgoKey: string;
+  redeemScript?: string;
+  witnessScript?: string;
+  scriptPubKey: string;
+  address: string;
+};
+
+const placeholders = {
+  '%c': 'chain',
+  '%i': 'index',
+  '%p': 'userPath',
+  '%t': 'type',
+  '%p0': 'userPath',
+  '%p1': 'backupPath',
+  '%p2': 'bitgoPath',
+  '%k0': 'userKey',
+  '%k1': 'backupKey',
+  '%k2': 'bitgoKey',
+  '%s': 'scriptPubKey',
+  '%r': 'redeemScript',
+  '%w': 'witnessScript',
+  '%a': 'address',
+} as const;
+
+export function getAddressPlaceholderDescription(): string {
+  return Object.entries(placeholders)
+    .map(([placeholder, prop]) => `${placeholder} -> ${prop}`)
+    .join('\n');
+}
+
+function getAddressProperties(
+  keys: utxolib.bitgo.RootWalletKeys,
+  chain: utxolib.bitgo.ChainCode,
+  index: number,
+  network: utxolib.Network
+): AddressProperties {
+  const [userPath, backupPath, bitgoPath] = keys.triple.map((k) => keys.getDerivationPath(k, chain, index));
+  const scripts = utxolib.bitgo.getWalletOutputScripts(keys, chain, index);
+  const [userKey, backupKey, bitgoKey] = keys.triple.map((k) => k.derivePath(userPath).publicKey.toString('hex'));
+  const address = utxolib.address.fromOutputScript(scripts.scriptPubKey, network);
+  return {
+    chain,
+    index,
+    type: utxolib.bitgo.scriptTypeForChain(chain),
+    userPath,
+    backupPath,
+    bitgoPath,
+    userKey,
+    backupKey,
+    bitgoKey,
+    scriptPubKey: scripts.scriptPubKey.toString('hex'),
+    redeemScript: scripts.redeemScript?.toString('hex'),
+    witnessScript: scripts.witnessScript?.toString('hex'),
+    address,
+  };
+}
+
+function formatAddress(
+  keys: utxolib.bitgo.RootWalletKeys,
+  chain: utxolib.bitgo.ChainCode,
+  index: number,
+  network: utxolib.Network,
+  format: string
+): string {
+  const props = getAddressProperties(keys, chain, index, network);
+
+  // replace all patterns with a % prefix from format string with the corresponding property
+  // e.g. %p0 -> userPath, %k1 -> backupKey, etc.
+  return format.replace(/%[a-z0-9]+/gi, (match) => {
+    if (match in placeholders) {
+      const prop = placeholders[match as keyof typeof placeholders];
+      return String(props[prop]);
+    }
+    return match;
+  });
+}
+
 export function* generateAddress(argv: {
   network?: utxolib.Network;
   userKey: string;
   backupKey: string;
   bitgoKey: string;
   chain?: number[];
+  format: string;
   limit: number;
-  showDerivationPath?: boolean;
 }): Generator<string> {
   const xpubs = [argv.userKey, argv.backupKey, argv.bitgoKey].map((k) => utxolib.bip32.fromBase58(k));
   assert(utxolib.bitgo.isTriple(xpubs));
   const rootXpubs = new utxolib.bitgo.RootWalletKeys(xpubs);
-  const chains =
-    argv.chain ??
-    utxolib.bitgo.chainCodes.filter(
-      // these are rare and show an annoying warning in stderr
-      (c) => utxolib.bitgo.scriptTypeForChain(c) !== 'p2tr' && utxolib.bitgo.scriptTypeForChain(c) !== 'p2trMusig2'
-    );
+  const chains = argv.chain ?? getDefaultChainCodes();
   for (let i = 0; i < argv.limit; i++) {
     for (const chain of chains) {
       assert(utxolib.bitgo.isChainCode(chain));
-      const scripts = utxolib.bitgo.getWalletOutputScripts(rootXpubs, chain, i);
-      const parts = [];
-      if (argv.showDerivationPath) {
-        // FIXME: can be different for other keys
-        parts.push(rootXpubs.getDerivationPath(rootXpubs.user, chain, i));
-      }
-      parts.push(utxolib.address.fromOutputScript(scripts.scriptPubKey, argv.network ?? utxolib.networks.bitcoin));
-      yield parts.join('\t');
+      yield formatAddress(rootXpubs, chain, i, argv.network ?? utxolib.networks.bitcoin, argv.format);
     }
   }
 }

--- a/modules/utxo-bin/test/generateAddress.ts
+++ b/modules/utxo-bin/test/generateAddress.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { generateAddress, parseIndexRange } from '../src/generateAddress';
+import { formatAddressWithFormatString, generateAddress, parseIndexRange } from '../src/generateAddress';
 import { getKeyTriple } from './parseAddress';
 
 describe('generateAddresses', function () {
@@ -14,7 +14,7 @@ describe('generateAddresses', function () {
       format: '%a',
       chain: [0, 1],
     })) {
-      lines.push(l);
+      lines.push(formatAddressWithFormatString(l, '%a'));
     }
 
     assert.strictEqual(lines.length, 4);

--- a/modules/utxo-bin/test/generateAddress.ts
+++ b/modules/utxo-bin/test/generateAddress.ts
@@ -1,0 +1,28 @@
+import * as assert from 'assert';
+import { generateAddress, parseIndexRange } from '../src/generateAddress';
+import { getKeyTriple } from './parseAddress';
+
+describe('generateAddresses', function () {
+  it('should generate addresses', function () {
+    const [userKey, backupKey, bitgoKey] = getKeyTriple('generateAddress').map((k) => k.neutered().toBase58());
+    const lines = [];
+    for (const l of generateAddress({
+      userKey,
+      backupKey,
+      bitgoKey,
+      index: parseIndexRange('0-1'),
+      format: '%a',
+      chain: [0, 1],
+    })) {
+      lines.push(l);
+    }
+
+    assert.strictEqual(lines.length, 4);
+    assert.deepStrictEqual(lines, [
+      '38FHxcU7KY4E2nDEezEVcKWGvHy9717ehF',
+      '35Qg1UqVWSJdtF1ysfz9h3KRGdk9uH8iYx',
+      '3ARnshsLXE9QfJemQdoKL2kp6TRqGohLDz',
+      '3QxKW93NN8CQrKaNqkDsAXPyxPsrxfTYME',
+    ]);
+  });
+});


### PR DESCRIPTION
Issue: BTC-0

5e62fc13f
feat(utxo-bin): make index argument more flexible

Allow passing index ranges

Issue: BTC-0

852ea2f74
feat(utxo-bin): add more flexible formatting for generateAddresses

With the `--format` option, the user can now specify a format string that
will be used to print the addresses. The format string can contain
placeholders that will be replaced with the corresponding address property.

Issue: BTC-0