### PR TITLE
chore(sdk-core): clarify outputs/outputAmount

### DIFF
--- a/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
@@ -85,7 +85,9 @@ export interface ITransactionExplanation<TFee = any, TAmount = any> {
   /** @deprecated */
   displayOrder?: string[];
   id: string;
+  /** NOTE: External recipients */
   outputs: ITransactionRecipient[];
+  /** NOTE: External amount */
   outputAmount: TAmount;
   changeOutputs: ITransactionRecipient[];
   changeAmount: TAmount;


### PR DESCRIPTION
It is unclear from the type definition that the outputs are external

Issue: BTC-1450
