### PR TITLE
fix(utxo-lib): remove prev tx from psbt

### DIFF
--- a/modules/bitgo/test/v2/unit/coins/utxo/prebuildAndSign.ts
+++ b/modules/bitgo/test/v2/unit/coins/utxo/prebuildAndSign.ts
@@ -47,13 +47,13 @@ const keyDocumentObjects = rootWalletKeys.triple.map((bip32, keyIdx) => {
 
 function run(coin: AbstractUtxoCoin, inputScripts: ScriptType[], txFormat: TxFormat): void {
   function createPrebuildPsbt(inputs: Input[], outputs: { scriptType: 'p2sh'; value: bigint }[]) {
-    return utxolib.testutil.constructPsbt(
-      inputs as utxolib.testutil.Input[],
+    return utxolib.testutil.constructPsbt({
+      inputs: inputs as utxolib.testutil.Input[],
       outputs,
-      coin.network,
+      network: coin.network,
       rootWalletKeys,
-      'unsigned'
-    );
+      sign: 'unsigned',
+    });
   }
 
   function createNocks(params: {

--- a/modules/bitgo/test/v2/unit/coins/utxo/transaction.ts
+++ b/modules/bitgo/test/v2/unit/coins/utxo/transaction.ts
@@ -177,7 +177,7 @@ describe(`UTXO coin signTransaction`, async function () {
     }));
     const unspentSum = inputs.reduce((prev: bigint, curr) => prev + curr.value, BigInt(0));
     const outputs: testutil.Output[] = [{ scriptType: 'p2sh', value: unspentSum - BigInt(1000) }];
-    const psbt = testutil.constructPsbt(inputs, outputs, coin.network, rootWalletKeys, 'unsigned');
+    const psbt = testutil.constructPsbt({ inputs, outputs, network: coin.network, rootWalletKeys, sign: 'unsigned' });
 
     for (const v of [false, true]) {
       await signTransaction(psbt, v);
@@ -193,7 +193,7 @@ describe(`UTXO coin signTransaction`, async function () {
       }));
     const unspentSum = inputs.reduce((prev: bigint, cur) => prev + cur.value, BigInt(0));
     const outputs: testutil.Output[] = [{ scriptType: 'p2sh', value: unspentSum - BigInt(1000) }];
-    const psbt = testutil.constructPsbt(inputs, outputs, coin.network, rootWalletKeys, 'unsigned');
+    const psbt = testutil.constructPsbt({ inputs, outputs, network: coin.network, rootWalletKeys, sign: 'unsigned' });
 
     for (const v of [false, true]) {
       await signTransaction(psbt, v);
@@ -221,7 +221,7 @@ describe(`UTXO coin signTransaction`, async function () {
     const inputs: testutil.Input[] = [{ scriptType: 'taprootKeyPathSpend', value: BigInt(1000) }];
     const unspentSum = inputs.reduce((prev: bigint, curr) => prev + curr.value, BigInt(0));
     const outputs: testutil.Output[] = [{ scriptType: 'p2sh', value: unspentSum - BigInt(1000) }];
-    const psbt = testutil.constructPsbt(inputs, outputs, coin.network, rootWalletKeys, 'unsigned');
+    const psbt = testutil.constructPsbt({ inputs, outputs, network: coin.network, rootWalletKeys, sign: 'unsigned' });
 
     await assert.rejects(
       async () => {
@@ -363,7 +363,7 @@ function run<TNumber extends number | bigint = number>(
       );
       const unspentSum = inputs.reduce((prev: bigint, curr) => prev + curr.value, BigInt(0));
       const outputs: testutil.Output[] = [{ scriptType: 'p2sh', value: unspentSum - BigInt(1000) }];
-      return testutil.constructPsbt(inputs, outputs, coin.network, walletKeys, 'unsigned');
+      return testutil.constructPsbt({ inputs, outputs, network: coin.network, walletKeys, sign: 'unsigned' });
     }
 
     async function getTransactionStages(): Promise<TransactionStages> {

--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -370,13 +370,13 @@ describe('V2 Wallet:', function () {
     }
 
     it('should use a custom signing function if provided for PSBT with taprootKeyPathSpend input', async function () {
-      const psbt = utxoLib.testutil.constructPsbt(
-        [{ scriptType: 'taprootKeyPathSpend', value: BigInt(1000) }],
-        [{ scriptType: 'p2sh', value: BigInt(900) }],
-        basecoin.network,
-        rootWalletKey,
-        'unsigned'
-      );
+      const psbt = utxoLib.testutil.constructPsbt({
+        inputs: [{ scriptType: 'taprootKeyPathSpend', value: BigInt(1000) }],
+        outputs: [{ scriptType: 'p2sh', value: BigInt(900) }],
+        network: basecoin.network,
+        rootWalletKeys: rootWalletKey,
+        sign: 'unsigned',
+      });
       const scope = nocks({ txHex: psbt.toHex() });
       const result = await wallet.sendMany({ recipients, customSigningFunction });
 
@@ -387,13 +387,13 @@ describe('V2 Wallet:', function () {
     });
 
     it('should use a custom signing function if provided for PSBT without taprootKeyPathSpend input', async function () {
-      const psbt = utxoLib.testutil.constructPsbt(
-        [{ scriptType: 'p2wsh', value: BigInt(1000) }],
-        [{ scriptType: 'p2sh', value: BigInt(900) }],
-        basecoin.network,
-        rootWalletKey,
-        'unsigned'
-      );
+      const psbt = utxoLib.testutil.constructPsbt({
+        inputs: [{ scriptType: 'p2wsh', value: BigInt(1000) }],
+        outputs: [{ scriptType: 'p2sh', value: BigInt(900) }],
+        network: basecoin.network,
+        rootWalletKeys: rootWalletKey,
+        sign: 'unsigned',
+      });
       const scope = nocks({ txHex: psbt.toHex() });
       const result = await wallet.sendMany({ recipients, customSigningFunction });
 

--- a/modules/utxo-bin/test/fixtures.ts
+++ b/modules/utxo-bin/test/fixtures.ts
@@ -59,7 +59,13 @@ export async function getPsbt(
       throw e;
     }
   }
-  const transaction = utxolib.testutil.constructPsbt(inputs, outputs, network, walletKeys, stage);
+  const transaction = utxolib.testutil.constructPsbt({
+    inputs,
+    outputs,
+    network,
+    rootWalletKeys: walletKeys,
+    sign: stage,
+  });
   if (writeFixture) {
     await fs.writeFile(writeFixture, JSON.stringify(transaction.toHex()), 'utf8');
   }

--- a/modules/utxo-lib/src/bitgo/zcash/ZcashPsbt.ts
+++ b/modules/utxo-lib/src/bitgo/zcash/ZcashPsbt.ts
@@ -126,20 +126,11 @@ export class ZcashPsbt extends UtxoPsbt<ZcashTransaction<bigint>> {
   // transactions because zcash hashes the value directly. Thus, it is unnecessary to have
   // the previous transaction hash on the unspent.
   signInput(inputIndex: number, keyPair: Signer, sighashTypes?: number[]): this {
-    return this.withUnsafeSignNonSegwitTrue(super.signInput.bind(this, inputIndex, keyPair, sighashTypes));
+    return super.signInput(inputIndex, keyPair, { sighashTypes, unsafeSignNonSegwit: true });
   }
 
   validateSignaturesOfInput(inputIndex: number, validator: ValidateSigFunction, pubkey?: Buffer): boolean {
-    return this.withUnsafeSignNonSegwitTrue(super.validateSignaturesOfInput.bind(this, inputIndex, validator, pubkey));
-  }
-
-  private withUnsafeSignNonSegwitTrue<T>(fn: () => T): T {
-    (this as any).__CACHE.__UNSAFE_SIGN_NONSEGWIT = true;
-    try {
-      return fn();
-    } finally {
-      (this as any).__CACHE.__UNSAFE_SIGN_NONSEGWIT = false;
-    }
+    return super.validateSignaturesOfInput(inputIndex, validator, { pubkey, unsafeSignNonSegwit: true });
   }
 
   private setPropertyCheckSignatures(propName: keyof ZcashTransaction<bigint>, value: unknown) {

--- a/modules/utxo-lib/test/bitgo/psbt/SignVerifyPsbtAndTx.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/SignVerifyPsbtAndTx.ts
@@ -63,7 +63,7 @@ function runPsbt(network: Network, sign: SignatureTargetType, inputs: Input[], o
 
   describe(`psbt build, sign and verify for ${coin} ${sign}`, function () {
     it(`getSignatureValidationArray with globalXpub ${coin} ${sign}`, function () {
-      const psbt = constructPsbt(inputs, outputs, network, rootWalletKeys, sign);
+      const psbt = constructPsbt({ inputs, outputs, network, rootWalletKeys, sign });
       addXpubsToPsbt(psbt, neutratedRootWalletKeys);
       psbt.data.inputs.forEach((input, inputIndex) => {
         const isP2shP2pk = inputs[inputIndex].scriptType === 'p2shP2pk';
@@ -79,7 +79,7 @@ function runPsbt(network: Network, sign: SignatureTargetType, inputs: Input[], o
     });
 
     it(`getSignatureValidationArray with rootNodes ${coin} ${sign}`, function () {
-      const psbt = constructPsbt(inputs, outputs, network, rootWalletKeys, sign);
+      const psbt = constructPsbt({ inputs, outputs, network, rootWalletKeys, sign });
       addXpubsToPsbt(psbt, neutratedRootWalletKeys);
       psbt.data.inputs.forEach((input, inputIndex) => {
         const isP2shP2pk = inputs[inputIndex].scriptType === 'p2shP2pk';
@@ -95,7 +95,7 @@ function runPsbt(network: Network, sign: SignatureTargetType, inputs: Input[], o
     });
 
     it(`getSignatureValidationArrayPsbt  ${coin} ${sign}`, function () {
-      const psbt = constructPsbt(inputs, outputs, network, rootWalletKeys, sign);
+      const psbt = constructPsbt({ inputs, outputs, network, rootWalletKeys, sign });
       const sigValidations = getSignatureValidationArrayPsbt(psbt, neutratedRootWalletKeys);
       psbt.data.inputs.forEach((input, inputIndex) => {
         const expectedSigValid = getSigValidArray(inputs[inputIndex].scriptType, sign);
@@ -106,7 +106,7 @@ function runPsbt(network: Network, sign: SignatureTargetType, inputs: Input[], o
     });
 
     it(`psbt signature counts ${coin} ${sign}`, function () {
-      const psbt = constructPsbt(inputs, outputs, network, rootWalletKeys, sign);
+      const psbt = constructPsbt({ inputs, outputs, network, rootWalletKeys, sign });
       const counts = getStrictSignatureCounts(psbt);
       const countsFromInputs = getStrictSignatureCounts(psbt.data.inputs);
 


### PR DESCRIPTION
Large and unknown type prevTx (nonWitnessUtxo) causes issues in hsm This util function will help to remove it in WP and tests.

Ticket: BTC-376

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
