### PR TITLE
fix: rename injective erc20 token

### DIFF
--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -3832,7 +3832,7 @@ export const coins = CoinMap.fromCoins([
   erc20(
     'fa128781-36cf-416f-bbf0-0ae247e66d51',
     'injv2',
-    'Injective Token',
+    'Injective (ERC20)',
     18,
     '0xe28b3b32b6c345a34ff64674606124dd5aceca30',
     UnderlyingAsset.INJV2


### PR DESCRIPTION
This PR renames INJ ERC20 token. This helps user differentiate the native INJ coin from its ERC20 counterpart. IMO, this is a temporary fix and ideally our UI should help with this by appending the network icon alongwith the coin icon

Ticket: EA-2371