### PR TITLE
fix(sdk-coin-sol): set priority fee in initBuilder

### DIFF
--- a/modules/sdk-coin-sol/src/lib/transactionBuilder.ts
+++ b/modules/sdk-coin-sol/src/lib/transactionBuilder.ts
@@ -76,6 +76,10 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
     this.feePayer(txData.feePayer as string);
     this.nonce(txData.nonce, txData.durableNonce);
     this._instructionsData = instructionParamsFactory(tx.type, tx.solTransaction.instructions);
+    // Parse priority fee instruction data
+    const filteredPriorityFeeInstructionsData = txData.instructionsData.filter(
+      (data) => data.type === InstructionBuilderTypes.SetPriorityFee
+    );
 
     for (const instruction of this._instructionsData) {
       if (instruction.type === InstructionBuilderTypes.Memo) {
@@ -86,6 +90,12 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
       if (instruction.type === InstructionBuilderTypes.NonceAdvance) {
         const advanceNonceInstruction: Nonce = instruction;
         this.nonce(txData.nonce, advanceNonceInstruction.params);
+      }
+
+      // If prio fee instruction exists, set the priority fee variable
+      if (instruction.type === InstructionBuilderTypes.SetPriorityFee) {
+        const priorityFeeInstructionsData = filteredPriorityFeeInstructionsData[0];
+        this.setPriorityFee({ amount: Number(priorityFeeInstructionsData.params.fee) });
       }
     }
   }

--- a/modules/sdk-coin-sol/test/unit/transactionBuilder/transactionBuilder.ts
+++ b/modules/sdk-coin-sol/test/unit/transactionBuilder/transactionBuilder.ts
@@ -3,7 +3,7 @@ import * as bs58 from 'bs58';
 
 import { getBuilderFactory } from '../getBuilderFactory';
 import { KeyPair, TokenTransferBuilder } from '../../../src';
-import { Eddsa, FeeOptions, TransactionType } from '@bitgo/sdk-core';
+import { Eddsa, TransactionType } from '@bitgo/sdk-core';
 import * as testData from '../../resources/sol';
 import BigNumber from 'bignumber.js';
 import { Ed25519Bip32HdTree } from '@bitgo/sdk-lib-mpc';
@@ -164,10 +164,9 @@ describe('Sol Transaction Builder', async () => {
       testData.TOKEN_TRANSFER_SIGNED_TX_WITH_MEMO_AND_DURABLE_NONCE
     ) as TokenTransferBuilder;
     const prioFeeMicroLamports = '10000000';
-    const priorityFee: FeeOptions = {
-      amount: prioFeeMicroLamports,
-    };
-    txBuilder.setPriorityFee(priorityFee);
+    // We don't have to manually set the priority fee here as the raw txn already has the priority fee instruction;
+    // therefore once initBuilder is called (it's called within fromImplementation), it will set the txBuilder's priorityFee field
+    // which will then be used in txBuilder.build() by tokenTransferBuilder to add the set compute fee instruction
     const builtTx = await txBuilder.build();
     should.equal(builtTx.type, TransactionType.Send);
     should.equal(


### PR DESCRIPTION
Ticket: COIN-2932

We currently only set the priority fee from the tokenTransfer and the consolidation builder. But in WP, we also create the builder using the raw transaction object, which requires some necessary fields to be set again. Due to this, the priority fee variable was not set, so the tokenTransfer/consolidation builder (in SDK) did not attach any set priority fee instruction even though WP was setting the priority fee. This PR amends this flow to set the priority fee variable even while creating the builder through the raw txn data