### PR TITLE
fix(statics): updates decimal for opeth:usdt

### DIFF
--- a/modules/sdk-coin-opeth/test/unit/opeth.ts
+++ b/modules/sdk-coin-opeth/test/unit/opeth.ts
@@ -610,7 +610,7 @@ describe('Optimism', function () {
         })) as OfflineVaultTxInfo;
       } catch (e) {
         e.message.should.equal(
-          'Backup key address 0x4f2c4830cc37f2785c646f89ded8a919219fa0e9 has balance 100000 Gwei.This address must have a balance of at least 12000000 Gwei to perform recoveries. Try sending some funds to this address then retry.'
+          'Backup key address 0x4f2c4830cc37f2785c646f89ded8a919219fa0e9 has balance 100000 Gwei.This address must have a balance of at least 11000000 Gwei to perform recoveries. Try sending some funds to this address then retry.'
         );
       }
     });

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -14634,7 +14634,7 @@ export const coins = CoinMap.fromCoins([
     '634d052e-8c1c-47ed-aded-d0a2399439b0',
     'opeth:usdt',
     'Tether USD',
-    18,
+    6,
     '0x94b008aa00579c1307b0ef2c499ad98a8ce58e58',
     UnderlyingAsset['opeth:usdt']
   ),

--- a/modules/statics/src/tokenConfig.ts
+++ b/modules/statics/src/tokenConfig.ts
@@ -223,7 +223,7 @@ export const ethGasConfigs = {
   minimumGasLimit: 30000, // minimum gas limit a user can set for a send
   maximumGasLimit: 20000000, // Customers cannot set gas limits beyond this amount
   newEthLikeCoinsMinGasLimit: 400000, // minimum gas limit a user can set for a send for eth like coins like arbitrum, optimism, etc
-  opethGasL1Fees: 2000000000000000, // Buffer for opeth gas fees
+  opethGasL1Fees: 1000000000000000, // Buffer for opeth L1 gas fees
 };
 // Get the list of Stellar tokens from statics and format it properly
 const formattedStellarTokens = coins.reduce((acc: StellarTokenConfig[], coin) => {


### PR DESCRIPTION
WIN-2412
TICKET: WIN-2412

This PR corrects the decimals for opeth:usdt token. It also decreases the buffer provided for covering L1 gas fees for WRW

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
