### PR TITLE
fix(sdk-core): add change address type for utxo coins

### DIFF
--- a/modules/sdk-core/src/bitgo/wallet/BuildParams.ts
+++ b/modules/sdk-core/src/bitgo/wallet/BuildParams.ts
@@ -4,8 +4,10 @@ import * as t from 'io-ts';
 import { getCodecProperties } from '../utils/codecProps';
 
 export const BuildParamsUTXO = t.partial({
-  /* the change address type */
+  /* deprecated. the change address type */
   addressType: t.unknown,
+  /* the change address type */
+  changeAddressType: t.unknown,
   /* a fixed change address */
   changeAddress: t.unknown,
   cpfpFeeRate: t.unknown,

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -91,6 +91,7 @@ export interface PrebuildTransactionOptions {
   instant?: boolean;
   memo?: Memo;
   addressType?: string;
+  changeAddressType?: string;
   hop?: boolean;
   walletPassphrase?: string;
   reservation?: {

--- a/modules/sdk-core/test/unit/bitgo/wallet/SendTransactionRequest.ts
+++ b/modules/sdk-core/test/unit/bitgo/wallet/SendTransactionRequest.ts
@@ -5,7 +5,7 @@ import { getCodecProperties } from '../../../../src/bitgo/utils/codecProps';
 
 describe('SendTransactionRequest', function () {
   it('has expected property count', function () {
-    assert.strictEqual(getCodecProperties(BuildParams).length, 73);
+    assert.strictEqual(getCodecProperties(BuildParams).length, 74);
   });
 
   it('enforces codec', function () {


### PR DESCRIPTION
The name of the build param addressType is misleading. So it is deprecated and replaced with changeAddressType in WP.

Ticket: BTC-446
<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
