### PR TITLE
chore(deps-dev): bump secp256k1 to 5.0.1

### DIFF
--- a/examples/ts/tss-recovery/package.json
+++ b/examples/ts/tss-recovery/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@bitgo/sdk-core": "28.10.0",
     "@bitgo/sdk-lib-mpc": "10.0.0",
-    "secp256k1": "5.0.0"
+    "secp256k1": "5.0.1"
   },
   "devDependencies": {
     "ts-node": "10.9.1",

--- a/modules/abstract-eth/package.json
+++ b/modules/abstract-eth/package.json
@@ -55,12 +55,12 @@
     "ethers": "^5.1.3",
     "keccak": "^3.0.3",
     "lodash": "4.17.21",
-    "secp256k1": "5.0.0",
+    "secp256k1": "5.0.1",
     "superagent": "^9.0.1"
   },
   "devDependencies": {
     "@bitgo/sdk-api": "^1.55.2",
     "@bitgo/sdk-test": "^8.0.46",
-    "secp256k1": "5.0.0"
+    "secp256k1": "5.0.1"
   }
 }

--- a/modules/sdk-api/package.json
+++ b/modules/sdk-api/package.json
@@ -53,7 +53,7 @@
     "lodash": "^4.17.15",
     "proxy-agent": "6.4.0",
     "sanitize-html": "^2.11",
-    "secp256k1": "^4.0.2",
+    "secp256k1": "^4.0.4",
     "secrets.js-grempe": "^1.1.0",
     "superagent": "^9.0.1"
   },

--- a/modules/sdk-coin-arbeth/package.json
+++ b/modules/sdk-coin-arbeth/package.json
@@ -51,6 +51,6 @@
   "devDependencies": {
     "@bitgo/sdk-api": "^1.55.2",
     "@bitgo/sdk-test": "^8.0.46",
-    "secp256k1": "5.0.0"
+    "secp256k1": "5.0.1"
   }
 }

--- a/modules/sdk-coin-avaxc/package.json
+++ b/modules/sdk-coin-avaxc/package.json
@@ -52,7 +52,7 @@
     "ethereumjs-util": "7.1.5",
     "keccak": "^3.0.3",
     "lodash": "^4.17.14",
-    "secp256k1": "5.0.0",
+    "secp256k1": "5.0.1",
     "superagent": "^9.0.1"
   },
   "devDependencies": {

--- a/modules/sdk-coin-cspr/package.json
+++ b/modules/sdk-coin-cspr/package.json
@@ -48,7 +48,7 @@
     "bignumber.js": "^9.0.0",
     "casper-js-sdk": "2.7.6",
     "lodash": "^4.17.15",
-    "secp256k1": "5.0.0"
+    "secp256k1": "5.0.1"
   },
   "devDependencies": {
     "@bitgo/sdk-api": "^1.55.2",

--- a/modules/sdk-coin-eth/package.json
+++ b/modules/sdk-coin-eth/package.json
@@ -51,7 +51,7 @@
     "ethereumjs-util": "7.1.5",
     "ethers": "^5.1.3",
     "lodash": "^4.17.14",
-    "secp256k1": "5.0.0",
+    "secp256k1": "5.0.1",
     "superagent": "^9.0.1"
   },
   "devDependencies": {

--- a/modules/sdk-coin-opeth/package.json
+++ b/modules/sdk-coin-opeth/package.json
@@ -51,6 +51,6 @@
   "devDependencies": {
     "@bitgo/sdk-api": "^1.55.2",
     "@bitgo/sdk-test": "^8.0.46",
-    "secp256k1": "5.0.0"
+    "secp256k1": "5.0.1"
   }
 }

--- a/modules/sdk-coin-polygon/package.json
+++ b/modules/sdk-coin-polygon/package.json
@@ -53,6 +53,6 @@
     "@bitgo/sdk-api": "^1.55.2",
     "@bitgo/sdk-opensslbytes": "^2.0.0",
     "@bitgo/sdk-test": "^8.0.46",
-    "secp256k1": "5.0.0"
+    "secp256k1": "5.0.1"
   }
 }

--- a/modules/sdk-coin-trx/package.json
+++ b/modules/sdk-coin-trx/package.json
@@ -54,7 +54,7 @@
     "ethers": "^5.7.2",
     "lodash": "^4.17.14",
     "protobufjs": "7.2.5",
-    "secp256k1": "5.0.0",
+    "secp256k1": "5.0.1",
     "superagent": "^9.0.1",
     "tronweb": "5.1.0"
   },

--- a/modules/sdk-coin-zketh/package.json
+++ b/modules/sdk-coin-zketh/package.json
@@ -49,6 +49,6 @@
   "devDependencies": {
     "@bitgo/sdk-api": "^1.55.2",
     "@bitgo/sdk-test": "^8.0.46",
-    "secp256k1": "5.0.0"
+    "secp256k1": "5.0.1"
   }
 }

--- a/modules/sdk-core/package.json
+++ b/modules/sdk-core/package.json
@@ -69,7 +69,7 @@
     "noble-bls12-381": "0.7.2",
     "openpgp": "5.10.1",
     "paillier-bigint": "3.3.0",
-    "secp256k1": "5.0.0",
+    "secp256k1": "5.0.1",
     "strip-hex-prefix": "^1.0.0",
     "superagent": "^9.0.1",
     "tweetnacl": "^1.0.3",

--- a/modules/sdk-lib-mpc/package.json
+++ b/modules/sdk-lib-mpc/package.json
@@ -49,7 +49,7 @@
     "libsodium-wrappers-sumo": "^0.7.9",
     "openpgp": "5.10.1",
     "paillier-bigint": "3.3.0",
-    "secp256k1": "5.0.0"
+    "secp256k1": "5.0.1"
   },
   "devDependencies": {
     "@bitgo/sdk-opensslbytes": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9611,7 +9611,7 @@ elliptic@6.5.4:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
-elliptic@^6.4.0, elliptic@^6.4.1, elliptic@^6.5.2, elliptic@^6.5.3, elliptic@^6.5.4, elliptic@^6.5.5:
+elliptic@^6.4.0, elliptic@^6.4.1, elliptic@^6.5.2, elliptic@^6.5.3, elliptic@^6.5.4, elliptic@^6.5.5, elliptic@^6.5.7:
   version "6.5.7"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.7.tgz#8ec4da2cb2939926a1b9a73619d768207e647c8b"
   integrity sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==
@@ -17538,6 +17538,15 @@ secp256k1@5.0.0:
     node-addon-api "^5.0.0"
     node-gyp-build "^4.2.0"
 
+secp256k1@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-5.0.1.tgz#dc2c86187d48ff2da756f0f7e96417ee03c414b1"
+  integrity sha512-lDFs9AAIaWP9UCdtWrotXWWF9t8PWgQDcxqgAnpM9rMqxb3Oaq2J0thzPVSxBwdJgyQtkU/sYtFtbM1RSt/iYA==
+  dependencies:
+    elliptic "^6.5.7"
+    node-addon-api "^5.0.0"
+    node-gyp-build "^4.2.0"
+
 secp256k1@^4.0.0, secp256k1@^4.0.1, secp256k1@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-4.0.3.tgz#c4559ecd1b8d3c1827ed2d1b94190d69ce267303"
@@ -17545,6 +17554,15 @@ secp256k1@^4.0.0, secp256k1@^4.0.1, secp256k1@^4.0.2:
   dependencies:
     elliptic "^6.5.4"
     node-addon-api "^2.0.0"
+    node-gyp-build "^4.2.0"
+
+secp256k1@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-4.0.4.tgz#58f0bfe1830fe777d9ca1ffc7574962a8189f8ab"
+  integrity sha512-6JfvwvjUOn8F/jUoBY2Q1v5WY5XS+rj8qSe0v8Y4ezH4InLgTEeOOPQsRll9OV429Pvo6BCHGavIyJfr3TAhsw==
+  dependencies:
+    elliptic "^6.5.7"
+    node-addon-api "^5.0.0"
     node-gyp-build "^4.2.0"
 
 secrets.js-grempe@^1.1.0:


### PR DESCRIPTION
As per https://github.com/advisories/GHSA-584q-6j8j-r5pm
secp256k1 5.0.0 has high severity.

This PR aims to bump it to 5.0.1
<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
