### PR TITLE
feat(abstract-utxo): add internal/external info when known

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -33,7 +33,6 @@ import {
   IBaseCoin,
   InvalidAddressDerivationPropertyError,
   InvalidAddressError,
-  InvalidAddressVerificationObjectPropertyError,
   IRequestTracer,
   isTriple,
   ITransactionExplanation as BaseTransactionExplanation,
@@ -967,7 +966,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
    * @throws {UnexpectedAddressError}
    */
   async isWalletAddress(params: VerifyAddressOptions): Promise<boolean> {
-    const { address, addressType, keychains, coinSpecific, chain, index } = params;
+    const { address, addressType, keychains, chain, index } = params;
 
     if (!this.isValidAddress(address)) {
       throw new InvalidAddressError(`invalid address: ${address}`);
@@ -976,12 +975,6 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
     if ((_.isUndefined(chain) && _.isUndefined(index)) || !(_.isFinite(chain) && _.isFinite(index))) {
       throw new InvalidAddressDerivationPropertyError(
         `address validation failure: invalid chain (${chain}) or index (${index})`
-      );
-    }
-
-    if (!_.isObject(coinSpecific)) {
-      throw new InvalidAddressVerificationObjectPropertyError(
-        'address validation failure: coinSpecific field must be an object'
       );
     }
 

--- a/modules/utxo-lib/src/bitgo/parseInput.ts
+++ b/modules/utxo-lib/src/bitgo/parseInput.ts
@@ -698,3 +698,20 @@ export function parsePubScript(
 
   return result;
 }
+
+export function getChainAndIndexFromPath(path: string): { chain: number; index: number } {
+  const parts = path.split('/');
+  if (parts.length <= 2) {
+    throw new Error(`invalid path "${path}"`);
+  }
+  const chain = Number(parts[parts.length - 2]);
+  const index = Number(parts[parts.length - 1]);
+  if (isNaN(chain) || isNaN(index)) {
+    throw new Error(`Could not parse chain and index into numbers from path ${path}`);
+  }
+  if (chain < 0 || index < 0) {
+    throw new Error(`chain and index must be non-negative`);
+  }
+
+  return { chain, index };
+}

--- a/modules/utxo-lib/test/bitgo/wallet/chains.ts
+++ b/modules/utxo-lib/test/bitgo/wallet/chains.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import {
   ChainCode,
   chainCodes,
+  getChainAndIndexFromPath,
   getExternalChainCode,
   getInternalChainCode,
   isChainCode,
@@ -56,5 +57,30 @@ describe('chain codes', function () {
       assert.strictEqual(isExternalChainCode(c) && isInternalChainCode(c), false);
       assert.strictEqual(isExternalChainCode(c) ? getExternalChainCode(c) : getInternalChainCode(c), c);
     });
+  });
+});
+
+describe('getChainAndIndexFromPath', function () {
+  it('should throw if path is not the right length', function () {
+    assert.throws(() => getChainAndIndexFromPath('/'), /invalid path/);
+    assert.throws(() => getChainAndIndexFromPath('m0000ssss'), /invalid path/);
+  });
+
+  it('should throw if the path is not a number', function () {
+    assert.throws(() => getChainAndIndexFromPath('m/0/ssss'), /Could not parse chain and index into numbers from path/);
+    assert.throws(
+      () => getChainAndIndexFromPath('//d/dd/d/d/dd/dd'),
+      /Could not parse chain and index into numbers from path/
+    );
+  });
+
+  it('should throw if chain or index is negative', function () {
+    assert.throws(() => getChainAndIndexFromPath('m/-1/0'), /chain and index must be non-negative/);
+    assert.throws(() => getChainAndIndexFromPath('m/0/-1'), /chain and index must be non-negative/);
+  });
+
+  it('should set the chain and index correctly', function () {
+    assert.deepStrictEqual(getChainAndIndexFromPath('m/1/2'), { chain: 1, index: 2 });
+    assert.deepStrictEqual(getChainAndIndexFromPath('m/4/3/2'), { chain: 3, index: 2 });
   });
 });


### PR DESCRIPTION
In the case that we have a PSBT, we do not want to query WP for all of the outputs to see if they are internal and external since we have that information already.

TICKET: BTC-1268

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
