### PR TITLE
chore(utxo-lib)!: remove unnecessary properties from WalletUnspent

### DIFF
--- a/modules/abstract-utxo/src/recovery/backupKeyRecovery.ts
+++ b/modules/abstract-utxo/src/recovery/backupKeyRecovery.ts
@@ -36,7 +36,7 @@ import { signAndVerifyPsbt } from '../sign';
 import { getMainnet, networks } from '@bitgo/utxo-lib';
 
 export interface OfflineVaultTxInfo {
-  inputs: WalletUnspent<number>[];
+  inputs: WalletUnspentJSON[];
 }
 
 export interface FormattedOfflineVaultTxInfo {
@@ -239,7 +239,7 @@ async function getRecoveryFeePerBytes(
 }
 
 export type BackupKeyRecoveryTransansaction = {
-  inputs?: WalletUnspent<number>[];
+  inputs?: WalletUnspentJSON[];
   transactionHex: string;
   coin: string;
   backupKey: string;

--- a/modules/utxo-lib/src/bitgo/wallet/Unspent.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/Unspent.ts
@@ -47,8 +47,6 @@ export const MAX_BIP125_RBF_SEQUENCE = 0xffffffff - 2;
 export interface WalletUnspent<TNumber extends number | bigint = number> extends Unspent<TNumber> {
   chain: ChainCode;
   index: number;
-  witnessScript?: string;
-  valueString?: string;
 }
 
 export interface NonWitnessWalletUnspent<TNumber extends number | bigint = number>


### PR DESCRIPTION
The type contains some fields that are only relevant in the JSON api and don't
belong in utxo-lib

Issue: BTC-1351
