### PR TITLE
fix(key-card): broken keycard img scaling based on fixed size

### DIFF
--- a/modules/key-card/src/drawKeycard.ts
+++ b/modules/key-card/src/drawKeycard.ts
@@ -1,7 +1,7 @@
 import { jsPDF } from 'jspdf';
 import * as QRCode from 'qrcode';
-import { splitKeys } from './utils';
 import { IDrawKeyCard } from './types';
+import { splitKeys } from './utils';
 
 enum KeyCurveName {
   ed25519 = 'EDDSA',
@@ -68,6 +68,27 @@ function drawOnePageOfQrCodes(
   return qrIndex + 1;
 }
 
+function computeKeyCardImageDimensions(keyCardImage: HTMLImageElement) {
+  // Max dimensions stablished by fixed available PDF space
+  const KEY_CARD_IMAGE_MAX_DIMENSIONS = {
+    width: 303,
+    height: 40,
+  };
+
+  const { width: imgWidth, height: imgHeight } = keyCardImage;
+  const { width: maxWidth, height: maxHeight } = KEY_CARD_IMAGE_MAX_DIMENSIONS;
+
+  // Try scaling ratio based on width
+  const wRatio = imgWidth / maxWidth;
+  let finalRatio = wRatio;
+
+  // If resized height exceeds the available height space, base ratio also on height
+  if (imgHeight / finalRatio > maxHeight) {
+    finalRatio = imgHeight / maxHeight;
+  }
+  return [imgWidth / finalRatio, imgHeight / finalRatio];
+}
+
 export async function drawKeycard({
   activationCode,
   questions,
@@ -89,7 +110,8 @@ export async function drawKeycard({
   y = moveDown(y, 30);
 
   if (keyCardImage) {
-    doc.addImage(keyCardImage, left(0), y, 303, 40);
+    const [imgWidth, imgHeight] = computeKeyCardImageDimensions(keyCardImage);
+    doc.addImage(keyCardImage, left(0), y, imgWidth, imgHeight);
   }
 
   // Activation Code


### PR DESCRIPTION
TICKET: WP-2122

KeyCardImage rendered on pdf (the one with the coin logo) was using as dimensions 303 x 40 for every coin but some images comes with different sizes so the solution is to re-scalate based on the available size and checking if one of the dimensions still exceeds after the dimensions change.

