### PR TITLE
fix(sdk-core): handle txRequest full PA before signing

### DIFF
--- a/modules/bitgo/test/v2/unit/internal/tssUtils/eddsa.ts
+++ b/modules/bitgo/test/v2/unit/internal/tssUtils/eddsa.ts
@@ -907,6 +907,35 @@ describe('TSS Utils:', async function () {
     });
   });
 
+  describe('isPendingApprovalTxRequestFull', () => {
+    it('should return true for full apiVersion and pendingApproval state', async () => {
+      const txRequest = {
+        apiVersion: 'full',
+        state: 'pendingApproval',
+      } as TxRequest;
+      const result = await tssUtils.isPendingApprovalTxRequestFull(txRequest);
+      result.should.be.true();
+    });
+
+    it('should return false for non-full apiVersion', async () => {
+      const txRequest = {
+        apiVersion: 'lite',
+        state: 'pendingApproval',
+      } as TxRequest;
+      const result = await tssUtils.isPendingApprovalTxRequestFull(txRequest);
+      result.should.be.false();
+    });
+
+    it('should return false for non-pendingApproval state', async () => {
+      const txRequest = {
+        apiVersion: 'full',
+        state: 'pendingDelivery',
+      } as TxRequest;
+      const result = await tssUtils.isPendingApprovalTxRequestFull(txRequest);
+      result.should.be.false();
+    });
+  });
+
   // #region Nock helpers
   async function generateBitgoKeychain(params: {
     coin: string;

--- a/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
@@ -6,7 +6,7 @@ import { IMarkets } from '../market';
 import { IPendingApprovals } from '../pendingApproval';
 import { InitiateRecoveryOptions } from '../recovery';
 import { EcdsaUtils } from '../utils/tss/ecdsa';
-import EddsaUtils from '../utils/tss/eddsa';
+import EddsaUtils, { TxRequest } from '../utils/tss/eddsa';
 import { CustomSigningFunction, IWallet, IWallets, Wallet, WalletData } from '../wallet';
 
 import { IWebhooks } from '../webhook/iWebhooks';
@@ -369,7 +369,8 @@ export type SignedTransaction =
   | HalfSignedAccountTransaction
   | HalfSignedUtxoTransaction
   | FullySignedTransaction
-  | SignedTransactionRequest;
+  | SignedTransactionRequest
+  | TxRequest;
 
 export interface SignedMessage {
   coin?: string;

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
@@ -414,4 +414,9 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
     }
     return [];
   }
+
+  isPendingApprovalTxRequestFull(txRequest: TxRequest): boolean {
+    const { apiVersion, state } = txRequest;
+    return apiVersion === 'full' && 'pendingApproval' === state;
+  }
 }

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -1855,6 +1855,14 @@ export class Wallet implements IWallet {
       });
     }
 
+    if (mustUseTxRequestFull && signingParams.txPrebuild.txRequestId) {
+      assert(this.tssUtils, 'tssUtils must be defined for TSS wallets');
+      const txRequest = await this.tssUtils.getTxRequest(signingParams.txPrebuild.txRequestId);
+      if (this.tssUtils.isPendingApprovalTxRequestFull(txRequest)) {
+        return txRequest;
+      }
+    }
+
     try {
       return await this.signTransaction(signingParams);
     } catch (error) {


### PR DESCRIPTION
In the txRequest full flow, we have to check if the txRequest is pending approval before trying to sign.

WP-439

TICKET: WP-439

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
