### PR TITLE
fix(statics): rename Bitcoin TRC20 token

### DIFF
--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -12193,7 +12193,7 @@ export const coins = CoinMap.fromCoins([
   tronToken(
     'd8d505d2-f525-4922-b538-317b879bd316',
     'trx:btc',
-    'Bitcoin',
+    'Bitcoin (TRC20)',
     8,
     'TN3W4H6rK2ce4vX9YnFQHwKENnHjoxb3m9',
     UnderlyingAsset.BTC


### PR DESCRIPTION
TICKET: [COIN-1462](https://bitgoinc.atlassian.net/browse/COIN-1462)

Updated the token name to `Bitcoin (TRC20)`

[COIN-1462]: https://bitgoinc.atlassian.net/browse/COIN-1462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ