### PR TITLE
feat(sdk-core): whitelist distributed custody params

### DIFF
--- a/modules/sdk-core/src/bitgo/keychain/iKeychains.ts
+++ b/modules/sdk-core/src/bitgo/keychain/iKeychains.ts
@@ -71,6 +71,7 @@ export interface AddKeychainOptions {
   userGPGPublicKey?: string;
   backupGPGPublicKey?: string;
   algoUsed?: string;
+  isDistributedCustody?: boolean;
 }
 
 export interface ApiKeyShare {
@@ -103,6 +104,7 @@ export interface CreateBitGoOptions {
   enterprise?: string;
   reqId?: IRequestTracer;
   keyType?: KeyType;
+  isDistributedCustody?: boolean;
 }
 
 export interface CreateMpcOptions {

--- a/modules/sdk-core/src/bitgo/keychain/keychains.ts
+++ b/modules/sdk-core/src/bitgo/keychain/keychains.ts
@@ -197,6 +197,7 @@ export class Keychains implements IKeychains {
         'originalPasscodeEncryptionCode',
         'enterprise',
         'derivedFromParentWithSeed',
+        'isDistributedCustody',
       ]
     );
 
@@ -230,6 +231,7 @@ export class Keychains implements IKeychains {
         userGPGPublicKey: params.userGPGPublicKey,
         backupGPGPublicKey: params.backupGPGPublicKey,
         algoUsed: params.algoUsed,
+        isDistributedCustody: params.isDistributedCustody,
       })
       .result();
   }


### PR DESCRIPTION
We need to be able to pass in `isDistributedCustody` in for creating a bitgoKey.

TICKET: BTC-396

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
