### PR TITLE
fix(root): improve error handling for consolidateAccount

### DIFF
--- a/modules/bitgo/test/v2/unit/accountConsolidations.ts
+++ b/modules/bitgo/test/v2/unit/accountConsolidations.ts
@@ -63,6 +63,19 @@ describe('Account Consolidations:', function () {
 
           scope.isDone().should.be.True();
         });
+
+        it('should throw if the result is an empty array', async function () {
+          const scope = nock(bgUrl)
+            .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/consolidateAccount/build`)
+            .query({})
+            .reply(200, []);
+
+          await wallet
+            .buildAccountConsolidations()
+            .should.be.rejectedWith('No receive addresses with balance found to consolidate.');
+
+          scope.isDone().should.be.True();
+        });
       });
 
       describe('Sending', function () {
@@ -154,6 +167,8 @@ describe('Account Consolidations:', function () {
             .onCall(1)
             .resolves(fixtures.signedAccountConsolidationBuilds[1]);
 
+          sinon.stub(wallet, 'getKeychainsAndValidatePassphrase').resolves([]);
+
           const scopeFirstSigned = nock(bgUrl)
             .post(
               `/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/send`,
@@ -190,6 +205,8 @@ describe('Account Consolidations:', function () {
             .resolves(fixtures.signedAccountConsolidationBuilds[0])
             .onCall(1)
             .resolves(fixtures.signedAccountConsolidationBuilds[1]);
+
+          sinon.stub(wallet, 'getKeychainsAndValidatePassphrase').resolves([]);
 
           const scopeWithSuccess = nock(bgUrl)
             .post(

--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -666,12 +666,11 @@ describe('V2 Wallet:', function () {
             '{"iv":"15FsbDVI1zG9OggD8YX+Hg==","v":1,"iter":10000,"ks":256,"ts":64,"mode":"ccm","adata":"","cipher":"aes","salt":"hHbNH3Sz/aU=","ct":"WoNVKz7afiRxXI2w/YkzMdMyoQg/B15u1Q8aQgi96jJZ9wk6TIaSEc6bXFH3AHzD9MdJCWJQUpRhoQc/rgytcn69scPTjKeeyVMElGCxZdFVS/psQcNE+lue3//2Zlxj+6t1NkvYO+8yAezSMRBK5OdftXEjNQI="}',
           coinSpecific: {},
         });
-      try {
-        await ethWallet.sendMany({ ...sendManyParamsCorrectPassPhrase, walletPassphrase: 'wrongPassphrase' });
-      } catch (e) {
-        e.code.should.equal('wallet_passphrase_incorrect');
-        e.message.should.equal(errorMessage);
-      }
+
+      await ethWallet
+        .sendMany({ ...sendManyParamsCorrectPassPhrase, walletPassphrase: 'wrongPassphrase' })
+        .should.be.rejectedWith(errorMessage);
+
       try {
         const customSigningFunction = () => {
           return 'mock';

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -51,7 +51,7 @@ export interface Memo {
   type: string;
 }
 
-export interface BuildConsolidationTransactionOptions extends PrebuildTransactionOptions {
+export interface BuildConsolidationTransactionOptions extends PrebuildTransactionOptions, WalletSignTransactionOptions {
   consolidateAddresses?: string[];
 }
 


### PR DESCRIPTION
Using the wallet method sendAccountConsolidations if the wrong password was provided there was no check for it, so now before building and trying to sign the tx, it will fail earlier. Also when the buildConsolidation returned an empty array(meaning no receive address has balance to consolidate) we return an error.

WP-1034

TICKET: WP-1034

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
