### PR TITLE
feat(eos): add ability to do explainTransaction with txHex for eos

### DIFF
--- a/modules/sdk-coin-eos/src/eos.ts
+++ b/modules/sdk-coin-eos/src/eos.ts
@@ -1,6 +1,7 @@
 /**
  * @prettier
  */
+import assert from 'assert';
 import { BigNumber } from 'bignumber.js';
 import { bip32, BIP32Interface } from '@bitgo/utxo-lib';
 import { createHash, randomBytes } from 'crypto';
@@ -158,8 +159,9 @@ interface VoteActionData {
 }
 
 interface ExplainTransactionOptions {
-  transaction: { packed_trx: string };
+  transaction: { packed_trx?: string };
   headers: EosTransactionHeaders;
+  txHex?: string;
 }
 
 interface RecoveryTransaction {
@@ -519,6 +521,7 @@ export class Eos extends BaseCoin {
     transaction,
     headers,
   }: ExplainTransactionOptions): Promise<DeserializedEosTransaction> {
+    assert(transaction.packed_trx, 'missing packed_trx in transaction');
     // create an eosjs API client
     const api = new Api({
       abiProvider: new OfflineAbiProvider(),
@@ -731,6 +734,13 @@ export class Eos extends BaseCoin {
   async explainTransaction(params: ExplainTransactionOptions): Promise<TransactionExplanation> {
     let transaction;
     try {
+      if (params.txHex) {
+        const txFromHex = Buffer.from(params.txHex, 'hex');
+        const txDataWithPadding = txFromHex.slice(32);
+        const txData = txDataWithPadding.slice(0, txDataWithPadding.length - 32);
+        params.transaction = { packed_trx: txData.toString('hex') };
+      }
+      assert(params.transaction.packed_trx, 'missing packed_trx in transaction');
       transaction = await this.deserializeTransaction(params);
     } catch (e) {
       throw new Error('invalid EOS transaction or headers: ' + e.toString());

--- a/modules/sdk-coin-eos/test/unit/eos.ts
+++ b/modules/sdk-coin-eos/test/unit/eos.ts
@@ -242,6 +242,24 @@ describe('EOS:', function () {
       explainedTx.id.should.equal('6132f3bf4a746e6ecad8a31df67d71b4741fc5b7c868ae36dde18309a91df8a6');
       explainedTx.memo.should.equal('1');
     });
+    it('should explain an EOS transaction when we only pass in txHex', async function () {
+      const explainTransactionParams = {
+        headers: {
+          ref_block_prefix: 100,
+          ref_block_num: 995,
+          expiration: '2018-04-27T18:40:34.000Z',
+        },
+        txHex:
+          '5fff1dae8dc8e2fc4d5b23b2c7665c97f9e9d8edf2b6485a86ba311c256391915a77ca65dfaaac9ae2200000000100408c7a02ea3055000000000085269d00060531343339320100a6823403ea3055000000572d3ccdcd01403599e98cf9fb7600000000a8ed323221403599e98cf9fb7610201db53053c8c4dd0700000000000004454f530000000000000000000000000000000000000000000000000000000000000000000000000000',
+      };
+
+      const explainedTx = await basecoin.explainTransaction(explainTransactionParams);
+      explainedTx.outputAmount.should.equal('2013');
+      explainedTx.outputs.length.should.equal(1);
+      explainedTx.outputs[0].amount.should.equal('2013');
+      explainedTx.outputs[0].address.should.equal('sn45ag5p3ok1');
+      explainedTx.id.should.equal('b5a2310cb281b00afa671e0be370f6742dab4f5c3bc6bf76adeaa4356be1286b');
+    });
     it(
       'explains EOS native transfer transaction',
       testExplainTransaction(EosInputs.explainTransactionInputNative, EosResponses.explainTransactionOutputNative)


### PR DESCRIPTION
Ticket: WP-1507

 Becomes a pain to have to pass in `transaction.packed_trx` for all `explainTransaction` implementations with EOS. This PR allows you to pass in a `txHex` parameter, and then under the hood it'll convert the txHex to the packed_trx. Specifically remedies the fact that we cannot use `explainTransaction` for EOS in the AOK signing flow.