### PR TITLE
feat(abstract-utxo): validate descriptors depending on env

### DIFF
--- a/modules/abstract-utxo/src/descriptor/descriptorWallet.ts
+++ b/modules/abstract-utxo/src/descriptor/descriptorWallet.ts
@@ -1,8 +1,10 @@
 import * as t from 'io-ts';
-import { NamedDescriptor } from './NamedDescriptor';
-import { AbstractUtxoCoinWalletData } from '../abstractUtxoCoin';
-import { DescriptorMap, toDescriptorMap } from '../core/descriptor';
 import { IWallet, WalletCoinSpecific } from '@bitgo/sdk-core';
+
+import { NamedDescriptor } from './NamedDescriptor';
+import { DescriptorMap } from '../core/descriptor';
+import { AbstractUtxoCoinWalletData } from '../abstractUtxoCoin';
+import { DescriptorValidationPolicy, KeyTriple, toDescriptorMapValidate } from './validatePolicy';
 
 type DescriptorWalletCoinSpecific = {
   descriptors: NamedDescriptor[];
@@ -30,10 +32,10 @@ export function isDescriptorWallet(obj: IWallet): obj is IDescriptorWallet {
   return isDescriptorWalletCoinSpecific(obj.coinSpecific());
 }
 
-export function getDescriptorMapFromWalletData(wallet: DescriptorWalletData): DescriptorMap {
-  return toDescriptorMap(wallet.coinSpecific.descriptors);
-}
-
-export function getDescriptorMapFromWallet(wallet: IDescriptorWallet): DescriptorMap {
-  return toDescriptorMap(wallet.coinSpecific().descriptors);
+export function getDescriptorMapFromWallet(
+  wallet: IDescriptorWallet,
+  walletKeys: KeyTriple,
+  policy: DescriptorValidationPolicy
+): DescriptorMap {
+  return toDescriptorMapValidate(wallet.coinSpecific().descriptors, walletKeys, policy);
 }

--- a/modules/abstract-utxo/src/descriptor/index.ts
+++ b/modules/abstract-utxo/src/descriptor/index.ts
@@ -1,9 +1,4 @@
 export { Miniscript, Descriptor } from '@bitgo/wasm-miniscript';
 export { assertDescriptorWalletAddress } from './assertDescriptorWalletAddress';
 export { NamedDescriptor } from './NamedDescriptor';
-export {
-  isDescriptorWallet,
-  isDescriptorWalletData,
-  getDescriptorMapFromWallet,
-  getDescriptorMapFromWalletData,
-} from './descriptorWallet';
+export { isDescriptorWallet, getDescriptorMapFromWallet } from './descriptorWallet';

--- a/modules/abstract-utxo/src/descriptor/validatePolicy.ts
+++ b/modules/abstract-utxo/src/descriptor/validatePolicy.ts
@@ -1,0 +1,69 @@
+import { Descriptor } from '@bitgo/wasm-miniscript';
+import { EnvironmentName, Triple } from '@bitgo/sdk-core';
+import * as utxolib from '@bitgo/utxo-lib';
+
+import { DescriptorBuilder, parseDescriptor } from './builder';
+import { NamedDescriptor } from './NamedDescriptor';
+import { DescriptorMap, toDescriptorMap } from '../core/descriptor';
+
+export type DescriptorValidationPolicy = { allowedTemplates: DescriptorBuilder['name'][] } | 'allowAll';
+
+export type KeyTriple = Triple<utxolib.BIP32Interface>;
+
+function isDescriptorWithTemplate(
+  d: Descriptor,
+  name: DescriptorBuilder['name'],
+  walletKeys: Triple<utxolib.BIP32Interface>
+): boolean {
+  const parsed = parseDescriptor(d);
+  if (parsed.name !== name) {
+    return false;
+  }
+  if (parsed.keys.length !== walletKeys.length) {
+    return false;
+  }
+  return parsed.keys.every((k, i) => k.toBase58() === walletKeys[i].toBase58());
+}
+
+export function assertDescriptorPolicy(
+  descriptor: Descriptor,
+  policy: DescriptorValidationPolicy,
+  walletKeys: Triple<utxolib.BIP32Interface>
+): void {
+  if (policy === 'allowAll') {
+    return;
+  }
+
+  if ('allowedTemplates' in policy) {
+    const allowed = policy.allowedTemplates;
+    if (!allowed.some((t) => isDescriptorWithTemplate(descriptor, t, walletKeys))) {
+      throw new Error(`Descriptor ${descriptor.toString()} does not match any allowed template`);
+    }
+  }
+
+  throw new Error(`Unknown descriptor validation policy: ${policy}`);
+}
+
+export function toDescriptorMapValidate(
+  descriptors: NamedDescriptor[],
+  walletKeys: KeyTriple,
+  policy: DescriptorValidationPolicy
+): DescriptorMap {
+  const map = toDescriptorMap(descriptors);
+  for (const descriptor of map.values()) {
+    assertDescriptorPolicy(descriptor, policy, walletKeys);
+  }
+  return map;
+}
+
+export function getPolicyForEnv(env: EnvironmentName): DescriptorValidationPolicy {
+  switch (env) {
+    case 'adminProd':
+    case 'prod':
+      return {
+        allowedTemplates: ['Wsh2Of3', 'ShWsh2Of3CltvDrop'],
+      };
+    default:
+      return 'allowAll';
+  }
+}

--- a/modules/abstract-utxo/src/keychains.ts
+++ b/modules/abstract-utxo/src/keychains.ts
@@ -1,5 +1,7 @@
-import { AbstractUtxoCoin } from './abstractUtxoCoin';
+import * as utxolib from '@bitgo/utxo-lib';
 import { IRequestTracer, IWallet, Keychain, KeyIndices, promiseProps, Triple } from '@bitgo/sdk-core';
+
+import { AbstractUtxoCoin } from './abstractUtxoCoin';
 
 export type NamedKeychains = {
   user?: Keychain;
@@ -13,6 +15,13 @@ export function toKeychainTriple(keychains: NamedKeychains): Triple<Keychain> {
     throw new Error('keychains must include user, backup, and bitgo');
   }
   return [user, backup, bitgo];
+}
+
+export function toBip32Triple(keychains: Triple<{ pub: string }> | Triple<string>): Triple<utxolib.BIP32Interface> {
+  return keychains.map((keychain: { pub: string } | string) => {
+    const v = typeof keychain === 'string' ? keychain : keychain.pub;
+    return utxolib.bip32.fromBase58(v);
+  }) as Triple<utxolib.BIP32Interface>;
 }
 
 export async function fetchKeychains(

--- a/modules/abstract-utxo/test/core/descriptor/descriptor.utils.ts
+++ b/modules/abstract-utxo/test/core/descriptor/descriptor.utils.ts
@@ -1,11 +1,12 @@
+import { Triple } from '@bitgo/sdk-core';
 import { Descriptor } from '@bitgo/wasm-miniscript';
+import { BIP32Interface } from '@bitgo/utxo-lib';
 
 import { DescriptorMap, PsbtParams } from '../../../src/core/descriptor';
 import { getKeyTriple, KeyTriple } from '../key.utils';
-import { BIP32Interface } from '@bitgo/utxo-lib';
 
-export function getDefaultXPubs(seed?: string): string[] {
-  return getKeyTriple(seed).map((k) => k.neutered().toBase58());
+export function getDefaultXPubs(seed?: string): Triple<string> {
+  return getKeyTriple(seed).map((k) => k.neutered().toBase58()) as Triple<string>;
 }
 
 function toDescriptorMap(v: Record<string, string>): DescriptorMap {

--- a/modules/abstract-utxo/test/descriptor/descriptorWallet.ts
+++ b/modules/abstract-utxo/test/descriptor/descriptorWallet.ts
@@ -1,21 +1,27 @@
 import assert from 'assert';
-import { getDescriptorMapFromWalletData, isDescriptorWalletData } from '../../src/descriptor';
-import { AbstractUtxoCoinWalletData } from '../../src';
-import { getDescriptorMap } from '../core/descriptor/descriptor.utils';
+import { getDescriptorMapFromWallet, isDescriptorWallet } from '../../src/descriptor';
+import { AbstractUtxoCoinWallet } from '../../src';
+import { getDefaultXPubs, getDescriptorMap } from '../core/descriptor/descriptor.utils';
+import { toBip32Triple } from '../../src/keychains';
 
 describe('isDescriptorWalletData', function () {
   const descriptorMap = getDescriptorMap('Wsh2Of3');
   it('should return true for valid DescriptorWalletData', function () {
-    const walletData: AbstractUtxoCoinWalletData = {
-      coinSpecific: {
-        descriptors: [...descriptorMap.entries()].map(([name, descriptor]) => ({
-          name,
-          value: descriptor.toString(),
-        })),
+    const wallet: AbstractUtxoCoinWallet = {
+      coinSpecific() {
+        return {
+          descriptors: [...descriptorMap.entries()].map(([name, descriptor]) => ({
+            name,
+            value: descriptor.toString(),
+          })),
+        };
       },
-    } as unknown as AbstractUtxoCoinWalletData;
+    } as unknown as AbstractUtxoCoinWallet;
 
-    assert(isDescriptorWalletData(walletData));
-    assert.strictEqual(getDescriptorMapFromWalletData(walletData).size, descriptorMap.size);
+    assert(isDescriptorWallet(wallet));
+    assert.strictEqual(
+      getDescriptorMapFromWallet(wallet, toBip32Triple(getDefaultXPubs()), 'allowAll').size,
+      descriptorMap.size
+    );
   });
 });

--- a/modules/bitgo/test/v2/unit/coins/utxo/descriptorAddress.ts
+++ b/modules/bitgo/test/v2/unit/coins/utxo/descriptorAddress.ts
@@ -65,7 +65,15 @@ describe('descriptor wallets', function () {
     it(`should return ${expected} for address ${address} with index ${index} and descriptor ${descriptorName} with checksum ${descriptorChecksum}`, async function () {
       const wallet = getIWalletWithDescriptors([descFoo, descBar]);
       async function f() {
-        return coin.isWalletAddress({ address, index, coinSpecific: { descriptorName, descriptorChecksum } }, wallet);
+        return coin.isWalletAddress(
+          {
+            address,
+            index,
+            coinSpecific: { descriptorName, descriptorChecksum },
+            keychains: xpubs.map((pub) => ({ pub })),
+          },
+          wallet
+        );
       }
       if (expected === true) {
         assert.equal(await f(), expected);


### PR DESCRIPTION
On prod/adminProd we are very restrictive and only allow `Wsh2Of3` and
`ShWsh2Of3CltvDrop` descriptors for now.

On all other environments we allow all descriptors.

Issue: BTC-1450
