### PR TITLE
chore: remove duplicate char in regex character class

### DIFF
--- a/modules/sdk-coin-atom/src/lib/constants.ts
+++ b/modules/sdk-coin-atom/src/lib/constants.ts
@@ -1,6 +1,6 @@
 export const validDenoms = ['natom', 'uatom', 'matom', 'atom'];
-export const accountAddressRegex = /^(cosmos)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
-export const validatorAddressRegex = /^(cosmosvaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
-export const contractAddressRegex = /^(cosmos)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']+)$/;
+export const accountAddressRegex = /^(cosmos)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
+export const validatorAddressRegex = /^(cosmosvaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
+export const contractAddressRegex = /^(cosmos)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]+)$/;
 export const GAS_AMOUNT = '100000';
 export const GAS_LIMIT = 200000;

--- a/modules/sdk-coin-bera/src/lib/constants.ts
+++ b/modules/sdk-coin-bera/src/lib/constants.ts
@@ -1,6 +1,6 @@
 export const validDenoms = ['abera'];
-export const accountAddressRegex = /^(bera)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
-export const validatorAddressRegex = /^(beravaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
+export const accountAddressRegex = /^(bera)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
+export const validatorAddressRegex = /^(beravaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
 export const GAS_LIMIT = 100000;
 export const GAS_AMOUNT = '1000';
 export const ADDRESS_PREFIX = 'bera';

--- a/modules/sdk-coin-bld/src/lib/constants.ts
+++ b/modules/sdk-coin-bld/src/lib/constants.ts
@@ -1,4 +1,4 @@
 export const validDenoms = ['nbld', 'ubld', 'mbld', 'bld'];
-export const accountAddressRegex = /^(agoric)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
-export const validatorAddressRegex = /^(agoricvaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
-export const contractAddressRegex = /^(agoric)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']+)$/;
+export const accountAddressRegex = /^(agoric)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
+export const validatorAddressRegex = /^(agoricvaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
+export const contractAddressRegex = /^(agoric)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]+)$/;

--- a/modules/sdk-coin-coreum/src/lib/constants.ts
+++ b/modules/sdk-coin-coreum/src/lib/constants.ts
@@ -1,11 +1,11 @@
 export const mainnetValidDenoms = ['ucore'];
-export const mainnetAccountAddressRegex = /^(core)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
-export const mainnetValidatorAddressRegex = /^(corevaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
+export const mainnetAccountAddressRegex = /^(core)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
+export const mainnetValidatorAddressRegex = /^(corevaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
 export const MAINNET_ADDRESS_PREFIX = 'core';
 
 export const testnetValidDenoms = ['utestcore'];
-export const testnetAccountAddressRegex = /^(testcore)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
-export const testnetValidatorAddressRegex = /^(testcorevaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
+export const testnetAccountAddressRegex = /^(testcore)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
+export const testnetValidatorAddressRegex = /^(testcorevaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
 export const TESTNET_ADDRESS_PREFIX = 'testcore';
 
 export const GAS_LIMIT = 200000;

--- a/modules/sdk-coin-hash/src/lib/constants.ts
+++ b/modules/sdk-coin-hash/src/lib/constants.ts
@@ -1,10 +1,10 @@
 export const validDenoms = ['nhash', 'uhash', 'mhash', 'hash'];
-export const mainnetAccountAddressRegex = /^(pb)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
-export const mainnetValidatorAddressRegex = /^(pbvaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
-export const mainnetContractAddressRegex = /^(pb)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']+)$/;
+export const mainnetAccountAddressRegex = /^(pb)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
+export const mainnetValidatorAddressRegex = /^(pbvaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
+export const mainnetContractAddressRegex = /^(pb)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]+)$/;
 export const MAINNET_ADDRESS_PREFIX = 'pb';
 
-export const testnetAccountAddressRegex = /^(tp)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
-export const testnetValidatorAddressRegex = /^(tpvaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
-export const testnetContractAddressRegex = /^(tp)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']+)$/;
+export const testnetAccountAddressRegex = /^(tp)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
+export const testnetValidatorAddressRegex = /^(tpvaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
+export const testnetContractAddressRegex = /^(tp)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]+)$/;
 export const TESTNET_ADDRESS_PREFIX = 'tp';

--- a/modules/sdk-coin-injective/src/lib/constants.ts
+++ b/modules/sdk-coin-injective/src/lib/constants.ts
@@ -1,4 +1,4 @@
 export const validDenoms = ['ninj', 'uinj', 'minj', 'inj'];
-export const accountAddressRegex = /^(inj)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
-export const validatorAddressRegex = /^(injvaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
-export const contractAddressRegex = /^(inj)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']+)$/;
+export const accountAddressRegex = /^(inj)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
+export const validatorAddressRegex = /^(injvaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
+export const contractAddressRegex = /^(inj)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]+)$/;

--- a/modules/sdk-coin-islm/src/lib/constants.ts
+++ b/modules/sdk-coin-islm/src/lib/constants.ts
@@ -1,6 +1,6 @@
 export const validDenoms = ['aISLM'];
-export const accountAddressRegex = /^(haqq)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
-export const validatorAddressRegex = /^(haqqvaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
+export const accountAddressRegex = /^(haqq)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
+export const validatorAddressRegex = /^(haqqvaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
 export const GAS_LIMIT = 200000;
 export const GAS_AMOUNT = '4000000000000000';
 export const ADDRESS_PREFIX = 'haqq';

--- a/modules/sdk-coin-osmo/src/lib/constants.ts
+++ b/modules/sdk-coin-osmo/src/lib/constants.ts
@@ -1,4 +1,4 @@
 export const validDenoms = ['nosmo', 'uosmo', 'mosmo', 'osmo'];
-export const accountAddressRegex = /^(osmo)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
-export const validatorAddressRegex = /^(osmovaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
-export const contractAddressRegex = /^(osmo)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']+)$/;
+export const accountAddressRegex = /^(osmo)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
+export const validatorAddressRegex = /^(osmovaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
+export const contractAddressRegex = /^(osmo)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]+)$/;

--- a/modules/sdk-coin-sei/src/lib/constants.ts
+++ b/modules/sdk-coin-sei/src/lib/constants.ts
@@ -1,4 +1,4 @@
 export const validDenoms = ['nsei', 'usei', 'msei', 'sei'];
-export const accountAddressRegex = /^(sei)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
-export const validatorAddressRegex = /^(seivaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
-export const contractAddressRegex = /^(sei)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']+)$/;
+export const accountAddressRegex = /^(sei)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
+export const validatorAddressRegex = /^(seivaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
+export const contractAddressRegex = /^(sei)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]+)$/;

--- a/modules/sdk-coin-tia/src/lib/constants.ts
+++ b/modules/sdk-coin-tia/src/lib/constants.ts
@@ -1,4 +1,4 @@
 export const validDenoms = ['ntia', 'utia', 'mtia', 'tia'];
-export const accountAddressRegex = /^(celestia)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
-export const validatorAddressRegex = /^(celestiavaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
-export const contractAddressRegex = /^(celestia)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']+)$/;
+export const accountAddressRegex = /^(celestia)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
+export const validatorAddressRegex = /^(celestiavaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
+export const contractAddressRegex = /^(celestia)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]+)$/;

--- a/modules/sdk-coin-zeta/src/lib/constants.ts
+++ b/modules/sdk-coin-zeta/src/lib/constants.ts
@@ -1,6 +1,6 @@
 export const validDenoms = ['azeta'];
-export const accountAddressRegex = /^(zeta)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
-export const validatorAddressRegex = /^(zetavaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']{38})$/;
-export const contractAddressRegex = /^(zeta)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l']+)$/;
+export const accountAddressRegex = /^(zeta)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
+export const validatorAddressRegex = /^(zetavaloper)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38})$/;
+export const contractAddressRegex = /^(zeta)1(['qpzry9x8gf2tvdw0s3jn54khce6mua7l]+)$/;
 export const GAS_LIMIT = 250000;
 export const GAS_AMOUNT = '125000';


### PR DESCRIPTION
This commit removes a duplicate character in a regex character class, which has no effect when specified more than once.

Closes Ticket: VL-1904