### PR TITLE
chore: update explorer link to use etherscan for holesky

### DIFF
--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -486,9 +486,9 @@ class Goerli extends Testnet implements EthereumNetwork {
 class Holesky extends Testnet implements EthereumNetwork {
   name = 'Holesky';
   family = CoinFamily.ETH;
-  explorerUrl = 'https://holesky.beaconcha.in/tx/';
-  accountExplorerUrl = 'https://holesky.beaconcha.in/address/';
-  blockExplorerUrl = 'https://holesky.beaconcha.in/block/';
+  explorerUrl = 'https://holesky.etherscan.io/tx/';
+  accountExplorerUrl = 'https://holesky.etherscan.io/address/';
+  blockExplorerUrl = 'https://holesky.etherscan.io/block/';
   // https://chainlist.org/chain/17000
   chainId = 17000;
   batcherContractAddress = '0x8ae286c75a339ffabaed3a22088c52eb4f589780';


### PR DESCRIPTION
etherscan exploror has a bit more features
and usability compared to the beaconchain
exploror. So updating the exploror link
to use etherscan

TICKET: WIN-3056

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
