### PR TITLE
fix: Change example wallet creation in sdk to take in enterprise ID

### DIFF
--- a/examples/js/create-wallet.js
+++ b/examples/js/create-wallet.js
@@ -24,6 +24,9 @@ const label = 'Example Test Wallet';
 // TODO: set your passphrase for your new wallet here
 const passphrase = 'test_wallet_passphrase';
 
+// TODO: set your enterprise ID for your new wallet here
+const enterprise = 'your_enterprise_id';
+
 const coin = 'tltc';
 
 // Create the wallet
@@ -33,6 +36,7 @@ Promise.coroutine(function* () {
   const walletOptions = {
     label,
     passphrase,
+    enterprise
   };
 
   const wallet = yield bitgo.coin(coin).wallets().generateWallet(walletOptions);

--- a/examples/ts/create-wallet.ts
+++ b/examples/ts/create-wallet.ts
@@ -37,10 +37,14 @@ const label = 'Example Test Wallet';
 // TODO: set your passphrase for your new wallet here
 const passphrase = 'test_wallet_passphrase';
 
+// TODO: set your enterprise ID for your new wallet here
+const enterprise = 'your_enterprise_id';
+
 async function main() {
   const response = await bitgo.coin(coin).wallets().generateWallet({
     label,
     passphrase,
+    enterprise
   });
 
   const { wallet } = response;


### PR DESCRIPTION
Change example wallet creation in sdk to take in enterprise ID

Ticket: [WP-1663](https://bitgoinc.atlassian.net/browse/WP-1663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)



[WP-1663]: https://bitgoinc.atlassian.net/browse/WP-1663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ