### PR TITLE
feat(sdk-core): add postWithCodec utility function

### DIFF
--- a/modules/sdk-core/src/bitgo/utils/postWithCodec.ts
+++ b/modules/sdk-core/src/bitgo/utils/postWithCodec.ts
@@ -1,0 +1,77 @@
+import * as t from 'io-ts';
+import { BitGoBase } from '../bitgoBase';
+import { BitGoRequest } from '../../api';
+import { SuperAgent, SuperAgentRequest } from 'superagent';
+import { isLeft } from 'fp-ts/Either';
+
+/**
+ * @param body
+ * @param encodedBody
+ * @returns a list of unknown properties that are present in the body but not the codec.
+ */
+function getUnknownProperties(body: Record<string, unknown>, encodedBody: Record<string, unknown>): string[] {
+  const unknownProperties: string[] = [];
+  if (body && encodedBody) {
+    const bodyKeys = Object.keys(body);
+    const encodedBodyKeys = Object.keys(encodedBody);
+    const unknownKeys = bodyKeys.filter((key) => !encodedBodyKeys.includes(key));
+    unknownProperties.push(...unknownKeys);
+  }
+  return unknownProperties;
+}
+
+function getDecodeErrorKeys<A extends Record<string, unknown>, O extends Record<string, unknown>>(
+  codec: t.Type<A, O>,
+  body: A
+): string[] {
+  function toKeyPath(context: t.Context): string {
+    return context.flatMap((c) => (c.key ? [c.key] : [])).join('.');
+  }
+  const errors = codec.decode(body);
+  if (isLeft(errors)) {
+    return errors.left.map((error) => toKeyPath(error.context));
+  }
+  return [];
+}
+
+/**
+ * Try to encode the body with the codec and send the request.
+ * If the codec fails to encode the body, send the request with the body as is and set the 'codec-error' header to true.
+ * Set the 'io-ts-unknown-properties' header to the list of unknown properties that are present in the body but not the codec.
+ * @param bitgo
+ * @param url
+ * @param codec
+ * @param body
+ * @param [useEncodedBody=true] - when false, send the original body. Useful when writing new codecs.
+ */
+export function postWithCodec<
+  TAgent extends BitGoBase | SuperAgent<any>,
+  A extends Record<string, unknown>,
+  O extends Record<string, unknown>
+>(
+  agent: TAgent,
+  url: string,
+  codec: t.Type<A, O>,
+  body: A,
+  {
+    useEncodedBody = true,
+  }: {
+    useEncodedBody?: boolean;
+  } = {}
+): TAgent extends BitGoBase ? BitGoRequest : SuperAgentRequest {
+  let encodedBody: O | undefined;
+  let codecError;
+  try {
+    encodedBody = codec.encode(body);
+    codecError = false;
+  } catch (e) {
+    console.error('error encoding request body for url', url, e);
+    codecError = true;
+  }
+  return agent
+    .post(url)
+    .set('io-ts-codec-encode-error', codecError ? 'true' : 'false')
+    .set('io-ts-codec-decode-error', getDecodeErrorKeys(codec, body).join(','))
+    .set('io-ts-unknown-properties', encodedBody ? getUnknownProperties(body, encodedBody).join(',') : 'NA')
+    .send(useEncodedBody && encodedBody ? encodedBody : body);
+}

--- a/modules/sdk-core/test/unit/bitgo/utils/postWithCodec.ts
+++ b/modules/sdk-core/test/unit/bitgo/utils/postWithCodec.ts
@@ -1,0 +1,105 @@
+import assert from 'assert';
+import * as t from 'io-ts';
+import { agent, SuperAgentRequest } from 'superagent';
+
+import { postWithCodec } from '../../../../src/bitgo/utils/postWithCodec';
+
+describe('postWithCodec', function () {
+  type Headers = Record<string, unknown>;
+  function getRequest<A extends Record<string, unknown>, O extends Record<string, unknown>>(
+    codec: t.Type<A, O>,
+    body: A,
+    { useEncodedBody = true } = {}
+  ): {
+    body: unknown;
+    headers: Headers;
+  } {
+    const request = postWithCodec(agent(), 'http://example.com', codec, body, {
+      useEncodedBody,
+    }) as SuperAgentRequest & {
+      /*
+      Some private properties. A bit ugly, but the alternative is to make an actual request against
+      a nock, and tease out the headers from there. Not pretty either.
+      */
+      _data: unknown;
+      header: Headers;
+    };
+    return {
+      headers: request.header,
+      body: request._data,
+    };
+  }
+
+  function assertRequestContains(
+    request: {
+      body: unknown;
+      headers: Headers;
+    },
+    body: unknown,
+    headers: Headers
+  ) {
+    assert.deepStrictEqual(request.body, body);
+    for (const [key, value] of Object.entries(headers)) {
+      assert.deepStrictEqual(request.headers[key], value, `header ${key} does not match`);
+    }
+  }
+
+  const codec = t.exact(t.intersection([t.type({ foo: t.string }), t.partial({ bar: t.unknown })]));
+
+  it('has expected values with value matching codec', function () {
+    assertRequestContains(
+      getRequest(codec, { foo: 'bar' }),
+      { foo: 'bar' },
+      {
+        'io-ts-codec-encode-error': 'false',
+        'io-ts-codec-decode-error': '',
+        'io-ts-unknown-properties': '',
+      }
+    );
+
+    assertRequestContains(
+      getRequest(codec, { foo: 'bar', bar: null }),
+      { foo: 'bar', bar: null },
+      {
+        'io-ts-codec-encode-error': 'false',
+        'io-ts-codec-decode-error': '',
+        'io-ts-unknown-properties': '',
+      }
+    );
+  });
+
+  it('has expected values with value not matching codec', function () {
+    // invalid value
+    assertRequestContains(
+      getRequest(codec, { foo: null } as any),
+      { foo: null },
+      {
+        'io-ts-codec-encode-error': 'false',
+        'io-ts-codec-decode-error': '0.foo',
+        'io-ts-unknown-properties': '',
+      }
+    );
+
+    // non-exact value
+    assertRequestContains(
+      getRequest(codec, { foo: 'bar', boo: 1 } as any),
+      { foo: 'bar' },
+      {
+        'io-ts-codec-encode-error': 'false',
+        'io-ts-codec-decode-error': '',
+        'io-ts-unknown-properties': 'boo',
+      }
+    );
+
+    // non-exact value, useEncodedBody=false
+    assertRequestContains(
+      getRequest(codec, { foo: 'bar', boo: 1 } as any, { useEncodedBody: false }),
+      { foo: 'bar', boo: 1 },
+      {
+        'io-ts-codec-encode-error': 'false',
+        'io-ts-codec-decode-error': '',
+        'io-ts-unknown-properties': 'boo',
+      }
+    );
+  });
+});

--- a/modules/sdk-core/tsconfig.json
+++ b/modules/sdk-core/tsconfig.json
@@ -7,7 +7,7 @@
     "esModuleInterop": true,
     "typeRoots": ["../../types", "./node_modules/@types", "../../node_modules/@types"]
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "test/**/*"],
   "exclude": ["node_modules"],
   "references": [
     {


### PR DESCRIPTION
This is a helper method for the development of request codecs.

Since it is difficult to get the codec right the first time, this method 
allows to send the request with the original body and set some header flags
to indicate that the codec failed to decode or encode the body.

Issue: BTC-368