### PR TITLE
Add support for commonkeychain in TSS recovery for eth-like coins

### DIFF
--- a/modules/abstract-eth/package.json
+++ b/modules/abstract-eth/package.json
@@ -59,6 +59,7 @@
   },
   "devDependencies": {
     "@bitgo/sdk-api": "^1.56.1",
-    "@bitgo/sdk-test": "^8.0.48"
+    "@bitgo/sdk-test": "^8.0.48",
+    "@bitgo/sdk-lib-mpc": "^10.1.0"
   }
 }

--- a/modules/bitgo/test/v2/unit/recovery.ts
+++ b/modules/bitgo/test/v2/unit/recovery.ts
@@ -708,7 +708,7 @@ describe('Recovery:', function () {
         params: {
           module: 'account',
           action: 'txlist',
-          address: '0xe7406dc43d13f698fb41a345c7783d39a4c2d191',
+          address: '0xd18ee37daeab8468020dd65fa7f6f6b9ac741584',
         },
         response: {
           status: '0',
@@ -720,7 +720,7 @@ describe('Recovery:', function () {
         params: {
           module: 'account',
           action: 'balance',
-          address: '0xe7406dc43d13f698fb41a345c7783d39a4c2d191',
+          address: '0xd18ee37daeab8468020dd65fa7f6f6b9ac741584',
         },
         response: {
           status: '1',
@@ -1098,12 +1098,13 @@ describe('Recovery:', function () {
 
       const basecoin = bitgo.coin('hteth');
 
-      const userKey = '03f8606a595917de4cf2244e27b7fba172505469392ad385d2dd2b3588a6bb878c';
-      const backupKey = '03f8606a595917de4cf2244e27b7fba172505469392ad385d2dd2b3588a6bb878c';
+      const bitgoKey =
+        '03ffd706c97ce5438ffa38016f3708a3e4ffa7126a2d03d3e02a087767950d72c9197ee747c5c146ae62f8d80fe313c943139190ce3e49727a9707e9626b15fc0d';
 
       recoveryParams = {
-        userKey: userKey,
-        backupKey: backupKey,
+        userKey: '',
+        backupKey: '',
+        bitgoKey: bitgoKey,
         walletContractAddress: '0xe7406dc43d13f698fb41a345c7783d39a4c2d191',
         recoveryDestination: '0xac05da78464520aa7c9d4c19bd7a440b111b3054',
         walletPassphrase: TestBitGo.V2.TEST_RECOVERY_PASSCODE,

--- a/modules/sdk-core/src/bitgo/recovery/initiate.ts
+++ b/modules/sdk-core/src/bitgo/recovery/initiate.ts
@@ -78,12 +78,17 @@ export function getIsKrsRecovery({ backupKey, userKey }: { backupKey: string; us
 export function getIsUnsignedSweep({
   backupKey,
   userKey,
+  bitgoKey,
   isTss,
 }: {
   backupKey: string;
   userKey: string;
+  bitgoKey?: string;
   isTss?: boolean;
 }): boolean {
+  if (isTss && bitgoKey) {
+    return true;
+  }
   if (isTss) {
     try {
       return typeof JSON.parse(backupKey) === 'string' && typeof JSON.parse(userKey) === 'string';


### PR DESCRIPTION

## Description

Link to Jira: https://bitgoinc.atlassian.net/browse/WP-2971

This is to prevent the error "Unsupported public key" when trying to create an unsigned sweep for a TSS SMC wallet (eth-like), and to allow the user to go ahead with creating their unsigned transaction. 

Type of change: Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

These SDK changes have been tested in wallet-recovery-wizard by modifying in node_modules. TODO: use the SDK beta version from this PR to test. 

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

