### PR TITLE
feat(sdk-core): added missing request tracer propagation

### DIFF
--- a/modules/sdk-core/src/bitgo/tss/common.ts
+++ b/modules/sdk-core/src/bitgo/tss/common.ts
@@ -109,6 +109,7 @@ export async function sendSignatureShare(
  * @param mpcAlgorithm
  * @param multisigTypeVersion
  * @param signerGpgPublicKey
+ * @param reqId
  * @returns {Promise<SignatureShareRecord>} - a Signature Share
  */
 export async function sendSignatureShareV2(
@@ -120,7 +121,8 @@ export async function sendSignatureShareV2(
   mpcAlgorithm: 'eddsa' | 'ecdsa',
   signerGpgPublicKey: string,
   signerShare?: string,
-  multisigTypeVersion?: 'MPCv2' | undefined
+  multisigTypeVersion?: 'MPCv2' | undefined,
+  reqId?: IRequestTracer
 ): Promise<TxRequest> {
   const addendum = requestType === RequestType.tx ? '/transactions/0' : '/messages/0';
   const urlPath = '/wallet/' + walletId + '/txrequests/' + txRequestId + addendum + '/sign';
@@ -136,6 +138,8 @@ export async function sendSignatureShareV2(
     signerShare,
     signerGpgPublicKey,
   };
+  const reqTracer = reqId || new RequestTracer();
+  bitgo.setRequestTracer(reqTracer);
   return bitgo.post(bitgo.url(urlPath, 2)).send(requestBody).result();
 }
 
@@ -146,16 +150,20 @@ export async function sendSignatureShareV2(
  * @param {String} walletId - the wallet id  *
  * @param {String} txRequestId - the txRequest Id
  * @param requestType - The type of request being submitted (either tx or message for signing)
+ * @param {IRequestTracer} reqId - request tracer request id
  * @returns {Promise<SignatureShareRecord>} - a Signature Share
  */
 export async function sendTxRequest(
   bitgo: BitGoBase,
   walletId: string,
   txRequestId: string,
-  requestType: RequestType
+  requestType: RequestType,
+  reqId?: IRequestTracer
 ): Promise<TxRequest> {
   const addendum = requestType === RequestType.tx ? '/transactions/0' : '/messages/0';
   const urlPath = '/wallet/' + walletId + '/txrequests/' + txRequestId + addendum + '/send';
+  const reqTracer = reqId || new RequestTracer();
+  bitgo.setRequestTracer(reqTracer);
   return bitgo.post(bitgo.url(urlPath, 2)).send().result();
 }
 

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
@@ -878,7 +878,7 @@ export class EcdsaUtils extends BaseEcdsaUtils {
 
     const txRequest: TxRequest =
       typeof params.txRequest === 'string'
-        ? await getTxRequest(this.bitgo, this.wallet.id(), params.txRequest)
+        ? await getTxRequest(this.bitgo, this.wallet.id(), params.txRequest, params.reqId)
         : params.txRequest;
 
     let signablePayload = new Buffer('');
@@ -899,7 +899,8 @@ export class EcdsaUtils extends BaseEcdsaUtils {
       txRequest.txRequestId,
       requestType,
       paillierModulus.userPaillierModulus,
-      0
+      0,
+      params.reqId
     );
 
     const step1Return = await this.createTssEcdsaStep1SigningMaterial({
@@ -920,7 +921,8 @@ export class EcdsaUtils extends BaseEcdsaUtils {
       step1Return.vssProof,
       step1Return.privateShareProof,
       step1Return.publicShare,
-      step1Return.userPublicGpgKey
+      step1Return.userPublicGpgKey,
+      params.reqId
     )) as Omit<AShare, 'ntilde' | 'h1' | 'h2'>; // WP/HSM does not return the initial challenge
 
     const step2Return = await this.createTssEcdsaStep2SigningMaterial({
@@ -936,7 +938,13 @@ export class EcdsaUtils extends BaseEcdsaUtils {
       txRequest.txRequestId,
       requestType,
       SendShareType.MUShare,
-      step2Return.muDShare
+      step2Return.muDShare,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      params.reqId
     )) as DShare;
 
     // If only the getHashFunction() is defined for the coin use it otherwise
@@ -962,9 +970,15 @@ export class EcdsaUtils extends BaseEcdsaUtils {
       txRequest.txRequestId,
       requestType,
       SendShareType.SShare,
-      userSShare
+      userSShare,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      params.reqId
     );
-    return await getTxRequest(this.bitgo, this.wallet.id(), txRequest.txRequestId);
+    return await getTxRequest(this.bitgo, this.wallet.id(), txRequest.txRequestId, params.reqId);
   }
 
   /**

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
@@ -522,14 +522,14 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
     const userKeyShare = Buffer.from(params.prv, 'base64');
     const txRequest: TxRequest =
       typeof params.txRequest === 'string'
-        ? await getTxRequest(this.bitgo, this.wallet.id(), params.txRequest)
+        ? await getTxRequest(this.bitgo, this.wallet.id(), params.txRequest, params.reqId)
         : params.txRequest;
 
     let derivationPath: string;
     let txToSign: string;
     const [userGpgKey, bitgoGpgPubKey] = await Promise.all([
       generateGPGKeyPair('secp256k1'),
-      this.getBitgoGpgPubkeyBasedOnFeatureFlags(txRequest.enterpriseId, true).then(
+      this.getBitgoGpgPubkeyBasedOnFeatureFlags(txRequest.enterpriseId, true, params.reqId).then(
         (pubKey) => pubKey ?? this.bitgoMPCv2PublicGpgKey
       ),
     ]);
@@ -570,7 +570,8 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
       this.baseCoin.getMPCAlgorithm(),
       userGpgKey.publicKey,
       undefined,
-      this.wallet.multisigTypeVersion()
+      this.wallet.multisigTypeVersion(),
+      params.reqId
     );
     assert(latestTxRequest.transactions);
 
@@ -613,7 +614,8 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
       this.baseCoin.getMPCAlgorithm(),
       userGpgKey.publicKey,
       undefined,
-      this.wallet.multisigTypeVersion()
+      this.wallet.multisigTypeVersion(),
+      params.reqId
     );
     assert(latestTxRequest.transactions);
 
@@ -656,10 +658,11 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
       this.baseCoin.getMPCAlgorithm(),
       userGpgKey.publicKey,
       undefined,
-      this.wallet.multisigTypeVersion()
+      this.wallet.multisigTypeVersion(),
+      params.reqId
     );
 
-    return sendTxRequest(this.bitgo, txRequest.walletId, txRequest.txRequestId, RequestType.tx);
+    return sendTxRequest(this.bitgo, txRequest.walletId, txRequest.txRequestId, RequestType.tx, params.reqId);
   }
 
   // #endregion

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
@@ -556,7 +556,7 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
     const { txRequest, prv } = params;
 
     if (typeof txRequest === 'string') {
-      txRequestResolved = await getTxRequest(this.bitgo, this.wallet.id(), txRequest);
+      txRequestResolved = await getTxRequest(this.bitgo, this.wallet.id(), txRequest, params.reqId);
       txRequestId = txRequestResolved.txRequestId;
     } else {
       txRequestResolved = txRequest;


### PR DESCRIPTION
TICKET: WP-2086

## Description

Previous tickets have propagated the request tracer between build and send api's, hwoever some places are still missing the `setRequestTracer` call and need the request tracer propagated. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Mostly just adding optional parameters. End to end testing will reveal if there are any other missing propagations

