### PR TITLE
chore(sdk-api): enable esModuleInterop

### DIFF
--- a/modules/sdk-api/src/api.ts
+++ b/modules/sdk-api/src/api.ts
@@ -2,12 +2,12 @@
  * @prettier
  */
 import Debug from 'debug';
-import * as eol from 'eol';
-import * as _ from 'lodash';
-import * as sanitizeHtml from 'sanitize-html';
-import * as superagent from 'superagent';
-import * as urlLib from 'url';
-import * as querystring from 'querystring';
+import eol from 'eol';
+import _ from 'lodash';
+import sanitizeHtml from 'sanitize-html';
+import superagent from 'superagent';
+import urlLib from 'url';
+import querystring from 'querystring';
 
 import { ApiResponseError, BitGoRequest } from '@bitgo/sdk-core';
 

--- a/modules/sdk-api/src/v1/blockchain.ts
+++ b/modules/sdk-api/src/v1/blockchain.ts
@@ -12,8 +12,8 @@
 // Copyright 2014, BitGo, Inc.  All Rights Reserved.
 //
 
-import * as Bluebird from 'bluebird';
-import * as _ from 'lodash';
+import Bluebird from 'bluebird';
+import _ from 'lodash';
 
 import { common } from '@bitgo/sdk-core';
 

--- a/modules/sdk-api/src/v1/keychains.ts
+++ b/modules/sdk-api/src/v1/keychains.ts
@@ -15,7 +15,7 @@ import { bip32 } from '@bitgo/utxo-lib';
 import { randomBytes } from 'crypto';
 import { common, Util, sanitizeLegacyPath } from '@bitgo/sdk-core';
 const _ = require('lodash');
-import * as Bluebird from 'bluebird';
+import Bluebird from 'bluebird';
 const co = Bluebird.coroutine;
 
 //

--- a/modules/sdk-api/src/v1/markets.ts
+++ b/modules/sdk-api/src/v1/markets.ts
@@ -11,7 +11,7 @@
 // Copyright 2015, BitGo, Inc.  All Rights Reserved.
 //
 
-import * as Bluebird from 'bluebird';
+import Bluebird from 'bluebird';
 
 import { common } from '@bitgo/sdk-core';
 

--- a/modules/sdk-api/src/v1/pendingapproval.ts
+++ b/modules/sdk-api/src/v1/pendingapproval.ts
@@ -12,8 +12,8 @@
 import { common } from '@bitgo/sdk-core';
 import * as utxolib from '@bitgo/utxo-lib';
 
-import * as Bluebird from 'bluebird';
-import * as _ from 'lodash';
+import Bluebird from 'bluebird';
+import _ from 'lodash';
 
 //
 // Constructor

--- a/modules/sdk-api/src/v1/pendingapprovals.ts
+++ b/modules/sdk-api/src/v1/pendingapprovals.ts
@@ -11,7 +11,7 @@
 // Copyright 2015, BitGo, Inc.  All Rights Reserved.
 //
 
-import * as Bluebird from 'bluebird';
+import Bluebird from 'bluebird';
 import * as _ from 'lodash';
 
 import { common } from '@bitgo/sdk-core';

--- a/modules/sdk-api/src/v1/signPsbt.ts
+++ b/modules/sdk-api/src/v1/signPsbt.ts
@@ -1,6 +1,6 @@
 import * as utxolib from '@bitgo/utxo-lib';
 
-import * as buildDebug from 'debug';
+import buildDebug from 'debug';
 
 const debug = buildDebug('bitgo:v1:txb');
 

--- a/modules/sdk-api/src/v1/transactionBuilder.ts
+++ b/modules/sdk-api/src/v1/transactionBuilder.ts
@@ -12,9 +12,9 @@
 //
 
 import { bip32 } from '@bitgo/utxo-lib';
-import * as Bluebird from 'bluebird';
+import Bluebird from 'bluebird';
 import * as utxolib from '@bitgo/utxo-lib';
-import * as _ from 'lodash';
+import _ from 'lodash';
 import { VirtualSizes } from '@bitgo/unspents';
 import debugLib = require('debug');
 const debug = debugLib('bitgo:v1:txb');

--- a/modules/sdk-api/src/v1/travelRule.ts
+++ b/modules/sdk-api/src/v1/travelRule.ts
@@ -13,8 +13,8 @@
 import { common, getNetwork, getSharedSecret, makeRandomKey, sanitizeLegacyPath } from '@bitgo/sdk-core';
 import { bip32, BIP32Interface } from '@bitgo/utxo-lib';
 import * as utxolib from '@bitgo/utxo-lib';
-import * as Bluebird from 'bluebird';
-import * as _ from 'lodash';
+import Bluebird from 'bluebird';
+import _ from 'lodash';
 
 interface DecryptReceivedTravelRuleOptions {
   tx?: {

--- a/modules/sdk-api/src/v1/wallet.ts
+++ b/modules/sdk-api/src/v1/wallet.ts
@@ -12,7 +12,7 @@
 //
 
 import { VirtualSizes } from '@bitgo/unspents';
-import * as assert from 'assert';
+import assert from 'assert';
 
 import * as utxolib from '@bitgo/utxo-lib';
 import { bip32 } from '@bitgo/utxo-lib';
@@ -24,8 +24,8 @@ import {
   makeRandomKey,
   sanitizeLegacyPath,
 } from '@bitgo/sdk-core';
-import * as Bluebird from 'bluebird';
-import * as _ from 'lodash';
+import Bluebird from 'bluebird';
+import _ from 'lodash';
 import { signPsbtRequest } from './signPsbt';
 
 const TransactionBuilder = require('./transactionBuilder');

--- a/modules/sdk-api/src/v1/wallets.ts
+++ b/modules/sdk-api/src/v1/wallets.ts
@@ -20,8 +20,8 @@ import {
 } from '@bitgo/sdk-core';
 import { bip32 } from '@bitgo/utxo-lib';
 import * as utxolib from '@bitgo/utxo-lib';
-import * as _ from 'lodash';
-import * as Bluebird from 'bluebird';
+import _ from 'lodash';
+import Bluebird from 'bluebird';
 const co = Bluebird.coroutine;
 const Wallet = require('./wallet');
 

--- a/modules/sdk-api/test/unit/encrypt.ts
+++ b/modules/sdk-api/test/unit/encrypt.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import assert from 'assert';
 import { randomBytes } from 'crypto';
 
 import { decrypt, encrypt } from '../../src';

--- a/modules/sdk-api/test/unit/v1/wallet.ts
+++ b/modules/sdk-api/test/unit/v1/wallet.ts
@@ -12,7 +12,7 @@ import * as _ from 'lodash';
 import { common } from '@bitgo/sdk-core';
 import * as utxolib from '@bitgo/utxo-lib';
 import * as should from 'should';
-import * as nock from 'nock';
+import nock from 'nock';
 import * as sinon from 'sinon';
 
 import { getFixtures } from './fixtures/accelerate-tx';

--- a/modules/sdk-api/tsconfig.json
+++ b/modules/sdk-api/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": ".",
-    "esModuleInterop": false,
+    "esModuleInterop": true,
     "typeRoots": ["../../types", "./node_modules/@types", "../../node_modules/@types"]
   },
   "include": ["src/**/*", "package.json", "test/**/*"],


### PR DESCRIPTION
Requires some changes to the imports in the codebase to use the default import
syntax.

Issue: BTC-1351
