### PR TITLE
feat: ignore additional external outputs

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -178,6 +178,7 @@ export interface TransactionPrebuild<TNumber extends number | bigint = number> e
 
 export interface TransactionParams extends BaseTransactionParams {
   walletPassphrase?: string;
+  allowExternalChangeAddress?: boolean;
   changeAddress?: string;
   rbfTxIds?: string[];
 }
@@ -324,6 +325,7 @@ export interface VerifyUserPublicKeyOptions {
 export interface VerifyTransactionOptions<TNumber extends number | bigint = number>
   extends BaseVerifyTransactionOptions {
   txPrebuild: TransactionPrebuild<TNumber>;
+  txParams: TransactionParams;
   wallet: AbstractUtxoCoinWallet;
 }
 
@@ -923,7 +925,9 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       payAsYouGoLimit.toString()
     );
     // the additional external outputs can only be BitGo's pay-as-you-go fee, but we cannot verify the wallet address
-    if (nonChangeAmount.gt(payAsYouGoLimit)) {
+    // If allowExternalChangeAddress is set to true then allow the additional external outputs to be more than
+    // something other than BitGo's pay-as-you-go fee
+    if (nonChangeAmount.gt(payAsYouGoLimit) && !params.txParams.allowExternalChangeAddress) {
       // there are some addresses that are outside the scope of intended recipients that are not change addresses
       throw new Error('prebuild attempts to spend to unintended external recipients');
     }


### PR DESCRIPTION
Update the validation of paygo amount in output only in case of absence of `allowExternalChangeOutputs`, and check for the presence of the external change output in case this flag is passed in.

TICKET: BTC-1313

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
