### PR TITLE
feat(abstract-utxo): add 'max' output support in `outputDifference`

### DIFF
--- a/modules/abstract-utxo/src/transaction/descriptor/outputDifference.ts
+++ b/modules/abstract-utxo/src/transaction/descriptor/outputDifference.ts
@@ -1,20 +1,38 @@
-export type ComparableOutput = {
+export type ComparableOutput<TValue> = {
   script: Buffer;
-  value: bigint;
+  value: TValue;
 };
 
-export function equalOutput<T extends ComparableOutput>(a: T, b: T): boolean {
-  return a.value === b.value && a.script.equals(b.script);
+/** Actual outputs have fixed values. */
+export type ActualOutput = ComparableOutput<bigint>;
+
+/** Expected outputs can have a fixed value or 'max'. */
+export type ExpectedOutput = ComparableOutput<bigint | 'max'>;
+
+/**
+ * @param a
+ * @param b
+ * @returns whether the two outputs are equal. Outputs with value `max` are considered equal to any other output with the same script.
+ */
+export function matchingOutput<TValue>(a: ComparableOutput<TValue>, b: ComparableOutput<TValue>): boolean {
+  if (a.value === 'max' || b.value === 'max') {
+    return a.script.equals(b.script);
+  }
+  return a.script.equals(b.script) && a.value === b.value;
 }
 
 /**
- * @returns all outputs in the first array that are not in the second array
+ * @returns all outputs in the first array that are not in the second array.
  * Outputs can occur more than once in each array.
+ * An output with value `max` is considered equal to any other output with the same script.
  */
-export function outputDifference<T extends ComparableOutput>(first: T[], second: T[]): T[] {
+export function outputDifference<A extends ActualOutput | ExpectedOutput, B extends ActualOutput | ExpectedOutput>(
+  first: A[],
+  second: B[]
+): A[] {
   first = first.slice();
   for (const output of second) {
-    const index = first.findIndex((o) => equalOutput(o, output));
+    const index = first.findIndex((o) => matchingOutput(o, output));
     if (index !== -1) {
       first.splice(index, 1);
     }
@@ -22,18 +40,18 @@ export function outputDifference<T extends ComparableOutput>(first: T[], second:
   return first;
 }
 
-export type OutputDifferenceWithExpected<T extends ComparableOutput> = {
+export type OutputDifferenceWithExpected<TActual extends ActualOutput, TExpected extends ExpectedOutput> = {
   /** These are the external outputs that were expected and found in the transaction. */
-  explicitExternalOutputs: T[];
+  explicitExternalOutputs: TActual[];
   /**
    * These are the surprise external outputs that were not explicitly specified in the transaction.
    * They can be PayGo fees.
    */
-  implicitExternalOutputs: T[];
+  implicitExternalOutputs: TActual[];
   /**
    * These are the outputs that were expected to be in the transaction but were not found.
    */
-  missingOutputs: T[];
+  missingOutputs: TExpected[];
 };
 
 /**
@@ -41,10 +59,10 @@ export type OutputDifferenceWithExpected<T extends ComparableOutput> = {
  * @param expectedExternalOutputs - external outputs that were expected to be in the transaction
  * @returns the difference between the actual and expected external outputs
  */
-export function outputDifferencesWithExpected<T extends ComparableOutput>(
-  actualExternalOutputs: T[],
-  expectedExternalOutputs: T[]
-): OutputDifferenceWithExpected<T> {
+export function outputDifferencesWithExpected<TActual extends ActualOutput, TExpected extends ExpectedOutput>(
+  actualExternalOutputs: TActual[],
+  expectedExternalOutputs: TExpected[]
+): OutputDifferenceWithExpected<TActual, TExpected> {
   const implicitExternalOutputs = outputDifference(actualExternalOutputs, expectedExternalOutputs);
   const explicitExternalOutputs = outputDifference(actualExternalOutputs, implicitExternalOutputs);
   const missingOutputs = outputDifference(expectedExternalOutputs, actualExternalOutputs);

--- a/modules/abstract-utxo/src/transaction/descriptor/parse.ts
+++ b/modules/abstract-utxo/src/transaction/descriptor/parse.ts
@@ -25,7 +25,8 @@ function toParsedOutput(recipient: ITransactionRecipient, network: utxolib.Netwo
   };
 }
 
-type ParsedOutputs = OutputDifferenceWithExpected<ParsedOutput> & {
+// TODO(BTC-1697): allow outputs with `value: 'max'` here
+type ParsedOutputs = OutputDifferenceWithExpected<ParsedOutput, ParsedOutput> & {
   outputs: ParsedOutput[];
   changeOutputs: ParsedOutput[];
 };

--- a/modules/abstract-utxo/src/transaction/descriptor/parse.ts
+++ b/modules/abstract-utxo/src/transaction/descriptor/parse.ts
@@ -17,16 +17,20 @@ import { fromExtendedAddressFormatToScript, toExtendedAddressFormat } from '../r
 
 import { outputDifferencesWithExpected, OutputDifferenceWithExpected } from './outputDifference';
 
-function toParsedOutput(recipient: ITransactionRecipient, network: utxolib.Network): ParsedOutput {
+export type RecipientOutput = Omit<ParsedOutput, 'value'> & {
+  value: bigint | 'max';
+};
+
+function toRecipientOutput(recipient: ITransactionRecipient, network: utxolib.Network): RecipientOutput {
   return {
     address: recipient.address,
-    value: BigInt(recipient.amount),
+    value: recipient.amount === 'max' ? 'max' : BigInt(recipient.amount),
     script: fromExtendedAddressFormatToScript(recipient.address, network),
   };
 }
 
 // TODO(BTC-1697): allow outputs with `value: 'max'` here
-type ParsedOutputs = OutputDifferenceWithExpected<ParsedOutput, ParsedOutput> & {
+type ParsedOutputs = OutputDifferenceWithExpected<ParsedOutput, RecipientOutput> & {
   outputs: ParsedOutput[];
   changeOutputs: ParsedOutput[];
 };
@@ -34,7 +38,7 @@ type ParsedOutputs = OutputDifferenceWithExpected<ParsedOutput, ParsedOutput> & 
 function parseOutputsWithPsbt(
   psbt: utxolib.bitgo.UtxoPsbt,
   descriptorMap: coreDescriptors.DescriptorMap,
-  recipientOutputs: ParsedOutput[]
+  recipientOutputs: RecipientOutput[]
 ): ParsedOutputs {
   const parsed = coreDescriptors.parse(psbt, descriptorMap, psbt.network);
   const externalOutputs = parsed.outputs.filter((o) => o.scriptId === undefined);
@@ -51,17 +55,22 @@ function sumValues(arr: { value: bigint }[]): bigint {
   return arr.reduce((sum, e) => sum + e.value, BigInt(0));
 }
 
-function toBaseOutputs(outputs: ParsedOutput[], network: utxolib.Network): BaseOutput<bigint>[] {
+function toBaseOutputs(outputs: ParsedOutput[], network: utxolib.Network): BaseOutput<bigint>[];
+function toBaseOutputs(outputs: RecipientOutput[], network: utxolib.Network): BaseOutput<bigint | 'max'>[];
+function toBaseOutputs(
+  outputs: (ParsedOutput | RecipientOutput)[],
+  network: utxolib.Network
+): BaseOutput<bigint | 'max'>[] {
   return outputs.map(
-    (o): BaseOutput<bigint> => ({
+    (o): BaseOutput<bigint | 'max'> => ({
       address: toExtendedAddressFormat(o.script, network),
-      amount: BigInt(o.value),
+      amount: o.value === 'max' ? 'max' : BigInt(o.value),
       external: o.scriptId === undefined,
     })
   );
 }
 
-export type ParsedOutputsBigInt = BaseParsedTransactionOutputs<bigint, BaseOutput<bigint>>;
+export type ParsedOutputsBigInt = BaseParsedTransactionOutputs<bigint, BaseOutput<bigint | 'max'>>;
 
 function toBaseParsedTransactionOutputs(
   { outputs, changeOutputs, explicitExternalOutputs, implicitExternalOutputs, missingOutputs }: ParsedOutputs,
@@ -88,7 +97,7 @@ export function toBaseParsedTransactionOutputsFromPsbt(
     parseOutputsWithPsbt(
       psbt,
       descriptorMap,
-      recipients.map((r) => toParsedOutput(r, psbt.network))
+      recipients.map((r) => toRecipientOutput(r, psbt.network))
     ),
     network
   );
@@ -96,7 +105,7 @@ export function toBaseParsedTransactionOutputsFromPsbt(
 
 export type ParsedDescriptorTransaction<TAmount extends number | bigint> = BaseParsedTransaction<
   TAmount,
-  BaseOutput<TAmount>
+  BaseOutput<TAmount | 'max'>
 >;
 
 export function parse(

--- a/modules/abstract-utxo/src/transaction/descriptor/parseToAmountType.ts
+++ b/modules/abstract-utxo/src/transaction/descriptor/parseToAmountType.ts
@@ -6,6 +6,9 @@ import { parse, ParsedDescriptorTransaction } from './parse';
 type AmountType = 'number' | 'bigint' | 'string';
 
 export function toAmountType(v: number | bigint | string, t: AmountType): number | bigint | string {
+  if (v === 'max') {
+    return v;
+  }
   switch (t) {
     case 'number':
       return Number(v);
@@ -22,7 +25,7 @@ type AmountTypeOptions = {
 };
 
 function baseOutputToTNumber<TAmount extends number | bigint>(
-  output: BaseOutput<bigint>,
+  output: BaseOutput<bigint | 'max'>,
   amountType: AmountType
 ): BaseOutput<TAmount> {
   return {

--- a/modules/abstract-utxo/src/transaction/descriptor/verifyTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/descriptor/verifyTransaction.ts
@@ -13,13 +13,13 @@ export class ValidationError extends Error {
 }
 
 export class ErrorMissingOutputs extends ValidationError {
-  constructor(public missingOutputs: BaseOutput<bigint>[]) {
+  constructor(public missingOutputs: BaseOutput<bigint | 'max'>[]) {
     super(`missing outputs (count=${missingOutputs.length})`);
   }
 }
 
 export class ErrorImplicitExternalOutputs extends ValidationError {
-  constructor(public implicitExternalOutputs: BaseOutput<bigint>[]) {
+  constructor(public implicitExternalOutputs: BaseOutput<bigint | 'max'>[]) {
     super(`unexpected implicit external outputs (count=${implicitExternalOutputs.length})`);
   }
 }
@@ -31,7 +31,7 @@ export class AggregateValidationError extends ValidationError {
 }
 
 export function assertExpectedOutputDifference(
-  parsedOutputs: BaseParsedTransactionOutputs<bigint, BaseOutput<bigint>>
+  parsedOutputs: BaseParsedTransactionOutputs<bigint, BaseOutput<bigint | 'max'>>
 ): void {
   const errors: ValidationError[] = [];
   if (parsedOutputs.missingOutputs.length > 0) {

--- a/modules/abstract-utxo/test/transaction/descriptor/outputDifference.ts
+++ b/modules/abstract-utxo/test/transaction/descriptor/outputDifference.ts
@@ -1,59 +1,77 @@
 import assert from 'assert';
 
 import {
-  ComparableOutput,
-  equalOutput,
+  ActualOutput,
+  ExpectedOutput,
+  matchingOutput,
   outputDifference,
   outputDifferencesWithExpected,
 } from '../../../src/transaction/descriptor/outputDifference';
 
 describe('outputDifference', function () {
-  function output(script: string, value: bigint | number) {
+  function output(script: string, value: bigint | number): ActualOutput;
+  function output(script: string, value: 'max'): ExpectedOutput;
+  function output(script: string, value: bigint | number | 'max'): ActualOutput | ExpectedOutput {
     const scriptBuffer = Buffer.from(script, 'hex');
     if (scriptBuffer.toString('hex') !== script) {
       throw new Error('invalid script');
     }
     return {
       script: Buffer.from(script, 'hex'),
-      value: BigInt(value),
+      value: value === 'max' ? 'max' : BigInt(value),
     };
   }
 
   const a = output('aa', 1);
   const a2 = output('aa', 2);
-  const b = output('bb', 2);
-  const c = output('cc', 3);
+  const aMax = output('aa', 'max');
+  const b = output('bb', 1);
+  const c = output('cc', 1);
 
   describe('equalOutput', function () {
     it('has expected result', function () {
-      assert.deepStrictEqual(equalOutput(a, a), true);
-      assert.deepStrictEqual(equalOutput(a, a2), false);
-      assert.deepStrictEqual(equalOutput(a, b), false);
+      assert.deepStrictEqual(matchingOutput(a, a), true);
+      assert.deepStrictEqual(matchingOutput(a, a2), false);
+      assert.deepStrictEqual(matchingOutput(a, b), false);
+      assert.deepStrictEqual(matchingOutput(aMax, b), false);
+
+      assert.deepStrictEqual(matchingOutput(aMax, a), true);
+      assert.deepStrictEqual(matchingOutput(a, aMax), true);
+      // this one does not appear in practice but is a valid comparison
+      assert.deepStrictEqual(matchingOutput(aMax, aMax), true);
     });
   });
 
   describe('outputDifference', function () {
-    assert.deepStrictEqual(outputDifference([], []), []);
-    assert.deepStrictEqual(outputDifference([a], []), [a]);
-    assert.deepStrictEqual(outputDifference([], [a]), []);
-    assert.deepStrictEqual(outputDifference([a], [a]), []);
-    assert.deepStrictEqual(outputDifference([a, a], [a]), [a]);
-    assert.deepStrictEqual(outputDifference([a, a, a], [a]), [a, a]);
-    assert.deepStrictEqual(outputDifference([a, b, c], [a, b]), [c]);
-    assert.deepStrictEqual(outputDifference([a, b, c, a], [a, b]), [c, a]);
+    it('has expected result', function () {
+      assert.deepStrictEqual(outputDifference([], []), []);
+      assert.deepStrictEqual(outputDifference([a], []), [a]);
+      assert.deepStrictEqual(outputDifference([aMax], []), [aMax]);
+      assert.deepStrictEqual(outputDifference([], [a]), []);
+      assert.deepStrictEqual(outputDifference([], [aMax]), []);
+      assert.deepStrictEqual(outputDifference([a], [a]), []);
+      assert.deepStrictEqual(outputDifference([a], [aMax]), []);
+      assert.deepStrictEqual(outputDifference([aMax], [a]), []);
+      assert.deepStrictEqual(outputDifference([a, a], [a]), [a]);
+      assert.deepStrictEqual(outputDifference([a, a], [aMax]), [a]);
+      assert.deepStrictEqual(outputDifference([a, a, a], [a]), [a, a]);
+      assert.deepStrictEqual(outputDifference([a, b, c], [a, b]), [c]);
+      assert.deepStrictEqual(outputDifference([a, b, c], [aMax, b]), [c]);
+      assert.deepStrictEqual(outputDifference([a, b, c, a], [a, b]), [c, a]);
 
-    assert.deepStrictEqual(outputDifference([a], [a2]), [a]);
-    assert.deepStrictEqual(outputDifference([a2], [a]), [a2]);
+      assert.deepStrictEqual(outputDifference([a], [a2]), [a]);
+      assert.deepStrictEqual(outputDifference([a2], [a]), [a2]);
+    });
   });
 
   describe('outputDifferencesWithExpected', function () {
     function test(
-      outputs: ComparableOutput[],
-      recipients: ComparableOutput[],
+      outputs: ActualOutput[],
+      recipients: ExpectedOutput[],
       expected: {
-        missing: ComparableOutput[];
-        explicit: ComparableOutput[];
-        implicit: ComparableOutput[];
+        missing: ExpectedOutput[];
+        explicit: ActualOutput[];
+        implicit: ActualOutput[];
       }
     ) {
       const result = outputDifferencesWithExpected(outputs, recipients);
@@ -64,12 +82,14 @@ describe('outputDifference', function () {
       });
     }
 
-    test([a], [], { missing: [], explicit: [], implicit: [a] });
-    test([], [a], { missing: [a], explicit: [], implicit: [] });
-    test([a], [a], { missing: [], explicit: [a], implicit: [] });
-    test([a], [a2], { missing: [a2], explicit: [], implicit: [a] });
-    test([b], [a], { missing: [a], explicit: [], implicit: [b] });
-    test([a, a], [a], { missing: [], explicit: [a], implicit: [a] });
-    test([a, b], [a], { missing: [], explicit: [a], implicit: [b] });
+    it('has expected result', function () {
+      test([a], [], { missing: [], explicit: [], implicit: [a] });
+      test([], [a], { missing: [a], explicit: [], implicit: [] });
+      test([a], [a], { missing: [], explicit: [a], implicit: [] });
+      test([a], [a2], { missing: [a2], explicit: [], implicit: [a] });
+      test([b], [a], { missing: [a], explicit: [], implicit: [b] });
+      test([a, a], [a], { missing: [], explicit: [a], implicit: [a] });
+      test([a, b], [a], { missing: [], explicit: [a], implicit: [b] });
+    });
   });
 });


### PR DESCRIPTION
- **feat(abstract-utxo): allow 'max' value in ExpectedOutput**
  Issue: BTC-1697
  

- **feat(abstract-utxo): add support for 'max' value parse.ts**
  Issue: BTC-1697
  