### PR TITLE
fix(utxo-lib): psbt clone should use valid create tx function

### DIFF
--- a/modules/utxo-lib/src/bitgo/wallet/Psbt.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/Psbt.ts
@@ -15,7 +15,7 @@ import {
 } from '../outputScripts';
 import { DerivedWalletKeys, RootWalletKeys } from './WalletKeys';
 import { toPrevOutputWithPrevTx } from '../Unspent';
-import { createPsbtFromHex, createPsbtFromTransaction } from '../transaction';
+import { createPsbtFromHex, createPsbtFromTransaction, createTransactionFromBuffer } from '../transaction';
 import { isWalletUnspent, WalletUnspent } from './Unspent';
 
 import {
@@ -581,7 +581,7 @@ export function clonePsbtWithoutNonWitnessUtxo(psbt: UtxoPsbt): UtxoPsbt {
 
   psbt.data.inputs.forEach((input, i) => {
     if (input.nonWitnessUtxo && !input.witnessUtxo) {
-      const tx = UtxoTransaction.fromBuffer<bigint>(input.nonWitnessUtxo, false, 'bigint', psbt.network);
+      const tx = createTransactionFromBuffer(input.nonWitnessUtxo, psbt.network, { amountType: 'bigint' });
       if (!txInputs[i].hash.equals(tx.getHash())) {
         throw new Error(`Non-witness UTXO hash for input #${i} doesn't match the hash specified in the prevout`);
       }


### PR DESCRIPTION
clonePsbtWithoutNonWitnessUtxo should use createTransactionFromBuffer which is capable to work for alt-coins.

Ticket: BTC-1115

TICKET: BTC-1115

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
