### PR TITLE
fix: use whitelisted send params for tx initiate

### DIFF
--- a/modules/bitgo/test/v2/unit/accountConsolidations.ts
+++ b/modules/bitgo/test/v2/unit/accountConsolidations.ts
@@ -87,8 +87,8 @@ describe('Account Consolidations:', function () {
             .reply(200);
 
           const params = { prebuildTx: fixtures.buildAccountConsolidation[0] };
-          const paramsWithJunk = { ...params, junk: 'junk' };
-          const paramsAfterCodec = { ...params, type: 'consolidate' };
+          const paramsWithJunk = { ...params, junk: 'junk', otp: '000000' };
+          const paramsAfterCodec = { type: 'consolidate', otp: '000000' };
 
           sinon.stub(wallet, 'prebuildAndSignTransaction').resolves(fixtures.signedAccountConsolidationBuilds[0]);
           await custodialWallet.sendAccountConsolidation(paramsWithJunk);

--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -3574,8 +3574,12 @@ describe('V2 Wallet:', function () {
       };
 
       const initiateTxPath = `/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/initiate`;
+      let initiateTxBody;
       const response = nock(bgUrl)
-        .post(initiateTxPath, _.matches(initiateTxParams)) // use _.matches to do a partial match on request body object instead of strict matching
+        .post(initiateTxPath, (body) => {
+          initiateTxBody = body;
+          return true;
+        })
         .reply(200);
 
       const feeEstimationPath = `/api/v2/${wallet.coin()}/tx/fee?hop=true&recipient=${address}&amount=10000000000000000&type=Export`;
@@ -3590,6 +3594,20 @@ describe('V2 Wallet:', function () {
         console.log(e);
         // test is successful if nock is consumed, HMAC errors expected
       }
+      _.isMatch(initiateTxBody, {
+        hopParams: {
+          gasPriceMax: 7187500000,
+        },
+        type: 'Export',
+        gasLimit: 500000,
+        recipients: [
+          {
+            amount: '10000000000000000',
+            address,
+          },
+        ],
+      }).should.be.true();
+
       response.isDone().should.be.true();
     });
   });

--- a/modules/sdk-core/package.json
+++ b/modules/sdk-core/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@bitgo/bls-dkg": "^1.3.1",
-    "@bitgo/public-types": "1.1.2",
+    "@bitgo/public-types": "1.2.1",
     "@bitgo/sdk-lib-mpc": "^8.18.0",
     "@bitgo/statics": "^32.0.0",
     "@bitgo/utxo-lib": "^9.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1030,10 +1030,10 @@
     "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
-"@bitgo/public-types@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@bitgo/public-types/-/public-types-1.1.2.tgz#125ff179cb1b6df3a2d7bf0f7cc430cab6e3990b"
-  integrity sha512-Z/mg63Pj8VFXEV9/J6F8w0L2XAPzzul7mT7mF7K2J0FtXNyHyJT5JBS1cRLc6lQ7bv/egG0YLTVZLyf3QUZgEg==
+"@bitgo/public-types@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@bitgo/public-types/-/public-types-1.2.1.tgz#45028dd7ba89103d3fabde295cf33e1b733cc9bc"
+  integrity sha512-smOGrsMtxIJZxPP0CN6FMSP+k0NMxYM1dFbvhAxEZ9rAyMBGknVrCGUtZsman9a1ixE30nBv0SCjHB/6vn1bxA==
   dependencies:
     io-ts "^2.2.20"
 


### PR DESCRIPTION
- limit params sent to the /tx/initiate API

Ticket: CE-3211

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
