### PR TITLE
refactor(abstract-utxo): rename, improve core parse method

### DIFF
--- a/modules/abstract-utxo/src/core/descriptor/index.ts
+++ b/modules/abstract-utxo/src/core/descriptor/index.ts
@@ -3,8 +3,7 @@ export type { DescriptorMap } from './DescriptorMap';
 export type { PsbtParams } from './psbt';
 
 export { createAddressFromDescriptor, createScriptPubKeyFromDescriptor } from './address';
-export { createPsbt, finalizePsbt } from './psbt';
+export { createPsbt, finalizePsbt, parse } from './psbt';
 export { toDescriptorMap } from './DescriptorMap';
 export { toDerivedDescriptorWalletOutput } from './Output';
 export { signTxLocal } from './signTxLocal';
-export { parseAndValidateTransaction } from './parseTransaction';

--- a/modules/abstract-utxo/src/core/descriptor/parseTransaction/index.ts
+++ b/modules/abstract-utxo/src/core/descriptor/parseTransaction/index.ts
@@ -1,1 +1,0 @@
-export * from './parseTransaction';

--- a/modules/abstract-utxo/src/core/descriptor/psbt/index.ts
+++ b/modules/abstract-utxo/src/core/descriptor/psbt/index.ts
@@ -1,4 +1,5 @@
 export type { PsbtParams } from './createPsbt';
 export { createPsbt } from './createPsbt';
+export { parse } from './parse';
 
 export { finalizePsbt } from './wrap';

--- a/modules/abstract-utxo/src/core/descriptor/psbt/parse.ts
+++ b/modules/abstract-utxo/src/core/descriptor/psbt/parse.ts
@@ -3,25 +3,25 @@ import * as utxolib from '@bitgo/utxo-lib';
 
 import { DescriptorMap } from '../DescriptorMap';
 import { getVirtualSize } from '../VirtualSize';
-import { findDescriptorForInput, findDescriptorForOutput } from '../psbt/findDescriptors';
-import { assertSatisfiable } from '../psbt/assertSatisfiable';
+import { findDescriptorForInput, findDescriptorForOutput } from './findDescriptors';
+import { assertSatisfiable } from './assertSatisfiable';
 
-type ScriptId = { descriptor: Descriptor; index: number };
+export type ScriptId = { descriptor: Descriptor; index: number };
 
-type ParsedInput = {
+export type ParsedInput = {
   address: string;
   value: bigint;
   scriptId: ScriptId;
 };
 
-type ParsedOutput = {
+export type ParsedOutput = {
   address?: string;
   script: Buffer;
   value: bigint;
   scriptId?: ScriptId;
 };
 
-type ParsedDescriptorTransaction = {
+export type ParsedDescriptorTransaction = {
   inputs: ParsedInput[];
   outputs: ParsedOutput[];
   spendAmount: bigint;
@@ -33,7 +33,7 @@ function sum(...values: bigint[]): bigint {
   return values.reduce((a, b) => a + b, BigInt(0));
 }
 
-export function parseAndValidateTransaction(
+export function parse(
   psbt: utxolib.Psbt,
   descriptorMap: DescriptorMap,
   network: utxolib.Network

--- a/modules/abstract-utxo/test/core/descriptor/psbt/fixtures/Wsh2Of3.parse.json
+++ b/modules/abstract-utxo/test/core/descriptor/psbt/fixtures/Wsh2Of3.parse.json
@@ -1,0 +1,39 @@
+{
+  "inputs": [
+    {
+      "address": "bc1q2yau645jl7k577lmanqn9a0ulcgcqm0wrrmx09dppd3kcwguvyzqk86umj",
+      "value": "1000000",
+      "scriptId": {
+        "descriptor": "wsh(multi(2,xpub661MyMwAqRbcGgAiE61i1eaQhbbjc4bbNGs29j3pDwR6nWEve2UsfFvNjBCVq55ou4CRNmwFJaes68he1Dv4DtZijPb1rKyCAe7QUeSNrHv/0/*,xpub661MyMwAqRbcEhTeHonWEhBz8fEB77o21PhGm6SvrbDBQfMiyLi1QP9sqoocVxmpU88J81v5DN8TQycPtZpeyATTPgfQZNz5XLCAiwjubBt/0/*,xpub661MyMwAqRbcGYdhWFrcJryS4koZw7EhwAWy8K1ohYycNketUENNBbSXB8RNLdaob7TanDsmT2Cn2Me7Bt4wBjQurPcqBaWkiCNQPQ1rVUG/0/*))#7njj32qu",
+        "index": 0
+      }
+    },
+    {
+      "address": "bc1qaq3yqn0dfs20gqd0mtm24mgu7vv77guqcw4t4rxxu0vgjhlsn47seygpq7",
+      "value": "1000000",
+      "scriptId": {
+        "descriptor": "wsh(multi(2,xpub661MyMwAqRbcGgAiE61i1eaQhbbjc4bbNGs29j3pDwR6nWEve2UsfFvNjBCVq55ou4CRNmwFJaes68he1Dv4DtZijPb1rKyCAe7QUeSNrHv/0/*,xpub661MyMwAqRbcEhTeHonWEhBz8fEB77o21PhGm6SvrbDBQfMiyLi1QP9sqoocVxmpU88J81v5DN8TQycPtZpeyATTPgfQZNz5XLCAiwjubBt/0/*,xpub661MyMwAqRbcGYdhWFrcJryS4koZw7EhwAWy8K1ohYycNketUENNBbSXB8RNLdaob7TanDsmT2Cn2Me7Bt4wBjQurPcqBaWkiCNQPQ1rVUG/0/*))#7njj32qu",
+        "index": 1
+      }
+    }
+  ],
+  "outputs": [
+    {
+      "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477",
+      "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+      "value": "400000"
+    },
+    {
+      "address": "bc1q2yau645jl7k577lmanqn9a0ulcgcqm0wrrmx09dppd3kcwguvyzqk86umj",
+      "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104",
+      "value": "400000",
+      "scriptId": {
+        "descriptor": "wsh(multi(2,xpub661MyMwAqRbcGgAiE61i1eaQhbbjc4bbNGs29j3pDwR6nWEve2UsfFvNjBCVq55ou4CRNmwFJaes68he1Dv4DtZijPb1rKyCAe7QUeSNrHv/0/*,xpub661MyMwAqRbcEhTeHonWEhBz8fEB77o21PhGm6SvrbDBQfMiyLi1QP9sqoocVxmpU88J81v5DN8TQycPtZpeyATTPgfQZNz5XLCAiwjubBt/0/*,xpub661MyMwAqRbcGYdhWFrcJryS4koZw7EhwAWy8K1ohYycNketUENNBbSXB8RNLdaob7TanDsmT2Cn2Me7Bt4wBjQurPcqBaWkiCNQPQ1rVUG/0/*))#7njj32qu",
+        "index": 0
+      }
+    }
+  ],
+  "spendAmount": "800000",
+  "minerFee": "1200000",
+  "virtualSize": 307
+}

--- a/modules/abstract-utxo/test/core/descriptor/psbt/parse.ts
+++ b/modules/abstract-utxo/test/core/descriptor/psbt/parse.ts
@@ -1,0 +1,34 @@
+import assert from 'assert';
+import { parse } from '../../../../src/core/descriptor';
+import { DescriptorTemplate, getDefaultXPubs, getDescriptorMap } from '../descriptor.utils';
+import { mockPsbtDefaultWithDescriptorTemplate } from './mock.utils';
+import { getFixture } from '../../fixtures.utils';
+import { ParsedDescriptorTransaction } from '../../../../src/core/descriptor/psbt/parse';
+import { toPlainObject } from '../../toPlainObject.utils';
+import { Descriptor } from '@bitgo/wasm-miniscript';
+
+function normalize(parsed: ParsedDescriptorTransaction) {
+  return toPlainObject(
+    parsed,
+    {
+      apply(v, path) {
+        if (v instanceof Descriptor) {
+          return v.toString();
+        }
+      },
+    },
+    []
+  );
+}
+
+function describeWithTemplate(t: DescriptorTemplate) {
+  describe(`parse ${t}`, function () {
+    it('parses a PSBT with descriptors', async function () {
+      const psbt = mockPsbtDefaultWithDescriptorTemplate(t);
+      const parsed = normalize(parse(psbt, getDescriptorMap(t, getDefaultXPubs('a')), psbt.network));
+      assert.deepStrictEqual(parsed, await getFixture(__dirname + `/fixtures/${t}.parse.json`, parsed));
+    });
+  });
+}
+
+describeWithTemplate('Wsh2Of3');

--- a/modules/abstract-utxo/test/core/toPlainObject.utils.ts
+++ b/modules/abstract-utxo/test/core/toPlainObject.utils.ts
@@ -2,6 +2,7 @@ type ToPlainObjectOpts = {
   propertyDescriptors?: boolean;
   skipUndefinedValues?: boolean;
   ignorePaths?: string[] | ((path: PathElement[]) => boolean);
+  apply?: (v: unknown, path: PathElement[]) => unknown;
 };
 export type PathElement = string | number;
 
@@ -50,6 +51,13 @@ function toPlainObjectFromPropertyDescriptors(v: unknown, opts: ToPlainObjectOpt
 }
 
 export function toPlainObject(v: unknown, opts: ToPlainObjectOpts, path: PathElement[]): unknown {
+  if (opts.apply) {
+    const result = opts.apply(v, path);
+    if (result !== undefined) {
+      return result;
+    }
+  }
+
   switch (typeof v) {
     case 'string':
     case 'number':


### PR DESCRIPTION
- **feat(abstract-utxo): add apply option to toPlainObject**
  This allows lower-level control
  
  Issue: BTC-1450
  

- **refactor(abstract-utxo): improve parse method**
  Rename and add tests
  
  TICKET: BTC-1450
  