### PR TITLE
fix(abstract-utxo): scriptPubKey prefix

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -83,7 +83,7 @@ import {
   fromExtendedAddressFormat,
   getPsbtTxInputs,
   getTxInputs,
-  isExtendedAddressFormat,
+  isScriptRecipient,
 } from './transaction';
 import { assertDescriptorWalletAddress } from './descriptor/assertDescriptorWalletAddress';
 
@@ -483,7 +483,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
 
   checkRecipient(recipient: { address: string; amount: number | string }): void {
     assertValidTransactionRecipient(recipient);
-    if (!isExtendedAddressFormat(recipient.address)) {
+    if (!isScriptRecipient(recipient.address)) {
       super.checkRecipient(recipient);
     }
   }

--- a/modules/abstract-utxo/src/transaction.ts
+++ b/modules/abstract-utxo/src/transaction.ts
@@ -11,28 +11,38 @@ import {
 } from './abstractUtxoCoin';
 import { bip32, BIP32Interface, bitgo } from '@bitgo/utxo-lib';
 
-const ScriptRecipientPrefix = 'scriptPubkey:';
+const ScriptRecipientPrefix = 'scriptPubKey:';
 
 /**
- * An extended address is one that encodes either a regular address or a hex encoded script with the prefix `scriptPubkey:`.
+ * Check if the address is in the extended address format.
+ * @param address
+ */
+export function isExtendedAddressFormat(address: string): boolean {
+  return address.toLowerCase().startsWith(ScriptRecipientPrefix);
+}
+
+/**
+ * An extended address is one that encodes either a regular address or a hex encoded script with the prefix `scriptPubKey:`.
  * This function converts the extended address format to either a script or an address.
  * @param extendedAddress
  */
 export function fromExtendedAddressFormat(extendedAddress: string): { address: string } | { script: string } {
-  if (extendedAddress.startsWith(ScriptRecipientPrefix)) {
-    return { script: extendedAddress.replace(ScriptRecipientPrefix, '') };
+  if (isExtendedAddressFormat(extendedAddress)) {
+    return { script: extendedAddress.slice(ScriptRecipientPrefix.length) };
   }
   return { address: extendedAddress };
 }
 
+/**
+ * Convert a script or address to the extended address format.
+ * @param script
+ * @param network
+ * @returns if the script is an OP_RETURN script, then it will be prefixed with `scriptPubKey:`, otherwise it will be converted to an address.
+ */
 export function toExtendedAddressFormat(script: Buffer, network: utxolib.Network): string {
   return script[0] === utxolib.opcodes.OP_RETURN
     ? `${ScriptRecipientPrefix}${script.toString('hex')}`
     : utxolib.address.fromOutputScript(script, network);
-}
-
-export function isExtendedAddressFormat(address: string): boolean {
-  return address.startsWith(ScriptRecipientPrefix);
 }
 
 export function assertValidTransactionRecipient(output: { amount: bigint | number | string; address?: string }): void {

--- a/modules/abstract-utxo/src/transaction.ts
+++ b/modules/abstract-utxo/src/transaction.ts
@@ -14,11 +14,11 @@ import { bip32, BIP32Interface, bitgo } from '@bitgo/utxo-lib';
 const ScriptRecipientPrefix = 'scriptPubKey:';
 
 /**
- * Check if the address is in the extended address format.
+ * Check if the address is a script recipient (starts with `scriptPubKey:`).
  * @param address
  */
-export function isExtendedAddressFormat(address: string): boolean {
-  return address.toLowerCase().startsWith(ScriptRecipientPrefix);
+export function isScriptRecipient(address: string): boolean {
+  return address.toLowerCase().startsWith(ScriptRecipientPrefix.toLowerCase());
 }
 
 /**
@@ -27,7 +27,7 @@ export function isExtendedAddressFormat(address: string): boolean {
  * @param extendedAddress
  */
 export function fromExtendedAddressFormat(extendedAddress: string): { address: string } | { script: string } {
-  if (isExtendedAddressFormat(extendedAddress)) {
+  if (isScriptRecipient(extendedAddress)) {
     return { script: extendedAddress.slice(ScriptRecipientPrefix.length) };
   }
   return { address: extendedAddress };
@@ -48,7 +48,7 @@ export function toExtendedAddressFormat(script: Buffer, network: utxolib.Network
 export function assertValidTransactionRecipient(output: { amount: bigint | number | string; address?: string }): void {
   // In the case that this is an OP_RETURN output or another non-encodable scriptPubkey, we dont have an address.
   // We will verify that the amount is zero, and if it isnt then we will throw an error.
-  if (!output.address || output.address.startsWith(ScriptRecipientPrefix)) {
+  if (!output.address || isScriptRecipient(output.address)) {
     if (output.amount.toString() !== '0') {
       throw new Error(`Only zero amounts allowed for non-encodeable scriptPubkeys: ${JSON.stringify(output)}`);
     }

--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -1872,7 +1872,7 @@ describe('V2 Wallet:', function () {
       const blockHeight = 100;
       const blockHeightStub = sinon.stub(basecoin, 'getLatestBlockHeight').resolves(blockHeight);
       const postProcessStub = sinon.stub(basecoin, 'postProcessPrebuild').resolves({});
-      await wallet.prebuildTransaction({ recipients: [{ address: `scriptPubkey:${script}`, amount: 1e6 }] });
+      await wallet.prebuildTransaction({ recipients: [{ address: `scriptPubKey:${script}`, amount: 1e6 }] });
       blockHeightStub.should.have.been.calledOnce();
       postProcessStub.should.have.been.calledOnceWith({
         blockHeight: 100,


### PR DESCRIPTION
- **feat: fix scriptPubKey prefix**
  The capitalization of the scriptPubKey was not consistent with the one used in
  bitcoin core[1].
  
  Fix capitalization and make parsing case-insensitive.
  
  1: https://github.com/bitcoin/bitcoin/blob/v28.0/src/rpc/blockchain.cpp#L657
  
  Issue: BTC-1582
  

- **fix(abstract-utxo): rename isExtendedAddressFormat to isScriptRecipient**
  The extended address format includes both regular addresses and strings starting
  with 'scriptPubKey:'. This commit renames the function to isScriptRecipient to
  better reflect its purpose.
  
  Issue: BTC-1582
  