### PR TITLE
feat(abstract-utxo): implement signTx for descriptor wallets

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -296,6 +296,7 @@ type UtxoBaseSignTransactionOptions<TNumber extends number | bigint = number> = 
    * transaction (nonWitnessUtxo)
    */
   allowNonSegwitSigningWithoutPrevTx?: boolean;
+  wallet?: UtxoWallet;
 };
 
 export type SignTransactionOptions<TNumber extends number | bigint = number> = UtxoBaseSignTransactionOptions<TNumber> &

--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -508,9 +508,6 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
   async postProcessPrebuild<TNumber extends number | bigint>(
     prebuild: TransactionPrebuild<TNumber>
   ): Promise<TransactionPrebuild<TNumber>> {
-    if (_.isUndefined(prebuild.txHex)) {
-      throw new Error('missing required txPrebuild property txHex');
-    }
     const tx = this.decodeTransactionFromPrebuild(prebuild);
     if (_.isUndefined(prebuild.blockHeight)) {
       prebuild.blockHeight = (await this.getLatestBlockHeight()) as number;

--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -835,7 +835,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
   async signTransaction<TNumber extends number | bigint = number>(
     params: SignTransactionOptions<TNumber>
   ): Promise<SignedTransaction | HalfSignedUtxoTransaction> {
-    return signTransaction<TNumber>(this, params);
+    return signTransaction<TNumber>(this, this.bitgo, params);
   }
 
   /**

--- a/modules/abstract-utxo/src/transaction/descriptor/index.ts
+++ b/modules/abstract-utxo/src/transaction/descriptor/index.ts
@@ -3,3 +3,4 @@ export { explainPsbt } from './explainPsbt';
 export { parse } from './parse';
 export { parseToAmountType } from './parseToAmountType';
 export { verifyTransaction } from './verifyTransaction';
+export { signPsbt } from './signPsbt';

--- a/modules/abstract-utxo/src/transaction/descriptor/signPsbt.ts
+++ b/modules/abstract-utxo/src/transaction/descriptor/signPsbt.ts
@@ -1,0 +1,47 @@
+import * as utxolib from '@bitgo/utxo-lib';
+import { DescriptorMap } from '../../core/descriptor';
+import { findDescriptorForInput } from '../../core/descriptor/psbt/findDescriptors';
+
+export class ErrorUnknownInput extends Error {
+  constructor(public vin: number) {
+    super(`missing descriptor for input ${vin}`);
+  }
+}
+
+/**
+ * Sign a PSBT with the given keychain.
+ *
+ * Checks the descriptor map for each input in the PSBT. If the input is not
+ * found in the descriptor map, the behavior is determined by the `onUnknownInput`
+ * parameter.
+ *
+ *
+ * @param tx - psbt to sign
+ * @param descriptorMap - map of input index to descriptor
+ * @param signerKeychain - key to sign with
+ * @param params - onUnknownInput: 'throw' | 'skip' | 'sign'.
+ *                 Determines what to do when an input is not found in the
+ *                 descriptor map.
+ */
+export function signPsbt(
+  tx: utxolib.Psbt,
+  descriptorMap: DescriptorMap,
+  signerKeychain: utxolib.BIP32Interface,
+  params: {
+    onUnknownInput: 'throw' | 'skip' | 'sign';
+  }
+): void {
+  for (const [vin, input] of tx.data.inputs.entries()) {
+    if (!findDescriptorForInput(input, descriptorMap)) {
+      switch (params.onUnknownInput) {
+        case 'skip':
+          continue;
+        case 'throw':
+          throw new ErrorUnknownInput(vin);
+        case 'sign':
+          break;
+      }
+    }
+    tx.signInputHD(vin, signerKeychain);
+  }
+}

--- a/modules/abstract-utxo/src/transaction/signTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/signTransaction.ts
@@ -1,8 +1,29 @@
 import _ from 'lodash';
+import { IWallet } from '@bitgo/sdk-core';
+import * as utxolib from '@bitgo/utxo-lib';
+import { bip32 } from '@bitgo/utxo-lib';
+import buildDebug from 'debug';
+
 import { AbstractUtxoCoin, SignTransactionOptions } from '../abstractUtxoCoin';
 import { isDescriptorWallet } from '../descriptor';
 import * as fixedScript from './fixedScript';
-import { IWallet } from '@bitgo/sdk-core';
+
+const debug = buildDebug('bitgo:abstract-utxo:transaction:signTransaction');
+
+function getSignerKeychain(userPrv: unknown): utxolib.BIP32Interface | undefined {
+  if (userPrv === undefined) {
+    return undefined;
+  }
+  if (typeof userPrv !== 'string') {
+    throw new Error('expected user private key to be a string');
+  }
+  const signerKeychain = bip32.fromBase58(userPrv, utxolib.networks.bitcoin);
+  if (signerKeychain.isNeutered()) {
+    throw new Error('expected user private key but received public key');
+  }
+  debug(`Here is the public key of the xprv you used to sign: ${signerKeychain.neutered().toBase58()}`);
+  return signerKeychain;
+}
 
 export async function signTransaction<TNumber extends number | bigint>(
   coin: AbstractUtxoCoin,
@@ -22,11 +43,10 @@ export async function signTransaction<TNumber extends number | bigint>(
   if (params.wallet && isDescriptorWallet(params.wallet as IWallet)) {
     throw new Error('Descriptor wallets are not supported');
   } else {
-    return fixedScript.signTransaction(coin, tx, {
+    return fixedScript.signTransaction(coin, tx, getSignerKeychain(params.prv), {
       walletId: params.txPrebuild.walletId,
       txInfo: params.txPrebuild.txInfo,
       isLastSignature: params.isLastSignature ?? false,
-      prv: typeof params.prv === 'string' ? params.prv : undefined,
       signingStep: params.signingStep,
       allowNonSegwitSigningWithoutPrevTx: params.allowNonSegwitSigningWithoutPrevTx ?? false,
       pubs: params.pubs,

--- a/modules/abstract-utxo/test/transaction/descriptor/sign.ts
+++ b/modules/abstract-utxo/test/transaction/descriptor/sign.ts
@@ -1,0 +1,30 @@
+import { mockPsbtDefaultWithDescriptorTemplate } from '../../core/descriptor/psbt/mock.utils';
+import { signPsbt } from '../../../src/transaction/descriptor';
+import { getKeyTriple } from '../../core/key.utils';
+import { getDescriptorMap } from '../../core/descriptor/descriptor.utils';
+import assert from 'assert';
+import { ErrorUnknownInput } from '../../../src/transaction/descriptor/signPsbt';
+
+describe('sign', function () {
+  const psbtUnsigned = mockPsbtDefaultWithDescriptorTemplate('Wsh2Of3');
+  const keychain = getKeyTriple('a');
+  const descriptorMap = getDescriptorMap('Wsh2Of3', keychain);
+  const emptyDescriptorMap = new Map();
+
+  it('should sign a transaction', async function () {
+    const psbt = psbtUnsigned.clone();
+    signPsbt(psbt, descriptorMap, keychain[0], { onUnknownInput: 'throw' });
+    assert(psbt.validateSignaturesOfAllInputs());
+  });
+
+  it('should be sensitive to onUnknownInput', async function () {
+    const psbt = psbtUnsigned.clone();
+    assert.throws(() => {
+      signPsbt(psbt, emptyDescriptorMap, keychain[0], { onUnknownInput: 'throw' });
+    }, new ErrorUnknownInput(0));
+    signPsbt(psbt, emptyDescriptorMap, keychain[0], { onUnknownInput: 'skip' });
+    assert(psbt.data.inputs[0].partialSig === undefined);
+    signPsbt(psbt, emptyDescriptorMap, keychain[0], { onUnknownInput: 'sign' });
+    assert(psbt.validateSignaturesOfAllInputs());
+  });
+});


### PR DESCRIPTION
- **fix(abstract-utxo): remove txHex check from postProcessPrebuild**
  We now call decodeTransactionFromPrebuild
  
  Issue: BTC-1450
  

- **fix(abstract-utxo): pass actual wallet to signTransaction**
  Issue: BTC-1450
  

- **feat(abstract-utxo): extract signer keychain earlier**
  Do the whole decode dance before calling signTransaction
  
  Issue: BTC-1450
  

- **feat(abstract-utxo): implement sign for descriptor wallets**
  Issue: BTC-1450
  