### PR TITLE
feat(sdk-core): improve wallet.signTransaction to get the user key

### DIFF
--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -206,6 +206,7 @@ export interface WalletSignTransactionOptions extends WalletSignBaseOptions {
   customMPCv2SigningRound3GenerationFunction?: CustomMPCv2SigningRound3GeneratingFunction;
   apiVersion?: ApiVersion;
   multisigTypeVersion?: 'MPCv2';
+  walletPassphrase?: string;
   [index: string]: unknown;
 }
 

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -1717,6 +1717,21 @@ export class Wallet implements IWallet {
       params.txPrebuild = { txRequestId };
     }
 
+    if (params.walletPassphrase && !(params.keychain || params.key)) {
+      if (!_.isString(params.walletPassphrase)) {
+        throw new Error('walletPassphrase must be a string');
+      }
+      const keychains = await this.getKeychainsAndValidatePassphrase({
+        reqId: params.reqId,
+        walletPassphrase: params.walletPassphrase,
+      });
+      const userKeychain = keychains[0];
+      if (!userKeychain || !userKeychain.encryptedPrv) {
+        throw new Error('the user keychain does not have property encryptedPrv');
+      }
+      params.keychain = userKeychain;
+    }
+
     const presign = await this.baseCoin.presignTransaction({
       ...params,
       walletData: this._wallet,


### PR DESCRIPTION
In order to allow the signTssTx express endpoint to sign tx without external signer, we need to modify the signTransaction method to get the key if the walletPassphrase is provided

WP-2535

TICKET: WP-2523

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
