### PR TITLE
Handle a transaction with an OP_RETURN

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -104,6 +104,7 @@ type UtxoCustomSigningFunction<TNumber extends number | bigint> = {
   }): Promise<SignedTransaction>;
 };
 
+export const ScriptRecipientPrefix = 'scriptPubkey:';
 const { getExternalChainCode, isChainCode, scriptTypeForChain, outputScripts } = bitgo;
 type Unspent<TNumber extends number | bigint = number> = bitgo.Unspent<TNumber>;
 
@@ -457,6 +458,17 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
     }
     const chainhead = await this.bitgo.get(this.url('/public/block/latest')).result();
     return (chainhead as any).height;
+  }
+
+  checkRecipient(recipient: { address: string; amount: number | string }): void {
+    if (recipient.address.startsWith(ScriptRecipientPrefix)) {
+      const amount = BigInt(recipient.amount);
+      if (amount !== BigInt(0)) {
+        throw new Error('Only zero amounts allowed for non-encodeable scriptPubkeys');
+      }
+    } else {
+      super.checkRecipient(recipient);
+    }
   }
 
   /**

--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -448,6 +448,21 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
     }
   }
 
+  preprocessBuildParams(params: Record<string, any>): Record<string, any> {
+    params.recipients =
+      params.recipients && params.recipients instanceof Array
+        ? params?.recipients?.map((recipient) => {
+            if (recipient.address.startsWith(ScriptRecipientPrefix)) {
+              const { address, ...rest } = recipient;
+              return { ...rest, script: address.replace(ScriptRecipientPrefix, '') };
+            }
+            return recipient;
+          })
+        : params.recipients;
+
+    return params;
+  }
+
   /**
    * Get the latest block height
    * @param reqId

--- a/modules/abstract-utxo/src/parseOutput.ts
+++ b/modules/abstract-utxo/src/parseOutput.ts
@@ -213,6 +213,15 @@ export async function parseOutput({
   const disableNetworking = !!verification.disableNetworking;
   const currentAddress = currentOutput.address;
 
+  if (currentAddress === undefined) {
+    // In the case that the address is undefined, it means that the output has a non-encodeable scriptPubkey
+    // If this is the case, then we need to check that the amount is 0 and we can skip the rest.
+    if (currentOutput.amount.toString() !== '0') {
+      throw new Error('output with undefined address must have amount of 0');
+    }
+    return currentOutput;
+  }
+
   // attempt to grab the address details from either the prebuilt tx, or the verification params.
   // If both of these are empty, then we will try to get the address details from bitgo instead
   const addressDetailsPrebuild = _.get(txPrebuild, `txInfo.walletAddressDetails.${currentAddress}`, {});

--- a/modules/abstract-utxo/src/transaction.ts
+++ b/modules/abstract-utxo/src/transaction.ts
@@ -8,12 +8,42 @@ import {
   TransactionExplanation,
   TransactionPrebuild,
   Output,
-  ScriptRecipientPrefix,
 } from './abstractUtxoCoin';
 import { bip32, BIP32Interface, bitgo } from '@bitgo/utxo-lib';
 
-// https://github.com/bitcoin/bitcoin/blob/5961b23898ee7c0af2626c46d5d70e80136578d3/src/script/script.h#L47
-const OP_RETURN_IDENTIFIER = Buffer.from('6a', 'hex');
+const ScriptRecipientPrefix = 'scriptPubkey:';
+
+/**
+ * An extended address is one that encodes either a regular address or a hex encoded script with the prefix `scriptPubkey:`.
+ * This function converts the extended address format to either a script or an address.
+ * @param extendedAddress
+ */
+export function fromExtendedAddressFormat(extendedAddress: string): { address: string } | { script: string } {
+  if (extendedAddress.startsWith(ScriptRecipientPrefix)) {
+    return { script: extendedAddress.replace(ScriptRecipientPrefix, '') };
+  }
+  return { address: extendedAddress };
+}
+
+export function toExtendedAddressFormat(script: Buffer, network: utxolib.Network): string {
+  return script[0] === utxolib.opcodes.OP_RETURN
+    ? `${ScriptRecipientPrefix}${script.toString('hex')}`
+    : utxolib.address.fromOutputScript(script, network);
+}
+
+export function isExtendedAddressFormat(address: string): boolean {
+  return address.startsWith(ScriptRecipientPrefix);
+}
+
+export function assertValidTransactionRecipient(output: { amount: bigint | number | string; address?: string }): void {
+  // In the case that this is an OP_RETURN output or another non-encodable scriptPubkey, we dont have an address.
+  // We will verify that the amount is zero, and if it isnt then we will throw an error.
+  if (!output.address || output.address.startsWith(ScriptRecipientPrefix)) {
+    if (output.amount.toString() !== '0') {
+      throw new Error(`Only zero amounts allowed for non-encodeable scriptPubkeys: ${JSON.stringify(output)}`);
+    }
+  }
+}
 
 /**
  * Get the inputs for a psbt from a prebuild.
@@ -112,12 +142,7 @@ function explainCommon<TNumber extends number | bigint>(
   tx.outs.forEach((currentOutput) => {
     // Try to encode the script pubkey with an address. If it fails, try to parse it as an OP_RETURN output with the prefix.
     // If that fails, then it is an unrecognized scriptPubkey and should fail
-    let currentAddress: string;
-    if (currentOutput.script.subarray(0, 1).equals(OP_RETURN_IDENTIFIER)) {
-      currentAddress = `${ScriptRecipientPrefix}${currentOutput.script.toString('hex')}`;
-    } else {
-      currentAddress = utxolib.address.fromOutputScript(currentOutput.script, network);
-    }
+    const currentAddress = toExtendedAddressFormat(currentOutput.script, network);
     const currentAmount = BigInt(currentOutput.value);
 
     if (changeAddresses.includes(currentAddress)) {

--- a/modules/sdk-core/src/bitgo/baseCoin/baseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/baseCoin.ts
@@ -250,6 +250,14 @@ export abstract class BaseCoin implements IBaseCoin {
   }
 
   /**
+   * Preprocess the build parameters before sending to the API
+   * @param buildParams
+   */
+  preprocessBuildParams(buildParams: Record<string, any>): Record<string, any> {
+    return buildParams;
+  }
+
+  /**
    * Sign message with private key
    *
    * @param key

--- a/modules/sdk-core/src/bitgo/baseCoin/baseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/baseCoin.ts
@@ -225,6 +225,16 @@ export abstract class BaseCoin implements IBaseCoin {
     return bigNumber.toFormat(null as any, null as any, { groupSeparator: '', decimalSeparator: '.' });
   }
 
+  checkRecipient(recipient: { address: string; amount: string | number }): void {
+    const amount = new BigNumber(recipient.amount);
+    if (amount.isNegative()) {
+      throw new Error('invalid argument for amount - positive number greater than zero or numeric string expected');
+    }
+    if (!this.valuelessTransferAllowed() && amount.isZero()) {
+      throw new Error('invalid argument for amount - positive number greater than zero or numeric string expected');
+    }
+  }
+
   /**
    * Convert a currency amount represented in big units (btc, eth, xrp, xlm)
    * to base units (satoshi, wei, atoms, drops, stroops)

--- a/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
@@ -485,6 +485,7 @@ export interface IBaseCoin {
   getBaseFactor(): number | string;
   baseUnitsToBigUnits(baseUnits: string | number): string;
   bigUnitsToBaseUnits(bigUnits: string | number): string;
+  preprocessBuildParams(params: Record<string, any>): Record<string, any>;
   signMessage(key: { prv: string }, message: string): Promise<Buffer>;
   createKeySignatures(
     prv: string,

--- a/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
@@ -473,6 +473,7 @@ export interface IBaseCoin {
   getFamily(): string;
   getFullName(): string;
   valuelessTransferAllowed(): boolean;
+  checkRecipient(recipient: { address: string; amount: string | number }): void;
   sweepWithSendMany(): boolean;
   transactionDataAllowed(): boolean;
   allowsAccountConsolidations(): boolean;

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -1747,7 +1747,7 @@ export class Wallet implements IWallet {
     }
 
     // Whitelist params to build tx
-    const whitelistedParams = _.pick(params, this.prebuildWhitelistedParams());
+    const whitelistedParams = this.baseCoin.preprocessBuildParams(_.pick(params, this.prebuildWhitelistedParams()));
     debug('prebuilding transaction: %O', whitelistedParams);
 
     if (params.reqId) {
@@ -3655,7 +3655,7 @@ export class Wallet implements IWallet {
     // extract the whitelisted params from the top level, in case
     // other invalid params are present that would fail encoding
     // and fall back to the body params
-    const whitelistedParams = _.pick(params, whitelistedSendParams);
+    const whitelistedParams = this.baseCoin.preprocessBuildParams(_.pick(params, whitelistedSendParams));
     const reqTracer = reqId || new RequestTracer();
     this.bitgo.setRequestTracer(reqTracer);
     return postWithCodec(

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -2484,13 +2484,7 @@ export class Wallet implements IWallet {
     const coin = this.baseCoin;
     if (_.isObject(params.recipients)) {
       params.recipients.map(function (recipient) {
-        const amount = new BigNumber(recipient.amount);
-        if (amount.isNegative()) {
-          throw new Error('invalid argument for amount - positive number greater than zero or numeric string expected');
-        }
-        if (!coin.valuelessTransferAllowed() && amount.isZero()) {
-          throw new Error('invalid argument for amount - positive number greater than zero or numeric string expected');
-        }
+        coin.checkRecipient(recipient);
       });
     }
 


### PR DESCRIPTION
Have the SDK handle parameters to build a transactions with an OP_RETURN output.

In the SDK we handle OP_RETURN outputs by setting them in the address field of the output with the format `scriptPubkey:HEX_ENCODED_SCRIPT_PUBKEY`. When we submit to wallet platform, we want to convert that output to the format { script: string, amount: string | number }.

Before submitting the buildParams to the API, we want to convert it. In every other instance for other coins we just want to return the same parameters.

BTC-1582
<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
