### PR TITLE
fix(sdk-coin-avaxc): fix avaxc queryAddressTokenBalance method

### DIFF
--- a/modules/sdk-coin-avaxc/src/avaxc.ts
+++ b/modules/sdk-coin-avaxc/src/avaxc.ts
@@ -365,13 +365,16 @@ export class AvaxC extends BaseCoin {
    * @returns {Promise<BigNumber>} address balance
    */
   async queryAddressTokenBalance(address: string, contractAddress: string): Promise<BN> {
+    // get token balance using contract call
+    const tokenBalanceData = optionalDeps.ethAbi.simpleEncode('balanceOf(address)', address).toString('hex');
+    const tokenBalanceDataHex = optionalDeps.ethUtil.addHexPrefix(tokenBalanceData);
     const result = await this.recoveryBlockchainExplorerQuery({
       jsonrpc: '2.0',
       method: 'eth_call',
       params: [
         {
           to: contractAddress,
-          data: optionalDeps.ethAbi.simpleEncode('balanceOf(address)', address).toString('hex'),
+          data: tokenBalanceDataHex,
         },
         'latest',
       ],

--- a/modules/sdk-coin-avaxc/test/unit/avaxc.ts
+++ b/modules/sdk-coin-avaxc/test/unit/avaxc.ts
@@ -914,9 +914,11 @@ describe('Avalanche C-Chain', function () {
           params: [
             {
               to: tokenContractAddress,
-              data: optionalDeps.ethAbi
-                .simpleEncode('balanceOf(address)', recoveryUsers.hotWalletRecoveryUser.walletContractAddress)
-                .toString('hex'),
+              data: optionalDeps.ethUtil.addHexPrefix(
+                optionalDeps.ethAbi
+                  .simpleEncode('balanceOf(address)', recoveryUsers.hotWalletRecoveryUser.walletContractAddress)
+                  .toString('hex')
+              ),
             },
             'latest',
           ],
@@ -930,9 +932,11 @@ describe('Avalanche C-Chain', function () {
           params: [
             {
               to: tokenContractAddress,
-              data: optionalDeps.ethAbi
-                .simpleEncode('balanceOf(address)', recoveryUsers.coldWalletRecoveryUser.walletContractAddress)
-                .toString('hex'),
+              data: optionalDeps.ethUtil.addHexPrefix(
+                optionalDeps.ethAbi
+                  .simpleEncode('balanceOf(address)', recoveryUsers.coldWalletRecoveryUser.walletContractAddress)
+                  .toString('hex')
+              ),
             },
             'latest',
           ],


### PR DESCRIPTION
Throws an error because data is not formatted correctly - must be hex. Change fixes this

TICKET: WP-1117