### PR TITLE
feat(sdk-coin-avaxp): replace export fee for import fee on output val…

### DIFF
--- a/modules/sdk-coin-avaxp/src/avaxp.ts
+++ b/modules/sdk-coin-avaxp/src/avaxp.ts
@@ -97,14 +97,14 @@ export class AvaxP extends BaseCoin {
       throw new Error('Export Tx requires one recipient');
     }
 
+    const maxImportFee = (this._staticsCoin.network as AvalancheNetwork).maxImportFee;
     const recipientAmount = new BigNumber(recipients[0].amount);
-
     if (
       recipientAmount.isGreaterThan(explainedTx.outputAmount) ||
-      recipientAmount.plus(explainedTx.fee.fee).isLessThan(explainedTx.outputAmount)
+      recipientAmount.plus(maxImportFee).isLessThan(explainedTx.outputAmount)
     ) {
       throw new Error(
-        `Tx total amount ${explainedTx.outputAmount} does not match with expected total amount field ${recipientAmount} and fixed fee ${explainedTx.fee.fee}`
+        `Tx total amount ${explainedTx.outputAmount} does not match with expected total amount field ${recipientAmount} and max import fee ${maxImportFee}`
       );
     }
 

--- a/modules/sdk-coin-avaxp/test/unit/avaxp.ts
+++ b/modules/sdk-coin-avaxp/test/unit/avaxp.ts
@@ -558,7 +558,7 @@ describe('Avaxp', function () {
       await basecoin
         .verifyTransaction({ txParams, txPrebuild })
         .should.be.rejectedWith(
-          `Tx total amount ${EXPORT_P_2_C_VERIFY.amount} does not match with expected total amount field 9999999 and fixed fee 1000000`
+          `Tx total amount ${EXPORT_P_2_C_VERIFY.amount} does not match with expected total amount field 9999999 and max import fee 10000000`
         );
     });
 

--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -49,6 +49,7 @@ export interface AvalancheNetwork extends BaseNetwork {
   // current valid asset id is AVAX
   readonly avaxAssetID: string;
   readonly txFee: string;
+  readonly maxImportFee: string; // 0.01 AVAX
 }
 
 export interface AccountNetwork extends BaseNetwork {
@@ -192,6 +193,7 @@ class AvalancheP extends Mainnet implements AvalancheNetwork {
   alias = 'P';
   vm = 'platformvm';
   txFee = '1000000'; // 1 MILLIAVAX
+  maxImportFee = '10000000'; // 0.01 AVAX
   createSubnetTx = '1000000000'; // 1 AVAX
   createChainTx = '1000000000'; // 1 AVAX
   creationTxFee = '10000000'; // 1 CENTIAVAX
@@ -218,6 +220,7 @@ class AvalanchePTestnet extends Testnet implements AvalancheNetwork {
   hrp = 'fuji';
   vm = 'platformvm';
   txFee = '1000000'; // 1 MILLIAVAX
+  maxImportFee = '10000000'; // 0.01 AVAX
   createSubnetTx = '1000000000'; // 1 AVAX
   createChainTx = '1000000000'; // 1 AVAX
   creationTxFee = '10000000'; // 1 CENTIAVAX


### PR DESCRIPTION
…idation

recipient amount plus import fee is equal to output amount. The import fee is absent durring verify of export tx. A max import fee is added on static and used in export verification.

TICKET: EA-2155

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
