### PR TITLE
fix: pipeline failuers due to use of ubuntu-latest runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
       #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   browser-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
It was noticed that pipelines are failing because ubuntu-latest is provisioning runner with OS ubuntu-24.04. This commit points runner to last working one ie. ubuntu-22.04

Ticket: [DO-0000](https://bitgoinc.atlassian.net/browse/DO-0000)