### PR TITLE
chore: bump crypto-js dependency

### DIFF
--- a/modules/sdk-coin-algo/package.json
+++ b/modules/sdk-coin-algo/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@bitgo/sdk-core": "^26.6.0",
     "@bitgo/statics": "^48.4.0",
-    "@hashgraph/cryptography": "1.1.2",
+    "@hashgraph/cryptography": "1.4.8-beta.5",
     "@stablelib/hex": "^1.0.0",
     "algosdk": "1.14.0",
     "bignumber.js": "^9.0.0",

--- a/modules/sdk-coin-hbar/package.json
+++ b/modules/sdk-coin-hbar/package.json
@@ -44,7 +44,7 @@
     "@bitgo/sdk-core": "^26.6.0",
     "@bitgo/statics": "^48.4.0",
     "@hashgraph/proto": "2.12.0",
-    "@hashgraph/sdk": "2.29.0",
+    "@hashgraph/sdk": "2.42.0",
     "@stablelib/sha384": "^1.0.0",
     "bignumber.js": "^9.0.0",
     "lodash": "^4.17.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2449,30 +2449,20 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@hashgraph/cryptography@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.1.2.tgz"
-  integrity sha512-oSnDDs5foNq6Yni4kCwbA01NuVY2mewVr1jhkJG7yNDT6+xIBCztRWDeINb1JuShXe57Cuf88M1zmN5iFN7JgA==
+"@hashgraph/cryptography@1.4.8-beta.5":
+  version "1.4.8-beta.5"
+  resolved "https://registry.yarnpkg.com/@hashgraph/cryptography/-/cryptography-1.4.8-beta.5.tgz#c0a30838d83080086bce5fbf2d8f19924a27805f"
+  integrity sha512-soq2vGLRkdl2Evr+gIvIjCXJjqA1hOAjysBGG+dhP6tKx2PEgEjb3hON/sMbxm3Q4qQdkML/vEthdAV707+flw==
   dependencies:
-    bignumber.js "^9.0.2"
-    crypto-js "^4.1.1"
-    elliptic "^6.5.4"
-    expo-crypto "^10.1.2"
-    expo-random "^12.1.2"
-    js-base64 "^3.7.2"
-    tweetnacl "^1.0.3"
-    utf8 "^3.0.0"
-
-"@hashgraph/cryptography@1.4.6":
-  version "1.4.6"
-  resolved "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.6.tgz"
-  integrity sha512-3HmnT1Lek71l6nHxc4GOyT/hSx/LmgusyWfE7hQda2dnE5vL2umydDw5TK2wq8gqmD9S3uRSMhz/BO55wtzxRA==
-  dependencies:
+    asn1js "^3.0.5"
     bignumber.js "^9.1.1"
-    bn.js "^5.1.1"
-    crypto-js "^4.1.1"
+    bn.js "^5.2.1"
+    buffer "^6.0.3"
+    crypto-js "^4.2.0"
     elliptic "^6.5.4"
     js-base64 "^3.7.4"
+    node-forge "^1.3.1"
+    spark-md5 "^3.0.2"
     tweetnacl "^1.0.3"
     utf8 "^3.0.0"
 
@@ -2485,26 +2475,36 @@
     protobufjs "^7.1.2"
     protobufjs-cli "^1.0.2"
 
-"@hashgraph/sdk@2.29.0":
-  version "2.29.0"
-  resolved "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.29.0.tgz"
-  integrity sha512-dMv2q7OCa2Xyi0ooGjo4JJRFxHKzKBvMd8G/n30j4jHx1JiSfI2ckPTAOwfCbYZ/o+EMDZzevyD5+Juf9iph+A==
+"@hashgraph/proto@2.14.0-beta.4":
+  version "2.14.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@hashgraph/proto/-/proto-2.14.0-beta.4.tgz#82049f9e738afc7b529c61e0f56f7e0a3b5907e0"
+  integrity sha512-DCmK9CivuVpdDuay1VcYt++Zhms55uu8JZgJI6fBtJuv/WkMuYLNtmnihKcQ39Ykmm8SV6iL6trTziTINHV44g==
+  dependencies:
+    long "^4.0.0"
+    protobufjs "^7.2.5"
+
+"@hashgraph/sdk@2.42.0":
+  version "2.42.0"
+  resolved "https://registry.yarnpkg.com/@hashgraph/sdk/-/sdk-2.42.0.tgz#abf79cb7c7b8fa44839b9de996acfe51cd064e7e"
+  integrity sha512-47E08ZHGRKoZCmJJhbcaFWcAWNPpJfs5F0SvqocDNFHs616+zrAwFDPXqWLtGx3JhyeCZClgpDYvJX7CVBFCtA==
   dependencies:
     "@ethersproject/abi" "^5.7.0"
     "@ethersproject/bignumber" "^5.7.0"
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/rlp" "^5.7.0"
     "@grpc/grpc-js" "1.8.2"
-    "@hashgraph/cryptography" "1.4.6"
-    "@hashgraph/proto" "2.12.0"
-    axios "^1.3.1"
+    "@hashgraph/cryptography" "1.4.8-beta.5"
+    "@hashgraph/proto" "2.14.0-beta.4"
+    axios "^1.6.4"
     bignumber.js "^9.1.1"
-    crypto-js "^4.1.1"
+    bn.js "^5.1.1"
+    crypto-js "^4.2.0"
     js-base64 "^3.7.4"
     long "^4.0.0"
     pino "^8.14.1"
     pino-pretty "^10.0.0"
-    protobufjs "^7.1.2"
+    protobufjs "^7.2.5"
+    rfc4648 "^1.5.3"
     utf8 "^3.0.0"
 
 "@humanwhocodes/config-array@^0.5.0":
@@ -6553,7 +6553,7 @@ axios@^0.26.1:
   dependencies:
     follow-redirects "^1.14.8"
 
-axios@^1.0.0, axios@^1.3.1, axios@^1.3.4, axios@^1.4.0:
+axios@^1.0.0, axios@^1.3.4, axios@^1.4.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.1.tgz#76550d644bf0a2d469a01f9244db6753208397d7"
   integrity sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==
@@ -6568,6 +6568,15 @@ axios@^1.6.0:
   integrity sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==
   dependencies:
     follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
+axios@^1.6.4:
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.7.tgz#7b48c2e27c96f9c68a2f8f31e2ab19f59b06b0a7"
+  integrity sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==
+  dependencies:
+    follow-redirects "^1.15.4"
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
@@ -8460,7 +8469,7 @@ crypto-browserify@3.12.0, crypto-browserify@^3.0.0, crypto-browserify@^3.12.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-crypto-js@^4.1.1:
+crypto-js@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
   integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
@@ -10331,11 +10340,6 @@ executable@^4.1.1:
   dependencies:
     pify "^2.2.0"
 
-expo-crypto@^10.1.2:
-  version "10.2.0"
-  resolved "https://registry.npmjs.org/expo-crypto/-/expo-crypto-10.2.0.tgz"
-  integrity sha512-YVFp+DJXBtt4t6oZXepnzb+xwpKzFbXn3B9Oma1Tfh6J0rIlm/I20UW/5apdvEdbj44fxJ5DsiZeyADI3bcZkQ==
-
 expo-modules-autolinking@^0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/expo-modules-autolinking/-/expo-modules-autolinking-0.0.3.tgz#45ba8cb1798f9339347ae35e96e9cc70eafb3727"
@@ -10351,13 +10355,6 @@ expo-random@*:
   version "13.4.0"
   resolved "https://registry.yarnpkg.com/expo-random/-/expo-random-13.4.0.tgz#b07967778c036c43fb5488e7f73d2d1e15c1786f"
   integrity sha512-Z/Bbd+1MbkK8/4ukspgA3oMlcu0q3YTCu//7q2xHwy35huN6WCv4/Uw2OGyCiOQjAbU02zwq6swA+VgVmJRCEw==
-  dependencies:
-    base64-js "^1.3.0"
-
-expo-random@^12.1.2:
-  version "12.3.0"
-  resolved "https://registry.npmjs.org/expo-random/-/expo-random-12.3.0.tgz"
-  integrity sha512-q+AsTfGNT+Q+fb2sRrYtRkI3g5tV4H0kuYXM186aueILGO/vLn/YYFa7xFZj1IZ8LJZg2h96JDPDpsqHfRG2mQ==
   dependencies:
     base64-js "^1.3.0"
 
@@ -10719,7 +10716,7 @@ flux@^4.0.1:
     fbemitter "^3.0.0"
     fbjs "^3.0.1"
 
-follow-redirects@1.15.4, follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.14.7, follow-redirects@^1.14.8, follow-redirects@^1.14.9, follow-redirects@^1.15.0:
+follow-redirects@1.15.4, follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.14.7, follow-redirects@^1.14.8, follow-redirects@^1.14.9, follow-redirects@^1.15.0, follow-redirects@^1.15.4:
   version "1.15.4"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.4.tgz#cdc7d308bf6493126b17ea2191ea0ccf3e535adf"
   integrity sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==
@@ -12720,7 +12717,7 @@ joycon@^3.1.1:
   resolved "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz"
   integrity sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==
 
-js-base64@^3.7.2, js-base64@^3.7.4:
+js-base64@^3.7.4:
   version "3.7.5"
   resolved "https://registry.npmjs.org/js-base64/-/js-base64-3.7.5.tgz"
   integrity sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA==
@@ -14366,7 +14363,7 @@ node-fetch@^3.3.1:
     fetch-blob "^3.1.4"
     formdata-polyfill "^4.0.10"
 
-node-forge@^1:
+node-forge@^1, node-forge@^1.3.1:
   version "1.3.1"
   resolved "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz"
   integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
@@ -15889,7 +15886,7 @@ protobufjs-cli@^1.0.2:
     tmp "^0.2.1"
     uglify-js "^3.7.7"
 
-protobufjs@7.2.4, protobufjs@^6.8.8, protobufjs@^7.0.0, protobufjs@^7.1.2, protobufjs@^7.2.4, protobufjs@~6.11.2, protobufjs@~6.11.3:
+protobufjs@7.2.4, protobufjs@^6.8.8, protobufjs@^7.0.0, protobufjs@^7.1.2, protobufjs@^7.2.4, protobufjs@^7.2.5, protobufjs@~6.11.2, protobufjs@~6.11.3:
   version "7.2.5"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.5.tgz#45d5c57387a6d29a17aab6846dcc283f9b8e7f2d"
   integrity sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==
@@ -16698,6 +16695,11 @@ reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
+rfc4648@^1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/rfc4648/-/rfc4648-1.5.3.tgz#e62b81736c10361ca614efe618a566e93d0b41c0"
+  integrity sha512-MjOWxM065+WswwnmNONOT+bD1nXzY9Km6u3kzvnx8F8/HXGZdz3T6e6vZJ8Q/RIMUSp/nxqjH3GwvJDy8ijeQQ==
 
 rfdc@^1.3.0:
   version "1.3.0"
@@ -17591,6 +17593,11 @@ sourcemap-codec@^1.4.8:
   version "1.4.8"
   resolved "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
+
+spark-md5@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-3.0.2.tgz#7952c4a30784347abcee73268e473b9c0167e3fc"
+  integrity sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==
 
 spawn-wrap@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
TICKET: CE-3554

## Description

crypto-js version is causing a dependabot alert for bitgo-ui: https://github.com/BitGo/bitgo-ui/security/dependabot/36. 
This PR updates the `@hashgraph/cryptography` and `@hashgraph/sdk` packages which subsequently updates the `crypto-js` dependency

