### PR TITLE
fix: adding PayGo to coinFeatures for utxo coins

### DIFF
--- a/modules/statics/src/utxo.ts
+++ b/modules/statics/src/utxo.ts
@@ -21,6 +21,7 @@ export class UtxoCoin extends BaseCoin {
     CoinFeature.CUSTODY,
     CoinFeature.CUSTODY_BITGO_TRUST,
     CoinFeature.MULTISIG_COLD,
+    CoinFeature.PAYGO,
   ];
 
   /**


### PR DESCRIPTION
Ticket: WP-1525

Needed to add CoinFeatures.PAYGO to UTXO coins, so they show up when we're making PayGo wallets in the UI.
