### PR TITLE
chore(ton): update the name of the smallest TON unit to nanoton

### DIFF
--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -1379,7 +1379,7 @@ export enum BaseUnit {
   XTZ = 'micro xtz',
   STX = 'micro-STX',
   SUI = 'MIST',
-  TON = 'nanos',
+  TON = 'nanoton',
   NEAR = 'yocto',
   OFC = 'ofcCoin',
   OSMO = 'uosmo',


### PR DESCRIPTION
The whitepaper refers to it as nano, nton and nanoton

We’ll use nanoton across the board to follow the SDK implementation and avoid confusion

Source: https://github.com/toncenter/tonweb/blob/80640625aad2b6ec65f34a5b0fb824df27020d33/src/test-payments.js#L10-L13

Ticket: EA-1948
