### PR TITLE
fix(sdk-coin-sui): remove keychain check from isWalletAddress()

### DIFF
--- a/modules/sdk-coin-sui/src/sui.ts
+++ b/modules/sdk-coin-sui/src/sui.ts
@@ -155,29 +155,11 @@ export class Sui extends BaseCoin {
   }
 
   async isWalletAddress(params: TssVerifyAddressOptions): Promise<boolean> {
-    const { keychains, address: newAddress, index } = params;
+    const { address: newAddress } = params;
 
     if (!this.isValidAddress(newAddress)) {
       throw new InvalidAddressError(`invalid address: ${newAddress}`);
     }
-
-    if (!keychains) {
-      throw new Error('missing required param keychains');
-    }
-
-    for (const keychain of keychains) {
-      const MPC = await EDDSAMethods.getInitializedMpcInstance();
-      const commonKeychain = keychain.commonKeychain as string;
-
-      const derivationPath = 'm/' + index;
-      const derivedPublicKey = MPC.deriveUnhardened(commonKeychain, derivationPath).slice(0, 64);
-      const expectedAddress = this.getAddressFromPublicKey(derivedPublicKey);
-
-      if (newAddress !== expectedAddress) {
-        return false;
-      }
-    }
-
     return true;
   }
 

--- a/modules/sdk-coin-sui/test/unit/sui.ts
+++ b/modules/sdk-coin-sui/test/unit/sui.ts
@@ -307,14 +307,6 @@ describe('SUI:', function () {
       (await basecoin.isWalletAddress(params)).should.equal(true);
     });
 
-    it('should return false for isWalletAddress with valid address for index 5 and address is for a different index', async function () {
-      const wrongAddressForIndex5 = '0xc392383b676f4008bbf7c290c3712aa04d0cb3fe10a5f2db14cf5019c26fe0bb';
-      const index = 5;
-
-      const params = { commonKeychain, address: wrongAddressForIndex5, index, keychains };
-      (await basecoin.isWalletAddress(params)).should.equal(false);
-    });
-
     it('should throw error for isWalletAddress when keychains is missing', async function () {
       const address = '0x2959bfc3fdb7dc23fed8deba2fafb70f3e606a59';
       const index = 0;


### PR DESCRIPTION
**Context:**
New address is getting generated but toast msg is invalid.
**Steps to reproduce:**
1. goto a cold SUI wallet
2. Create on generate address button.
**Issue**: it throws unable to generate address toast msg


https://github.com/user-attachments/assets/1ec106f7-10e2-4206-b28f-814212a0db1e

**Solution:**
Remove the keychain check from isWalletAddress() function because it returns false for cold wallets
created with key derivation using seed.

**TICKET:** WIN-3358

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
