### PR TITLE
feat(sdk-core): refactor tss ecdsa hot wallet signing logic to be in sdk

### DIFF
--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -3178,6 +3178,51 @@ describe('V2 Wallet:', function () {
       });
     });
 
+    describe('signAndSendTxRequest', function () {
+      const exampleSignedTx = {
+        txHex: '0x123',
+        txid: '0x456',
+        status: 'signed',
+      };
+
+      afterEach(async function () {
+        sandbox.restore();
+      });
+
+      it('should sign lite transaction', async function () {
+        const getUserKeyAndSignTssTxSpy = sandbox.stub(tssSolWallet, 'getUserKeyAndSignTssTransaction');
+        getUserKeyAndSignTssTxSpy.resolves(exampleSignedTx);
+        const submitTxSpy = sandbox.stub(tssSolWallet, 'submitTransaction');
+        submitTxSpy.resolves(exampleSignedTx);
+
+        const signedTx = await tssSolWallet.signAndSendTxRequest({
+          walletPassphrase: 'passphrase',
+          txRequestId: 'id',
+          isTxRequestFull: false,
+        });
+
+        sandbox.assert.calledOnce(getUserKeyAndSignTssTxSpy);
+        sandbox.assert.calledOnce(submitTxSpy);
+        signedTx.should.deepEqual(exampleSignedTx);
+      });
+
+      it('should sign full transaction', async function () {
+        const deleteSignatureSharesSpy = sandbox.stub(TssUtils.prototype, 'deleteSignatureShares');
+        const getUserKeyAndSignTssTxSpy = sandbox.stub(tssSolWallet, 'getUserKeyAndSignTssTransaction');
+        getUserKeyAndSignTssTxSpy.resolves(exampleSignedTx);
+
+        const signedTx = await tssSolWallet.signAndSendTxRequest({
+          walletPassphrase: 'passphrase',
+          txRequestId: 'id',
+          isTxRequestFull: true,
+        });
+
+        sandbox.assert.calledOnce(deleteSignatureSharesSpy);
+        sandbox.assert.calledOnce(getUserKeyAndSignTssTxSpy);
+        signedTx.should.deepEqual(exampleSignedTx);
+      });
+    });
+
     describe('Message Signing', function () {
       const txHash = '0xrrrsss1b';
       const txRequestForMessageSigning: TxRequest = {

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -233,6 +233,12 @@ export interface WalletSignTypedDataOptions extends WalletSignMessageBase {
   typedData: TypedData;
 }
 
+export interface SignAndSendTxRequestOptions {
+  txRequestId: string;
+  walletPassphrase: string;
+  isTxRequestFull: boolean;
+}
+
 export interface GetUserPrvOptions {
   keychain?: Keychain;
   key?: Keychain;
@@ -837,6 +843,7 @@ export interface IWallet {
   signTransaction(params?: WalletSignTransactionOptions): Promise<SignedTransaction>;
   getUserPrv(params?: GetUserPrvOptions): string;
   prebuildAndSignTransaction(params?: PrebuildAndSignTransactionOptions): Promise<SignedTransaction>;
+  signAndSendTxRequest(params?: SignAndSendTxRequestOptions): Promise<SignedTransaction>;
   accelerateTransaction(params?: AccelerateTransactionOptions): Promise<any>;
   submitTransaction(params?: SubmitTransactionOptions): Promise<any>;
   send(params?: SendOptions): Promise<any>;


### PR DESCRIPTION
## Description

This is to move logic for signing TSS hot wallet from the UI to the SDK. The original fixed logic is from this PR: https://github.com/BitGo/bitgo-ui/pull/4910

## Issue Number

Ticket: WP-2822

## Type of change

New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Followed steps from https://github.com/BitGo/bitgo-ui/pull/4910: 
1. In a hot wallet, start making a withdrawal transaction. Before clicking "Initiate withdrawal", open the network tab, enable throttling to 3G, filter network requests by "sign". 
2. Click "Initiate withdrawal". Once the third call to the "sign" API is in preflight, quickly refresh. 
3. Go back to the transactions list (in the Transactions tab). The transaction should say that it is Pending Approval. Try to sign this. 

Specifically, to test these changes, I used the SDK alpha release in my bitgo-ui. I ensured that the flow works as desired. 

# Checklist: 

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [x] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

