### PR TITLE
feat(sdk-core): add encryptedWalletPassphrase to generateWallet method

### DIFF
--- a/modules/bitgo/test/v2/unit/lightning/lightningWallets.ts
+++ b/modules/bitgo/test/v2/unit/lightning/lightningWallets.ts
@@ -1,3 +1,4 @@
+import * as assert from 'assert';
 import { TestBitGo } from '@bitgo/sdk-test';
 import * as nock from 'nock';
 
@@ -164,7 +165,14 @@ describe('Lightning wallets', function () {
         .post('/api/v2/tlnbtc/wallet', (body) => validateWalletRequest(body))
         .reply(200, { id: 'walletId' });
 
-      await wallets.generateWallet(params);
+      const response = await wallets.generateWallet(params);
+
+      assert.ok(response.wallet);
+      assert.ok(response.encryptedWalletPassphrase);
+      assert.equal(
+        bitgo.decrypt({ input: response.encryptedWalletPassphrase, password: params.passcodeEncryptionCode }),
+        params.passphrase
+      );
     });
   });
 });

--- a/modules/sdk-core/src/bitgo/wallet/iWallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallets.ts
@@ -9,12 +9,14 @@ export interface WalletWithKeychains extends KeychainsTriplet {
   responseType: 'WalletWithKeychains';
   wallet: IWallet;
   warning?: string;
+  encryptedWalletPassphrase?: string;
 }
 
 export interface LightningWalletWithKeychains extends LightningKeychainsTriplet {
   responseType: 'LightningWalletWithKeychains';
   wallet: IWallet;
   warning?: string;
+  encryptedWalletPassphrase?: string;
 }
 
 export interface GetWalletOptions {


### PR DESCRIPTION
Added a new field in the generateWallet response that its the wallet passphrase encrypted with the passcode, this data can be used to do recover the original password, same as the box D on a keycard. Its only available for hot wallets and if passphrase and the passcode is provided

WP-2525

TICKET: WP-2525

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
