### PR TITLE
feat: remove bounceable address as default for ton

### DIFF
--- a/modules/sdk-coin-ton/src/lib/iface.ts
+++ b/modules/sdk-coin-ton/src/lib/iface.ts
@@ -11,4 +11,5 @@ export interface TxData {
   expirationTime: number;
   publicKey: string;
   signature: string;
+  bounceable: boolean;
 }

--- a/modules/sdk-coin-ton/src/lib/transactionBuilder.ts
+++ b/modules/sdk-coin-ton/src/lib/transactionBuilder.ts
@@ -60,6 +60,17 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
     return this;
   }
 
+  /**
+   * Sets the transaction to be bounceable or not.
+   *
+   * @param {string} bounceable whether the transaction can be bounced
+   * @returns {TransactionBuilder} This transaction builder
+   */
+  bounceable(bounceable: boolean): this {
+    this.transaction.bounceable = bounceable;
+    return this;
+  }
+
   fee(feeOptions: FeeOptions): this {
     throw new Error('Method not implemented.');
   }

--- a/modules/sdk-coin-ton/src/ton.ts
+++ b/modules/sdk-coin-ton/src/ton.ts
@@ -86,7 +86,7 @@ export class Ton extends BaseCoin {
     if (txParams.recipients !== undefined) {
       const filteredRecipients = txParams.recipients?.map((recipient) => {
         return {
-          address: new TonWeb.Address(recipient.address).toString(true, true, true),
+          address: new TonWeb.Address(recipient.address).toString(true, true, transaction.bounceable),
           amount: BigInt(recipient.amount),
         };
       });

--- a/modules/sdk-coin-ton/test/resources/ton.ts
+++ b/modules/sdk-coin-ton/test/resources/ton.ts
@@ -12,7 +12,7 @@ export const privateKeys = {
 
 export const addresses = {
   validAddresses: [
-    'EQA0i8-CdGnF_DhUHHf92R1ONH6sIA9vLZ_WLcCIhfBBXwtG',
+    'UQA0i8-CdGnF_DhUHHf92R1ONH6sIA9vLZ_WLcCIhfBBX1aD',
     'EQBuEuh47sv0NSCjRsQukMu1jKi9QUspsQGeYL4LWtrU81Cb',
   ],
   invalidAddresses: [
@@ -23,7 +23,7 @@ export const addresses = {
 };
 
 export const sender = {
-  address: 'EQC7YVwYHggAw51s8wxryeS8gNdcsMro-u24sE727ymJySAJ',
+  address: 'UQAbJug-k-tufWMjEC1RKSM0iiJTDUcYkC7zWANHrkT55Afg',
   publicKey: 'c0c3b9dc09932121ee351b2448c50a3ae2571b12951245c85f3bd95d5e7a06f8',
 };
 
@@ -35,11 +35,11 @@ export const recipients: Recipient[] = [
 ];
 
 export const signedTransaction = {
-  tx: 'te6cckEBAgEAsQAB4YgAQmy8N765HIcsCkExBYpKsfl7LUuXYW7MvV53d6EqWoADFgjyqp/3qccthFjfvskQ1XUeecHe8JVQ9DFGSmpwRovdPiRamZZ3PR2isMd1i5k+MdQCc9TCP/E5+rfkvMbYQU1NGLsruXHwAAAAgAAcAQB2QgB9Jzc15Nkj1GPyoSR0hIg9lzcoUjVC0MYRF1GRn2tVHpzEtAAAAAAAAAAAAAAAAAAAAAAAAHRlc3SUlVNc',
-  txId: '9gEyvIsHrA79g8pmEP1EBtO8GlpZ98QnUveSYmEx6fc=',
-  signable: 'q28coBQ7sbBBAR/hG4eUdDayLDsPC9FKQtA/lSYYaSQ=',
+  tx: 'te6cckEBAgEAqQAB4YgBJAxo7vqHF++LJ4bC/kJ8A1uVRskrKlrKJZ8rIB0tF+gCadlSX+hPo2mmhZyi0p3zTVUYVRkcmrCm97cSUFSa2vzvCArM3APg+ww92r3IcklNjnzfKOgysJVQXiCvj9SAaU1NGLsotvRwAAAAMAAcAQBmQgAaRefBOjTi/hwqDjv+7I6nGj9WEAe3ls/rFuBEQvggr5zEtAAAAAAAAAAAAAAAAAAAdfZO7w==',
+  txId: 'tuyOkyFUMv_neV_FeNBH24Nd4cML2jUgDP4zjGkuOFI=',
+  signable: 'k4XUmjB65j3klMXCXdh5Vs3bJZzo3NSfnXK8NIYFayI=',
   recipient: {
-    address: 'EQD6Tm5rybJHqMflQkjpCRB7Lm5QpGqFoYwiLqMjPtaqPSdZ',
+    address: 'UQA0i8-CdGnF_DhUHHf92R1ONH6sIA9vLZ_WLcCIhfBBX1aD',
     amount: '10000000',
   },
 };

--- a/modules/sdk-coin-ton/test/unit/ton.ts
+++ b/modules/sdk-coin-ton/test/unit/ton.ts
@@ -135,7 +135,7 @@ describe('TON:', function () {
       })) as TransactionExplanation;
       explainedTransaction.should.deepEqual({
         displayOrder: ['id', 'outputs', 'outputAmount', 'changeOutputs', 'changeAmount', 'fee'],
-        id: '9gEyvIsHrA79g8pmEP1EBtO8GlpZ98QnUveSYmEx6fc=',
+        id: 'tuyOkyFUMv_neV_FeNBH24Nd4cML2jUgDP4zjGkuOFI=',
         outputs: [
           {
             address: testData.signedTransaction.recipient.address,
@@ -171,14 +171,14 @@ describe('TON:', function () {
 
     const transferInputsResponse = [
       {
-        address: 'EQAhNl4b31yOQ5YFIJiCxSVY_L2Wpcuwt2Zerzu70JUtQCRu',
+        address: 'UQCSBjR3fUOL98WTw2F_IT4BrcqjZJWVLWUSz5WQDpaL9Meg',
         amount: '10000000',
       },
     ];
 
     const transferOutputsResponse = [
       {
-        address: 'EQD6Tm5rybJHqMflQkjpCRB7Lm5QpGqFoYwiLqMjPtaqPSdZ',
+        address: 'UQA0i8-CdGnF_DhUHHf92R1ONH6sIA9vLZ_WLcCIhfBBX1aD',
         amount: '10000000',
       },
     ];
@@ -244,7 +244,7 @@ describe('TON:', function () {
     });
 
     it('should return true when validating a well formatted address', async function () {
-      const address = 'EQA0i8-CdGnF_DhUHHf92R1ONH6sIA9vLZ_WLcCIhfBBXwtG';
+      const address = 'UQB0Hyt1bTRfI0WK_ULZyKvrvP0PPtpTQFi_jKXVXX6KFOMi';
       basecoin.isValidAddress(address).should.equal(true);
     });
 

--- a/modules/sdk-coin-ton/test/unit/transferBuilder.ts
+++ b/modules/sdk-coin-ton/test/unit/transferBuilder.ts
@@ -10,7 +10,7 @@ import TonWeb from 'tonweb';
 describe('Ton Transfer Builder', () => {
   const factory = new TransactionBuilderFactory(coins.get('tton'));
   it('should build a unsigned transfer tx', async function () {
-    const txId = 'jW8_S7Cu9Xed5SniogjsskOy5vSBKz2qWRdgEw3VQwM='.replace(/\//g, '_').replace(/\+/g, '-');
+    const txId = 'jQhv4EPr4l-nZ8AfzSdVUSftfX2B8Qo0TwMBstsdpcs='.replace(/\//g, '_').replace(/\+/g, '-');
     const txBuilder = factory.getTransferBuilder();
     txBuilder.sender(testData.sender.address);
     txBuilder.sequenceNumber(0);
@@ -20,6 +20,7 @@ describe('Ton Transfer Builder', () => {
     txBuilder.setMessage('test');
     const tx = await txBuilder.build();
     should.equal(tx.type, TransactionType.Send);
+    should.equal(tx.toJson().bounceable, false);
     tx.inputs.length.should.equal(1);
     tx.inputs[0].should.deepEqual({
       address: testData.sender.address,
@@ -36,7 +37,40 @@ describe('Ton Transfer Builder', () => {
     const rawTx = tx.toBroadcastFormat();
     console.log(rawTx);
     rawTx.should.equal(
-      'te6cckECGAEAA7cAAuGIAXbCuDA8EAGHOtnmGNeTyXkBrrlhldH123Fgne3eUxOSGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACmpoxdJlgLSAAAAAAADgEXAgE0AhYBFP8A9KQT9LzyyAsDAgEgBBECAUgFCALm0AHQ0wMhcbCSXwTgItdJwSCSXwTgAtMfIYIQcGx1Z70ighBkc3RyvbCSXwXgA/pAMCD6RAHIygfL/8nQ7UTQgQFA1yH0BDBcgQEI9ApvoTGzkl8H4AXTP8glghBwbHVnupI4MOMNA4IQZHN0crqSXwbjDQYHAHgB+gD0BDD4J28iMFAKoSG+8uBQghBwbHVngx6xcIAYUATLBSbPFlj6Ahn0AMtpF8sfUmDLPyDJgED7AAYAilAEgQEI9Fkw7UTQgQFA1yDIAc8W9ADJ7VQBcrCOI4IQZHN0coMesXCAGFAFywVQA88WI/oCE8tqyx/LP8mAQPsAkl8D4gIBIAkQAgEgCg8CAVgLDAA9sp37UTQgQFA1yH0BDACyMoHy//J0AGBAQj0Cm+hMYAIBIA0OABmtznaiaEAga5Drhf/AABmvHfaiaEAQa5DrhY/AABG4yX7UTQ1wsfgAWb0kK29qJoQICga5D6AhhHDUCAhHpJN9KZEM5pA+n/mDeBKAG3gQFImHFZ8xhAT48oMI1xgg0x/TH9MfAvgju/Jk7UTQ0x/TH9P/9ATRUUO68qFRUbryogX5AVQQZPkQ8qP4ACSkyMsfUkDLH1Iwy/9SEPQAye1U+A8B0wchwACfbFGTINdKltMH1AL7AOgw4CHAAeMAIcAC4wABwAORMOMNA6TIyx8Syx/L/xITFBUAbtIH+gDU1CL5AAXIygcVy//J0Hd0gBjIywXLAiLPFlAF+gIUy2sSzMzJc/sAyEAUgQEI9FHypwIAcIEBCNcY+gDTP8hUIEeBAQj0UfKnghBub3RlcHSAGMjLBcsCUAbPFlAE+gIUy2oSyx/LP8lz+wACAGyBAQjXGPoA0z8wUiSBAQj0WfKnghBkc3RycHSAGMjLBcsCUAXPFlAD+gITy2rLHxLLP8lz+wAACvQAye1UAFEAAAAAKamjF8DDudwJkyEh7jUbJEjFCjriVxsSlRJFyF872V1eegb4QAB4QgAaRefBOjTi/hwqDjv+7I6nGj9WEAe3ls/rFuBEQvggr6A613oAAAAAAAAAAAAAAAAAAAAAAAB0ZXN0NQo8vQ=='
+      'te6cckECGAEAA7cAAuGIADZN0H0n1tz6xkYgWqJSRmkURKYajjEgXeawBo9cifPIGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACmpoxdJlgLSAAAAAAADgEXAgE0AhYBFP8A9KQT9LzyyAsDAgEgBBECAUgFCALm0AHQ0wMhcbCSXwTgItdJwSCSXwTgAtMfIYIQcGx1Z70ighBkc3RyvbCSXwXgA/pAMCD6RAHIygfL/8nQ7UTQgQFA1yH0BDBcgQEI9ApvoTGzkl8H4AXTP8glghBwbHVnupI4MOMNA4IQZHN0crqSXwbjDQYHAHgB+gD0BDD4J28iMFAKoSG+8uBQghBwbHVngx6xcIAYUATLBSbPFlj6Ahn0AMtpF8sfUmDLPyDJgED7AAYAilAEgQEI9Fkw7UTQgQFA1yDIAc8W9ADJ7VQBcrCOI4IQZHN0coMesXCAGFAFywVQA88WI/oCE8tqyx/LP8mAQPsAkl8D4gIBIAkQAgEgCg8CAVgLDAA9sp37UTQgQFA1yH0BDACyMoHy//J0AGBAQj0Cm+hMYAIBIA0OABmtznaiaEAga5Drhf/AABmvHfaiaEAQa5DrhY/AABG4yX7UTQ1wsfgAWb0kK29qJoQICga5D6AhhHDUCAhHpJN9KZEM5pA+n/mDeBKAG3gQFImHFZ8xhAT48oMI1xgg0x/TH9MfAvgju/Jk7UTQ0x/TH9P/9ATRUUO68qFRUbryogX5AVQQZPkQ8qP4ACSkyMsfUkDLH1Iwy/9SEPQAye1U+A8B0wchwACfbFGTINdKltMH1AL7AOgw4CHAAeMAIcAC4wABwAORMOMNA6TIyx8Syx/L/xITFBUAbtIH+gDU1CL5AAXIygcVy//J0Hd0gBjIywXLAiLPFlAF+gIUy2sSzMzJc/sAyEAUgQEI9FHypwIAcIEBCNcY+gDTP8hUIEeBAQj0UfKnghBub3RlcHSAGMjLBcsCUAbPFlAE+gIUy2oSyx/LP8lz+wACAGyBAQjXGPoA0z8wUiSBAQj0WfKnghBkc3RycHSAGMjLBcsCUAXPFlAD+gITy2rLHxLLP8lz+wAACvQAye1UAFEAAAAAKamjF8DDudwJkyEh7jUbJEjFCjriVxsSlRJFyF872V1eegb4QAB4QgAaRefBOjTi/hwqDjv+7I6nGj9WEAe3ls/rFuBEQvggr6A613oAAAAAAAAAAAAAAAAAAAAAAAB0ZXN0VouPug=='
+    );
+  });
+
+  it('should build a unsigned transfer tx with bounceable flag', async function () {
+    const txId = 'gMLc2d3RLcR-oLQLx_16Z1a2oyepCd4EJ10E33VunZw='.replace(/\//g, '_').replace(/\+/g, '-');
+    const txBuilder = factory.getTransferBuilder();
+    txBuilder.sender(testData.sender.address);
+    txBuilder.sequenceNumber(0);
+    txBuilder.publicKey(testData.sender.publicKey);
+    txBuilder.expireTime(1234567890);
+    txBuilder.send(testData.recipients[0]);
+    txBuilder.setMessage('test');
+    txBuilder.bounceable(true);
+    const tx = await txBuilder.build();
+    should.equal(tx.type, TransactionType.Send);
+    should.equal(tx.toJson().bounceable, true);
+    tx.inputs.length.should.equal(1);
+    tx.inputs[0].should.deepEqual({
+      address: testData.sender.address,
+      value: testData.recipients[0].amount,
+      coin: 'tton',
+    });
+    tx.outputs.length.should.equal(1);
+    tx.outputs[0].should.deepEqual({
+      address: testData.recipients[0].address,
+      value: testData.recipients[0].amount,
+      coin: 'tton',
+    });
+    tx.id.should.equal(txId);
+    const rawTx = tx.toBroadcastFormat();
+    console.log(rawTx);
+    rawTx.should.equal(
+      'te6cckECGAEAA7cAAuGIADZN0H0n1tz6xkYgWqJSRmkURKYajjEgXeawBo9cifPIGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACmpoxdJlgLSAAAAAAADgEXAgE0AhYBFP8A9KQT9LzyyAsDAgEgBBECAUgFCALm0AHQ0wMhcbCSXwTgItdJwSCSXwTgAtMfIYIQcGx1Z70ighBkc3RyvbCSXwXgA/pAMCD6RAHIygfL/8nQ7UTQgQFA1yH0BDBcgQEI9ApvoTGzkl8H4AXTP8glghBwbHVnupI4MOMNA4IQZHN0crqSXwbjDQYHAHgB+gD0BDD4J28iMFAKoSG+8uBQghBwbHVngx6xcIAYUATLBSbPFlj6Ahn0AMtpF8sfUmDLPyDJgED7AAYAilAEgQEI9Fkw7UTQgQFA1yDIAc8W9ADJ7VQBcrCOI4IQZHN0coMesXCAGFAFywVQA88WI/oCE8tqyx/LP8mAQPsAkl8D4gIBIAkQAgEgCg8CAVgLDAA9sp37UTQgQFA1yH0BDACyMoHy//J0AGBAQj0Cm+hMYAIBIA0OABmtznaiaEAga5Drhf/AABmvHfaiaEAQa5DrhY/AABG4yX7UTQ1wsfgAWb0kK29qJoQICga5D6AhhHDUCAhHpJN9KZEM5pA+n/mDeBKAG3gQFImHFZ8xhAT48oMI1xgg0x/TH9MfAvgju/Jk7UTQ0x/TH9P/9ATRUUO68qFRUbryogX5AVQQZPkQ8qP4ACSkyMsfUkDLH1Iwy/9SEPQAye1U+A8B0wchwACfbFGTINdKltMH1AL7AOgw4CHAAeMAIcAC4wABwAORMOMNA6TIyx8Syx/L/xITFBUAbtIH+gDU1CL5AAXIygcVy//J0Hd0gBjIywXLAiLPFlAF+gIUy2sSzMzJc/sAyEAUgQEI9FHypwIAcIEBCNcY+gDTP8hUIEeBAQj0UfKnghBub3RlcHSAGMjLBcsCUAbPFlAE+gIUy2oSyx/LP8lz+wACAGyBAQjXGPoA0z8wUiSBAQj0WfKnghBkc3RycHSAGMjLBcsCUAXPFlAD+gITy2rLHxLLP8lz+wAACvQAye1UAFEAAAAAKamjF8DDudwJkyEh7jUbJEjFCjriVxsSlRJFyF872V1eegb4QAB4YgAaRefBOjTi/hwqDjv+7I6nGj9WEAe3ls/rFuBEQvggr6A613oAAAAAAAAAAAAAAAAAAAAAAAB0ZXN0mIHxPg=='
     );
   });
 
@@ -53,11 +87,11 @@ describe('Ton Transfer Builder', () => {
     should.equal(builtTx.toBroadcastFormat(), testData.signedTransaction.tx);
     builtTx.inputs.length.should.equal(1);
     builtTx.outputs.length.should.equal(1);
-    jsonTx.sender.should.equal('EQAhNl4b31yOQ5YFIJiCxSVY_L2Wpcuwt2Zerzu70JUtQCRu');
-    jsonTx.destination.should.equal('EQD6Tm5rybJHqMflQkjpCRB7Lm5QpGqFoYwiLqMjPtaqPSdZ');
+    jsonTx.sender.should.equal('UQCSBjR3fUOL98WTw2F_IT4BrcqjZJWVLWUSz5WQDpaL9Meg');
+    jsonTx.destination.should.equal('UQA0i8-CdGnF_DhUHHf92R1ONH6sIA9vLZ_WLcCIhfBBX1aD');
     jsonTx.amount.should.equal('10000000');
-    jsonTx.seqno.should.equal(16);
-    jsonTx.expirationTime.should.equal(1702309438);
+    jsonTx.seqno.should.equal(6);
+    jsonTx.expirationTime.should.equal(1695997582);
   });
 
   xit('should build a signed transfer tx and submit onchain', async function () {
@@ -123,13 +157,14 @@ describe('Ton Transfer Builder', () => {
     should.equal(tx.toBroadcastFormat(), tx2.toBroadcastFormat());
   });
 
-  it('should build transfer tx for non-bouncable address', async function () {
+  it('should build transfer tx for non-bounceable address', async function () {
     const txBuilder = factory.getTransferBuilder();
     txBuilder.sender(testData.sender.address);
     txBuilder.sequenceNumber(0);
     txBuilder.publicKey(testData.sender.publicKey);
     txBuilder.expireTime(1234567890);
     const address = 'UQAWzEKcdnykvXfUNouqdS62tvrp32bCxuKS6eQrS6ISgZ8t';
+    const otherFormat = 'EQAWzEKcdnykvXfUNouqdS62tvrp32bCxuKS6eQrS6ISgcLo';
     const amount = '10000000';
     txBuilder.send({ address, amount });
     txBuilder.setMessage('test');
@@ -152,6 +187,6 @@ describe('Ton Transfer Builder', () => {
     const builder2 = factory.from(tx.toBroadcastFormat());
     const tx2 = await builder2.build();
     const txJson2 = tx2.toJson();
-    txJson2.destinationAlias.should.equal(address);
+    txJson2.destinationAlias.should.equal(otherFormat);
   });
 });


### PR DESCRIPTION
Ticket: WIN-3114

We were by default converting recipient addresses to bounceable format (EQ) for ton transactions. This might result in bounce backs if the receiver is an uninitialized wallet. Since with Ton v1 wallets we are switching to UQ address formats (non bouncable), our transactions should also not enforce bounceable format.