### PR TITLE
feat(sdk-api): add adata param to encryption methods

### DIFF
--- a/modules/sdk-api/src/encrypt.ts
+++ b/modules/sdk-api/src/encrypt.ts
@@ -18,15 +18,27 @@ export function bytesToWord(bytes?: Uint8Array | number[]): number {
 export function encrypt(
   password: string,
   plaintext: string,
-  { salt = randomBytes(8), iv = randomBytes(16) } = {}
+  options?: {
+    salt?: Buffer;
+    iv?: Buffer;
+    adata?: string;
+  }
 ): string {
+  const salt = options?.salt || randomBytes(8);
   if (salt.length !== 8) {
     throw new Error(`salt must be 8 bytes`);
   }
+  const iv = options?.iv || randomBytes(16);
   if (iv.length !== 16) {
     throw new Error(`iv must be 16 bytes`);
   }
-  const encryptOptions = {
+  const encryptOptions: {
+    iter: number;
+    ks: number;
+    salt: number[];
+    iv: number[];
+    adata?: string;
+  } = {
     iter: 10000,
     ks: 256,
     salt: [bytesToWord(salt.slice(0, 4)), bytesToWord(salt.slice(4))],
@@ -37,6 +49,10 @@ export function encrypt(
       bytesToWord(iv.slice(12, 16)),
     ],
   };
+
+  if (options?.adata) {
+    encryptOptions.adata = options.adata;
+  }
 
   return sjcl.encrypt(password, plaintext, encryptOptions);
 }

--- a/modules/sdk-api/test/unit/encrypt.ts
+++ b/modules/sdk-api/test/unit/encrypt.ts
@@ -1,0 +1,71 @@
+import * as assert from 'assert';
+import { randomBytes } from 'crypto';
+
+import { decrypt, encrypt } from '../../src';
+
+describe('encryption methods tests', () => {
+  describe('encrypt', () => {
+    it('encrypts the plaintext with the given password', () => {
+      const password = 'myPassword';
+      const plaintext = 'Hello, World!';
+      const ciphertext = encrypt(password, plaintext);
+
+      assert(ciphertext !== plaintext, 'ciphertext should not be equal to plaintext');
+    });
+
+    it('returns a different ciphertext for the same plaintext and password', () => {
+      const password = 'myPassword';
+      const plaintext = 'Hello, World!';
+      const ciphertext1 = encrypt(password, plaintext);
+      const ciphertext2 = encrypt(password, plaintext);
+
+      assert(ciphertext1 !== ciphertext2, 'ciphertexts should not be equal');
+    });
+
+    it('throws an error if the salt length is not 8 bytes', () => {
+      const password = 'myPassword';
+      const plaintext = 'Hello, World!';
+      const options = { salt: randomBytes(4) };
+
+      assert.throws(() => encrypt(password, plaintext, options), new Error(`salt must be 8 bytes`));
+    });
+
+    it('throws an error if the iv length is not 16 bytes', () => {
+      const password = 'myPassword';
+      const plaintext = 'Hello, World!';
+      const options = { iv: randomBytes(4) };
+
+      assert.throws(() => encrypt(password, plaintext, options), new Error(`iv must be 16 bytes`));
+    });
+  });
+
+  describe('decrypt', () => {
+    it('decrypts the ciphertext with the given password', () => {
+      const password = 'myPassword';
+      const plaintext = 'Hello, World!';
+      const ciphertext = encrypt(password, plaintext);
+      const decrypted = decrypt(password, ciphertext);
+
+      assert(decrypted === plaintext, 'decrypted should be equal to plaintext');
+    });
+
+    it('throws an error if the password is wrong', () => {
+      const password = 'myPassword';
+      const plaintext = 'Hello, World!';
+      const ciphertext = encrypt(password, plaintext);
+      const wrongPassword = 'wrongPassword';
+
+      assert.throws(() => decrypt(wrongPassword, ciphertext), 'sjcl exception: cc: invalid aes key');
+    });
+
+    it('decrypts the ciphertext with the given password and adata', () => {
+      const password = 'myPassword';
+      const plaintext = 'Hello, World!';
+      const adata = 'additional data';
+      const ciphertext = encrypt(password, plaintext, { adata });
+      const decrypted = decrypt(password, ciphertext);
+
+      assert(decrypted === plaintext, 'decrypted should be equal to plaintext');
+    });
+  });
+});


### PR DESCRIPTION
added adata param to encryption methods

WP-2177

TICKET: WP-2177

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
