### PR TITLE
feat(sdk-core): add Signable type and canonicalizeObject

### DIFF
--- a/modules/sdk-core/src/bitgo/lightning/index.ts
+++ b/modules/sdk-core/src/bitgo/lightning/index.ts
@@ -2,3 +2,4 @@ export * from './iLightning';
 export * from './lightning';
 export * from './lnurlCodec';
 export * from './lightningUtils';
+export * from './signableJson';

--- a/modules/sdk-core/src/bitgo/lightning/signableJson.ts
+++ b/modules/sdk-core/src/bitgo/lightning/signableJson.ts
@@ -1,0 +1,38 @@
+export type Signable = boolean | number | string | SignableRecord | SignableArray;
+
+export interface SignableRecord {
+  [key: string]: Signable;
+}
+
+export interface SignableArray {
+  [key: number]: Signable;
+}
+
+/**
+ * Recursively canonicalizes an object by sorting its keys.
+ *
+ * @param obj - The object to be canonicalized. It can be a boolean, number, string,
+ *              a record of signable values, or an array of signable values.
+ * @returns The canonicalized object with sorted keys.
+ * @throws Will throw an error if the object type is invalid.
+ */
+export function canonicalizeObject(obj: Signable): Signable {
+  if (typeof obj === 'boolean' || typeof obj === 'number' || typeof obj === 'string') {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(canonicalizeObject);
+  }
+
+  if (obj !== null && typeof obj === 'object') {
+    return Object.keys(obj)
+      .sort()
+      .reduce((result: Record<string, Signable>, key) => {
+        result[key] = canonicalizeObject((obj as { [key: string]: Signable })[key]);
+        return result;
+      }, {});
+  }
+
+  throw new Error('Invalid object type');
+}

--- a/modules/sdk-core/test/unit/bitgo/lightning/signableJson.ts
+++ b/modules/sdk-core/test/unit/bitgo/lightning/signableJson.ts
@@ -1,0 +1,52 @@
+import { canonicalizeObject } from '../../../../src/bitgo/lightning';
+import assert from 'assert';
+
+describe('canonicalizeObject', function () {
+  it('should return the canonicalized object with sorted keys', function () {
+    const input = { b: 1, a: 2 };
+    const expected = { a: 2, b: 1 };
+    const result = canonicalizeObject(input);
+    assert.notDeepStrictEqual(JSON.stringify(input), JSON.stringify(expected));
+    assert.deepStrictEqual(JSON.stringify(result), JSON.stringify(expected));
+  });
+
+  it('should handle nested objects and sort their keys', function () {
+    const input = { b: { d: 4, c: 3 }, a: 2 };
+    const expected = { a: 2, b: { c: 3, d: 4 } };
+    const result = canonicalizeObject(input);
+    assert.notDeepStrictEqual(JSON.stringify(input), JSON.stringify(expected));
+    assert.deepStrictEqual(JSON.stringify(result), JSON.stringify(expected));
+  });
+
+  it('should handle arrays within objects', function () {
+    const input = { b: [3, 2, 1], a: 2 };
+    const expected = { a: 2, b: [3, 2, 1] };
+    const result = canonicalizeObject(input);
+    assert.notDeepStrictEqual(JSON.stringify(input), JSON.stringify(expected));
+    assert.deepStrictEqual(JSON.stringify(result), JSON.stringify(expected));
+  });
+
+  it('should handle arrays of objects and sort their keys', function () {
+    const input = [
+      { b: 2, a: 1 },
+      { d: 4, c: 3 },
+    ];
+    const expected = [
+      { a: 1, b: 2 },
+      { c: 3, d: 4 },
+    ];
+    const result = canonicalizeObject(input);
+    assert.notDeepStrictEqual(JSON.stringify(input), JSON.stringify(expected));
+    assert.deepStrictEqual(JSON.stringify(result), JSON.stringify(expected));
+  });
+
+  it('should return primitive values as is', function () {
+    assert.strictEqual(JSON.stringify(canonicalizeObject(42)), JSON.stringify(42));
+    assert.strictEqual(JSON.stringify(canonicalizeObject('string')), JSON.stringify('string'));
+  });
+
+  it('should throw an error for invalid object types', function () {
+    assert.throws(() => canonicalizeObject(null as never), /Invalid object type/);
+    assert.throws(() => canonicalizeObject(undefined as never), /Invalid object type/);
+  });
+});


### PR DESCRIPTION
This PR adds Signable type and canonicalizeObject utility function to sign a serialized sorted object for lightning payment requests. 

Ticket: BTC-1401