### PR TITLE
fix: disable v8 compile cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
         run: yarn run check-fmt
 
       - name: build packages
+        env:
+          # Workaround for https://github.com/nodejs/node/issues/51555
+          DISABLE_V8_COMPILE_CACHE: '1'
         run: yarn run postinstall
 
       - name: Check Package Dependencies
@@ -172,6 +175,9 @@ jobs:
 
       - name: build packages
         if: steps.lerna-cache.outputs.cache-hit == 'true'
+        env:
+          # Workaround for https://github.com/nodejs/node/issues/51555
+          DISABLE_V8_COMPILE_CACHE: '1'
         run: yarn run postinstall
 
       - name: Browser Tests

--- a/.github/workflows/test_package_updates.yml
+++ b/.github/workflows/test_package_updates.yml
@@ -45,6 +45,9 @@ jobs:
         run: rm yarn.lock
 
       - name: Install Packages
+        env:
+          # Workaround for https://github.com/nodejs/node/issues/51555
+          DISABLE_V8_COMPILE_CACHE: '1'
         run: yarn install
 
       - name: Unit test all


### PR DESCRIPTION
This is an experiment to work around an inconsistent error [that we are seeing in ci](https://github.com/BitGo/BitGoJS/actions/runs/12200153317/job/34035660628)

Ticket: VL-0

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
