### PR TITLE
feat: use canonical address when checking if owned by wallet

### DIFF
--- a/modules/abstract-utxo/src/recovery/crossChainRecovery.ts
+++ b/modules/abstract-utxo/src/recovery/crossChainRecovery.ts
@@ -140,7 +140,11 @@ async function getAllRecoveryOutputs<TNumber extends number | bigint = number>(
   const walletAddresses = (
     await Promise.all(
       tx.outputs.map(async (output) => {
-        const isWalletOwned = await isWalletAddress(wallet, output.address);
+        // For some coins (bch) we need to convert the address to legacy format since the api returns the address
+        // in non legacy format. However, we want to keep the address in the same format as the response since we
+        // are going to hit the API again to fetch address unspents.
+        const canonicalAddress = coin.canonicalAddress(output.address);
+        const isWalletOwned = await isWalletAddress(wallet, canonicalAddress);
         return isWalletOwned ? output.address : null;
       })
     )


### PR DESCRIPTION
Blockchair API returns bch addresses in non legacy format which we dont support downstream. When checking if an address is owned by a wallet we should get the address is canonical format.

Ticket: BTC-1084

TICKET: BTC-1084

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
