### PR TITLE
feat: add flag to override signing for non-segwit transactions

### DIFF
--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -688,6 +688,9 @@ export class Wallet implements IWallet {
         assert(k.pub);
         return k.pub;
       }),
+      // Building PSBTs with the bulk flag does not include the previous transaction for non-segwit inputs.
+      // Manually override the signing and validating to not fail.
+      allowNonSegwitSigningWithoutPrevTx: !!params.bulk,
     };
 
     const txPrebuilds = Array.isArray(buildResponse) ? buildResponse : [buildResponse];


### PR DESCRIPTION
There is an explicit check in PSBTs to fail signing and verification if there is no `nonWitnessUtxo` for non-segwit input types. This flag overrides this functionality for bulk consolidation transactions. This reduces the size of the transaction by a factor of ~99.5%

BTC-721
<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
