### PR TITLE
fix(utxo): descriptor address validation

### DIFF
--- a/modules/abstract-utxo/package.json
+++ b/modules/abstract-utxo/package.json
@@ -46,6 +46,7 @@
     "@types/bluebird": "^3.5.25",
     "@types/lodash": "^4.14.121",
     "@types/superagent": "4.1.15",
+    "io-ts": "2.1.3",
     "bignumber.js": "^9.0.2",
     "bitcoinjs-message": "npm:@bitgo-forks/bitcoinjs-message@1.0.0-master.2",
     "bluebird": "^3.5.3",

--- a/modules/abstract-utxo/src/descriptor/NamedDescriptor.ts
+++ b/modules/abstract-utxo/src/descriptor/NamedDescriptor.ts
@@ -1,0 +1,8 @@
+import * as t from 'io-ts';
+
+export const NamedDescriptor = t.type({
+  name: t.string,
+  value: t.string,
+});
+
+export type NamedDescriptor = t.TypeOf<typeof NamedDescriptor>;

--- a/modules/abstract-utxo/src/descriptor/assertDescriptorWalletAddress.ts
+++ b/modules/abstract-utxo/src/descriptor/assertDescriptorWalletAddress.ts
@@ -1,0 +1,44 @@
+import * as assert from 'assert';
+import * as t from 'io-ts';
+import * as utxolib from '@bitgo/utxo-lib';
+import { Descriptor } from '@bitgo/wasm-miniscript';
+
+import { UtxoCoinSpecific, VerifyAddressOptions } from '../abstractUtxoCoin';
+import { NamedDescriptor } from './NamedDescriptor';
+
+class DescriptorAddressMismatchError extends Error {
+  constructor(descriptor: Descriptor, index: number, derivedAddress: string, expectedAddress: string) {
+    super(
+      `Address mismatch for descriptor ${descriptor.toString()} at index ${index}: ${derivedAddress} !== ${expectedAddress}`
+    );
+  }
+}
+
+export function assertDescriptorWalletAddress(
+  network: utxolib.Network,
+  params: VerifyAddressOptions<UtxoCoinSpecific>,
+  descriptors: unknown
+): void {
+  assert(params.coinSpecific);
+  assert(t.array(NamedDescriptor).is(descriptors));
+  assert('descriptorName' in params.coinSpecific);
+  assert('descriptorChecksum' in params.coinSpecific);
+  const descriptorName = params.coinSpecific.descriptorName;
+  const descriptorChecksum = params.coinSpecific.descriptorChecksum;
+  const namedDescriptor = descriptors.find((d) => d.name === descriptorName);
+  if (!namedDescriptor) {
+    throw new Error(`Descriptor ${descriptorName} not found`);
+  }
+  const descriptor = Descriptor.fromString(namedDescriptor.value, 'derivable');
+  const checksum = descriptor.toString().slice(-8);
+  if (checksum !== descriptorChecksum) {
+    throw new Error(
+      `Descriptor checksum mismatch for descriptor name=${descriptorName}: ${checksum} !== ${descriptorChecksum}`
+    );
+  }
+  const derivedScript = Buffer.from(descriptor.atDerivationIndex(params.index).scriptPubkey());
+  const derivedAddress = utxolib.address.fromOutputScript(derivedScript, network);
+  if (params.address !== derivedAddress) {
+    throw new DescriptorAddressMismatchError(descriptor, params.index, derivedAddress, params.address);
+  }
+}

--- a/modules/abstract-utxo/src/descriptor/index.ts
+++ b/modules/abstract-utxo/src/descriptor/index.ts
@@ -1,0 +1,3 @@
+export { Miniscript, Descriptor } from '@bitgo/wasm-miniscript';
+export { assertDescriptorWalletAddress } from './assertDescriptorWalletAddress';
+export { NamedDescriptor } from './NamedDescriptor';

--- a/modules/abstract-utxo/src/index.ts
+++ b/modules/abstract-utxo/src/index.ts
@@ -3,3 +3,5 @@ export * from './config';
 export * from './recovery';
 export * from './replayProtection';
 export * from './sign';
+
+export * as descriptor from './descriptor';

--- a/modules/bitgo/.mocharc.yml
+++ b/modules/bitgo/.mocharc.yml
@@ -5,4 +5,3 @@ reporter-option:
   - 'cdn=true'
   - 'json=false'
 exit: true
-spec: ['test/v2/unit/**/*.ts', test/unit/**/*.ts]

--- a/modules/bitgo/package.json
+++ b/modules/bitgo/package.json
@@ -26,7 +26,7 @@
     "webpack-dev": "cross-env NODE_ENV=development webpack",
     "webpack-prod": "NODE_OPTIONS=--max-old-space-size=4096 cross-env NODE_ENV=production webpack",
     "test": "npm run coverage",
-    "unit-test": "mocha",
+    "unit-test": "mocha 'test/v2/unit/**/*.ts' 'test/unit/**/*.ts'",
     "coverage": "nyc -- npm run unit-test",
     "integration-test": "nyc -- mocha \"test/v2/integration/**/*.ts\"",
     "browser-test": "karma start karma.conf.js",

--- a/modules/bitgo/test/v2/unit/coins/abstractUtxoCoin.ts
+++ b/modules/bitgo/test/v2/unit/coins/abstractUtxoCoin.ts
@@ -7,12 +7,10 @@ import { BitGo } from '../../../../src/bitgo';
 import {
   AbstractUtxoCoin,
   AbstractUtxoCoinWallet,
-  NamedDescriptor,
   Output,
   TransactionExplanation,
   TransactionParams,
 } from '@bitgo/abstract-utxo';
-import * as assert from 'node:assert';
 
 describe('Abstract UTXO Coin:', () => {
   describe('Parse Transaction:', () => {
@@ -555,8 +553,18 @@ describe('Abstract UTXO Coin:', () => {
         keySignatures: {},
         outputs: [],
         missingOutputs: [],
-        explicitExternalOutputs: [{ address: 'external_address', amount: '10000' }],
-        implicitExternalOutputs: [{ address: 'external_address_2', amount: '15' }],
+        explicitExternalOutputs: [
+          {
+            address: 'external_address',
+            amount: '10000',
+          },
+        ],
+        implicitExternalOutputs: [
+          {
+            address: 'external_address_2',
+            amount: '15',
+          },
+        ],
         changeOutputs: [],
         explicitExternalSpendAmount: BigInt(10000),
         implicitExternalSpendAmount: BigInt(15),
@@ -582,50 +590,6 @@ describe('Abstract UTXO Coin:', () => {
 
       coinMock.restore();
       bitcoinMock.restore();
-    });
-  });
-
-  describe('descriptor wallets', () => {
-    const bitgo: BitGo = TestBitGo.decorate(BitGo, { env: 'mock' });
-    const coin = bitgo.coin('tbtc') as AbstractUtxoCoin;
-
-    const rawDescriptor: NamedDescriptor = {
-      name: 'foo',
-      value:
-        "sh(multi(2,[00000000/111'/222]xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y/0/*))",
-      signatures: [],
-      lastIndex: 0,
-    };
-
-    it('should create an address', async () => {
-      const address = coin.generateAddress({ descriptor: rawDescriptor, index: 0 });
-
-      should.exist(address);
-      should.deepEqual(address.address, '2NAukrNbhcZNNZ83zFPN48X44FE5qNdYgDv');
-      assert('descriptor' in address.coinSpecific);
-      should.deepEqual(address.coinSpecific.descriptor, rawDescriptor);
-    });
-
-    it('should check if isWalletAddress', async () => {
-      const matchingAddressResult = await coin.isWalletAddress({
-        coinSpecific: { descriptor: rawDescriptor },
-        index: 0,
-        address: '2NAukrNbhcZNNZ83zFPN48X44FE5qNdYgDv',
-      });
-      should.equal(matchingAddressResult, true);
-
-      try {
-        await coin.isWalletAddress({
-          coinSpecific: { descriptor: rawDescriptor },
-          index: 1,
-          address: '2NAukrNbhcZNNZ83zFPN48X44FE5qNdYgDv',
-        });
-        throw '';
-      } catch (e) {
-        e.message.should.equal(
-          'address validation failure: expected 2N49LHwLRJ8oNXzLYWJM6sVVawC6QeC9B54 but got 2NAukrNbhcZNNZ83zFPN48X44FE5qNdYgDv'
-        );
-      }
     });
   });
 });

--- a/modules/bitgo/test/v2/unit/coins/utxo/descriptorAddress.ts
+++ b/modules/bitgo/test/v2/unit/coins/utxo/descriptorAddress.ts
@@ -1,0 +1,83 @@
+import * as assert from 'node:assert';
+
+import { TestBitGo } from '@bitgo/sdk-test';
+import { AbstractUtxoCoin, descriptor as utxod } from '@bitgo/abstract-utxo';
+import * as utxolib from '@bitgo/utxo-lib';
+import { IWallet, WalletCoinSpecific } from '@bitgo/sdk-core';
+
+import { BitGo } from '../../../../../src';
+
+export function getDescriptorAddress(d: string, index: number, network: utxolib.Network): string {
+  const derivedScript = Buffer.from(
+    utxod.Descriptor.fromString(d, 'derivable').atDerivationIndex(index).scriptPubkey()
+  );
+  return utxolib.address.fromOutputScript(derivedScript, network);
+}
+
+describe('descriptor wallets', function () {
+  const bitgo: BitGo = TestBitGo.decorate(BitGo, { env: 'mock' });
+  const coin = bitgo.coin('tbtc') as AbstractUtxoCoin;
+  const xpubs = utxolib.testutil.getKeyTriple('setec astronomy').map((k) => k.neutered().toBase58());
+
+  function withChecksum(descriptor: string): string {
+    return utxod.Descriptor.fromString(descriptor, 'derivable').toString();
+  }
+
+  function getNamedDescriptor2Of2(name: string, a: string, b: string): utxod.NamedDescriptor {
+    return {
+      name,
+      value: withChecksum(`sh(multi(2,${a}/*,${b}/*))`),
+    };
+  }
+
+  function getIWalletWithDescriptors(descriptors: utxod.NamedDescriptor[]): IWallet {
+    return {
+      coinSpecific() {
+        return { descriptors } as unknown as WalletCoinSpecific;
+      },
+    } as IWallet;
+  }
+
+  const descFoo = getNamedDescriptor2Of2('foo', xpubs[0], xpubs[1]);
+  const descBar = getNamedDescriptor2Of2('bar', xpubs[1], xpubs[0]);
+  const addressFoo0 = getDescriptorAddress(descFoo.value, 0, coin.network);
+  const addressFoo1 = getDescriptorAddress(descFoo.value, 1, coin.network);
+  const addressBar0 = getDescriptorAddress(descBar.value, 0, coin.network);
+
+  it('has expected values', function () {
+    assert.deepStrictEqual(
+      [addressFoo0, addressFoo1, addressBar0],
+      [
+        '2N9b1trWxMJN16mTzGJypFn6pEWfXtgh689',
+        '2N1YFzj4ECzcjuruaEvSzGaGGH1topMXMXZ',
+        '2N9oN5Kc2fLt2MrxEkuQPsy8Fg2KdrFfeKH',
+      ]
+    );
+  });
+
+  function runTestIsAddress(
+    address: string,
+    index: number,
+    descriptorName: string,
+    descriptorChecksum: string,
+    expected: true | Error | RegExp
+  ) {
+    it(`should return ${expected} for address ${address} with index ${index} and descriptor ${descriptorName} with checksum ${descriptorChecksum}`, async function () {
+      const wallet = getIWalletWithDescriptors([descFoo, descBar]);
+      async function f() {
+        return coin.isWalletAddress({ address, index, coinSpecific: { descriptorName, descriptorChecksum } }, wallet);
+      }
+      if (expected === true) {
+        assert.equal(await f(), expected);
+      } else {
+        // because isWalletAddress is stupid it actually throws instead of returning false
+        await assert.rejects(f, expected);
+      }
+    });
+  }
+
+  runTestIsAddress(addressFoo0, 0, 'foo', descFoo.value.slice(-8), true);
+  runTestIsAddress(addressFoo1, 0, 'foo', descFoo.value.slice(-8), /Address mismatch for descriptor/);
+  runTestIsAddress(addressBar0, 0, 'bar', descFoo.value.slice(-8), /Descriptor checksum mismatch/);
+  runTestIsAddress(addressFoo0, 0, 'bar', descBar.value.slice(-8), /Address mismatch for descriptor/);
+});

--- a/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
@@ -496,7 +496,7 @@ export interface IBaseCoin {
   explainTransaction(options: Record<string, any>): Promise<ITransactionExplanation<any, string | number> | undefined>;
   verifyTransaction(params: VerifyTransactionOptions): Promise<boolean>;
   verifyAddress(params: VerifyAddressOptions): Promise<boolean>;
-  isWalletAddress(params: VerifyAddressOptions): Promise<boolean>;
+  isWalletAddress(params: VerifyAddressOptions, wallet?: IWallet): Promise<boolean>;
   canonicalAddress(address: string, format: unknown): string;
   supportsBlockTarget(): boolean;
   supportsLightning(): boolean;

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -1246,7 +1246,7 @@ export class Wallet implements IWallet {
         // can't verify addresses which are pending chain initialization, as the address is hidden
         let isWalletAddress = false;
         try {
-          isWalletAddress = await this.baseCoin.isWalletAddress(verificationData);
+          isWalletAddress = await this.baseCoin.isWalletAddress(verificationData, this);
         } catch (e) {
           if (!(e instanceof MethodNotImplementedError)) {
             throw e;


### PR DESCRIPTION
- **refactor: pass wallet instance to isWalletAddress**
  Address verification can depend on the type of wallet that is being used.
  
  Pass the wallet instance to the isWalletAddress method so that the method
  can decide how to verify the address based on the wallet type.
  
  Issue: BTC-1451
  

- **fix(abstract-utxo): address verification**
  The previous version of address verification used data from the API response
  that was not available.
  
  This version branches out to a custom address verification function that
  uses the data that is available and performs the correct checks.
  
  Issue: BTC-1451
  