### PR TITLE
fix(sdk-coin-xlm): fix muxed address check in verifyTransaction

### DIFF
--- a/modules/sdk-coin-xlm/src/xlm.ts
+++ b/modules/sdk-coin-xlm/src/xlm.ts
@@ -1063,8 +1063,7 @@ export class Xlm extends BaseCoin {
 
       _.forEach(txParams.recipients, (expectedOutput, index) => {
         const expectedOutputAddressDetails = this.getAddressDetails(expectedOutput.address);
-        // for muxed accounts, the destination will be the baseAddress
-        const expectedOutputAddress = expectedOutputAddressDetails.baseAddress;
+        const expectedOutputAddress = expectedOutputAddressDetails.address;
         const output = outputOperations[index] as stellar.Operation.Payment | stellar.Operation.CreateAccount;
         if (output.destination !== expectedOutputAddress) {
           throw new Error('transaction prebuild does not match expected recipient');


### PR DESCRIPTION
Ticket: WIN-1106

The tx build response from wallet-platform uses the muxed address but in SDK we (erroneously)expect it to be the base address, this is causing prebuildAndSignTransaction to fail for any transactions to xlm muxed address