### PR TITLE
feat: use psbt for prebuild when wallet is distributedCustody

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -1442,7 +1442,11 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
     };
   }
 
-  async getExtraPrebuildParams(buildParams: ExtraPrebuildParamsOptions): Promise<any> {
+  async getExtraPrebuildParams(buildParams: ExtraPrebuildParamsOptions & { wallet: Wallet }): Promise<any> {
+    if (buildParams.wallet.subType() === 'distributedCustody') {
+      return { txFormat: 'psbt' };
+    }
+
     return {};
   }
 

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -72,6 +72,7 @@ import {
   ShareWalletOptions,
   SimulateWebhookOptions,
   SubmitTransactionOptions,
+  SubWalletType,
   SweepOptions,
   TransferBySequenceIdOptions,
   TransferCommentOptions,
@@ -249,6 +250,10 @@ export class Wallet implements IWallet {
 
   multisigType(): 'onchain' | 'tss' {
     return this._wallet.multisigType;
+  }
+
+  subType(): SubWalletType | undefined {
+    return this._wallet.subType;
   }
 
   /**


### PR DESCRIPTION
When the wallet is of type distributed custody want to always use 'psbt' as the transaction format.

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
