### PR TITLE
fix(sdk-coin-dot): make controller optional for bond call

### DIFF
--- a/modules/sdk-coin-dot/src/lib/batchTransactionBuilder.ts
+++ b/modules/sdk-coin-dot/src/lib/batchTransactionBuilder.ts
@@ -211,7 +211,8 @@ export class BatchTransactionBuilder extends TransactionBuilder {
     const baseTxInfo = this.createBaseTxInfo();
     const unsigned = methods.staking.bond(
       {
-        controller: args.controller.id,
+        // TODO(EA-1242): update DOT library to remove controller optional field -> https://github.com/paritytech/txwrapper-core/pull/309 and https://github.com/paritytech/substrate/pull/14039
+        controller: args.controller?.id || '',
         value: args.value,
         payee: this.getPayee(args.payee),
       },

--- a/modules/sdk-coin-dot/src/lib/iface.ts
+++ b/modules/sdk-coin-dot/src/lib/iface.ts
@@ -179,7 +179,7 @@ export type StakeArgsPayeeRaw = { controller?: null; stash?: null; staked?: null
  */
 export interface StakeArgs {
   value: string;
-  controller: { id: string };
+  controller?: { id: string };
   payee: StakeArgsPayee;
 }
 
@@ -275,7 +275,7 @@ export type StakeBatchCallPayee =
 
 export interface StakeBatchCallArgs {
   value: string;
-  controller: { id: string };
+  controller?: { id: string };
   payee: StakeBatchCallPayee;
 }
 

--- a/modules/sdk-coin-dot/src/lib/stakingBuilder.ts
+++ b/modules/sdk-coin-dot/src/lib/stakingBuilder.ts
@@ -125,7 +125,7 @@ export class StakingBuilder extends TransactionBuilder {
     if (decodedTxn.method?.name === MethodNames.Bond) {
       const txMethod = decodedTxn.method.args as unknown as StakeArgs;
       const value = txMethod.value;
-      const controller = txMethod.controller.id;
+      const controller = txMethod.controller?.id;
       const payee = txMethod.payee;
       const validationResult = StakeTransactionSchema.validate({ value, controller, payee });
       if (validationResult.error) {
@@ -150,7 +150,7 @@ export class StakingBuilder extends TransactionBuilder {
       console.log('[Dot staking debug] calling owner: ', JSON.stringify(txMethod));
       this.owner({
         address: utils.decodeDotAddress(
-          txMethod.controller.id,
+          txMethod.controller?.id || '',
           utils.getAddressFormat(this._coinConfig.name as DotAssetTypes)
         ),
       });

--- a/modules/sdk-coin-dot/src/lib/stakingBuilder.ts
+++ b/modules/sdk-coin-dot/src/lib/stakingBuilder.ts
@@ -29,10 +29,7 @@ export class StakingBuilder extends TransactionBuilder {
    */
   protected buildTransaction(): UnsignedTransaction {
     const baseTxInfo = this.createBaseTxInfo();
-    console.log('[Dot staking debug] buildTransaction info', JSON.stringify(baseTxInfo));
-    console.log('[Dot staking debug] _addToStake', this._addToStake);
     if (this._addToStake) {
-      console.log('calling bondExtra');
       return methods.staking.bondExtra(
         {
           maxAdditional: this._amount,
@@ -41,10 +38,7 @@ export class StakingBuilder extends TransactionBuilder {
         baseTxInfo.options
       );
     } else {
-      console.log('[Dot staking debug] calling bond: ');
-      console.log('[Dot staking debug] this._amount: ', this._amount);
-      console.log('[Dot staking debug] this._controller: ', this._controller);
-      const bondMethod = methods.staking.bond(
+      return methods.staking.bond(
         {
           value: this._amount,
           controller: this._controller,
@@ -53,8 +47,6 @@ export class StakingBuilder extends TransactionBuilder {
         baseTxInfo.baseTxInfo,
         baseTxInfo.options
       );
-      console.log('[Dot staking debug] encoded method: ', JSON.stringify(bondMethod.method));
-      return bondMethod;
     }
   }
 
@@ -147,7 +139,6 @@ export class StakingBuilder extends TransactionBuilder {
     if (this._method?.name === MethodNames.Bond) {
       const txMethod = this._method.args as StakeArgs;
       this.amount(txMethod.value);
-      console.log('[Dot staking debug] calling owner: ', JSON.stringify(txMethod));
       this.owner({
         address: utils.decodeDotAddress(
           txMethod.controller?.id || '',

--- a/modules/sdk-coin-dot/src/lib/transaction.ts
+++ b/modules/sdk-coin-dot/src/lib/transaction.ts
@@ -216,7 +216,9 @@ export class Transaction extends BaseTransaction {
       const txMethod = decodedTx.method.args;
       if (utils.isBond(txMethod)) {
         const keypair = new KeyPair({
-          pub: Buffer.from(decodeAddress(txMethod.controller.id, false, this._registry.chainSS58)).toString('hex'),
+          pub: Buffer.from(decodeAddress(txMethod.controller?.id || '', false, this._registry.chainSS58)).toString(
+            'hex'
+          ),
         });
 
         result.controller = keypair.getAddress(utils.getAddressFormat(this._coinConfig.name as DotAssetTypes));

--- a/modules/sdk-coin-dot/src/lib/txnSchema.ts
+++ b/modules/sdk-coin-dot/src/lib/txnSchema.ts
@@ -52,7 +52,7 @@ export const TransferAllTransactionSchema = joi.object({
 
 const CreateStakeTransactionSchema = joi.object({
   value: joi.string().required(),
-  controller: addressSchema.required(),
+  controller: joi.string().optional(),
   payee: [
     joi.string(),
     joi.object({


### PR DESCRIPTION
TODO(EA-1242): update DOT library to remove controller optional field -> https://github.com/paritytech/txwrapper-core/pull/309 and https://github.com/paritytech/substrate/pull/14039


EA-1060
EA-1176
