### PR TITLE
fix(utxo-lib): correct logic for unsafe segwit unspent update

### DIFF
--- a/modules/utxo-lib/src/bitgo/wallet/Unspent.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/Unspent.ts
@@ -255,7 +255,7 @@ export function updateWalletUnspentForPsbt(
   // with the previous transaction. Therefore, we can treat Zcash non-segwit transactions as Bitcoin
   // segwit transactions
   const isZcashOrSegwit = isSegwit(u.chain) || getMainnet(psbt.network) === networks.zcash;
-  if ((isZcashOrSegwit && !input.witnessUtxo) || customParams?.skipNonWitnessUtxo) {
+  if ((isZcashOrSegwit || customParams?.skipNonWitnessUtxo) && !input.witnessUtxo) {
     const { script, value } = toPrevOutput(u, psbt.network);
     psbt.updateInput(inputIndex, { witnessUtxo: { script, value } });
   } else if (!isZcashOrSegwit) {


### PR DESCRIPTION
In the case that we are updating a PSBT input where we are explicitly flagging that we want to substitute the nonWitnessUtxo for a witnessUtxo for a non-segwit input, we were not checking if the witnessUtxo already existed. This will throw an error for duplicate data

TICKET: BTC-855

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
