### PR TITLE
fix(sdk-coin-avaxc): fix unsigned recovery txn format for tokens

### DIFF
--- a/modules/sdk-coin-avaxc/src/avaxc.ts
+++ b/modules/sdk-coin-avaxc/src/avaxc.ts
@@ -738,6 +738,7 @@ export class AvaxC extends BaseCoin {
         userKey,
         backupKey,
         coin: this.getChain(),
+        token: tokenName,
         gasPrice: optionalDeps.ethUtil.bufferToInt(gasPrice).toFixed(),
         gasLimit,
         recipients: [txInfo.recipient],

--- a/modules/sdk-coin-avaxc/src/iface.ts
+++ b/modules/sdk-coin-avaxc/src/iface.ts
@@ -69,6 +69,7 @@ export interface OfflineVaultTxInfo {
   amount: string;
   backupKeyNonce: number;
   eip1559?: EIP1559;
+  token?: string;
 }
 // endregion
 

--- a/modules/sdk-coin-avaxc/test/unit/avaxc.ts
+++ b/modules/sdk-coin-avaxc/test/unit/avaxc.ts
@@ -1158,6 +1158,8 @@ describe('Avalanche C-Chain', function () {
 
         recoveryTxn.should.not.be.undefined();
         recoveryTxn.should.have.property('txHex');
+        recoveryTxn.should.have.property('token');
+        recoveryTxn.token.should.equal('tavaxc:link');
         const txBuilder = tavaxCoin.getTransactionBuilder() as TransactionBuilder;
         txBuilder.from(recoveryTxn.txHex);
         const tx = await txBuilder.build();


### PR DESCRIPTION
The avaxc unsigned token recovery txn does not have a token field and displays incorrectly in ovc signing. Asset displayed is native asset instead of token asset:

<img width="1201" alt="Screen Shot 2023-12-06 at 1 40 01 PM" src="https://github.com/BitGo/BitGoJS/assets/107073833/460a38b1-f4e1-4533-9031-cf59c4908607">

Change introduced fixes this and has been tested e2e:

<img width="1199" alt="Screen Shot 2023-12-06 at 1 09 34 PM" src="https://github.com/BitGo/BitGoJS/assets/107073833/2bd66e37-2b85-4068-bd55-47d3bf125eac">

TICKET: WP-1118