### PR TITLE
fix(sdk-core): only add headers if they exist and nonempty

### DIFF
--- a/modules/sdk-core/src/bitgo/utils/postWithCodec.ts
+++ b/modules/sdk-core/src/bitgo/utils/postWithCodec.ts
@@ -68,10 +68,17 @@ export function postWithCodec<
     console.error('error encoding request body for url', url, e);
     codecError = true;
   }
-  return agent
-    .post(url)
-    .set('io-ts-codec-encode-error', codecError ? 'true' : 'false')
-    .set('io-ts-codec-decode-error', getDecodeErrorKeys(codec, body).join(','))
-    .set('io-ts-unknown-properties', encodedBody ? getUnknownProperties(body, encodedBody).join(',') : 'NA')
-    .send(useEncodedBody && encodedBody ? encodedBody : body);
+  const postRequest = agent.post(url).set('io-ts-codec-encode-error', codecError ? 'true' : 'false');
+
+  if (codec) {
+    const decodeErrorKeys = getDecodeErrorKeys(codec, body).join(',');
+    if (decodeErrorKeys.trim() !== '') {
+      postRequest.set('io-ts-codec-decode-error', decodeErrorKeys);
+    }
+  }
+
+  const unknownProperties = encodedBody ? getUnknownProperties(body, encodedBody).join(',') : 'NA';
+  postRequest.set('io-ts-unknown-properties', unknownProperties || 'NA');
+
+  return postRequest.send(useEncodedBody && encodedBody ? encodedBody : body);
 }

--- a/modules/sdk-core/test/unit/bitgo/utils/postWithCodec.ts
+++ b/modules/sdk-core/test/unit/bitgo/utils/postWithCodec.ts
@@ -52,8 +52,7 @@ describe('postWithCodec', function () {
       { foo: 'bar' },
       {
         'io-ts-codec-encode-error': 'false',
-        'io-ts-codec-decode-error': '',
-        'io-ts-unknown-properties': '',
+        'io-ts-unknown-properties': 'NA',
       }
     );
 
@@ -62,8 +61,7 @@ describe('postWithCodec', function () {
       { foo: 'bar', bar: null },
       {
         'io-ts-codec-encode-error': 'false',
-        'io-ts-codec-decode-error': '',
-        'io-ts-unknown-properties': '',
+        'io-ts-unknown-properties': 'NA',
       }
     );
   });
@@ -76,7 +74,7 @@ describe('postWithCodec', function () {
       {
         'io-ts-codec-encode-error': 'false',
         'io-ts-codec-decode-error': '0.foo',
-        'io-ts-unknown-properties': '',
+        'io-ts-unknown-properties': 'NA',
       }
     );
 
@@ -86,7 +84,6 @@ describe('postWithCodec', function () {
       { foo: 'bar' },
       {
         'io-ts-codec-encode-error': 'false',
-        'io-ts-codec-decode-error': '',
         'io-ts-unknown-properties': 'boo',
       }
     );
@@ -97,7 +94,6 @@ describe('postWithCodec', function () {
       { foo: 'bar', boo: 1 },
       {
         'io-ts-codec-encode-error': 'false',
-        'io-ts-codec-decode-error': '',
         'io-ts-unknown-properties': 'boo',
       }
     );


### PR DESCRIPTION
Ticket: [CE-3344](https://bitgoinc.atlassian.net/browse/CE-3344)
As we should not be calling .set('some-header', undefined/null/'') , so only add headers if they exist and are not empty string
Old
see empty header for `lo-Ts-Codec-Decode-Error` & `lo-Ts-Unknown-Properties`
<img width="595" alt="Screenshot 2023-12-20 at 10 08 19 AM" src="https://github.com/BitGo/BitGoJS/assets/51216522/d3bce203-929a-42a9-a6d7-32850b98709c">
New
<img width="586" alt="Screenshot 2023-12-20 at 12 20 40 PM" src="https://github.com/BitGo/BitGoJS/assets/51216522/a8138a42-6439-4e0b-af76-a9173168889d">


[CE-3344]: https://bitgoinc.atlassian.net/browse/CE-3344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ