### PR TITLE
Win 1087 add common method in abstract eth

### DIFF
--- a/modules/abstract-eth/src/lib/transactionBuilder.ts
+++ b/modules/abstract-eth/src/lib/transactionBuilder.ts
@@ -38,7 +38,7 @@ import {
   isValidEthAddress,
   getV1WalletInitializationData,
 } from './utils';
-import { defaultWalletVersion, defaultForwarderVersion } from './walletUtil';
+import { defaultWalletVersion, defaultForwarderVersion, walletSimpleConstructor } from './walletUtil';
 import { ERC1155TransferBuilder } from './transferBuilders/transferBuilderERC1155';
 import { ERC721TransferBuilder } from './transferBuilders/transferBuilderERC721';
 import { Transaction } from './transaction';
@@ -85,6 +85,9 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
   // Common parameter for wallet initialization and address initialization transaction
   private _salt: string;
 
+  // walletsimplebytecode
+  protected _walletSimpleByteCode: string;
+
   /**
    * Public constructor.
    *
@@ -100,6 +103,7 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
     this._forwarderVersion = 0;
     this._walletVersion = 0;
     this.transaction = new Transaction(this._coinConfig, this._common);
+    this._walletSimpleByteCode = '';
   }
 
   /** @inheritdoc */
@@ -573,7 +577,13 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
    * @param {string[]} addresses - the contract signers
    * @returns {string} - the smart contract encoded data
    */
-  protected abstract getContractData(addresses: string[]): string;
+  protected getContractData(addresses: string[]): string {
+    const params = [addresses];
+    const resultEncodedParameters = EthereumAbi.rawEncode(walletSimpleConstructor, params)
+      .toString('hex')
+      .replace('0x', '');
+    return this._walletSimpleByteCode + resultEncodedParameters;
+  }
 
   // endregion
 

--- a/modules/sdk-coin-arbeth/package.json
+++ b/modules/sdk-coin-arbeth/package.json
@@ -43,8 +43,7 @@
     "@bitgo/abstract-eth": "^1.6.0",
     "@bitgo/sdk-core": "^8.26.0",
     "@bitgo/statics": "^29.0.0",
-    "@ethereumjs/common": "^2.6.5",
-    "ethereumjs-abi": "^0.6.5"
+    "@ethereumjs/common": "^2.6.5"
   },
   "devDependencies": {
     "@bitgo/sdk-api": "^1.24.0",

--- a/modules/sdk-coin-arbeth/src/lib/index.ts
+++ b/modules/sdk-coin-arbeth/src/lib/index.ts
@@ -4,3 +4,4 @@ export { TransactionBuilder } from './transactionBuilder';
 export { TransferBuilder } from './transferBuilder';
 export { Transaction, KeyPair } from '@bitgo/abstract-eth';
 export { Utils };
+export * from './walletUtil';

--- a/modules/sdk-coin-arbeth/src/lib/transactionBuilder.ts
+++ b/modules/sdk-coin-arbeth/src/lib/transactionBuilder.ts
@@ -1,12 +1,6 @@
 import { BaseCoin as CoinConfig } from '@bitgo/statics';
-import EthereumAbi from 'ethereumjs-abi';
 import { BuildTransactionError, TransactionType } from '@bitgo/sdk-core';
-import {
-  KeyPair,
-  Transaction,
-  TransactionBuilder as EthLikeTransactionBuilder,
-  walletSimpleConstructor,
-} from '@bitgo/abstract-eth';
+import { KeyPair, Transaction, TransactionBuilder as EthLikeTransactionBuilder } from '@bitgo/abstract-eth';
 import { getCommon } from './utils';
 import { TransferBuilder } from './transferBuilder';
 import { walletSimpleByteCode } from './walletUtil';
@@ -18,6 +12,7 @@ export class TransactionBuilder extends EthLikeTransactionBuilder {
     super(_coinConfig);
     this._common = getCommon(this._coinConfig.network.type);
     this.transaction = new Transaction(this._coinConfig, this._common);
+    this._walletSimpleByteCode = walletSimpleByteCode;
   }
 
   /** @inheritdoc */
@@ -29,20 +24,6 @@ export class TransactionBuilder extends EthLikeTransactionBuilder {
       this._transfer = new TransferBuilder(data);
     }
     return this._transfer;
-  }
-
-  /**
-   * Returns the smart contract encoded data
-   *
-   * @param {string[]} addresses - the contract signers
-   * @returns {string} - the smart contract encoded data
-   */
-  protected getContractData(addresses: string[]): string {
-    const params = [addresses];
-    const resultEncodedParameters = EthereumAbi.rawEncode(walletSimpleConstructor, params)
-      .toString('hex')
-      .replace('0x', '');
-    return walletSimpleByteCode + resultEncodedParameters;
   }
 
   publicKey(key: string): void {

--- a/modules/sdk-coin-eth/src/lib/transactionBuilder.ts
+++ b/modules/sdk-coin-eth/src/lib/transactionBuilder.ts
@@ -1,11 +1,9 @@
 import { BaseCoin as CoinConfig, EthereumNetwork } from '@bitgo/statics';
-import EthereumAbi from 'ethereumjs-abi';
 import {
   Transaction,
   getCommon,
   TransactionBuilder as EthLikeTransactionBuilder,
   TransferBuilder,
-  walletSimpleConstructor,
 } from '@bitgo/abstract-eth';
 import { BuildTransactionError, TransactionType } from '@bitgo/sdk-core';
 
@@ -25,22 +23,8 @@ export class TransactionBuilder extends EthLikeTransactionBuilder {
     super(_coinConfig);
     this._common = getCommon(this._coinConfig.network as EthereumNetwork);
     this.transaction = new Transaction(this._coinConfig, this._common);
+    this._walletSimpleByteCode = walletSimpleByteCode;
   }
-
-  /**
-   * Returns the smart contract encoded data
-   *
-   * @param {string[]} addresses - the contract signers
-   * @returns {string} - the smart contract encoded data
-   */
-  protected getContractData(addresses: string[]): string {
-    const params = [addresses];
-    const resultEncodedParameters = EthereumAbi.rawEncode(walletSimpleConstructor, params)
-      .toString('hex')
-      .replace('0x', '');
-    return walletSimpleByteCode + resultEncodedParameters;
-  }
-  // endregion
 
   /**
    * Gets the transfer funds builder if exist, or creates a new one for this transaction and returns it

--- a/modules/sdk-coin-eth/test/unit/getBuilder.ts
+++ b/modules/sdk-coin-eth/test/unit/getBuilder.ts
@@ -1,4 +1,4 @@
-import { TransactionBuilder } from '../../src/lib/transactionBuilder';
+import { TransactionBuilder } from '../../src';
 import { coins } from '@bitgo/statics';
 
 export const getBuilder = (coin: string): TransactionBuilder => {

--- a/modules/sdk-coin-opeth/package.json
+++ b/modules/sdk-coin-opeth/package.json
@@ -43,8 +43,7 @@
     "@bitgo/abstract-eth": "^1.6.0",
     "@bitgo/sdk-core": "^8.26.0",
     "@bitgo/statics": "^29.0.0",
-    "@ethereumjs/common": "^2.6.5",
-    "ethereumjs-abi": "^0.6.5"
+    "@ethereumjs/common": "^2.6.5"
   },
   "devDependencies": {
     "@bitgo/sdk-api": "^1.24.0",

--- a/modules/sdk-coin-opeth/src/lib/index.ts
+++ b/modules/sdk-coin-opeth/src/lib/index.ts
@@ -4,3 +4,4 @@ export { TransactionBuilder } from './transactionBuilder';
 export { TransferBuilder } from './transferBuilder';
 export { Transaction, KeyPair } from '@bitgo/abstract-eth';
 export { Utils };
+export * from './walletUtil';

--- a/modules/sdk-coin-opeth/src/lib/transactionBuilder.ts
+++ b/modules/sdk-coin-opeth/src/lib/transactionBuilder.ts
@@ -1,12 +1,6 @@
 import { BaseCoin as CoinConfig } from '@bitgo/statics';
-import EthereumAbi from 'ethereumjs-abi';
 import { BuildTransactionError, TransactionType } from '@bitgo/sdk-core';
-import {
-  KeyPair,
-  Transaction,
-  TransactionBuilder as EthLikeTransactionBuilder,
-  walletSimpleConstructor,
-} from '@bitgo/abstract-eth';
+import { KeyPair, Transaction, TransactionBuilder as EthLikeTransactionBuilder } from '@bitgo/abstract-eth';
 import { getCommon } from './utils';
 import { TransferBuilder } from './transferBuilder';
 import { walletSimpleByteCode } from './walletUtil';
@@ -18,20 +12,7 @@ export class TransactionBuilder extends EthLikeTransactionBuilder {
     super(_coinConfig);
     this._common = getCommon(this._coinConfig.network.type);
     this.transaction = new Transaction(this._coinConfig, this._common);
-  }
-
-  /**
-   * Returns the smart contract encoded data
-   *
-   * @param {string[]} addresses - the contract signers
-   * @returns {string} - the smart contract encoded data
-   */
-  protected getContractData(addresses: string[]): string {
-    const params = [addresses];
-    const resultEncodedParameters = EthereumAbi.rawEncode(walletSimpleConstructor, params)
-      .toString('hex')
-      .replace('0x', '');
-    return walletSimpleByteCode + resultEncodedParameters;
+    this._walletSimpleByteCode = walletSimpleByteCode;
   }
 
   /** @inheritdoc */

--- a/modules/sdk-coin-polygon/package.json
+++ b/modules/sdk-coin-polygon/package.json
@@ -47,7 +47,6 @@
     "@bitgo/statics": "^29.0.0",
     "@bitgo/utxo-lib": "^9.16.0",
     "@ethereumjs/common": "^2.6.5",
-    "ethereumjs-abi": "^0.6.5",
     "superagent": "^3.8.3"
   },
   "devDependencies": {

--- a/modules/sdk-coin-polygon/src/lib/index.ts
+++ b/modules/sdk-coin-polygon/src/lib/index.ts
@@ -4,3 +4,4 @@ export { TransferBuilder } from './transferBuilder';
 
 import * as Utils from './utils';
 export { Utils };
+export * from './walletUtil';

--- a/modules/sdk-coin-polygon/src/lib/transactionBuilder.ts
+++ b/modules/sdk-coin-polygon/src/lib/transactionBuilder.ts
@@ -1,9 +1,8 @@
 import { TransactionBuilder as EthTransactionBuilder } from '@bitgo/sdk-coin-eth';
 import { BuildTransactionError, TransactionType } from '@bitgo/sdk-core';
 import { BaseCoin as CoinConfig } from '@bitgo/statics';
-import EthereumAbi from 'ethereumjs-abi';
 import { getCommon } from './utils';
-import { walletSimpleByteCode, walletSimpleConstructor } from './walletUtil';
+import { walletSimpleByteCode } from './walletUtil';
 import { Transaction, TransferBuilder } from './';
 
 export class TransactionBuilder extends EthTransactionBuilder {
@@ -13,20 +12,7 @@ export class TransactionBuilder extends EthTransactionBuilder {
     super(_coinConfig);
     this._common = getCommon(this._coinConfig.network.type);
     this.transaction = new Transaction(this._coinConfig, this._common);
-  }
-
-  /**
-   * Returns the smart contract encoded data
-   *
-   * @param {string[]} addresses - the contract signers
-   * @returns {string} - the smart contract encoded data
-   */
-  protected getContractData(addresses: string[]): string {
-    const params = [addresses];
-    const resultEncodedParameters = EthereumAbi.rawEncode(walletSimpleConstructor, params)
-      .toString('hex')
-      .replace('0x', '');
-    return walletSimpleByteCode + resultEncodedParameters;
+    this._walletSimpleByteCode = walletSimpleByteCode;
   }
 
   /** @inheritdoc */


### PR DESCRIPTION
This PR adds getContractData method in abstract-eth, so that it can be removed from coinSpecific modules
WIN-1087

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
