### PR TITLE
feat(abstract-cosmos): add message type for rune

### DIFF
--- a/modules/abstract-cosmos/src/lib/constants.ts
+++ b/modules/abstract-cosmos/src/lib/constants.ts
@@ -7,3 +7,4 @@ export const withdrawDelegatorRewardMsgTypeUrl = '/cosmos.distribution.v1beta1.M
 export const executeContractMsgTypeUrl = '/cosmwasm.wasm.v1.MsgExecuteContract';
 export const UNAVAILABLE_TEXT = 'UNAVAILABLE';
 export const ROOT_PATH = 'm/0';
+export const sendMsgType = '/types.MsgSend'; // thorchain uses this custom message type

--- a/modules/abstract-cosmos/src/lib/utils.ts
+++ b/modules/abstract-cosmos/src/lib/utils.ts
@@ -38,7 +38,7 @@ import {
 import { CosmosKeyPair as KeyPair } from './keyPair';
 
 export class CosmosUtils implements BaseUtils {
-  private registry;
+  protected registry;
 
   constructor() {
     this.registry = new Registry([...defaultRegistryTypes]);
@@ -339,6 +339,8 @@ export class CosmosUtils implements BaseUtils {
   getTransactionTypeFromTypeUrl(typeUrl: string): TransactionType | undefined {
     switch (typeUrl) {
       case constants.sendMsgTypeUrl:
+        return TransactionType.Send;
+      case constants.sendMsgType:
         return TransactionType.Send;
       case constants.delegateMsgTypeUrl:
         return TransactionType.StakingActivate;


### PR DESCRIPTION
Also made registry protected as sdk rune needs to override a method which uses registry varaible.

Ticket: COIN-2038

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
