### PR TITLE
fix(sdk-core): call txRequest migration for all apiVersion=full

### DIFF
--- a/modules/sdk-core/src/bitgo/pendingApproval/iPendingApproval.ts
+++ b/modules/sdk-core/src/bitgo/pendingApproval/iPendingApproval.ts
@@ -60,6 +60,7 @@ export interface PendingApprovalData {
 
 export interface IPendingApproval {
   id(): string;
+  toJSON(): PendingApprovalData;
   ownerType(): OwnerType;
   walletId(): string | undefined;
   enterpriseId(): string | undefined;

--- a/modules/sdk-core/src/bitgo/pendingApproval/pendingApproval.ts
+++ b/modules/sdk-core/src/bitgo/pendingApproval/pendingApproval.ts
@@ -69,6 +69,10 @@ export class PendingApproval implements IPendingApproval {
     return this._pendingApproval.id;
   }
 
+  toJSON(): PendingApprovalData {
+    return this._pendingApproval;
+  }
+
   /**
    * Get the owner type (wallet or enterprise)
    * Pending approvals can be approved or modified by different scopes (depending on how they were created)

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -255,6 +255,12 @@ export enum RequestType {
   tx,
   message,
 }
+export type SignedTx = {
+  id: string;
+  tx: string;
+  publicKey?: string;
+  signature?: string;
+};
 
 export type TxRequest = {
   txRequestId: string;
@@ -280,6 +286,7 @@ export type TxRequest = {
     state: TransactionState;
     unsignedTx: UnsignedTransactionTss; // Should override with blockchain / sig specific unsigned tx
     signatureShares: SignatureShareRecord[];
+    signedTx?: SignedTx;
     commitmentShares?: CommitmentShareRecord[];
   }[];
   messages?: {

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -3312,8 +3312,7 @@ export class Wallet implements IWallet {
       throw new Error('txRequestId missing from signed transaction');
     }
 
-    // TODO: BG-51122 Remove conditional when moved to txRequestFull for everything
-    if (this._wallet.type === 'custodial') {
+    if (apiVersion === 'full') {
       await this.bitgo
         .post(
           this.bitgo.url(

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -19,10 +19,10 @@ import { BitGoBase } from '../bitgoBase';
 import { getSharedSecret } from '../ecdh';
 import { AddressGenerationError, MethodNotImplementedError } from '../errors';
 import * as internal from '../internal/internal';
-import { drawKeycard } from '../internal/keycard';
+import { drawKeycard } from '../internal';
 import { decryptKeychainPrivateKey, Keychain, KeychainWithEncryptedPrv } from '../keychain';
-import { IPendingApproval, PendingApproval } from '../pendingApproval';
-import { TradingAccount } from '../trading/tradingAccount';
+import { IPendingApproval, PendingApproval, PendingApprovals } from '../pendingApproval';
+import { TradingAccount } from '../trading';
 import {
   inferAddressType,
   RequestTracer,
@@ -92,7 +92,7 @@ import {
   WalletSignTypedDataOptions,
   WalletType,
 } from './iWallet';
-import { StakingWallet } from '../staking/stakingWallet';
+import { StakingWallet } from '../staking';
 import { Lightning } from '../lightning';
 import EddsaUtils from '../utils/tss/eddsa';
 import { EcdsaMPCv2Utils, EcdsaUtils } from '../utils/tss/ecdsa';
@@ -3312,20 +3312,32 @@ export class Wallet implements IWallet {
       throw new Error('txRequestId missing from signed transaction');
     }
 
-    if (apiVersion === 'full') {
-      await this.bitgo
+    if (onlySupportsTxRequestFull || apiVersion === 'full') {
+      const latestTxRequest = await getTxRequest(this.bitgo, this.id(), signedTransaction.txRequestId);
+      const transfer: { state: string; pendingApproval?: string; txid?: string } = await this.bitgo
         .post(
           this.bitgo.url(
             '/wallet/' + this._wallet.id + '/txrequests/' + signedTransaction.txRequestId + '/transfers',
             2
           )
         )
-        .send();
-    }
-
-    // ECDSA TSS uses TxRequestFull
-    if (apiVersion === 'full' || onlySupportsTxRequestFull) {
-      return getTxRequest(this.bitgo, this.id(), signedTransaction.txRequestId);
+        .send()
+        .result();
+      if (latestTxRequest.state === 'pendingApproval') {
+        const pendingApprovals = new PendingApprovals(this.bitgo, this.baseCoin);
+        const pendingApproval = await pendingApprovals.get({ id: latestTxRequest.pendingApprovalId });
+        return {
+          pendingApproval: pendingApproval.toJSON(),
+          txRequest: latestTxRequest,
+        };
+      }
+      return {
+        transfer,
+        txRequest: latestTxRequest,
+        txid: (latestTxRequest.transactions ?? [])[0]?.signedTx?.id,
+        tx: (latestTxRequest.transactions ?? [])[0]?.signedTx?.tx,
+        status: transfer.state,
+      };
     }
 
     return this.tssUtils?.sendTxRequest(signedTransaction.txRequestId);


### PR DESCRIPTION
This PR updates `sendManyTss` to return the expected return value from `sendMany`. After this PR it should be aligned with the return value from `v2.wallet.send`.

Blocked till June 4th.

