### PR TITLE
feat(utxo-lib): add convertExtendedKeyNetwork function

### DIFF
--- a/modules/utxo-lib/test/bitgo/keyutil.ts
+++ b/modules/utxo-lib/test/bitgo/keyutil.ts
@@ -1,9 +1,15 @@
+import { networks } from '../../src';
+
 const assert = require('assert');
 const crypto = require('crypto');
 
 import { ECPairInterface } from 'ecpair';
-import { privateKeyBufferFromECPair, privateKeyBufferToECPair } from '../../src/bitgo/keyutil';
-import { ECPair } from '../../src/noble_ecc';
+import {
+  convertExtendedKeyNetwork,
+  privateKeyBufferFromECPair,
+  privateKeyBufferToECPair,
+} from '../../src/bitgo/keyutil';
+import { bip32, ECPair } from '../../src/noble_ecc';
 
 describe('privateKeyBufferFromECPair', function () {
   it('pads short private keys', function () {
@@ -53,5 +59,45 @@ describe('privateKeyBufferToECPair', function () {
     assert.throws(function () {
       privateKeyBufferToECPair(Buffer.alloc(33, 0x00));
     }, new RegExp('invalid private key buffer'));
+  });
+});
+
+describe('convertExtendedKeyNetwork', function () {
+  const prvKeyBuffer = crypto.randomBytes(32);
+  const mainnetHdNode = bip32.fromSeed(prvKeyBuffer, networks.bitcoin);
+  const testnetHdNode = bip32.fromSeed(prvKeyBuffer, networks.testnet);
+
+  it('should return the same extended key if fromNetwork and targetNetwork are the same', () => {
+    const extendedKey = mainnetHdNode.toBase58();
+    const result = convertExtendedKeyNetwork(extendedKey, networks.bitcoin, networks.bitcoin);
+    assert.strictEqual(result, extendedKey);
+  });
+
+  it('should change the network from mainnet to testnet for a neutered (public) key', () => {
+    const extendedKey = mainnetHdNode.neutered().toBase58();
+    const expectedKey = convertExtendedKeyNetwork(extendedKey, networks.bitcoin, networks.testnet);
+    const testnetHdNodeFromExpected = bip32.fromBase58(expectedKey, networks.testnet);
+    assert.deepStrictEqual(testnetHdNodeFromExpected.publicKey, mainnetHdNode.neutered().publicKey);
+  });
+
+  it('should change the network from testnet to mainnet for a neutered (public) key', () => {
+    const extendedKey = testnetHdNode.neutered().toBase58();
+    const expectedKey = convertExtendedKeyNetwork(extendedKey, networks.testnet, networks.bitcoin);
+    const mainnetHdNodeFromExpected = bip32.fromBase58(expectedKey, networks.bitcoin);
+    assert.deepStrictEqual(mainnetHdNodeFromExpected.publicKey, testnetHdNode.neutered().publicKey);
+  });
+
+  it('should change the network from mainnet to testnet for a non-neutered (private) key', () => {
+    const extendedKey = mainnetHdNode.toBase58();
+    const expectedKey = convertExtendedKeyNetwork(extendedKey, networks.bitcoin, networks.testnet);
+    const testnetHdNodeFromExpected = bip32.fromBase58(expectedKey, networks.testnet);
+    assert.deepStrictEqual(testnetHdNodeFromExpected.privateKey, mainnetHdNode.privateKey);
+  });
+
+  it('should change the network from testnet to mainnet for a non-neutered (private) key', () => {
+    const extendedKey = testnetHdNode.toBase58();
+    const expectedKey = convertExtendedKeyNetwork(extendedKey, networks.testnet, networks.bitcoin);
+    const mainnetHdNodeFromExpected = bip32.fromBase58(expectedKey, networks.bitcoin);
+    assert.deepStrictEqual(mainnetHdNodeFromExpected.privateKey, testnetHdNode.privateKey);
   });
 });


### PR DESCRIPTION
To convert extended key from one network to another

Ticket: BTC-1467

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
