### PR TITLE
feat(sdk-core): get utxo script types by coin

### DIFF
--- a/modules/sdk-core/src/bitgo/utils/abstractUtxoCoinUtil.ts
+++ b/modules/sdk-core/src/bitgo/utils/abstractUtxoCoinUtil.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+import { coins, UtxoCoin } from '@bitgo/statics';
 import * as utxolib from '@bitgo/utxo-lib';
 import ScriptType2Of3 = utxolib.bitgo.outputScripts.ScriptType2Of3;
 
@@ -5,4 +7,16 @@ export function inferAddressType(addressDetails: { chain: number }): ScriptType2
   return utxolib.bitgo.isChainCode(addressDetails.chain)
     ? utxolib.bitgo.scriptTypeForChain(addressDetails.chain)
     : null;
+}
+
+/**
+ * Get the supported 2 of 3 script types for a given utxo coin
+ */
+export function getUtxoCoinScriptTypes2Of3(coinName: string): utxolib.bitgo.outputScripts.ScriptType2Of3[] {
+  const coin = coins.get(coinName);
+  assert(coin instanceof UtxoCoin, `coin ${coinName} is not a utxo coin`);
+  const network = utxolib.networks[coin.network.utxolibName as utxolib.NetworkName];
+  return utxolib.bitgo.outputScripts.scriptTypes2Of3.filter((v) =>
+    utxolib.bitgo.outputScripts.isSupportedScriptType(network, v)
+  );
 }

--- a/modules/sdk-core/test/unit/bitgo/utils/abstractUtxoCoinUtil.ts
+++ b/modules/sdk-core/test/unit/bitgo/utils/abstractUtxoCoinUtil.ts
@@ -1,0 +1,30 @@
+import assert from 'assert';
+
+import { getUtxoCoinScriptTypes2Of3 } from '../../../../src';
+import * as utxolib from '@bitgo/utxo-lib';
+
+describe('getUtxoCoinScriptTypes', function () {
+  it('success', function () {
+    const fn = (coin: string, arr: utxolib.bitgo.outputScripts.ScriptType2Of3[]) => {
+      const scriptTypes = getUtxoCoinScriptTypes2Of3(coin);
+      return arr.find((v) => scriptTypes.includes(v));
+    };
+    assert.ok(fn('btc', ['p2sh', 'p2shP2wsh', 'p2wsh', 'p2tr', 'p2trMusig2']));
+    assert.ok(fn('ltc', ['p2sh', 'p2shP2wsh', 'p2wsh']));
+    assert.ok(fn('doge', ['p2sh']));
+  });
+
+  it('fail for invalid coin name', function () {
+    assert.throws(
+      () => getUtxoCoinScriptTypes2Of3('dummy'),
+      (e: any) => e.message === `coin 'dummy' is not defined`
+    );
+  });
+
+  it('fail for non-utxo coin name', function () {
+    assert.throws(
+      () => getUtxoCoinScriptTypes2Of3('eth'),
+      (e: any) => e.message === 'coin eth is not a utxo coin'
+    );
+  });
+});


### PR DESCRIPTION
util function to get utxo script types by coin

Ticket: BTC-535
<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
