### PR TITLE
docs: update readme to reflect support of node18

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ We specifically limit our support to these versions of Node, not because this pa
 As each Node LTS version reaches its end-of-life we will exclude that version from the node engines property of our package's package.json file. Removing a Node version is considered a breaking change and will entail the publishing of a new major version of this package. We will not accept any requests to support an end-of-life version of Node, and any pull requests or issues regarding support for an end-of-life version of Node will be closed. We will accept code that allows this package to run on newer, non-LTS, versions of Node. Furthermore, we will attempt to ensure our own changes work on the latest version of Node. To help in that commitment, our continuous integration setup runs the full test suite on the latest release of the following versions of node:
 
 - `16`
+- `18`
 
 JavaScript package managers should allow you to install this package with any version of Node, with, at most, a warning if your version of Node does not fall within the range specified by our node engines property. If you encounter issues installing this package on a supported version of Node, please report the issue to us.
 


### PR DESCRIPTION
## Description

[This line in a GHA workflow makes me think the docs need to be updated to reflect we support Node18.](https://github.com/BitGo/BitGoJS/blob/c6ac3efd478be313ecfc73d74dc59f6b6ced1005/.github/workflows/ci.yml#L19)

## Issue Number

VL-0

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?

No, testing markdown is really hard.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [x] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
-->
