### PR TITLE
feat(sdk-coin-sol): fetch prio fees from WP

### DIFF
--- a/modules/sdk-coin-sol/src/lib/iface.ts
+++ b/modules/sdk-coin-sol/src/lib/iface.ts
@@ -108,7 +108,9 @@ export interface StakingAuthorize {
 
 export interface SetPriorityFee {
   type: InstructionBuilderTypes.SetPriorityFee;
-  params: Record<string, never>;
+  params: {
+    fee: number | bigint;
+  };
 }
 
 export interface AtaInit {

--- a/modules/sdk-coin-sol/src/lib/instructionParamsFactory.ts
+++ b/modules/sdk-coin-sol/src/lib/instructionParamsFactory.ts
@@ -13,6 +13,7 @@ import {
   StakeProgram,
   SystemInstruction,
   TransactionInstruction,
+  ComputeBudgetInstruction,
 } from '@solana/web3.js';
 
 import { NotSupported, TransactionType } from '@bitgo/sdk-core';
@@ -195,9 +196,12 @@ function parseSendInstructions(
         instructionData.push(ataClose);
         break;
       case ValidInstructionTypesEnum.SetPriorityFee:
+        const setComputeUnitPriceParams = ComputeBudgetInstruction.decodeSetComputeUnitPrice(instruction);
         const setPriorityFee: SetPriorityFee = {
           type: InstructionBuilderTypes.SetPriorityFee,
-          params: {},
+          params: {
+            fee: setComputeUnitPriceParams.microLamports,
+          },
         };
         instructionData.push(setPriorityFee);
         break;

--- a/modules/sdk-coin-sol/src/lib/solInstructionFactory.ts
+++ b/modules/sdk-coin-sol/src/lib/solInstructionFactory.ts
@@ -94,10 +94,8 @@ function advanceNonceInstruction(data: Nonce): TransactionInstruction[] {
 }
 
 function fetchPriorityFeeInstruction(instructionToBuild: SetPriorityFee): TransactionInstruction[] {
-  // 200k * 10000000 microlamports => prio fee
-  // https://www.quicknode.com/gas-tracker/solana
   const addPriorityFee = ComputeBudgetProgram.setComputeUnitPrice({
-    microLamports: 10000000,
+    microLamports: instructionToBuild.params.fee,
   });
 
   return [addPriorityFee];

--- a/modules/sdk-coin-sol/src/lib/tokenTransferBuilder.ts
+++ b/modules/sdk-coin-sol/src/lib/tokenTransferBuilder.ts
@@ -142,10 +142,17 @@ export class TokenTransferBuilder extends TransactionBuilder {
     );
     const addPriorityFeeInstruction: SetPriorityFee = {
       type: InstructionBuilderTypes.SetPriorityFee,
-      params: {},
+      params: {
+        fee: this._priorityFee ?? BigInt(0),
+      },
     };
-    // order is important, createAtaInstructions must be before sendInstructions
-    this._instructionsData = [addPriorityFeeInstruction, ...createAtaInstructions, ...sendInstructions];
+
+    if (!this._priorityFee) {
+      this._instructionsData = [...createAtaInstructions, ...sendInstructions];
+    } else {
+      // order is important, createAtaInstructions must be before sendInstructions
+      this._instructionsData = [addPriorityFeeInstruction, ...createAtaInstructions, ...sendInstructions];
+    }
     return await super.buildImplementation();
   }
 }

--- a/modules/sdk-coin-sol/src/lib/transactionBuilder.ts
+++ b/modules/sdk-coin-sol/src/lib/transactionBuilder.ts
@@ -41,6 +41,7 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
   protected _signers: KeyPair[] = [];
   protected _memo?: string;
   protected _feePayer?: string;
+  protected _priorityFee: number | bigint;
 
   constructor(_coinConfig: Readonly<CoinConfig>) {
     super(_coinConfig);
@@ -242,6 +243,11 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
 
   fee(feeOptions: FeeOptions): this {
     this._lamportsPerSignature = Number(feeOptions.amount);
+    return this;
+  }
+
+  public setPriorityFee(feeOptions: FeeOptions): this {
+    this._priorityFee = BigInt(feeOptions.amount);
     return this;
   }
 

--- a/modules/sdk-coin-sol/src/lib/transferBuilderV2.ts
+++ b/modules/sdk-coin-sol/src/lib/transferBuilderV2.ts
@@ -170,18 +170,19 @@ export class TransferBuilderV2 extends TransactionBuilder {
 
     let addPriorityFeeInstruction: SetPriorityFee;
     // If there are createAtaInstructions, then token is involved and we need to add a priority fee instruction
-    if (
+    if (!this._priorityFee) {
+      this._instructionsData = [...createAtaInstructions, ...sendInstructions];
+    } else if (
       createAtaInstructions.length !== 0 ||
       sendInstructions.some((instruction) => instruction.type === InstructionBuilderTypes.TokenTransfer)
     ) {
       addPriorityFeeInstruction = {
         type: InstructionBuilderTypes.SetPriorityFee,
-        params: {},
+        params: {
+          fee: this._priorityFee ?? BigInt(0),
+        },
       };
       this._instructionsData = [addPriorityFeeInstruction, ...createAtaInstructions, ...sendInstructions];
-    } else {
-      // order is important, createAtaInstructions must be before sendInstructions
-      this._instructionsData = [...createAtaInstructions, ...sendInstructions];
     }
 
     return await super.buildImplementation();

--- a/modules/sdk-coin-sol/test/unit/sol.ts
+++ b/modules/sdk-coin-sol/test/unit/sol.ts
@@ -1883,31 +1883,30 @@ describe('SOL:', function () {
       should.equal(tokenTxnJson.numSignatures, testData.SolInputData.durableNonceSignatures);
 
       const instructionsData = tokenTxnJson.instructionsData as InstructionParams[];
-      should.equal(instructionsData.length, 4);
+      should.equal(instructionsData.length, 3);
       should.equal(instructionsData[0].type, 'NonceAdvance');
 
       const destinationUSDTTokenAccount = await getAssociatedTokenAccountAddress(
         usdtMintAddress,
         testData.keys.destinationPubKey
       );
-      should.equal(instructionsData[1].type, 'SetPriorityFee');
-      should.equal(instructionsData[2].type, 'CreateAssociatedTokenAccount');
-      should.equal((instructionsData[2] as AtaInit).params.mintAddress, usdtMintAddress);
-      should.equal((instructionsData[2] as AtaInit).params.ataAddress, destinationUSDTTokenAccount);
-      should.equal((instructionsData[2] as AtaInit).params.ownerAddress, testData.keys.destinationPubKey);
-      should.equal((instructionsData[2] as AtaInit).params.tokenName, 'tsol:usdt');
-      should.equal((instructionsData[2] as AtaInit).params.payerAddress, testData.wrwUser.walletAddress0);
+      should.equal(instructionsData[1].type, 'CreateAssociatedTokenAccount');
+      should.equal((instructionsData[1] as AtaInit).params.mintAddress, usdtMintAddress);
+      should.equal((instructionsData[1] as AtaInit).params.ataAddress, destinationUSDTTokenAccount);
+      should.equal((instructionsData[1] as AtaInit).params.ownerAddress, testData.keys.destinationPubKey);
+      should.equal((instructionsData[1] as AtaInit).params.tokenName, 'tsol:usdt');
+      should.equal((instructionsData[1] as AtaInit).params.payerAddress, testData.wrwUser.walletAddress0);
 
       const sourceUSDTTokenAccount = await getAssociatedTokenAccountAddress(
         usdtMintAddress,
         testData.wrwUser.walletAddress0
       );
-      should.equal(instructionsData[3].type, 'TokenTransfer');
-      should.equal((instructionsData[3] as TokenTransfer).params.fromAddress, testData.wrwUser.walletAddress0);
-      should.equal((instructionsData[3] as TokenTransfer).params.toAddress, destinationUSDTTokenAccount);
-      should.equal((instructionsData[3] as TokenTransfer).params.amount, '2000000000');
-      should.equal((instructionsData[3] as TokenTransfer).params.tokenName, 'tsol:usdt');
-      should.equal((instructionsData[3] as TokenTransfer).params.sourceAddress, sourceUSDTTokenAccount);
+      should.equal(instructionsData[2].type, 'TokenTransfer');
+      should.equal((instructionsData[2] as TokenTransfer).params.fromAddress, testData.wrwUser.walletAddress0);
+      should.equal((instructionsData[2] as TokenTransfer).params.toAddress, destinationUSDTTokenAccount);
+      should.equal((instructionsData[2] as TokenTransfer).params.amount, '2000000000');
+      should.equal((instructionsData[2] as TokenTransfer).params.tokenName, 'tsol:usdt');
+      should.equal((instructionsData[2] as TokenTransfer).params.sourceAddress, sourceUSDTTokenAccount);
 
       const solCoin = basecoin as any;
       sandBox.assert.callCount(solCoin.getDataFromNode, 7);
@@ -1941,7 +1940,7 @@ describe('SOL:', function () {
       should.equal(tokenTxnJson.numSignatures, testData.SolInputData.durableNonceSignatures);
 
       const instructionsData = tokenTxnJson.instructionsData as TokenTransfer[];
-      should.equal(instructionsData.length, 3);
+      should.equal(instructionsData.length, 2);
       should.equal(instructionsData[0].type, 'NonceAdvance');
 
       const sourceUSDTTokenAccount = await getAssociatedTokenAccountAddress(
@@ -1952,13 +1951,12 @@ describe('SOL:', function () {
         usdtMintAddress,
         testData.keys.destinationPubKey2
       );
-      should.equal(instructionsData[1].type, 'SetPriorityFee');
-      should.equal(instructionsData[2].type, 'TokenTransfer');
-      should.equal(instructionsData[2].params.fromAddress, testData.wrwUser.walletAddress0);
-      should.equal(instructionsData[2].params.toAddress, destinationUSDTTokenAccount);
-      should.equal(instructionsData[2].params.amount, '2000000000');
-      should.equal(instructionsData[2].params.tokenName, 'tsol:usdt');
-      should.equal(instructionsData[2].params.sourceAddress, sourceUSDTTokenAccount);
+      should.equal(instructionsData[1].type, 'TokenTransfer');
+      should.equal(instructionsData[1].params.fromAddress, testData.wrwUser.walletAddress0);
+      should.equal(instructionsData[1].params.toAddress, destinationUSDTTokenAccount);
+      should.equal(instructionsData[1].params.amount, '2000000000');
+      should.equal(instructionsData[1].params.tokenName, 'tsol:usdt');
+      should.equal(instructionsData[1].params.sourceAddress, sourceUSDTTokenAccount);
 
       const solCoin = basecoin as any;
       sandBox.assert.callCount(solCoin.getDataFromNode, 7);

--- a/modules/sdk-coin-sol/test/unit/transactionBuilder/tokenTransferBuilder.ts
+++ b/modules/sdk-coin-sol/test/unit/transactionBuilder/tokenTransferBuilder.ts
@@ -2,6 +2,7 @@ import { getBuilderFactory } from '../getBuilderFactory';
 import { KeyPair, Utils } from '../../../src';
 import should from 'should';
 import * as testData from '../../resources/sol';
+import { FeeOptions } from '@bitgo/sdk-core';
 
 describe('Sol Token Transfer Builder', () => {
   let ataAddress;
@@ -26,6 +27,10 @@ describe('Sol Token Transfer Builder', () => {
   const owner = testData.tokenTransfers.owner;
   const walletPK = testData.associatedTokenAccounts.accounts[0].pub;
   const walletSK = testData.associatedTokenAccounts.accounts[0].prv;
+  const prioFeeMicroLamports = '10000000';
+  const priorityFee: FeeOptions = {
+    amount: prioFeeMicroLamports,
+  };
   describe('Succeed', () => {
     before(async () => {
       ataAddress = await Utils.getAssociatedTokenAccountAddress(mintUSDC, otherAccount.pub);
@@ -37,6 +42,7 @@ describe('Sol Token Transfer Builder', () => {
       txBuilder.sender(walletPK);
       txBuilder.send({ address: otherAccount.pub, amount, tokenName: nameUSDC });
       txBuilder.memo(memo);
+      txBuilder.setPriorityFee(priorityFee);
       const tx = await txBuilder.build();
       tx.inputs.length.should.equal(1);
       tx.inputs[0].should.deepEqual({
@@ -60,6 +66,7 @@ describe('Sol Token Transfer Builder', () => {
       txBuilder.nonce(recentBlockHash, { walletNonceAddress: nonceAccount.pub, authWalletAddress: walletPK });
       txBuilder.sender(walletPK);
       txBuilder.send({ address: otherAccount.pub, amount, tokenName: nameUSDC });
+      txBuilder.setPriorityFee(priorityFee);
       const tx = await txBuilder.build();
       tx.inputs.length.should.equal(1);
       tx.inputs[0].should.deepEqual({
@@ -89,6 +96,7 @@ describe('Sol Token Transfer Builder', () => {
       txBuilder.sender(walletPK);
       txBuilder.send({ address: otherAccount.pub, amount, tokenName: nameUSDC });
       txBuilder.memo(memo);
+      txBuilder.setPriorityFee(priorityFee);
       const tx = await txBuilder.build();
       tx.inputs.length.should.equal(1);
       tx.inputs[0].should.deepEqual({
@@ -112,6 +120,7 @@ describe('Sol Token Transfer Builder', () => {
       txBuilder.nonce(recentBlockHash);
       txBuilder.sender(walletPK);
       txBuilder.send({ address: otherAccount.pub, amount, tokenName: nameUSDC });
+      txBuilder.setPriorityFee(priorityFee);
       const tx = await txBuilder.build();
       tx.inputs.length.should.equal(1);
       tx.inputs[0].should.deepEqual({
@@ -140,6 +149,7 @@ describe('Sol Token Transfer Builder', () => {
       txBuilder.send({ address: otherAccount.pub, amount, tokenName: nameUSDC });
       txBuilder.memo(memo);
       txBuilder.sign({ key: walletSK });
+      txBuilder.setPriorityFee(priorityFee);
       const tx = await txBuilder.build();
       tx.id.should.not.equal(undefined);
       tx.inputs.length.should.equal(1);
@@ -177,6 +187,7 @@ describe('Sol Token Transfer Builder', () => {
       txBuilder.send({ address: account5.pub, amount, tokenName: nameUSDC });
       txBuilder.memo(memo);
       txBuilder.sign({ key: authAccount.prv });
+      txBuilder.setPriorityFee(priorityFee);
       const tx = await txBuilder.build();
       tx.inputs.length.should.equal(6);
       tx.inputs[0].should.deepEqual({
@@ -259,6 +270,7 @@ describe('Sol Token Transfer Builder', () => {
       txBuilder.send({ address: account1.pub, amount, tokenName: nameUSDC });
       txBuilder.send({ address: account2.pub, amount, tokenName: nameSRM });
       txBuilder.send({ address: account3.pub, amount, tokenName: nameRAY });
+      txBuilder.setPriorityFee(priorityFee);
       const tx = await txBuilder.build();
       tx.inputs.length.should.equal(4);
       tx.inputs[0].should.deepEqual({
@@ -325,6 +337,7 @@ describe('Sol Token Transfer Builder', () => {
       txBuilder.nonce(recentBlockHash);
       txBuilder.sender(owner);
       txBuilder.send({ address: account1.pub, amount, tokenName: nameUSDC });
+      txBuilder.setPriorityFee(priorityFee);
       const tx = await txBuilder.build();
 
       tx.outputs.should.deepEqual([
@@ -343,6 +356,7 @@ describe('Sol Token Transfer Builder', () => {
       txBuilder.send({ address: otherAccount.pub, amount, tokenName: nameUSDC });
       txBuilder.memo(memo);
       txBuilder.createAssociatedTokenAccount({ ownerAddress: otherAccount.pub, tokenName: nameUSDC });
+      txBuilder.setPriorityFee(priorityFee);
       const tx = await txBuilder.build();
       tx.inputs.length.should.equal(1);
       tx.inputs[0].should.deepEqual({
@@ -399,6 +413,7 @@ describe('Sol Token Transfer Builder', () => {
       txBuilder.createAssociatedTokenAccount({ ownerAddress: otherAccount.pub, tokenName: nameUSDC });
       txBuilder.createAssociatedTokenAccount({ ownerAddress: account1.pub, tokenName: nameUSDC });
       txBuilder.createAssociatedTokenAccount({ ownerAddress: account2.pub, tokenName: nameUSDC });
+      txBuilder.setPriorityFee(priorityFee);
       const tx = await txBuilder.build();
       tx.inputs.length.should.equal(3);
       tx.inputs[0].should.deepEqual({
@@ -503,6 +518,7 @@ describe('Sol Token Transfer Builder', () => {
       txBuilder.createAssociatedTokenAccount({ ownerAddress: otherAccount.pub, tokenName: nameUSDC });
       txBuilder.createAssociatedTokenAccount({ ownerAddress: otherAccount.pub, tokenName: nameUSDC });
       txBuilder.createAssociatedTokenAccount({ ownerAddress: otherAccount.pub, tokenName: nameUSDC });
+      txBuilder.setPriorityFee(priorityFee);
       const tx = await txBuilder.build();
       tx.inputs.length.should.equal(3);
       tx.inputs[0].should.deepEqual({

--- a/modules/sdk-coin-sol/test/unit/transactionBuilder/transactionBuilder.ts
+++ b/modules/sdk-coin-sol/test/unit/transactionBuilder/transactionBuilder.ts
@@ -2,8 +2,8 @@ import should from 'should';
 import * as bs58 from 'bs58';
 
 import { getBuilderFactory } from '../getBuilderFactory';
-import { KeyPair } from '../../../src';
-import { Eddsa, TransactionType } from '@bitgo/sdk-core';
+import { KeyPair, TokenTransferBuilder } from '../../../src';
+import { Eddsa, FeeOptions, TransactionType } from '@bitgo/sdk-core';
 import * as testData from '../../resources/sol';
 import BigNumber from 'bignumber.js';
 import { Ed25519Bip32HdTree } from '@bitgo/sdk-lib-mpc';
@@ -160,7 +160,14 @@ describe('Sol Transaction Builder', async () => {
   });
 
   it('build a send from raw token transaction', async () => {
-    const txBuilder = factory.from(testData.TOKEN_TRANSFER_SIGNED_TX_WITH_MEMO_AND_DURABLE_NONCE);
+    const txBuilder = factory.from(
+      testData.TOKEN_TRANSFER_SIGNED_TX_WITH_MEMO_AND_DURABLE_NONCE
+    ) as TokenTransferBuilder;
+    const prioFeeMicroLamports = '10000000';
+    const priorityFee: FeeOptions = {
+      amount: prioFeeMicroLamports,
+    };
+    txBuilder.setPriorityFee(priorityFee);
     const builtTx = await txBuilder.build();
     should.equal(builtTx.type, TransactionType.Send);
     should.equal(
@@ -188,9 +195,12 @@ describe('Sol Transaction Builder', async () => {
       walletNonceAddress: '8Y7RM6JfcX4ASSNBkrkrmSbRu431YVi9Y3oLFnzC2dCh',
       authWalletAddress: testData.associatedTokenAccounts.accounts[0].pub,
     });
+    const priorityFeeBigInt = BigInt(prioFeeMicroLamports);
     jsonTx.instructionsData.should.deepEqual([
       {
-        params: {},
+        params: {
+          fee: priorityFeeBigInt,
+        },
         type: 'SetPriorityFee',
       },
       {

--- a/modules/sdk-coin-sol/test/unit/transactionBuilder/transferBuilderV2.ts
+++ b/modules/sdk-coin-sol/test/unit/transactionBuilder/transferBuilderV2.ts
@@ -2,6 +2,7 @@ import { getBuilderFactory } from '../getBuilderFactory';
 import { KeyPair, Utils } from '../../../src';
 import * as testData from '../../resources/sol';
 import should from 'should';
+import { FeeOptions } from '@bitgo/sdk-core';
 
 describe('Sol Transfer Builder V2', () => {
   let ataAddress;
@@ -20,7 +21,10 @@ describe('Sol Transfer Builder V2', () => {
   const owner = testData.tokenTransfers.owner;
   const walletPK = testData.associatedTokenAccounts.accounts[0].pub;
   const walletSK = testData.associatedTokenAccounts.accounts[0].prv;
-
+  const prioFeeMicroLamports = '10000000';
+  const priorityFee: FeeOptions = {
+    amount: prioFeeMicroLamports,
+  };
   const transferBuilderV2 = () => {
     const txBuilder = factory.getTransferBuilderV2();
     txBuilder.nonce(recentBlockHash);
@@ -287,6 +291,7 @@ describe('Sol Transfer Builder V2', () => {
       txBuilder.sender(walletPK);
       txBuilder.send({ address: otherAccount.pub, amount, tokenName: nameUSDC });
       txBuilder.memo(memo);
+      txBuilder.setPriorityFee(priorityFee);
       const tx = await txBuilder.build();
       tx.inputs.length.should.equal(1);
       tx.inputs[0].should.deepEqual({
@@ -311,6 +316,7 @@ describe('Sol Transfer Builder V2', () => {
       txBuilder.feePayer(feePayerAccount.pub);
       txBuilder.sender(walletPK);
       txBuilder.send({ address: otherAccount.pub, amount, tokenName: nameUSDC });
+      txBuilder.setPriorityFee(priorityFee);
       const tx = await txBuilder.build();
       tx.inputs.length.should.equal(1);
       tx.inputs[0].should.deepEqual({
@@ -341,6 +347,7 @@ describe('Sol Transfer Builder V2', () => {
       txBuilder.sender(walletPK);
       txBuilder.send({ address: otherAccount.pub, amount, tokenName: nameUSDC });
       txBuilder.memo(memo);
+      txBuilder.setPriorityFee(priorityFee);
       const tx = await txBuilder.build();
       tx.inputs.length.should.equal(1);
       tx.inputs[0].should.deepEqual({
@@ -365,6 +372,7 @@ describe('Sol Transfer Builder V2', () => {
       txBuilder.feePayer(feePayerAccount.pub);
       txBuilder.sender(walletPK);
       txBuilder.send({ address: otherAccount.pub, amount, tokenName: nameUSDC });
+      txBuilder.setPriorityFee(priorityFee);
       const tx = await txBuilder.build();
       tx.inputs.length.should.equal(1);
       tx.inputs[0].should.deepEqual({
@@ -394,6 +402,7 @@ describe('Sol Transfer Builder V2', () => {
       txBuilder.send({ address: otherAccount.pub, amount, tokenName: nameUSDC });
       txBuilder.memo(memo);
       txBuilder.sign({ key: walletSK });
+      txBuilder.setPriorityFee(priorityFee);
       const tx = await txBuilder.build();
       tx.id.should.not.equal(undefined);
       tx.inputs.length.should.equal(1);
@@ -425,6 +434,7 @@ describe('Sol Transfer Builder V2', () => {
       txBuilder.memo(memo);
       txBuilder.createAssociatedTokenAccount({ ownerAddress: otherAccount.pub, tokenName: nameUSDC });
       txBuilder.sign({ key: walletSK });
+      txBuilder.setPriorityFee(priorityFee);
       const tx = await txBuilder.build();
       tx.id.should.not.equal(undefined);
       tx.inputs.length.should.equal(1);
@@ -485,6 +495,7 @@ describe('Sol Transfer Builder V2', () => {
       txBuilder.send({ address: account5.pub, amount, tokenName: nameUSDC });
       txBuilder.memo(memo);
       txBuilder.sign({ key: authAccount.prv });
+      txBuilder.setPriorityFee(priorityFee);
       const tx = await txBuilder.build();
       tx.inputs.length.should.equal(6);
       tx.inputs[0].should.deepEqual({
@@ -568,6 +579,7 @@ describe('Sol Transfer Builder V2', () => {
       txBuilder.send({ address: account1.pub, amount, tokenName: nameUSDC });
       txBuilder.send({ address: account2.pub, amount, tokenName: nameSRM });
       txBuilder.send({ address: account3.pub, amount, tokenName: nameRAY });
+      txBuilder.setPriorityFee(priorityFee);
       const tx = await txBuilder.build();
       tx.inputs.length.should.equal(4);
       tx.inputs[0].should.deepEqual({
@@ -658,6 +670,7 @@ describe('Sol Transfer Builder V2', () => {
       txBuilder.sender(authAccount.pub);
       txBuilder.send({ address: otherAccount.pub, amount });
       txBuilder.send({ address: otherAccount.pub, amount, tokenName: nameUSDC });
+      txBuilder.setPriorityFee(priorityFee);
       const tx = await txBuilder.build();
       tx.inputs.length.should.equal(2);
       tx.inputs[0].should.deepEqual({
@@ -694,6 +707,7 @@ describe('Sol Transfer Builder V2', () => {
       txBuilder.send({ address: otherAccount.pub, amount, tokenName: nameUSDC });
       txBuilder.send({ address: otherAccount.pub, amount, tokenName: nameUSDC });
       txBuilder.send({ address: otherAccount.pub, amount, tokenName: nameUSDC });
+      txBuilder.setPriorityFee(priorityFee);
       const tx = await txBuilder.build();
       tx.inputs.length.should.equal(4);
       tx.inputs[0].should.deepEqual({


### PR DESCRIPTION
Ticket: CR-1224

Allowing WP to set the prio fees for token transactions (this can be extended for other types as well since this implementation lives in the transaction builder and therefore other txn type builders in WP can also set this value if needed along with corresponding change in the SDK builder to add the necessary instruction)
