### PR TITLE
refactor(sdk-core): remove vssProof from Eddsa singing

### DIFF
--- a/modules/bitgo/test/v2/unit/tss/eddsa.ts
+++ b/modules/bitgo/test/v2/unit/tss/eddsa.ts
@@ -561,10 +561,6 @@ describe('test tss helper functions', function () {
           validUserSignShare,
           'signerShare',
           undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
           reqId
         ).should.be.fulfilled();
         nock.isDone().should.equal(true);

--- a/modules/sdk-core/src/bitgo/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/bitgo/tss/eddsa/eddsa.ts
@@ -203,10 +203,6 @@ export async function offerUserToBitgoRShare(
   userSignShare: SignShare,
   encryptedSignerShare: string,
   apiMode: 'full' | 'lite' = 'lite',
-  vssProof?: string,
-  privateShareProof?: string,
-  userPublicGpgKey?: string,
-  publicShare?: string,
   reqId?: IRequestTracer
 ): Promise<void> {
   const rShare: RShare = userSignShare.rShares[ShareKeyPosition.BITGO];
@@ -220,9 +216,6 @@ export async function offerUserToBitgoRShare(
     from: SignatureShareType.USER,
     to: SignatureShareType.BITGO,
     share: rShare.r + rShare.R,
-    vssProof,
-    privateShareProof,
-    publicShare,
   };
 
   // TODO (BG-57944): implement message signing for EDDSA
@@ -235,7 +228,7 @@ export async function offerUserToBitgoRShare(
     encryptedSignerShare,
     'eddsa',
     apiMode,
-    userPublicGpgKey,
+    undefined,
     reqId
   );
 }

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
@@ -527,10 +527,6 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
       rShare,
       encryptedSignerShare.share,
       apiVersion,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
       reqId
     );
     const bitgoToUserRShare = await getBitgoToUserRShare(this.bitgo, this.wallet.id(), txRequestId, reqId);
@@ -596,12 +592,6 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
     const bitgoGpgKey = await this.pickBitgoPubGpgKeyForSigning(false, params.reqId, txRequestResolved.enterpriseId);
     const userToBitgoEncryptedSignerShare = await encryptText(signerShare, bitgoGpgKey);
 
-    const userGpgKey = await generateGPGKeyPair('secp256k1');
-    const privateShareProof = await createShareProof(userGpgKey.privateKey, signingKey.yShares[bitgoIndex].u, 'eddsa');
-    const vssProof = signingKey.yShares[bitgoIndex].v;
-    const userPublicGpgKey = userGpgKey.publicKey;
-    const publicShare = signingKey.yShares[bitgoIndex].y + signingKey.yShares[bitgoIndex].chaincode;
-
     const userToBitgoCommitment = userSignShare.rShares[bitgoIndex].commitment;
     assert(userToBitgoCommitment, 'Missing userToBitgoCommitment commitment');
 
@@ -625,10 +615,6 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
       userSignShare,
       userToBitgoEncryptedSignerShare,
       apiVersion,
-      vssProof,
-      privateShareProof,
-      userPublicGpgKey,
-      publicShare,
       params.reqId
     );
 


### PR DESCRIPTION
Removed vssProof from MPC Eddsa signing is not needed and not being used

WP-3393

TICKET: WP-3393

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
