### PR TITLE
feat: add FIAT jira prefix to commitlint config

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -58,6 +58,7 @@ module.exports = {
         'WIN-',
         'WP-',
         'COIN-',
+        'FIAT-',
         '#', // Prefix used by GitHub issues
       ],
     },


### PR DESCRIPTION
Noticed commitlint errors on several repos when using the new FIAT jira board. Found a thread on slack facing the same issue and followed the PR https://github.com/BitGo/BitGoJS/pull/3635

Jira Project: https://bitgoinc.atlassian.net/jira/software/c/projects/FIAT/issues?jql=project%20%3D%20%22FIAT%22%20ORDER%20BY%20created%20DESC

Update: found that this would probably be needed in the infra repo as well so put up a PR there too

Ticket: FIAT-13
