### PR TITLE
fix: remove no-redeclare rule from eslint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -54,7 +54,6 @@
     "no-path-concat": "off",
     "no-process-env": "off",
     "no-process-exit": "off",
-    "no-redeclare": ["error", { "builtinGlobals": true }],
     "no-sync": "warn",
     "no-trailing-spaces": ["warn", { "skipBlankLines": true, "ignoreComments": true }],
     "no-undef": "error",


### PR DESCRIPTION
This rule yields false positives when exporting a type and a const with the same
name (as common in io-ts codec and type pairs).

The rule is checked by the typescript compiler, so it is not necessary to have
it in the eslint config.

See https://typescript-eslint.io/rules/no-redeclare/

Issue: BTC-1472
