### PR TITLE
feat(abstract-utxo): support trustless change outputs from explaintx

### DIFF
--- a/modules/bitgo/test/v2/unit/coins/utxo/prebuildAndSign.ts
+++ b/modules/bitgo/test/v2/unit/coins/utxo/prebuildAndSign.ts
@@ -60,13 +60,15 @@ const keyDocumentObjects = rootWalletKeys.triple.map((bip32, keyIdx) => {
 
 function run(coin: AbstractUtxoCoin, inputScripts: ScriptType[], txFormat: TxFormat): void {
   function createPrebuildPsbt(inputs: Input[], outputs: { scriptType: 'p2sh'; value: bigint }[]) {
-    return utxolib.testutil.constructPsbt(
+    const psbt = utxolib.testutil.constructPsbt(
       inputs as utxolib.testutil.Input[],
       outputs,
       coin.network,
       rootWalletKeys,
       'unsigned'
     );
+    utxolib.bitgo.addXpubsToPsbt(psbt, rootWalletKeys);
+    return psbt;
   }
 
   function createNocks(params: {

--- a/modules/utxo-lib/src/bitgo/wallet/index.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/index.ts
@@ -5,3 +5,5 @@ export * from './WalletOutput';
 export * from './WalletUnspentSigner';
 export * from './WalletScripts';
 export * from './WalletKeys';
+export * from './psbt/PsbtOutputs';
+export * from './psbt/RootNodes';

--- a/modules/utxo-lib/src/bitgo/wallet/psbt/RootNodes.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/psbt/RootNodes.ts
@@ -17,6 +17,15 @@ import { createTransactionFromBuffer } from '../../transaction';
 import { getPsbtInputScriptType, toScriptType2Of3s } from '../Psbt';
 
 /**
+ * Error thrown when no multi-sig input is found in a PSBT.
+ * */
+export class ErrorNoMultiSigInputFound extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+/**
  * Retrieves unsorted root BIP32Interface nodes from a PSBT if available.
  * @param psbt - The PSBT from which to extract the global Xpubs.
  * @returns An array of BIP32Interface objects or undefined if not available.
@@ -122,7 +131,7 @@ function getFirstMultiSigInputData(psbt: UtxoPsbt): {
     return { parsedScriptType, scriptPubKey, derivationPath };
   }
 
-  throw new Error('No multi sig input found');
+  throw new ErrorNoMultiSigInputFound('No multi sig input found');
 }
 
 /**


### PR DESCRIPTION
explainTransaction uses change addresses from platform for its change outputs
Now, they are trustlessly deduced from PSBT

TICKET: BTC-1112

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
