### PR TITLE
fix(abstract-eth): fix issue with ethlike signTx

### DIFF
--- a/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
+++ b/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
@@ -1013,7 +1013,12 @@ export abstract class AbstractEthLikeNewCoins extends AbstractEthLikeCoin {
     }
     const transaction = await txBuilder.build();
 
-    const recipients = transaction.outputs.map((output) => ({ address: output.address, amount: output.value }));
+    // In case of tx with contract data from a custodial wallet, we are running into an issue
+    // as halfSigned is not having the data field. So, we are adding the data field to the halfSigned tx
+    let recipients = params.txPrebuild.recipients || params.recipients;
+    if (recipients === undefined) {
+      recipients = transaction.outputs.map((output) => ({ address: output.address, amount: output.value }));
+    }
 
     const txParams = {
       eip1559: params.txPrebuild.eip1559,


### PR DESCRIPTION
In case of signing a custodial tx with contract data, we were getting transaction data does not match original because halfSigned tx was not having data field. This PR fixes the same. Taking recipients from params similar to [eth](https://github.com/BitGo/BitGoJS/blob/acaeff7bef27d6dd48075dbd1b27ecee526bb851/modules/sdk-coin-eth/src/eth.ts#L454)

COIN-2506
TICKET: COIN-2506

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
