### PR TITLE
fix(drawKeycard.ts): QR codes printed without alphabetical order, swa…

### DIFF
--- a/modules/key-card/src/drawKeycard.ts
+++ b/modules/key-card/src/drawKeycard.ts
@@ -131,8 +131,7 @@ export async function drawKeycard({
   // Generate the first page's data for the backup PDF
   y = moveDown(y, 35);
   const qrSize = 130;
-
-  const qrKeys = ['user', 'userMasterPublicKey', 'passcode', 'backup', 'backupMasterPublicKey', 'bitgo'].filter(
+  const qrKeys = ['user', 'userMasterPublicKey', 'backup', 'backupMasterPublicKey', 'bitgo', 'passcode'].filter(
     (key) => !!qrData[key]
   );
   for (let index = 0; index < qrKeys.length; index++) {


### PR DESCRIPTION
…pped place of some dictionary-keys

TICKET: WP-926

## Description

The QR codes inside a KeyCard are in a non-alphabetical order. The current order is

A: User Key
D: Encrypted wallet Password
B: Backup Key
C: BitGo Public Key

The expected order is:

A: User Key
B: Backup Key
C: BitGo Public Key
D: Encrypted wallet Password

The change doesn´t require to modify any external dependencies.
The change is in the ordering of the dictionary keys of qrKeys to match the expected output when generating a KeyCard PDF.

## Issue Number

WP-926

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)

# How to reproduce / test?

1) Go to https://app.bitgo-test.com/
2) Login and go to Assets/
3) Touch the "+ Create Wallet" button.
4) Create a TXRP Wallet (the name of the wallet doesn't matter) and Choose Self-Managed Hot. Press Continue in the bottom of the screen.
5) Enter a password for your wallet
6) In the "Self-Managed Hot Wallet" screen, choose the 3rd option "Create a Key in BitGo"
7) Press the button "Generate KeyCard" on the bottom of the screen.
8) On the generated PDF file, check for options in the expected order (A, B, C, D)