### PR TITLE
fix(sdk-core): do not sign txRequest full with PA

### DIFF
--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -1876,11 +1876,11 @@ describe('V2 Wallet:', function () {
       multisigType: 'tss',
     };
 
-    const tssWallet = new Wallet(bitgo, tsol, walletData);
+    const tssSolWallet = new Wallet(bitgo, tsol, walletData);
 
     let tssEthWallet = new Wallet(bitgo, bitgo.coin('teth'), ethWalletData);
     const tssPolygonWallet = new Wallet(bitgo, bitgo.coin('tpolygon'), polygonWalletData);
-    const custodialTssWallet = new Wallet(bitgo, tsol, { ...walletData, type: 'custodial' });
+    const custodialTssSolWallet = new Wallet(bitgo, tsol, { ...walletData, type: 'custodial' });
 
     const txRequest: TxRequest = {
       txRequestId: 'id',
@@ -2011,15 +2011,15 @@ describe('V2 Wallet:', function () {
           intentType: 'payment',
         });
 
-        const txPrebuild = await tssWallet.prebuildTransaction({
+        const txPrebuild = await tssSolWallet.prebuildTransaction({
           reqId,
           recipients,
           type: 'transfer',
         });
 
         txPrebuild.should.deepEqual({
-          walletId: tssWallet.id(),
-          wallet: tssWallet,
+          walletId: tssSolWallet.id(),
+          wallet: tssSolWallet,
           txRequestId: 'id',
           txHex: 'ababcdcd',
           buildParams: {
@@ -2058,7 +2058,7 @@ describe('V2 Wallet:', function () {
           },
         });
 
-        const txPrebuild = await tssWallet.prebuildTransaction({
+        const txPrebuild = await tssSolWallet.prebuildTransaction({
           reqId,
           recipients,
           type: 'transfer',
@@ -2069,8 +2069,8 @@ describe('V2 Wallet:', function () {
         });
 
         txPrebuild.should.deepEqual({
-          walletId: tssWallet.id(),
-          wallet: tssWallet,
+          walletId: tssSolWallet.id(),
+          wallet: tssSolWallet,
           txRequestId: 'id',
           txHex: 'ababcdcd',
           buildParams: {
@@ -2105,7 +2105,7 @@ describe('V2 Wallet:', function () {
           tokenName,
         });
 
-        const txPrebuild = await tssWallet.prebuildTransaction({
+        const txPrebuild = await tssSolWallet.prebuildTransaction({
           reqId,
           recipients,
           type: 'enabletoken',
@@ -2117,8 +2117,8 @@ describe('V2 Wallet:', function () {
         });
 
         txPrebuild.should.deepEqual({
-          walletId: tssWallet.id(),
-          wallet: tssWallet,
+          walletId: tssSolWallet.id(),
+          wallet: tssSolWallet,
           txRequestId: 'id',
           txHex: 'ababcdcd',
           buildParams: {
@@ -2138,7 +2138,7 @@ describe('V2 Wallet:', function () {
       });
 
       it('should fail for non-transfer transaction types', async function () {
-        await tssWallet
+        await tssSolWallet
           .prebuildTransaction({
             reqId,
             recipients: [
@@ -2153,7 +2153,7 @@ describe('V2 Wallet:', function () {
       });
 
       it('should fail for full api version compatibility', async function () {
-        await custodialTssWallet
+        await custodialTssSolWallet
           .prebuildTransaction({
             reqId,
             apiVersion: 'lite',
@@ -2188,15 +2188,15 @@ describe('V2 Wallet:', function () {
           'full'
         );
 
-        const txPrebuild = await custodialTssWallet.prebuildTransaction({
+        const txPrebuild = await custodialTssSolWallet.prebuildTransaction({
           reqId,
           recipients,
           type: 'transfer',
         });
 
         txPrebuild.should.deepEqual({
-          walletId: tssWallet.id(),
-          wallet: custodialTssWallet,
+          walletId: tssSolWallet.id(),
+          wallet: custodialTssSolWallet,
           txRequestId: 'id',
           txHex: 'ababcdcd',
           buildParams: {
@@ -2581,7 +2581,7 @@ describe('V2 Wallet:', function () {
           'full'
         );
 
-        const txPrebuild = await custodialTssWallet.prebuildTransaction({
+        const txPrebuild = await custodialTssSolWallet.prebuildTransaction({
           reqId,
           apiVersion: 'full',
           recipients,
@@ -2589,8 +2589,8 @@ describe('V2 Wallet:', function () {
         });
 
         txPrebuild.should.deepEqual({
-          walletId: tssWallet.id(),
-          wallet: custodialTssWallet,
+          walletId: tssSolWallet.id(),
+          wallet: custodialTssSolWallet,
           txRequestId: 'id',
           txHex: 'ababcdcd',
           buildParams: {
@@ -2614,12 +2614,12 @@ describe('V2 Wallet:', function () {
         signTxRequest.calledOnceWithExactly({ txRequest, prv: 'secretKey', reqId });
 
         const txPrebuild = {
-          walletId: tssWallet.id(),
-          wallet: tssWallet,
+          walletId: tssSolWallet.id(),
+          wallet: tssSolWallet,
           txRequestId: 'id',
           txHex: 'ababcdcd',
         };
-        const signedTransaction = await tssWallet.signTransaction({
+        const signedTransaction = await tssSolWallet.signTransaction({
           reqId,
           txPrebuild,
           prv: 'sercretKey',
@@ -2631,11 +2631,11 @@ describe('V2 Wallet:', function () {
 
       it('should fail to sign transaction without txRequestId', async function () {
         const txPrebuild = {
-          walletId: tssWallet.id(),
-          wallet: tssWallet,
+          walletId: tssSolWallet.id(),
+          wallet: tssSolWallet,
           txHex: 'ababcdcd',
         };
-        await tssWallet
+        await tssSolWallet
           .signTransaction({
             reqId,
             txPrebuild,
@@ -2692,7 +2692,7 @@ describe('V2 Wallet:', function () {
       });
 
       it('should throw error for unsupported coins', async function () {
-        await tssWallet
+        await tssSolWallet
           .signMessage({
             reqId,
             message: { messageRaw },
@@ -2856,7 +2856,7 @@ describe('V2 Wallet:', function () {
       });
 
       it('should throw error for unsupported coins', async function () {
-        await tssWallet
+        await tssSolWallet
           .signTypedData({
             reqId,
             typedData: typedDataBase,
@@ -3046,7 +3046,7 @@ describe('V2 Wallet:', function () {
           txRequestId: 'txRequestId',
         };
 
-        const prebuildAndSignTransaction = sandbox.stub(tssWallet, 'prebuildAndSignTransaction');
+        const prebuildAndSignTransaction = sandbox.stub(tssSolWallet, 'prebuildAndSignTransaction');
         prebuildAndSignTransaction.resolves(signedTransaction);
         // TODO(BG-59686): this is not doing anything if we don't check the return value, we should also move this check to happen after we invoke sendMany
         prebuildAndSignTransaction.calledOnceWithExactly(sendManyInput);
@@ -3056,7 +3056,7 @@ describe('V2 Wallet:', function () {
         // TODO(BG-59686): this is not doing anything if we don't check the return value, we should also move this check to happen after we invoke sendMany
         sendTxRequest.calledOnceWithExactly(signedTransaction.txRequestId);
 
-        const sendMany = await tssWallet.sendMany(sendManyInput);
+        const sendMany = await tssSolWallet.sendMany(sendManyInput);
         sendMany.should.deepEqual('sendTxResponse');
       });
 
@@ -3065,7 +3065,7 @@ describe('V2 Wallet:', function () {
           txRequestId: 'txRequestId',
         };
 
-        const prebuildAndSignTransaction = sandbox.stub(custodialTssWallet, 'prebuildAndSignTransaction');
+        const prebuildAndSignTransaction = sandbox.stub(custodialTssSolWallet, 'prebuildAndSignTransaction');
         prebuildAndSignTransaction.resolves(signedTransaction);
         // TODO(BG-59686): this is not doing anything if we don't check the return value, we should also move this check to happen after we invoke sendMany
         prebuildAndSignTransaction.calledOnceWithExactly(sendManyInput);
@@ -3098,7 +3098,7 @@ describe('V2 Wallet:', function () {
           .post(`/api/v2/wallet/${walletData.id}/txrequests/${signedTransaction.txRequestId}/transfers`)
           .reply(200);
 
-        const sendMany = await custodialTssWallet.sendMany(sendManyInput);
+        const sendMany = await custodialTssSolWallet.sendMany(sendManyInput);
         sendMany.should.deepEqual(txRequest);
         txRequestNock.isDone().should.be.true();
         createTransferNock.isDone().should.be.true();
@@ -3109,12 +3109,14 @@ describe('V2 Wallet:', function () {
           txHex: 'deadbeef',
         };
 
-        const prebuildAndSignTransaction = sandbox.stub(tssWallet, 'prebuildAndSignTransaction');
+        const prebuildAndSignTransaction = sandbox.stub(tssSolWallet, 'prebuildAndSignTransaction');
         prebuildAndSignTransaction.resolves(signedTransaction);
         // TODO(BG-59686): this is not doing anything if we don't check the return value, we should also move this check to happen after we invoke sendMany
         prebuildAndSignTransaction.calledOnceWithExactly(sendManyInput);
 
-        await tssWallet.sendMany(sendManyInput).should.be.rejectedWith('txRequestId missing from signed transaction');
+        await tssSolWallet
+          .sendMany(sendManyInput)
+          .should.be.rejectedWith('txRequestId missing from signed transaction');
       });
     });
 
@@ -3122,10 +3124,10 @@ describe('V2 Wallet:', function () {
       it('should submit transaction with txRequestId', async function () {
         const nockSendTx = nock(bgUrl)
           .persist(false)
-          .post(tssWallet.url('/tx/send').replace(bgUrl, ''))
+          .post(tssSolWallet.url('/tx/send').replace(bgUrl, ''))
           .reply(200, { message: 'success' });
 
-        const submittedTx = await tssWallet.submitTransaction({
+        const submittedTx = await tssSolWallet.submitTransaction({
           txRequestId: 'id',
         });
         submittedTx.should.deepEqual({ message: 'success' });
@@ -3133,7 +3135,7 @@ describe('V2 Wallet:', function () {
       });
 
       it('should fail when txRequestId and txHex are both provided', async function () {
-        await tssWallet
+        await tssSolWallet
           .submitTransaction({
             txRequestId: 'id',
             txHex: 'beef',
@@ -3142,7 +3144,7 @@ describe('V2 Wallet:', function () {
       });
 
       it('should fail when txRequestId and halfSigned are both provided', async function () {
-        await tssWallet
+        await tssSolWallet
           .submitTransaction({
             txRequestId: 'id',
             halfSigned: {
@@ -3153,7 +3155,7 @@ describe('V2 Wallet:', function () {
       });
 
       it('should fail when txHex and halfSigned are both provided', async function () {
-        await tssWallet
+        await tssSolWallet
           .submitTransaction({
             txHex: 'beef',
             halfSigned: {
@@ -3323,23 +3325,23 @@ describe('V2 Wallet:', function () {
         // commonPub + commonChaincode
         const commonKeychain = randomBytes(32).toString('hex') + randomBytes(32).toString('hex');
         const getKeyNock = nock(bgUrl)
-          .get(`/api/v2/tsol/key/${tssWallet.keyIds()[0]}`)
+          .get(`/api/v2/tsol/key/${tssSolWallet.keyIds()[0]}`)
           .reply(200, {
-            id: tssWallet.keyIds()[0],
+            id: tssSolWallet.keyIds()[0],
             commonKeychain: commonKeychain,
             source: 'user',
             encryptedPrv: bitgo.encrypt({ input: 'xprv1', password: walletPassphrase }),
             coinSpecific: {},
           });
 
-        const stub = sinon.stub(tssWallet, 'createShare').callsFake(async (options) => {
+        const stub = sinon.stub(tssSolWallet, 'createShare').callsFake(async (options) => {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           options!.keychain!.pub!.should.not.be.undefined();
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           options!.keychain!.pub!.should.equal(TssUtils.getPublicKeyFromCommonKeychain(commonKeychain));
           return undefined;
         });
-        await tssWallet.shareWallet({ email, permissions, walletPassphrase });
+        await tssSolWallet.shareWallet({ email, permissions, walletPassphrase });
 
         stub.calledOnce.should.be.true();
         getSharingKeyNock.isDone().should.be.True();

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
@@ -415,6 +415,11 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
     return [];
   }
 
+  /**
+   * Returns true if the txRequest is using apiVersion == full and is pending approval
+   * @param txRequest
+   * @returns boolean
+   */
   isPendingApprovalTxRequestFull(txRequest: TxRequest): boolean {
     const { apiVersion, state } = txRequest;
     return apiVersion === 'full' && 'pendingApproval' === state;


### PR DESCRIPTION
Previously we had a check against `mustUseTxRequestFull` before we checked if we should skip signing in the preBuildAndTransaction function. This works fine for ecdsa, but fails for eddsa hot wallets that are using apiVersion === full since they also support lite. 

Reading through the code, we shouldn't need to restrict flows if a coin supports only txRequestFull, instead we should base the flows based on what version of the txRequest we are dealing with. 

TICKET: WP-664


<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->