### PR TITLE
fix(sdk-coin-avaxp): stake output cannot be 0

### DIFF
--- a/modules/sdk-coin-avaxp/src/lib/permissionlessValidatorTxBuilder.ts
+++ b/modules/sdk-coin-avaxp/src/lib/permissionlessValidatorTxBuilder.ts
@@ -475,7 +475,7 @@ export class PermissionlessValidatorTxBuilder extends TransactionBuilder {
         );
         stakeOutputs.push(stakeOutput);
 
-        if (currentTotal >= totalTarget) {
+        if (currentTotal > totalTarget) {
           const changeOutput = new avaxSerial.TransferableOutput(
             assetId,
             new TransferOutput(

--- a/modules/sdk-coin-avaxp/test/resources/avaxp.ts
+++ b/modules/sdk-coin-avaxp/test/resources/avaxp.ts
@@ -614,6 +614,7 @@ export const BUILD_AND_SIGN_ADD_PERMISSIONLESS_VALIDATOR_SAMPLE = {
   startTime: '1656423398',
   endTime: '1659053398',
   stakeAmount: '2370000000',
+  stakeAmountNoOutput: '4097000000',
   delegationFeeRate: 10,
   nodeId: 'NodeID-2hMqBQdjZMWdHvYu7ZPLA2CmrAdbTvpGf',
   blsPublicKey: '0xad9e9476b701edec88e53b1c314456053b3cf846a1192117872e41455f440c074d6ee89530d45e88f79ac0eda06f2887',

--- a/modules/sdk-coin-avaxp/test/unit/lib/permissionlessValidatorTxBuilder.ts
+++ b/modules/sdk-coin-avaxp/test/unit/lib/permissionlessValidatorTxBuilder.ts
@@ -298,4 +298,30 @@ describe('AvaxP permissionlessValidatorTxBuilder', () => {
       console.log(fullSignedTx.toJson());
     });
   });
+  it('Should fail to build if utxos change output 0', async () => {
+    const unixNow = BigInt(Math.round(new Date().getTime() / 1000));
+    const startTime = unixNow + BigInt(60);
+    const endTime = startTime + BigInt(60 * 60 * 24 + 600);
+
+    const txBuilder = new AvaxpLib.TransactionBuilderFactory(coins.get('tavaxp'))
+      .getPermissionlessValidatorTxBuilder()
+      .threshold(testData.BUILD_AND_SIGN_ADD_PERMISSIONLESS_VALIDATOR_SAMPLE.threshold)
+      .locktime(testData.BUILD_AND_SIGN_ADD_PERMISSIONLESS_VALIDATOR_SAMPLE.locktime)
+      .recoverMode(false)
+      .fromPubKey(testData.BUILD_AND_SIGN_ADD_PERMISSIONLESS_VALIDATOR_SAMPLE.bitgoAddresses)
+      .startTime(startTime.toString())
+      .endTime(endTime.toString())
+      .stakeAmount(testData.BUILD_AND_SIGN_ADD_PERMISSIONLESS_VALIDATOR_SAMPLE.stakeAmountNoOutput)
+      .delegationFeeRate(testData.BUILD_AND_SIGN_ADD_PERMISSIONLESS_VALIDATOR_SAMPLE.delegationFeeRate)
+      .nodeID(testData.BUILD_AND_SIGN_ADD_PERMISSIONLESS_VALIDATOR_SAMPLE.nodeId)
+      .blsPublicKey(testData.BUILD_AND_SIGN_ADD_PERMISSIONLESS_VALIDATOR_SAMPLE.blsPublicKey)
+      .blsSignature(testData.BUILD_AND_SIGN_ADD_PERMISSIONLESS_VALIDATOR_SAMPLE.blsSignature)
+      .utxos(testData.BUILD_AND_SIGN_ADD_PERMISSIONLESS_VALIDATOR_SAMPLE.utxos);
+    const tx = await txBuilder.build();
+    const txJson = tx.toJson();
+    const txExplain = tx.explainTransaction();
+    txJson.changeOutputs.length.should.equal(0);
+    txExplain.changeOutputs.length.should.equal(0);
+    txExplain.changeAmount.should.equal('0');
+  });
 });


### PR DESCRIPTION
throw error if change output is 0 for permissionless validator tx

CR-1073

TICKET: CR-1073

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
