### PR TITLE
feat(sdk-core): propagate reqId for prebuildTransaction downstream methods

### DIFF
--- a/modules/bitgo/test/v2/unit/internal/tssUtils/eddsa.ts
+++ b/modules/bitgo/test/v2/unit/internal/tssUtils/eddsa.ts
@@ -833,6 +833,24 @@ describe('TSS Utils:', async function () {
       response.should.length(1);
       nock.isDone().should.equal(true);
     });
+
+    it('should call setRequestTracer', async function () {
+      const signatureShare = { from: 'user', to: 'bitgo', share: '128bytestring' } as SignatureShareRecord;
+      const nock = await nockDeleteSignatureShare({
+        walletId: wallet.id(),
+        txRequestId: txRequest.txRequestId,
+        signatureShare,
+      });
+      const reqId = new RequestTracer();
+      const setRequestTracerSpy = sinon.spy(bitgo, 'setRequestTracer');
+      setRequestTracerSpy.withArgs(reqId);
+      const response = await tssUtils.deleteSignatureShares(txRequest.txRequestId, reqId);
+      response.should.deepEqual([signatureShare]);
+      response.should.length(1);
+      nock.isDone().should.equal(true);
+      sinon.assert.calledOnce(setRequestTracerSpy);
+      setRequestTracerSpy.restore();
+    });
   });
 
   describe('sendTxRequest:', async function () {
@@ -844,6 +862,21 @@ describe('TSS Utils:', async function () {
       });
       await tssUtils.sendTxRequest(txRequest.txRequestId).should.be.fulfilled();
       nock.isDone().should.equal(true);
+    });
+
+    it('should call setRequestTracer', async function () {
+      const nock = await nockSendTxRequest({
+        coin: coinName,
+        walletId: wallet.id(),
+        txRequestId: txRequest.txRequestId,
+      });
+      const reqId = new RequestTracer();
+      const setRequestTracerSpy = sinon.spy(bitgo, 'setRequestTracer');
+      setRequestTracerSpy.withArgs(reqId);
+      await tssUtils.sendTxRequest(txRequest.txRequestId, reqId).should.be.fulfilled();
+      nock.isDone().should.equal(true);
+      sinon.assert.calledOnce(setRequestTracerSpy);
+      setRequestTracerSpy.restore();
     });
   });
 

--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -1743,6 +1743,20 @@ describe('V2 Wallet:', function () {
       ethWallet = new Wallet(bitgo, bitgo.coin('teth'), walletData);
     });
 
+    it('should return reqId if it was passed in the params', async function () {
+      const params = { offlineVerification: true };
+      const scope = nock(bgUrl)
+        .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/build`, tbtcHotWalletDefaultParams)
+        .query(params)
+        .reply(200, {});
+      const blockHeight = 100;
+      sinon.stub(basecoin, 'getLatestBlockHeight').resolves(blockHeight);
+      sinon.stub(basecoin, 'postProcessPrebuild').resolves({});
+      const txRequest = await wallet.prebuildTransaction({ ...params, reqId: reqId });
+      txRequest.reqId?.should.containEql(reqId);
+      scope.done();
+    });
+
     it('should pass offlineVerification=true query param if passed truthy value', async function () {
       const params = { offlineVerification: true };
       const scope = nock(bgUrl)

--- a/modules/sdk-core/src/bitgo/tss/common.ts
+++ b/modules/sdk-core/src/bitgo/tss/common.ts
@@ -182,6 +182,7 @@ export async function commonVerifyWalletSignature(params: {
  * @param index
  * @param requestType
  * @param paillierModulus
+ * @param reqId
  */
 export async function getTxRequestChallenge(
   bitgo: BitGoBase,
@@ -189,7 +190,8 @@ export async function getTxRequestChallenge(
   txRequestId: string,
   index: string,
   requestType: RequestType,
-  paillierModulus: string
+  paillierModulus: string,
+  reqId?: IRequestTracer
 ): Promise<TxRequestChallengeResponse> {
   let addendum = '';
   switch (requestType) {
@@ -201,5 +203,7 @@ export async function getTxRequestChallenge(
       break;
   }
   const urlPath = '/wallet/' + walletId + '/txrequests/' + txRequestId + addendum + '/challenge';
+  const reqTracer = reqId || new RequestTracer();
+  bitgo.setRequestTracer(reqTracer);
   return await bitgo.post(bitgo.url(urlPath, 2)).send({ paillierModulus }).result();
 }

--- a/modules/sdk-core/src/bitgo/tss/common.ts
+++ b/modules/sdk-core/src/bitgo/tss/common.ts
@@ -30,12 +30,8 @@ export async function getTxRequest(
   txRequestId: string,
   reqId?: IRequestTracer
 ): Promise<TxRequest> {
-  if (reqId) {
-    bitgo.setRequestTracer(reqId);
-  } else {
-    const reqId = new RequestTracer();
-    bitgo.setRequestTracer(reqId);
-  }
+  const reqTracer = reqId || new RequestTracer();
+  bitgo.setRequestTracer(reqTracer);
   const txRequestRes = await bitgo
     .get(bitgo.url('/wallet/' + walletId + '/txrequests', 2))
     .query({ txRequestIds: txRequestId, latest: 'true' })
@@ -89,12 +85,8 @@ export async function sendSignatureShare(
       break;
   }
   const urlPath = '/wallet/' + walletId + '/txrequests/' + txRequestId + addendum + '/signatureshares';
-  if (reqId) {
-    bitgo.setRequestTracer(reqId);
-  } else {
-    const reqId = new RequestTracer();
-    bitgo.setRequestTracer(reqId);
-  }
+  const reqTracer = reqId || new RequestTracer();
+  bitgo.setRequestTracer(reqTracer);
   return bitgo
     .post(bitgo.url(urlPath, 2))
     .send({
@@ -130,12 +122,8 @@ export async function exchangeEddsaCommitments(
     addendum = '/transactions/0';
   }
   const urlPath = '/wallet/' + walletId + '/txrequests/' + txRequestId + addendum + '/commit';
-  if (reqId) {
-    bitgo.setRequestTracer(reqId);
-  } else {
-    const reqId = new RequestTracer();
-    bitgo.setRequestTracer(reqId);
-  }
+  const reqTracer = reqId || new RequestTracer();
+  bitgo.setRequestTracer(reqTracer);
   return await bitgo.post(bitgo.url(urlPath, 2)).send({ commitmentShare, encryptedSignerShare }).result();
 }
 

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
@@ -327,12 +327,8 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
    * @returns {SignatureShareRecord[]}
    */
   async deleteSignatureShares(txRequestId: string, reqId?: IRequestTracer): Promise<SignatureShareRecord[]> {
-    if (reqId) {
-      this.bitgo.setRequestTracer(reqId);
-    } else {
-      const reqId = new RequestTracer();
-      this.bitgo.setRequestTracer(reqId);
-    }
+    const reqTracer = reqId || new RequestTracer();
+    this.bitgo.setRequestTracer(reqTracer);
     return this.bitgo
       .del(this.bitgo.url(`/wallet/${this.wallet.id()}/txrequests/${txRequestId}/signatureshares`, 2))
       .send()
@@ -348,12 +344,8 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async sendTxRequest(txRequestId: string, reqId?: IRequestTracer): Promise<any> {
-    if (reqId) {
-      this.bitgo.setRequestTracer(reqId);
-    } else {
-      const reqId = new RequestTracer();
-      this.bitgo.setRequestTracer(reqId);
-    }
+    const reqTracer = reqId || new RequestTracer();
+    this.bitgo.setRequestTracer(reqTracer);
     return this.bitgo
       .post(this.baseCoin.url('/wallet/' + this.wallet.id() + '/tx/send'))
       .send({ txRequestId })

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
@@ -373,10 +373,11 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
    * Gets the latest Tx Request by id
    *
    * @param {String} txRequestId - the txRequest Id
+   * @param {IRequestTracer} reqId - request tracer request id
    * @returns {Promise<TxRequest>}
    */
-  async getTxRequest(txRequestId: string): Promise<TxRequest> {
-    return getTxRequest(this.bitgo, this.wallet.id(), txRequestId);
+  async getTxRequest(txRequestId: string, reqId?: IRequestTracer): Promise<TxRequest> {
+    return getTxRequest(this.bitgo, this.wallet.id(), txRequestId, reqId);
   }
 
   /**

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
@@ -35,6 +35,7 @@ import {
   CustomSShareGeneratingFunction,
 } from './baseTypes';
 import { GShare, SignShare } from '../../../account-lib/mpc/tss';
+import { RequestTracer } from '../util';
 
 /**
  * BaseTssUtil class which different signature schemes have to extend
@@ -322,9 +323,16 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
    * Call delete signature shares for a txRequest, the endpoint delete the signatures and return them
    *
    * @param {string} txRequestId tx id reference to delete signature shares
+   * @param {IRequestTracer} reqId - the request tracer request id
    * @returns {SignatureShareRecord[]}
    */
-  async deleteSignatureShares(txRequestId: string): Promise<SignatureShareRecord[]> {
+  async deleteSignatureShares(txRequestId: string, reqId?: IRequestTracer): Promise<SignatureShareRecord[]> {
+    if (reqId) {
+      this.bitgo.setRequestTracer(reqId);
+    } else {
+      const reqId = new RequestTracer();
+      this.bitgo.setRequestTracer(reqId);
+    }
     return this.bitgo
       .del(this.bitgo.url(`/wallet/${this.wallet.id()}/txrequests/${txRequestId}/signatureshares`, 2))
       .send()
@@ -335,10 +343,17 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
    * Initialize the send procedure once Bitgo has the User To Bitgo GShare
    *
    * @param {String} txRequestId - the txRequest Id
+   * @param {IRequestTracer} reqId - the request tracer request id
    * @returns {Promise<any>}
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async sendTxRequest(txRequestId: string): Promise<any> {
+  async sendTxRequest(txRequestId: string, reqId?: IRequestTracer): Promise<any> {
+    if (reqId) {
+      this.bitgo.setRequestTracer(reqId);
+    } else {
+      const reqId = new RequestTracer();
+      this.bitgo.setRequestTracer(reqId);
+    }
     return this.bitgo
       .post(this.baseCoin.url('/wallet/' + this.wallet.id() + '/tx/send'))
       .send({ txRequestId })

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
@@ -609,7 +609,8 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
       txRequestId,
       commitmentShare,
       encryptedSignerShare,
-      apiVersion
+      apiVersion,
+      params.reqId
     );
 
     await offerUserToBitgoRShare(
@@ -622,10 +623,11 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
       vssProof,
       privateShareProof,
       userPublicGpgKey,
-      publicShare
+      publicShare,
+      params.reqId
     );
 
-    const bitgoToUserRShare = await getBitgoToUserRShare(this.bitgo, this.wallet.id(), txRequestId);
+    const bitgoToUserRShare = await getBitgoToUserRShare(this.bitgo, this.wallet.id(), txRequestId, params.reqId);
 
     const userToBitGoGShare = await createUserToBitGoGShare(
       userSignShare,
@@ -636,9 +638,9 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
       bitgoToUserCommitment
     );
 
-    await sendUserToBitgoGShare(this.bitgo, this.wallet.id(), txRequestId, userToBitGoGShare, apiVersion);
+    await sendUserToBitgoGShare(this.bitgo, this.wallet.id(), txRequestId, userToBitGoGShare, apiVersion, params.reqId);
 
-    return await getTxRequest(this.bitgo, this.wallet.id(), txRequestId);
+    return await getTxRequest(this.bitgo, this.wallet.id(), txRequestId, params.reqId);
   }
 
   /**

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
@@ -36,6 +36,7 @@ import baseTSSUtils from '../baseTSSUtils';
 import { KeychainsTriplet } from '../../../baseCoin';
 import { exchangeEddsaCommitments } from '../../../tss/common';
 import { Ed25519Bip32HdTree } from '@bitgo/sdk-lib-mpc';
+import { IRequestTracer } from '../../../../api';
 
 /**
  * Utility functions for TSS work flows.
@@ -481,12 +482,13 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
     txRequest: string | TxRequest,
     externalSignerCommitmentGenerator: CustomCommitmentGeneratingFunction,
     externalSignerRShareGenerator: CustomRShareGeneratingFunction,
-    externalSignerGShareGenerator: CustomGShareGeneratingFunction
+    externalSignerGShareGenerator: CustomGShareGeneratingFunction,
+    reqId?: IRequestTracer
   ): Promise<TxRequest> {
     let txRequestResolved: TxRequest;
     let txRequestId: string;
     if (typeof txRequest === 'string') {
-      txRequestResolved = await getTxRequest(this.bitgo, this.wallet.id(), txRequest);
+      txRequestResolved = await getTxRequest(this.bitgo, this.wallet.id(), txRequest, reqId);
       txRequestId = txRequestResolved.txRequestId;
     } else {
       txRequestResolved = txRequest;
@@ -504,7 +506,8 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
       txRequestId,
       userToBitgoCommitment,
       encryptedSignerShare,
-      apiVersion
+      apiVersion,
+      reqId
     );
 
     const { rShare } = await externalSignerRShareGenerator({
@@ -518,9 +521,14 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
       txRequestId,
       rShare,
       encryptedSignerShare.share,
-      apiVersion
+      apiVersion,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      reqId
     );
-    const bitgoToUserRShare = await getBitgoToUserRShare(this.bitgo, this.wallet.id(), txRequestId);
+    const bitgoToUserRShare = await getBitgoToUserRShare(this.bitgo, this.wallet.id(), txRequestId, reqId);
     const gSignShareTransactionParams = {
       txRequest: txRequestResolved,
       bitgoToUserRShare: bitgoToUserRShare,
@@ -528,8 +536,8 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
       bitgoToUserCommitment,
     };
     const gShare = await externalSignerGShareGenerator(gSignShareTransactionParams);
-    await sendUserToBitgoGShare(this.bitgo, this.wallet.id(), txRequestId, gShare, apiVersion);
-    return await getTxRequest(this.bitgo, this.wallet.id(), txRequestId);
+    await sendUserToBitgoGShare(this.bitgo, this.wallet.id(), txRequestId, gShare, apiVersion, reqId);
+    return await getTxRequest(this.bitgo, this.wallet.id(), txRequestId, reqId);
   }
 
   /**

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -167,6 +167,7 @@ export interface PrebuildTransactionResult extends TransactionPrebuild {
     feeString?: string;
   };
   pendingApprovalId?: string;
+  reqId?: IRequestTracer;
 }
 
 export interface CustomSigningFunction {

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -1982,7 +1982,7 @@ export class Wallet implements IWallet {
 
     if (signingParams.txPrebuild.txRequestId) {
       assert(this.tssUtils, 'tssUtils must be defined for TSS wallets');
-      const txRequest = await this.tssUtils.getTxRequest(signingParams.txPrebuild.txRequestId);
+      const txRequest = await this.tssUtils.getTxRequest(signingParams.txPrebuild.txRequestId, params.reqId);
       if (this.tssUtils.isPendingApprovalTxRequestFull(txRequest)) {
         return txRequest;
       }
@@ -3136,7 +3136,7 @@ export class Wallet implements IWallet {
         {
           txRequest: txRequestId,
           prv: '',
-          reqId: new RequestTracer(),
+          reqId: params.reqId || new RequestTracer(),
         },
         RequestType.tx,
         params.customPaillierModulusGeneratingFunction,
@@ -3212,7 +3212,7 @@ export class Wallet implements IWallet {
         txRequest = await this.tssUtils!.createTxRequestWithIntentForMessageSigning(intentOption);
         params.message.txRequestId = txRequest.txRequestId;
       } else {
-        txRequest = await getTxRequest(this.bitgo, this.id(), params.message.txRequestId);
+        txRequest = await getTxRequest(this.bitgo, this.id(), params.message.txRequestId, params.reqId);
       }
 
       const signedMessageRequest = await this.tssUtils!.signTxRequestForMessage({
@@ -3268,7 +3268,7 @@ export class Wallet implements IWallet {
         txRequest = await this.tssUtils!.createTxRequestWithIntentForTypedDataSigning(intentOptions);
         params.typedData.txRequestId = txRequest.txRequestId;
       } else {
-        txRequest = await getTxRequest(this.bitgo, this.id(), params.typedData.txRequestId);
+        txRequest = await getTxRequest(this.bitgo, this.id(), params.typedData.txRequestId, params.reqId);
       }
 
       const signedTypedDataRequest = await this.tssUtils!.signTxRequestForMessage({
@@ -3316,7 +3316,7 @@ export class Wallet implements IWallet {
     }
 
     if (onlySupportsTxRequestFull || apiVersion === 'full') {
-      const latestTxRequest = await getTxRequest(this.bitgo, this.id(), signedTransaction.txRequestId);
+      const latestTxRequest = await getTxRequest(this.bitgo, this.id(), signedTransaction.txRequestId, params.reqId);
       const reqId = params.reqId || new RequestTracer();
       this.bitgo.setRequestTracer(reqId);
       const transfer: { state: string; pendingApproval?: string; txid?: string } = await this.bitgo

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -101,7 +101,6 @@ import { buildParamKeys, BuildParams } from './BuildParams';
 import { postWithCodec } from '../utils/postWithCodec';
 import { TxSendBody } from '@bitgo/public-types';
 import { AddressBook, IAddressBook } from '../address-book';
-import { IRequestTracer } from '../../api';
 
 const debug = require('debug')('bitgo:v2:wallet');
 
@@ -3080,10 +3079,7 @@ export class Wallet implements IWallet {
 
     assert(this.tssUtils, 'tssUtils must be defined');
     // adding this to rebuild the transaction just before signing for EdDSA transaction using external signer
-    let reqId: IRequestTracer | undefined;
-    if (params.reqId) {
-      reqId = params.reqId;
-    }
+    const reqId = params.reqId || undefined;
     await this.tssUtils.deleteSignatureShares(txRequestId, reqId);
 
     try {
@@ -3321,12 +3317,8 @@ export class Wallet implements IWallet {
 
     if (onlySupportsTxRequestFull || apiVersion === 'full') {
       const latestTxRequest = await getTxRequest(this.bitgo, this.id(), signedTransaction.txRequestId);
-      if (params.reqId) {
-        this.bitgo.setRequestTracer(params.reqId);
-      } else {
-        const reqId = new RequestTracer();
-        this.bitgo.setRequestTracer(reqId);
-      }
+      const reqId = params.reqId || new RequestTracer();
+      this.bitgo.setRequestTracer(reqId);
       const transfer: { state: string; pendingApproval?: string; txid?: string } = await this.bitgo
         .post(
           this.bitgo.url(
@@ -3353,11 +3345,7 @@ export class Wallet implements IWallet {
       };
     }
 
-    let reqId: IRequestTracer | undefined;
-    if (params.reqId) {
-      reqId = params.reqId;
-    }
-
+    const reqId = params.reqId || undefined;
     return this.tssUtils?.sendTxRequest(signedTransaction.txRequestId, reqId);
   }
 


### PR DESCRIPTION
TICKET: WP-1862


## Description

Added `reqId` as a prameter to methods and fucntions that are called downstrea of `prebuildTransaction`. I've also updated `prebuildTransaction` to return the request tracer `reqId`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I have added unit tests where possible to make sure that the api's `setRequestTracer` method is being called properly. I have also tested that `reqId` is returned from `prebuildTransaction`

