### PR TITLE
feat(root) implement external signer for mpcv2

### DIFF
--- a/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsa.ts
+++ b/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsa.ts
@@ -943,7 +943,6 @@ describe('TSS Ecdsa Utils:', async function () {
       const step1SigningMaterial = await tssUtils.createOfflineKShare({
         tssParams: {
           txRequest,
-          prv: '',
           reqId: reqId,
         },
         challenges: {
@@ -975,7 +974,6 @@ describe('TSS Ecdsa Utils:', async function () {
         .createOfflineKShare({
           tssParams: {
             txRequest: txRequest.txRequestId,
-            prv: '',
             reqId: reqId,
           },
           challenges: {
@@ -1031,7 +1029,6 @@ describe('TSS Ecdsa Utils:', async function () {
       const step3SigningMaterial = await tssUtils.createOfflineSShare({
         tssParams: {
           txRequest: txRequest,
-          prv: '',
           reqId: reqId,
         },
         dShareFromBitgo: dShare,
@@ -1051,7 +1048,6 @@ describe('TSS Ecdsa Utils:', async function () {
         .createOfflineSShare({
           tssParams: {
             txRequest: txRequest.txRequestId,
-            prv: '',
             reqId: reqId,
           },
           dShareFromBitgo: dShare,

--- a/modules/express/package.json
+++ b/modules/express/package.json
@@ -51,6 +51,7 @@
     "superagent": "^9.0.1"
   },
   "devDependencies": {
+    "@bitgo/public-types": "2.29.0",
     "@bitgo/sdk-lib-mpc": "^9.9.0",
     "@bitgo/sdk-test": "^8.0.30",
     "@types/argparse": "^1.0.36",

--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -4,6 +4,7 @@
 import {
   EddsaUtils,
   EcdsaUtils,
+  EcdsaMPCv2Utils,
   CustomGShareGeneratingFunction,
   CustomRShareGeneratingFunction,
   UnsupportedCoinError,
@@ -24,6 +25,10 @@ import {
   CreateNetworkConnectionParams,
   GetNetworkPartnersResponse,
   encryptRsaWithAesGcm,
+  Wallet,
+  CustomMPCv2Round1GeneratingFunction,
+  CustomMPCv2Round2GeneratingFunction,
+  CustomMPCv2Round3GeneratingFunction,
 } from '@bitgo/sdk-core';
 import { BitGo, BitGoOptions, Coin, CustomSigningFunction, SignedTransaction, SignedTransactionRequest } from 'bitgo';
 import * as bodyParser from 'body-parser';
@@ -440,20 +445,42 @@ export async function handleV2GenerateShareTSS(req: express.Request): Promise<an
           );
       }
     } else if (coin.getMPCAlgorithm() === MPCType.ECDSA) {
-      const ecdsaUtils = new EcdsaUtils(bitgo, coin);
-      switch (req.params.sharetype) {
-        case ShareType.PaillierModulus:
-          return ecdsaUtils.getOfflineSignerPaillierModulus(req.body);
-        case ShareType.K:
-          return await ecdsaUtils.createOfflineKShare(req.body);
-        case ShareType.MuDelta:
-          return await ecdsaUtils.createOfflineMuDeltaShare(req.body);
-        case ShareType.S:
-          return await ecdsaUtils.createOfflineSShare(req.body);
-        default:
-          throw new Error(
-            `Share type ${req.params.sharetype} not supported, only PaillierModulus, K, MUDelta, and S share generation is supported.`
-          );
+      const isMPCv2 = [
+        ShareType.MPCv2Round1.toString(),
+        ShareType.MPCv2Round2.toString(),
+        ShareType.MPCv2Round3.toString(),
+      ].includes(req.params.sharetype);
+
+      if (isMPCv2) {
+        const ecdsaMPCv2Utils = new EcdsaMPCv2Utils(bitgo, coin);
+        switch (req.params.sharetype) {
+          case ShareType.MPCv2Round1:
+            return await ecdsaMPCv2Utils.createOfflineRound1Share(req.body);
+          case ShareType.MPCv2Round2:
+            return await ecdsaMPCv2Utils.createOfflineRound2Share(req.body);
+          case ShareType.MPCv2Round3:
+            return await ecdsaMPCv2Utils.createOfflineRound3Share(req.body);
+          default:
+            throw new Error(
+              `Share type ${req.params.sharetype} not supported for MPCv2, only MPCv2Round1, MPCv2Round2 and MPCv2Round3 is supported.`
+            );
+        }
+      } else {
+        const ecdsaUtils = new EcdsaUtils(bitgo, coin);
+        switch (req.params.sharetype) {
+          case ShareType.PaillierModulus:
+            return ecdsaUtils.getOfflineSignerPaillierModulus(req.body);
+          case ShareType.K:
+            return await ecdsaUtils.createOfflineKShare(req.body);
+          case ShareType.MuDelta:
+            return await ecdsaUtils.createOfflineMuDeltaShare(req.body);
+          case ShareType.S:
+            return await ecdsaUtils.createOfflineSShare(req.body);
+          default:
+            throw new Error(
+              `Share type ${req.params.sharetype} not supported, only PaillierModulus, K, MUDelta, and S share generation is supported.`
+            );
+        }
       }
     } else {
       throw new Error(`MPC Algorithm ${coin.getMPCAlgorithm()} is not supported.`);
@@ -469,7 +496,7 @@ export async function handleV2SignTSSWalletTx(req: express.Request) {
   const coin = bitgo.coin(req.params.coin);
   const wallet = await coin.wallets().get({ id: req.params.id });
   try {
-    return await wallet.signTransaction(createTSSSendParams(req));
+    return await wallet.signTransaction(createTSSSendParams(req, wallet));
   } catch (error) {
     console.error('error while signing wallet transaction ', error);
     throw error;
@@ -755,7 +782,7 @@ export async function handleV2ConsolidateAccount(req: express.Request) {
   let result: any;
   try {
     if (coin.supportsTss()) {
-      result = await wallet.sendAccountConsolidations(createTSSSendParams(req));
+      result = await wallet.sendAccountConsolidations(createTSSSendParams(req, wallet));
     } else {
       result = await wallet.sendAccountConsolidations(createSendParams(req));
     }
@@ -828,7 +855,7 @@ function createSendParams(req: express.Request) {
   }
 }
 
-function createTSSSendParams(req: express.Request) {
+function createTSSSendParams(req: express.Request, wallet?: Wallet) {
   if (req.config?.externalSignerUrl !== undefined) {
     const coin = req.bitgo.coin(req.params.coin);
     if (coin.getMPCAlgorithm() === MPCType.EDDSA) {
@@ -842,19 +869,37 @@ function createTSSSendParams(req: express.Request) {
         customGShareGeneratingFunction: createCustomGShareGenerator(req.config.externalSignerUrl, req.params.coin),
       };
     } else if (coin.getMPCAlgorithm() === MPCType.ECDSA) {
-      return {
-        ...req.body,
-        customPaillierModulusGeneratingFunction: createCustomPaillierModulusGetter(
-          req.config.externalSignerUrl,
-          req.params.coin
-        ),
-        customKShareGeneratingFunction: createCustomKShareGenerator(req.config.externalSignerUrl, req.params.coin),
-        customMuDeltaShareGeneratingFunction: createCustomMuDeltaShareGenerator(
-          req.config.externalSignerUrl,
-          req.params.coin
-        ),
-        customSShareGeneratingFunction: createCustomSShareGenerator(req.config.externalSignerUrl, req.params.coin),
-      };
+      if (wallet?._wallet.multisigTypeVersion === 'MPCv2') {
+        return {
+          ...req.body,
+          customMPCv2Round1GenerationFunction: createCustomMPCv2Round1Generator(
+            req.config.externalSignerUrl,
+            req.params.coin
+          ),
+          customMPCv2Round2GenerationFunction: createCustomMPCv2Round2Generator(
+            req.config.externalSignerUrl,
+            req.params.coin
+          ),
+          customMPCv2Round3GenerationFunction: createCustomMPCv2Round3Generator(
+            req.config.externalSignerUrl,
+            req.params.coin
+          ),
+        };
+      } else {
+        return {
+          ...req.body,
+          customPaillierModulusGeneratingFunction: createCustomPaillierModulusGetter(
+            req.config.externalSignerUrl,
+            req.params.coin
+          ),
+          customKShareGeneratingFunction: createCustomKShareGenerator(req.config.externalSignerUrl, req.params.coin),
+          customMuDeltaShareGeneratingFunction: createCustomMuDeltaShareGenerator(
+            req.config.externalSignerUrl,
+            req.params.coin
+          ),
+          customSShareGeneratingFunction: createCustomSShareGenerator(req.config.externalSignerUrl, req.params.coin),
+        };
+      }
     } else {
       throw new Error(`MPC Algorithm ${coin.getMPCAlgorithm()} is not supported.`);
     }
@@ -900,7 +945,7 @@ async function handleV2SendMany(req: express.Request) {
   let result;
   try {
     if (wallet._wallet.multisigType === 'tss') {
-      result = await wallet.sendMany(createTSSSendParams(req));
+      result = await wallet.sendMany(createTSSSendParams(req, wallet));
     } else {
       result = await wallet.sendMany(createSendParams(req));
     }
@@ -1339,6 +1384,51 @@ export function createCustomGShareGenerator(externalSignerUrl: string, coin: str
       }
     );
     return signedTx;
+  };
+}
+
+export function createCustomMPCv2Round1Generator(
+  externalSignerUrl: string,
+  coin: string
+): CustomMPCv2Round1GeneratingFunction {
+  return async function (params) {
+    const { body: result } = await retryPromise(
+      () => superagent.post(`${externalSignerUrl}/api/v2/${coin}/tssshare/MPCv2Round1`).type('json').send(params),
+      (err, tryCount) => {
+        debug(`failed to connect to external signer (attempt ${tryCount}, error: ${err.message})`);
+      }
+    );
+    return result;
+  };
+}
+
+export function createCustomMPCv2Round2Generator(
+  externalSignerUrl: string,
+  coin: string
+): CustomMPCv2Round2GeneratingFunction {
+  return async function (params) {
+    const { body: result } = await retryPromise(
+      () => superagent.post(`${externalSignerUrl}/api/v2/${coin}/tssshare/MPCv2Round2`).type('json').send(params),
+      (err, tryCount) => {
+        debug(`failed to connect to external signer (attempt ${tryCount}, error: ${err.message})`);
+      }
+    );
+    return result;
+  };
+}
+
+export function createCustomMPCv2Round3Generator(
+  externalSignerUrl: string,
+  coin: string
+): CustomMPCv2Round3GeneratingFunction {
+  return async function (params) {
+    const { body: result } = await retryPromise(
+      () => superagent.post(`${externalSignerUrl}/api/v2/${coin}/tssshare/MPCv2Round3`).type('json').send(params),
+      (err, tryCount) => {
+        debug(`failed to connect to external signer (attempt ${tryCount}, error: ${err.message})`);
+      }
+    );
+    return result;
   };
 }
 

--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -26,9 +26,9 @@ import {
   GetNetworkPartnersResponse,
   encryptRsaWithAesGcm,
   Wallet,
-  CustomMPCv2Round1GeneratingFunction,
-  CustomMPCv2Round2GeneratingFunction,
-  CustomMPCv2Round3GeneratingFunction,
+  CustomMPCv2SigningRound1GeneratingFunction,
+  CustomMPCv2SigningRound2GeneratingFunction,
+  CustomMPCv2SigningRound3GeneratingFunction,
 } from '@bitgo/sdk-core';
 import { BitGo, BitGoOptions, Coin, CustomSigningFunction, SignedTransaction, SignedTransactionRequest } from 'bitgo';
 import * as bodyParser from 'body-parser';
@@ -855,7 +855,7 @@ function createSendParams(req: express.Request) {
   }
 }
 
-function createTSSSendParams(req: express.Request, wallet?: Wallet) {
+function createTSSSendParams(req: express.Request, wallet: Wallet) {
   if (req.config?.externalSignerUrl !== undefined) {
     const coin = req.bitgo.coin(req.params.coin);
     if (coin.getMPCAlgorithm() === MPCType.EDDSA) {
@@ -869,18 +869,18 @@ function createTSSSendParams(req: express.Request, wallet?: Wallet) {
         customGShareGeneratingFunction: createCustomGShareGenerator(req.config.externalSignerUrl, req.params.coin),
       };
     } else if (coin.getMPCAlgorithm() === MPCType.ECDSA) {
-      if (wallet?._wallet.multisigTypeVersion === 'MPCv2') {
+      if (wallet._wallet.multisigTypeVersion === 'MPCv2') {
         return {
           ...req.body,
-          customMPCv2Round1GenerationFunction: createCustomMPCv2Round1Generator(
+          customMPCv2SigningRound1GenerationFunction: createCustomMPCv2SigningRound1Generator(
             req.config.externalSignerUrl,
             req.params.coin
           ),
-          customMPCv2Round2GenerationFunction: createCustomMPCv2Round2Generator(
+          customMPCv2SigningRound2GenerationFunction: createCustomMPCv2SigningRound2Generator(
             req.config.externalSignerUrl,
             req.params.coin
           ),
-          customMPCv2Round3GenerationFunction: createCustomMPCv2Round3Generator(
+          customMPCv2SigningRound3GenerationFunction: createCustomMPCv2SigningRound3Generator(
             req.config.externalSignerUrl,
             req.params.coin
           ),
@@ -1387,10 +1387,10 @@ export function createCustomGShareGenerator(externalSignerUrl: string, coin: str
   };
 }
 
-export function createCustomMPCv2Round1Generator(
+export function createCustomMPCv2SigningRound1Generator(
   externalSignerUrl: string,
   coin: string
-): CustomMPCv2Round1GeneratingFunction {
+): CustomMPCv2SigningRound1GeneratingFunction {
   return async function (params) {
     const { body: result } = await retryPromise(
       () => superagent.post(`${externalSignerUrl}/api/v2/${coin}/tssshare/MPCv2Round1`).type('json').send(params),
@@ -1402,10 +1402,10 @@ export function createCustomMPCv2Round1Generator(
   };
 }
 
-export function createCustomMPCv2Round2Generator(
+export function createCustomMPCv2SigningRound2Generator(
   externalSignerUrl: string,
   coin: string
-): CustomMPCv2Round2GeneratingFunction {
+): CustomMPCv2SigningRound2GeneratingFunction {
   return async function (params) {
     const { body: result } = await retryPromise(
       () => superagent.post(`${externalSignerUrl}/api/v2/${coin}/tssshare/MPCv2Round2`).type('json').send(params),
@@ -1417,10 +1417,10 @@ export function createCustomMPCv2Round2Generator(
   };
 }
 
-export function createCustomMPCv2Round3Generator(
+export function createCustomMPCv2SigningRound3Generator(
   externalSignerUrl: string,
   coin: string
-): CustomMPCv2Round3GeneratingFunction {
+): CustomMPCv2SigningRound3GeneratingFunction {
   return async function (params) {
     const { body: result } = await retryPromise(
       () => superagent.post(`${externalSignerUrl}/api/v2/${coin}/tssshare/MPCv2Round3`).type('json').send(params),

--- a/modules/express/test/unit/clientRoutes/mocks/gpgKeys.ts
+++ b/modules/express/test/unit/clientRoutes/mocks/gpgKeys.ts
@@ -1,0 +1,34 @@
+export const bitgoGpgKey = {
+  private:
+    '-----BEGIN PGP PRIVATE KEY BLOCK-----\n' +
+    '\n' +
+    'xXQEZo2rshMFK4EEAAoCAwQC6HQa7PXiX2nnpZr/asCcEbgCOcjsR8gcSI8v\n' +
+    'vMADk59KsFweg+kIzCR3UqfMe2uG6JHwOYpvDREHp/hqtA+hAAD/XgjiTu4D\n' +
+    '0d9YzSx3ZP8lUAcruvJbyMIIlr26QIeHq5kRQM0FYml0Z2/CjAQQEwgAPgWC\n' +
+    'Zo2rsgQLCQcICZA8EZGJCCwPOAMVCAoEFgACAQIZAQKbAwIeARYhBLSGUeOq\n' +
+    'bM5ym4aSnjwRkYkILA84AABXoQD+KkO5kWGw8GgWN142t+pGULPLzGo6353r\n' +
+    'H8FwgKxe9ikBAKEjJI17aVlozG0RzFVxctBLLVqjYO5tBZQhoQbHHkGdx3gE\n' +
+    'Zo2rshIFK4EEAAoCAwTBwmMa+htUmjUoqlKTuQaoWcY0Det+ee/6fV9+vnis\n' +
+    'EyphRUFXnA0K0LyGpSnNlqKisSoArwUkZTiWwTbMWjTdAwEIBwABAJmAlxnB\n' +
+    'IZ5bw88Duvw0yaRRcgXt5tDP0z23l6cvJWgKEJbCeAQYEwgAKgWCZo2rsgmQ\n' +
+    'PBGRiQgsDzgCmwwWIQS0hlHjqmzOcpuGkp48EZGJCCwPOAAA3/4BAIozuxF1\n' +
+    'JEoSQXe8YFIFqowwCiVwr2K6NqqRn+mGM1NjAQCYWIsZq+4+UCBIKScVknTG\n' +
+    'uu2Utd5ZMyNYZTWCxLk9+g==\n' +
+    '=iXOB\n' +
+    '-----END PGP PRIVATE KEY BLOCK-----\n',
+  public:
+    '-----BEGIN PGP PUBLIC KEY BLOCK-----\n' +
+    '\n' +
+    'xk8EZo2rshMFK4EEAAoCAwQC6HQa7PXiX2nnpZr/asCcEbgCOcjsR8gcSI8v\n' +
+    'vMADk59KsFweg+kIzCR3UqfMe2uG6JHwOYpvDREHp/hqtA+hzQViaXRnb8KM\n' +
+    'BBATCAA+BYJmjauyBAsJBwgJkDwRkYkILA84AxUICgQWAAIBAhkBApsDAh4B\n' +
+    'FiEEtIZR46psznKbhpKePBGRiQgsDzgAAFehAP4qQ7mRYbDwaBY3Xja36kZQ\n' +
+    's8vMajrfnesfwXCArF72KQEAoSMkjXtpWWjMbRHMVXFy0EstWqNg7m0FlCGh\n' +
+    'BsceQZ3OUwRmjauyEgUrgQQACgIDBMHCYxr6G1SaNSiqUpO5BqhZxjQN6355\n' +
+    '7/p9X36+eKwTKmFFQVecDQrQvIalKc2WoqKxKgCvBSRlOJbBNsxaNN0DAQgH\n' +
+    'wngEGBMIACoFgmaNq7IJkDwRkYkILA84ApsMFiEEtIZR46psznKbhpKePBGR\n' +
+    'iQgsDzgAAN/+AQCKM7sRdSRKEkF3vGBSBaqMMAolcK9iujaqkZ/phjNTYwEA\n' +
+    'mFiLGavuPlAgSCknFZJ0xrrtlLXeWTMjWGU1gsS5Pfo=\n' +
+    '=7uRX\n' +
+    '-----END PGP PUBLIC KEY BLOCK-----\n',
+};

--- a/modules/sdk-api/src/bitgoAPI.ts
+++ b/modules/sdk-api/src/bitgoAPI.ts
@@ -653,11 +653,11 @@ export class BitGoAPI implements BitGoBase {
    * Utility function to encrypt locally.
    */
   encrypt(params: EncryptOptions): string {
-    common.validateParams(params, ['input', 'password'], []);
+    common.validateParams(params, ['input', 'password'], ['adata']);
     if (!params.password) {
       throw new Error(`cannot encrypt without password`);
     }
-    return encrypt(params.password, params.input);
+    return encrypt(params.password, params.input, { adata: params.adata });
   }
 
   /**

--- a/modules/sdk-core/src/api/types.ts
+++ b/modules/sdk-core/src/api/types.ts
@@ -12,6 +12,7 @@ export interface DecryptOptions {
 export interface EncryptOptions {
   input: string;
   password?: string;
+  adata?: string;
 }
 
 export interface GetSharingKeyOptions {

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
@@ -33,6 +33,8 @@ import {
   CustomKShareGeneratingFunction,
   CustomMuDeltaShareGeneratingFunction,
   CustomSShareGeneratingFunction,
+  CustomMPCv2Round1GeneratingFunction,
+  CustomMPCv2Round3GeneratingFunction,
 } from './baseTypes';
 import { GShare, SignShare } from '../../../account-lib/mpc/tss';
 import { RequestTracer } from '../util';
@@ -150,6 +152,25 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
     externalSignerKShareGenerator: CustomKShareGeneratingFunction,
     externalSignerMuDeltaShareGenerator: CustomMuDeltaShareGeneratingFunction,
     externalSignerSShareGenerator: CustomSShareGeneratingFunction
+  ): Promise<TxRequest> {
+    throw new Error('Method not implemented.');
+  }
+
+  /**
+   * Signs a transaction using TSS MPCv2 for ECDSA and through utilization of custom share generators
+   *
+   * @param {params: TSSParams | TSSParamsForMessage} params - params object that represents parameters to sign a transaction or a message.
+   * @param {RequestType} requestType - the type of the request to sign (transaction or message).
+   * @param {CustomMPCv2Round1GeneratingFunction} externalSignerMPCv2Round1Generator add description.
+   * @param {CustomMPCv2Round2GeneratingFunction} externalSignerMPCv2Round3Generator add description.
+   * @param {CustomMPCv2Round3GeneratingFunction} externalSignerMPCv2Round3Generator add description.
+   */
+  signEcdsaMPCv2TssUsingExternalSigner(
+    params: TSSParams | TSSParamsForMessage,
+    requestType: RequestType,
+    externalSignerMPCv2Round1Generator: CustomMPCv2Round1GeneratingFunction,
+    externalSignerMPCv2Round2Generator: CustomMPCv2Round3GeneratingFunction,
+    externalSignerMPCv2Round3Generator: CustomMPCv2Round3GeneratingFunction
   ): Promise<TxRequest> {
     throw new Error('Method not implemented.');
   }

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
@@ -33,8 +33,10 @@ import {
   CustomKShareGeneratingFunction,
   CustomMuDeltaShareGeneratingFunction,
   CustomSShareGeneratingFunction,
-  CustomMPCv2Round1GeneratingFunction,
-  CustomMPCv2Round3GeneratingFunction,
+  CustomMPCv2SigningRound1GeneratingFunction,
+  CustomMPCv2SigningRound2GeneratingFunction,
+  CustomMPCv2SigningRound3GeneratingFunction,
+  TSSParamsWithPrv,
 } from './baseTypes';
 import { GShare, SignShare } from '../../../account-lib/mpc/tss';
 import { RequestTracer } from '../util';
@@ -110,11 +112,11 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
     throw new Error('Method not implemented.');
   }
 
-  signTxRequest(params: TSSParams): Promise<TxRequest> {
+  signTxRequest(params: TSSParamsWithPrv): Promise<TxRequest> {
     throw new Error('Method not implemented.');
   }
 
-  signTxRequestForMessage(params: TSSParams): Promise<TxRequest> {
+  signTxRequestForMessage(params: TSSParamsForMessage): Promise<TxRequest> {
     throw new Error('Method not implemented.');
   }
 
@@ -159,18 +161,19 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
   /**
    * Signs a transaction using TSS MPCv2 for ECDSA and through utilization of custom share generators
    *
-   * @param {params: TSSParams | TSSParamsForMessage} params - params object that represents parameters to sign a transaction or a message.
+   * @param {TSSParams | TSSParamsForMessage} params - params object that represents parameters to sign a transaction or a message.
+   * @param {CustomMPCv2SigningRound1GeneratingFunction} externalSignerMPCv2SigningRound1Generator - a function that creates MPCv2 Round 1 shares in the ECDSA TSS MPCv2 flow.
+   * @param {CustomMPCv2SigningRound2GeneratingFunction} externalSignerMPCv2SigningRound2Generator - a function that creates MPCv2 Round 2 shares in the ECDSA TSS MPCv2 flow.
+   * @param {CustomMPCv2SigningRound3GeneratingFunction} externalSignerMPCv2SigningRound3Generator - a function that creates MPCv2 Round 3 shares in the ECDSA TSS MPCv2 flow.
    * @param {RequestType} requestType - the type of the request to sign (transaction or message).
-   * @param {CustomMPCv2Round1GeneratingFunction} externalSignerMPCv2Round1Generator add description.
-   * @param {CustomMPCv2Round2GeneratingFunction} externalSignerMPCv2Round3Generator add description.
-   * @param {CustomMPCv2Round3GeneratingFunction} externalSignerMPCv2Round3Generator add description.
+   * @returns {Promise<TxRequest>} - a signed tx request
    */
   signEcdsaMPCv2TssUsingExternalSigner(
     params: TSSParams | TSSParamsForMessage,
-    requestType: RequestType,
-    externalSignerMPCv2Round1Generator: CustomMPCv2Round1GeneratingFunction,
-    externalSignerMPCv2Round2Generator: CustomMPCv2Round3GeneratingFunction,
-    externalSignerMPCv2Round3Generator: CustomMPCv2Round3GeneratingFunction
+    externalSignerMPCv2SigningRound1Generator: CustomMPCv2SigningRound1GeneratingFunction,
+    externalSignerMPCv2SigningRound2Generator: CustomMPCv2SigningRound2GeneratingFunction,
+    externalSignerMPCv2SigningRound3Generator: CustomMPCv2SigningRound3GeneratingFunction,
+    requestType?: RequestType
   ): Promise<TxRequest> {
     throw new Error('Method not implemented.');
   }

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -111,16 +111,36 @@ export interface CustomGShareGeneratingFunction {
   }): Promise<GShare>;
 }
 
-export interface CustomMPCv2Round1GeneratingFunction {
-  (params: { txRequest: TxRequest }): Promise<unknown>;
+export interface CustomMPCv2SigningRound1GeneratingFunction {
+  (params: { txRequest: TxRequest }): Promise<{
+    signatureShareRound1: SignatureShareRecord;
+    encryptedRound1Session: string;
+    userGpgPubKey: string;
+    encryptedUserGpgPrvKey: string;
+  }>;
 }
 
-export interface CustomMPCv2Round2GeneratingFunction {
-  (params: { txRequest: TxRequest }): Promise<unknown>;
+export interface CustomMPCv2SigningRound2GeneratingFunction {
+  (params: {
+    txRequest: TxRequest;
+    bitgoPublicGpgKey: string;
+    encryptedUserGpgPrvKey: string;
+    encryptedRound1Session: string;
+  }): Promise<{
+    signatureShareRound2: SignatureShareRecord;
+    encryptedRound2Session: string;
+  }>;
 }
 
-export interface CustomMPCv2Round3GeneratingFunction {
-  (params: { txRequest: TxRequest }): Promise<unknown>;
+export interface CustomMPCv2SigningRound3GeneratingFunction {
+  (params: {
+    txRequest: TxRequest;
+    bitgoPublicGpgKey: string;
+    encryptedUserGpgPrvKey: string;
+    encryptedRound2Session: string;
+  }): Promise<{
+    signatureShareRound3: SignatureShareRecord;
+  }>;
 }
 
 export enum TokenType {
@@ -365,9 +385,16 @@ export interface EncryptedSignerShareRecord extends ShareBaseRecord {
   type: EncryptedSignerShareType;
 }
 
+export type TSSParamsWithPrv = TSSParams & {
+  prv: string;
+};
+
+export type TSSParamsForMessageWithPrv = TSSParamsForMessage & {
+  prv: string;
+};
+
 export type TSSParams = {
   txRequest: string | TxRequest; // can be either a string or TxRequest
-  prv: string;
   reqId: IRequestTracer;
   apiVersion?: ApiVersion;
 };

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -43,6 +43,9 @@ export enum ShareType {
   K = 'K',
   MuDelta = 'MuDelta',
   PaillierModulus = 'PaillierModulus',
+  MPCv2Round1 = 'MPCv2Round1',
+  MPCv2Round2 = 'MPCv2Round2',
+  MPCv2Round3 = 'MPCv2Round3',
 }
 
 export enum MPCType {
@@ -107,6 +110,19 @@ export interface CustomGShareGeneratingFunction {
     bitgoToUserCommitment: CommitmentShareRecord;
   }): Promise<GShare>;
 }
+
+export interface CustomMPCv2Round1GeneratingFunction {
+  (params: { txRequest: TxRequest }): Promise<unknown>;
+}
+
+export interface CustomMPCv2Round2GeneratingFunction {
+  (params: { txRequest: TxRequest }): Promise<unknown>;
+}
+
+export interface CustomMPCv2Round3GeneratingFunction {
+  (params: { txRequest: TxRequest }): Promise<unknown>;
+}
+
 export enum TokenType {
   ERC721 = 'ERC721',
   ERC1155 = 'ERC1155',

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
@@ -28,6 +28,8 @@ import {
   RequestType,
   TSSParams,
   TSSParamsForMessage,
+  TSSParamsForMessageWithPrv,
+  TSSParamsWithPrv,
   TxRequest,
 } from '../baseTypes';
 import { getTxRequest } from '../../../tss';
@@ -861,7 +863,10 @@ export class EcdsaUtils extends BaseEcdsaUtils {
    * @param { string} params.reqId - request id
    * @returns {Promise<TxRequest>}
    */
-  private async signRequestBase(params: TSSParams | TSSParamsForMessage, requestType: RequestType): Promise<TxRequest> {
+  private async signRequestBase(
+    params: TSSParamsWithPrv | TSSParamsForMessageWithPrv,
+    requestType: RequestType
+  ): Promise<TxRequest> {
     const pendingEcdsaTssInitialization = this.wallet.coinSpecific()?.pendingEcdsaTssInitialization;
     if (pendingEcdsaTssInitialization) {
       throw new Error(
@@ -988,7 +993,7 @@ export class EcdsaUtils extends BaseEcdsaUtils {
    * @param {string} params.reqId - request id
    * @returns {Promise<TxRequest>} fully signed TxRequest object
    */
-  async signTxRequest(params: TSSParams): Promise<TxRequest> {
+  async signTxRequest(params: TSSParamsWithPrv): Promise<TxRequest> {
     this.bitgo.setRequestTracer(params.reqId);
     return this.signRequestBase(params, RequestType.tx);
   }
@@ -1000,7 +1005,7 @@ export class EcdsaUtils extends BaseEcdsaUtils {
    * @param {string} params.reqId - request id
    * @returns {Promise<TxRequest>} fully signed TxRequest object
    */
-  async signTxRequestForMessage(params: TSSParamsForMessage): Promise<TxRequest> {
+  async signTxRequestForMessage(params: TSSParamsForMessageWithPrv): Promise<TxRequest> {
     if (!params.messageRaw) {
       throw new Error('Raw message required to sign message');
     }

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
@@ -786,4 +786,24 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
     };
   }
   // #endregion
+
+  // #region external signer
+  /** @inheritdoc */
+  async signEcdsaTssMPCv2UsingExternalSigner(): Promise<TxRequest> {
+    throw new Error('Method not implemented');
+  }
+
+  async createOfflineRound1Share(params: Record<string, unknown>) {
+    throw new Error('Method not implemented');
+  }
+
+  async createOfflineRound2Share(params: Record<string, unknown>) {
+    throw new Error('Method not implemented');
+  }
+
+  async createOfflineRound3Share(params: Record<string, unknown>) {
+    throw new Error('Method not implemented');
+  }
+
+  // #endregion
 }

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
@@ -28,7 +28,7 @@ import {
   EncryptedSignerShareType,
   SignatureShareRecord,
   SignatureShareType,
-  TSSParams,
+  TSSParamsWithPrv,
   TxRequest,
 } from '../baseTypes';
 import { CreateEddsaBitGoKeychainParams, CreateEddsaKeychainParams, KeyShare, YShare } from './types';
@@ -548,7 +548,7 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
    * @param reqId - request id
    * @returns {Promise<TxRequest>} fully signed TxRequest object
    */
-  async signTxRequest(params: TSSParams): Promise<TxRequest> {
+  async signTxRequest(params: TSSParamsWithPrv): Promise<TxRequest> {
     this.bitgo.setRequestTracer(params.reqId);
     let txRequestResolved: TxRequest;
     let txRequestId: string;

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -18,9 +18,9 @@ import {
   CustomCommitmentGeneratingFunction,
   CustomGShareGeneratingFunction,
   CustomKShareGeneratingFunction,
-  CustomMPCv2Round1GeneratingFunction,
-  CustomMPCv2Round2GeneratingFunction,
-  CustomMPCv2Round3GeneratingFunction,
+  CustomMPCv2SigningRound1GeneratingFunction,
+  CustomMPCv2SigningRound2GeneratingFunction,
+  CustomMPCv2SigningRound3GeneratingFunction,
   CustomMuDeltaShareGeneratingFunction,
   CustomPaillierModulusGetterFunction,
   CustomRShareGeneratingFunction,
@@ -201,9 +201,9 @@ export interface WalletSignTransactionOptions extends WalletSignBaseOptions {
   customKShareGeneratingFunction?: CustomKShareGeneratingFunction;
   customMuDeltaShareGeneratingFunction?: CustomMuDeltaShareGeneratingFunction;
   customSShareGeneratingFunction?: CustomSShareGeneratingFunction;
-  customMPCv2Round1GenerationFunction?: CustomMPCv2Round1GeneratingFunction;
-  customMPCv2Round2GenerationFunction?: CustomMPCv2Round2GeneratingFunction;
-  customMPCv2Round3GenerationFunction?: CustomMPCv2Round3GeneratingFunction;
+  customMPCv2SigningRound1GenerationFunction?: CustomMPCv2SigningRound1GeneratingFunction;
+  customMPCv2SigningRound2GenerationFunction?: CustomMPCv2SigningRound2GeneratingFunction;
+  customMPCv2SigningRound3GenerationFunction?: CustomMPCv2SigningRound3GeneratingFunction;
   apiVersion?: ApiVersion;
   multisigTypeVersion?: 'MPCv2';
   [index: string]: unknown;

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -18,6 +18,9 @@ import {
   CustomCommitmentGeneratingFunction,
   CustomGShareGeneratingFunction,
   CustomKShareGeneratingFunction,
+  CustomMPCv2Round1GeneratingFunction,
+  CustomMPCv2Round2GeneratingFunction,
+  CustomMPCv2Round3GeneratingFunction,
   CustomMuDeltaShareGeneratingFunction,
   CustomPaillierModulusGetterFunction,
   CustomRShareGeneratingFunction,
@@ -198,6 +201,9 @@ export interface WalletSignTransactionOptions extends WalletSignBaseOptions {
   customKShareGeneratingFunction?: CustomKShareGeneratingFunction;
   customMuDeltaShareGeneratingFunction?: CustomMuDeltaShareGeneratingFunction;
   customSShareGeneratingFunction?: CustomSShareGeneratingFunction;
+  customMPCv2Round1GenerationFunction?: CustomMPCv2Round1GeneratingFunction;
+  customMPCv2Round2GenerationFunction?: CustomMPCv2Round2GeneratingFunction;
+  customMPCv2Round3GenerationFunction?: CustomMPCv2Round3GeneratingFunction;
   apiVersion?: ApiVersion;
   multisigTypeVersion?: 'MPCv2';
   [index: string]: unknown;

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -1698,8 +1698,9 @@ export class Wallet implements IWallet {
     }
 
     if (
-      _.isFunction(params.customMPCv2Round1GenerationFunction) &&
-      _.isFunction(params.customMPCv2Round2GenerationFunction)
+      _.isFunction(params.customMPCv2SigningRound1GenerationFunction) &&
+      _.isFunction(params.customMPCv2SigningRound2GenerationFunction) &&
+      _.isFunction(params.customMPCv2SigningRound3GenerationFunction)
     ) {
       // invoke external signer TSS for ECDSA MPCv2workflow
       return this.signTransactionTssExternalSignerECDSAMPCv2(this.baseCoin, params);
@@ -3146,7 +3147,6 @@ export class Wallet implements IWallet {
       const signedTxRequest = await this.tssUtils.signEcdsaTssUsingExternalSigner(
         {
           txRequest: txRequestId,
-          prv: '',
           reqId: params.reqId || new RequestTracer(),
         },
         RequestType.tx,
@@ -3179,15 +3179,15 @@ export class Wallet implements IWallet {
       throw new Error('TxRequestId required to sign TSS transactions with External Signer.');
     }
 
-    if (!params.customMPCv2Round1GenerationFunction) {
+    if (!params.customMPCv2SigningRound1GenerationFunction) {
       throw new Error('Generator function for MPCv2 Round 1 share required to sign transactions with External Signer.');
     }
 
-    if (!params.customMPCv2Round2GenerationFunction) {
+    if (!params.customMPCv2SigningRound2GenerationFunction) {
       throw new Error('Generator function for MPCv2 Round 2 share required to sign transactions with External Signer.');
     }
 
-    if (!params.customMPCv2Round3GenerationFunction) {
+    if (!params.customMPCv2SigningRound3GenerationFunction) {
       throw new Error('Generator function for MPCv2 Round 3 share required to sign transactions with External Signer.');
     }
 
@@ -3196,13 +3196,11 @@ export class Wallet implements IWallet {
       const signedTxRequest = await this.tssUtils.signEcdsaMPCv2TssUsingExternalSigner(
         {
           txRequest: txRequestId,
-          prv: '',
           reqId: params.reqId || new RequestTracer(),
         },
-        RequestType.tx,
-        params.customMPCv2Round1GenerationFunction,
-        params.customMPCv2Round2GenerationFunction,
-        params.customMPCv2Round3GenerationFunction
+        params.customMPCv2SigningRound1GenerationFunction,
+        params.customMPCv2SigningRound2GenerationFunction,
+        params.customMPCv2SigningRound3GenerationFunction
       );
       return signedTxRequest;
     } catch (e) {

--- a/modules/sdk-core/src/index.ts
+++ b/modules/sdk-core/src/index.ts
@@ -8,6 +8,8 @@ import { EddsaUtils } from './bitgo/utils/tss/eddsa/eddsa';
 export { EddsaUtils };
 import { EcdsaUtils } from './bitgo/utils/tss/ecdsa/ecdsa';
 export { EcdsaUtils };
+import { EcdsaMPCv2Utils } from './bitgo/utils/tss/ecdsa/ecdsaMPCv2';
+export { EcdsaMPCv2Utils };
 export { GShare, SignShare, YShare } from './account-lib/mpc/tss/eddsa/types';
 export { TssEcdsaStep1ReturnMessage, TssEcdsaStep2ReturnMessage } from './bitgo/tss/types';
 export { SShare } from './bitgo/tss/ecdsa/types';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1017,6 +1017,18 @@
     monocle-ts "2.3.13"
     newtype-ts "0.3.5"
 
+"@bitgo/public-types@2.29.0":
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/@bitgo/public-types/-/public-types-2.29.0.tgz#ebf8bf64baee70d00066df7374bbe7662f38565d"
+  integrity sha512-Vk2FOxiAYD5SuwiQsdnGFtQKfrnr0ZvJky/g5nrUyjRoFwZTfcLUH49HusVzLt3+1oQlXkcikZEkQsVMZJo8IQ==
+  dependencies:
+    "@api-ts/io-ts-http" "1.0.0"
+    fp-ts "2.16.2"
+    io-ts "2.1.3"
+    io-ts-types "0.5.16"
+    monocle-ts "2.3.13"
+    newtype-ts "0.3.5"
+
 "@brandonblack/musig@^0.0.1-alpha.0":
   version "0.0.1-alpha.1"
   resolved "https://registry.yarnpkg.com/@brandonblack/musig/-/musig-0.0.1-alpha.1.tgz#0895f59977bedf519099ff6e2fcbcbced30bc761"


### PR DESCRIPTION
added base utils for MPCv2 external signer
added MPCv2 base code to support external signer
Implemented singing using external signer for MPCv2
Use the hashed signableTx as Adata to verify that the encrypted session matches with the tx during
the second and third DSG rounds in external signer, this would prevent re using the stored session
for a different tx

WP-2136
<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
