### PR TITLE
fix: replace getFees rpc call with getFeeForMessage

### DIFF
--- a/modules/sdk-coin-sol/test/fixtures/sol.ts
+++ b/modules/sdk-coin-sol/test/fixtures/sol.ts
@@ -108,6 +108,21 @@ const getFeesResponse = {
   },
 };
 
+const getFeesForMessageResponse = {
+  status: 200,
+  body: {
+    jsonrpc: '2.0',
+    result: {
+      context: {
+        apiVersion: '2.0.13',
+        slot: 332103639,
+      },
+      value: 5000,
+    },
+    id: 1,
+  },
+};
+
 const getMinimumBalanceForRentExemptionResponse = {
   status: 200,
   body: {
@@ -475,6 +490,7 @@ const getTokenAccountsByOwnerResponse3 = {
 export const SolResponses = {
   getBlockhashResponse,
   getFeesResponse,
+  getFeesForMessageResponse,
   getAccountBalanceResponse,
   getTokenInfoResponse,
   getAccountInfoResponse,

--- a/modules/sdk-coin-sol/test/unit/sol.ts
+++ b/modules/sdk-coin-sol/test/unit/sol.ts
@@ -1448,10 +1448,16 @@ describe('SOL:', function () {
           payload: {
             id: '1',
             jsonrpc: '2.0',
-            method: 'getFees',
+            method: 'getFeeForMessage',
+            params: [
+              sinon.match.string,
+              {
+                commitment: 'finalized',
+              },
+            ],
           },
         })
-        .resolves(testData.SolResponses.getFeesResponse);
+        .resolves(testData.SolResponses.getFeesForMessageResponse);
       callBack
         .withArgs({
           payload: {
@@ -2043,10 +2049,16 @@ describe('SOL:', function () {
           payload: {
             id: '1',
             jsonrpc: '2.0',
-            method: 'getFees',
+            method: 'getFeeForMessage',
+            params: [
+              sinon.match.string,
+              {
+                commitment: 'finalized',
+              },
+            ],
           },
         })
-        .resolves(testData.SolResponses.getFeesResponse);
+        .resolves(testData.SolResponses.getFeesForMessageResponse);
       callBack
         .withArgs({
           payload: {


### PR DESCRIPTION
TICKET: COIN-1879

`getFees` rpc method is deprecated used `getFeeForMessage` instead
https://www.quicknode.com/docs/solana/getFeeForMessage
<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
