### PR TITLE
fix(sdk-coin-sui): trim gas inputs in `getTxData` when input objects > 255

### DIFF
--- a/modules/sdk-coin-sui/src/lib/stakingTransaction.ts
+++ b/modules/sdk-coin-sui/src/lib/stakingTransaction.ts
@@ -21,7 +21,7 @@ import {
 } from './mystenlab/builder';
 import { CallArg, normalizeSuiAddress } from './mystenlab/types';
 import { BCS } from '@mysten/bcs';
-import { SUI_ADDRESS_LENGTH } from './constants';
+import { MAX_GAS_OBJECTS, SUI_ADDRESS_LENGTH } from './constants';
 
 export class StakingTransaction extends Transaction<StakingProgrammableTransaction> {
   constructor(_coinConfig: Readonly<CoinConfig>) {
@@ -204,7 +204,10 @@ export class StakingTransaction extends Transaction<StakingProgrammableTransacti
     return {
       sender: this._suiTransaction.sender,
       expiration: { None: null },
-      gasData: this._suiTransaction.gasData,
+      gasData: {
+        ...this._suiTransaction.gasData,
+        payment: this._suiTransaction.gasData.payment.slice(0, MAX_GAS_OBJECTS - 1),
+      },
       kind: {
         ProgrammableTransaction: programmableTx,
       },

--- a/modules/sdk-coin-sui/src/lib/transferTransaction.ts
+++ b/modules/sdk-coin-sui/src/lib/transferTransaction.ts
@@ -9,7 +9,7 @@ import {
 } from '@bitgo/sdk-core';
 import { SuiTransaction, TransactionExplanation, TransferProgrammableTransaction, TxData } from './iface';
 import { BaseCoin as CoinConfig } from '@bitgo/statics';
-import { SUI_ADDRESS_LENGTH, UNAVAILABLE_TEXT } from './constants';
+import { MAX_GAS_OBJECTS, SUI_ADDRESS_LENGTH, UNAVAILABLE_TEXT } from './constants';
 import { Buffer } from 'buffer';
 import { Transaction } from './transaction';
 import { CallArg, SuiObjectRef, normalizeSuiAddress } from './mystenlab/types';
@@ -193,7 +193,10 @@ export class TransferTransaction extends Transaction<TransferProgrammableTransac
     return {
       sender: this._suiTransaction.sender,
       expiration: { None: null },
-      gasData: this._suiTransaction.gasData,
+      gasData: {
+        ...this._suiTransaction.gasData,
+        payment: this._suiTransaction.gasData.payment.slice(0, MAX_GAS_OBJECTS - 1),
+      },
       kind: {
         ProgrammableTransaction: programmableTx,
       },

--- a/modules/sdk-coin-sui/test/unit/transactionBuilder/stakingBuilder.ts
+++ b/modules/sdk-coin-sui/test/unit/transactionBuilder/stakingBuilder.ts
@@ -92,6 +92,7 @@ describe('Sui Staking Builder', () => {
       should.equal(utils.isValidRawTransaction(rawTx), true);
       const rebuilder = factory.getStakingBuilder();
       rebuilder.from(rawTx);
+      rebuilder.addSignature({ pub: testData.sender.publicKey }, Buffer.from(testData.sender.signatureHex));
       const rebuiltTx = await rebuilder.build();
       rebuiltTx.toBroadcastFormat().should.equal(rawTx);
     });

--- a/modules/sdk-coin-sui/test/unit/transactionBuilder/transferBuilder.ts
+++ b/modules/sdk-coin-sui/test/unit/transactionBuilder/transferBuilder.ts
@@ -138,6 +138,7 @@ describe('Sui Transfer Builder', () => {
       should.equal(utils.isValidRawTransaction(rawTx), true);
       const rebuilder = factory.getTransferBuilder();
       rebuilder.from(rawTx);
+      rebuilder.addSignature({ pub: testData.sender.publicKey }, Buffer.from(testData.sender.signatureHex));
       const rebuiltTx = await rebuilder.build();
       rebuiltTx.toBroadcastFormat().should.equal(rawTx);
     });


### PR DESCRIPTION
Ticket: WIN-2924

This was missed in #4588 causing transaction serialization to fail, in turn causing `addSignature` to fail