### PR TITLE
feat: add utils to convert to and from cosmos evm address

### DIFF
--- a/modules/abstract-cosmos/src/lib/utils.ts
+++ b/modules/abstract-cosmos/src/lib/utils.ts
@@ -6,7 +6,7 @@ import {
   TransactionType,
 } from '@bitgo/sdk-core';
 import { encodeSecp256k1Pubkey, encodeSecp256k1Signature } from '@cosmjs/amino';
-import { fromBase64, fromBech32, fromHex, toHex } from '@cosmjs/encoding';
+import { fromBase64, fromBech32, fromHex, toHex, toBech32 } from '@cosmjs/encoding';
 import {
   DecodedTxRaw,
   EncodeObject,
@@ -286,6 +286,29 @@ export class CosmosUtils implements BaseUtils {
         typeUrl: message.typeUrl,
       };
     });
+  }
+
+  /**
+   * Get a cosmos chain address from its equivalent hex
+   * @param {string} prefix
+   * @param {string} addressHex
+   * @returns {string}
+   */
+  getCosmosLikeAddressFromHex(prefix: string, addressHex: string): string {
+    if (addressHex.indexOf('0x') === 0) {
+      addressHex = addressHex.slice(2);
+    }
+    return toBech32(prefix, fromHex(addressHex));
+  }
+
+  /**
+   * Get a EVM chain address from its equivalent hex
+   * @param {string} prefix
+   * @param {string} addressHex
+   * @returns {string}
+   */
+  getEvmLikeAddressFromCosmos(cosmosLikeAddress: string): string {
+    return '0x' + toHex(fromBech32(cosmosLikeAddress).data);
   }
 
   /**

--- a/modules/sdk-coin-zeta/test/resources/zeta.ts
+++ b/modules/sdk-coin-zeta/test/resources/zeta.ts
@@ -437,3 +437,6 @@ export const mockAccountDetailsResponse = {
     code_hash: '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470',
   },
 };
+
+export const zetaEvmAddress = '0x603871c2ddd41c26ee77495e2e31e6de7f9957e0';
+export const zetaCosmosAddress = 'zeta1vqu8rska6swzdmnhf90zuv0xmelej4lqmktpwc';

--- a/modules/sdk-coin-zeta/test/unit/utils.ts
+++ b/modules/sdk-coin-zeta/test/unit/utils.ts
@@ -44,4 +44,19 @@ describe('utils', () => {
       'transactionBuilder: validateAmount: Invalid denom: ' + testData.coinAmounts.amount5.denom
     );
   });
+
+  it('should convert evm address to zeta address correctly', () => {
+    const result = utils.getCosmosLikeAddressFromHex('zeta', testData.zetaEvmAddress);
+    should.equal(result, testData.zetaCosmosAddress);
+  });
+
+  it('should convert evm address to zeta address correctly without 0x prefix', () => {
+    const result = utils.getCosmosLikeAddressFromHex('zeta', testData.zetaEvmAddress.slice(2));
+    should.equal(result, testData.zetaCosmosAddress);
+  });
+
+  it('should convert zeta address to its evm equivalent correctly', () => {
+    const result = utils.getEvmLikeAddressFromCosmos(testData.zetaCosmosAddress);
+    should.equal(result, testData.zetaEvmAddress);
+  });
 });


### PR DESCRIPTION
this change adds utils to convert to and fro between
cosmos and evm addresses

Ticket: WIN-2077

TICKET: WIN-2077

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
