### PR TITLE
fix(sdk-core): refactoring generate custodial multisig to not need pw

### DIFF
--- a/modules/bitgo/test/v2/unit/wallets.ts
+++ b/modules/bitgo/test/v2/unit/wallets.ts
@@ -407,7 +407,6 @@ describe('V2 Wallets:', function () {
         label: 'test wallet',
         enterprise: 'myenterprise',
         type: 'custodial',
-        passphrase: 'secret',
       };
 
       const walletNock = nock(bgUrl)
@@ -419,15 +418,11 @@ describe('V2 Wallets:', function () {
           should.not.exist(body.keySignatures);
           return true;
         })
-        .reply(200);
+        .reply(200, { id: '123', baseCoin: bitgo.coin('tbtc'), keys: ['123', '456', '789'] });
 
-      nock(bgUrl)
-        .post('/api/v2/tbtc/key', _.matches({ source: 'bitgo' }))
-        .reply(200, { pub: 'bitgoPub' });
-      nock(bgUrl).post('/api/v2/tbtc/key', _.matches({})).reply(200);
-      nock(bgUrl)
-        .post('/api/v2/tbtc/key', _.matches({ source: 'backup' }))
-        .reply(200, { pub: 'backupPub' });
+      nock(bgUrl).get('/api/v2/tbtc/key/123').reply(200, { pub: 'bitgoPub', id: '789' });
+      nock(bgUrl).get('/api/v2/tbtc/key/456', _.matches({})).reply(200);
+      nock(bgUrl).get('/api/v2/tbtc/key/789').reply(200, { pub: 'backupPub', id: '789' });
 
       const response = await wallets.generateWallet(params);
 


### PR DESCRIPTION
For custodial multisig, we've been passing in the password parameter, which is not needed. The flow needs to be updated so that when we don't pass in the password, there's no error thrown.

Ticket: WP-2535