### PR TITLE
refactor(wp): send many uniform error messages changes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -52,6 +52,7 @@
 /modules/sdk-coin-atom/ @BitGo/ethalt-team
 /modules/sdk-coin-avaxc/ @BitGo/ethalt-team
 /modules/sdk-coin-avaxp/ @BitGo/ethalt-team
+/modules/sdk-coin-bera/ @BitGo/ethalt-team
 /modules/sdk-coin-bsc/ @BitGo/ethalt-team
 /modules/sdk-coin-coredao/ @BitGo/ethalt-team
 /modules/sdk-coin-cspr/ @BitGo/ethalt-team

--- a/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
+++ b/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
@@ -2280,8 +2280,10 @@ export abstract class AbstractEthLikeNewCoins extends AbstractEthLikeCoin {
     if (txParams.hop && txParams.recipients.length > 1) {
       throw new Error(`tx cannot be both a batch and hop transaction`);
     }
-    if (txPrebuild.recipients.length !== 1) {
-      throw new Error(`txPrebuild should only have 1 recipient but ${txPrebuild.recipients.length} found`);
+    if (txPrebuild.recipients.length > 1) {
+      throw new Error(
+        `${this.getChain()} doesn't support sending to more than 1 destination address within a single transaction. Try again, using only a single recipient.`
+      );
     }
     if (txParams.hop && txPrebuild.hopTransaction) {
       // Check recipient amount for hop transaction

--- a/modules/abstract-eth/test/unit/coin.ts
+++ b/modules/abstract-eth/test/unit/coin.ts
@@ -348,7 +348,9 @@ export function runTransactionVerificationTests(coinName: string, bitgo: TestBit
 
       await basecoin
         .verifyTransaction({ txParams, txPrebuild, wallet, verification })
-        .should.be.rejectedWith('txPrebuild should only have 1 recipient but 2 found');
+        .should.be.rejectedWith(
+          `${coinTest} doesn't support sending to more than 1 destination address within a single transaction. Try again, using only a single recipient.`
+        );
     });
 
     it('should reject a hop txPrebuild that does not send to its hop address', async () => {

--- a/modules/sdk-coin-arbeth/test/unit/arbeth.ts
+++ b/modules/sdk-coin-arbeth/test/unit/arbeth.ts
@@ -402,7 +402,9 @@ describe('Arbitrum', function () {
 
       await basecoin
         .verifyTransaction({ txParams, txPrebuild, wallet, verification })
-        .should.be.rejectedWith('txPrebuild should only have 1 recipient but 2 found');
+        .should.be.rejectedWith(
+          `tarbeth doesn't support sending to more than 1 destination address within a single transaction. Try again, using only a single recipient.`
+        );
     });
 
     it('should reject a hop txPrebuild that does not send to its hop address', async function () {

--- a/modules/sdk-coin-avaxc/src/avaxc.ts
+++ b/modules/sdk-coin-avaxc/src/avaxc.ts
@@ -170,8 +170,10 @@ export class AvaxC extends AbstractEthLikeNewCoins {
     if (txParams.hop && txParams.recipients.length > 1) {
       throw new Error(`tx cannot be both a batch and hop transaction`);
     }
-    if (txPrebuild.recipients.length !== 1) {
-      throw new Error(`txPrebuild should only have 1 recipient but ${txPrebuild.recipients.length} found`);
+    if (txPrebuild.recipients.length > 1) {
+      throw new Error(
+        `${this.getChain()} doesn't support sending to more than 1 destination address within a single transaction. Try again, using only a single recipient.`
+      );
     }
     if (txParams.hop && txPrebuild.hopTransaction) {
       // Check recipient amount for hop transaction

--- a/modules/sdk-coin-avaxc/test/unit/avaxc.ts
+++ b/modules/sdk-coin-avaxc/test/unit/avaxc.ts
@@ -610,7 +610,9 @@ describe('Avalanche C-Chain', function () {
 
       await tavaxCoin
         .verifyTransaction({ txParams, txPrebuild, wallet, verification })
-        .should.be.rejectedWith('txPrebuild should only have 1 recipient but 2 found');
+        .should.be.rejectedWith(
+          `tavaxc doesn't support sending to more than 1 destination address within a single transaction. Try again, using only a single recipient.`
+        );
     });
 
     it('should reject a hop txPrebuild that does not send to its hop address', async function () {

--- a/modules/sdk-coin-bera/test/unit/bera.ts
+++ b/modules/sdk-coin-bera/test/unit/bera.ts
@@ -302,7 +302,9 @@ describe('Bera', function () {
 
       await basecoin
         .verifyTransaction({ txParams, txPrebuild, wallet, verification })
-        .should.be.rejectedWith('txPrebuild should only have 1 recipient but 2 found');
+        .should.be.rejectedWith(
+          `tbera doesn't support sending to more than 1 destination address within a single transaction. Try again, using only a single recipient.`
+        );
     });
 
     it('should reject a normal txPrebuild from the bitgo server with the wrong amount', async function () {

--- a/modules/sdk-coin-celo/src/celo.ts
+++ b/modules/sdk-coin-celo/src/celo.ts
@@ -32,7 +32,9 @@ export class Celo extends AbstractEthLikeCoin {
   async verifyTransaction(params: VerifyTransactionOptions): Promise<boolean> {
     const { txParams } = params;
     if (Array.isArray(txParams.recipients) && txParams.recipients.length > 1) {
-      throw new Error(`txParams should only have 1 recipient but ${txParams?.recipients?.length} found`);
+      throw new Error(
+        `${this.getChain()} doesn't support sending to more than 1 destination address within a single transaction. Try again, using only a single recipient.`
+      );
     }
     return true;
   }

--- a/modules/sdk-coin-celo/test/unit/celo.ts
+++ b/modules/sdk-coin-celo/test/unit/celo.ts
@@ -40,7 +40,9 @@ describe('Celo Gold', function () {
 
       await basecoin
         .verifyTransaction({ txParams })
-        .should.be.rejectedWith('txParams should only have 1 recipient but 2 found');
+        .should.be.rejectedWith(
+          `celo doesn't support sending to more than 1 destination address within a single transaction. Try again, using only a single recipient.`
+        );
     });
   });
 });

--- a/modules/sdk-coin-dot/src/dot.ts
+++ b/modules/sdk-coin-dot/src/dot.ts
@@ -641,7 +641,9 @@ export class Dot extends BaseCoin {
   async verifyTransaction(params: VerifyTransactionOptions): Promise<boolean> {
     const { txParams } = params;
     if (Array.isArray(txParams.recipients) && txParams.recipients.length > 1) {
-      throw new Error(`txParams should only have 1 recipient but ${txParams?.recipients?.length} found`);
+      throw new Error(
+        `${this.getChain()} doesn't support sending to more than 1 destination address within a single transaction. Try again, using only a single recipient.`
+      );
     }
     return true;
   }

--- a/modules/sdk-coin-dot/test/unit/dot.ts
+++ b/modules/sdk-coin-dot/test/unit/dot.ts
@@ -665,7 +665,9 @@ describe('DOT:', function () {
 
       await basecoin
         .verifyTransaction({ txParams })
-        .should.be.rejectedWith('txParams should only have 1 recipient but 2 found');
+        .should.be.rejectedWith(
+          `tdot doesn't support sending to more than 1 destination address within a single transaction. Try again, using only a single recipient.`
+        );
     });
   });
 });

--- a/modules/sdk-coin-eth/test/unit/eth.ts
+++ b/modules/sdk-coin-eth/test/unit/eth.ts
@@ -411,7 +411,9 @@ describe('ETH:', function () {
 
       await coin
         .verifyTransaction({ txParams, txPrebuild: txPrebuild as any, wallet, verification })
-        .should.be.rejectedWith('txPrebuild should only have 1 recipient but 2 found');
+        .should.be.rejectedWith(
+          `teth doesn't support sending to more than 1 destination address within a single transaction. Try again, using only a single recipient.`
+        );
     });
 
     it('should reject a hop txPrebuild that does not send to its hop address', async function () {

--- a/modules/sdk-coin-opeth/test/unit/opeth.ts
+++ b/modules/sdk-coin-opeth/test/unit/opeth.ts
@@ -398,7 +398,9 @@ describe('Optimism', function () {
 
       await basecoin
         .verifyTransaction({ txParams, txPrebuild, wallet, verification })
-        .should.be.rejectedWith('txPrebuild should only have 1 recipient but 2 found');
+        .should.be.rejectedWith(
+          `topeth doesn't support sending to more than 1 destination address within a single transaction. Try again, using only a single recipient.`
+        );
     });
 
     it('should reject a hop txPrebuild that does not send to its hop address', async function () {

--- a/modules/sdk-coin-polygon/test/unit/polygon.ts
+++ b/modules/sdk-coin-polygon/test/unit/polygon.ts
@@ -387,9 +387,10 @@ describe('Polygon', function () {
 
       await basecoin
         .verifyTransaction({ txParams, txPrebuild, wallet, verification })
-        .should.be.rejectedWith('txPrebuild should only have 1 recipient but 2 found');
+        .should.be.rejectedWith(
+          `tpolygon doesn't support sending to more than 1 destination address within a single transaction. Try again, using only a single recipient.`
+        );
     });
-
     it('should reject a hop txPrebuild that does not send to its hop address', async function () {
       const wallet = new Wallet(bitgo, basecoin, {});
 

--- a/modules/sdk-coin-stx/src/stx.ts
+++ b/modules/sdk-coin-stx/src/stx.ts
@@ -48,7 +48,9 @@ export class Stx extends BaseCoin {
   async verifyTransaction(params: VerifyTransactionOptions): Promise<boolean> {
     const { txParams } = params;
     if (Array.isArray(txParams.recipients) && txParams.recipients.length > 1) {
-      throw new Error(`txParams should only have 1 recipient but ${txParams?.recipients?.length} found`);
+      throw new Error(
+        `${this.getChain()} doesn't support sending to more than 1 destination address within a single transaction. Try again, using only a single recipient.`
+      );
     }
     return true;
   }

--- a/modules/sdk-coin-stx/test/unit/stx.ts
+++ b/modules/sdk-coin-stx/test/unit/stx.ts
@@ -303,7 +303,9 @@ describe('STX:', function () {
 
       await basecoin
         .verifyTransaction({ txParams })
-        .should.be.rejectedWith('txParams should only have 1 recipient but 2 found');
+        .should.be.rejectedWith(
+          `tstx doesn't support sending to more than 1 destination address within a single transaction. Try again, using only a single recipient.`
+        );
     });
   });
 });

--- a/modules/sdk-coin-xrp/src/xrp.ts
+++ b/modules/sdk-coin-xrp/src/xrp.ts
@@ -319,7 +319,9 @@ export class Xrp extends BaseCoin {
 
     if (txParams.type === 'enabletoken') {
       if (txParams.recipients?.length !== 1) {
-        throw new Error('Only one recipient is allowed.');
+        throw new Error(
+          `${this.getChain()} doesn't support sending to more than 1 destination address within a single transaction. Try again, using only a single recipient.`
+        );
       }
       const recipient = txParams.recipients[0];
       if (!recipient.tokenName) {

--- a/modules/sdk-coin-xtz/src/xtz.ts
+++ b/modules/sdk-coin-xtz/src/xtz.ts
@@ -106,7 +106,9 @@ export class Xtz extends BaseCoin {
   async verifyTransaction(params: VerifyTransactionOptions): Promise<boolean> {
     const { txParams } = params;
     if (Array.isArray(txParams.recipients) && txParams.recipients.length > 1) {
-      throw new Error(`txParams should only have 1 recipient but ${txParams?.recipients?.length} found`);
+      throw new Error(
+        `${this.getChain()} doesn't support sending to more than 1 destination address within a single transaction. Try again, using only a single recipient.`
+      );
     }
     return true;
   }

--- a/modules/sdk-coin-xtz/test/unit/xtz.ts
+++ b/modules/sdk-coin-xtz/test/unit/xtz.ts
@@ -218,7 +218,9 @@ describe('Tezos:', function () {
 
       await basecoin
         .verifyTransaction({ txParams })
-        .should.be.rejectedWith('txParams should only have 1 recipient but 2 found');
+        .should.be.rejectedWith(
+          `txtz doesn't support sending to more than 1 destination address within a single transaction. Try again, using only a single recipient.`
+        );
     });
   });
 });

--- a/modules/sdk-coin-zketh/test/unit/zketh.ts
+++ b/modules/sdk-coin-zketh/test/unit/zketh.ts
@@ -400,7 +400,9 @@ describe('zkSync', function () {
 
       await basecoin
         .verifyTransaction({ txParams, txPrebuild, wallet, verification })
-        .should.be.rejectedWith('txPrebuild should only have 1 recipient but 2 found');
+        .should.be.rejectedWith(
+          `tzketh doesn't support sending to more than 1 destination address within a single transaction. Try again, using only a single recipient.`
+        );
     });
 
     it('should reject a hop txPrebuild that does not send to its hop address', async function () {


### PR DESCRIPTION
Standardized error messages for the Bulk Withdrawal API across different assets to ensure consistency.
Ticket: COIN-1957