### PR TITLE
fix(bitgo): update ada pledge example

### DIFF
--- a/examples/js/ada/send-pledge-transaction.js
+++ b/examples/js/ada/send-pledge-transaction.js
@@ -62,7 +62,7 @@ Promise.coroutine(function* () {
 })();
 
 function parseWitnessCborHex(witnessCborHex) {
-  const regexPattern = /^825820([a-z0-9]{64})5840([a-z0-9]{128})$/;
+  const regexPattern = /^(8200)?825820([a-z0-9]{64})5840([a-z0-9]{128})$/;
   const regex = new RegExp(regexPattern);
   const result = regex.exec(witnessCborHex);
 


### PR DESCRIPTION
Latest cardano-cli transaction witness generates a different CBOR format.

EA-4175

