### PR TITLE
fix(sdk-core): fix hash for tss ecdsa PA signing

### DIFF
--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -5,7 +5,6 @@ import { ApiKeyShare, Keychain } from '../../keychain';
 import { ApiVersion, Memo, WalletType } from '../../wallet';
 import { EDDSA, GShare, SignShare, Signature } from '../../../account-lib/mpc/tss';
 import { KeyShare } from './ecdsa';
-import { Hash } from 'crypto';
 import { EcdsaTypes } from '@bitgo/sdk-lib-mpc';
 import { TssEcdsaStep1ReturnMessage, TssEcdsaStep2ReturnMessage, TxRequestChallengeResponse } from '../../tss/types';
 import { AShare, DShare, SShare } from '../../tss/ecdsa/types';
@@ -346,7 +345,6 @@ export type TSSParams = {
   prv: string;
   reqId: IRequestTracer;
   apiVersion?: ApiVersion;
-  hash?: Hash;
 };
 
 export type TSSParamsForMessage = TSSParams & {

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
@@ -3,6 +3,7 @@ import { Buffer } from 'buffer';
 import { Key, SerializedKeyPair } from 'openpgp';
 import * as openpgp from 'openpgp';
 import { ec } from 'elliptic';
+import { Hash } from 'crypto';
 
 import { EcdsaPaillierProof, EcdsaRangeProof, EcdsaTypes, hexToBigInt, minModulusBitLength } from '@bitgo/sdk-lib-mpc';
 import { bip32 } from '@bitgo/utxo-lib';
@@ -973,11 +974,20 @@ export class EcdsaUtils extends baseTSSUtils<KeyShare> {
       step2Return.muDShare
     )) as DShare;
 
+    // If only the getHashFunction() is defined for the coin use it otherwise
+    // pass undefined hash, default hash will be used in that case.
+    let hash: Hash | undefined;
+    try {
+      hash = this.baseCoin.getHashFunction();
+    } catch (err) {
+      hash = undefined;
+    }
+
     const userSShare = await ECDSAMethods.createUserSignatureShare(
       step2Return.oShare as OShare,
       bitgoToUserDShare,
       signablePayload,
-      params.hash
+      hash
     );
 
     // signing stage three with SShare send to bitgo and receives SShare

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -96,7 +96,6 @@ import { Lightning } from '../lightning';
 import EddsaUtils from '../utils/tss/eddsa';
 import { EcdsaUtils } from '../utils/tss/ecdsa';
 import { getTxRequest } from '../tss';
-import { Hash } from 'crypto';
 import { ofcTokens } from '@bitgo/statics';
 import { buildParamKeys, BuildParams } from './BuildParams';
 import { postWithCodec } from '../utils/postWithCodec';
@@ -3138,21 +3137,12 @@ export class Wallet implements IWallet {
       throw new Error('prv required to sign transactions with TSS');
     }
 
-    // If only the getHashFunction() is defined for the coin use it otherwise
-    // pass undefined hash, default hash will be used in that case.
-    let hash: Hash | undefined;
-    try {
-      hash = this.baseCoin.getHashFunction();
-    } catch (err) {
-      hash = undefined;
-    }
     try {
       const signedTxRequest = await this.tssUtils!.signTxRequest({
         txRequest: params.txPrebuild.txRequestId,
         prv: params.prv,
         reqId: params.reqId || new RequestTracer(),
         apiVersion: params.apiVersion,
-        hash,
       });
       return {
         txRequestId: signedTxRequest.txRequestId,


### PR DESCRIPTION
Moved hash selection to EcDSA utils to fix PA signing and avoid the need to pass the hash to the signer

WP-1186

TICKET: WP-1186

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
