### PR TITLE
feat(utxo-lib): allow both compressed & uncompressed pubkeys

### DIFF
--- a/modules/utxo-lib/src/bitgo/index.ts
+++ b/modules/utxo-lib/src/bitgo/index.ts
@@ -4,6 +4,7 @@ export * as bcashAddress from './bitcoincash';
 export * as keyutil from './keyutil';
 export * as nonStandardHalfSigned from './nonStandardHalfSigned';
 export * as outputScripts from './outputScripts';
+export * as legacySafe from './legacysafe';
 export * as musig2 from './Musig2';
 export * from './dash';
 export * from './parseInput';

--- a/modules/utxo-lib/src/bitgo/legacysafe/index.ts
+++ b/modules/utxo-lib/src/bitgo/legacysafe/index.ts
@@ -48,8 +48,12 @@ export function createLegacySafeOutputScript2of3(
   }
 
   pubkeys.forEach((key) => {
-    if (key.length !== 65) {
-      throw new Error(`Unexpected key length ${key.length}. Must use uncompressed keys.`);
+    if (key.length !== pubkeys[0].length) {
+      throw new Error(`all pubkeys must have the same length`);
+    }
+    if (key.length !== 65 && key.length !== 33) {
+      // V1 Safe BTC wallets could contain either uncompressed or compressed pubkeys
+      throw new Error(`Unexpected key length ${key.length}, neither compressed nor uncompressed.`);
     }
   });
 

--- a/modules/utxo-lib/test/bitgo/legacysafe/index.ts
+++ b/modules/utxo-lib/test/bitgo/legacysafe/index.ts
@@ -31,12 +31,11 @@ describe('public key conversion', function () {
 
 describe('legacy safe scripts creation', function () {
   const compressedKeyPairs = getKeyTriple('utxo');
-  const compressedPubKeys = compressedKeyPairs.map((keyPair) => keyPair.publicKey);
 
-  it('throws error for compressed public keys', function () {
+  it('throws error for invalid public keys', function () {
     assert.throws(
-      () => createLegacySafeOutputScript2of3(compressedPubKeys, networks.bitcoin),
-      /^Error: Unexpected key length 33. Must use uncompressed keys.$/
+      () => createLegacySafeOutputScript2of3([Buffer.alloc(10), Buffer.alloc(11), Buffer.alloc(12)], networks.bitcoin),
+      /^Error: Unexpected key length 10, neither compressed nor uncompressed.$/
     );
   });
 


### PR DESCRIPTION
in output script creation of v1 safe wallets

Also export legacySafe functions from utxolib

BTC-335

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
