### PR TITLE
feat(abstract-utxo): This enables PSBT (unless explicitly disabled) for

### DIFF
--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -54,11 +54,13 @@ describe('V2 Wallet:', function () {
     keys: ['5b3424f91bf349930e34017500000000', '5b3424f91bf349930e34017600000000', '5b3424f91bf349930e34017700000000'],
     coinSpecific: {},
     multisigType: 'onchain',
+    type: 'hot',
   };
   const wallet = new Wallet(bitgo, basecoin, walletData);
   const bgUrl = common.Environments[bitgo.getEnv()].uri;
   const address1 = '0x174cfd823af8ce27ed0afee3fcf3c3ba259116be';
   const address2 = '0x7e85bdc27c050e3905ebf4b8e634d9ad6edd0de6';
+  const tbtcHotWalletDefaultParams = { txFormat: 'psbt', addressType: 'p2trMusig2' };
 
   describe('Wallet transfers', function () {
     it('should search in wallet for a transfer', async function () {
@@ -1703,7 +1705,7 @@ describe('V2 Wallet:', function () {
     it('should pass offlineVerification=true query param if passed truthy value', async function () {
       const params = { offlineVerification: true };
       const scope = nock(bgUrl)
-        .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/build`)
+        .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/build`, tbtcHotWalletDefaultParams)
         .query(params)
         .reply(200, {});
       const blockHeight = 100;
@@ -1714,7 +1716,7 @@ describe('V2 Wallet:', function () {
       postProcessStub.should.have.been.calledOnceWith({
         blockHeight: 100,
         wallet: wallet,
-        buildParams: {},
+        buildParams: tbtcHotWalletDefaultParams,
       });
       scope.done();
       blockHeightStub.restore();
@@ -1723,7 +1725,10 @@ describe('V2 Wallet:', function () {
 
     it('should not pass the offlineVerification query param if passed a falsey value', async function () {
       const params = { offlineVerification: false };
-      nock(bgUrl).post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/build`).query({}).reply(200, {});
+      nock(bgUrl)
+        .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/build`, tbtcHotWalletDefaultParams)
+        .query({})
+        .reply(200, {});
       const blockHeight = 100;
       const blockHeightStub = sinon.stub(basecoin, 'getLatestBlockHeight').resolves(blockHeight);
       const postProcessStub = sinon.stub(basecoin, 'postProcessPrebuild').resolves({});
@@ -1732,7 +1737,7 @@ describe('V2 Wallet:', function () {
       postProcessStub.should.have.been.calledOnceWith({
         blockHeight: 100,
         wallet: wallet,
-        buildParams: {},
+        buildParams: tbtcHotWalletDefaultParams,
       });
       blockHeightStub.restore();
       postProcessStub.restore();
@@ -1740,7 +1745,10 @@ describe('V2 Wallet:', function () {
 
     it('prebuild should call build and getLatestBlockHeight for utxo coins', async function () {
       const params = {};
-      nock(bgUrl).post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/build`).query(params).reply(200, {});
+      nock(bgUrl)
+        .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/build`, tbtcHotWalletDefaultParams)
+        .query(params)
+        .reply(200, {});
       const blockHeight = 100;
       const blockHeightStub = sinon.stub(basecoin, 'getLatestBlockHeight').resolves(blockHeight);
       const postProcessStub = sinon.stub(basecoin, 'postProcessPrebuild').resolves({});
@@ -1749,7 +1757,7 @@ describe('V2 Wallet:', function () {
       postProcessStub.should.have.been.calledOnceWith({
         blockHeight: 100,
         wallet: wallet,
-        buildParams: {},
+        buildParams: tbtcHotWalletDefaultParams,
       });
       blockHeightStub.restore();
       postProcessStub.restore();


### PR DESCRIPTION
Distributed custody wallets
Testnet hot wallets
This enables addressType=p2trMusig2 for

Testnet hot wallets on bitcoin testnet

TICKET: BTC-659

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
