### PR TITLE
feat(utxo-core): add bitcoin descriptor formatting and validation

### DIFF
--- a/modules/utxo-core/.eslintrc.js
+++ b/modules/utxo-core/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  extends: ['../../.eslintrc.json'],
+  rules: {
+    // 'import/order': ['error', { 'newlines-between': 'always' }],
+    // 'import/no-internal-modules': 'off',
+    '@typescript-eslint/ban-types': 'off',
+  },
+};

--- a/modules/utxo-core/package.json
+++ b/modules/utxo-core/package.json
@@ -27,7 +27,7 @@
     "lint": "eslint --quiet .",
     "prepare": "npm run build",
     "test": "npm run unit-test",
-    "unit-test": "mocha --recursive test/"
+    "unit-test": "mocha --recursive test/ && tstyche"
   },
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
@@ -56,5 +56,8 @@
     "@bitgo/wasm-miniscript": "^2.0.0-beta.2",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4"
   },
-  "gitHead": "18e460ddf02de2dbf13c2aa243478188fb539f0c"
+  "gitHead": "18e460ddf02de2dbf13c2aa243478188fb539f0c",
+  "devDependencies": {
+    "tstyche": "^3.5.0"
+  }
 }

--- a/modules/utxo-core/src/descriptor/formatNode.ts
+++ b/modules/utxo-core/src/descriptor/formatNode.ts
@@ -1,0 +1,94 @@
+/*
+
+This file contains type definitions for building an Abstract Syntax Tree for
+Bitcoin Descriptors and Miniscript expressions.
+
+Currently, the types do not encode any validity or soundness checks, so it is
+possible to construct invalid descriptors.
+
+*/
+type Key = string;
+
+// https://bitcoin.sipa.be/miniscript/
+// r is for custom bitgo extension OP_DROP
+type Identities = 'a' | 's' | 'c' | 't' | 'd' | 'v' | 'j' | 'n' | 'l' | 'u' | 'r';
+
+// Union of all possible prefixes: { f: T } => { 'a:f': T } | { 's:f': T } | ...
+type PrefixWith<T, P extends string> = {
+  [K in keyof T & string as `${P}:${K}`]: T[K];
+};
+type PrefixIdUnion<T> = { [P in Identities]: PrefixWith<T, P> }[Identities];
+
+// Wrap a type with a union of all possible prefixes
+type Wrap<T> = T | PrefixIdUnion<T>;
+
+type Miniscript =
+  | Wrap<{ pk: Key }>
+  | Wrap<{ pkh: Key }>
+  | Wrap<{ wpkh: Key }>
+  | Wrap<{ multi: [number, ...Key[]] }>
+  | Wrap<{ sortedmulti: [number, ...Key[]] }>
+  | Wrap<{ multi_a: [number, ...Key[]] }>
+  | Wrap<{ sortedmulti_a: [number, ...Key[]] }>
+  | Wrap<{ tr: Key | [Key, Miniscript] }>
+  | Wrap<{ sh: Miniscript }>
+  | Wrap<{ wsh: Miniscript }>
+  | Wrap<{ and_v: [Miniscript, Miniscript] }>
+  | Wrap<{ and_b: [Miniscript, Miniscript] }>
+  | Wrap<{ andor: [Miniscript, Miniscript, Miniscript] }>
+  | Wrap<{ or_b: [Miniscript, Miniscript] }>
+  | Wrap<{ or_c: [Miniscript, Miniscript] }>
+  | Wrap<{ or_d: [Miniscript, Miniscript] }>
+  | Wrap<{ or_i: [Miniscript, Miniscript] }>
+  | Wrap<{ thresh: [number, ...Miniscript[]] }>
+  | Wrap<{ sha256: string }>
+  | Wrap<{ ripemd160: string }>
+  | Wrap<{ hash256: string }>
+  | Wrap<{ hash160: string }>
+  | Wrap<{ older: number }>
+  | Wrap<{ after: number }>;
+
+// Top level descriptor expressions
+// https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md#reference
+type Descriptor =
+  | { sh: Miniscript | { wsh: Miniscript } }
+  | { wsh: Miniscript }
+  | { pk: Key }
+  | { pkh: Key }
+  | { wpkh: Key }
+  | { combo: Key }
+  | { tr: [Key, Miniscript] }
+  | { addr: string }
+  | { raw: string }
+  | { rawtr: string };
+
+type Node = Miniscript | Descriptor | number | string;
+
+function formatN(n: Node | Node[]): string {
+  if (typeof n === 'string') {
+    return n;
+  }
+  if (typeof n === 'number') {
+    return String(n);
+  }
+  if (Array.isArray(n)) {
+    return n.map(formatN).join(',');
+  }
+  if (n && typeof n === 'object') {
+    const entries = Object.entries(n);
+    if (entries.length !== 1) {
+      throw new Error(`Invalid node: ${n}`);
+    }
+    const [name, value] = entries[0];
+    return `${name}(${formatN(value)})`;
+  }
+  throw new Error(`Invalid node: ${n}`);
+}
+
+export type MiniscriptNode = Miniscript;
+export type DescriptorNode = Descriptor;
+
+/** Format a Miniscript or Descriptor node as a descriptor string (without checksum) */
+export function formatNode(n: MiniscriptNode | DescriptorNode): string {
+  return formatN(n);
+}

--- a/modules/utxo-core/src/descriptor/index.ts
+++ b/modules/utxo-core/src/descriptor/index.ts
@@ -7,3 +7,4 @@ export { createAddressFromDescriptor, createScriptPubKeyFromDescriptor } from '.
 export { createPsbt, finalizePsbt, parse } from './psbt';
 export { toDescriptorMap } from './DescriptorMap';
 export { toDerivedDescriptorWalletOutput } from './Output';
+export * from './formatNode';

--- a/modules/utxo-core/test/descriptor/formatNode.ts
+++ b/modules/utxo-core/test/descriptor/formatNode.ts
@@ -1,0 +1,11 @@
+import assert from 'assert';
+
+import { formatNode } from '../../src/descriptor';
+
+describe('formatNode', function () {
+  it('formats simple nodes', function () {
+    assert.strictEqual(formatNode({ pk: 'lol' }), 'pk(lol)');
+    assert.strictEqual(formatNode({ after: 1 }), 'after(1)');
+    assert.strictEqual(formatNode({ and_v: [{ after: 1 }, { after: 1 }] }), 'and_v(after(1),after(1))');
+  });
+});

--- a/modules/utxo-core/test/descriptor/psbt/createPsbt.ts
+++ b/modules/utxo-core/test/descriptor/psbt/createPsbt.ts
@@ -3,11 +3,10 @@ import * as assert from 'assert';
 import * as utxolib from '@bitgo/utxo-lib';
 import { BIP32Interface } from '@bitgo/utxo-lib';
 
-import { DescriptorTemplate, getPsbtParams } from '../../../src/testutil/descriptor/descriptors';
+import { DescriptorTemplate, getDescriptor, getPsbtParams } from '../../../src/testutil/descriptor/descriptors';
 import { getFixture } from '../../../src/testutil/fixtures.utils';
 import { finalizePsbt } from '../../../src/descriptor';
 import { getKeyTriple } from '../../../src/testutil/key.utils';
-
 import { mockPsbtDefaultWithDescriptorTemplate } from '../../../src/testutil/descriptor/mock.utils';
 import { toPlainObjectFromPsbt, toPlainObjectFromTx } from '../../../src/testutil/descriptor/psbt.utils';
 
@@ -28,7 +27,7 @@ async function assertEqualsFixture(t: DescriptorTemplate, filename: string, valu
     return assert.deepStrictEqual(toPlainObjectFromTx(value), await getFixture(filename, toPlainObjectFromTx(value)));
   }
 
-  throw new Error(`unknown value type: ${typeof value}`);
+  assert.deepStrictEqual(value, await getFixture(filename, value));
 }
 
 function describeCreatePsbt(t: DescriptorTemplate) {
@@ -42,6 +41,16 @@ function describeCreatePsbt(t: DescriptorTemplate) {
       }
       return cloned;
     }
+
+    it('creates expected descriptors', async function () {
+      const descriptor0 = getDescriptor(t).atDerivationIndex(0);
+      await assertEqualsFixture(t, 'descriptors.json', {
+        index: 0,
+        descriptor: descriptor0.toString(),
+        scriptPubkey: Buffer.from(descriptor0.scriptPubkey()).toString('hex'),
+        node: descriptor0.node(),
+      });
+    });
 
     it('creates psbt with expected properties', async function () {
       const psbt = mockPsbtDefaultWithDescriptorTemplate(t, getPsbtParams(t));

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/ShWsh2Of3CltvDrop.descriptors.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/ShWsh2Of3CltvDrop.descriptors.json
@@ -1,0 +1,36 @@
+{
+  "index": 0,
+  "descriptor": "sh(wsh(and_v(r:after(1),multi(2,xpub661MyMwAqRbcFXS2qwsTkaFc7PEpwDXWgY1Hx2MS7XywhW24sTjQzxiUgnGNW5v6DsW9Z8JcAqf8a22v21jDSA3DwLbbpt2ra3WbP83QNvP/0/0,xpub661MyMwAqRbcGfiaWcoeKLerFu3qRfy6zSYAwnmxSKW8JSauRajFsAsRHs2pV4q5rxkb4ynx4Bm8t54McTCp8V27s7XsdpD8T4s56etpjro/0/0,xpub661MyMwAqRbcH4HzWiCwmYajy1SXZngxHvpYDNEX4xjrDAneAm6rnpPuPPXcBRsSgxupDBmH2tzPHkikNrnLbsvTHemPFHSFbZxonZcCwFi/0/0))))#rlztmw3g",
+  "scriptPubkey": "a91431c0e962f3928e8fc682c9c2b91a7b3d350bbe9187",
+  "node": {
+    "Sh": {
+      "Wsh": {
+        "Ms": {
+          "AndV": [
+            {
+              "Drop": {
+                "After": {
+                  "absLockTime": 1
+                }
+              }
+            },
+            {
+              "Multi": [
+                2,
+                {
+                  "XPub": "xpub661MyMwAqRbcFXS2qwsTkaFc7PEpwDXWgY1Hx2MS7XywhW24sTjQzxiUgnGNW5v6DsW9Z8JcAqf8a22v21jDSA3DwLbbpt2ra3WbP83QNvP/0/0"
+                },
+                {
+                  "XPub": "xpub661MyMwAqRbcGfiaWcoeKLerFu3qRfy6zSYAwnmxSKW8JSauRajFsAsRHs2pV4q5rxkb4ynx4Bm8t54McTCp8V27s7XsdpD8T4s56etpjro/0/0"
+                },
+                {
+                  "XPub": "xpub661MyMwAqRbcH4HzWiCwmYajy1SXZngxHvpYDNEX4xjrDAneAm6rnpPuPPXcBRsSgxupDBmH2tzPHkikNrnLbsvTHemPFHSFbZxonZcCwFi/0/0"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Tr2Of3-NoKeyPath.descriptors.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Tr2Of3-NoKeyPath.descriptors.json
@@ -1,0 +1,26 @@
+{
+  "index": 0,
+  "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,multi_a(2,xpub661MyMwAqRbcFXS2qwsTkaFc7PEpwDXWgY1Hx2MS7XywhW24sTjQzxiUgnGNW5v6DsW9Z8JcAqf8a22v21jDSA3DwLbbpt2ra3WbP83QNvP/0/0,xpub661MyMwAqRbcGfiaWcoeKLerFu3qRfy6zSYAwnmxSKW8JSauRajFsAsRHs2pV4q5rxkb4ynx4Bm8t54McTCp8V27s7XsdpD8T4s56etpjro/0/0,xpub661MyMwAqRbcH4HzWiCwmYajy1SXZngxHvpYDNEX4xjrDAneAm6rnpPuPPXcBRsSgxupDBmH2tzPHkikNrnLbsvTHemPFHSFbZxonZcCwFi/0/0))#82q34xv2",
+  "scriptPubkey": "51207e8c409f0ab01197f9676efc3a9505f1f09ed0f21693e46a3aa3b6b54d437aa2",
+  "node": {
+    "Tr": {
+      "internalKey": {
+        "Single": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
+      },
+      "tree": {
+        "MultiA": [
+          2,
+          {
+            "XPub": "xpub661MyMwAqRbcFXS2qwsTkaFc7PEpwDXWgY1Hx2MS7XywhW24sTjQzxiUgnGNW5v6DsW9Z8JcAqf8a22v21jDSA3DwLbbpt2ra3WbP83QNvP/0/0"
+          },
+          {
+            "XPub": "xpub661MyMwAqRbcGfiaWcoeKLerFu3qRfy6zSYAwnmxSKW8JSauRajFsAsRHs2pV4q5rxkb4ynx4Bm8t54McTCp8V27s7XsdpD8T4s56etpjro/0/0"
+          },
+          {
+            "XPub": "xpub661MyMwAqRbcH4HzWiCwmYajy1SXZngxHvpYDNEX4xjrDAneAm6rnpPuPPXcBRsSgxupDBmH2tzPHkikNrnLbsvTHemPFHSFbZxonZcCwFi/0/0"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Wsh2Of3.descriptors.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Wsh2Of3.descriptors.json
@@ -1,0 +1,23 @@
+{
+  "index": 0,
+  "descriptor": "wsh(multi(2,xpub661MyMwAqRbcFXS2qwsTkaFc7PEpwDXWgY1Hx2MS7XywhW24sTjQzxiUgnGNW5v6DsW9Z8JcAqf8a22v21jDSA3DwLbbpt2ra3WbP83QNvP/0/0,xpub661MyMwAqRbcGfiaWcoeKLerFu3qRfy6zSYAwnmxSKW8JSauRajFsAsRHs2pV4q5rxkb4ynx4Bm8t54McTCp8V27s7XsdpD8T4s56etpjro/0/0,xpub661MyMwAqRbcH4HzWiCwmYajy1SXZngxHvpYDNEX4xjrDAneAm6rnpPuPPXcBRsSgxupDBmH2tzPHkikNrnLbsvTHemPFHSFbZxonZcCwFi/0/0))#ctqx3wks",
+  "scriptPubkey": "0020e958ec29c98ca10323ac1d9948ee37cfd5087886c2dc6a4131a30d5b252973ac",
+  "node": {
+    "Wsh": {
+      "Ms": {
+        "Multi": [
+          2,
+          {
+            "XPub": "xpub661MyMwAqRbcFXS2qwsTkaFc7PEpwDXWgY1Hx2MS7XywhW24sTjQzxiUgnGNW5v6DsW9Z8JcAqf8a22v21jDSA3DwLbbpt2ra3WbP83QNvP/0/0"
+          },
+          {
+            "XPub": "xpub661MyMwAqRbcGfiaWcoeKLerFu3qRfy6zSYAwnmxSKW8JSauRajFsAsRHs2pV4q5rxkb4ynx4Bm8t54McTCp8V27s7XsdpD8T4s56etpjro/0/0"
+          },
+          {
+            "XPub": "xpub661MyMwAqRbcH4HzWiCwmYajy1SXZngxHvpYDNEX4xjrDAneAm6rnpPuPPXcBRsSgxupDBmH2tzPHkikNrnLbsvTHemPFHSFbZxonZcCwFi/0/0"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/modules/utxo-core/typetests/formatNode.test.ts
+++ b/modules/utxo-core/typetests/formatNode.test.ts
@@ -1,0 +1,9 @@
+import { expect } from 'tstyche';
+
+import { MiniscriptNode } from '../src/descriptor';
+
+{
+  expect({ pk: 1 }).type.not.toBeAssignableTo<MiniscriptNode>();
+  expect({ pk: 'lol' }).type.toBeAssignableTo<MiniscriptNode>();
+  expect({ 'a:pk': 'lol' }).type.toBeAssignableTo<MiniscriptNode>();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -19311,6 +19311,11 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
+tstyche@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.npmjs.org/tstyche/-/tstyche-3.5.0.tgz#2cf1797c9664c544e6ebe8c2fada772680460755"
+  integrity sha512-N4SUp/ZWaMGEcglpVFIzKez0GQEiBdfFDgcnqwv9O1mePZgos8N1cZCzNgGtPGo/w0ym04MjJcDnsw1sorEzgA==
+
 tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz"
@@ -20042,11 +20047,11 @@ web3-core@1.3.6:
     web3-utils "1.3.6"
 
 web3-errors@^1.1.4, web3-errors@^1.2.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/web3-errors/-/web3-errors-1.3.0.tgz"
-  integrity sha512-j5JkAKCtuVMbY3F5PYXBqg1vWrtF4jcyyMY1rlw8a4PV67AkqlepjGgpzWJZd56Mt+TvHy6DA1F/3Id8LatDSQ==
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/web3-errors/-/web3-errors-1.3.1.tgz#163bc4d869f98614760b683d733c3ed1fb415d98"
+  integrity sha512-w3NMJujH+ZSW4ltIZZKtdbkbyQEvBzyp3JRn59Ckli0Nz4VMsVq8aF1bLWM7A2kuQ+yVEm3ySeNU+7mSRwx7RQ==
   dependencies:
-    web3-types "^1.7.0"
+    web3-types "^1.10.0"
 
 web3-eth-abi@1.3.6:
   version "1.3.6"
@@ -20189,10 +20194,10 @@ web3-shh@1.3.6:
     web3-core-subscriptions "1.3.6"
     web3-net "1.3.6"
 
-web3-types@^1.5.0, web3-types@^1.6.0, web3-types@^1.7.0:
-  version "1.9.0"
-  resolved "https://registry.npmjs.org/web3-types/-/web3-types-1.9.0.tgz"
-  integrity sha512-I520KBPoXqEaM/ybj6xHD1E3gRb8/WdudLQaRBvJNQSSfHuPW9P2sD59mbhm6dsKtnje+T90dIxSyzVVFlEdlg==
+web3-types@^1.10.0, web3-types@^1.5.0, web3-types@^1.6.0:
+  version "1.10.0"
+  resolved "https://registry.npmjs.org/web3-types/-/web3-types-1.10.0.tgz#41b0b4d2dd75e919d5b6f37bf139e29f445db04e"
+  integrity sha512-0IXoaAFtFc8Yin7cCdQfB9ZmjafrbP6BO0f0KT/khMhXKUpoJ6yShrVhiNpyRBo8QQjuOagsWzwSK2H49I7sbw==
 
 web3-utils@1.3.6, web3-utils@4.2.1:
   version "4.2.1"
@@ -20207,7 +20212,7 @@ web3-utils@1.3.6, web3-utils@4.2.1:
 
 web3-validator@^2.0.4:
   version "2.0.6"
-  resolved "https://registry.npmjs.org/web3-validator/-/web3-validator-2.0.6.tgz"
+  resolved "https://registry.npmjs.org/web3-validator/-/web3-validator-2.0.6.tgz#a0cdaa39e1d1708ece5fae155b034e29d6a19248"
   integrity sha512-qn9id0/l1bWmvH4XfnG/JtGKKwut2Vokl6YXP5Kfg424npysmtRLe9DgiNBM9Op7QL/aSiaA0TVXibuIuWcizg==
   dependencies:
     ethereum-cryptography "^2.0.0"
@@ -20906,6 +20911,6 @@ yocto-queue@^1.0.0:
   integrity sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==
 
 zod@^3.21.4:
-  version "3.23.8"
-  resolved "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz"
-  integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==
+  version "3.24.2"
+  resolved "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz#8efa74126287c675e92f46871cfc8d15c34372b3"
+  integrity sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==


### PR DESCRIPTION

Add node formatting and type checking for bitcoin descriptors. Include test
fixtures for multiple wallet types.

Closes BTC-1829