### PR TITLE
ci: avoid duplicate JavaScript scan

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['javascript', 'javascript-typescript']
+        language: ['javascript-typescript']
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This commit removes duplicate languages from the CodeQL configuration,
as instructed by CI[^1].

This documentation shows the diff does not change behavior: https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning

Ticket: VL-0

[^1]: https://github.com/BitGo/BitGoJS/actions/runs/10374057429