### PR TITLE
chore(sdk-core): switch to new API url for create wallet

### DIFF
--- a/modules/bitgo/test/v2/unit/lightning/lightningWallets.ts
+++ b/modules/bitgo/test/v2/unit/lightning/lightningWallets.ts
@@ -165,7 +165,7 @@ describe('Lightning wallets', function () {
         .reply(200, { id: 'keyId3' });
 
       nock(bgUrl)
-        .post('/api/v2/' + coinName + '/wallet', (body) => validateWalletRequest(body))
+        .post('/api/v2/' + coinName + '/wallet/add', (body) => validateWalletRequest(body))
         .reply(200, { id: 'walletId' });
 
       const response = await wallets.generateWallet(params);

--- a/modules/bitgo/test/v2/unit/wallets.ts
+++ b/modules/bitgo/test/v2/unit/wallets.ts
@@ -80,7 +80,7 @@ describe('V2 Wallets:', function () {
 
     it('creates a paired custodial wallet', async function () {
       nock(bgUrl)
-        .post('/api/v2/tbtc/wallet', function (body) {
+        .post('/api/v2/tbtc/wallet/add', function (body) {
           body.isCustodial.should.be.true();
           body.should.have.property('keys');
           body.m.should.equal(2);
@@ -97,7 +97,7 @@ describe('V2 Wallets:', function () {
       const eosWallets = eosBitGo.coin('teos').wallets();
       const address = 'testeosaddre';
       nock(bgUrl)
-        .post('/api/v2/teos/wallet', function (body) {
+        .post('/api/v2/teos/wallet/add', function (body) {
           body.should.have.property('keys');
           body.m.should.equal(2);
           body.n.should.equal(3);
@@ -110,7 +110,7 @@ describe('V2 Wallets:', function () {
 
     it('creates a single custodial wallet', async function () {
       nock(bgUrl)
-        .post('/api/v2/tbtc/wallet', function (body) {
+        .post('/api/v2/tbtc/wallet/add', function (body) {
           body.type.should.equal('custodial');
           body.should.not.have.property('keys');
           body.should.not.have.property('m');
@@ -126,7 +126,7 @@ describe('V2 Wallets:', function () {
       ethBitGo.initializeTestVars();
       const ethWallets = ethBitGo.coin('teth').wallets();
       nock(bgUrl)
-        .post('/api/v2/teth/wallet', function (body) {
+        .post('/api/v2/teth/wallet/add', function (body) {
           body.type.should.equal('custodial');
           body.gasPrice.should.equal(20000000000);
           body.should.not.have.property('keys');
@@ -148,7 +148,7 @@ describe('V2 Wallets:', function () {
       ethBitGo.initializeTestVars();
       const ethWallets = ethBitGo.coin('teth').wallets();
       nock(bgUrl)
-        .post('/api/v2/teth/wallet', function (body) {
+        .post('/api/v2/teth/wallet/add', function (body) {
           body.type.should.equal('custodial');
           body.walletVersion.should.equal(1);
           body.should.not.have.property('keys');
@@ -162,7 +162,7 @@ describe('V2 Wallets:', function () {
 
     it('creates a new hot wallet with userKey', async function () {
       nock(bgUrl)
-        .post('/api/v2/tbtc/wallet', function (body) {
+        .post('/api/v2/tbtc/wallet/add', function (body) {
           body.type.should.equal('hot');
           body.should.have.property('keys');
           body.should.have.property('m');
@@ -330,7 +330,7 @@ describe('V2 Wallets:', function () {
         .reply(200);
 
       // wallet
-      nock(bgUrl).post('/api/v2/tbtc/wallet').reply(200);
+      nock(bgUrl).post('/api/v2/tbtc/wallet/add').reply(200);
 
       await wallets.generateWallet(params);
     });
@@ -367,7 +367,7 @@ describe('V2 Wallets:', function () {
         .reply(200);
 
       // wallet
-      nock(bgUrl).post('/api/v2/tbtc/wallet').reply(200);
+      nock(bgUrl).post('/api/v2/tbtc/wallet/add').reply(200);
 
       await wallets.generateWallet(params);
     });
@@ -402,7 +402,7 @@ describe('V2 Wallets:', function () {
         .reply(200);
 
       // wallet
-      const walletNock = nock(bgUrl).post('/api/v2/tbtc/wallet').reply(200);
+      const walletNock = nock(bgUrl).post('/api/v2/tbtc/wallet/add').reply(200);
 
       await wallets.generateWallet(params);
       for (const scope of [bitgoKeyNock, userKeyNock, backupKeyNock, walletNock]) {
@@ -418,7 +418,7 @@ describe('V2 Wallets:', function () {
       };
 
       const walletNock = nock(bgUrl)
-        .post('/api/v2/tbtc/wallet', function (body) {
+        .post('/api/v2/tbtc/wallet/add', function (body) {
           body.type.should.equal('custodial');
           should.not.exist(body.m);
           should.not.exist(body.n);
@@ -449,7 +449,7 @@ describe('V2 Wallets:', function () {
       };
 
       const walletNock = nock(bgUrl)
-        .post('/api/v2/tbtc/wallet', function (body) {
+        .post('/api/v2/tbtc/wallet/add', function (body) {
           body.type.should.equal('hot');
           return true;
         })
@@ -527,7 +527,7 @@ describe('V2 Wallets:', function () {
       };
       sandbox.stub(TssUtils.prototype, 'createKeychains').resolves(stubbedKeychainsTriplet);
 
-      const walletNock = nock('https://bitgo.fakeurl').post('/api/v2/tsol/wallet').reply(200);
+      const walletNock = nock('https://bitgo.fakeurl').post('/api/v2/tsol/wallet/add').reply(200);
 
       const wallets = new Wallets(bitgo, tsol);
 
@@ -574,7 +574,7 @@ describe('V2 Wallets:', function () {
       };
       sandbox.stub(TssUtils.prototype, 'createKeychains').resolves(stubbedKeychainsTriplet);
 
-      const walletNock = nock('https://bitgo.fakeurl').post('/api/v2/tsol/wallet').reply(200);
+      const walletNock = nock('https://bitgo.fakeurl').post('/api/v2/tsol/wallet/add').reply(200);
 
       const wallets = new Wallets(bitgo, tsol);
 
@@ -612,7 +612,7 @@ describe('V2 Wallets:', function () {
       };
       sandbox.stub(ECDSAUtils.EcdsaUtils.prototype, 'createKeychains').resolves(stubbedKeychainsTriplet);
 
-      const walletNock = nock('https://bitgo.fakeurl').post('/api/v2/tpolygon/wallet').reply(200);
+      const walletNock = nock('https://bitgo.fakeurl').post('/api/v2/tpolygon/wallet/add').reply(200);
 
       const wallets = new Wallets(bitgo, tpolygon);
 
@@ -651,7 +651,7 @@ describe('V2 Wallets:', function () {
         .post('/api/v2/tbtc/key', _.matches({ source: 'backup' }))
         .reply(200);
 
-      nock(bgUrl).post('/api/v2/tbtc/wallet').reply(200);
+      nock(bgUrl).post('/api/v2/tbtc/wallet/add').reply(200);
 
       // create a non tss wallet for coin that doesn't support tss even though multisigType is set to tss
       await wallets.generateWallet({ ...params, multisigType: 'tss' });
@@ -688,7 +688,7 @@ describe('V2 Wallets:', function () {
       };
 
       const walletNock = nock('https://bitgo.fakeurl')
-        .post('/api/v2/tsol/wallet')
+        .post('/api/v2/tsol/wallet/add')
         .times(1)
         .reply(200, { ...walletParams, keys });
 
@@ -777,7 +777,7 @@ describe('V2 Wallets:', function () {
       };
 
       const walletNock = nock('https://bitgo.fakeurl')
-        .post('/api/v2/tsol/wallet', walletNockExpected)
+        .post('/api/v2/tsol/wallet/add', walletNockExpected)
         .reply(200, { ...walletNockExpected, responseType: 'WalletWithKeychains' });
 
       const wallets = new Wallets(bitgo, tsol);
@@ -917,7 +917,7 @@ describe('V2 Wallets:', function () {
           .stub(ECDSAUtils.EcdsaMPCv2Utils.prototype, 'createKeychains')
           .resolves(stubbedKeychainsTriplet);
 
-        const walletNock = nock('https://bitgo.fakeurl').post(`/api/v2/${coin}/wallet`).reply(200);
+        const walletNock = nock('https://bitgo.fakeurl').post(`/api/v2/${coin}/wallet/add`).reply(200);
 
         const wallets = new Wallets(bitgo, testCoin);
 
@@ -971,7 +971,7 @@ describe('V2 Wallets:', function () {
         .resolves(stubbedKeychainsTriplet);
 
       const walletNock = nock('https://bitgo.fakeurl')
-        .post(`/api/v2/hteth/wallet`, (body) => {
+        .post(`/api/v2/hteth/wallet/add`, (body) => {
           body.walletVersion.should.equal(6);
           return true;
         })
@@ -1028,7 +1028,7 @@ describe('V2 Wallets:', function () {
         .resolves(stubbedKeychainsTriplet);
 
       const walletNock = nock('https://bitgo.fakeurl')
-        .post(`/api/v2/hteth/wallet`, (body) => {
+        .post(`/api/v2/hteth/wallet/add`, (body) => {
           body.walletVersion.should.equal(5);
           return true;
         })
@@ -1124,7 +1124,7 @@ describe('V2 Wallets:', function () {
       };
       sandbox.stub(BlsUtils.prototype, 'createKeychains').resolves(stubbedKeychainsTriplet);
 
-      const walletNock = nock('https://bitgo.fakeurl').post('/api/v2/eth2/wallet').reply(200);
+      const walletNock = nock('https://bitgo.fakeurl').post('/api/v2/eth2/wallet/add').reply(200);
 
       const wallets = new Wallets(bitgo, eth2);
 

--- a/modules/sdk-core/src/bitgo/wallet/wallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallets.ts
@@ -150,7 +150,7 @@ export class Wallets implements IWallets {
       throw new Error('invalid argument for address - valid address string expected');
     }
 
-    const newWallet = await this.bitgo.post(this.baseCoin.url('/wallet')).send(params).result();
+    const newWallet = await this.bitgo.post(this.baseCoin.url('/wallet/add')).send(params).result();
     return {
       wallet: new Wallet(this.bitgo, this.baseCoin, newWallet),
     };
@@ -197,7 +197,7 @@ export class Wallets implements IWallets {
       coinSpecific: { [this.baseCoin.getChain()]: { keys: [userAuthKeychain.id, nodeAuthKeychain.id] } },
     };
 
-    const newWallet = await this.bitgo.post(this.baseCoin.url('/wallet')).send(walletParams).result();
+    const newWallet = await this.bitgo.post(this.baseCoin.url('/wallet/add')).send(walletParams).result();
     const wallet = new Wallet(this.bitgo, this.baseCoin, newWallet);
     return {
       wallet,
@@ -466,7 +466,7 @@ export class Wallets implements IWallets {
       walletParams.keys = undefined;
       walletParams.keySignatures = undefined;
 
-      const newWallet = await this.bitgo.post(this.baseCoin.url('/wallet')).send(walletParams).result(); // returns the ids
+      const newWallet = await this.bitgo.post(this.baseCoin.url('/wallet/add')).send(walletParams).result(); // returns the ids
 
       const userKeychain = this.baseCoin.keychains().get({ id: newWallet.keys[KeyIndices.USER], reqId });
       const backupKeychain = this.baseCoin.keychains().get({ id: newWallet.keys[KeyIndices.BACKUP], reqId });
@@ -582,7 +582,7 @@ export class Wallets implements IWallets {
       }
 
       this.bitgo.setRequestTracer(reqId);
-      const newWallet = await this.bitgo.post(this.baseCoin.url('/wallet')).send(finalWalletParams).result();
+      const newWallet = await this.bitgo.post(this.baseCoin.url('/wallet/add')).send(finalWalletParams).result();
 
       const result: WalletWithKeychains = {
         wallet: new Wallet(this.bitgo, this.baseCoin, newWallet),
@@ -1010,7 +1010,7 @@ export class Wallets implements IWallets {
       walletVersion,
     };
     const finalWalletParams = await this.baseCoin.supplementGenerateWallet(walletParams, keychains);
-    const newWallet = await this.bitgo.post(this.baseCoin.url('/wallet')).send(finalWalletParams).result();
+    const newWallet = await this.bitgo.post(this.baseCoin.url('/wallet/add')).send(finalWalletParams).result();
 
     const result: WalletWithKeychains = {
       wallet: new Wallet(this.bitgo, this.baseCoin, newWallet),
@@ -1094,7 +1094,7 @@ export class Wallets implements IWallets {
     };
 
     const finalWalletParams = await this.baseCoin.supplementGenerateWallet(walletParams, keychains);
-    const newWallet = await this.bitgo.post(this.baseCoin.url('/wallet')).send(finalWalletParams).result();
+    const newWallet = await this.bitgo.post(this.baseCoin.url('/wallet/add')).send(finalWalletParams).result();
 
     const result: WalletWithKeychains = {
       wallet: new Wallet(this.bitgo, this.baseCoin, newWallet),
@@ -1130,7 +1130,7 @@ export class Wallets implements IWallets {
     };
 
     // Create Wallet
-    const newWallet = await this.bitgo.post(this.baseCoin.url('/wallet')).send(finalWalletParams).result();
+    const newWallet = await this.bitgo.post(this.baseCoin.url('/wallet/add')).send(finalWalletParams).result();
     const wallet = new Wallet(this.bitgo, this.baseCoin, newWallet);
     const keychains = wallet.keyIds();
     const result: WalletWithKeychains = {


### PR DESCRIPTION
The prev create wallet API is being deprecated in
favour of /api/v2/:coin/wallet/add

TICKET: WP-3152

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
