### PR TITLE
ci(root): add DX prefix to commitlint

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -29,6 +29,7 @@ module.exports = {
         'DES-',
         'DO-',
         'DOS-',
+        'DX-',
         'EA-',
         'ERC20-',
         'FAC-',


### PR DESCRIPTION
## Description

The DX prefix is used by the DevEx team, and commits referencing DevEx tickets would fail if this isn't added

## Issue Number

DX-315

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI change

# How Has This Been Tested?

A commit was pushed with the new prefix, and all tests passed

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
