### PR TITLE
fix(sdk-core): pad alpha and mu shares of MPCV1

### DIFF
--- a/modules/sdk-core/src/account-lib/mpc/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/account-lib/mpc/tss/ecdsa/ecdsa.ts
@@ -60,6 +60,8 @@ import {
 } from './types';
 
 const _5n = BigInt(5);
+// Size of alpha and mu shares in bytes expected by the implementation of the protocol
+const ALPHAMUSIZE = 768;
 
 /**
  * ECDSA TSS implementation supporting 2:n Threshold
@@ -546,7 +548,7 @@ export default class Ecdsa {
     const rb = await randomPositiveCoPrimeTo(pka.n);
     const cb = pka.encrypt(beta0, rb);
     const alpha = pka.addition(pka.multiply(k, g), cb);
-    const alphaToBeSent = bigIntToBufferBE(alpha, 32).toString('hex');
+    const alphaToBeSent = bigIntToBufferBE(alpha, ALPHAMUSIZE).toString('hex');
     // Prove $\gamma_i \in Z_{N^2}$.
     const gx = Ecdsa.curve.basePointMult(g);
     let proof = await EcdsaRangeProof.proveWithCheck(
@@ -586,7 +588,7 @@ export default class Ecdsa {
     const rn = await randomPositiveCoPrimeTo(pka.n);
     const cn = pka.encrypt(nu0, rn);
     const mu = pka.addition(pka.multiply(k, w), cn);
-    const muToBeSent = bigIntToBufferBE(mu, 32).toString('hex');
+    const muToBeSent = bigIntToBufferBE(mu, ALPHAMUSIZE).toString('hex');
     // Prove $\w_i \in Z_{N^2}$.
     const wx = Ecdsa.curve.basePointMult(w);
     proof = await EcdsaRangeProof.proveWithCheck(
@@ -798,7 +800,7 @@ export default class Ecdsa {
     const rb = await randomPositiveCoPrimeTo(pkb.n);
     const cb = pkb.encrypt(beta0, rb);
     const alpha = pkb.addition(pkb.multiply(k, g), cb);
-    const alphaToBeSent = bigIntToBufferBE(alpha, 32).toString('hex');
+    const alphaToBeSent = bigIntToBufferBE(alpha, ALPHAMUSIZE).toString('hex');
     // Prove $\gamma_i \in Z_{N^2}$.
     const gx = Ecdsa.curve.basePointMult(g);
     let proof = await EcdsaRangeProof.proveWithCheck(
@@ -838,7 +840,7 @@ export default class Ecdsa {
     const rn = await randomPositiveCoPrimeTo(pkb.n);
     const cn = pkb.encrypt(nu0, rn);
     const mu = pkb.addition(pkb.multiply(k, w), cn);
-    const muToBeSent = bigIntToBufferBE(mu, 32).toString('hex');
+    const muToBeSent = bigIntToBufferBE(mu, ALPHAMUSIZE).toString('hex');
     // Prove $\w_i \in Z_{N^2}$.
     const wx = Ecdsa.curve.basePointMult(w);
     proof = await EcdsaRangeProof.proveWithCheck(


### PR DESCRIPTION
TICKET: HSM-395

BitGo's side of the protocol is expecting 1536 hex length alpha and mu shares.
<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
