### PR TITLE
fix(express): adding missing external signer mode sig param

### DIFF
--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -1276,10 +1276,12 @@ export function createCustomSigningFunction(externalSignerUrl: string): CustomSi
   return async function (params): Promise<SignedTransaction> {
     const { body: signedTx } = await retryPromise(
       () =>
-        superagent
-          .post(`${externalSignerUrl}/api/v2/${params.coin.getChain()}/sign`)
-          .type('json')
-          .send({ txPrebuild: params.txPrebuild, pubs: params.pubs, derivationSeed: params.derivationSeed }),
+        superagent.post(`${externalSignerUrl}/api/v2/${params.coin.getChain()}/sign`).type('json').send({
+          txPrebuild: params.txPrebuild,
+          pubs: params.pubs,
+          derivationSeed: params.derivationSeed,
+          signingStep: params.signingStep,
+        }),
       (err, tryCount) => {
         debug(`failed to connect to external signer (attempt ${tryCount}, error: ${err.message})`);
       }

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -179,6 +179,7 @@ export interface CustomSigningFunction {
     txPrebuild: TransactionPrebuild;
     pubs?: string[];
     derivationSeed?: string;
+    signingStep?: 'signerNonce' | 'signerSignature' | 'cosignerNonce';
   }): Promise<SignedTransaction>;
 }
 


### PR DESCRIPTION
External signer mode requires signingStep param of musig2.

Ticket: BTC-1487

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
