### PR TITLE
BTC 1786.fix tr change outputs

### DIFF
--- a/modules/abstract-utxo/test/core/descriptor/psbt/findDescriptors.ts
+++ b/modules/abstract-utxo/test/core/descriptor/psbt/findDescriptors.ts
@@ -5,10 +5,10 @@ import { findDescriptorForInput, findDescriptorForOutput } from '../../../../src
 
 import { mockPsbt } from './mock.utils';
 
-function describeWithTemplates(tA: DescriptorTemplate, tB: DescriptorTemplate) {
-  describe(`parsePsbt [${tA},${tB}]`, function () {
-    const descriptorA = getDescriptor(tA, getDefaultXPubs('a'));
-    const descriptorB = getDescriptor(tB, getDefaultXPubs('b'));
+function describeWithTemplates(templateSelf: DescriptorTemplate, templateOther: DescriptorTemplate) {
+  describe(`parsePsbt [${templateSelf},${templateOther}]`, function () {
+    const descriptorA = getDescriptor(templateSelf, getDefaultXPubs('a'));
+    const descriptorB = getDescriptor(templateOther, getDefaultXPubs('b'));
     const descriptorMap = new Map([
       ['a', descriptorA],
       ['b', descriptorB],
@@ -41,3 +41,4 @@ function describeWithTemplates(tA: DescriptorTemplate, tB: DescriptorTemplate) {
 
 describeWithTemplates('Wsh2Of3', 'Wsh2Of3');
 describeWithTemplates('Wsh2Of3', 'Tr2Of3-NoKeyPath');
+describeWithTemplates('Tr2Of3-NoKeyPath', 'Tr2Of3-NoKeyPath');


### PR DESCRIPTION
- **feat(abstract-utxo): extend Tr2Of3 test for findDescriptors**
  The previous test was incomplete as we used Tr2Of3 only for the external output
  
  Issue: BTC-1786
  

- **fix(abstract-utxo): fix findDescriptorForOutput for taproot outputs**
  Issue: BTC-1786
  