### PR TITLE
fix(sdk-coin-sui): return all input objects in `toJson` result

### DIFF
--- a/modules/sdk-coin-sui/src/lib/iface.ts
+++ b/modules/sdk-coin-sui/src/lib/iface.ts
@@ -39,6 +39,7 @@ export interface TxData {
   kind: {
     ProgrammableTransaction: SuiProgrammableTransaction;
   };
+  inputObjects?: SuiObjectRef[];
 }
 
 export type TransferProgrammableTransaction =

--- a/modules/sdk-coin-sui/src/lib/stakingBuilder.ts
+++ b/modules/sdk-coin-sui/src/lib/stakingBuilder.ts
@@ -149,10 +149,7 @@ export class StakingBuilder extends TransactionBuilder<StakingProgrammableTransa
     const txData = tx.toJson();
     this.type(SuiTransactionType.AddStake);
     this.sender(txData.sender);
-    this.gasData({
-      ...txData.gasData,
-      payment: this.getInputGasPaymentObjectsFromTxData(txData),
-    });
+    this.gasData(txData.gasData);
 
     const requests = utils.getStakeRequests(tx.suiTransaction.tx);
     this.stake(requests);

--- a/modules/sdk-coin-sui/src/lib/stakingTransaction.ts
+++ b/modules/sdk-coin-sui/src/lib/stakingTransaction.ts
@@ -70,7 +70,10 @@ export class StakingTransaction extends Transaction<StakingProgrammableTransacti
       id: this._id,
       sender: tx.sender,
       kind: { ProgrammableTransaction: tx.tx },
-      gasData: tx.gasData,
+      gasData: {
+        ...tx.gasData,
+        payment: [...tx.gasData.payment, ...this.getInputGasPaymentObjectsFromTx(tx.tx)],
+      },
       expiration: { None: null },
     };
   }

--- a/modules/sdk-coin-sui/src/lib/transactionBuilder.ts
+++ b/modules/sdk-coin-sui/src/lib/transactionBuilder.ts
@@ -11,14 +11,13 @@ import {
 } from '@bitgo/sdk-core';
 import assert from 'assert';
 import { Transaction } from './transaction';
-import utils, { isImmOrOwnedObj } from './utils';
+import utils from './utils';
 import BigNumber from 'bignumber.js';
 import { BaseCoin as CoinConfig } from '@bitgo/statics';
-import { SuiProgrammableTransaction, SuiTransactionType, TxData } from './iface';
+import { SuiProgrammableTransaction, SuiTransactionType } from './iface';
 import { DUMMY_SUI_GAS_PRICE } from './constants';
 import { KeyPair } from './keyPair';
 import { GasData, SuiObjectRef } from './mystenlab/types';
-import { MergeCoinsTransaction } from './mystenlab/builder';
 
 export abstract class TransactionBuilder<T = SuiProgrammableTransaction> extends BaseTransactionBuilder {
   protected _transaction: Transaction<T>;
@@ -179,36 +178,6 @@ export abstract class TransactionBuilder<T = SuiProgrammableTransaction> extends
     if (value.isLessThan(0)) {
       throw new BuildTransactionError('Value cannot be less than zero');
     }
-  }
-
-  /**
-   * When building transactions with > 255 input gas payment objects, we first use MergeCoins Tranasactions to merge the
-   * additional inputs into the gas coin & slice them from the payment in gasData. When initializing the builder using
-   * decoded tx data, we need to get these inputs from MergeCoins & add them back to the gas payment to be able to
-   * rebuild from a raw transaction.
-   */
-  protected getInputGasPaymentObjectsFromTxData(txData: TxData): SuiObjectRef[] {
-    const txInputs = txData.kind.ProgrammableTransaction.inputs;
-    const transactions = txData.kind.ProgrammableTransaction.transactions;
-    const inputGasPaymentObjects: SuiObjectRef[] = txData.gasData.payment;
-
-    transactions.forEach((transaction) => {
-      if (transaction.kind === 'MergeCoins') {
-        const { destination, sources } = transaction as MergeCoinsTransaction;
-        if (destination.kind === 'GasCoin') {
-          sources.forEach((source) => {
-            if (source.kind === 'Input') {
-              const input = txInputs[source.index];
-              if ('Object' in input && isImmOrOwnedObj(input.Object)) {
-                inputGasPaymentObjects.push(input.Object.ImmOrOwned);
-              }
-            }
-          });
-        }
-      }
-    });
-
-    return inputGasPaymentObjects;
   }
   // endregion
 }

--- a/modules/sdk-coin-sui/src/lib/transferBuilder.ts
+++ b/modules/sdk-coin-sui/src/lib/transferBuilder.ts
@@ -86,10 +86,7 @@ export class TransferBuilder extends TransactionBuilder<TransferProgrammableTran
     const txData = tx.toJson();
     this.type(SuiTransactionType.Transfer);
     this.sender(txData.sender);
-    this.gasData({
-      ...txData.gasData,
-      payment: this.getInputGasPaymentObjectsFromTxData(txData),
-    });
+    this.gasData(txData.gasData);
 
     const recipients = utils.getRecipients(tx.suiTransaction);
     this.send(recipients);

--- a/modules/sdk-coin-sui/src/lib/transferTransaction.ts
+++ b/modules/sdk-coin-sui/src/lib/transferTransaction.ts
@@ -73,7 +73,10 @@ export class TransferTransaction extends Transaction<TransferProgrammableTransac
       id: this._id,
       sender: tx.sender,
       kind: { ProgrammableTransaction: tx.tx },
-      gasData: tx.gasData,
+      gasData: {
+        ...tx.gasData,
+        payment: [...tx.gasData.payment, ...this.getInputGasPaymentObjectsFromTx(tx.tx)],
+      },
       expiration: { None: null },
     };
   }

--- a/modules/sdk-coin-sui/test/unit/transactionBuilder/stakingBuilder.ts
+++ b/modules/sdk-coin-sui/test/unit/transactionBuilder/stakingBuilder.ts
@@ -95,6 +95,7 @@ describe('Sui Staking Builder', () => {
       rebuilder.addSignature({ pub: testData.sender.publicKey }, Buffer.from(testData.sender.signatureHex));
       const rebuiltTx = await rebuilder.build();
       rebuiltTx.toBroadcastFormat().should.equal(rawTx);
+      rebuiltTx.toJson().gasData.payment.length.should.equal(numberOfPaymentObjects);
     });
   });
 

--- a/modules/sdk-coin-sui/test/unit/transactionBuilder/tokenTransferBuilder.ts
+++ b/modules/sdk-coin-sui/test/unit/transactionBuilder/tokenTransferBuilder.ts
@@ -74,6 +74,8 @@ describe('Sui Token Transfer Builder', () => {
       rebuilder.addSignature({ pub: testData.sender.publicKey }, Buffer.from(testData.sender.signatureHex));
       const rebuiltTx = await rebuilder.build();
       rebuiltTx.toBroadcastFormat().should.equal(rawTx);
+      rebuiltTx.toJson().gasData.payment.length.should.equal(numberOfGasPaymentObjects);
+      rebuiltTx.toJson().inputObjects.length.should.equal(numberOfInputObjects);
     });
   });
 

--- a/modules/sdk-coin-sui/test/unit/transactionBuilder/transferBuilder.ts
+++ b/modules/sdk-coin-sui/test/unit/transactionBuilder/transferBuilder.ts
@@ -141,6 +141,7 @@ describe('Sui Transfer Builder', () => {
       rebuilder.addSignature({ pub: testData.sender.publicKey }, Buffer.from(testData.sender.signatureHex));
       const rebuiltTx = await rebuilder.build();
       rebuiltTx.toBroadcastFormat().should.equal(rawTx);
+      rebuiltTx.toJson().gasData.payment.length.should.equal(numberOfPaymentObjects);
     });
   });
 


### PR DESCRIPTION
Ticket: WIN-3242

- Adds `inputObjects[]` to TxData for sui transactions. `inputObjects[]` is a list of Sui token objects used in building a token transaction. The native sui objects used as gas payment are still returned as part of `gasData`
- Fixes `toJson()` result when number of native sui objects is greater than 255 (only supported for native transfers & staking) . In this case the we parse the objects from the transaction and append it to `gasData.payment[]`