### PR TITLE
feat(bitgo): add bitgo mena fze entity

### DIFF
--- a/modules/statics/src/account.ts
+++ b/modules/statics/src/account.ts
@@ -34,6 +34,7 @@ export class AccountCoin extends BaseCoin {
     CoinFeature.TRANSACTION_DATA,
     CoinFeature.CUSTODY,
     CoinFeature.CUSTODY_BITGO_TRUST,
+    CoinFeature.CUSTODY_BITGO_MENA_FZE,
     CoinFeature.CUSTODY_BITGO_SINGAPORE,
     CoinFeature.CUSTODY_BITGO_KOREA,
     CoinFeature.CUSTODY_BITGO_EUROPE_APS,

--- a/modules/statics/src/ada.ts
+++ b/modules/statics/src/ada.ts
@@ -22,6 +22,7 @@ export class Ada extends BaseCoin {
     CoinFeature.TRANSACTION_DATA,
     CoinFeature.REQUIRES_BIG_NUMBER,
     CoinFeature.CUSTODY_BITGO_TRUST,
+    CoinFeature.CUSTODY_BITGO_MENA_FZE,
     CoinFeature.STAKING,
     CoinFeature.BULK_TRANSACTION,
   ];

--- a/modules/statics/src/avaxp.ts
+++ b/modules/statics/src/avaxp.ts
@@ -17,6 +17,7 @@ export class AVAXPCoin extends BaseCoin {
   public static readonly DEFAULT_FEATURES = [
     CoinFeature.UNSPENT_MODEL,
     CoinFeature.CUSTODY_BITGO_TRUST,
+    CoinFeature.CUSTODY_BITGO_MENA_FZE,
     CoinFeature.CUSTODY_BITGO_GERMANY,
     CoinFeature.CUSTODY_BITGO_FRANKFURT,
     CoinFeature.MULTISIG_COLD,

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -239,6 +239,10 @@ export enum CoinFeature {
    * This coin supports custody in BitGo Europe ApS entities
    */
   CUSTODY_BITGO_EUROPE_APS = 'custody-bitgo-europe-aps',
+  /**
+   * This coin supports custody in BitGo MENA FZE entities
+   */
+  CUSTODY_BITGO_MENA_FZE = 'custody-bitgo-mena-fze',
   /*
    * This coin has transactions that expire after a certain amount of time.
    */

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -137,7 +137,12 @@ const XTZ_FEATURES = [
   ...AccountCoin.DEFAULT_FEATURES,
   CoinFeature.MULTISIG_COLD,
   CoinFeature.ENTERPRISE_PAYS_FEES,
-].filter((feature) => feature !== CoinFeature.CUSTODY && feature !== CoinFeature.CUSTODY_BITGO_TRUST);
+].filter(
+  (feature) =>
+    feature !== CoinFeature.CUSTODY &&
+    feature !== CoinFeature.CUSTODY_BITGO_TRUST &&
+    feature !== CoinFeature.CUSTODY_BITGO_MENA_FZE
+);
 
 const XRP_FEATURES = [
   ...AccountCoin.DEFAULT_FEATURES,

--- a/modules/statics/src/ofc.ts
+++ b/modules/statics/src/ofc.ts
@@ -27,6 +27,7 @@ export class OfcCoin extends BaseCoin {
     CoinFeature.REQUIRES_BIG_NUMBER,
     CoinFeature.CUSTODY,
     CoinFeature.CUSTODY_BITGO_TRUST,
+    CoinFeature.CUSTODY_BITGO_MENA_FZE,
   ];
 
   // If set, this coin is the native address format for this token.

--- a/modules/statics/src/utxo.ts
+++ b/modules/statics/src/utxo.ts
@@ -20,6 +20,7 @@ export class UtxoCoin extends BaseCoin {
     CoinFeature.CHILD_PAYS_FOR_PARENT,
     CoinFeature.CUSTODY,
     CoinFeature.CUSTODY_BITGO_TRUST,
+    CoinFeature.CUSTODY_BITGO_MENA_FZE,
     CoinFeature.MULTISIG_COLD,
     CoinFeature.PAYGO,
   ];

--- a/modules/statics/test/unit/coins.ts
+++ b/modules/statics/test/unit/coins.ts
@@ -615,10 +615,15 @@ coins.forEach((coin, coinName) => {
       it(`should return true for CUSTODY_BITGO_TRUST ${coin.family} coin feature`, () => {
         coin.features.includes(CoinFeature.CUSTODY_BITGO_TRUST).should.eql(true);
       });
+
+      it(`should return true for CUSTODY_BITGO_MENA_FZE ${coin.family} coin feature`, () => {
+        coin.features.includes(CoinFeature.CUSTODY_BITGO_MENA_FZE).should.eql(true);
+      });
     } else if (coin.family === CoinFamily.XTZ || coin.features.includes(CoinFeature.GENERIC_TOKEN)) {
       it(`should return false for all custody ${coin.family} coin feature`, () => {
         coin.features.includes(CoinFeature.CUSTODY).should.eql(false);
         coin.features.includes(CoinFeature.CUSTODY_BITGO_TRUST).should.eql(false);
+        coin.features.includes(CoinFeature.CUSTODY_BITGO_MENA_FZE).should.eql(false);
         coin.features.includes(CoinFeature.CUSTODY_BITGO_NEW_YORK).should.eql(false);
         coin.features.includes(CoinFeature.CUSTODY_BITGO_GERMANY).should.eql(false);
         coin.features.includes(CoinFeature.CUSTODY_BITGO_SWITZERLAND).should.eql(false);
@@ -629,6 +634,7 @@ coins.forEach((coin, coinName) => {
         const coinSupportsCustody = coin.family !== CoinFamily.LNBTC;
         coin.features.includes(CoinFeature.CUSTODY).should.eql(coinSupportsCustody);
         coin.features.includes(CoinFeature.CUSTODY_BITGO_TRUST).should.eql(coinSupportsCustody);
+        coin.features.includes(CoinFeature.CUSTODY_BITGO_MENA_FZE).should.eql(coinSupportsCustody);
       });
 
       it('should return false for all non-SD coin feature', () => {


### PR DESCRIPTION
## Description

Adding `BitGo MENA FZE / Dubai` entity. It will support every assets supported in South Dakota.
This is required to unblock the proof of concept to the Dubai regulator.

## Issue Number

TICKET: [CEN-299](https://bitgoinc.atlassian.net/browse/CEN-299)
TICKET: [COPS-3277](https://bitgoinc.atlassian.net/browse/COPS-3277)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

[COPS-3277]: https://bitgoinc.atlassian.net/browse/COPS-3277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CEN-299]: https://bitgoinc.atlassian.net/browse/CEN-299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ