### PR TITLE
feat(unspents): default unspents dimensions to recovery path

### DIFF
--- a/modules/abstract-utxo/src/recovery/crossChainRecovery.ts
+++ b/modules/abstract-utxo/src/recovery/crossChainRecovery.ts
@@ -266,7 +266,10 @@ function createSweepTransaction<TNumber extends number | bigint = number>(
   amountType: 'number' | 'bigint' = 'number'
 ): utxolib.bitgo.UtxoTransaction<TNumber> {
   const inputValue = unspentSum<TNumber>(unspents, amountType);
-  const vsize = Dimensions.fromUnspents(unspents)
+  const vsize = Dimensions.fromUnspents(unspents, {
+    p2tr: { scriptPathLevel: 1 },
+    p2trMusig2: { scriptPathLevel: undefined },
+  })
     .plus(Dimensions.fromOutput({ script: utxolib.address.toOutputScript(targetAddress, network) }))
     .getVSize();
   const fee = vsize * feeRateSatVB;
@@ -342,7 +345,12 @@ function getFeeInfo<TNumber extends number | bigint = number>(
   unspents: WalletUnspent<TNumber>[],
   amountType: 'number' | 'bigint' = 'number'
 ): FeeInfo {
-  const vsize = Dimensions.fromUnspents(unspents).plus(Dimensions.fromOutputs(transaction.outs)).getVSize();
+  const vsize = Dimensions.fromUnspents(unspents, {
+    p2tr: { scriptPathLevel: 1 },
+    p2trMusig2: { scriptPathLevel: undefined },
+  })
+    .plus(Dimensions.fromOutputs(transaction.outs))
+    .getVSize();
   const inputAmount = utxolib.bitgo.unspentSum<TNumber>(unspents, amountType);
   const outputAmount = transaction.outs.reduce((sum, o) => sum + BigInt(o.value), BigInt(0));
   const fee = Number(BigInt(inputAmount) - outputAmount);

--- a/modules/unspents/src/dimensions.ts
+++ b/modules/unspents/src/dimensions.ts
@@ -64,11 +64,13 @@ export interface FromUnspentParams {
 
 const defaultUnspentParams: FromUnspentParams = {
   p2tr: {
-    scriptPathLevel: 1,
+    // Default to recovery script paths, to make it easier for recovery case callers (WRW etc).
+    // WP can explicitly pass scriptPathLevel: 1 to use happy path.
+    scriptPathLevel: 2,
   },
   p2trMusig2: {
     // Default to script path spend, to make it easier for recovery case callers (WRW etc).
-    // WP can explicitly pass undefined to use key path.
+    // WP can explicitly pass scriptPathLevel: undefined to use key path.
     scriptPathLevel: 1,
   },
 };
@@ -382,7 +384,7 @@ export class Dimensions {
   /**
    * Return dimensions of an unspent according to `chain` parameter
    * @param chain - Chain code as defined by utxo.chain
-   * @param params - Hint for unspents with variable input sizes (p2tr).
+   * @param params - Hint for unspents with variable input sizes (p2tr, p2trMusig2)
    * @return {Dimensions} of the unspent
    * @throws if the chain code is invalid or unsupported
    */
@@ -401,14 +403,15 @@ export class Dimensions {
 
   /**
    * @param unspents
+   * @param params - Hint for unspents with variable input sizes (p2tr, p2trMusig2)
    * @return {Dimensions} sum of the dimensions for each unspent (@see Dimensions.fromUnspent())
    */
-  static fromUnspents(unspents: { chain: ChainCode }[]): Dimensions {
+  static fromUnspents(unspents: { chain: ChainCode }[], params: FromUnspentParams = defaultUnspentParams): Dimensions {
     if (!Array.isArray(unspents)) {
       throw new TypeError(`unspents must be array`);
     }
     // Convert the individual unspents into dimensions and sum them up
-    return Dimensions.sum(...unspents.map((u) => Dimensions.fromUnspent(u)));
+    return Dimensions.sum(...unspents.map((u) => Dimensions.fromUnspent(u, params)));
   }
 
   /**

--- a/modules/unspents/test/dimensions.ts
+++ b/modules/unspents/test/dimensions.ts
@@ -148,11 +148,11 @@ describe('Dimensions from unspent types', function () {
     );
 
     chainCodesP2tr.forEach((chain) => {
-      Dimensions.fromUnspent({ chain }).should.eql(Dimensions.sum({ nP2trScriptPathLevel1Inputs: 1 }));
+      Dimensions.fromUnspent({ chain }).should.eql(Dimensions.sum({ nP2trScriptPathLevel2Inputs: 1 }));
       Dimensions.fromUnspent(
         { chain },
-        { p2tr: { scriptPathLevel: 2 }, p2trMusig2: { scriptPathLevel: undefined } }
-      ).should.eql(Dimensions.sum({ nP2trScriptPathLevel2Inputs: 1 }));
+        { p2tr: { scriptPathLevel: 1 }, p2trMusig2: { scriptPathLevel: undefined } }
+      ).should.eql(Dimensions.sum({ nP2trScriptPathLevel1Inputs: 1 }));
     });
 
     chainCodesP2trMusig2.forEach((chain) => {
@@ -169,7 +169,23 @@ describe('Dimensions from unspent types', function () {
         nP2shInputs: 2,
         nP2wshInputs: 2,
         nP2trKeypathInputs: 0,
-        nP2trScriptPathLevel1Inputs: 4,
+        nP2trScriptPathLevel1Inputs: 2,
+        nP2trScriptPathLevel2Inputs: 2,
+        nP2shP2pkInputs: 0,
+        outputs: { count: 0, size: 0 },
+      })
+    );
+
+    Dimensions.fromUnspents(
+      chainCodes.map((chain) => ({ chain })),
+      { p2tr: { scriptPathLevel: 1 }, p2trMusig2: { scriptPathLevel: undefined } }
+    ).should.eql(
+      new Dimensions({
+        nP2shP2wshInputs: 2,
+        nP2shInputs: 2,
+        nP2wshInputs: 2,
+        nP2trKeypathInputs: 2,
+        nP2trScriptPathLevel1Inputs: 2,
         nP2trScriptPathLevel2Inputs: 0,
         nP2shP2pkInputs: 0,
         outputs: { count: 0, size: 0 },

--- a/modules/utxo-ord/src/psbt.ts
+++ b/modules/utxo-ord/src/psbt.ts
@@ -144,7 +144,11 @@ export function findOutputLayoutForWalletUnspents(
     minInscriptionOutput,
     maxInscriptionOutput,
     feeFixed: getFee(
-      VirtualSizes.txSegOverheadVSize + Dimensions.fromUnspents(inputs).getInputsVSize(),
+      VirtualSizes.txSegOverheadVSize +
+        Dimensions.fromUnspents(inputs, {
+          p2tr: { scriptPathLevel: 1 },
+          p2trMusig2: { scriptPathLevel: undefined },
+        }).getInputsVSize(),
       constraints.feeRateSatKB
     ),
     feePerOutput: getFee(


### PR DESCRIPTION
Default to recovery path cost for p2tr and p2trMusig2 unspents.

Ticket: BTC-651
<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
