### PR TITLE
fix(sdk-coin-trx): skip sweep address with balance lower than a threshold

### DIFF
--- a/modules/sdk-coin-trx/src/trx.ts
+++ b/modules/sdk-coin-trx/src/trx.ts
@@ -579,7 +579,7 @@ export class Trx extends BaseCoin {
     let isReceiveAddress = false;
     let addressInfo: AddressInfo | undefined;
 
-    if (recoveryAmount > 0) {
+    if (recoveryAmount > SAFE_TRON_TRANSACTION_FEE) {
       const userXPub = keys[0].neutered().toBase58();
       const backupXPub = keys[1].neutered().toBase58();
 


### PR DESCRIPTION
Dust left after sweeping is normal. But it shall not prevent sweeping the next address.

```Error: Amount of funds to recover wouldnt be able to fund a send```

EA-1327