### PR TITLE
build(root): lock xrp libs versions

### DIFF
--- a/modules/sdk-coin-xrp/package.json
+++ b/modules/sdk-coin-xrp/package.json
@@ -45,9 +45,9 @@
     "@bitgo/utxo-lib": "^11.2.1",
     "bignumber.js": "^9.0.0",
     "lodash": "^4.17.14",
-    "ripple-binary-codec": "^2.1.0",
-    "ripple-keypairs": "^2.0.0",
-    "xrpl": "^4.0.0"
+    "ripple-binary-codec": "2.1.0",
+    "ripple-keypairs": "2.0.0",
+    "xrpl": "4.0.0"
   },
   "devDependencies": {
     "@bitgo/sdk-api": "^1.57.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17357,7 +17357,7 @@ ripple-address-codec@^5.0.0:
     "@scure/base" "^1.1.3"
     "@xrplf/isomorphic" "^1.0.0"
 
-ripple-binary-codec@^2.1.0:
+ripple-binary-codec@2.1.0, ripple-binary-codec@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-2.1.0.tgz#f1ef81f8d1f05a6cecc06fc6d9b13456569cafda"
   integrity sha512-q0GAx+hj3UVcDbhXVjk7qeNfgUMehlElYJwiCuIBwqs/51GVTOwLr39Ht3eNsX5ow2xPRaC5mqHwcFDvLRm6cA==
@@ -17366,7 +17366,7 @@ ripple-binary-codec@^2.1.0:
     bignumber.js "^9.0.0"
     ripple-address-codec "^5.0.0"
 
-ripple-keypairs@^2.0.0:
+ripple-keypairs@2.0.0, ripple-keypairs@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ripple-keypairs/-/ripple-keypairs-2.0.0.tgz#4a1a8142e9a58c07e61b3cc6cfe7317db718d289"
   integrity sha512-b5rfL2EZiffmklqZk1W+dvSy97v3V/C7936WxCCgDynaGPp7GE6R2XO7EU9O2LlM/z95rj870IylYnOQs+1Rag==
@@ -20528,7 +20528,7 @@ xmlhttprequest-ssl@~1.6.2:
   resolved "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz#03b713873b01659dfa2c1c5d056065b27ddc2de6"
   integrity sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==
 
-xrpl@^4.0.0:
+xrpl@4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/xrpl/-/xrpl-4.0.0.tgz#c031b848c2a3e955b69b1dd438b1156e6826a2d6"
   integrity sha512-VZm1lQWHQ6PheAAFGdH+ISXKvqB2hZDQ0w4ZcdAEtmqZQXtSIVQHOKPz95rEgGANbos7+XClxJ73++joPhA8Cw==


### PR DESCRIPTION
removing the  carat(^) from xrp libs to prevent auto ugprades that include breaking changes

WP-3396

TICKET: WP-3396

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
