### PR TITLE
feat(ton): support non-bounceable address format

### DIFF
--- a/modules/sdk-coin-ton/src/lib/utils.ts
+++ b/modules/sdk-coin-ton/src/lib/utils.ts
@@ -48,7 +48,7 @@ export class Utils implements BaseUtils {
     }
   }
 
-  async getAddressFromPublicKey(publicKey: string): Promise<string> {
+  async getAddressFromPublicKey(publicKey: string, bounceable = true): Promise<string> {
     const tonweb = new TonWeb(new TonWeb.HttpProvider(''));
     const WalletClass = tonweb.wallet.all['v4R2'];
     const wallet = new WalletClass(tonweb.provider, {
@@ -56,7 +56,19 @@ export class Utils implements BaseUtils {
       wc: 0,
     });
     const address = await wallet.getAddress();
-    return address.toString(true, true, true);
+    return address.toString(true, true, bounceable);
+  }
+
+  getAddress(address: string, bounceable = true): string {
+    if (bounceable) {
+      return new TonWeb.Address(address).isBounceable
+        ? address
+        : new TonWeb.Address(address).toString(true, true, bounceable);
+    } else {
+      return new TonWeb.Address(address).isBounceable
+        ? new TonWeb.Address(address).toString(true, true, bounceable)
+        : address;
+    }
   }
 
   async getMessageHashFromData(data: string): Promise<string> {


### PR DESCRIPTION
Ticket: WIN-2969

Moving from EQ (bounceable) addresses to UQ (non-bounceable) addresses to fix bouncing deposits issues.

BREAKING CHANGE: All new wallets will generate UQ addresses for ton. External applications and clients depending on these kind of addresses should migrate. No change is being done to existing EQ address wallets.

Wallet Platform will use the bounceable flag based on the walletVersion.