### PR TITLE
feat: encrypt and return backup key by default

### DIFF
--- a/modules/bitgo/test/v2/unit/keychains.ts
+++ b/modules/bitgo/test/v2/unit/keychains.ts
@@ -600,9 +600,17 @@ describe('V2 Keychains', function () {
     });
   });
 
-  it('should generate backup without encryptedPrv when passphrase not provided', () => {
-    const backup = keychains.createBackup({});
+  it('should generate backup without encryptedPrv when passphrase not provided', async () => {
+    const scope = nock(bgUrl)
+      .post('/api/v2/tltc/key', (body) => {
+        return body.encryptedPrv === undefined && body.prv === undefined;
+      })
+      .reply(200);
+
+    const backup = await keychains.createBackup({});
+    scope.isDone().should.be.true();
     backup.should.not.have.property('encryptedPrv');
+    backup.should.have.property('prv');
   });
 
   it('should generate backup and call endpoint with encryptedPrv when passphrase is provided', async () => {

--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -616,10 +616,10 @@ export async function handleV2GenerateWallet(req: express.Request) {
   const bitgo = req.bitgo;
   const coin = bitgo.coin(req.params.coin);
   const result = await coin.wallets().generateWallet(req.body);
-  if (req.query.includeKeychains) {
-    return { ...result, wallet: result.wallet.toJSON() };
+  if (req.query.includeKeychains === 'false') {
+    return result.wallet.toJSON();
   }
-  return result.wallet.toJSON();
+  return { ...result, wallet: result.wallet.toJSON() };
 }
 
 /**

--- a/modules/sdk-core/src/bitgo/keychain/iKeychains.ts
+++ b/modules/sdk-core/src/bitgo/keychain/iKeychains.ts
@@ -128,6 +128,7 @@ export interface CreateBackupOptions {
   commonKeychain?: string;
   prv?: string;
   encryptedPrv?: string;
+  passphrase?: string;
 }
 
 export interface CreateBitGoOptions {

--- a/modules/sdk-core/src/bitgo/keychain/keychains.ts
+++ b/modules/sdk-core/src/bitgo/keychain/keychains.ts
@@ -265,6 +265,9 @@ export class Keychains implements IKeychains {
       // if the provider is undefined, we generate a local key and add the source details
       const key = this.create();
       _.extend(params, key);
+      if (params.passphrase !== undefined) {
+        _.extend(params, { encryptedPrv: this.bitgo.encrypt({ input: key.prv, password: params.passphrase }) });
+      }
     }
 
     const serverResponse = await this.add(params);

--- a/modules/sdk-core/src/bitgo/wallet/wallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallets.ts
@@ -431,6 +431,7 @@ export class Wallets implements IWallets {
           disableKRSEmail: params.disableKRSEmail,
           krsSpecific: params.krsSpecific,
           type: this.baseCoin.getChain(),
+          passphrase: params.passphrase,
           reqId,
         });
       }
@@ -448,7 +449,7 @@ export class Wallets implements IWallets {
           throw new Error('cannot generate backup keypair without passphrase');
         }
         // No provided backup xpub or address, so default to creating one here
-        return this.baseCoin.keychains().createBackup({ reqId });
+        return this.baseCoin.keychains().createBackup({ reqId, passphrase: params.passphrase });
       }
     };
 


### PR DESCRIPTION
This PR does 2 things:
 1. it by default returns the private information that is created during `generateWallet` - this is the breaking change
 2. it by default saves the `encryptedPrv` of the backup key in the key document. The old behavior is that this never happened. Note that this only affects hot wallets

TSS keys are already encrypted (and backed up) by default, so this only affects non-TSS keys.

TICKET: BTC-1174