### PR TITLE
refactor(abstract-utxo): make BaseParsedTransaction generic over TOutput

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -125,21 +125,21 @@ export interface VerifyAddressOptions<TCoinSpecific extends UtxoCoinSpecific> ex
   coinSpecific?: TCoinSpecific;
 }
 
-export interface BaseOutput {
+export interface BaseOutput<TAmount = string | number> {
   address: string;
-  amount: string | number;
+  amount: TAmount;
   // Even though this external flag is redundant with the chain property, it is necessary for backwards compatibility
   // with legacy transaction format.
   external?: boolean;
 }
 
-export interface FixedScriptWalletOutput extends BaseOutput {
+export interface FixedScriptWalletOutput<TAmount = string | number> extends BaseOutput<TAmount> {
   needsCustomChangeKeySignatureVerification?: boolean;
   chain: number;
   index: number;
 }
 
-export type Output = BaseOutput | FixedScriptWalletOutput;
+export type Output<TAmount = string | number> = BaseOutput<TAmount> | FixedScriptWalletOutput<TAmount>;
 
 export function isWalletOutput(output: Output): output is FixedScriptWalletOutput {
   return (
@@ -206,22 +206,35 @@ export interface ParseTransactionOptions<TNumber extends number | bigint = numbe
   reqId?: IRequestTracer;
 }
 
-export type ParsedTransaction<TNumber extends number | bigint = number> = {
+export type BaseParsedTransaction<TNumber extends number | bigint, TOutput> = {
   keychains: UtxoNamedKeychains;
   keySignatures: {
     backupPub?: string;
     bitgoPub?: string;
   };
-  outputs: Output[];
-  missingOutputs: Output[];
-  explicitExternalOutputs: Output[];
-  implicitExternalOutputs: Output[];
-  changeOutputs: Output[];
+  /** all transaction outputs */
+  outputs: TOutput[];
+  /** transaction outputs that were specified as recipients but are missing from the transaction */
+  missingOutputs: TOutput[];
+  /** transaction outputs that were specified as recipients and are present in the transaction */
+  explicitExternalOutputs: TOutput[];
+  /** transaction outputs that were not specified as recipients but are present in the transaction */
+  implicitExternalOutputs: TOutput[];
+  /** transaction outputs that are change outputs */
+  changeOutputs: TOutput[];
+  /** sum of all explicit external outputs */
   explicitExternalSpendAmount: TNumber;
+  /** sum of all implicit external outputs */
   implicitExternalSpendAmount: TNumber;
   needsCustomChangeKeySignatureVerification: boolean;
   customChange?: CustomChangeOptions;
 };
+
+/**
+ * This type is a bit silly because it allows the type for the aggregate amounts to be different from the type of
+ * individual amounts.
+ */
+export type ParsedTransaction<TNumber extends number | bigint = number> = BaseParsedTransaction<TNumber, Output>;
 
 export interface GenerateAddressOptions {
   addressType?: ScriptType2Of3;

--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -206,12 +206,7 @@ export interface ParseTransactionOptions<TNumber extends number | bigint = numbe
   reqId?: IRequestTracer;
 }
 
-export type BaseParsedTransaction<TNumber extends number | bigint, TOutput> = {
-  keychains: UtxoNamedKeychains;
-  keySignatures: {
-    backupPub?: string;
-    bitgoPub?: string;
-  };
+export type BaseParsedTransactionOutputs<TNumber extends number | bigint, TOutput> = {
   /** all transaction outputs */
   outputs: TOutput[];
   /** transaction outputs that were specified as recipients but are missing from the transaction */
@@ -226,6 +221,17 @@ export type BaseParsedTransaction<TNumber extends number | bigint, TOutput> = {
   explicitExternalSpendAmount: TNumber;
   /** sum of all implicit external outputs */
   implicitExternalSpendAmount: TNumber;
+};
+
+export type BaseParsedTransaction<TNumber extends number | bigint, TOutput> = BaseParsedTransactionOutputs<
+  TNumber,
+  TOutput
+> /** Some extra properties that have nothing to do with an individual transaction */ & {
+  keychains: UtxoNamedKeychains;
+  keySignatures: {
+    backupPub?: string;
+    bitgoPub?: string;
+  };
   needsCustomChangeKeySignatureVerification: boolean;
   customChange?: CustomChangeOptions;
 };


### PR DESCRIPTION
The regular `ParsedTransaction` type was a bit silly

Issue: BTC-1450
