### PR TITLE
feat(sdk-core): supply isMPCv2 for MPCv2 key creation

### DIFF
--- a/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsaMPCv2/createKeychains.ts
+++ b/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsaMPCv2/createKeychains.ts
@@ -430,7 +430,7 @@ describe('TSS Ecdsa MPCv2 Utils:', async function () {
 
   async function nockAddKeyChain(coin: string, times = 1) {
     return nock('https://bitgo.fakeurl')
-      .post(`/api/v2/${coin}/key`, (body) => body.keyType === 'tss')
+      .post(`/api/v2/${coin}/key`, (body) => body.keyType === 'tss' && body.isMPCv2)
       .times(times)
       .reply(200, async (uri, requestBody: AddKeychainOptions) => {
         return {

--- a/modules/sdk-core/src/bitgo/keychain/iKeychains.ts
+++ b/modules/sdk-core/src/bitgo/keychain/iKeychains.ts
@@ -103,6 +103,8 @@ export interface AddKeychainOptions {
   backupGPGPublicKey?: string;
   algoUsed?: string;
   isDistributedCustody?: boolean;
+  // indicates if the key is MPCv2 or not
+  isMPCv2?: boolean;
 }
 
 export interface ApiKeyShare {

--- a/modules/sdk-core/src/bitgo/keychain/keychains.ts
+++ b/modules/sdk-core/src/bitgo/keychain/keychains.ts
@@ -236,6 +236,7 @@ export class Keychains implements IKeychains {
         backupGPGPublicKey: params.backupGPGPublicKey,
         algoUsed: params.algoUsed,
         isDistributedCustody: params.isDistributedCustody,
+        isMPCv2: params.isMPCv2,
       })
       .result();
   }

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
@@ -360,6 +360,7 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
       commonKeychain,
       encryptedPrv,
       originalPasscodeEncryptionCode,
+      isMPCv2: true,
     };
 
     const keychains = this.baseCoin.keychains();


### PR DESCRIPTION
To enable a smooth roll-out of MPCv2, platform needs to know what types are keys are being created. As MPCv1 and MPCv2 keys are the same structure in terms of what platform can see/parse, there needs to be some client indication on what keys are being created. 

This is being done so that clients have some migration period to upgrade the sdk so that wallet creation does not break for MPCv1 in that transitory period.

TICKET: WP-1997


