### PR TITLE
chore(root): fix dockerfile update script

### DIFF
--- a/scripts/update-dockerfile.ts
+++ b/scripts/update-dockerfile.ts
@@ -72,16 +72,6 @@ async function updateDockerFile(lerna) {
     .join(' && \\\n');
   const linkContent = `RUN cd /var/bitgo-express && \\\n${linkers}\n`;
 
-  // add metadata about the build to docker labels
-  let labelContent = `LABEL created="${new Date().toUTCString()}"\n`; // add created timestamp;
-  labelContent += `LABEL version=${require('../modules/express/package.json').version}\n`; // set current image version from express
-  labelContent += `LABEL git_hash=${require('child_process').execSync(`git rev-parse HEAD`).toString().trim()}\n`; // set to latest git HEAD hash
-
-  dockerContents = dockerContents
-    .replace(/#COPY_START((.|\n)*)#COPY_END/, `#COPY_START\n${copyContent}#COPY_END`)
-    .replace(/#LINK_START((.|\n)*)#LINK_END/, `#LINK_START\n${linkContent}#LINK_END`)
-    .replace(/#LABEL_START((.|\n)*)#LABEL_END/, `#LABEL_START\n${labelContent}#LABEL_END`);
-
   fs.writeFileSync('Dockerfile', dockerContents);
 }
 


### PR DESCRIPTION
Fixing dockerfile update script to dont modify the Dockerfile labels since its not doing a release of Express

WP-0000

TICKET: WP-0000

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
