### PR TITLE
fix(abstract-eth): fix opeth:op transfers

### DIFF
--- a/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
+++ b/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
@@ -1730,7 +1730,11 @@ export abstract class AbstractEthLikeNewCoins extends AbstractEthLikeCoin {
     const transferBuilder = txBuilder.transfer() as TransferBuilder;
 
     const network = this.getNetwork();
-    const token = getToken(params.tokenContractAddress as string, network as EthLikeNetwork)?.name as string;
+    const token = getToken(
+      params.tokenContractAddress as string,
+      network as EthLikeNetwork,
+      this.staticsCoin?.family as string
+    )?.name as string;
 
     transferBuilder
       .coin(token)

--- a/modules/abstract-eth/src/lib/transaction.ts
+++ b/modules/abstract-eth/src/lib/transaction.ts
@@ -101,7 +101,7 @@ export class Transaction extends BaseTransaction {
       const { to, amount, tokenContractAddress, signature } = decodeTransferData(txData.data);
       let coinName: string;
       if (tokenContractAddress) {
-        const token = getToken(tokenContractAddress, this._coinConfig.network);
+        const token = getToken(tokenContractAddress, this._coinConfig.network, this._coinConfig.family);
         coinName = token ? token.name : UNSUPPORTED_COIN_NAME;
       } else {
         coinName = this._coinConfig.name;

--- a/modules/abstract-eth/src/lib/utils.ts
+++ b/modules/abstract-eth/src/lib/utils.ts
@@ -638,13 +638,23 @@ export function getBufferedByteCode(methodId: string, rawData: string): Buffer {
  * Get the statics coin object matching a given contract address if it exists
  *
  * @param tokenContractAddress The contract address to match against
+ * @param network - the coin network
+ * @param family - the coin family
  * @returns statics BaseCoin object for the matching token
  */
-export function getToken(tokenContractAddress: string, network: BaseNetwork): Readonly<BaseCoin> | undefined {
+export function getToken(
+  tokenContractAddress: string,
+  network: BaseNetwork,
+  family: string
+): Readonly<BaseCoin> | undefined {
+  // filter the coins array to find the token with the matching contract address, network and coin family
+  // coin family is needed to avoid causing issues when a token has same contract address on two different chains
   const tokens = coins.filter((coin) => {
     if (coin instanceof ContractAddressDefinedToken) {
       return (
-        coin.network.type === network.type && coin.contractAddress.toLowerCase() === tokenContractAddress.toLowerCase()
+        coin.network.type === network.type &&
+        coin.family === family &&
+        coin.contractAddress.toLowerCase() === tokenContractAddress.toLowerCase()
       );
     }
     return false;

--- a/modules/sdk-coin-opeth/test/unit/opethToken.ts
+++ b/modules/sdk-coin-opeth/test/unit/opethToken.ts
@@ -1,19 +1,24 @@
 import 'should';
-
+import assert from 'assert';
 import { TestBitGo, TestBitGoAPI } from '@bitgo/sdk-test';
-import { register } from '../../src';
 import { BitGoAPI } from '@bitgo/sdk-api';
+import { getToken } from '@bitgo/abstract-eth';
+
+import { register } from '../../src';
 
 describe('Opeth Token:', function () {
   let bitgo: TestBitGoAPI;
   let opethTokenCoin;
+  let opTokenCoin;
   const tokenName = 'topeth:terc18dp';
+  const opToken = 'opeth:op';
 
   before(function () {
     bitgo = TestBitGo.decorate(BitGoAPI, { env: 'test' });
     register(bitgo);
     bitgo.initializeTestVars();
     opethTokenCoin = bitgo.coin(tokenName);
+    opTokenCoin = bitgo.coin(opToken);
   });
 
   it('should return constants', function () {
@@ -31,5 +36,15 @@ describe('Opeth Token:', function () {
   it('should return same token by contract address', function () {
     const tokencoinBycontractAddress = bitgo.coin(opethTokenCoin.tokenContractAddress);
     opethTokenCoin.should.deepEqual(tokencoinBycontractAddress);
+  });
+
+  it('should return only one token for optimism token contract address', function () {
+    const token = getToken(
+      '0x4200000000000000000000000000000000000042',
+      opTokenCoin.getNetwork(),
+      opTokenCoin.getFamily()
+    );
+    assert(token);
+    token.name.should.equal('opeth:op');
   });
 });


### PR DESCRIPTION
WIN-2643
TICKET: WIN-2643

This PR fixes the issue with optimism token transfers. Optimism token has the same contract address on eth and op chain, which is causing issues while transferring the token.

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
