### PR TITLE
fix(sdk-core): deprecate displayOrder in ITransactionExplanation

### DIFF
--- a/modules/sdk-coin-dot/src/lib/transaction.ts
+++ b/modules/sdk-coin-dot/src/lib/transaction.ts
@@ -282,7 +282,7 @@ export class Transaction extends BaseTransaction {
   }
 
   explainTransferTransaction(json: TxData, explanationResult: TransactionExplanation): TransactionExplanation {
-    explanationResult.displayOrder.push('owner', 'forceProxyType');
+    explanationResult.displayOrder?.push('owner', 'forceProxyType');
     return {
       ...explanationResult,
       outputs: [
@@ -297,7 +297,7 @@ export class Transaction extends BaseTransaction {
   }
 
   explainStakingActivateTransaction(json: TxData, explanationResult: TransactionExplanation): TransactionExplanation {
-    explanationResult.displayOrder.push('payee', 'forceProxyType');
+    explanationResult.displayOrder?.push('payee', 'forceProxyType');
     return {
       ...explanationResult,
       outputs: [
@@ -315,7 +315,7 @@ export class Transaction extends BaseTransaction {
     json: TxData,
     explanationResult: TransactionExplanation
   ): TransactionExplanation {
-    explanationResult.displayOrder.push('owner', 'proxyType', 'delay');
+    explanationResult.displayOrder?.push('owner', 'proxyType', 'delay');
     return {
       ...explanationResult,
       owner: json.owner,

--- a/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
@@ -82,7 +82,8 @@ export interface ITransactionFee<TAmount = string> {
 }
 
 export interface ITransactionExplanation<TFee = any, TAmount = any> {
-  displayOrder: string[];
+  /** @deprecated */
+  displayOrder?: string[];
   id: string;
   outputs: ITransactionRecipient[];
   outputAmount: TAmount;


### PR DESCRIPTION
I could not find any usage of displayOrder outside of tests.

Our UI does not seem to depend on it.

Issue: BTC-1450
