### PR TITLE
docs: add example doc and script for sending non-ERC20 tokens

### DIFF
--- a/examples/docs/multiple-recipients-transfer-for-non-erc20-tokens.md
+++ b/examples/docs/multiple-recipients-transfer-for-non-erc20-tokens.md
@@ -1,0 +1,34 @@
+# Send Tokens for Non-ERC20 Coins Using wallet.sendMany()
+
+This guide explains how to send tokens for non-ERC20 coins like Solana using the `wallet.sendMany()` method from the BitGo SDK.
+
+## Prerequisites
+
+
+- BitGo SDK installed
+- BitGo account and API access token
+- .env file with necessary environment variables
+
+#### Create a .env file in your project's root directory and add your BitGo access token:
+
+TESTNET_ACCESS_TOKEN=your_access_token_here
+## Running the examples
+
+First, run `yarn install` from the root directory of the repository.
+
+Then change into the `examples/ts/sol/utils/nonce-account-creation` directory and use `npx ts-node` to run the desired example:
+
+```
+$ cd examples/ts/sol/utils/nonce-account-creation
+$ npx ts-node multi-recipient-pay-transaction.ts
+```
+
+
+### Sample Code
+- Please refer [this](../ts/sol/utils/nonce-account-creation/multi-recipient-pay-transaction.ts) sample script to understand how to send the USDC token on the Solana Testnet using the wallet.sendMany() method
+### Note
+
+- Ensure your wallet ID and passphrase are correct.
+- Replace placeholder values with actual data from your BitGo account.
+- The tokenName parameter specifies the token to be sent (e.g., tsol:usdc for Solana USDC). Make sure to pass it along with the recipient array in params
+

--- a/examples/ts/sol/utils/nonce-account-creation/multi-recipient-pay-transaction.ts
+++ b/examples/ts/sol/utils/nonce-account-creation/multi-recipient-pay-transaction.ts
@@ -1,0 +1,64 @@
+/**
+ * Send non-erc20 tokens for coins like Solana or Tron, using the wallet.sendMany() method
+ *
+ * Copyright 2024, BitGo, Inc.  All Rights Reserved.
+ */
+import { BitGoAPI } from '@bitgo/sdk-api';
+import { Tsol } from '@bitgo/sdk-coin-sol';
+
+require('dotenv').config({ path: '../../../../../.env' });
+
+const bitgo = new BitGoAPI({
+  accessToken: process.env.TESTNET_ACCESS_TOKEN,
+  env: 'test',
+});
+
+const coin = 'tsol'; // Your coin here
+bitgo.register(coin, Tsol.createInstance);
+
+// TODO: set your walletId here
+const walletId = 'your_wallet_id_here';
+
+// TODO: set your wallet passphrase here
+const walletPassphrase = 'your_wallet_passphrase_here';
+
+async function main() {
+  try {
+    const walletInstance = await bitgo.coin(coin).wallets().get({ id: walletId });
+
+    const newReceiveAddress1 = await walletInstance.createAddress();
+    const newReceiveAddress2 = await walletInstance.createAddress();
+
+    const transaction = await walletInstance.sendMany({
+      //  TODO: Make sure to add the tokenName param in recipients in case of tokens and also the amount for each
+      recipients: [
+        {
+          amount: 'amount_for_address1',
+          address: newReceiveAddress1.address,
+          tokenName: 'tsol:usdc',
+        },
+        {
+          amount: 'amount_for_address2',
+          address: newReceiveAddress2.address,
+          tokenName: 'tsol:usdc',
+        },
+      ],
+      walletPassphrase: walletPassphrase,
+      type: 'transfer',
+    });
+
+    const explanation = await bitgo.coin(coin).explainTransaction({
+      txBase64: transaction.tx,
+      feeInfo: { fee: transaction.transfer.feeString },
+    });
+
+    console.log('Wallet ID:', walletInstance.id());
+    console.log('Current Receive Address:', walletInstance.receiveAddress());
+    console.log('New Transaction:', JSON.stringify(transaction, null, 4));
+    console.log('Transaction Explanation:', JSON.stringify(explanation, null, 4));
+  } catch (e) {
+    console.error('Error:', e);
+  }
+}
+
+main();


### PR DESCRIPTION
Add sample script and README to demonstrate how to send non-ERC20 tokens like Solana or Tron using the wallet.sendMany() method with the tokenName param in the recipients.

TICKET: [COIN-1072](https://bitgoinc.atlassian.net/browse/COIN-1072)

Readme:

<img width="821" alt="Screenshot 2024-07-09 at 4 58 54 PM" src="https://github.com/BitGo/BitGoJS/assets/174322161/04cf10f2-d4e9-413d-ac6d-17e3ed020240">


[COIN-1072]: https://bitgoinc.atlassian.net/browse/COIN-1072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ