### PR TITLE
refactor: make AbstractUtxoCoin more concrete

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -88,6 +88,8 @@ import {
 } from './transaction';
 import { assertDescriptorWalletAddress } from './descriptor/assertDescriptorWalletAddress';
 
+import { getChainFromNetwork, getFamilyFromNetwork, getFullNameFromNetwork } from './names';
+
 type UtxoCustomSigningFunction<TNumber extends number | bigint> = {
   (params: {
     coin: IBaseCoin;
@@ -389,6 +391,30 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
 
   get network() {
     return this._network;
+  }
+
+  getChain() {
+    return getChainFromNetwork(this.network);
+  }
+
+  getFamily() {
+    return getFamilyFromNetwork(this.network);
+  }
+
+  getFullName() {
+    return getFullNameFromNetwork(this.network);
+  }
+
+  /** Indicates whether the coin supports a block target */
+  supportsBlockTarget() {
+    // FIXME: the SDK does not seem to use this anywhere so it is unclear what the purpose of this method is
+    switch (getMainnet(this.network)) {
+      case utxolib.networks.bitcoin:
+      case utxolib.networks.dogecoin:
+        return true;
+      default:
+        return false;
+    }
   }
 
   sweepWithSendMany(): boolean {
@@ -1108,14 +1134,6 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       );
     }
 
-    return true;
-  }
-
-  /**
-   * Indicates whether coin supports a block target
-   * @returns {boolean}
-   */
-  supportsBlockTarget() {
     return true;
   }
 

--- a/modules/abstract-utxo/src/names.ts
+++ b/modules/abstract-utxo/src/names.ts
@@ -1,0 +1,141 @@
+import * as utxolib from '@bitgo/utxo-lib';
+
+function getNetworkName(n: utxolib.Network): utxolib.NetworkName {
+  const name = utxolib.getNetworkName(n);
+  if (!name) {
+    throw new Error('Unknown network');
+  }
+  return name;
+}
+
+/**
+ * @param n
+ * @returns the family name for a network. Testnets and mainnets of the same coin share the same family name.
+ */
+export function getFamilyFromNetwork(n: utxolib.Network): string {
+  switch (getNetworkName(n)) {
+    case 'bitcoin':
+    case 'testnet':
+    case 'bitcoinPublicSignet':
+    case 'bitcoinTestnet4':
+    case 'bitcoinBitGoSignet':
+      return 'btc';
+    case 'bitcoincash':
+    case 'bitcoincashTestnet':
+      return 'bch';
+    case 'ecash':
+    case 'ecashTest':
+      return 'bcha';
+    case 'bitcoingold':
+    case 'bitcoingoldTestnet':
+      return 'btg';
+    case 'bitcoinsv':
+    case 'bitcoinsvTestnet':
+      return 'bsv';
+    case 'dash':
+    case 'dashTest':
+      return 'dash';
+    case 'dogecoin':
+    case 'dogecoinTest':
+      return 'doge';
+    case 'litecoin':
+    case 'litecoinTest':
+      return 'ltc';
+    case 'zcash':
+    case 'zcashTest':
+      return 'zec';
+  }
+}
+
+/**
+ * Get the chain name for a network.
+ * The chain is different for every network.
+ */
+export function getChainFromNetwork(n: utxolib.Network): string {
+  switch (getNetworkName(n)) {
+    case 'bitcoinPublicSignet':
+      return 'tbtcsig';
+    case 'bitcoinTestnet4':
+      return 'tbtc4';
+    case 'bitcoinBitGoSignet':
+      return 'tbtcbgsig';
+    case 'bitcoin':
+    case 'testnet':
+    case 'bitcoincash':
+    case 'bitcoincashTestnet':
+    case 'ecash':
+    case 'ecashTest':
+    case 'bitcoingold':
+    case 'bitcoingoldTestnet':
+    case 'bitcoinsv':
+    case 'bitcoinsvTestnet':
+    case 'dash':
+    case 'dashTest':
+    case 'dogecoin':
+    case 'dogecoinTest':
+    case 'litecoin':
+    case 'litecoinTest':
+    case 'zcash':
+    case 'zcashTest':
+      const mainnetName = getFamilyFromNetwork(n);
+      return utxolib.isTestnet(n) ? `t${mainnetName}` : mainnetName;
+  }
+}
+
+export function getFullNameFromNetwork(n: utxolib.Network): string {
+  const name = getNetworkName(n);
+
+  let prefix: string;
+  switch (name) {
+    case 'bitcoinTestnet4':
+      prefix = 'Testnet4 ';
+      break;
+    case 'bitcoinPublicSignet':
+      prefix = 'Public Signet ';
+      break;
+    case 'bitcoinBitGoSignet':
+      prefix = 'BitGo Signet ';
+      break;
+    default:
+      if (utxolib.isTestnet(n)) {
+        prefix = 'Testnet ';
+      } else {
+        prefix = '';
+      }
+  }
+
+  switch (name) {
+    case 'bitcoin':
+    case 'testnet':
+    case 'bitcoinTestnet4':
+    case 'bitcoinPublicSignet':
+    case 'bitcoinBitGoSignet':
+      return prefix + 'Bitcoin';
+    case 'bitcoincash':
+    case 'bitcoincashTestnet':
+      return prefix + 'Bitcoin Cash';
+    case 'ecash':
+    case 'ecashTest':
+      return prefix + 'Bitcoin ABC';
+    case 'bitcoingold':
+    case 'bitcoingoldTestnet':
+      return prefix + 'Bitcoin Gold';
+    case 'bitcoinsv':
+    case 'bitcoinsvTestnet':
+      return prefix + 'Bitcoin SV';
+    case 'dash':
+    case 'dashTest':
+      return prefix + 'Dash';
+    case 'dogecoin':
+    case 'dogecoinTest':
+      return prefix + 'Dogecoin';
+    case 'litecoin':
+    case 'litecoinTest':
+      return prefix + 'Litecoin';
+    case 'zcash':
+    case 'zcashTest':
+      return prefix + 'ZCash';
+    default:
+      throw new Error('Unknown network');
+  }
+}

--- a/modules/bitgo/test/v2/unit/coins/utxo/coins.ts
+++ b/modules/bitgo/test/v2/unit/coins/utxo/coins.ts
@@ -1,40 +1,38 @@
-/**
- * prettier
- */
-import 'should';
+import * as assert from 'assert';
 import * as utxolib from '@bitgo/utxo-lib';
+
 import { getUtxoCoinForNetwork, utxoCoins } from './util';
 
 describe('utxoCoins', function () {
   it('has expected chain/network values for items', function () {
-    utxoCoins
-      .map((c) => [c.getChain(), utxolib.getNetworkName(c.network)])
-      .should.eql([
-        ['btc', 'bitcoin'],
-        ['tbtc', 'testnet'],
-        ['tbtcsig', 'bitcoinPublicSignet'],
-        ['tbtc4', 'bitcoinTestnet4'],
-        ['tbtcbgsig', 'bitcoinBitGoSignet'],
-        ['bch', 'bitcoincash'],
-        ['tbch', 'bitcoincashTestnet'],
-        ['btg', 'bitcoingold'],
-        ['bsv', 'bitcoinsv'],
-        ['tbsv', 'bitcoinsvTestnet'],
-        ['dash', 'dash'],
-        ['tdash', 'dashTest'],
-        ['doge', 'dogecoin'],
-        ['tdoge', 'dogecoinTest'],
-        ['bcha', 'ecash'],
-        ['tbcha', 'ecashTest'],
-        ['ltc', 'litecoin'],
-        ['tltc', 'litecoinTest'],
-        ['zec', 'zcash'],
-        ['tzec', 'zcashTest'],
-      ]);
+    assert.deepStrictEqual(
+      utxoCoins.map((c) => [c.getChain(), c.getFamily(), c.getFullName(), utxolib.getNetworkName(c.network)]),
+      [
+        ['btc', 'btc', 'Bitcoin', 'bitcoin'],
+        ['tbtc', 'btc', 'Testnet Bitcoin', 'testnet'],
+        ['tbtcsig', 'btc', 'Public Signet Bitcoin', 'bitcoinPublicSignet'],
+        ['tbtc4', 'btc', 'Testnet4 Bitcoin', 'bitcoinTestnet4'],
+        ['tbtcbgsig', 'btc', 'BitGo Signet Bitcoin', 'bitcoinBitGoSignet'],
+        ['bch', 'bch', 'Bitcoin Cash', 'bitcoincash'],
+        ['tbch', 'bch', 'Testnet Bitcoin Cash', 'bitcoincashTestnet'],
+        ['btg', 'btg', 'Bitcoin Gold', 'bitcoingold'],
+        ['bsv', 'bsv', 'Bitcoin SV', 'bitcoinsv'],
+        ['tbsv', 'bsv', 'Testnet Bitcoin SV', 'bitcoinsvTestnet'],
+        ['dash', 'dash', 'Dash', 'dash'],
+        ['tdash', 'tdash', 'Testnet Dash', 'dashTest'],
+        ['doge', 'doge', 'Dogecoin', 'dogecoin'],
+        ['tdoge', 'doge', 'Testnet Dogecoin', 'dogecoinTest'],
+        ['bcha', 'bcha', 'Bitcoin ABC', 'ecash'],
+        ['tbcha', 'bcha', 'Testnet Bitcoin ABC', 'ecashTest'],
+        ['ltc', 'ltc', 'Litecoin', 'litecoin'],
+        ['tltc', 'ltc', 'Testnet Litecoin', 'litecoinTest'],
+        ['zec', 'zec', 'ZCash', 'zcash'],
+        ['tzec', 'zec', 'Testnet ZCash', 'zcashTest'],
+      ]
+    );
 
-    utxolib
-      .getNetworkList()
-      .map((network): [string | undefined, string | undefined] => {
+    assert.deepStrictEqual(
+      utxolib.getNetworkList().map((network): [string | undefined, string | undefined] => {
         let coin;
         try {
           coin = getUtxoCoinForNetwork(network);
@@ -43,8 +41,8 @@ describe('utxoCoins', function () {
         }
 
         return [utxolib.getNetworkName(network), coin?.getChain()];
-      })
-      .should.eql([
+      }),
+      [
         ['bitcoin', 'btc'],
         ['testnet', 'tbtc'],
         ['bitcoinPublicSignet', 'tbtcsig'],
@@ -66,6 +64,7 @@ describe('utxoCoins', function () {
         ['litecoinTest', 'tltc'],
         ['zcash', 'zec'],
         ['zcashTest', 'tzec'],
-      ]);
+      ]
+    );
   });
 });

--- a/modules/bitgo/test/v2/unit/coins/utxo/coins.ts
+++ b/modules/bitgo/test/v2/unit/coins/utxo/coins.ts
@@ -19,7 +19,7 @@ describe('utxoCoins', function () {
         ['bsv', 'bsv', 'Bitcoin SV', 'bitcoinsv'],
         ['tbsv', 'bsv', 'Testnet Bitcoin SV', 'bitcoinsvTestnet'],
         ['dash', 'dash', 'Dash', 'dash'],
-        ['tdash', 'tdash', 'Testnet Dash', 'dashTest'],
+        ['tdash', 'dash', 'Testnet Dash', 'dashTest'],
         ['doge', 'doge', 'Dogecoin', 'dogecoin'],
         ['tdoge', 'doge', 'Testnet Dogecoin', 'dogecoinTest'],
         ['bcha', 'bcha', 'Bitcoin ABC', 'ecash'],

--- a/modules/sdk-coin-bch/src/bch.ts
+++ b/modules/sdk-coin-bch/src/bch.ts
@@ -11,22 +11,6 @@ export class Bch extends AbstractUtxoCoin {
     return new Bch(bitgo);
   }
 
-  getChain() {
-    return 'bch';
-  }
-
-  getFamily() {
-    return 'bch';
-  }
-
-  getFullName() {
-    return 'Bitcoin Cash';
-  }
-
-  supportsBlockTarget() {
-    return false;
-  }
-
   /**
    * Canonicalize a Bitcoin Cash address for a specific version
    *

--- a/modules/sdk-coin-bch/src/tbch.ts
+++ b/modules/sdk-coin-bch/src/tbch.ts
@@ -13,12 +13,4 @@ export class Tbch extends Bch {
   static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Tbch(bitgo);
   }
-
-  getChain() {
-    return 'tbch';
-  }
-
-  getFullName() {
-    return 'Testnet Bitcoin Cash';
-  }
 }

--- a/modules/sdk-coin-bcha/src/bcha.ts
+++ b/modules/sdk-coin-bcha/src/bcha.ts
@@ -12,18 +12,6 @@ export class Bcha extends Bch {
     return new Bcha(bitgo);
   }
 
-  getChain(): string {
-    return 'bcha';
-  }
-
-  getFamily(): string {
-    return 'bcha';
-  }
-
-  getFullName(): string {
-    return 'Bitcoin ABC';
-  }
-
   canonicalAddress(address: string, version: unknown = 'base58'): string {
     if (version === 'base58') {
       return utxolib.addressFormat.toCanonicalFormat(address, this.network);

--- a/modules/sdk-coin-bcha/src/tbcha.ts
+++ b/modules/sdk-coin-bcha/src/tbcha.ts
@@ -13,12 +13,4 @@ export class Tbcha extends Bcha {
   static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Tbcha(bitgo);
   }
-
-  getChain(): string {
-    return 'tbcha';
-  }
-
-  getFullName(): string {
-    return 'Testnet Bitcoin ABC';
-  }
 }

--- a/modules/sdk-coin-bsv/src/bsv.ts
+++ b/modules/sdk-coin-bsv/src/bsv.ts
@@ -11,16 +11,4 @@ export class Bsv extends Bch {
   static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Bsv(bitgo);
   }
-
-  getChain(): string {
-    return 'bsv';
-  }
-
-  getFamily(): string {
-    return 'bsv';
-  }
-
-  getFullName(): string {
-    return 'Bitcoin SV';
-  }
 }

--- a/modules/sdk-coin-bsv/src/tbsv.ts
+++ b/modules/sdk-coin-bsv/src/tbsv.ts
@@ -13,12 +13,4 @@ export class Tbsv extends Bsv {
   static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Tbsv(bitgo);
   }
-
-  getChain(): string {
-    return 'tbsv';
-  }
-
-  getFullName(): string {
-    return 'Testnet Bitcoin SV';
-  }
 }

--- a/modules/sdk-coin-btc/src/btc.ts
+++ b/modules/sdk-coin-btc/src/btc.ts
@@ -21,22 +21,6 @@ export class Btc extends AbstractUtxoCoin {
     return new Btc(bitgo);
   }
 
-  getChain(): string {
-    return 'btc';
-  }
-
-  getFamily(): string {
-    return 'btc';
-  }
-
-  getFullName(): string {
-    return 'Bitcoin';
-  }
-
-  supportsBlockTarget(): boolean {
-    return true;
-  }
-
   supportsLightning(): boolean {
     return true;
   }

--- a/modules/sdk-coin-btc/src/tbtc.ts
+++ b/modules/sdk-coin-btc/src/tbtc.ts
@@ -13,12 +13,4 @@ export class Tbtc extends Btc {
   static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Tbtc(bitgo);
   }
-
-  getChain() {
-    return 'tbtc';
-  }
-
-  getFullName() {
-    return 'Testnet Bitcoin';
-  }
 }

--- a/modules/sdk-coin-btc/src/tbtc4.ts
+++ b/modules/sdk-coin-btc/src/tbtc4.ts
@@ -13,12 +13,4 @@ export class Tbtc4 extends Btc {
   static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Tbtc4(bitgo);
   }
-
-  getChain() {
-    return 'tbtc4';
-  }
-
-  getFullName() {
-    return 'Testnet4 Bitcoin';
-  }
 }

--- a/modules/sdk-coin-btc/src/tbtcbgsig.ts
+++ b/modules/sdk-coin-btc/src/tbtcbgsig.ts
@@ -13,12 +13,4 @@ export class Tbtcbgsig extends Btc {
   static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Tbtcbgsig(bitgo);
   }
-
-  getChain(): string {
-    return 'tbtcbgsig';
-  }
-
-  getFullName(): string {
-    return 'BitGo Signet Bitcoin';
-  }
 }

--- a/modules/sdk-coin-btc/src/tbtcsig.ts
+++ b/modules/sdk-coin-btc/src/tbtcsig.ts
@@ -13,12 +13,4 @@ export class Tbtcsig extends Btc {
   static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Tbtcsig(bitgo);
   }
-
-  getChain() {
-    return 'tbtcsig';
-  }
-
-  getFullName() {
-    return 'Public Signet Bitcoin';
-  }
 }

--- a/modules/sdk-coin-btg/src/btg.ts
+++ b/modules/sdk-coin-btg/src/btg.ts
@@ -10,20 +10,4 @@ export class Btg extends AbstractUtxoCoin {
   static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Btg(bitgo);
   }
-
-  getChain(): string {
-    return 'btg';
-  }
-
-  getFamily(): string {
-    return 'btg';
-  }
-
-  getFullName(): string {
-    return 'Bitcoin Gold';
-  }
-
-  supportsBlockTarget(): boolean {
-    return false;
-  }
 }

--- a/modules/sdk-coin-dash/src/dash.ts
+++ b/modules/sdk-coin-dash/src/dash.ts
@@ -10,20 +10,4 @@ export class Dash extends AbstractUtxoCoin {
   static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Dash(bitgo);
   }
-
-  getChain(): string {
-    return 'dash';
-  }
-
-  getFamily(): string {
-    return 'dash';
-  }
-
-  getFullName(): string {
-    return 'Dash';
-  }
-
-  supportsBlockTarget(): boolean {
-    return false;
-  }
 }

--- a/modules/sdk-coin-dash/src/tdash.ts
+++ b/modules/sdk-coin-dash/src/tdash.ts
@@ -12,16 +12,4 @@ export class Tdash extends Dash {
   static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Tdash(bitgo);
   }
-
-  getChain(): string {
-    return 'tdash';
-  }
-
-  getFamily(): string {
-    return 'tdash';
-  }
-
-  getFullName(): string {
-    return 'Testnet Dash';
-  }
 }

--- a/modules/sdk-coin-doge/src/doge.ts
+++ b/modules/sdk-coin-doge/src/doge.ts
@@ -64,18 +64,6 @@ export class Doge extends AbstractUtxoCoin {
     return new Doge(bitgo);
   }
 
-  getChain(): string {
-    return 'doge';
-  }
-
-  getFamily(): string {
-    return 'doge';
-  }
-
-  getFullName(): string {
-    return 'Dogecoin';
-  }
-
   supportsBlockTarget(): boolean {
     return true;
   }

--- a/modules/sdk-coin-doge/src/tdoge.ts
+++ b/modules/sdk-coin-doge/src/tdoge.ts
@@ -12,12 +12,4 @@ export class Tdoge extends Doge {
   static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Tdoge(bitgo);
   }
-
-  getChain(): string {
-    return 'tdoge';
-  }
-
-  getFullName(): string {
-    return 'Testnet Dogecoin';
-  }
 }

--- a/modules/sdk-coin-ltc/src/ltc.ts
+++ b/modules/sdk-coin-ltc/src/ltc.ts
@@ -14,20 +14,4 @@ export class Ltc extends AbstractUtxoCoin {
   static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Ltc(bitgo);
   }
-
-  getChain(): string {
-    return 'ltc';
-  }
-
-  getFamily(): string {
-    return 'ltc';
-  }
-
-  getFullName(): string {
-    return 'Litecoin';
-  }
-
-  supportsBlockTarget(): boolean {
-    return false;
-  }
 }

--- a/modules/sdk-coin-ltc/src/tltc.ts
+++ b/modules/sdk-coin-ltc/src/tltc.ts
@@ -12,12 +12,4 @@ export class Tltc extends Ltc {
   static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Tltc(bitgo);
   }
-
-  getChain(): string {
-    return 'tltc';
-  }
-
-  getFullName(): string {
-    return 'Testnet Litecoin';
-  }
 }

--- a/modules/sdk-coin-zec/src/tzec.ts
+++ b/modules/sdk-coin-zec/src/tzec.ts
@@ -10,12 +10,4 @@ export class Tzec extends Zec {
   static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Tzec(bitgo);
   }
-
-  getChain() {
-    return 'tzec';
-  }
-
-  getFullName() {
-    return 'Testnet ZCash';
-  }
 }

--- a/modules/sdk-coin-zec/src/zec.ts
+++ b/modules/sdk-coin-zec/src/zec.ts
@@ -13,20 +13,4 @@ export class Zec extends AbstractUtxoCoin {
   static createInstance(bitgo: BitGoBase): BaseCoin {
     return new Zec(bitgo);
   }
-
-  getChain() {
-    return 'zec';
-  }
-
-  getFamily() {
-    return 'zec';
-  }
-
-  getFullName() {
-    return 'ZCash';
-  }
-
-  supportsBlockTarget() {
-    return false;
-  }
 }


### PR DESCRIPTION
- **feat(bitgo): extend utxoCoins test to cover new fields**
  Issue: BTC-1450
  

- **feat(abstract-utxo): make AbstractUtxoCoin less abstract**
  This commit now implements more methods of the BaseCoin class, making
  AbstractUtxoCoin easier to instantiate.
  
  We can now write tests more easily since we can instantiate AbstractUtxoCoin
  with just the network parameter.
  
  Also fixes a bug where Testnet Dash had the wrong family name (`tdash` instead
  of `dash`).
  
  Issue: BTC-1450
  