### PR TITLE
fix: update protobufjs to fix critical vulnerability

### DIFF
--- a/modules/sdk-coin-hbar/package.json
+++ b/modules/sdk-coin-hbar/package.json
@@ -49,7 +49,7 @@
     "bignumber.js": "^9.0.0",
     "lodash": "^4.17.15",
     "long": "^4.0.0",
-    "protobufjs": "7.2.4",
+    "protobufjs": "7.2.5",
     "stellar-sdk": "^10.0.1",
     "tweetnacl": "^1.0.3"
   },

--- a/modules/sdk-coin-islm/package.json
+++ b/modules/sdk-coin-islm/package.json
@@ -51,7 +51,7 @@
     "cosmjs-types": "^0.6.1",
     "ethers": "^5.7.2",
     "keccak": "3.0.3",
-    "protobufjs": "^7.2.4"
+    "protobufjs": "7.2.5"
   },
   "devDependencies": {
     "@bitgo/sdk-api": "^1.45.0",

--- a/modules/sdk-coin-trx/package.json
+++ b/modules/sdk-coin-trx/package.json
@@ -53,7 +53,7 @@
     "bignumber.js": "^9.0.0",
     "ethers": "^5.7.2",
     "lodash": "^4.17.14",
-    "protobufjs": "7.2.4",
+    "protobufjs": "7.2.5",
     "secp256k1": "5.0.0",
     "superagent": "^3.8.3",
     "tronweb": "5.1.0"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "terser": "^5.14.2",
     "json5": "^2.2.2",
     "ua-parser-js": ">0.7.30 <0.8.0",
-    "protobufjs": "^7.2.4",
     "socks": "2.7.3",
     "web3-utils": "4.2.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2465,7 +2465,7 @@
 
 "@hashgraph/cryptography@1.4.6":
   version "1.4.6"
-  resolved "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.6.tgz"
+  resolved "https://registry.yarnpkg.com/@hashgraph/cryptography/-/cryptography-1.4.6.tgz#abec5f0cddeb8814f5e7bc1c4de2063a8c698f96"
   integrity sha512-3HmnT1Lek71l6nHxc4GOyT/hSx/LmgusyWfE7hQda2dnE5vL2umydDw5TK2wq8gqmD9S3uRSMhz/BO55wtzxRA==
   dependencies:
     bignumber.js "^9.1.1"
@@ -2487,7 +2487,7 @@
 
 "@hashgraph/sdk@2.29.0":
   version "2.29.0"
-  resolved "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.29.0.tgz"
+  resolved "https://registry.yarnpkg.com/@hashgraph/sdk/-/sdk-2.29.0.tgz#aeaaea672f2564d66c98b6f7dddbc6b77c850680"
   integrity sha512-dMv2q7OCa2Xyi0ooGjo4JJRFxHKzKBvMd8G/n30j4jHx1JiSfI2ckPTAOwfCbYZ/o+EMDZzevyD5+Juf9iph+A==
   dependencies:
     "@ethersproject/abi" "^5.7.0"
@@ -6553,12 +6553,21 @@ axios@^0.26.1:
   dependencies:
     follow-redirects "^1.14.8"
 
-axios@^1.0.0, axios@^1.3.1, axios@^1.3.4, axios@^1.4.0:
+axios@^1.0.0, axios@^1.3.4, axios@^1.4.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.1.tgz#76550d644bf0a2d469a01f9244db6753208397d7"
   integrity sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==
   dependencies:
     follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
+axios@^1.3.1:
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.8.tgz#66d294951f5d988a00e87a0ffb955316a619ea66"
+  integrity sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==
+  dependencies:
+    follow-redirects "^1.15.6"
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
@@ -10730,7 +10739,7 @@ flux@^4.0.1:
     fbemitter "^3.0.0"
     fbjs "^3.0.1"
 
-follow-redirects@1.15.4, follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.14.7, follow-redirects@^1.14.8, follow-redirects@^1.14.9, follow-redirects@^1.15.0:
+follow-redirects@1.15.4, follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.14.7, follow-redirects@^1.14.8, follow-redirects@^1.14.9, follow-redirects@^1.15.0, follow-redirects@^1.15.6:
   version "1.15.4"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.4.tgz#cdc7d308bf6493126b17ea2191ea0ccf3e535adf"
   integrity sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==
@@ -15900,7 +15909,7 @@ protobufjs-cli@^1.0.2:
     tmp "^0.2.1"
     uglify-js "^3.7.7"
 
-protobufjs@7.2.4, protobufjs@^6.8.8, protobufjs@^7.0.0, protobufjs@^7.1.2, protobufjs@^7.2.4, protobufjs@~6.11.2, protobufjs@~6.11.3:
+protobufjs@7.2.5, protobufjs@^7.0.0, protobufjs@^7.1.2:
   version "7.2.5"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.5.tgz#45d5c57387a6d29a17aab6846dcc283f9b8e7f2d"
   integrity sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==
@@ -15917,6 +15926,25 @@ protobufjs@7.2.4, protobufjs@^6.8.8, protobufjs@^7.0.0, protobufjs@^7.1.2, proto
     "@protobufjs/utf8" "^1.1.0"
     "@types/node" ">=13.7.0"
     long "^5.0.0"
+
+protobufjs@^6.8.8, protobufjs@~6.11.2, protobufjs@~6.11.3:
+  version "6.11.4"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.4.tgz#29a412c38bf70d89e537b6d02d904a6f448173aa"
+  integrity sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.1"
+    "@types/node" ">=13.7.0"
+    long "^4.0.0"
 
 protocols@^2.0.0, protocols@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
## Description

* A vulnerability was found on a package called protobufjs, version 6 and 7 are compromised
* The vulneability is [CVE-2023-36665](https://github.com/advisories/GHSA-h755-8qp9-cq85), with a CRITICAL SEVERITY of 9.8
  * Both versions have patches against this issue, version 6.11.4 and 7.2.5
* Some coin SDKs that we use are using protobufjs
  * The ones using version 6 are up to date
  * The ones using version 7 are vulnerable
* HBAR, ISLM and TRX SDKs are affected

## Issue Number

DX-314

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Code builds and compiles, all tests pass

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
-->
