### PR TITLE
feat(sdk-core): add support to allow external change address

### DIFF
--- a/modules/sdk-core/src/bitgo/wallet/BuildParams.ts
+++ b/modules/sdk-core/src/bitgo/wallet/BuildParams.ts
@@ -10,6 +10,7 @@ export const BuildParamsUTXO = t.partial({
   changeAddressType: t.unknown,
   /* a fixed change address */
   changeAddress: t.unknown,
+  allowExternalChangeAddress: t.boolean,
   cpfpFeeRate: t.unknown,
   cpfpTxIds: t.unknown,
   unspents: t.unknown,

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -103,6 +103,7 @@ export interface PrebuildTransactionOptions {
   noSplitChange?: boolean;
   unspents?: any[];
   changeAddress?: string;
+  allowExternalChangeAddress?: boolean;
   type?: string;
   closeRemainderTo?: string;
   nonParticipation?: boolean;
@@ -533,6 +534,7 @@ export interface SendManyOptions extends PrebuildAndSignTransactionOptions {
   comment?: string;
   otp?: string;
   changeAddress?: string;
+  allowExternalChangeAddress?: boolean;
   instant?: boolean;
   memo?: Memo;
   transferId?: number;


### PR DESCRIPTION
Currently change address param in UTXO build API can be any valid address. Making it allow only change address of sender wallet by default. New param allowExternalChangeAddress is used to allow any valid address.

Ticket: BTC-802

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
