### PR TITLE
feat(abstract-utxo): add explainTransaction to offlineVault

### DIFF
--- a/modules/abstract-utxo/src/index.ts
+++ b/modules/abstract-utxo/src/index.ts
@@ -6,3 +6,4 @@ export * from './sign';
 
 export { UtxoWallet } from './wallet';
 export * as descriptor from './descriptor';
+export * as offlineVault from './offlineVault';

--- a/modules/abstract-utxo/src/offlineVault/OfflineVaultHalfSigned.ts
+++ b/modules/abstract-utxo/src/offlineVault/OfflineVaultHalfSigned.ts
@@ -4,7 +4,7 @@ import { BaseCoin } from '@bitgo/sdk-core';
 
 import { getNetworkFromChain } from '../names';
 
-import { OfflineVaultUnsigned } from './OfflineVaultUnsigned';
+import { OfflineVaultSignable } from './OfflineVaultSignable';
 import { DescriptorTransaction, getHalfSignedPsbt } from './descriptor';
 
 export type OfflineVaultHalfSigned = {
@@ -26,7 +26,7 @@ export function createHalfSigned(
     prv = utxolib.bip32.fromBase58(prv);
   }
   prv = BaseCoin.deriveKeyWithSeedBip32(prv, derivationId).key;
-  if (!OfflineVaultUnsigned.is(tx)) {
+  if (!OfflineVaultSignable.is(tx)) {
     throw new Error('unsupported transaction type');
   }
   if (DescriptorTransaction.is(tx)) {

--- a/modules/abstract-utxo/src/offlineVault/OfflineVaultSignable.ts
+++ b/modules/abstract-utxo/src/offlineVault/OfflineVaultSignable.ts
@@ -12,7 +12,7 @@ export type XPubWithDerivationPath = t.TypeOf<typeof XPubWithDerivationPath>;
 /**
  * This is the transaction payload that is sent to the offline vault to sign.
  */
-export const OfflineVaultUnsigned = t.type(
+export const OfflineVaultSignable = t.type(
   {
     xpubsWithDerivationPath: t.type({
       user: XPubWithDerivationPath,
@@ -24,7 +24,7 @@ export const OfflineVaultUnsigned = t.type(
   'BaseTransaction'
 );
 
-export type OfflineVaultUnsigned = t.TypeOf<typeof OfflineVaultUnsigned>;
+export type OfflineVaultUnsigned = t.TypeOf<typeof OfflineVaultSignable>;
 
 type WithXpub = { xpub: string };
 type NamedKeys = { user: WithXpub; backup: WithXpub; bitgo: WithXpub };

--- a/modules/abstract-utxo/src/offlineVault/TransactionExplanation.ts
+++ b/modules/abstract-utxo/src/offlineVault/TransactionExplanation.ts
@@ -1,0 +1,31 @@
+import { getNetworkFromChain } from '../names';
+
+import { OfflineVaultSignable } from './OfflineVaultSignable';
+import { DescriptorTransaction, getTransactionExplanationFromPsbt } from './descriptor';
+
+export interface ExplanationOutput {
+  address: string;
+  amount: string | number;
+}
+
+export interface TransactionExplanation {
+  outputs: ExplanationOutput[];
+  changeOutputs: ExplanationOutput[];
+  fee: {
+    /* network fee */
+    fee: string | number;
+    payGoFeeString: string | number | undefined;
+    payGoFeeAddress: string | undefined;
+  };
+}
+
+export function getTransactionExplanation(coin: string, tx: unknown): TransactionExplanation {
+  if (!OfflineVaultSignable.is(tx)) {
+    throw new Error('not a signable transaction');
+  }
+  if (DescriptorTransaction.is(tx)) {
+    return getTransactionExplanationFromPsbt(tx, getNetworkFromChain(coin));
+  }
+
+  throw new Error('unsupported transaction type');
+}

--- a/modules/abstract-utxo/src/offlineVault/descriptor/transaction.ts
+++ b/modules/abstract-utxo/src/offlineVault/descriptor/transaction.ts
@@ -10,7 +10,8 @@ import {
   toDescriptorMapValidate,
 } from '../../descriptor/validatePolicy';
 import { DescriptorMap } from '../../core/descriptor';
-import { signPsbt } from '../../transaction/descriptor';
+import { explainPsbt, signPsbt } from '../../transaction/descriptor';
+import { TransactionExplanation } from '../TransactionExplanation';
 
 export const DescriptorTransaction = t.intersection(
   [OfflineVaultSignable, t.type({ descriptors: t.array(NamedDescriptor) })],
@@ -40,4 +41,24 @@ export function getHalfSignedPsbt(
   const descriptorMap = getDescriptorsFromDescriptorTransaction(tx);
   signPsbt(psbt, descriptorMap, prv, { onUnknownInput: 'throw' });
   return psbt;
+}
+
+export function getTransactionExplanationFromPsbt(
+  tx: DescriptorTransaction,
+  network: utxolib.Network
+): TransactionExplanation {
+  const psbt = utxolib.bitgo.createPsbtDecode(tx.coinSpecific.txHex, network);
+  const descriptorMap = getDescriptorsFromDescriptorTransaction(tx);
+  const { outputs, changeOutputs, fee } = explainPsbt(psbt, descriptorMap);
+  return {
+    outputs,
+    changeOutputs,
+    fee: {
+      /* network fee */
+      fee,
+      /* TODO */
+      payGoFeeString: undefined,
+      payGoFeeAddress: undefined,
+    },
+  };
 }

--- a/modules/abstract-utxo/src/offlineVault/descriptor/transaction.ts
+++ b/modules/abstract-utxo/src/offlineVault/descriptor/transaction.ts
@@ -2,7 +2,7 @@ import * as utxolib from '@bitgo/utxo-lib';
 import * as t from 'io-ts';
 
 import { NamedDescriptor } from '../../descriptor';
-import { OfflineVaultUnsigned, toKeyTriple } from '../OfflineVaultUnsigned';
+import { OfflineVaultSignable, toKeyTriple } from '../OfflineVaultSignable';
 import {
   getValidatorOneOfTemplates,
   getValidatorSignedByUserKey,
@@ -13,7 +13,7 @@ import { DescriptorMap } from '../../core/descriptor';
 import { signPsbt } from '../../transaction/descriptor';
 
 export const DescriptorTransaction = t.intersection(
-  [OfflineVaultUnsigned, t.type({ descriptors: t.array(NamedDescriptor) })],
+  [OfflineVaultSignable, t.type({ descriptors: t.array(NamedDescriptor) })],
   'DescriptorTransaction'
 );
 

--- a/modules/abstract-utxo/src/offlineVault/index.ts
+++ b/modules/abstract-utxo/src/offlineVault/index.ts
@@ -1,2 +1,5 @@
 export * as descriptor from './descriptor';
 export * from './OfflineVaultHalfSigned';
+export { getTransactionExplanation } from './TransactionExplanation';
+export { TransactionExplanation } from './TransactionExplanation';
+export { ExplanationOutput } from './TransactionExplanation';

--- a/modules/abstract-utxo/test/offlineVault/fixtures/Wsh2Of3.buildAdmin.custodial.explanation.json
+++ b/modules/abstract-utxo/test/offlineVault/fixtures/Wsh2Of3.buildAdmin.custodial.explanation.json
@@ -1,0 +1,20 @@
+{
+  "outputs": [],
+  "changeOutputs": [
+    {
+      "address": "bc1q96awm56777g6enlzp6qskc2r6hjxvv5ay0d4vrf356nl0255s3xq94kt80",
+      "amount": "1000000"
+    },
+    {
+      "address": "bc1q96awm56777g6enlzp6qskc2r6hjxvv5ay0d4vrf356nl0255s3xq94kt80",
+      "amount": "2000000"
+    },
+    {
+      "address": "bc1qly6ftyymxjap6t9ff376j7ta32s4sxmzuu3ds2sr70rkg00v0exsm268t8",
+      "amount": "196995579"
+    }
+  ],
+  "fee": {
+    "fee": "4421"
+  }
+}

--- a/modules/abstract-utxo/test/offlineVault/halfSigned.ts
+++ b/modules/abstract-utxo/test/offlineVault/halfSigned.ts
@@ -6,13 +6,16 @@ import * as t from 'io-ts';
 import { decodeOrElse } from '@bitgo/sdk-core';
 import * as utxolib from '@bitgo/utxo-lib';
 
-import { createHalfSigned } from '../../src/offlineVault';
+import { createHalfSigned, getTransactionExplanation } from '../../src/offlineVault';
 import { DescriptorTransaction } from '../../src/offlineVault/descriptor';
+import { getFixtureRoot } from '../transaction/descriptor/fixtures.utils';
+
+const { assertEqualFixture } = getFixtureRoot(__dirname + '/fixtures');
 
 function getFixturesNames(): string[] {
   // I'm using sync here because mocha cannot do async setup
   // eslint-disable-next-line no-sync
-  return fs.readdirSync(__dirname + '/fixtures').filter((f) => f.endsWith('.json'));
+  return fs.readdirSync(__dirname + '/fixtures').filter((f) => f.endsWith('.json') && !f.endsWith('.explanation.json'));
 }
 
 const KeyPair = t.intersection([t.type({ xpub: t.string }), t.partial({ xprv: t.string })]);
@@ -93,6 +96,10 @@ describe('OfflineVaultHalfSigned', function () {
       for (const mutation of mutations) {
         assert.throws(() => createHalfSigned('btc', rootPrv, derivationId, mutation));
       }
+      await assertEqualFixture(
+        fixtureName.replace(/\.json$/, '.explanation.json'),
+        getTransactionExplanation('btc', response)
+      );
     });
   }
 });

--- a/modules/abstract-utxo/test/transaction/descriptor/explainPsbt.ts
+++ b/modules/abstract-utxo/test/transaction/descriptor/explainPsbt.ts
@@ -6,7 +6,9 @@ import { mockPsbtDefaultWithDescriptorTemplate } from '../../core/descriptor/psb
 import { getDescriptorMap } from '../../core/descriptor/descriptor.utils';
 import { getKeyTriple } from '../../core/key.utils';
 
-import { assertEqualFixture } from './fixtures.utils';
+import { getFixtureRoot } from './fixtures.utils';
+
+const { assertEqualFixture } = getFixtureRoot(__dirname + '/fixtures');
 
 function assertSignatureCount(expl: TransactionExplanation, signatures: number, inputSignatures: number[]) {
   assert.deepStrictEqual(expl.signatures, signatures);

--- a/modules/abstract-utxo/test/transaction/descriptor/fixtures.utils.ts
+++ b/modules/abstract-utxo/test/transaction/descriptor/fixtures.utils.ts
@@ -1,7 +1,18 @@
 import assert from 'assert';
+import path from 'path';
 
-import { getFixture } from '../../core/fixtures.utils';
+import { getFixture, jsonNormalize } from '../../core/fixtures.utils';
 
-export async function assertEqualFixture(name: string, v: unknown): Promise<void> {
-  assert.deepStrictEqual(v, await getFixture(__dirname + '/fixtures/' + name, v));
+interface FixtureRoot {
+  assertEqualFixture(name: string, v: unknown): Promise<void>;
+}
+
+type Normalize = (v: unknown) => unknown;
+
+export function getFixtureRoot(root: string): FixtureRoot {
+  return {
+    async assertEqualFixture(name: string, v: unknown, normalize: Normalize = jsonNormalize): Promise<void> {
+      assert.deepStrictEqual(normalize(v), await getFixture(path.join(root, name), normalize(v)));
+    },
+  };
 }

--- a/modules/abstract-utxo/test/transaction/descriptor/parse.ts
+++ b/modules/abstract-utxo/test/transaction/descriptor/parse.ts
@@ -13,7 +13,9 @@ import {
 import { toAmountType } from '../../../src/transaction/descriptor/parseToAmountType';
 import { BaseOutput } from '../../../src';
 
-import { assertEqualFixture } from './fixtures.utils';
+import { getFixtureRoot } from './fixtures.utils';
+
+const { assertEqualFixture } = getFixtureRoot(__dirname + '/fixtures');
 
 type OutputWithValue<T = number | bigint | string> = {
   address?: string;


### PR DESCRIPTION
- **refactor(wp): rename OfflineVaultUnsigned to OfflineVaultSignable**
  We do not know if the transaction is signed or unsigned. Let's describe it based
  on the properties it has.
  
  Issue: BTC-1731
  

- **feat: add getTransactionExplanation**
  TICKET: BTC-1731
  