### PR TITLE
feat(utxo-lib): add toPsbtBuffer

### DIFF
--- a/modules/utxo-lib/test/bitgo/psbt/toPsbtBuffer.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/toPsbtBuffer.ts
@@ -1,0 +1,27 @@
+import * as assert from 'assert';
+
+import { toPsbtBuffer } from '../../../src/bitgo';
+
+describe('bufferUtil', function () {
+  function variants(data: Buffer | string): (Buffer | string)[] {
+    return [
+      data,
+      data.toString('hex'),
+      Buffer.from(data.toString('hex')),
+      data.toString('base64'),
+      Buffer.from(data.toString('base64')),
+    ];
+  }
+
+  it('should convert a buffer to a string', function () {
+    const psbt = Buffer.from('psbt\xff', 'ascii');
+    for (const v of variants(psbt)) {
+      assert.ok(toPsbtBuffer(v).equals(psbt));
+    }
+
+    const nonPsbt = Buffer.from('hello world', 'ascii');
+    for (const v of variants(nonPsbt)) {
+      assert.throws(() => toPsbtBuffer(v));
+    }
+  });
+});


### PR DESCRIPTION
First checks if the input is already a buffer that starts with the magic PSBT
byte sequence. If not, it checks if the input is a base64- or hex-encoded string
that starts with the PSBT header.

This function is useful when reading a file or request that could be in any of
the above formats.

Issue: BTC-1351
