### PR TITLE
start splitting utxo and altcoin in statics

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -80,7 +80,8 @@
 /modules/sdk-test/ @BitGo/custody-experience @BitGo/wallet-platform
 /modules/sdk-unified-wallet @BitGo/ethalt-team
 /modules/sjcl/ @BitGo/coins @BitGo/custody-experience @BitGo/wallet-platform
-/modules/statics/ @BitGo/coins @BitGo/custody-experience @BitGo/wallet-platform
+/modules/statics/ @BitGo/custody-experience @BitGo/wallet-platform @BitGo/ethalt-team
+/modules/statics/src/utxo @BitGo/btc-team
 /modules/web-demo/ @BitGo/coins @BitGo/custody-experience @BitGo/wallet-platform
 /scripts/ @BitGo/coins @BitGo/custody-experience @BitGo/wallet-platform
 /types/ @BitGo/coins @BitGo/custody-experience @BitGo/wallet-platform

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -55,7 +55,7 @@ import {
   tofcHederaToken,
   tofcStellarToken,
 } from './ofc';
-import { utxo, UtxoCoin } from './utxo';
+import { utxo, UtxoCoin } from './utxo/utxo';
 
 const BCH_FEATURES = [
   ...UtxoCoin.DEFAULT_FEATURES,

--- a/modules/statics/src/index.ts
+++ b/modules/statics/src/index.ts
@@ -4,7 +4,7 @@ export * from './networks';
 export * from './errors';
 export * from './tokenConfig';
 export { OfcCoin } from './ofc';
-export { UtxoCoin } from './utxo';
+export { UtxoCoin } from './utxo/utxo';
 export {
   AccountCoin,
   CeloCoin,

--- a/modules/statics/src/utxo/utxo.ts
+++ b/modules/statics/src/utxo/utxo.ts
@@ -1,5 +1,5 @@
-import { BaseCoin, BaseUnit, CoinFeature, CoinKind, KeyCurve, UnderlyingAsset } from './base';
-import { UtxoNetwork } from './networks';
+import { BaseCoin, BaseUnit, CoinFeature, CoinKind, KeyCurve, UnderlyingAsset } from '../base';
+import { UtxoNetwork } from '../networks';
 
 export interface UtxoConstructorOptions {
   id: string;

--- a/modules/statics/test/unit/coins.ts
+++ b/modules/statics/test/unit/coins.ts
@@ -13,7 +13,7 @@ import {
   UnderlyingAsset,
   UtxoCoin,
 } from '../../src';
-import { utxo } from '../../src/utxo';
+import { utxo } from '../../src/utxo/utxo';
 import { expectedColdFeatures } from './fixtures/expectedColdFeatures';
 
 interface DuplicateCoinObject {


### PR DESCRIPTION
A majority of the changes within statics are new coins and token
onboarding which i don't think should include overall coins team
(which is no longer a thing) as a reviewer but rather eth-alts.
Anything under the utxo folder can be owner by the btc-team

Ticket: [BTC-1092](https://bitgoinc.atlassian.net/browse/BTC-1092)

[BTC-1092]: https://bitgoinc.atlassian.net/browse/BTC-1092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

This is the first of upcoming changes to better split eth-alt/utxo related statics code 