### PR TITLE
feat(wp): add manage unspents build flag to fanoutUnspents

### DIFF
--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -1500,7 +1500,6 @@ describe('V2 Wallet:', function () {
     it('should pass unspents parameter when calling fanout unspents', async function () {
       const path = `/api/v2/${wallet.coin()}/wallet/${wallet.id()}/fanoutUnspents`;
       const response = nock(bgUrl)
-        .persist()
         .post(path, _.matches({ unspents })) // use _.matches to do a partial match on request body object instead of strict matching
         .reply(200);
 
@@ -1516,13 +1515,18 @@ describe('V2 Wallet:', function () {
 
     it('should only build tx (not sign/send) while fanning out unspents', async function () {
       const path = `/api/v2/${wallet.coin()}/wallet/${wallet.id()}/fanoutUnspents`;
-      const response = nock(bgUrl).persist().post(path, _.matches({ unspents })).reply(200);
+      const response = nock(bgUrl).post(path, _.matches({ unspents })).reply(200);
 
       const unusedNocks = nock(bgUrl);
       unusedNocks.get(`/api/v2/${wallet.coin()}/key/${wallet.keyIds()[0]}`).reply(200);
       unusedNocks.post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/send`).reply(200);
 
-      await wallet.fanoutUnspents({ address, unspents }, ManageUnspentsOptions.BUILD_ONLY);
+      try {
+        await wallet.fanoutUnspents({ address, unspents }, ManageUnspentsOptions.BUILD_ONLY);
+      } catch (e) {
+        // the fanoutUnspents method will probably throw an exception for not having all of the correct nocks
+        // we only care about /fanoutUnspents and whether unspents is an allowed parameter
+      }
 
       response.isDone().should.be.true();
       unusedNocks.pendingMocks().length.should.eql(2);
@@ -1585,6 +1589,7 @@ describe('V2 Wallet:', function () {
       await wallet.consolidateUnspents({ bulk: true, walletPassphrase });
 
       nocks.forEach((n) => {
+        console.log(n);
         n.isDone().should.be.true();
       });
     });

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -815,9 +815,14 @@ export class Wallet implements IWallet {
    * @param {Number} params.maxFeeRate - The max limit for a fee rate in satoshis/kB
    * @param {Number} params.maxNumInputsToUse - the number of unspents you want to use in the transaction
    * @param {Number} params.numUnspentsToMake - the number of new unspents to make
+   *
+   * @param {ManageUnspentsOptions} option - flag to toggle build and send or build only
    */
-  async fanoutUnspents(params: FanoutUnspentsOptions = {}): Promise<unknown> {
-    return this.manageUnspents('fanout', params);
+  async fanoutUnspents(
+    params: FanoutUnspentsOptions = {},
+    option = ManageUnspentsOptions.BUILD_SIGN_SEND
+  ): Promise<unknown> {
+    return this.manageUnspents('fanout', params, option);
   }
 
   /**


### PR DESCRIPTION
TICKET: BTC-1527

Add ManageUnspentOptions options flag to enable building fanout transactions without signing and sending.
<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
