### PR TITLE
feat(sdk-core): remove hardcoded coinSpecific forwarderVersions

### DIFF
--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -1154,8 +1154,6 @@ export class Wallet implements IWallet {
         throw new Error('forwarderVersion has to be an integer 0, 1, 2, 3 or 4');
       }
       addressParams.forwarderVersion = forwarderVersion;
-    } else if (this._wallet.multisigType === 'tss' && this.baseCoin.getMPCAlgorithm() === 'ecdsa') {
-      addressParams.forwarderVersion = 3;
     }
 
     if (!_.isUndefined(label)) {


### PR DESCRIPTION
TICKET: WP-1930

MPCv2 wallets uses `forwarderVersion = 4`, and this line of code is setting the wrong version. 

There is no need to set for coinSpecific hardcoded defaults for forwarderVersions.
WP has logic to handle defaults based on the wallet.

**Testing**
- Tested mpcv2 forwarder addresses are still created if no body is passed in. 
- Tested mpcv2 receive addresses are still created if no body is passed in. 

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
