### PR TITLE
fix: handle 502 after tx broadcast

### DIFF
--- a/modules/bitgo/test/v2/unit/tss/helpers.ts
+++ b/modules/bitgo/test/v2/unit/tss/helpers.ts
@@ -43,6 +43,13 @@ export async function nockGetTxRequest(params: {
   }
   return n.reply(200, params.response);
 }
+
+export async function nockGetTxRequest502(params: { walletId: string; txRequestId: string }): Promise<nock.Scope> {
+  return nock('https://bitgo.fakeurl')
+    .get(`/api/v2/wallet/${params.walletId}/txrequests?txRequestIds=${params.txRequestId}&latest=true`)
+    .reply(502, { error: 'Bad Gateway' });
+}
+
 export async function nockGetEnterprise(params: {
   enterpriseId: string;
   response: any;

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
@@ -886,7 +886,17 @@ export class EcdsaUtils extends baseTSSUtils<KeyShare> {
       SendShareType.SShare,
       userSShare
     );
-    return await getTxRequest(this.bitgo, this.wallet.id(), txRequestObj.txRequestId);
+    try {
+      return await getTxRequest(this.bitgo, this.wallet.id(), txRequestObj.txRequestId);
+    } catch (error) {
+      if (error.status === 502) {
+        throw new Error(
+          'Transaction broadcasted successfully, but BitGo failed to get the transaction status ' + error
+        );
+      } else {
+        throw error;
+      }
+    }
   }
 
   /**
@@ -999,7 +1009,17 @@ export class EcdsaUtils extends baseTSSUtils<KeyShare> {
       SendShareType.SShare,
       userSShare
     );
-    return await getTxRequest(this.bitgo, this.wallet.id(), txRequest.txRequestId);
+    try {
+      return await getTxRequest(this.bitgo, this.wallet.id(), txRequest.txRequestId);
+    } catch (error) {
+      if (error.status === 502) {
+        throw new Error(
+          'Transaction broadcasted successfully, but BitGo failed to get the transaction status ' + error
+        );
+      } else {
+        throw error;
+      }
+    }
   }
 
   /**

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
@@ -529,7 +529,17 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
     };
     const gShare = await externalSignerGShareGenerator(gSignShareTransactionParams);
     await sendUserToBitgoGShare(this.bitgo, this.wallet.id(), txRequestId, gShare, apiVersion);
-    return await getTxRequest(this.bitgo, this.wallet.id(), txRequestId);
+    try {
+      return await getTxRequest(this.bitgo, this.wallet.id(), txRequestId);
+    } catch (error) {
+      if (error.status === 502) {
+        throw new Error(
+          'Transaction broadcasted successfully, but BitGo failed to get the transaction status ' + error
+        );
+      } else {
+        throw error;
+      }
+    }
   }
 
   /**
@@ -629,8 +639,17 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
     );
 
     await sendUserToBitgoGShare(this.bitgo, this.wallet.id(), txRequestId, userToBitGoGShare, apiVersion);
-
-    return await getTxRequest(this.bitgo, this.wallet.id(), txRequestId);
+    try {
+      return await getTxRequest(this.bitgo, this.wallet.id(), txRequestId);
+    } catch (error) {
+      if (error.status === 502) {
+        throw new Error(
+          'Transaction broadcasted successfully, but BitGo failed to get the transaction status ' + error
+        );
+      } else {
+        throw error;
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Handle 502 error after transaction broadcast

This commit adds error handling for the scenario where `sendUserToBitgoGShare` succeeds but `getTxRequest` fails with a 502 status code.
In such cases, it throws a specific error message indicating that the transaction was broadcasted successfully, but BitGo failed to update the transaction status.
This change ensures that more informative error message is provided when encountering bad gateway error during the transaction status retrieval.

Ticket: COIN-92

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
