### PR TITLE
feat(utxo-lib)!: require rootNodes to be passed into getSigValidArray

### DIFF
--- a/modules/utxo-lib/src/bitgo/UtxoPsbt.ts
+++ b/modules/utxo-lib/src/bitgo/UtxoPsbt.ts
@@ -701,10 +701,12 @@ export class UtxoPsbt<Tx extends UtxoTransaction<bigint> = UtxoTransaction<bigin
    * @param rootNodes optional input root bip32 nodes to verify with. If it is not provided, globalXpub will be used.
    * @return array of boolean values. True when corresponding index in `publicKeys` has signed the transaction.
    * If no signature in the tx or no public key matching signature, the validation is considered as false.
+   * If rootNodes are not explicitly passed in, the return array will be unordered.
+   * Use getSortedRootNodes() instead if ordering is important.
    */
   getSignatureValidationArray(
     inputIndex: number,
-    { rootNodes }: { rootNodes?: Triple<BIP32Interface> } = {}
+    { rootNodes }: { rootNodes: Triple<BIP32Interface> | undefined }
   ): Triple<boolean> {
     if (!rootNodes && (!this.data.globalMap.globalXpub?.length || !isTriple(this.data.globalMap.globalXpub))) {
       throw new Error('Cannot get signature validation array without 3 global xpubs');

--- a/modules/utxo-lib/test/bitgo/psbt/SignVerifyPsbtAndTx.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/SignVerifyPsbtAndTx.ts
@@ -68,7 +68,7 @@ function runPsbt(network: Network, sign: SignatureTargetType, inputs: Input[], o
       psbt.data.inputs.forEach((input, inputIndex) => {
         const isP2shP2pk = inputs[inputIndex].scriptType === 'p2shP2pk';
         const expectedSigValid = getSigValidArray(inputs[inputIndex].scriptType, sign);
-        psbt.getSignatureValidationArray(inputIndex).forEach((sv, i) => {
+        psbt.getSignatureValidationArray(inputIndex, { rootNodes: rootWalletKeys.triple }).forEach((sv, i) => {
           if (isP2shP2pk && sign !== 'unsigned' && i === 0) {
             assert.strictEqual(sv, true);
           } else {

--- a/modules/utxo-lib/test/bitgo/psbt/fromHalfSigned.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/fromHalfSigned.ts
@@ -127,7 +127,7 @@ function runTest(
           psbt.signAllInputs(s);
         }
       });
-      assert.deepStrictEqual(psbt.getSignatureValidationArray(0), signingKeys);
+      assert.deepStrictEqual(psbt.getSignatureValidationArray(0, { rootNodes: walletKeys.triple }), signingKeys);
       psbt.finalizeAllInputs();
       return psbt.extractTransaction();
     }

--- a/modules/utxo-lib/test/bitgo/psbt/signingAndValidation.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/signingAndValidation.ts
@@ -80,7 +80,7 @@ function runTest(scriptType: outputScripts.ScriptType, signerName: KeyName, cosi
         psbt.setAllInputsMusig2NonceHD(signer);
         psbt.setAllInputsMusig2NonceHD(cosigner);
       }
-      assert.ok(psbt.getSignatureValidationArray(0).every((res) => !res));
+      assert.ok(psbt.getSignatureValidationArray(0, { rootNodes: walletKeys.triple }).every((res) => !res));
       if (scriptType === 'p2shP2pk') {
         psbt.signAllInputs(signer);
       } else {
@@ -88,7 +88,7 @@ function runTest(scriptType: outputScripts.ScriptType, signerName: KeyName, cosi
         psbt.signAllInputsHD(cosigner);
       }
       assert(psbt.validateSignaturesOfAllInputs());
-      assert.deepStrictEqual(psbt.getSignatureValidationArray(0), signingKeys);
+      assert.deepStrictEqual(psbt.getSignatureValidationArray(0, { rootNodes: walletKeys.triple }), signingKeys);
       psbt.finalizeAllInputs();
       const tx = psbt.extractTransaction();
       assert(tx);


### PR DESCRIPTION
getSigValidArray returns an array with non-deterministic order if you do not pass in rootNodes

TICKET: BTC-1303

BREAKING CHANGE: require rootNodes in getSigValidArray