### PR TITLE
feat(abstract-eth): support token flush directly from forwarderV4 con…

### DIFF
--- a/modules/abstract-eth/src/lib/transactionBuilder.ts
+++ b/modules/abstract-eth/src/lib/transactionBuilder.ts
@@ -216,7 +216,7 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
         break;
       case TransactionType.FlushTokens:
         this.setContract(transactionJson.to);
-        const { forwarderAddress, tokenAddress } = decodeFlushTokensData(transactionJson.data);
+        const { forwarderAddress, tokenAddress } = decodeFlushTokensData(transactionJson.data, transactionJson.to);
         this.forwarderAddress(forwarderAddress);
         this.tokenAddress(tokenAddress);
         break;
@@ -720,7 +720,10 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
    * @returns {TxData} The Ethereum transaction data
    */
   private buildFlushTokensTransaction(): TxData {
-    return this.buildBase(flushTokensData(this._forwarderAddress, this._tokenAddress));
+    if (this._forwarderVersion >= 4 && this._contractAddress !== this._forwarderAddress) {
+      throw new BuildTransactionError('Invalid contract address: ' + this._contractAddress);
+    }
+    return this.buildBase(flushTokensData(this._forwarderAddress, this._tokenAddress, this._forwarderVersion));
   }
 
   /**

--- a/modules/abstract-eth/src/lib/walletUtil.ts
+++ b/modules/abstract-eth/src/lib/walletUtil.ts
@@ -8,6 +8,7 @@ export const createForwarderMethodId = '0xa68a76cc';
 export const walletInitializationFirstBytes = '0x60606040';
 export const recoveryWalletInitializationFirstBytes = '0x60c06040';
 export const flushForwarderTokensMethodId = '0x2da03409';
+export const flushForwarderTokensMethodIdV4 = '0x3ef13367';
 export const flushCoinsMethodId = '0x6b9f96ea';
 
 export const ERC721SafeTransferTypeMethodId = '0xb88d4fde';
@@ -19,6 +20,7 @@ export const defaultWalletVersion = 0;
 export const walletSimpleConstructor = ['address[]'];
 export const createV1WalletTypes = ['address[]', 'bytes32'];
 export const flushTokensTypes = ['address', 'address'];
+export const flushTokensTypesv4 = ['address'];
 export const flushCoinsTypes = [];
 
 export const sendMultiSigTypes = ['address', 'uint', 'bytes', 'uint', 'uint', 'bytes'];

--- a/modules/sdk-coin-eth/test/unit/transactionBuilder/flushTokens.ts
+++ b/modules/sdk-coin-eth/test/unit/transactionBuilder/flushTokens.ts
@@ -162,9 +162,8 @@ describe('Eth Transaction builder flush tokens', function () {
         contractAddress: '0x53b8e91bb3b8f618b5f01004ef108f134f219573',
         forwarderVersion: 4,
       });
-      const txBuiderFromRaw: any = getBuilder('teth');
+      const txBuiderFromRaw: any = getBuilder('tarbeth'); // we are not using teth anymore
       txBuiderFromRaw.fromImplementation(tx.toBroadcastFormat());
-      // txBuiderFromRaw.type.should.equal(TransactionType.FlushTokens);
       txBuiderFromRaw._forwarderAddress.should.equal('0x53b8e91bb3b8f618b5f01004ef108f134f219573');
       txBuiderFromRaw._tokenAddress.should.equal('0xbcf935d206ca32929e1b887a07ed240f0d8ccd22');
     });

--- a/modules/sdk-coin-eth/test/unit/transactionBuilder/flushTokens.ts
+++ b/modules/sdk-coin-eth/test/unit/transactionBuilder/flushTokens.ts
@@ -162,8 +162,9 @@ describe('Eth Transaction builder flush tokens', function () {
         contractAddress: '0x53b8e91bb3b8f618b5f01004ef108f134f219573',
         forwarderVersion: 4,
       });
-      const txBuiderFromRaw: any = getBuilder('tarbeth'); // we are not using teth anymore
+      const txBuiderFromRaw: any = getBuilder('teth');
       txBuiderFromRaw.fromImplementation(tx.toBroadcastFormat());
+      // txBuiderFromRaw.type.should.equal(TransactionType.FlushTokens);
       txBuiderFromRaw._forwarderAddress.should.equal('0x53b8e91bb3b8f618b5f01004ef108f134f219573');
       txBuiderFromRaw._tokenAddress.should.equal('0xbcf935d206ca32929e1b887a07ed240f0d8ccd22');
     });


### PR DESCRIPTION

Changes:
If forwarder version 4 is passed to transaction
builder, it will call flushToken method directly
 on forwarder contract

TICKET: WP-1652

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
