### PR TITLE
feat: bump typescript to 5.7

### DIFF
--- a/modules/abstract-eth/package.json
+++ b/modules/abstract-eth/package.json
@@ -58,6 +58,7 @@
     "superagent": "^9.0.1"
   },
   "devDependencies": {
+    "@types/keccak": "^3.0.5",
     "@bitgo/sdk-api": "^1.56.7",
     "@bitgo/sdk-test": "^8.0.54"
   }

--- a/modules/abstract-eth/src/lib/transferBuilder.ts
+++ b/modules/abstract-eth/src/lib/transferBuilder.ts
@@ -155,8 +155,8 @@ export class TransferBuilder {
 
     if (this._coinUsesNonPackedEncodingForTxData) {
       const types: string[] = operationData[0] as string[];
-      const values: string[] = operationData[1].map((item) =>
-        item instanceof Buffer ? '0x' + item.toString('hex') : item
+      const values: (string | number)[] = operationData[1].map((item) =>
+        typeof item === 'string' || typeof item === 'number' ? item : '0x' + item.toString('hex')
       );
       operationHash = keccak256(defaultAbiCoder.encode(types, values));
     } else {
@@ -166,7 +166,7 @@ export class TransferBuilder {
     return operationHash;
   }
 
-  protected getOperationData(): (string | Buffer)[][] {
+  protected getOperationData(): (string | number | Buffer)[][] {
     let operationData;
     const prefix = this.getOperationHashPrefix();
     if (this._tokenContractAddress !== undefined) {

--- a/modules/account-lib/package.json
+++ b/modules/account-lib/package.json
@@ -75,6 +75,7 @@
   "devDependencies": {
     "@solana/web3.js": "1.92.1",
     "@types/bs58": "^4.0.1",
+    "@types/keccak": "^3.0.5",
     "keccak": "3.0.3",
     "paillier-bigint": "3.3.0",
     "shx": "^0.3.4"

--- a/modules/account-lib/test/unit/mpc/tss/ecdsa/ecdsa.ts
+++ b/modules/account-lib/test/unit/mpc/tss/ecdsa/ecdsa.ts
@@ -340,7 +340,7 @@ describe('TSS ECDSA TESTS', function () {
         // and delta share received from the other signer
 
         const hashGenerator = (hashType?: string): Hash | undefined => {
-          return hashType === 'keccak256' ? createKeccakHash('keccak256') : undefined;
+          return hashType === 'keccak256' ? (createKeccakHash('keccak256') as Hash) : undefined;
         };
         const [signA, signB] = [
           MPC.sign(

--- a/modules/account-lib/tsconfig.json
+++ b/modules/account-lib/tsconfig.json
@@ -7,7 +7,7 @@
     "esModuleInterop": true,
     "typeRoots": ["../../types", "./node_modules/@types", "../../node_modules/@types"]
   },
-  "include": ["src/**/*", "resources/**/*"],
+  "include": ["src/**/*", "test/**/*", "resources/**/*"],
   "exclude": ["node_modules"],
   "references": [
     {

--- a/modules/sdk-api/src/v1/wallet.ts
+++ b/modules/sdk-api/src/v1/wallet.ts
@@ -2173,7 +2173,7 @@ Wallet.prototype.consolidateUnspents = function (params, callback) {
     return consolidationTransactions;
   });
 
-  return runNextConsolidation(this, target)
+  return runNextConsolidation()
     .catch(function (err) {
       if (err.message === 'Done') {
         return;

--- a/modules/sdk-api/test/unit/v1/wallet.ts
+++ b/modules/sdk-api/test/unit/v1/wallet.ts
@@ -23,8 +23,7 @@ const TestBitGo = {
   TEST_WALLET1_PASSCODE: 'iVWeATjqLS1jJShrPpETti0b',
 };
 const originalFetchConstants = BitGoAPI.prototype.fetchConstants;
-BitGoAPI.prototype.fetchConstants = function () {
-  // @ts-expect-error - no implicit this
+BitGoAPI.prototype.fetchConstants = function (this: any) {
   nock(this._baseUrl).get('/api/v1/client/constants').reply(200, { ttl: 3600, constants: {} });
 
   // force client constants reload

--- a/modules/sdk-coin-ada/src/ada.ts
+++ b/modules/sdk-coin-ada/src/ada.ts
@@ -161,7 +161,7 @@ export class Ada extends BaseCoin {
   /** @inheritDoc */
   async signMessage(key: KeyPair, message: string | Buffer): Promise<Buffer> {
     const adaKeypair = new AdaKeyPair({ prv: key.prv });
-    const messageHex = message instanceof Buffer ? message.toString('hex') : message;
+    const messageHex = typeof message === 'string' ? message : message.toString('hex');
 
     return Buffer.from(adaKeypair.signMessage(messageHex));
   }

--- a/modules/sdk-coin-avaxc/package.json
+++ b/modules/sdk-coin-avaxc/package.json
@@ -58,6 +58,7 @@
   "devDependencies": {
     "@bitgo/sdk-api": "^1.56.7",
     "@bitgo/sdk-test": "^8.0.54",
+    "@types/keccak": "^3.0.5",
     "ethers": "^5.1.3"
   }
 }

--- a/modules/sdk-coin-cspr/src/cspr.ts
+++ b/modules/sdk-coin-cspr/src/cspr.ts
@@ -247,7 +247,7 @@ export class Cspr extends BaseCoin {
    */
   async signMessage(key: KeyPair, message: string | Buffer): Promise<Buffer> {
     const keyPair = new CsprLib.KeyPair({ prv: key.prv });
-    const messageHex = message instanceof Buffer ? message.toString('hex') : message;
+    const messageHex = typeof message === 'string' ? message : message.toString('hex');
     const signatureData = CsprLib.Utils.signMessage(keyPair, messageHex);
     return Buffer.from(signatureData.signature);
   }

--- a/modules/sdk-coin-islm/package.json
+++ b/modules/sdk-coin-islm/package.json
@@ -54,6 +54,7 @@
     "protobufjs": "7.2.5"
   },
   "devDependencies": {
+    "@types/keccak": "^3.0.5",
     "@bitgo/sdk-api": "^1.56.7",
     "@bitgo/sdk-test": "^8.0.54"
   }

--- a/modules/sdk-coin-islm/src/lib/utils.ts
+++ b/modules/sdk-coin-islm/src/lib/utils.ts
@@ -95,7 +95,7 @@ export class IslmUtils extends CosmosUtils {
 
   /** @inheritdoc */
   getHashFunction(): Hash {
-    return Keccak('keccak256');
+    return Keccak('keccak256') as Hash;
   }
 }
 

--- a/modules/sdk-coin-polygon/test/unit/transactionBuilder/send.ts
+++ b/modules/sdk-coin-polygon/test/unit/transactionBuilder/send.ts
@@ -23,7 +23,7 @@ describe('Polygon transaction builder send', () => {
       ];
       const types: string[] = operationParams[0] as string[];
       const values: (string | number)[] = operationParams[1].map((item) =>
-        item instanceof Buffer ? '0x' + item.toString('hex') : item
+        typeof item === 'string' || typeof item === 'number' ? item : '0x' + item.toString('hex')
       );
       return keccak256(defaultAbiCoder.encode(types, values));
     };

--- a/modules/sdk-core/package.json
+++ b/modules/sdk-core/package.json
@@ -76,6 +76,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@types/keccak": "^3.0.5",
     "@bitgo/sdk-opensslbytes": "^2.0.0",
     "@openpgp/web-stream-tools": "0.0.14",
     "@types/lodash": "^4.14.151",

--- a/modules/sdk-core/src/bitgo/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/bitgo/tss/ecdsa/ecdsa.ts
@@ -173,7 +173,7 @@ export async function createUserSignatureShare(
   oShare: OShare,
   dShare: DShare,
   message: Buffer,
-  hash: Hash = createKeccakHash('keccak256')
+  hash: Hash = createKeccakHash('keccak256') as Hash
 ): Promise<SignatureShare> {
   if (oShare.i !== ShareKeyPosition.USER) {
     throw new Error(`Invalid OShare, doesn't belong to the User`);

--- a/modules/sdk-test/src/bitgo/lib/test_bitgo.ts
+++ b/modules/sdk-test/src/bitgo/lib/test_bitgo.ts
@@ -582,8 +582,7 @@ export class TestBitGo {
       }
     };
 
-    BitGoAPI.prototype.fetchConstants = function () {
-      // @ts-expect-error - no implicit this
+    BitGoAPI.prototype.fetchConstants = function (this: any) {
       nock(this._baseUrl)
         .get('/api/v1/client/constants')
         .reply(200, {

--- a/modules/utxo-lib/src/bitgo/wallet/Psbt.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/Psbt.ts
@@ -357,6 +357,7 @@ export function parsePsbtInput(input: PsbtInput): ParsedPsbtP2ms | ParsedPsbtTap
     return {
       ...parsedPubScript,
       ...signatures,
+      scriptType: parsedPubScript.scriptType,
     };
   }
   if (parsedPubScript.scriptType === 'taprootScriptPathSpend') {
@@ -372,6 +373,7 @@ export function parsePsbtInput(input: PsbtInput): ParsedPsbtP2ms | ParsedPsbtTap
     return {
       ...parsedPubScript,
       ...signatures,
+      scriptType: parsedPubScript.scriptType,
       controlBlock,
       scriptPathLevel,
       leafVersion,

--- a/modules/utxo-lib/test/bitgo/psbt/psbtUtil.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/psbtUtil.ts
@@ -145,7 +145,6 @@ export function validatePsbtParsing(
     } else {
       const psbtParsed = parsePsbtInput(psbt.data.inputs[i]);
       assert.strictEqual(psbtParsed.scriptType, scriptType === 'p2tr' ? 'taprootScriptPathSpend' : scriptType);
-      assert.ok(psbtParsed.scriptType !== 'p2shP2pk');
       const txParsed = parseSignatureScript2Of3(tx.ins[i]);
       validateScript(psbtParsed, txParsed);
       validatePublicKeys(psbtParsed, txParsed);

--- a/modules/web-demo/tsconfig.json
+++ b/modules/web-demo/tsconfig.json
@@ -28,8 +28,7 @@
     "skipLibCheck": true,
     "strict": true,
     "useUnknownInCatchVariables": false,
-    "target": "es6",
-    "types": ["cypress", "@testing-library/cypress"]
+    "target": "es6"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"],

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "stream-http": "^3.2.0",
     "terser-webpack-plugin": "^5.3.3",
     "ts-node": "10.8.0",
-    "typescript": "4.9.5",
+    "typescript": "5.7.2",
     "typescript-cached-transpile": "^0.0.6",
     "url": "^0.11.0",
     "webpack": "5.76.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19344,7 +19344,12 @@ typescript-cached-transpile@^0.0.6:
     fs-extra "^8.1.0"
     tslib "^1.10.0"
 
-typescript@4.9.5, "typescript@^3 || ^4", typescript@^4.2.4:
+typescript@5.7.2:
+  version "5.7.2"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
+  integrity sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==
+
+"typescript@^3 || ^4", typescript@^4.2.4:
   version "4.9.5"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5258,6 +5258,13 @@
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/keccak@^3.0.5":
+  version "3.0.5"
+  resolved "https://registry.npmjs.org/@types/keccak/-/keccak-3.0.5.tgz#76db7c4fa73f1706cc396754cc890bb5d71398a7"
+  integrity sha512-Mvu4StIJ9KyfPXDVRv3h0fWNBAjHPBQZ8EPcxhqA8FG6pLzxtytVXU5owB6J2/8xZ+ZspWTXJEUjAHt0pk0I1Q==
+  dependencies:
+    "@types/node" "*"
+
 "@types/keyv@3.1.4", "@types/keyv@^3.1.4":
   version "3.1.4"
   resolved "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz#3ccdb1c6751b0c7e52300bcdacd5bcbf8faa75b6"


### PR DESCRIPTION
- **feat: add @types/keccak to packages that use it**
  This prepares for the Typescript 5.7 upgrade
  
  Issue: BTC-1450
  

- **fix: use better string conversion for message signing**
  It appears that `v instanceof Buffer` is not a reliable type guard in Typescript
  5.
  
  The new type guard is equivalent.
  
  Issue: BTC-1450
  

- **fix: type errors in old code**
  They are correctly detected with Typescript 5
  
  Issue: BTC-1450
  

- **fix: remove invalid types from tsconfig.json**
  These do not work any longer with Typescript 5.
  
  Issue: BTC-1450
  

- **feat: update typescript to 5.7.2**
  Hopefully this improves performance with the language server
  
  Issue: BTC-1450
  