### PR TITLE
feat(utxo-lib): find psbt outputs of internal and external bitgo wallets

### DIFF
--- a/modules/utxo-lib/src/bitgo/types.ts
+++ b/modules/utxo-lib/src/bitgo/types.ts
@@ -12,3 +12,12 @@ export type Triple<T> = [T, T, T];
 export function isTriple<T>(arr: T[]): arr is Triple<T> {
   return arr.length === 3;
 }
+
+/**
+ * Checks if the given value is an array of Buffer objects.
+ * @param v - The value to check.
+ * @returns A boolean indicating whether v is an array of Buffer objects.
+ */
+export function isBufferArray(v: unknown): v is Buffer[] {
+  return Array.isArray(v) && v.every((e) => Buffer.isBuffer(e));
+}

--- a/modules/utxo-lib/src/bitgo/wallet/Psbt.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/Psbt.ts
@@ -6,7 +6,13 @@ import { BIP32Interface } from 'bip32';
 import * as bs58check from 'bs58check';
 import { UtxoPsbt } from '../UtxoPsbt';
 import { UtxoTransaction } from '../UtxoTransaction';
-import { createOutputScript2of3, getLeafHash, scriptTypeForChain, toXOnlyPublicKey } from '../outputScripts';
+import {
+  createOutputScript2of3,
+  getLeafHash,
+  ScriptType2Of3,
+  scriptTypeForChain,
+  toXOnlyPublicKey,
+} from '../outputScripts';
 import { DerivedWalletKeys, RootWalletKeys } from './WalletKeys';
 import { toPrevOutputWithPrevTx } from '../Unspent';
 import { createPsbtFromHex, createPsbtFromTransaction } from '../transaction';
@@ -26,6 +32,7 @@ import {
   ParsedScriptType,
   isPlaceholderSignature,
   parseSignatureScript,
+  ParsedScriptType2Of3,
 } from '../parseInput';
 import { parsePsbtMusig2PartialSigs } from '../Musig2';
 import { isTuple, Triple } from '../types';
@@ -390,6 +397,19 @@ export function parsePsbtInput(input: PsbtInput): ParsedPsbtP2ms | ParsedPsbtTap
     };
   }
   throw new Error('invalid pub script');
+}
+
+/**
+ * Converts a parsed script type into an array of script types.
+ * @param parsedScriptType - The parsed script type.
+ * @returns An array of ScriptType2Of3 values corresponding to the parsed script type.
+ */
+export function toScriptType2Of3s(parsedScriptType: ParsedScriptType2Of3): ScriptType2Of3[] {
+  return parsedScriptType === 'taprootScriptPathSpend'
+    ? ['p2trMusig2', 'p2tr']
+    : parsedScriptType === 'taprootKeyPathSpend'
+    ? ['p2trMusig2']
+    : [parsedScriptType];
 }
 
 /**

--- a/modules/utxo-lib/src/bitgo/wallet/psbt/PsbtOutputs.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/psbt/PsbtOutputs.ts
@@ -1,0 +1,90 @@
+/**
+ * Contains helper methods for determining if a transaction output belongs to a given BitGo wallet
+ */
+
+import { isBufferArray, Triple } from '../../types';
+import { createOutputScript2of3, scriptTypes2Of3 } from '../../outputScripts';
+import { UtxoPsbt } from '../../UtxoPsbt';
+import { BIP32Interface } from 'bip32';
+import { checkForOutput } from 'bip174/src/lib/utils';
+import { PsbtOutput } from 'bip174/src/lib/interfaces';
+import { getSortedRootNodes } from './RootNodes';
+
+/**
+ * Derives the appropriate BIP32 key pair for a given output.
+ * It uses either tapBip32Derivation or bip32Derivation paths from the output.
+ * @param bip32 - The BIP32Interface object to derive from.
+ * @param output - The specific PSBT output to derive for.
+ * @returns The derived BIP32 key pair if master fingerprint matches, or undefined.
+ */
+export function deriveKeyPairForOutput(bip32: BIP32Interface, output: PsbtOutput): BIP32Interface | undefined {
+  return output.tapBip32Derivation?.length
+    ? UtxoPsbt.deriveKeyPair(bip32, output.tapBip32Derivation, { ignoreY: true })
+    : output.bip32Derivation?.length
+    ? UtxoPsbt.deriveKeyPair(bip32, output.bip32Derivation, { ignoreY: false })
+    : undefined;
+}
+
+/**
+ * Determines if a specified output in a PSBT is an output of the wallet represented by the given root nodes.
+ * @param psbt - The PSBT to check.
+ * @param outputIndex - The index of the output to check.
+ * @param rootWalletNodes - The root nodes representing the wallet.
+ * @returns A boolean indicating if the output belongs to the wallet.
+ */
+export function isWalletOutput(psbt: UtxoPsbt, outputIndex: number, rootWalletNodes: Triple<BIP32Interface>): boolean {
+  const output = checkForOutput(psbt.data.outputs, outputIndex);
+
+  const pubKeys = rootWalletNodes.map((rootNode) => deriveKeyPairForOutput(rootNode, output)?.publicKey);
+
+  if (!isBufferArray(pubKeys)) {
+    return false;
+  }
+
+  const outputScript = psbt.getOutputScript(outputIndex);
+  return scriptTypes2Of3.some((scriptType) =>
+    createOutputScript2of3(pubKeys, scriptType).scriptPubKey.equals(outputScript)
+  );
+}
+
+/**
+ * Finds indices of all outputs in a PSBT that belong to the wallet represented by the given root nodes.
+ * @param psbt - The PSBT to search through.
+ * @param rootWalletNodes - The root nodes representing the wallet.
+ * @returns An array of indices corresponding to wallet outputs.
+ */
+export function findWalletOutputIndices(psbt: UtxoPsbt, rootWalletNodes: Triple<BIP32Interface>): number[] {
+  return psbt.data.outputs.flatMap((_, i) => (isWalletOutput(psbt, i, rootWalletNodes) ? [i] : []));
+}
+
+/**
+ * Calculates the total amount of all wallet outputs in a PSBT for the wallet represented by the given root nodes.
+ * @param psbt - The PSBT to calculate for.
+ * @param rootWalletNodes - The root nodes representing the wallet.
+ * @returns The total amount of wallet outputs.
+ */
+export function getTotalAmountOfWalletOutputs(psbt: UtxoPsbt, rootWalletNodes: Triple<BIP32Interface>): bigint {
+  const indices = findWalletOutputIndices(psbt, rootWalletNodes);
+  const txOutputs = psbt.txOutputs;
+  return indices.reduce((sum, i) => sum + txOutputs[i].value, BigInt(0));
+}
+
+/**
+ * Finds indices of all internal outputs in a PSBT, identified as outputs belonging to the wallet's root nodes within the PSBT.
+ * @param psbt - The PSBT containing the wallet's root nodes as indicated by global Xpubs.
+ * @returns An array of indices of internal outputs.
+ */
+export function findInternalOutputIndices(psbt: UtxoPsbt): number[] {
+  const rootNodes = getSortedRootNodes(psbt);
+  return findWalletOutputIndices(psbt, rootNodes);
+}
+
+/**
+ * Calculates the total amount of all internal outputs in a PSBT, identified as outputs belonging to the wallet's root nodes within the PSBT.
+ * @param psbt - The PSBT containing the wallet's root nodes as indicated by global Xpubs.
+ * @returns The total amount of internal outputs.
+ */
+export function getTotalAmountOfInternalOutputs(psbt: UtxoPsbt): bigint {
+  const rootNodes = getSortedRootNodes(psbt);
+  return getTotalAmountOfWalletOutputs(psbt, rootNodes);
+}

--- a/modules/utxo-lib/src/bitgo/wallet/psbt/RootNodes.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/psbt/RootNodes.ts
@@ -1,0 +1,150 @@
+/**
+ * Contains helper methods for getting and sorting root nodes from a PSBT.
+ */
+
+import * as assert from 'assert';
+import * as bs58check from 'bs58check';
+
+import { UtxoPsbt } from '../../UtxoPsbt';
+import { isTriple, Triple } from '../../types';
+import { BIP32Factory, BIP32Interface } from 'bip32';
+import { ecc as eccLib } from '../../../noble_ecc';
+import { ParsedScriptType2Of3 } from '../../parseInput';
+import { Network } from '../../../networks';
+import { createOutputScript2of3 } from '../../outputScripts';
+import { PsbtInput } from 'bip174/src/lib/interfaces';
+import { createTransactionFromBuffer } from '../../transaction';
+import { getPsbtInputScriptType, toScriptType2Of3s } from '../Psbt';
+
+/**
+ * Retrieves unsorted root BIP32Interface nodes from a PSBT if available.
+ * @param psbt - The PSBT from which to extract the global Xpubs.
+ * @returns An array of BIP32Interface objects or undefined if not available.
+ */
+export function getUnsortedRootNodes(psbt: UtxoPsbt): Triple<BIP32Interface> | undefined {
+  const bip32s = psbt.data.globalMap.globalXpub?.map((xpub) =>
+    BIP32Factory(eccLib).fromBase58(bs58check.encode(xpub.extendedPubkey))
+  );
+  assert(!bip32s || isTriple(bip32s), `Invalid globalXpubs in PSBT. Expected 3 or none. Got ${bip32s?.length}`);
+  return bip32s;
+}
+
+/**
+ * Determines if the given public keys' permutation matches a specified script.
+ * @param params - Object containing public keys, permutation, script public key, script type, and network.
+ * @returns A boolean indicating if the permutation matches the script.
+ */
+function matchesScript({
+  pubKeys,
+  perm,
+  scriptPubKey,
+  parsedScriptType,
+  network,
+}: {
+  pubKeys: Buffer[];
+  perm: Triple<number>;
+  scriptPubKey: Buffer;
+  parsedScriptType: ParsedScriptType2Of3;
+  network: Network;
+}): boolean {
+  const pubKeysPerm: Triple<Buffer> = [pubKeys[perm[0]], pubKeys[perm[1]], pubKeys[perm[2]]];
+  const scriptTypes = toScriptType2Of3s(parsedScriptType);
+  return scriptTypes.some((scriptType) =>
+    createOutputScript2of3(pubKeysPerm, scriptType, network).scriptPubKey.equals(scriptPubKey)
+  );
+}
+
+/**
+ * Finds the correct order of public keys to match a given script.
+ * @param pubKeys - Array of public keys involved in the script.
+ * @param scriptPubKey - The script public key to match against.
+ * @param parsedScriptType - The parsed script type.
+ * @param network - Bitcoin network.
+ * @returns The order of public keys that match the script.
+ */
+function findSortOrderOfPubKeys(
+  pubKeys: Triple<Buffer>,
+  scriptPubKey: Buffer,
+  parsedScriptType: ParsedScriptType2Of3,
+  network: Network
+): Triple<number> {
+  const permutations: Array<Triple<number>> = [
+    [0, 1, 2],
+    [0, 2, 1],
+    [1, 0, 2],
+    [1, 2, 0],
+    [2, 0, 1],
+    [2, 1, 0],
+  ];
+
+  const order = permutations.find((perm) => matchesScript({ pubKeys, perm, scriptPubKey, parsedScriptType, network }));
+  assert(order, 'Could not find sort order of multi sig public keys');
+  return order;
+}
+
+/**
+ * Extracts multi-sig input data, including script type, script public key, and derivation path, from the first relevant PSBT input.
+ * @param psbt - The PSBT to extract data from.
+ * @returns An object containing the parsed script type, script public key, and derivation path.
+ */
+function getFirstMultiSigInputData(psbt: UtxoPsbt): {
+  parsedScriptType: ParsedScriptType2Of3;
+  scriptPubKey: Buffer;
+  derivationPath: string;
+} {
+  function getScriptPubKey(input: PsbtInput, prevOutIndex: number) {
+    const scriptPubKey =
+      input.witnessUtxo?.script ??
+      (input.nonWitnessUtxo
+        ? createTransactionFromBuffer(input.nonWitnessUtxo, psbt.network, { amountType: 'bigint' }).outs[prevOutIndex]
+            .script
+        : undefined);
+    assert(scriptPubKey, 'Input scriptPubKey can not be found');
+    return scriptPubKey;
+  }
+
+  function getDerivationPath(input: PsbtInput) {
+    const bip32Dv = input?.bip32Derivation ?? input?.tapBip32Derivation;
+    assert(bip32Dv?.length, 'Input Bip32Derivation can not be found');
+    return bip32Dv[0].path;
+  }
+
+  const txInputs = psbt.txInputs;
+
+  for (let i = 0; i < psbt.data.inputs.length; i++) {
+    const input = psbt.data.inputs[i];
+    const parsedScriptType = getPsbtInputScriptType(input);
+    if (parsedScriptType === 'p2shP2pk') {
+      continue;
+    }
+    const scriptPubKey = getScriptPubKey(input, txInputs[i].index);
+    const derivationPath = getDerivationPath(input);
+    return { parsedScriptType, scriptPubKey, derivationPath };
+  }
+
+  throw new Error('No multi sig input found');
+}
+
+/**
+ * Sorts given root nodes based on the script compatibility with the PSBT's multi-sig inputs.
+ * @param psbt - The PSBT containing multi-sig inputs.
+ * @param rootNodes - Array of root nodes to sort.
+ * @returns An array of BIP32Interface objects in the order that matches the multi-sig script.
+ */
+export function sortRootNodes(psbt: UtxoPsbt, rootNodes: Triple<BIP32Interface>): Triple<BIP32Interface> {
+  const { parsedScriptType, scriptPubKey, derivationPath } = getFirstMultiSigInputData(psbt);
+  const pubKeys = rootNodes.map((rootNode) => rootNode.derivePath(derivationPath).publicKey) as Triple<Buffer>;
+  const order = findSortOrderOfPubKeys(pubKeys, scriptPubKey, parsedScriptType, psbt.network);
+  return order.map((i) => rootNodes[i]) as Triple<BIP32Interface>;
+}
+
+/**
+ * Retrieves sorted root nodes from a PSBT, ensuring they are ordered according to script compatibility.
+ * @param psbt - The PSBT to extract and sort root nodes from.
+ * @returns An array of sorted BIP32Interface root nodes.
+ */
+export function getSortedRootNodes(psbt: UtxoPsbt): Triple<BIP32Interface> {
+  const unsortedRootNodes = getUnsortedRootNodes(psbt);
+  assert(unsortedRootNodes, 'Could not find root nodes in PSBT');
+  return sortRootNodes(psbt, unsortedRootNodes);
+}

--- a/modules/utxo-lib/test/bitgo/psbt/PsbtOutputs.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/PsbtOutputs.ts
@@ -1,0 +1,243 @@
+import * as assert from 'assert';
+
+import * as bs58check from 'bs58check';
+
+import { fromOutputScript } from '../../../src/address';
+import { createOutputScriptP2shP2pk, scriptTypes2Of3 } from '../../../src/bitgo/outputScripts';
+import { getDefaultWalletKeys, getKeyTriple, replayProtectionKeyPair } from '../../../src/testutil';
+import { networks, testutil } from '../../../src';
+import { addWalletOutputToPsbt, addXpubsToPsbt, getExternalChainCode, RootWalletKeys } from '../../../src/bitgo';
+import {
+  findInternalOutputIndices,
+  findWalletOutputIndices,
+  getTotalAmountOfInternalOutputs,
+  getTotalAmountOfWalletOutputs,
+} from '../../../src/bitgo/wallet/psbt/PsbtOutputs';
+import { GlobalXpub } from 'bip174/src/lib/interfaces';
+
+const network = networks.bitcoin;
+const rootWalletKeys = getDefaultWalletKeys();
+
+describe('psbt internal and wallet outputs', function () {
+  const value = BigInt(1e8);
+  const fee = BigInt(1000);
+  const externalAddress = fromOutputScript(
+    createOutputScriptP2shP2pk(replayProtectionKeyPair.publicKey).scriptPubKey,
+    networks.bitcoin
+  );
+
+  describe('success', function () {
+    it(`Find indices of psbt wallet & internal outputs`, function () {
+      const psbt = testutil.constructPsbt(
+        [
+          { scriptType: 'p2wsh', value: BigInt(value + value) },
+          { scriptType: 'p2shP2wsh', value: BigInt(value) },
+          { scriptType: 'p2trMusig2', value: BigInt(value) },
+          { scriptType: 'p2tr', value: BigInt(value) },
+          { scriptType: 'p2sh', value: BigInt(value) },
+        ],
+        [
+          { scriptType: 'p2sh', value: BigInt(value) },
+          { scriptType: 'p2shP2wsh', value: BigInt(value) },
+          { scriptType: 'p2wsh', value: BigInt(value) },
+          {
+            address: externalAddress,
+            value: BigInt(value - fee),
+          },
+          { scriptType: 'p2tr', value: BigInt(value), isInternalAddress: true },
+          { scriptType: 'p2trMusig2', value: BigInt(value), isInternalAddress: true },
+        ],
+        network,
+        rootWalletKeys,
+        'unsigned'
+      );
+      const expected = [0, 1, 2, 4, 5];
+      assert.deepEqual(findWalletOutputIndices(psbt, rootWalletKeys.triple), expected);
+      addXpubsToPsbt(psbt, rootWalletKeys);
+      assert.deepEqual(findInternalOutputIndices(psbt), expected);
+    });
+
+    scriptTypes2Of3.forEach((scriptType) => {
+      const psbt = testutil.constructPsbt(
+        [
+          { scriptType: scriptType, value: BigInt(value) },
+          { scriptType: 'p2wsh', value: BigInt(value) },
+          { scriptType: 'p2shP2wsh', value: BigInt(value) },
+          { scriptType: 'p2trMusig2', value: BigInt(value) },
+          { scriptType: 'p2tr', value: BigInt(value) },
+          { scriptType: 'p2sh', value: BigInt(value) },
+        ],
+        [
+          { scriptType: 'p2sh', value: BigInt(value) },
+          { scriptType: 'p2shP2wsh', value: BigInt(value) },
+          { scriptType: 'p2wsh', value: BigInt(value) },
+          {
+            address: externalAddress,
+            value: BigInt(value - fee),
+          },
+          { scriptType: 'p2tr', value: BigInt(value), isInternalAddress: true },
+          { scriptType: 'p2trMusig2', value: BigInt(value), isInternalAddress: true },
+        ],
+        network,
+        rootWalletKeys,
+        'unsigned'
+      );
+
+      addXpubsToPsbt(psbt, rootWalletKeys);
+
+      const totalInternalAmount = value * BigInt(psbt.inputCount - 1);
+
+      it(`PSBT with ${scriptType} input and globalXpub`, function () {
+        assert.strictEqual(getTotalAmountOfInternalOutputs(psbt), totalInternalAmount);
+      });
+
+      it(`Cloned PSBT with ${scriptType} input and globalXpub`, function () {
+        assert.strictEqual(getTotalAmountOfInternalOutputs(psbt.clone()), totalInternalAmount);
+      });
+
+      it(`PSBT with ${scriptType} input and ordered rootNodes`, function () {
+        assert.strictEqual(getTotalAmountOfWalletOutputs(psbt, rootWalletKeys.triple), totalInternalAmount);
+      });
+    });
+
+    it(`PSBT with p2shP2pk as first input`, function () {
+      const psbt = testutil.constructPsbt(
+        [
+          { scriptType: 'p2shP2pk', value: BigInt(value) },
+          { scriptType: 'p2wsh', value: BigInt(value) },
+        ],
+        [
+          { scriptType: 'p2sh', value: BigInt(value) },
+          {
+            address: externalAddress,
+            value: BigInt(value - fee),
+          },
+        ],
+        network,
+        rootWalletKeys,
+        'unsigned'
+      );
+      addXpubsToPsbt(psbt, rootWalletKeys);
+      assert.strictEqual(getTotalAmountOfInternalOutputs(psbt), value);
+    });
+
+    it(`PSBT with outputs of external wallet root nodes`, function () {
+      const psbt = testutil.constructPsbt(
+        [{ scriptType: 'p2wsh', value: BigInt(value) }],
+        [{ scriptType: 'p2sh', value: BigInt(value) }],
+        network,
+        rootWalletKeys,
+        'unsigned'
+      );
+      const externalAmount = BigInt(8888);
+      const externalRootWalletKeys = new RootWalletKeys(getKeyTriple('dummy'));
+      const indices = [0, 1];
+      indices.forEach((index) =>
+        addWalletOutputToPsbt(psbt, externalRootWalletKeys, getExternalChainCode('p2wsh'), index, externalAmount)
+      );
+      assert.strictEqual(
+        getTotalAmountOfWalletOutputs(psbt, externalRootWalletKeys.triple),
+        externalAmount * BigInt(indices.length)
+      );
+    });
+
+    it(`PSBT with no outputs of external wallet root nodes`, function () {
+      const psbt = testutil.constructPsbt(
+        [{ scriptType: 'p2wsh', value: BigInt(value) }],
+        [{ scriptType: 'p2sh', value: BigInt(value) }],
+        network,
+        rootWalletKeys,
+        'unsigned'
+      );
+      assert.strictEqual(
+        getTotalAmountOfWalletOutputs(psbt, new RootWalletKeys(getKeyTriple('dummy')).triple),
+        BigInt(0)
+      );
+    });
+
+    it(`PSBT with no internal output`, function () {
+      const psbt = testutil.constructPsbt(
+        [{ scriptType: 'p2wsh', value: BigInt(value) }],
+        [
+          {
+            address: externalAddress,
+            value: BigInt(value - fee),
+          },
+        ],
+        network,
+        rootWalletKeys,
+        'unsigned'
+      );
+      addXpubsToPsbt(psbt, rootWalletKeys);
+      assert.strictEqual(getTotalAmountOfInternalOutputs(psbt), BigInt(0));
+    });
+  });
+
+  describe('failure', function () {
+    it('PSBT without globalXpub', function () {
+      const psbt = testutil.constructPsbt([], [], network, rootWalletKeys, 'unsigned');
+      assert.throws(
+        () => getTotalAmountOfInternalOutputs(psbt),
+        (e: any) => e.message === 'Could not find root nodes in PSBT'
+      );
+    });
+
+    it('PSBT with invalid number of globalXpub', function () {
+      const psbt = testutil.constructPsbt([], [], network, rootWalletKeys, 'unsigned');
+      const globalXpub: GlobalXpub[] = [
+        {
+          extendedPubkey: bs58check.decode(rootWalletKeys.triple[0].neutered().toBase58()),
+          masterFingerprint: rootWalletKeys.triple[0].fingerprint,
+          path: 'm',
+        },
+      ];
+      psbt.updateGlobal({ globalXpub });
+      assert.throws(
+        () => getTotalAmountOfInternalOutputs(psbt),
+        (e: any) => e.message === 'Invalid globalXpubs in PSBT. Expected 3 or none. Got 1'
+      );
+    });
+
+    it('PSBT without input scriptPubKey', function () {
+      const psbt = testutil.constructPsbt(
+        [{ scriptType: 'p2wsh', value: BigInt(value) }],
+        [
+          {
+            address: externalAddress,
+            value: BigInt(value - fee),
+          },
+        ],
+        network,
+        rootWalletKeys,
+        'unsigned'
+      );
+      psbt.data.inputs[0].witnessUtxo = undefined;
+      addXpubsToPsbt(psbt, rootWalletKeys);
+      assert.throws(
+        () => getTotalAmountOfInternalOutputs(psbt),
+        (e: any) => e.message === 'Input scriptPubKey can not be found'
+      );
+    });
+
+    it('PSBT without input Bip32Derivation', function () {
+      const psbt = testutil.constructPsbt(
+        [{ scriptType: 'p2wsh', value: BigInt(value) }],
+        [
+          {
+            address: externalAddress,
+            value: BigInt(value - fee),
+          },
+        ],
+        network,
+        rootWalletKeys,
+        'unsigned'
+      );
+      psbt.data.inputs[0].bip32Derivation = undefined;
+      addXpubsToPsbt(psbt, rootWalletKeys);
+      assert.throws(
+        () => getTotalAmountOfInternalOutputs(psbt),
+        (e: any) => e.message === 'Input Bip32Derivation can not be found'
+      );
+    });
+  });
+});


### PR DESCRIPTION
Trustlessly find psbt output indices of internal bitgo wallet
Trustlessly calculate psbt output amount of internal bitgo wallet
Find psbt output indices of external bitgo wallet
Calculate psbt output amount of external bitgo wallet

ref https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#change-detection

TICKET: BTC-1070
<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
