### PR TITLE
feat(sdk-core): add custodial and smc tss wallet to generateWallet

### DIFF
--- a/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
@@ -166,7 +166,6 @@ export interface SupplementGenerateWalletOptions {
   };
   walletVersion?: number;
   keys: string[];
-  isCold: boolean;
   keySignatures?: {
     backup: string;
     bitgo: string;
@@ -174,6 +173,7 @@ export interface SupplementGenerateWalletOptions {
   rootPrivateKey?: string;
   disableKRSEmail?: boolean;
   multisigType?: 'tss' | 'onchain' | 'blsdkg';
+  type: 'hot' | 'cold' | 'custodial';
 }
 
 export interface FeeEstimateOptions {

--- a/modules/sdk-core/src/bitgo/wallet/iWallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallets.ts
@@ -14,15 +14,24 @@ export interface GetWalletOptions {
   id?: string;
 }
 
-export interface GenerateMpcWalletOptions {
-  multisigType: 'onchain' | 'tss' | 'blsdkg';
+export interface GenerateBaseMpcWalletOptions {
+  multisigType: 'tss' | 'blsdkg';
   label: string;
-  passphrase?: string;
-  originalPasscodeEncryptionCode?: string;
-  enterprise?: string;
+  enterprise: string;
   walletVersion?: number;
+}
+
+export interface GenerateMpcWalletOptions extends GenerateBaseMpcWalletOptions {
+  passphrase: string;
+  originalPasscodeEncryptionCode?: string;
   backupProvider?: BackupProvider;
 }
+export interface GenerateSMCMpcWalletOptions extends GenerateBaseMpcWalletOptions {
+  bitgoKeyId: string;
+  commonKeychain: string;
+  coldDerivationSeed?: string;
+}
+
 export const backupProviders = ['BitGoTrustAsKrs'] as const;
 export type BackupProvider = (typeof backupProviders)[number];
 export interface GenerateWalletOptions {
@@ -49,6 +58,9 @@ export interface GenerateWalletOptions {
   rootPrivateKey?: string;
   multisigType?: 'onchain' | 'tss' | 'blsdkg';
   isDistributedCustody?: boolean;
+  bitgoKeyId?: string;
+  commonKeychain?: string;
+  type?: 'hot' | 'cold' | 'custodial';
 }
 
 export interface GetWalletByAddressOptions {

--- a/modules/sdk-unified-wallet/src/ecdsa-unified-wallet/ecdsaEVMUnifiedWallets.ts
+++ b/modules/sdk-unified-wallet/src/ecdsa-unified-wallet/ecdsaEVMUnifiedWallets.ts
@@ -47,7 +47,7 @@ export class EcdsaEVMUnifiedWallets extends UnifiedWallets {
       m: 2,
       n: 3,
       keys: [keychainsTriplet.userKeychain.id, keychainsTriplet.backupKeychain.id, keychainsTriplet.bitgoKeychain.id],
-      isCold: false,
+      type: 'hot',
       multisigType: 'tss',
       enterprise: params.enterprise,
       walletVersion: params.walletVersion,

--- a/modules/sdk-unified-wallet/src/eddsa-unified-wallet/eddsaUnifiedWallets.ts
+++ b/modules/sdk-unified-wallet/src/eddsa-unified-wallet/eddsaUnifiedWallets.ts
@@ -53,7 +53,7 @@ export class EddsaUnifiedWallets extends UnifiedWallets {
       m: 2,
       n: 3,
       keys: [keychainsTriplet.userKeychain.id, keychainsTriplet.backupKeychain.id, keychainsTriplet.bitgoKeychain.id],
-      isCold: false,
+      type: 'hot',
       multisigType: 'tss',
       enterprise: params.enterprise,
       walletVersion: params.walletVersion,


### PR DESCRIPTION
Added to the generateWallet method custodial and smc tss wallets

WP-991

BREAKING CHANGES:
- wallets.generateWallets() now requires an enterpriseId as enterprise
- walletsParams for coin.supplementGenerateWallet() now requires the type of wallet ('hot', 'custodial' or 'cold') instead of the flag isCold

TICKET: WP-991

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
