### PR TITLE
feat(statics): ungate MATIC ERC20 for Frankfurt

### DIFF
--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -241,6 +241,8 @@ const MATIC_FEATURES = [
   CoinFeature.CUSTODY_BITGO_SWITZERLAND,
   CoinFeature.CUSTODY_BITGO_SINGAPORE,
 ];
+const MATIC_FEATURES_WITH_FRANKFURT = [...MATIC_FEATURES, CoinFeature.CUSTODY_BITGO_FRANKFURT];
+
 const WETH_FEATURES = [
   ...AccountCoin.DEFAULT_FEATURES,
   CoinFeature.MULTISIG_COLD,
@@ -5289,7 +5291,7 @@ export const coins = CoinMap.fromCoins([
     18,
     '0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0',
     UnderlyingAsset.MATIC,
-    MATIC_FEATURES
+    MATIC_FEATURES_WITH_FRANKFURT
   ),
   erc20(
     'ab8c9dac-5e2e-4a10-bb78-250203b93adf',

--- a/modules/statics/test/unit/coins.ts
+++ b/modules/statics/test/unit/coins.ts
@@ -105,7 +105,7 @@ const custodyFeatures: Record<string, { features: CoinFeature[] }> = {
     ],
   },
   dash: { features: [CoinFeature.CUSTODY_BITGO_FRANKFURT] },
-  matic: { features: [CoinFeature.CUSTODY_BITGO_SWITZERLAND] },
+  matic: { features: [CoinFeature.CUSTODY_BITGO_SWITZERLAND, CoinFeature.CUSTODY_BITGO_FRANKFURT] },
   near: { features: [CoinFeature.CUSTODY_BITGO_FRANKFURT] },
   weth: { features: [CoinFeature.CUSTODY_BITGO_SWITZERLAND] },
   eigen: { features: [CoinFeature.CUSTODY_BITGO_SWITZERLAND] },


### PR DESCRIPTION
Ticket: COIN-2519

This PR adds the missing MATIC ERC20 token for Frankfurt that was missed as part of #5255 