### PR TITLE
feat(sdk-core): allow tss signing with unencrypted prv

### DIFF
--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -28,6 +28,7 @@ import {
   ManageUnspentsOptions,
   SignedMessage,
   BaseTssUtils,
+  KeyType,
 } from '@bitgo/sdk-core';
 
 import { TestBitGo } from '@bitgo/sdk-test';
@@ -333,6 +334,34 @@ describe('V2 Wallet:', function () {
         },
       };
       wallet.getUserPrv(userPrvOptions).should.eql(derivedPrv);
+    });
+
+    it('should return the prv provided for TSS SMC', async () => {
+      const tssWalletData = {
+        id: '5b34252f1bf349930e34020a00000000',
+        coin: 'tsol',
+        keys: [
+          '5b3424f91bf349930e34017500000000',
+          '5b3424f91bf349930e34017600000000',
+          '5b3424f91bf349930e34017700000000',
+        ],
+        coinSpecific: {},
+        multisigType: 'tss',
+      };
+      const tsolcoin: any = bitgo.coin('tsol');
+      const wallet = new Wallet(bitgo, tsolcoin, tssWalletData);
+      const prv = 'longstringifiedjson';
+      const keychain = {
+        derivedFromParentWithSeed: 'random seed',
+        id: '123',
+        commonKeychain: 'longstring',
+        type: 'tss' as KeyType,
+      };
+      const userPrvOptions = {
+        prv,
+        keychain,
+      };
+      wallet.getUserPrv(userPrvOptions).should.eql(prv);
     });
   });
 

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -1595,7 +1595,7 @@ export class Wallet implements IWallet {
    * @return {*}
    */
   async signTransaction(params: WalletSignTransactionOptions = {}): Promise<SignedTransaction | TxRequest> {
-    const { txPrebuild, apiVersion } = params;
+    const { txPrebuild, apiVersion, txRequestId } = params;
 
     if (
       _.isFunction(params.customCommitmentGeneratingFunction) &&
@@ -1617,7 +1617,14 @@ export class Wallet implements IWallet {
     }
 
     if (!txPrebuild || typeof txPrebuild !== 'object') {
-      throw new Error('txPrebuild must be an object');
+      if (this.multisigType() === 'onchain') {
+        throw new Error('txPrebuild is required for on-chain multisig wallets');
+      }
+      if (!txRequestId) {
+        throw new Error('txPrebuild or txRequestId is required for TSS wallets');
+      }
+      // We only do this if we're not using the external signer TSS flow
+      params.txPrebuild = { txRequestId };
     }
 
     const presign = await this.baseCoin.presignTransaction({
@@ -1626,7 +1633,7 @@ export class Wallet implements IWallet {
       tssUtils: this.tssUtils,
     });
 
-    if (this._wallet.multisigType === 'tss') {
+    if (this.multisigType() === 'tss') {
       return this.signTransactionTss({ ...presign, prv: this.getUserPrv(presign as GetUserPrvOptions), apiVersion });
     }
 
@@ -1749,10 +1756,12 @@ export class Wallet implements IWallet {
 
     // use the `derivedFromParentWithSeed` property from the user keychain as the `coldDerivationSeed`
     // if no other `coldDerivationSeed` was explicitly provided
+    // Only for onchain multisig wallets, TSS key derivation happens during the signing process
     if (
       params.coldDerivationSeed === undefined &&
       params.keychain !== undefined &&
-      params.keychain.derivedFromParentWithSeed !== undefined
+      params.keychain.derivedFromParentWithSeed !== undefined &&
+      this.multisigType() === 'onchain'
     ) {
       params.coldDerivationSeed = params.keychain.derivedFromParentWithSeed;
     }


### PR DESCRIPTION
Modified the getUserPrv method to allow using the provided unencrypted prv and not try to derivate if its a TSS wallet, also fixed the signTransaction use the txRequestId if the txPrebuild is empty for a TSS wallet

WP-990

TICKET: WP-990

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
