### PR TITLE
feat: retrofit during GG18 user and backup recovery

### DIFF
--- a/modules/abstract-cosmos/package.json
+++ b/modules/abstract-cosmos/package.json
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "@bitgo/sdk-core": "^28.12.0",
-    "@bitgo/sdk-lib-mpc": "^10.1.0",
     "@bitgo/statics": "^50.5.0",
     "@bitgo/utxo-lib": "^11.0.1",
     "@cosmjs/amino": "^0.29.5",

--- a/modules/abstract-cosmos/src/lib/iface.ts
+++ b/modules/abstract-cosmos/src/lib/iface.ts
@@ -30,7 +30,6 @@ export interface SendMessage {
 export interface RecoveryOptions {
   userKey?: string; // Box A
   backupKey?: string; // Box B
-  bitgoKey: string; // Box C
   recoveryDestination: string;
   krsProvider?: string;
   walletPassphrase?: string;

--- a/modules/abstract-eth/package.json
+++ b/modules/abstract-eth/package.json
@@ -41,7 +41,6 @@
   },
   "dependencies": {
     "@bitgo/sdk-core": "^28.12.0",
-    "@bitgo/sdk-lib-mpc": "^10.1.0",
     "@bitgo/statics": "^50.5.0",
     "@bitgo/utxo-lib": "^11.0.1",
     "@ethereumjs/common": "^2.6.5",

--- a/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
+++ b/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
@@ -203,8 +203,12 @@ interface UnformattedTxInfo {
 
 export type RecoverOptionsWithBytes = {
   isTss: true;
-  openSSLBytes: Uint8Array;
+  /**
+   * @deprecated this is no longer used
+   */
+  openSSLBytes?: Uint8Array;
 };
+
 export type NonTSSRecoverOptions = {
   isTss?: false | undefined;
 };

--- a/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
+++ b/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
@@ -6,7 +6,6 @@ import {
   BitGoBase,
   BuildNftTransferDataOptions,
   common,
-  ECDSA,
   Ecdsa,
   ECDSAMethodTypes,
   EthereumLibraryUnavailableError,
@@ -14,7 +13,6 @@ import {
   FullySignedTransaction,
   getIsUnsignedSweep,
   HalfSignedTransaction,
-  hexToBigInt,
   InvalidAddressError,
   InvalidAddressVerificationObjectPropertyError,
   IWallet,
@@ -36,7 +34,6 @@ import {
   Wallet,
   ECDSAUtils,
 } from '@bitgo/sdk-core';
-import { EcdsaPaillierProof, EcdsaRangeProof, EcdsaTypes } from '@bitgo/sdk-lib-mpc';
 import {
   BaseCoin as StaticsBaseCoin,
   CoinMap,
@@ -1057,174 +1054,6 @@ export abstract class AbstractEthLikeNewCoins extends AbstractEthLikeCoin {
   }
 
   /**
-   * Method to sign tss recovery transaction
-   * @param {ECDSA.KeyCombined} userKeyCombined
-   * @param {ECDSA.KeyCombined} backupKeyCombined
-   * @param {string} txHex
-   * @param {Object} options
-   * @param {EcdsaTypes.SerializedNtilde} options.rangeProofChallenge
-   * @returns {Promise<ECDSAMethodTypes.Signature>}
-   */
-  private async signRecoveryTSS(
-    userKeyCombined: ECDSA.KeyCombined,
-    backupKeyCombined: ECDSA.KeyCombined,
-    txHex: string,
-    openSSLBytes: Uint8Array,
-    {
-      rangeProofChallenge,
-    }: {
-      rangeProofChallenge?: EcdsaTypes.SerializedNtilde;
-    } = {}
-  ): Promise<ECDSAMethodTypes.Signature> {
-    if (!userKeyCombined || !backupKeyCombined) {
-      throw new Error('Missing key combined shares for user or backup');
-    }
-
-    const MPC = new Ecdsa();
-    const signerOneIndex = userKeyCombined.xShare.i;
-    const signerTwoIndex = backupKeyCombined.xShare.i;
-
-    rangeProofChallenge =
-      rangeProofChallenge ?? EcdsaTypes.serializeNtildeWithProofs(await EcdsaRangeProof.generateNtilde(openSSLBytes));
-
-    const userToBackupPaillierChallenge = await EcdsaPaillierProof.generateP(
-      hexToBigInt(userKeyCombined.yShares[signerTwoIndex].n)
-    );
-    const backupToUserPaillierChallenge = await EcdsaPaillierProof.generateP(
-      hexToBigInt(backupKeyCombined.yShares[signerOneIndex].n)
-    );
-
-    const userXShare = MPC.appendChallenge(
-      userKeyCombined.xShare,
-      rangeProofChallenge,
-      EcdsaTypes.serializePaillierChallenge({ p: userToBackupPaillierChallenge })
-    );
-    const userYShare = MPC.appendChallenge(
-      userKeyCombined.yShares[signerTwoIndex],
-      rangeProofChallenge,
-      EcdsaTypes.serializePaillierChallenge({ p: backupToUserPaillierChallenge })
-    );
-    const backupXShare = MPC.appendChallenge(
-      backupKeyCombined.xShare,
-      rangeProofChallenge,
-      EcdsaTypes.serializePaillierChallenge({ p: backupToUserPaillierChallenge })
-    );
-    const backupYShare = MPC.appendChallenge(
-      backupKeyCombined.yShares[signerOneIndex],
-      rangeProofChallenge,
-      EcdsaTypes.serializePaillierChallenge({ p: userToBackupPaillierChallenge })
-    );
-
-    const signShares: ECDSA.SignShareRT = await MPC.signShare(userXShare, userYShare);
-
-    const signConvertS21 = await MPC.signConvertStep1({
-      xShare: backupXShare,
-      yShare: backupYShare, // YShare corresponding to the other participant signerOne
-      kShare: signShares.kShare,
-    });
-    const signConvertS12 = await MPC.signConvertStep2({
-      aShare: signConvertS21.aShare,
-      wShare: signShares.wShare,
-    });
-    const signConvertS21_2 = await MPC.signConvertStep3({
-      muShare: signConvertS12.muShare,
-      bShare: signConvertS21.bShare,
-    });
-
-    const [signCombineOne, signCombineTwo] = [
-      MPC.signCombine({
-        gShare: signConvertS12.gShare,
-        signIndex: {
-          i: signConvertS12.muShare.i,
-          j: signConvertS12.muShare.j,
-        },
-      }),
-      MPC.signCombine({
-        gShare: signConvertS21_2.gShare,
-        signIndex: {
-          i: signConvertS21_2.signIndex.i,
-          j: signConvertS21_2.signIndex.j,
-        },
-      }),
-    ];
-
-    const MESSAGE = Buffer.from(txHex, 'hex');
-
-    const [signA, signB] = [
-      MPC.sign(MESSAGE, signCombineOne.oShare, signCombineTwo.dShare, Keccak('keccak256')),
-      MPC.sign(MESSAGE, signCombineTwo.oShare, signCombineOne.dShare, Keccak('keccak256')),
-    ];
-
-    return MPC.constructSignature([signA, signB]);
-  }
-
-  /**
-   * Helper which combines key shares of user and backup
-   * @param {string} userPublicOrPrivateKeyShare
-   * @param {string} backupPrivateOrPublicKeyShare
-   * @param {string} walletPassphrase
-   * @returns {[ECDSAMethodTypes.KeyCombined, ECDSAMethodTypes.KeyCombined]}
-   */
-  private getKeyCombinedFromTssKeyShares(
-    userPublicOrPrivateKeyShare: string,
-    backupPrivateOrPublicKeyShare: string,
-    walletPassphrase?: string
-  ): [ECDSAMethodTypes.KeyCombined, ECDSAMethodTypes.KeyCombined] {
-    let backupPrv;
-    let userPrv;
-    try {
-      backupPrv = this.bitgo.decrypt({
-        input: backupPrivateOrPublicKeyShare,
-        password: walletPassphrase,
-      });
-      userPrv = this.bitgo.decrypt({
-        input: userPublicOrPrivateKeyShare,
-        password: walletPassphrase,
-      });
-    } catch (e) {
-      throw new Error(`Error decrypting backup keychain: ${e.message}`);
-    }
-
-    const userSigningMaterial = JSON.parse(userPrv) as ECDSAMethodTypes.SigningMaterial;
-    const backupSigningMaterial = JSON.parse(backupPrv) as ECDSAMethodTypes.SigningMaterial;
-
-    if (!userSigningMaterial.backupNShare) {
-      throw new Error('Invalid user key - missing backupNShare');
-    }
-
-    if (!backupSigningMaterial.userNShare) {
-      throw new Error('Invalid backup key - missing userNShare');
-    }
-
-    const MPC = new Ecdsa();
-
-    const userKeyCombined = MPC.keyCombine(userSigningMaterial.pShare, [
-      userSigningMaterial.bitgoNShare,
-      userSigningMaterial.backupNShare,
-    ]);
-    const userSigningKeyDerived = MPC.keyDerive(
-      userSigningMaterial.pShare,
-      [userSigningMaterial.bitgoNShare, userSigningMaterial.backupNShare],
-      'm/0'
-    );
-    const userKeyDerivedCombined = {
-      xShare: userSigningKeyDerived.xShare,
-      yShares: userKeyCombined.yShares,
-    };
-    const backupKeyCombined = MPC.keyCombine(backupSigningMaterial.pShare, [
-      userSigningKeyDerived.nShares[2],
-      backupSigningMaterial.bitgoNShare,
-    ]);
-    if (
-      userKeyDerivedCombined.xShare.y !== backupKeyCombined.xShare.y ||
-      userKeyDerivedCombined.xShare.chaincode !== backupKeyCombined.xShare.chaincode
-    ) {
-      throw new Error('Common keychains do not match');
-    }
-    return [userKeyDerivedCombined, backupKeyCombined];
-  }
-
-  /**
    * Helper which Adds signatures to tx object and re-serializes tx
    * @param {EthLikeCommon.default} ethCommon
    * @param {EthLikeTxLib.FeeMarketEIP1559Transaction | EthLikeTxLib.Transaction} tx
@@ -1289,7 +1118,7 @@ export abstract class AbstractEthLikeNewCoins extends AbstractEthLikeCoin {
    */
   async recover(params: RecoverOptions): Promise<RecoveryInfo | OfflineVaultTxInfo> {
     if (params.isTss === true) {
-      return this.recoverTSS(params, params.openSSLBytes);
+      return this.recoverTSS(params);
     }
     return this.recoverEthLike(params);
   }
@@ -1974,10 +1803,7 @@ export abstract class AbstractEthLikeNewCoins extends AbstractEthLikeCoin {
    * Recovers a tx with TSS key shares
    * same expected arguments as recover method, but with TSS key shares
    */
-  protected async recoverTSS(
-    params: RecoverOptions,
-    openSSLBytes: Uint8Array
-  ): Promise<RecoveryInfo | OfflineVaultTxInfo> {
+  protected async recoverTSS(params: RecoverOptions): Promise<RecoveryInfo | OfflineVaultTxInfo> {
     this.validateRecoveryParams(params);
     // Clean up whitespace from entered values
     const userPublicOrPrivateKeyShare = params.userKey.replace(/\s/g, '');
@@ -2010,48 +1836,19 @@ export abstract class AbstractEthLikeNewCoins extends AbstractEthLikeCoin {
         params.replayProtectionOptions
       );
     } else {
-      const isGG18SigningMaterial = ECDSAUtils.isGG18SigningMaterial(
+      const { userKeyShare, backupKeyShare, commonKeyChain } = await ECDSAUtils.getMpcV2RecoveryKeyShares(
         userPublicOrPrivateKeyShare,
+        backupPrivateOrPublicKeyShare,
         params.walletPassphrase
       );
-      let signature: ECDSAMethodTypes.Signature;
-      let unsignedTx: EthLikeTxLib.Transaction | EthLikeTxLib.FeeMarketEIP1559Transaction;
-      if (isGG18SigningMaterial) {
-        const [userKeyCombined, backupKeyCombined] = this.getKeyCombinedFromTssKeyShares(
-          userPublicOrPrivateKeyShare,
-          backupPrivateOrPublicKeyShare,
-          params.walletPassphrase
-        );
-        const backupKeyPair = new KeyPairLib({ pub: backupKeyCombined.xShare.y });
-        const baseAddress = backupKeyPair.getAddress();
 
-        unsignedTx = (await this.buildTssRecoveryTxn(baseAddress, gasPrice, gasLimit, params)).tx;
-
-        signature = await this.signRecoveryTSS(
-          userKeyCombined,
-          backupKeyCombined,
-          unsignedTx.getMessageToSign(false).toString('hex'),
-          openSSLBytes
-        );
-      } else {
-        const { userKeyShare, backupKeyShare, commonKeyChain } = await ECDSAUtils.getMpcV2RecoveryKeyShares(
-          userPublicOrPrivateKeyShare,
-          backupPrivateOrPublicKeyShare,
-          params.walletPassphrase
-        );
-
-        const MPC = new Ecdsa();
-        const derivedCommonKeyChain = MPC.deriveUnhardened(commonKeyChain, 'm');
-        const backupKeyPair = new KeyPairLib({ pub: derivedCommonKeyChain.slice(0, 66) });
-        const baseAddress = backupKeyPair.getAddress();
-
-        unsignedTx = (await this.buildTssRecoveryTxn(baseAddress, gasPrice, gasLimit, params)).tx;
-
-        const messageHash = unsignedTx.getMessageToSign(true);
-
-        signature = await ECDSAUtils.signRecoveryMpcV2(messageHash, userKeyShare, backupKeyShare, commonKeyChain);
-      }
-
+      const MPC = new Ecdsa();
+      const derivedCommonKeyChain = MPC.deriveUnhardened(commonKeyChain, 'm/0');
+      const backupKeyPair = new KeyPairLib({ pub: derivedCommonKeyChain.slice(0, 66) });
+      const baseAddress = backupKeyPair.getAddress();
+      const unsignedTx = (await this.buildTssRecoveryTxn(baseAddress, gasPrice, gasLimit, params)).tx;
+      const messageHash = unsignedTx.getMessageToSign(true);
+      const signature = await ECDSAUtils.signRecoveryMpcV2(messageHash, userKeyShare, backupKeyShare, commonKeyChain);
       const ethCommmon = AbstractEthLikeNewCoins.getEthLikeCommon(params.eip1559, params.replayProtectionOptions);
       const signedTx = this.getSignedTxFromSignature(ethCommmon, unsignedTx, signature);
 

--- a/modules/sdk-coin-atom/package.json
+++ b/modules/sdk-coin-atom/package.json
@@ -51,7 +51,6 @@
   },
   "devDependencies": {
     "@bitgo/sdk-api": "^1.56.1",
-    "@bitgo/sdk-opensslbytes": "^2.0.0",
     "@bitgo/sdk-test": "^8.0.48",
     "@types/lodash": "^4.14.183",
     "axios": "^1.3.4"

--- a/modules/sdk-coin-atom/test/unit/atom.ts
+++ b/modules/sdk-coin-atom/test/unit/atom.ts
@@ -574,18 +574,6 @@ describe('ATOM', function () {
         .should.rejectedWith('missing wallet passphrase');
     });
 
-    it('should throw error if openSSLBytes is not present', async function () {
-      await basecoin
-        .recover({
-          userKey: wrwUser.userKey,
-          backupKey: wrwUser.backupKey,
-          bitgoKey: wrwUser.bitgoKey,
-          walletPassphrase: wrwUser.walletPassphrase,
-          recoveryDestination: destinationAddress,
-        })
-        .should.rejectedWith('missing openSSLBytes');
-    });
-
     it('should throw error if there is no balance', async function () {
       await basecoin
         .recover(

--- a/modules/sdk-coin-atom/test/unit/atom.ts
+++ b/modules/sdk-coin-atom/test/unit/atom.ts
@@ -21,10 +21,6 @@ import {
 } from '../resources/atom';
 import should = require('should');
 
-import { loadWebAssembly } from '@bitgo/sdk-opensslbytes';
-
-const openSSLBytes = loadWebAssembly().buffer;
-
 describe('ATOM', function () {
   let bitgo: TestBitGoAPI;
   let basecoin;
@@ -433,16 +429,13 @@ describe('ATOM', function () {
     });
 
     it('should recover funds for non-bitgo recoveries', async function () {
-      const res = await basecoin.recover(
-        {
-          userKey: wrwUser.userKey,
-          backupKey: wrwUser.backupKey,
-          bitgoKey: wrwUser.bitgoKey,
-          walletPassphrase: wrwUser.walletPassphrase,
-          recoveryDestination: destinationAddress,
-        },
-        openSSLBytes
-      );
+      const res = await basecoin.recover({
+        userKey: wrwUser.userKey,
+        backupKey: wrwUser.backupKey,
+        bitgoKey: wrwUser.bitgoKey,
+        walletPassphrase: wrwUser.walletPassphrase,
+        recoveryDestination: destinationAddress,
+      });
       res.should.not.be.empty();
       res.should.hasOwnProperty('serializedTx');
       sandBox.assert.calledOnce(basecoin.getAccountBalance);
@@ -460,16 +453,13 @@ describe('ATOM', function () {
     });
 
     it('should recover funds for non-bitgo recoveries - DKLS type', async function () {
-      const res = await basecoin.recover(
-        {
-          userKey: wrwUserDkls.userKey,
-          backupKey: wrwUserDkls.backupKey,
-          bitgoKey: wrwUserDkls.bitgoKey,
-          walletPassphrase: wrwUserDkls.walletPassphrase,
-          recoveryDestination: wrwUserDkls.destinationAddress,
-        },
-        openSSLBytes
-      );
+      const res = await basecoin.recover({
+        userKey: wrwUserDkls.userKey,
+        backupKey: wrwUserDkls.backupKey,
+        bitgoKey: wrwUserDkls.bitgoKey,
+        walletPassphrase: wrwUserDkls.walletPassphrase,
+        recoveryDestination: wrwUserDkls.destinationAddress,
+      });
       res.should.not.be.empty();
       res.should.hasOwnProperty('serializedTx');
       sandBox.assert.calledOnce(basecoin.getAccountBalance);
@@ -487,18 +477,15 @@ describe('ATOM', function () {
     });
 
     it('should redelegate funds to new validator', async function () {
-      const res = await basecoin.redelegate(
-        {
-          userKey: wrwUser.userKey,
-          backupKey: wrwUser.backupKey,
-          bitgoKey: wrwUser.bitgoKey,
-          walletPassphrase: wrwUser.walletPassphrase,
-          amountToRedelegate: '10000000000000000',
-          validatorSrcAddress: 'cosmosvaloper1409te27da74uahh6hn0040x7l272hjs2padjuz',
-          validatorDstAddress: 'cosmosvaloper183aycgtstp67r6s4vd7ts2npp2ckk4xah7rxj6',
-        },
-        openSSLBytes
-      );
+      const res = await basecoin.redelegate({
+        userKey: wrwUser.userKey,
+        backupKey: wrwUser.backupKey,
+        bitgoKey: wrwUser.bitgoKey,
+        walletPassphrase: wrwUser.walletPassphrase,
+        amountToRedelegate: '10000000000000000',
+        validatorSrcAddress: 'cosmosvaloper1409te27da74uahh6hn0040x7l272hjs2padjuz',
+        validatorDstAddress: 'cosmosvaloper183aycgtstp67r6s4vd7ts2npp2ckk4xah7rxj6',
+      });
 
       res.should.not.be.empty();
       res.should.hasOwnProperty('serializedTx');
@@ -576,16 +563,13 @@ describe('ATOM', function () {
 
     it('should throw error if there is no balance', async function () {
       await basecoin
-        .recover(
-          {
-            userKey: wrwUser.userKey,
-            backupKey: wrwUser.backupKey,
-            bitgoKey: wrwUser.bitgoKey,
-            walletPassphrase: wrwUser.walletPassphrase,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          userKey: wrwUser.userKey,
+          backupKey: wrwUser.backupKey,
+          bitgoKey: wrwUser.bitgoKey,
+          walletPassphrase: wrwUser.walletPassphrase,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('Did not have enough funds to recover');
     });
   });

--- a/modules/sdk-coin-bld/package.json
+++ b/modules/sdk-coin-bld/package.json
@@ -51,7 +51,6 @@
   },
   "devDependencies": {
     "@bitgo/sdk-api": "^1.56.1",
-    "@bitgo/sdk-opensslbytes": "^2.0.0",
     "@bitgo/sdk-test": "^8.0.48",
     "@types/lodash": "^4.14.183"
   }

--- a/modules/sdk-coin-bld/test/unit/bld.ts
+++ b/modules/sdk-coin-bld/test/unit/bld.ts
@@ -19,10 +19,6 @@ import {
 } from '../resources/bld';
 import should = require('should');
 
-import { loadWebAssembly } from '@bitgo/sdk-opensslbytes';
-
-const openSSLBytes = loadWebAssembly().buffer;
-
 describe('BLD', function () {
   let bitgo: TestBitGoAPI;
   let basecoin;
@@ -378,16 +374,13 @@ describe('BLD', function () {
     });
 
     it('should recover funds for non-bitgo recoveries', async function () {
-      const res = await basecoin.recover(
-        {
-          userKey: wrwUser.userPrivateKey,
-          backupKey: wrwUser.backupPrivateKey,
-          bitgoKey: wrwUser.bitgoPublicKey,
-          walletPassphrase: wrwUser.walletPassphrase,
-          recoveryDestination: destinationAddress,
-        },
-        openSSLBytes
-      );
+      const res = await basecoin.recover({
+        userKey: wrwUser.userPrivateKey,
+        backupKey: wrwUser.backupPrivateKey,
+        bitgoKey: wrwUser.bitgoPublicKey,
+        walletPassphrase: wrwUser.walletPassphrase,
+        recoveryDestination: destinationAddress,
+      });
       res.should.not.be.empty();
       res.should.hasOwnProperty('serializedTx');
       sandBox.assert.calledOnce(basecoin.getAccountBalance);
@@ -406,18 +399,15 @@ describe('BLD', function () {
     });
 
     it('should redelegate funds to new validator', async function () {
-      const res = await basecoin.redelegate(
-        {
-          userKey: wrwUser.userPrivateKey,
-          backupKey: wrwUser.backupPrivateKey,
-          bitgoKey: wrwUser.bitgoPublicKey,
-          walletPassphrase: wrwUser.walletPassphrase,
-          amountToRedelegate: '10000000000000000',
-          validatorSrcAddress: 'agoricvaloper1wy3h3gne94xpmnjwfwd3eyaytv9g4nj6yykkkj',
-          validatorDstAddress: 'agoricvaloper1qd0h2hj7uljjhktw9l3fjnz5u22g0xu74aw38w',
-        },
-        openSSLBytes
-      );
+      const res = await basecoin.redelegate({
+        userKey: wrwUser.userPrivateKey,
+        backupKey: wrwUser.backupPrivateKey,
+        bitgoKey: wrwUser.bitgoPublicKey,
+        walletPassphrase: wrwUser.walletPassphrase,
+        amountToRedelegate: '10000000000000000',
+        validatorSrcAddress: 'agoricvaloper1wy3h3gne94xpmnjwfwd3eyaytv9g4nj6yykkkj',
+        validatorDstAddress: 'agoricvaloper1qd0h2hj7uljjhktw9l3fjnz5u22g0xu74aw38w',
+      });
 
       res.should.not.be.empty();
       res.should.hasOwnProperty('serializedTx');
@@ -462,58 +452,46 @@ describe('BLD', function () {
 
     it('should throw error if backupkey is not present', async function () {
       await basecoin
-        .recover(
-          {
-            userKey: wrwUser.userPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            walletPassphrase: wrwUser.walletPassphrase,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          userKey: wrwUser.userPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          walletPassphrase: wrwUser.walletPassphrase,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('missing backupKey');
     });
 
     it('should throw error if userkey is not present', async function () {
       await basecoin
-        .recover(
-          {
-            backupKey: wrwUser.backupPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            walletPassphrase: wrwUser.walletPassphrase,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          backupKey: wrwUser.backupPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          walletPassphrase: wrwUser.walletPassphrase,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('missing userKey');
     });
 
     it('should throw error if wallet passphrase is not present', async function () {
       await basecoin
-        .recover(
-          {
-            userKey: wrwUser.userPrivateKey,
-            backupKey: wrwUser.backupPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          userKey: wrwUser.userPrivateKey,
+          backupKey: wrwUser.backupPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('missing wallet passphrase');
     });
 
     it('should throw error if there is no balance', async function () {
       await basecoin
-        .recover(
-          {
-            userKey: wrwUser.userPrivateKey,
-            backupKey: wrwUser.backupPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            walletPassphrase: wrwUser.walletPassphrase,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          userKey: wrwUser.userPrivateKey,
+          backupKey: wrwUser.backupPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          walletPassphrase: wrwUser.walletPassphrase,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('Did not have enough funds to recover');
     });
   });

--- a/modules/sdk-coin-coreum/package.json
+++ b/modules/sdk-coin-coreum/package.json
@@ -51,7 +51,6 @@
   },
   "devDependencies": {
     "@bitgo/sdk-api": "^1.56.1",
-    "@bitgo/sdk-opensslbytes": "^2.0.0",
     "@bitgo/sdk-test": "^8.0.48"
   }
 }

--- a/modules/sdk-coin-coreum/test/unit/coreum.ts
+++ b/modules/sdk-coin-coreum/test/unit/coreum.ts
@@ -21,10 +21,6 @@ import {
 } from '../resources/tcoreum';
 import should = require('should');
 
-import { loadWebAssembly } from '@bitgo/sdk-opensslbytes';
-
-const openSSLBytes = loadWebAssembly().buffer;
-
 describe('Coreum', function () {
   let bitgo: TestBitGoAPI;
   let coreum;
@@ -427,16 +423,13 @@ describe('Coreum', function () {
     });
 
     it('should recover funds for non-bitgo recoveries', async function () {
-      const res = await tcoreum.recover(
-        {
-          userKey: wrwUser.userPrivateKey,
-          backupKey: wrwUser.backupPrivateKey,
-          bitgoKey: wrwUser.bitgoPublicKey,
-          walletPassphrase: wrwUser.walletPassphrase,
-          recoveryDestination: destinationAddress,
-        },
-        openSSLBytes
-      );
+      const res = await tcoreum.recover({
+        userKey: wrwUser.userPrivateKey,
+        backupKey: wrwUser.backupPrivateKey,
+        bitgoKey: wrwUser.bitgoPublicKey,
+        walletPassphrase: wrwUser.walletPassphrase,
+        recoveryDestination: destinationAddress,
+      });
       res.should.not.be.empty();
       res.should.hasOwnProperty('serializedTx');
       sandBox.assert.calledOnce(tcoreum.getAccountBalance);
@@ -482,58 +475,46 @@ describe('Coreum', function () {
 
     it('should throw error if backupkey is not present', async function () {
       await tcoreum
-        .recover(
-          {
-            userKey: wrwUser.userPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            walletPassphrase: wrwUser.walletPassphrase,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          userKey: wrwUser.userPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          walletPassphrase: wrwUser.walletPassphrase,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('missing backupKey');
     });
 
     it('should throw error if userkey is not present', async function () {
       await tcoreum
-        .recover(
-          {
-            backupKey: wrwUser.backupPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            walletPassphrase: wrwUser.walletPassphrase,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          backupKey: wrwUser.backupPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          walletPassphrase: wrwUser.walletPassphrase,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('missing userKey');
     });
 
     it('should throw error if wallet passphrase is not present', async function () {
       await tcoreum
-        .recover(
-          {
-            userKey: wrwUser.userPrivateKey,
-            backupKey: wrwUser.backupPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          userKey: wrwUser.userPrivateKey,
+          backupKey: wrwUser.backupPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('missing wallet passphrase');
     });
 
     it('should throw error if there is no balance', async function () {
       await tcoreum
-        .recover(
-          {
-            userKey: wrwUser.userPrivateKey,
-            backupKey: wrwUser.backupPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            walletPassphrase: wrwUser.walletPassphrase,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          userKey: wrwUser.userPrivateKey,
+          backupKey: wrwUser.backupPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          walletPassphrase: wrwUser.walletPassphrase,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('Did not have enough funds to recover');
     });
   });

--- a/modules/sdk-coin-hash/package.json
+++ b/modules/sdk-coin-hash/package.json
@@ -51,7 +51,6 @@
   },
   "devDependencies": {
     "@bitgo/sdk-api": "^1.56.1",
-    "@bitgo/sdk-opensslbytes": "^2.0.0",
     "@bitgo/sdk-test": "^8.0.48",
     "@types/lodash": "^4.14.183"
   }

--- a/modules/sdk-coin-hash/test/unit/hash.ts
+++ b/modules/sdk-coin-hash/test/unit/hash.ts
@@ -20,10 +20,6 @@ import {
 } from '../resources/hash';
 import should = require('should');
 
-import { loadWebAssembly } from '@bitgo/sdk-opensslbytes';
-
-const openSSLBytes = loadWebAssembly().buffer;
-
 describe('HASH', function () {
   let bitgo: TestBitGoAPI;
   let hash;
@@ -418,16 +414,13 @@ describe('HASH', function () {
     });
 
     it('should recover funds for non-bitgo recoveries', async function () {
-      const res = await thash.recover(
-        {
-          userKey: wrwUser.userPrivateKey,
-          backupKey: wrwUser.backupPrivateKey,
-          bitgoKey: wrwUser.bitgoPublicKey,
-          walletPassphrase: wrwUser.walletPassphrase,
-          recoveryDestination: destinationAddress,
-        },
-        openSSLBytes
-      );
+      const res = await thash.recover({
+        userKey: wrwUser.userPrivateKey,
+        backupKey: wrwUser.backupPrivateKey,
+        bitgoKey: wrwUser.bitgoPublicKey,
+        walletPassphrase: wrwUser.walletPassphrase,
+        recoveryDestination: destinationAddress,
+      });
       res.should.not.be.empty();
       res.should.hasOwnProperty('serializedTx');
       sandBox.assert.calledOnce(thash.getAccountBalance);
@@ -486,44 +479,35 @@ describe('HASH', function () {
 
     it('should throw error if userkey is not present', async function () {
       await thash
-        .recover(
-          {
-            backupKey: wrwUser.backupPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            walletPassphrase: wrwUser.walletPassphrase,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          backupKey: wrwUser.backupPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          walletPassphrase: wrwUser.walletPassphrase,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('missing userKey');
     });
 
     it('should throw error if wallet passphrase is not present', async function () {
       await thash
-        .recover(
-          {
-            userKey: wrwUser.userPrivateKey,
-            backupKey: wrwUser.backupPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          userKey: wrwUser.userPrivateKey,
+          backupKey: wrwUser.backupPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('missing wallet passphrase');
     });
 
     it('should throw error if there is no balance', async function () {
       await thash
-        .recover(
-          {
-            userKey: wrwUser.userPrivateKey,
-            backupKey: wrwUser.backupPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            walletPassphrase: wrwUser.walletPassphrase,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          userKey: wrwUser.userPrivateKey,
+          backupKey: wrwUser.backupPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          walletPassphrase: wrwUser.walletPassphrase,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('Did not have enough funds to recover');
     });
   });

--- a/modules/sdk-coin-injective/package.json
+++ b/modules/sdk-coin-injective/package.json
@@ -51,7 +51,6 @@
   },
   "devDependencies": {
     "@bitgo/sdk-api": "^1.56.1",
-    "@bitgo/sdk-opensslbytes": "^2.0.0",
     "@bitgo/sdk-test": "^8.0.48",
     "@types/lodash": "^4.14.183"
   }

--- a/modules/sdk-coin-injective/test/unit/injective.ts
+++ b/modules/sdk-coin-injective/test/unit/injective.ts
@@ -21,10 +21,6 @@ import {
 import should = require('should');
 import nock = require('nock');
 
-import { loadWebAssembly } from '@bitgo/sdk-opensslbytes';
-
-const openSSLBytes = loadWebAssembly().buffer;
-
 describe('INJ', function () {
   let bitgo: TestBitGoAPI;
   let basecoin;
@@ -379,16 +375,13 @@ describe('INJ', function () {
     });
 
     it('should recover funds for non-bitgo recoveries', async function () {
-      const res = await basecoin.recover(
-        {
-          userKey: wrwUser.userPrivateKey,
-          backupKey: wrwUser.backupPrivateKey,
-          bitgoKey: wrwUser.bitgoPublicKey,
-          walletPassphrase: wrwUser.walletPassphrase,
-          recoveryDestination: destinationAddress,
-        },
-        openSSLBytes
-      );
+      const res = await basecoin.recover({
+        userKey: wrwUser.userPrivateKey,
+        backupKey: wrwUser.backupPrivateKey,
+        bitgoKey: wrwUser.bitgoPublicKey,
+        walletPassphrase: wrwUser.walletPassphrase,
+        recoveryDestination: destinationAddress,
+      });
       res.should.not.be.empty();
       res.should.hasOwnProperty('serializedTx');
       sandBox.assert.calledOnce(basecoin.getAccountBalance);
@@ -434,58 +427,46 @@ describe('INJ', function () {
 
     it('should throw error if backupkey is not present', async function () {
       await basecoin
-        .recover(
-          {
-            userKey: wrwUser.userPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            walletPassphrase: wrwUser.walletPassphrase,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          userKey: wrwUser.userPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          walletPassphrase: wrwUser.walletPassphrase,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('missing backupKey');
     });
 
     it('should throw error if userkey is not present', async function () {
       await basecoin
-        .recover(
-          {
-            backupKey: wrwUser.backupPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            walletPassphrase: wrwUser.walletPassphrase,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          backupKey: wrwUser.backupPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          walletPassphrase: wrwUser.walletPassphrase,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('missing userKey');
     });
 
     it('should throw error if wallet passphrase is not present', async function () {
       await basecoin
-        .recover(
-          {
-            userKey: wrwUser.userPrivateKey,
-            backupKey: wrwUser.backupPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          userKey: wrwUser.userPrivateKey,
+          backupKey: wrwUser.backupPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('missing wallet passphrase');
     });
 
     it('should throw error if there is no balance', async function () {
       await basecoin
-        .recover(
-          {
-            userKey: wrwUser.userPrivateKey,
-            backupKey: wrwUser.backupPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            walletPassphrase: wrwUser.walletPassphrase,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          userKey: wrwUser.userPrivateKey,
+          backupKey: wrwUser.backupPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          walletPassphrase: wrwUser.walletPassphrase,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('Did not have enough funds to recover');
     });
   });

--- a/modules/sdk-coin-osmo/package.json
+++ b/modules/sdk-coin-osmo/package.json
@@ -51,7 +51,6 @@
   },
   "devDependencies": {
     "@bitgo/sdk-api": "^1.56.1",
-    "@bitgo/sdk-opensslbytes": "^2.0.0",
     "@bitgo/sdk-test": "^8.0.48",
     "@types/lodash": "^4.14.183"
   }

--- a/modules/sdk-coin-osmo/test/unit/osmo.ts
+++ b/modules/sdk-coin-osmo/test/unit/osmo.ts
@@ -20,10 +20,6 @@ import {
 } from '../resources/osmo';
 import should = require('should');
 
-import { loadWebAssembly } from '@bitgo/sdk-opensslbytes';
-
-const openSSLBytes = loadWebAssembly().buffer;
-
 describe('OSMO', function () {
   let bitgo: TestBitGoAPI;
   let basecoin;
@@ -436,16 +432,13 @@ describe('OSMO', function () {
     });
 
     it('should recover funds for non-bitgo recoveries', async function () {
-      const res = await basecoin.recover(
-        {
-          userKey: wrwUser.userPrivateKey,
-          backupKey: wrwUser.backupPrivateKey,
-          bitgoKey: wrwUser.bitgoPublicKey,
-          walletPassphrase: wrwUser.walletPassphrase,
-          recoveryDestination: destinationAddress,
-        },
-        openSSLBytes
-      );
+      const res = await basecoin.recover({
+        userKey: wrwUser.userPrivateKey,
+        backupKey: wrwUser.backupPrivateKey,
+        bitgoKey: wrwUser.bitgoPublicKey,
+        walletPassphrase: wrwUser.walletPassphrase,
+        recoveryDestination: destinationAddress,
+      });
       res.should.not.be.empty();
       res.should.hasOwnProperty('serializedTx');
       sandBox.assert.calledOnce(basecoin.getAccountBalance);
@@ -492,15 +485,12 @@ describe('OSMO', function () {
 
     it('should throw error if backupkey is not present', async function () {
       await basecoin
-        .recover(
-          {
-            userKey: wrwUser.userPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            walletPassphrase: wrwUser.walletPassphrase,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          userKey: wrwUser.userPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          walletPassphrase: wrwUser.walletPassphrase,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('missing backupKey');
     });
 
@@ -517,30 +507,24 @@ describe('OSMO', function () {
 
     it('should throw error if wallet passphrase is not present', async function () {
       await basecoin
-        .recover(
-          {
-            userKey: wrwUser.userPrivateKey,
-            backupKey: wrwUser.backupPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          userKey: wrwUser.userPrivateKey,
+          backupKey: wrwUser.backupPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('missing wallet passphrase');
     });
 
     it('should throw error if there is no balance', async function () {
       await basecoin
-        .recover(
-          {
-            userKey: wrwUser.userPrivateKey,
-            backupKey: wrwUser.backupPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            walletPassphrase: wrwUser.walletPassphrase,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          userKey: wrwUser.userPrivateKey,
+          backupKey: wrwUser.backupPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          walletPassphrase: wrwUser.walletPassphrase,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('Did not have enough funds to recover');
     });
   });

--- a/modules/sdk-coin-polygon/package.json
+++ b/modules/sdk-coin-polygon/package.json
@@ -51,7 +51,6 @@
   },
   "devDependencies": {
     "@bitgo/sdk-api": "^1.56.1",
-    "@bitgo/sdk-opensslbytes": "^2.0.0",
     "@bitgo/sdk-test": "^8.0.48",
     "secp256k1": "5.0.1"
   }

--- a/modules/sdk-coin-polygon/test/unit/polygon.ts
+++ b/modules/sdk-coin-polygon/test/unit/polygon.ts
@@ -13,10 +13,6 @@ import * as sjcl from '@bitgo/sjcl';
 
 nock.enableNetConnect();
 
-import { loadWebAssembly } from '@bitgo/sdk-opensslbytes';
-
-const openSSLBytes = loadWebAssembly().buffer;
-
 describe('Polygon', function () {
   let bitgo: TestBitGoAPI;
   let basecoin;
@@ -661,7 +657,6 @@ describe('Polygon', function () {
         recoveryDestination: '0xac05da78464520aa7c9d4c19bd7a440b111b3054',
         walletPassphrase: TestBitGo.V2.TEST_RECOVERY_PASSCODE,
         isTss: true,
-        openSSLBytes,
       };
 
       const recovery = await basecoin.recover(recoveryParams);
@@ -694,7 +689,6 @@ describe('Polygon', function () {
         recoveryDestination: '0xac05da78464520aa7c9d4c19bd7a440b111b3054',
         walletPassphrase: TestBitGo.V2.TEST_RECOVERY_PASSCODE,
         isTss: true,
-        openSSLBytes,
         gasPrice: 20000000000,
         gasLimit: 500000,
         replayProtectionOptions: {

--- a/modules/sdk-coin-sei/package.json
+++ b/modules/sdk-coin-sei/package.json
@@ -51,7 +51,6 @@
   },
   "devDependencies": {
     "@bitgo/sdk-api": "^1.56.1",
-    "@bitgo/sdk-opensslbytes": "^2.0.0",
     "@bitgo/sdk-test": "^8.0.48",
     "@types/lodash": "^4.14.183"
   }

--- a/modules/sdk-coin-sei/test/unit/sei.ts
+++ b/modules/sdk-coin-sei/test/unit/sei.ts
@@ -19,10 +19,6 @@ import {
 } from '../resources/sei';
 import should = require('should');
 
-import { loadWebAssembly } from '@bitgo/sdk-opensslbytes';
-
-const openSSLBytes = loadWebAssembly().buffer;
-
 describe('SEI', function () {
   let bitgo: TestBitGoAPI;
   let basecoin;
@@ -378,16 +374,13 @@ describe('SEI', function () {
     });
 
     it('should recover funds for non-bitgo recoveries', async function () {
-      const res = await basecoin.recover(
-        {
-          userKey: wrwUser.userPrivateKey,
-          backupKey: wrwUser.backupPrivateKey,
-          bitgoKey: wrwUser.bitgoPublicKey,
-          walletPassphrase: wrwUser.walletPassphrase,
-          recoveryDestination: destinationAddress,
-        },
-        openSSLBytes
-      );
+      const res = await basecoin.recover({
+        userKey: wrwUser.userPrivateKey,
+        backupKey: wrwUser.backupPrivateKey,
+        bitgoKey: wrwUser.bitgoPublicKey,
+        walletPassphrase: wrwUser.walletPassphrase,
+        recoveryDestination: destinationAddress,
+      });
       res.should.not.be.empty();
       res.should.hasOwnProperty('serializedTx');
       sandBox.assert.calledOnce(basecoin.getAccountBalance);
@@ -435,58 +428,46 @@ describe('SEI', function () {
 
     it('should throw error if backupkey is not present', async function () {
       await basecoin
-        .recover(
-          {
-            userKey: wrwUser.userPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            walletPassphrase: wrwUser.walletPassphrase,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          userKey: wrwUser.userPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          walletPassphrase: wrwUser.walletPassphrase,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('missing backupKey');
     });
 
     it('should throw error if userkey is not present', async function () {
       await basecoin
-        .recover(
-          {
-            backupKey: wrwUser.backupPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            walletPassphrase: wrwUser.walletPassphrase,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          backupKey: wrwUser.backupPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          walletPassphrase: wrwUser.walletPassphrase,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('missing userKey');
     });
 
     it('should throw error if wallet passphrase is not present', async function () {
       await basecoin
-        .recover(
-          {
-            userKey: wrwUser.userPrivateKey,
-            backupKey: wrwUser.backupPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          userKey: wrwUser.userPrivateKey,
+          backupKey: wrwUser.backupPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('missing wallet passphrase');
     });
 
     it('should throw error if there is no balance', async function () {
       await basecoin
-        .recover(
-          {
-            userKey: wrwUser.userPrivateKey,
-            backupKey: wrwUser.backupPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            walletPassphrase: wrwUser.walletPassphrase,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          userKey: wrwUser.userPrivateKey,
+          backupKey: wrwUser.backupPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          walletPassphrase: wrwUser.walletPassphrase,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('Did not have enough funds to recover');
     });
   });

--- a/modules/sdk-coin-tia/package.json
+++ b/modules/sdk-coin-tia/package.json
@@ -51,7 +51,6 @@
   },
   "devDependencies": {
     "@bitgo/sdk-api": "^1.56.1",
-    "@bitgo/sdk-opensslbytes": "^2.0.0",
     "@bitgo/sdk-test": "^8.0.48",
     "@types/lodash": "^4.14.183"
   }

--- a/modules/sdk-coin-tia/test/unit/tia.ts
+++ b/modules/sdk-coin-tia/test/unit/tia.ts
@@ -24,10 +24,6 @@ import {
 import should = require('should');
 import nock = require('nock');
 
-import { loadWebAssembly } from '@bitgo/sdk-opensslbytes';
-
-const openSSLBytes = loadWebAssembly().buffer;
-
 describe('TIA', function () {
   let bitgo: TestBitGoAPI;
   let basecoin;
@@ -479,16 +475,13 @@ describe('TIA', function () {
     });
 
     it('should recover funds for non-bitgo recoveries', async function () {
-      const res = await basecoin.recover(
-        {
-          userKey: wrwUser.userPrivateKey,
-          backupKey: wrwUser.backupPrivateKey,
-          bitgoKey: wrwUser.bitgoPublicKey,
-          walletPassphrase: wrwUser.walletPassphrase,
-          recoveryDestination: destinationAddress,
-        },
-        openSSLBytes
-      );
+      const res = await basecoin.recover({
+        userKey: wrwUser.userPrivateKey,
+        backupKey: wrwUser.backupPrivateKey,
+        bitgoKey: wrwUser.bitgoPublicKey,
+        walletPassphrase: wrwUser.walletPassphrase,
+        recoveryDestination: destinationAddress,
+      });
       res.should.not.be.empty();
       res.should.hasOwnProperty('serializedTx');
       sandBox.assert.calledOnce(basecoin.getAccountBalance);
@@ -534,58 +527,46 @@ describe('TIA', function () {
 
     it('should throw error if backupkey is not present', async function () {
       await basecoin
-        .recover(
-          {
-            userKey: wrwUser.userPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            walletPassphrase: wrwUser.walletPassphrase,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          userKey: wrwUser.userPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          walletPassphrase: wrwUser.walletPassphrase,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('missing backupKey');
     });
 
     it('should throw error if userkey is not present', async function () {
       await basecoin
-        .recover(
-          {
-            backupKey: wrwUser.backupPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            walletPassphrase: wrwUser.walletPassphrase,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          backupKey: wrwUser.backupPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          walletPassphrase: wrwUser.walletPassphrase,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('missing userKey');
     });
 
     it('should throw error if wallet passphrase is not present', async function () {
       await basecoin
-        .recover(
-          {
-            userKey: wrwUser.userPrivateKey,
-            backupKey: wrwUser.backupPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          userKey: wrwUser.userPrivateKey,
+          backupKey: wrwUser.backupPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('missing wallet passphrase');
     });
 
     it('should throw error if there is no balance', async function () {
       await basecoin
-        .recover(
-          {
-            userKey: wrwUser.userPrivateKey,
-            backupKey: wrwUser.backupPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            walletPassphrase: wrwUser.walletPassphrase,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          userKey: wrwUser.userPrivateKey,
+          backupKey: wrwUser.backupPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          walletPassphrase: wrwUser.walletPassphrase,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('Did not have enough funds to recover');
     });
   });

--- a/modules/sdk-coin-zeta/package.json
+++ b/modules/sdk-coin-zeta/package.json
@@ -51,7 +51,6 @@
   },
   "devDependencies": {
     "@bitgo/sdk-api": "^1.56.1",
-    "@bitgo/sdk-opensslbytes": "^2.0.0",
     "@bitgo/sdk-test": "^8.0.48",
     "@types/lodash": "^4.14.183"
   }

--- a/modules/sdk-coin-zeta/test/unit/zeta.ts
+++ b/modules/sdk-coin-zeta/test/unit/zeta.ts
@@ -23,10 +23,6 @@ import {
 import should = require('should');
 import nock = require('nock');
 
-import { loadWebAssembly } from '@bitgo/sdk-opensslbytes';
-
-const openSSLBytes = loadWebAssembly().buffer;
-
 describe('Zeta', function () {
   let bitgo: TestBitGoAPI;
   let basecoin;
@@ -381,16 +377,13 @@ describe('Zeta', function () {
     });
 
     it('should recover funds for non-bitgo recoveries', async function () {
-      const res = await basecoin.recover(
-        {
-          userKey: wrwUser.userPrivateKey,
-          backupKey: wrwUser.backupPrivateKey,
-          bitgoKey: wrwUser.bitgoPublicKey,
-          walletPassphrase: wrwUser.walletPassphrase,
-          recoveryDestination: destinationAddress,
-        },
-        openSSLBytes
-      );
+      const res = await basecoin.recover({
+        userKey: wrwUser.userPrivateKey,
+        backupKey: wrwUser.backupPrivateKey,
+        bitgoKey: wrwUser.bitgoPublicKey,
+        walletPassphrase: wrwUser.walletPassphrase,
+        recoveryDestination: destinationAddress,
+      });
       res.should.not.be.empty();
       res.should.hasOwnProperty('serializedTx');
       sandBox.assert.calledOnce(basecoin.getAccountBalance);
@@ -408,18 +401,15 @@ describe('Zeta', function () {
     });
 
     it('should redelegate funds to new validator', async function () {
-      const res = await basecoin.redelegate(
-        {
-          userKey: wrwUser.userPrivateKey,
-          backupKey: wrwUser.backupPrivateKey,
-          bitgoKey: wrwUser.bitgoPublicKey,
-          walletPassphrase: wrwUser.walletPassphrase,
-          amountToRedelegate: '10000000000000000',
-          validatorSrcAddress: 'zetavaloper1dhsk5v53h3xwg42pdg3r0w7zl83yxgyhs68v7l',
-          validatorDstAddress: 'zetavaloper19v07wvwm3zux9pawcmccr7c4hfezah0r8whsc6',
-        },
-        openSSLBytes
-      );
+      const res = await basecoin.redelegate({
+        userKey: wrwUser.userPrivateKey,
+        backupKey: wrwUser.backupPrivateKey,
+        bitgoKey: wrwUser.bitgoPublicKey,
+        walletPassphrase: wrwUser.walletPassphrase,
+        amountToRedelegate: '10000000000000000',
+        validatorSrcAddress: 'zetavaloper1dhsk5v53h3xwg42pdg3r0w7zl83yxgyhs68v7l',
+        validatorDstAddress: 'zetavaloper19v07wvwm3zux9pawcmccr7c4hfezah0r8whsc6',
+      });
 
       res.should.not.be.empty();
       res.should.hasOwnProperty('serializedTx');
@@ -463,58 +453,46 @@ describe('Zeta', function () {
 
     it('should throw error if backupkey is not present', async function () {
       await basecoin
-        .recover(
-          {
-            userKey: wrwUser.userPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            walletPassphrase: wrwUser.walletPassphrase,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          userKey: wrwUser.userPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          walletPassphrase: wrwUser.walletPassphrase,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('missing backupKey');
     });
 
     it('should throw error if userkey is not present', async function () {
       await basecoin
-        .recover(
-          {
-            backupKey: wrwUser.backupPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            walletPassphrase: wrwUser.walletPassphrase,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          backupKey: wrwUser.backupPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          walletPassphrase: wrwUser.walletPassphrase,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('missing userKey');
     });
 
     it('should throw error if wallet passphrase is not present', async function () {
       await basecoin
-        .recover(
-          {
-            userKey: wrwUser.userPrivateKey,
-            backupKey: wrwUser.backupPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          userKey: wrwUser.userPrivateKey,
+          backupKey: wrwUser.backupPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('missing wallet passphrase');
     });
 
     it('should throw error if there is no balance', async function () {
       await basecoin
-        .recover(
-          {
-            userKey: wrwUser.userPrivateKey,
-            backupKey: wrwUser.backupPrivateKey,
-            bitgoKey: wrwUser.bitgoPublicKey,
-            walletPassphrase: wrwUser.walletPassphrase,
-            recoveryDestination: destinationAddress,
-          },
-          openSSLBytes
-        )
+        .recover({
+          userKey: wrwUser.userPrivateKey,
+          backupKey: wrwUser.backupPrivateKey,
+          bitgoKey: wrwUser.bitgoPublicKey,
+          walletPassphrase: wrwUser.walletPassphrase,
+          recoveryDestination: destinationAddress,
+        })
         .should.rejectedWith('Did not have enough funds to recover');
     });
   });


### PR DESCRIPTION
This PR removes the need for openssl when recovering from GG18 wallets

For any GG18 wallet recovering with a user and backup key, we will instead perform a 2of2 retrofit to MPCv2, and sign with MPCv2.

TICKET: WP-2959