### PR TITLE
fix(utxo-lib): remove prev tx from psbt

### DIFF
--- a/modules/utxo-lib/src/bitgo/PsbtUtil.ts
+++ b/modules/utxo-lib/src/bitgo/PsbtUtil.ts
@@ -1,5 +1,6 @@
 import { decodeProprietaryKey, ProprietaryKey } from 'bip174/src/lib/proprietaryKeyVal';
 import { PsbtInput } from 'bip174/src/lib/interfaces';
+import { Psbt } from 'bitcoinjs-lib/src/psbt';
 
 /**
  * bitgo proprietary key identifier
@@ -103,4 +104,16 @@ export function isPsbt(data: Buffer | string): boolean {
     data = Buffer.from(data.slice(0, 10), 'hex');
   }
   return 5 <= data.length && data.readUInt32BE(0) === 0x70736274 && data.readUInt8(4) === 0xff;
+}
+
+/**
+ * This function allows signing or validating a psbt with non-segwit inputs those do not contain nonWitnessUtxo.
+ */
+export function withUnsafeNonSegwit<T>(psbt: Psbt, fn: () => T, unsafe = true): T {
+  (psbt as any).__CACHE.__UNSAFE_SIGN_NONSEGWIT = unsafe;
+  try {
+    return fn();
+  } finally {
+    (psbt as any).__CACHE.__UNSAFE_SIGN_NONSEGWIT = false;
+  }
 }

--- a/modules/utxo-lib/src/bitgo/wallet/Psbt.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/Psbt.ts
@@ -9,7 +9,7 @@ import { UtxoTransaction } from '../UtxoTransaction';
 import { createOutputScript2of3, getLeafHash, scriptTypeForChain, toXOnlyPublicKey } from '../outputScripts';
 import { DerivedWalletKeys, RootWalletKeys } from './WalletKeys';
 import { toPrevOutputWithPrevTx } from '../Unspent';
-import { createPsbtFromTransaction } from '../transaction';
+import { createPsbtForNetwork, createPsbtFromTransaction } from '../transaction';
 import { isWalletUnspent, WalletUnspent } from './Unspent';
 
 import {
@@ -549,4 +549,66 @@ export function extractP2msOnlyHalfSignedTx(psbt: UtxoPsbt): UtxoTransaction<big
   });
 
   return tx;
+}
+
+/**
+ * Clones the psbt without nonWitnessUtxo for non-segwit inputs and witnessUtxo is added instead.
+ * It is not BIP-174 compliant, so use it carefully.
+ */
+export function clonePsbtWithoutNonWitnessUtxo(psbt: UtxoPsbt): UtxoPsbt {
+  const newPsbt = createPsbtForNetwork({ network: psbt.network });
+  newPsbt.setVersion(psbt.version);
+  newPsbt.setLocktime(psbt.locktime);
+  newPsbt.updateGlobal({ ...psbt.data.globalMap });
+
+  psbt.txOutputs.forEach((output, i) => {
+    newPsbt.addOutput({ ...output });
+    newPsbt.updateOutput(i, psbt.data.outputs[i]);
+  });
+
+  const partialSigs = new Map<number, PartialSig[]>();
+  const tapScriptSigs = new Map<number, TapScriptSig[]>();
+
+  psbt.txInputs.forEach((txIn, i) => {
+    assert(!isPsbtInputFinalized(psbt.data.inputs[i]));
+    newPsbt.addInput({ ...txIn });
+    const { partialSig, tapScriptSig, ...input } = psbt.data.inputs[i];
+    if (partialSig) {
+      partialSigs.set(i, partialSig);
+    }
+    if (tapScriptSig) {
+      tapScriptSigs.set(i, tapScriptSig);
+    }
+    if (input.nonWitnessUtxo && !input.witnessUtxo) {
+      const tx = UtxoTransaction.fromBuffer<bigint>(input.nonWitnessUtxo, false, 'bigint', psbt.network);
+      if (!txIn.hash.equals(tx.getHash())) {
+        throw new Error(`Non-witness UTXO hash for input #${i} doesn't match the hash specified in the prevout`);
+      }
+      input.witnessUtxo = tx.outs[txIn.index];
+    }
+    delete input.nonWitnessUtxo;
+    newPsbt.updateInput(i, input);
+    input.unknownKeyVals?.forEach((keyVal) => newPsbt.addUnknownKeyValToInput(i, keyVal));
+  });
+
+  partialSigs.forEach((partialSig, i) => {
+    newPsbt.updateInput(i, { partialSig });
+  });
+  tapScriptSigs.forEach((tapScriptSig, i) => {
+    newPsbt.updateInput(i, { tapScriptSig });
+  });
+
+  return newPsbt;
+}
+
+/**
+ * Deletes witnessUtxo for non-segwit inputs to make the PSBT BIP-174 compliant.
+ */
+export function deleteWitnessUtxoForNonSegwitInputs(psbt: UtxoPsbt): void {
+  psbt.data.inputs.forEach((input, i) => {
+    const scriptType = getPsbtInputScriptType(input);
+    if (scriptType === 'p2sh' || scriptType === 'p2shP2pk') {
+      delete input.witnessUtxo;
+    }
+  });
 }


### PR DESCRIPTION
Large and unknown type prevTx (nonWitnessUtxo) causes issues in hsm
This util function will help to remove it in WP and tests.

Ticket: BTC-376

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
