### PR TITLE
feat(sdk-api): add check to see if the derived xpub matches

### DIFF
--- a/modules/sdk-api/src/v1/wallet.ts
+++ b/modules/sdk-api/src/v1/wallet.ts
@@ -1719,6 +1719,10 @@ Wallet.prototype.getAndPrepareSigningKeychain = function (params, callback) {
       } catch (e) {
         throw new Error('Unable to decrypt user keychain');
       }
+
+      if (keychain.xpub && bip32.fromBase58(keychain.xprv).neutered().toBase58() !== keychain.xpub) {
+        throw new Error('derived xpub does not match stored xpub');
+      }
       return keychain;
     });
   }


### PR DESCRIPTION
Check to see if the xpub derived from the decrypted private key matches the key on file. 

This came up because it seems that wallet sharing is broken on v1 - and had to spend hours to figure that out.

TICKET: BTC-683

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
