### PR TITLE
refactor(root): remove network argument from addWalletUnspentToPsbt()

### DIFF
--- a/modules/abstract-utxo/src/recovery/backupKeyRecovery.ts
+++ b/modules/abstract-utxo/src/recovery/backupKeyRecovery.ts
@@ -348,7 +348,7 @@ export async function backupKeyRecovery(
       : undefined;
 
   unspents.forEach((unspent) => {
-    utxolib.bitgo.addWalletUnspentToPsbt(psbt, unspent, walletKeys, 'user', 'backup', coin.network);
+    utxolib.bitgo.addWalletUnspentToPsbt(psbt, unspent, walletKeys, 'user', 'backup');
   });
 
   let krsFee = BigInt(0);

--- a/modules/utxo-lib/src/bitgo/wallet/Unspent.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/Unspent.ts
@@ -194,18 +194,7 @@ function addUnspentToPsbt(psbt: UtxoPsbt, id: string): void {
   });
 }
 
-export function addReplayProtectionUnspentToPsbt(
-  psbt: UtxoPsbt,
-  u: Unspent<bigint>,
-  redeemScript: Buffer,
-  /**
-   * @deprecated
-   */
-  network: Network = psbt.network
-): void {
-  if (psbt.network !== network) {
-    throw new Error('psbt network does not match network');
-  }
+export function addReplayProtectionUnspentToPsbt(psbt: UtxoPsbt, u: Unspent<bigint>, redeemScript: Buffer): void {
   addUnspentToPsbt(psbt, u.id);
   updateReplayProtectionUnspentToPsbt(psbt, psbt.inputCount - 1, u, redeemScript);
 }
@@ -356,15 +345,8 @@ export function addWalletUnspentToPsbt(
   u: WalletUnspent<bigint>,
   rootWalletKeys: RootWalletKeys,
   signer: KeyName,
-  cosigner: KeyName,
-  /**
-   * @deprecated
-   */
-  network: Network = psbt.network
+  cosigner: KeyName
 ): void {
-  if (psbt.network !== network) {
-    throw new Error('psbt network does not match network');
-  }
   addUnspentToPsbt(psbt, u.id);
   updateWalletUnspentForPsbt(psbt, psbt.inputCount - 1, u, rootWalletKeys, signer, cosigner);
 }

--- a/modules/utxo-ord/src/psbt.ts
+++ b/modules/utxo-ord/src/psbt.ts
@@ -56,14 +56,7 @@ export function createPsbtFromOutputLayout(
     throw new Error(`must provide at least one unspent`);
   }
   unspents.forEach((u) =>
-    bitgo.addWalletUnspentToPsbt(
-      psbt,
-      u,
-      inputBuilder.walletKeys,
-      inputBuilder.signer,
-      inputBuilder.cosigner,
-      psbt.network
-    )
+    bitgo.addWalletUnspentToPsbt(psbt, u, inputBuilder.walletKeys, inputBuilder.signer, inputBuilder.cosigner)
   );
   const ordInput = OrdOutput.joinAll(unspents.map((u) => new OrdOutput(u.value)));
   const ordOutputs = getOrdOutputsForLayout(ordInput, outputLayout);

--- a/modules/utxo-ord/test/inscription.ts
+++ b/modules/utxo-ord/test/inscription.ts
@@ -25,8 +25,7 @@ function createCommitTransactionPsbt(commitAddress: string, walletKeys: utxolib.
       u,
       inputBuilder.walletKeys,
       inputBuilder.signer,
-      inputBuilder.cosigner,
-      commitTransactionPsbt.network
+      inputBuilder.cosigner
     )
   );
   return commitTransactionPsbt;


### PR DESCRIPTION
This removes both the argument and also updates the usages of addWalletUnspentToPsbt() and addReplayProtectionUnspentToPsbt().

This is done because the network argument had been deprecated some time
back.

BREAKING CHANGE: The external users would need to stop passing the network argument in these function calls. Hopefully, they already have not been passing because that argument had been deprecated.

BTC-591

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
