### PR TITLE
feat(utxo-bin): bring back parameter `--limit`

### DIFF
--- a/modules/utxo-bin/src/generateAddress.ts
+++ b/modules/utxo-bin/src/generateAddress.ts
@@ -94,12 +94,15 @@ export function formatAddressWithFormatString(props: AddressProperties, format: 
   });
 }
 
-export function parseIndexRange(indexRange: string): number[] {
-  const ranges = indexRange.split(',');
+export function getRange(start: number, end: number): number[] {
+  return Array.from({ length: end - start + 1 }, (_, i) => start + i);
+}
+
+export function parseIndexRange(ranges: string[]): number[] {
   return ranges.flatMap((range) => {
     const [start, end] = range.split('-');
     if (end) {
-      return Array.from({ length: Number(end) - Number(start) + 1 }, (_, i) => Number(start) + i);
+      return getRange(Number(start), Number(end));
     }
     return [Number(start)];
   });

--- a/modules/utxo-bin/test/generateAddress.ts
+++ b/modules/utxo-bin/test/generateAddress.ts
@@ -10,7 +10,7 @@ describe('generateAddresses', function () {
       userKey,
       backupKey,
       bitgoKey,
-      index: parseIndexRange('0-1'),
+      index: parseIndexRange(['0-1']),
       format: '%a',
       chain: [0, 1],
     })) {


### PR DESCRIPTION
This is a convenience parameter that is equivalent to `--index 0-<limit-1>`.

Issue: BTC-0


<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->