### PR TITLE
chore(statics): use contractAddress to form issuerAddress and currenc…

### DIFF
--- a/modules/sdk-coin-xrp/src/xrpToken.ts
+++ b/modules/sdk-coin-xrp/src/xrpToken.ts
@@ -44,6 +44,10 @@ export class XrpToken extends Xrp {
     return this.tokenConfig.currencyCode;
   }
 
+  get contractAddress(): string {
+    return this.tokenConfig.contractAddress;
+  }
+
   get domain(): string {
     return this.tokenConfig.domain || '';
   }

--- a/modules/sdk-coin-xrp/test/unit/xrpToken.ts
+++ b/modules/sdk-coin-xrp/test/unit/xrpToken.ts
@@ -28,5 +28,10 @@ describe('Xrp Tokens', function () {
     xrpTokenCoin.coin.should.equal('txrp');
     xrpTokenCoin.network.should.equal('Testnet');
     xrpTokenCoin.decimalPlaces.should.equal(15);
+    xrpTokenCoin.contractAddress.should.equal(
+      'rQhWct2fv4Vc4KRjRgMrxa8xPN9Zx9iLKV::524C555344000000000000000000000000000000'
+    );
+    xrpTokenCoin.issuerAddress.should.equal('rQhWct2fv4Vc4KRjRgMrxa8xPN9Zx9iLKV');
+    xrpTokenCoin.currencyCode.should.equal('524C555344000000000000000000000000000000');
   });
 });

--- a/modules/statics/src/account.ts
+++ b/modules/statics/src/account.ts
@@ -451,8 +451,8 @@ export class XrpCoin extends AccountCoinToken {
     }
 
     this.domain = options.domain as string;
-    this.currencyCode = options.currencyCode;
-    this.issuerAddress = options.issuerAddress;
+    this.issuerAddress = options.contractAddress.split('::')[0];
+    this.currencyCode = options.contractAddress.split('::')[1];
     this.contractAddress = options.contractAddress;
   }
 }

--- a/modules/statics/src/tokenConfig.ts
+++ b/modules/statics/src/tokenConfig.ts
@@ -73,6 +73,7 @@ export type XrpTokenConfig = BaseNetworkConfig & {
   issuerAddress: string;
   currencyCode: string;
   domain?: string;
+  contractAddress: string;
 };
 
 export type SuiTokenConfig = BaseNetworkConfig & {
@@ -495,6 +496,7 @@ const formattedXrpTokens = coins.reduce((acc: XrpTokenConfig[], coin) => {
       issuerAddress: coin.issuerAddress,
       currencyCode: coin.currencyCode,
       domain: coin.domain,
+      contractAddress: coin.contractAddress,
     });
   }
   return acc;

--- a/modules/statics/test/unit/coins.ts
+++ b/modules/statics/test/unit/coins.ts
@@ -787,6 +787,17 @@ describe('Token contract address field defaults', () => {
         });
     });
   });
+  it('have issuerAddress and currencyCode formed from contractAddress', () => {
+    coins
+      .filter((coin) => coin.family === CoinFamily.XRP && coin instanceof XrpCoin)
+      .forEach((coin) => {
+        const xrpToken = coin as XrpCoin;
+        xrpToken.contractAddress.split('::')[0].should.not.be.empty();
+        xrpToken.contractAddress.split('::')[1].should.not.be.empty();
+        xrpToken.issuerAddress.should.eql(xrpToken.contractAddress.split('::')[0]);
+        xrpToken.currencyCode.should.eql(xrpToken.contractAddress.split('::')[1]);
+      });
+  });
 });
 
 describe('Cold Wallet Features', () => {


### PR DESCRIPTION
## Description

We want to generate `issuerAddress` and `currencyCode` from existing param `contractAddress`. `contractAddress` is formed using `issuerAddress::currencyCode`.  Eventually, we will be removing `issuerAddress` and `currencyCode` being passed from SDK statics.

## Issue Number

WIN-4541

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

We're simply changing how a variable gets its value. There's no new variable being created, hence if existing test cases are passing, we are good to go.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [x] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
