### PR TITLE
fix(sdk-core): do not hardcode eddsa tss utils in PA

### DIFF
--- a/modules/bitgo/test/v2/unit/pendingApproval.ts
+++ b/modules/bitgo/test/v2/unit/pendingApproval.ts
@@ -10,6 +10,8 @@ import { BitGo } from '../../../src';
 
 import {
   BaseCoin,
+  EcdsaUtils,
+  EddsaUtils,
   Environments,
   PendingApproval,
   PendingApprovalData,
@@ -75,6 +77,28 @@ describe('Pending Approvals:', () => {
     wallet = new Wallet(bitgo, basecoin, walletData);
     bgUrl = Environments[bitgo.getEnv()].uri;
     (pendingApprovalData as any).wallet = wallet;
+  });
+
+  ['tsol', 'teth', 'tbtc'].forEach((coinName) => {
+    it(`should use correct tssUtils for  ${coinName}`, () => {
+      const coin = bitgo.coin(coinName);
+      const pendingAproval = new PendingApproval(bitgo, coin, {} as unknown as PendingApprovalData);
+      if (coin.supportsTss()) {
+        if (coin.getMPCAlgorithm() === 'ecdsa') {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          pendingAproval.tssUtils.should.be.instanceOf(EcdsaUtils);
+        } else if (coin.getMPCAlgorithm() === 'eddsa') {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          pendingAproval.tssUtils.should.be.instanceOf(EddsaUtils);
+        }
+      } else {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        (pendingAproval.tssUtils === undefined).should.be.true();
+      }
+    });
   });
 
   it('should call consolidate instead of build when rebuilding consolidation pending approvals', async () => {
@@ -164,8 +188,15 @@ describe('Pending Approvals:', () => {
   testRecreateTransaction('tbtc', false, Type.TRANSACTION_REQUEST);
   testRecreateTransaction('tsol', true, Type.TRANSACTION_REQUEST);
   testRecreateTransaction('tsol', true, Type.TRANSACTION_REQUEST_FULL);
+  testRecreateTransaction('teth', true, Type.TRANSACTION_REQUEST_FULL);
 
   describe('recreateAndSignTSSTransaction', function () {
+    let coin: BaseCoin;
+
+    before(() => {
+      coin = bitgo.coin('tsol');
+    });
+
     it('should call approve and do the TSS flow and fail if the txRequestId is missing', async () => {
       const pendingApproval = wallet.pendingApprovals()[0];
       const reqId = new RequestTracer();
@@ -186,7 +217,7 @@ describe('Pending Approvals:', () => {
     });
 
     it('should call approve and do the TSS flow and fail if the wallet is missing', async () => {
-      const pendingApproval = new PendingApproval(bitgo, basecoin, pendingApprovalData);
+      const pendingApproval = new PendingApproval(bitgo, coin, pendingApprovalData);
       const reqId = new RequestTracer();
       const params = { walletPassphrase: 'test' };
       await pendingApproval.recreateAndSignTSSTransaction(params, reqId).should.be.rejectedWith('Wallet not found');
@@ -194,7 +225,7 @@ describe('Pending Approvals:', () => {
 
     it('should get txHex for transactionRequestLite', async () => {
       pendingApprovalData['txRequestId'] = 'requestTxIdTest';
-      const pendingApproval = new PendingApproval(bitgo, basecoin, pendingApprovalData, wallet);
+      const pendingApproval = new PendingApproval(bitgo, coin, pendingApprovalData, wallet);
       const reqId = new RequestTracer();
       const txRequestId = 'test';
       const walletPassphrase = 'test';
@@ -241,7 +272,7 @@ describe('Pending Approvals:', () => {
 
     it('should get txHex for transactionRequestFull ', async () => {
       pendingApprovalData['txRequestId'] = 'requestTxIdTest';
-      const pendingApproval = new PendingApproval(bitgo, basecoin, pendingApprovalData, wallet);
+      const pendingApproval = new PendingApproval(bitgo, coin, pendingApprovalData, wallet);
       const reqId = new RequestTracer();
       const txRequestId = 'test';
       const walletPassphrase = 'test';

--- a/modules/bitgo/test/v2/unit/pendingApproval.ts
+++ b/modules/bitgo/test/v2/unit/pendingApproval.ts
@@ -85,18 +85,12 @@ describe('Pending Approvals:', () => {
       const pendingAproval = new PendingApproval(bitgo, coin, {} as unknown as PendingApprovalData);
       if (coin.supportsTss()) {
         if (coin.getMPCAlgorithm() === 'ecdsa') {
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          pendingAproval.tssUtils.should.be.instanceOf(EcdsaUtils);
+          pendingAproval['tssUtils'].should.be.instanceOf(EcdsaUtils);
         } else if (coin.getMPCAlgorithm() === 'eddsa') {
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          pendingAproval.tssUtils.should.be.instanceOf(EddsaUtils);
+          pendingAproval['tssUtils'].should.be.instanceOf(EddsaUtils);
         }
       } else {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        (pendingAproval.tssUtils === undefined).should.be.true();
+        (pendingAproval['tssUtils'] === undefined).should.be.true();
       }
     });
   });


### PR DESCRIPTION
In the past the `tssUtils` in the Pending Approval class was actually the `EddsaUtils` implementation. A PA can be for a non-tss wallet, or a eddsa tss wallet or an ecdsa tss wallet. 

This PR updates the constructor of the PA handler to correctly set the `tssUtils` based on the coins features/support.

TICKET: WP-1353


