### PR TITLE
feat(sdk-core): support resigning enterprise and bitgo tss configs

### DIFF
--- a/modules/sdk-core/src/bitgo/bitgoBase.ts
+++ b/modules/sdk-core/src/bitgo/bitgoBase.ts
@@ -2,7 +2,7 @@ import { BitGoRequest, DecryptOptions, EncryptOptions, GetSharingKeyOptions, IRe
 import { IBaseCoin } from './baseCoin';
 import { CoinConstructor } from './coinFactory';
 import { EnvironmentName } from './environments';
-import { GetSigningKeyApi } from './keychain';
+import { EcdhDerivedKeypair, GetSigningKeyApi } from './keychain';
 
 export interface BitGoBase {
   wallets(): any; // TODO - define v1 wallets type
@@ -14,6 +14,7 @@ export interface BitGoBase {
   fetchConstants(): Promise<any>;
   get(url: string): BitGoRequest;
   getECDHKeychain(ecdhKeychainPub?: string): Promise<any>;
+  getEcdhKeypairPrivate(password: string, entId?: string): Promise<EcdhDerivedKeypair>;
   getEnv(): EnvironmentName;
   getSharingKey({ email }: GetSharingKeyOptions): Promise<any>;
   getSigningKeyForUser(enterpriseId: string, userId?: string): Promise<GetSigningKeyApi>;

--- a/modules/sdk-core/src/bitgo/enterprise/enterprises.ts
+++ b/modules/sdk-core/src/bitgo/enterprise/enterprises.ts
@@ -6,6 +6,8 @@ import { IBaseCoin } from '../baseCoin';
 import { BitGoBase } from '../bitgoBase';
 import { Enterprise } from './enterprise';
 import { GetEnterpriseOptions, IEnterprises } from './iEnterprises';
+import { EcdhDerivedKeypair } from '../keychain';
+import { SerializedNtildeWithVerifiers } from '../utils/tss/ecdsa';
 
 export class Enterprises implements IEnterprises {
   private readonly bitgo: BitGoBase;
@@ -53,5 +55,42 @@ export class Enterprises implements IEnterprises {
   public async create(params: any = {}): Promise<Enterprise> {
     const enterpriseData = (await this.bitgo.post(this.bitgo.url(`/enterprise`)).send(params).result()) as any;
     return new Enterprise(this.bitgo, this.baseCoin, enterpriseData);
+  }
+
+  /**
+   * Resign TSS configs of all enterprises belonging to the user with a
+   * new user password / ecdh keychain
+   */
+  public async resignTssConfigsForEnterprises(
+    oldEcdhKeypair: EcdhDerivedKeypair,
+    newEcdhKeypair: EcdhDerivedKeypair
+  ): Promise<void> {
+    const enterpriseTssConfigsForUser = await this.bitgo
+      .get(this.bitgo.url('/tssconfigs/ecdsa', 2))
+      .query({
+        createdBy: 'me',
+      })
+      .send()
+      .result();
+
+    const resigningPromises = enterpriseTssConfigsForUser.map(async (enterpriseTssConfig) => {
+      const enterprise = new Enterprise(this.bitgo, this.bitgo.coin('tbtc'), {
+        id: enterpriseTssConfig.enterpriseId,
+        name: '',
+      });
+      const enterpriseChallenge = enterpriseTssConfig.ecdsa.challenge?.enterprise as SerializedNtildeWithVerifiers;
+      const bitgoNitroChallenge = enterpriseTssConfig.ecdsa.challenge?.bitgoNitroHsm as SerializedNtildeWithVerifiers;
+      const bitgoInstChallenge = enterpriseTssConfig.ecdsa.challenge
+        ?.bitgoInstitutionalHsm as SerializedNtildeWithVerifiers;
+      await enterprise.resignEnterpriseChallenges(
+        oldEcdhKeypair,
+        newEcdhKeypair,
+        enterpriseChallenge,
+        bitgoInstChallenge,
+        bitgoNitroChallenge
+      );
+    });
+
+    await Promise.all(resigningPromises);
   }
 }

--- a/modules/sdk-core/src/bitgo/enterprise/iEnterprise.ts
+++ b/modules/sdk-core/src/bitgo/enterprise/iEnterprise.ts
@@ -3,7 +3,8 @@ import { EcdsaTypes } from '@bitgo/sdk-lib-mpc';
 import { ISettlements, IAffirmations } from '../trading';
 import { IWallet } from '../wallet';
 import { Buffer } from 'buffer';
-import { BitGoProofSignatures } from '../utils/tss/ecdsa';
+import { BitGoProofSignatures, SerializedNtildeWithVerifiers } from '../utils/tss/ecdsa';
+import { EcdhDerivedKeypair } from '../keychain';
 
 // useEnterpriseEcdsaTssChallenge is deprecated
 export type EnterpriseFeatureFlag = 'useEnterpriseEcdsaTssChallenge';
@@ -33,5 +34,12 @@ export interface IEnterprise {
     challenge?: EcdsaTypes.DeserializedNtildeWithProofs
   ): Promise<void>;
   getExistingTssEcdsaChallenge(): Promise<EcdsaTypes.DeserializedNtildeWithProofs>;
+  resignEnterpriseChallenges(
+    oldEcdhKeypair: EcdhDerivedKeypair,
+    newEcdhKeypair: EcdhDerivedKeypair,
+    entChallenge: SerializedNtildeWithVerifiers,
+    bitgoInstChallenge: SerializedNtildeWithVerifiers,
+    bitgoNitroChallenge: SerializedNtildeWithVerifiers
+  ): Promise<void>;
   hasFeatureFlags(flags: EnterpriseFeatureFlag[]): boolean;
 }

--- a/modules/sdk-core/src/bitgo/enterprise/iEnterprises.ts
+++ b/modules/sdk-core/src/bitgo/enterprise/iEnterprises.ts
@@ -1,4 +1,5 @@
 import { IEnterprise } from './iEnterprise';
+import { EcdhDerivedKeypair } from '../keychain';
 
 export interface GetEnterpriseOptions {
   id?: string;
@@ -8,4 +9,5 @@ export interface IEnterprises {
   list(params?: Record<string, never>): Promise<IEnterprise[]>;
   get(params?: GetEnterpriseOptions): Promise<IEnterprise>;
   create(params?: any): Promise<IEnterprise>;
+  resignTssConfigsForEnterprises(oldEcdhKeypair: EcdhDerivedKeypair, newEcdhKeypair: EcdhDerivedKeypair): Promise<void>;
 }

--- a/modules/sdk-core/src/bitgo/keychain/iKeychains.ts
+++ b/modules/sdk-core/src/bitgo/keychain/iKeychains.ts
@@ -127,6 +127,12 @@ export interface GetSigningKeyApi {
   ecdhKeychain?: string;
 }
 
+export interface EcdhDerivedKeypair {
+  derivedPubKey: string; // Hex string
+  derivationPath: string; // Derivation path of the keypair
+  xprv: string;
+}
+
 export enum KeyIndices {
   USER = 0,
   BACKUP = 1,

--- a/modules/sdk-core/src/bitgo/tss/ecdsa/types.ts
+++ b/modules/sdk-core/src/bitgo/tss/ecdsa/types.ts
@@ -1,5 +1,4 @@
 import { ECDSA } from './../../../account-lib/mpc/tss';
-import { SerializedNtilde } from "@bitgo/sdk-lib-mpc/dist/src/tss/ecdsa/types";
 
 export type NShare = ECDSA.NShare;
 export type KeyShare = ECDSA.KeyShare;
@@ -74,16 +73,6 @@ export type CreateCombinedKeyParams = {
   keyShare: ECDSA.KeyShare;
   encryptedNShares: DecryptableNShare[];
   commonKeychain: string;
-};
-
-interface NtildeVerifiers {
-  adminSignature: string;
-  bitgoNitroHsmSignature?: string;
-  bitgoInstitutionalHsmSignature?: string;
-}
-
-export type SerializedNtildeWithVerifiers = SerializedNtilde & {
-  verifiers: NtildeVerifiers;
 };
 
 export type SendShareToBitgoRT = AShare | DShare | SShare | Signature;

--- a/modules/sdk-core/src/bitgo/tss/ecdsa/types.ts
+++ b/modules/sdk-core/src/bitgo/tss/ecdsa/types.ts
@@ -1,4 +1,5 @@
 import { ECDSA } from './../../../account-lib/mpc/tss';
+import { SerializedNtilde } from "@bitgo/sdk-lib-mpc/dist/src/tss/ecdsa/types";
 
 export type NShare = ECDSA.NShare;
 export type KeyShare = ECDSA.KeyShare;
@@ -73,6 +74,16 @@ export type CreateCombinedKeyParams = {
   keyShare: ECDSA.KeyShare;
   encryptedNShares: DecryptableNShare[];
   commonKeychain: string;
+};
+
+interface NtildeVerifiers {
+  adminSignature: string;
+  bitgoNitroHsmSignature?: string;
+  bitgoInstitutionalHsmSignature?: string;
+}
+
+export type SerializedNtildeWithVerifiers = SerializedNtilde & {
+  verifiers: NtildeVerifiers;
 };
 
 export type SendShareToBitgoRT = AShare | DShare | SShare | Signature;

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
@@ -1371,7 +1371,7 @@ export class EcdsaUtils extends baseTSSUtils<KeyShare> {
    * This initiates ecdsa signing for the enterprise users.
    * @param bitgo
    * @param entId - enterprise to enable ecdsa signing on
-   * @param entChallengeWithProofs - client side generated ent challenge with ZK proofs
+   * @param entChallenge - client side generated ent challenge with ZK proofs
    * @param entChallengeSignature - signature on enterprise challenge
    * @param bitgoIntChallengeSignature - signature on BitGo's institutional HSM challenge
    * @param bitgoNitroChallengeSignature - signature on BitGo's nitro HSM challenge
@@ -1379,20 +1379,16 @@ export class EcdsaUtils extends baseTSSUtils<KeyShare> {
   static async uploadChallengesToEnterprise(
     bitgo: BitGoBase,
     entId: string,
-    entChallengeWithProofs: EcdsaTypes.SerializedNtildeWithProofs,
+    entChallenge: EcdsaTypes.SerializedNtilde | EcdsaTypes.SerializedNtildeWithProofs,
     entChallengeSignature: string,
     bitgoIntChallengeSignature: string,
     bitgoNitroChallengeSignature: string
   ): Promise<void> {
     const body = {
       enterprise: {
-        ntilde: entChallengeWithProofs.ntilde,
-        h1: entChallengeWithProofs.h1,
-        h2: entChallengeWithProofs.h2,
-        ntildeProof: {
-          h1WrtH2: entChallengeWithProofs.ntildeProof.h1WrtH2,
-          h2WrtH1: entChallengeWithProofs.ntildeProof.h2WrtH1,
-        },
+        ntilde: entChallenge.ntilde,
+        h1: entChallenge.h1,
+        h2: entChallenge.h2,
         verifiers: {
           adminSignature: entChallengeSignature,
         },
@@ -1408,6 +1404,9 @@ export class EcdsaUtils extends baseTSSUtils<KeyShare> {
         },
       },
     };
+    if ('ntildeProof' in entChallenge) {
+      body.enterprise['ntildeProof'] = entChallenge.ntildeProof;
+    }
     await bitgo
       .put(bitgo.url(`/enterprise/${entId}/tssconfig/ecdsa/challenge`, 2))
       .send(body)

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/types.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/types.ts
@@ -30,3 +30,13 @@ export type BitGoProofSignatures = {
   bitgoNitroHsmAdminSignature: Buffer;
   bitgoInstHsmAdminSignature: Buffer;
 };
+
+interface NtildeVerifiers {
+  adminSignature: string;
+  bitgoNitroHsmSignature?: string;
+  bitgoInstitutionalHsmSignature?: string;
+}
+
+export type SerializedNtildeWithVerifiers = EcdsaTypes.SerializedNtilde & {
+  verifiers: NtildeVerifiers;
+};


### PR DESCRIPTION
Currently when we create new enterprise MPC config's, they are signed by one of the admins. During signing, we verify that the config's signature by admin's keychain to confirm it's validity. 

In the case if the admin forgets and resets their password (in which case a new keychain is created), the MPC config needs to be re-signed. This PR exposes methods to support re-signing. Also, if an admin is removed from the enterprise, same helper methods can be used to resign. 

NOTE: Recommend reviewing commit by commit.

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
