### PR TITLE
feat(statics): removal of trust frankfurt for arbeth:arb

### DIFF
--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -301,7 +301,6 @@ const INJECTIVE_FEATURES = [
 ];
 const TOKEN_FEATURES_WITH_SWISS = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.CUSTODY_BITGO_SWITZERLAND];
 const TOKEN_FEATURES_WITH_NY = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.CUSTODY_BITGO_NEW_YORK];
-const TOKEN_FEATURES_WITH_FRANKFURT = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.CUSTODY_BITGO_FRANKFURT];
 const GENERIC_TOKEN_FEATURES = [
   CoinFeature.ACCOUNT_MODEL,
   CoinFeature.REQUIRES_BIG_NUMBER,
@@ -18287,8 +18286,7 @@ export const coins = CoinMap.fromCoins([
     'Arbitrum',
     18,
     '0x912ce59144191c1204e64559fe8253a0e49e6548',
-    UnderlyingAsset['arbeth:arb'],
-    TOKEN_FEATURES_WITH_FRANKFURT
+    UnderlyingAsset['arbeth:arb']
   ),
   arbethErc20(
     '65668b2e-6560-4749-a965-4d03eaeffaec',

--- a/modules/statics/test/unit/coins.ts
+++ b/modules/statics/test/unit/coins.ts
@@ -148,7 +148,6 @@ const custodyFeatures: Record<string, { features: CoinFeature[] }> = {
   wbtc: { features: [CoinFeature.CUSTODY_BITGO_FRANKFURT] },
   tkx: { features: [CoinFeature.CUSTODY_BITGO_FRANKFURT] },
   mana: { features: [CoinFeature.CUSTODY_BITGO_FRANKFURT] },
-  'arbeth:arb': { features: [CoinFeature.CUSTODY_BITGO_FRANKFURT] },
   // Test Coins
   talgo: {
     features: [


### PR DESCRIPTION
TICKET: COIN-1900
Reference in the Ticket for Removal of Trust Frankfurt for ARBETH:ARB : https://bitgoinc.atlassian.net/browse/COIN-1900?focusedCommentId=490048
<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
