### PR TITLE
fix(sdk-coin-dot) : throw error on sendmany API call when recipients > 1

### DIFF
--- a/modules/sdk-coin-dot/src/dot.ts
+++ b/modules/sdk-coin-dot/src/dot.ts
@@ -639,6 +639,10 @@ export class Dot extends BaseCoin {
   }
 
   async verifyTransaction(params: VerifyTransactionOptions): Promise<boolean> {
+    const { txParams } = params;
+    if (txParams?.recipients?.length !== 1) {
+      throw new Error(`txParams should only have 1 recipient but ${txParams?.recipients?.length} found`);
+    }
     return true;
   }
 

--- a/modules/sdk-coin-dot/test/unit/dot.ts
+++ b/modules/sdk-coin-dot/test/unit/dot.ts
@@ -6,6 +6,7 @@ import { Dot, Tdot, KeyPair } from '../../src';
 import * as testData from '../fixtures';
 import { chainName, txVersion, genesisHash, specVersion } from '../resources';
 import * as sinon from 'sinon';
+import { Wallet } from '@bitgo/sdk-core';
 
 describe('DOT:', function () {
   let bitgo: TestBitGoAPI;
@@ -644,6 +645,27 @@ describe('DOT:', function () {
           recoveryDestination: destAddr,
         })
         .should.rejectedWith('Did not find address with funds to recover');
+    });
+  });
+
+  describe('Verify Transaction', function () {
+    const address1 = '5Ge59qRnZa8bxyhVFE6BDoY3kuhSrNVETRxXYLty1Hh6XTaf';
+    const address2 = '5DiMLZugmcKEH3igPZP367FqummZkWeW5Z6zDCHLfxRjnPXe';
+    it('should reject a txPrebuild with more than one recipient', async function () {
+      const wallet = new Wallet(bitgo, basecoin, {});
+
+      const txParams = {
+        recipients: [
+          { amount: '1000000000000', address: address1 },
+          { amount: '2500000000000', address: address2 },
+        ],
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+      };
+
+      await basecoin
+        .verifyTransaction({ txParams })
+        .should.be.rejectedWith('txParams should only have 1 recipient but 2 found');
     });
   });
 });


### PR DESCRIPTION
TICKET: [COIN-1958](https://bitgoinc.atlassian.net/browse/COIN-1958)

[COIN-1958]: https://bitgoinc.atlassian.net/browse/COIN-1958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ