### PR TITLE
fix(sdk-core): remove onToken validation when creating address

### DIFF
--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -763,7 +763,6 @@ describe('V2 Wallet:', function () {
 
     it('should correctly validate arguments to create address on OFC wallet', async function () {
       await ofcWallet.createAddress().should.be.rejectedWith('onToken is a mandatory parameter for OFC wallets');
-      await ofcWallet.createAddress({ onToken: 'ofcMyCoin' }).should.be.rejectedWith('Unknown OFC token');
       // @ts-expect-error test passing invalid number argument
       await ofcWallet.createAddress({ onToken: 42 }).should.be.rejectedWith('onToken has to be a string');
     });

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -97,7 +97,6 @@ import { Lightning } from '../lightning';
 import EddsaUtils from '../utils/tss/eddsa';
 import { EcdsaUtils } from '../utils/tss/ecdsa';
 import { getTxRequest } from '../tss';
-import { ofcTokens } from '@bitgo/statics';
 import { buildParamKeys, BuildParams } from './BuildParams';
 import { postWithCodec } from '../utils/postWithCodec';
 import { TxSendBody } from '@bitgo/public-types';
@@ -1192,9 +1191,6 @@ export class Wallet implements IWallet {
       if (!_.isUndefined(onToken)) {
         if (!_.isString(onToken)) {
           throw new Error('onToken has to be a string');
-        }
-        if (!ofcTokens.includes(onToken)) {
-          throw new Error('Unknown OFC token');
         }
         addressParams.onToken = onToken;
       } else {

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -14731,10 +14731,3 @@ export const coins = CoinMap.fromCoins([
     UnderlyingAsset.GBP
   ),
 ]);
-
-export const ofcTokens: string[] = [];
-coins.forEach((coin) => {
-  if (coin.baseUnit === BaseUnit.OFC) {
-    ofcTokens.push(coin.name);
-  }
-});


### PR DESCRIPTION
The SDK is doing an additional check on the value of the onToken parameter. This cause the SDK to reject the call while the same parameter would have worked with calling the backend API directly.

We should remove this check in the SDK and let the backend do the check.

Ticket: WP-1627
