### PR TITLE
BTC-1553: fix isValidAddress returning false for valid cashaddr bch addresses

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -415,10 +415,15 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       throw new Error('deprecated');
     }
 
-    const formats = param && param.anyFormat ? undefined : ['default' as const];
+    const formats = utxolib.addressFormat.addressFormats.filter((format) =>
+      utxolib.addressFormat.isSupportedAddressFormat(format, this.network)
+    );
     try {
       const script = utxolib.addressFormat.toOutputScriptTryFormats(address, this.network, formats);
-      return address === utxolib.address.fromOutputScript(script, this.network);
+      const genAddresses = formats.map((format) =>
+        utxolib.addressFormat.fromOutputScriptWithFormat(script, format, this.network)
+      );
+      return genAddresses.includes(address);
     } catch (e) {
       return false;
     }

--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -242,6 +242,18 @@ describe('V2 Wallet:', function () {
     });
   });
 
+  it('should verify bch cashaddr format as valid', async function () {
+    const coin = bitgo.coin('tbch');
+    const valid = coin.isValidAddress('bchtest:pzfkxv532t0q5zchck2mhmmf2y02cdejyssq5qrz7a');
+    valid.should.be.True();
+  });
+
+  it('should verify bch legacy format as valid', async function () {
+    const coin = bitgo.coin('tbch');
+    const valid = coin.isValidAddress('2N6gY9r9iuXQQzZiSyngWJeoUuL5mC1x4Ac');
+    valid.should.be.True();
+  });
+
   describe('TETH Wallet Addresses', function () {
     let ethWallet;
 


### PR DESCRIPTION
TICKET: BTC-1553
Previously, `isValidAddress` verified the address by converting it to script and back. However, the previous implementation converts the script back to the legacy address and compares it against the original address. Thus, if the original was cashaddr format, it would fail. Fix this by generating addresses in all formats from the script and check if the original address is included.

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
