### PR TITLE
fix(sdk-coin-ada): add multi-asset to init builder flow

### DIFF
--- a/modules/sdk-coin-ada/test/unit/transactionBuilder.ts
+++ b/modules/sdk-coin-ada/test/unit/transactionBuilder.ts
@@ -66,6 +66,29 @@ describe('ADA Transaction Builder', async () => {
     should.equal(txBroadcast, testData.rawTx.unsignedTx5);
   });
 
+  it('should initialize and build tx with asset data', async () => {
+    const policyId = '279c909f348e533da5808898f87f9a14bb2c3dfbbacccd631d927a3f';
+    const assetName = '534e454b';
+    const quantity = '6000000';
+    const preBuiltTx = new Transaction(coins.get('tada'));
+    preBuiltTx.fromRawTransaction(testData.rawTx.unsignedTx3);
+    const txBuilder = factory.getTransferBuilder();
+    txBuilder.initBuilder(preBuiltTx);
+
+    const tx = (await txBuilder.build()) as Transaction;
+    const txData = tx.toJson();
+    const expectedAssetName = CardanoWasm.AssetName.new(Buffer.from(assetName, 'hex'));
+    const expectedPolicyId = CardanoWasm.ScriptHash.from_bytes(Buffer.from(policyId, 'hex'));
+    txData.outputs[0].should.have.property('multiAssets');
+    (txData.outputs[0].multiAssets as CardanoWasm.MultiAsset)
+      .get_asset(expectedPolicyId, expectedAssetName)
+      .to_str()
+      .should.equal(quantity);
+    txData.id.should.equal(testData.rawTx.txHash3);
+    const txBroadcast = tx.toBroadcastFormat();
+    should.equal(txBroadcast, testData.rawTx.unsignedTx3);
+  });
+
   it('should build a consolidate tx with single asset', async () => {
     const txBuilder = factory.getTransferBuilder();
     txBuilder.input({


### PR DESCRIPTION
Ticket: WIN-736

### Context

We recently added the following PRs for ADA token consolidation support:
 - SDK PRs: https://github.com/BitGo/BitGoJS/pull/3994, https://github.com/BitGo/BitGoJS/pull/4007
 - WP PR: https://github.com/BitGo/bitgo-microservices/pull/37276
 - IMS PRs: https://github.com/BitGo/indexerdb-microservice/pull/1002, https://github.com/BitGo/indexerdb-microservice/pull/1006

While testing the ADA token consolidation flow, we found that in the [parseTransaction](https://github.com/BitGo/bitgo-microservices/blob/develop/packages/wallet-platform/app/controllers/api/v2/coins/ada/ada.ts#L1025-L1032) method that's used in WP, we don't have the asset data in the tx. This is due to the fact that, asset data is [not added in outputs](https://github.com/BitGo/BitGoJS/blob/master/modules/sdk-coin-ada/src/lib/transactionBuilder.ts#L89-L92) of the `initBuilder` method. And when we [build the transaction](https://github.com/BitGo/bitgo-microservices/blob/develop/packages/wallet-platform/app/controllers/api/v2/coins/ada/ada.ts#L1032), we weren't adding the assets to the transaction outputs

This PR ensures that the tx data contains outputs, along with the asset data in them, especially in the parseTransaction flow