### PR TITLE
fix(sdk-coin-xlm): fix xlm root key tx signing

### DIFF
--- a/modules/sdk-coin-xlm/src/xlm.ts
+++ b/modules/sdk-coin-xlm/src/xlm.ts
@@ -774,7 +774,8 @@ export class Xlm extends BaseCoin {
     let keyPair: stellar.Keypair;
     if (!prv.startsWith('S')) {
       // Encode the raw root hex prv into a stellar S-prefixed private key
-      keyPair = stellar.Keypair.fromSecret(Utils.encodePrivateKey(Buffer.from(prv, 'hex')));
+      // Need to slice the prv because it may have the pub appended to it as well
+      keyPair = stellar.Keypair.fromSecret(Utils.encodePrivateKey(Buffer.from(prv.slice(0, 64), 'hex')));
     } else {
       keyPair = stellar.Keypair.fromSecret(prv);
     }
@@ -838,7 +839,7 @@ export class Xlm extends BaseCoin {
     if (key.prv.startsWith('S')) {
       keypair = stellar.Keypair.fromSecret(key.prv);
     } else {
-      keypair = stellar.Keypair.fromSecret(Utils.encodePrivateKey(Buffer.from(key.prv, 'hex')));
+      keypair = stellar.Keypair.fromSecret(Utils.encodePrivateKey(Buffer.from(key.prv.slice(0, 64), 'hex')));
     }
 
     return keypair.sign(message);

--- a/modules/sdk-coin-xlm/test/unit/xlm.ts
+++ b/modules/sdk-coin-xlm/test/unit/xlm.ts
@@ -413,6 +413,17 @@ describe('XLM:', function () {
       rootKeyHalfSignedTransaction.halfSigned.txBase64.should.equal(signedTxBase64);
     });
 
+    it('should sign a transaction with generated root key pair', async function () {
+      const seed = Buffer.from(rootKeychain.prv, 'hex');
+      const kp = basecoin.generateRootKeyPair(seed);
+      kp.prv.length.should.equal(128);
+      const halfSignedTx = await wallet.signTransaction({
+        txPrebuild: prebuild,
+        prv: kp.prv,
+      });
+      halfSignedTx.halfSigned.txBase64.should.equal(signedTxBase64);
+    });
+
     it('should verify the user signature on a tx', function () {
       const userPub = userKeychain.pub;
       const tx = new stellar.Transaction(halfSignedTransaction.halfSigned.txBase64, stellar.Networks.TESTNET);


### PR DESCRIPTION
TICKET: WP-1418

Root key tx signing was failing with this error:
`{"error":"secretKey length is invalid"}`

These changes should fix this issue

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
