### PR TITLE
fix(utxo-lib): check prevout script against computed for non-taproot inputs

### DIFF
--- a/modules/utxo-lib/src/bitgo/signature.ts
+++ b/modules/utxo-lib/src/bitgo/signature.ts
@@ -8,6 +8,7 @@ import {
   createOutputScript2of3,
   createOutputScriptP2shP2pk,
   createSpendScriptP2tr,
+  getOutputScript,
   ScriptType,
   ScriptType2Of3,
   scriptType2Of3AsPrevOutType,
@@ -99,6 +100,21 @@ export function getSignatureVerifications<TNumber extends number | bigint>(
 
     if (prevOutputs.length !== transaction.ins.length) {
       throw new Error(`prevOutputs length ${prevOutputs.length}, expected ${transaction.ins.length}`);
+    }
+  }
+
+  if (
+    parsedScript.scriptType !== 'taprootKeyPathSpend' &&
+    parsedScript.scriptType !== 'taprootScriptPathSpend' &&
+    prevOutputs
+  ) {
+    const prevOutScript = prevOutputs[inputIndex].script;
+
+    const output = getOutputScript(parsedScript.scriptType, parsedScript.pubScript);
+    if (!prevOutScript.equals(output)) {
+      throw new Error(
+        `prevout script ${prevOutScript.toString('hex')} does not match computed script ${output.toString('hex')}`
+      );
     }
   }
 

--- a/modules/utxo-lib/test/bitgo/signature.ts
+++ b/modules/utxo-lib/test/bitgo/signature.ts
@@ -29,7 +29,7 @@ import {
   getSignKeyCombinations,
   getUnsignedTransaction2Of3,
 } from '../transaction_util';
-import { getTransactionWithHighS } from './signatureModify';
+import { getPrevOutsWithInvalidOutputScript, getTransactionWithHighS } from './signatureModify';
 import { normDefault } from '../testutil/normalize';
 
 function getScriptTypes2Of3() {
@@ -291,6 +291,16 @@ function checkSignTransaction<TNumber extends number | bigint>(
           signKeys.length - 1
         );
       });
+
+      if (scriptType !== 'p2tr' && scriptType !== 'p2trMusig2') {
+        assert.throws(
+          () =>
+            signatureCount(
+              verifySignatureWithPublicKeys<TNumber>(tx, i, getPrevOutsWithInvalidOutputScript(prevOutputs, i), pubkeys)
+            ),
+          /prevout script .* does not match computed script .*/
+        );
+      }
     }
   });
 }

--- a/modules/utxo-lib/test/bitgo/signatureModify.ts
+++ b/modules/utxo-lib/test/bitgo/signatureModify.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-redeclare */
-import { script, ScriptSignature } from 'bitcoinjs-lib';
+import { script, ScriptSignature, TxOutput } from 'bitcoinjs-lib';
 import { isPlaceholderSignature, parseSignatureScript, UtxoTransaction } from '../../src/bitgo';
 
 const BN = require('bn.js');
@@ -77,5 +77,20 @@ export function getTransactionWithHighS<TNumber extends number | bigint>(
       throw new Error(`could not parse modified input`);
     }
     return [cloned];
+  });
+}
+
+/** Return transaction with script xored with 0xff for the given input */
+export function getPrevOutsWithInvalidOutputScript<TNumber extends number | bigint>(
+  prevOuts: TxOutput<TNumber>[],
+  inputIndex: number
+): TxOutput<TNumber>[] {
+  return prevOuts.map((prevOut, i) => {
+    return i === inputIndex
+      ? {
+          ...prevOut,
+          script: prevOut.script.map((v) => v ^ 0xff) as typeof prevOut.script,
+        }
+      : prevOut;
   });
 }


### PR DESCRIPTION
Make sure that we are actually signing the right script.

Taproot cases will follow.

Issue: BTC-428
