### PR TITLE
chore(statics): update batcher address for polygon and bsc

### DIFF
--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -250,6 +250,7 @@ class BinanceSmartChain extends Mainnet implements EthereumNetwork {
   explorerUrl = 'https://www.bscscan.com/tx/';
   accountExplorerUrl = 'https://www.bscscan.com/address/';
   chainId = 56;
+  batcherContractAddress = '0xb1b7e7cc1ecafbfd0771a5eb5454ab5b0356980d';
 }
 
 class BinanceSmartChainTestnet extends Testnet implements EthereumNetwork {
@@ -258,6 +259,7 @@ class BinanceSmartChainTestnet extends Testnet implements EthereumNetwork {
   explorerUrl = 'https://testnet.bscscan.com/tx/';
   accountExplorerUrl = 'https://testnet.bscscan.com/address/';
   chainId = 97;
+  batcherContractAddress = '0x6faf4b6bae3d4bf20c5d866c938f51992c63e825';
 }
 
 class LightningBitcoin extends Mainnet implements LightningNetwork {
@@ -928,7 +930,7 @@ class Polygon extends Mainnet implements EthereumNetwork {
   forwarderImplementationAddress = '0x5397d0869aba0d55e96d5716d383f6e1d8695ed7';
   walletFactoryAddress = '0xa7198f48c58e91f01317e70cd24c5cce475c1555';
   walletImplementationAddress = '0xe5dcdc13b628c2df813db1080367e929c1507ca0';
-  batcherContractAddress = '0x7adc9b3d7521710321bec7dd6897d337e53c2493';
+  batcherContractAddress = '0xb1b7e7cc1ecafbfd0771a5eb5454ab5b0356980d';
   nativeCoinOperationHashPrefix = 'POLYGON';
   tokenOperationHashPrefix = 'POLYGON-ERC20';
 }


### PR DESCRIPTION
Ticket: [coin-1062](https://bitgoinc.atlassian.net/browse/COIN-1062)

Deployed new batcher contract for polygon and bsc
Update contract address in config

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
