### PR TITLE
chore(sdk-coin-hbar): use contractAddress to form tokenId

### DIFF
--- a/modules/sdk-coin-hbar/src/hbarToken.ts
+++ b/modules/sdk-coin-hbar/src/hbarToken.ts
@@ -40,6 +40,18 @@ export class HbarToken extends Hbar {
     return this.tokenConfig.decimalPlaces;
   }
 
+  get nodeAccountId(): string {
+    return this.tokenConfig.nodeAccountId;
+  }
+
+  get tokenId(): string {
+    return this.tokenConfig.tokenId;
+  }
+
+  get contractAddress(): string {
+    return this.tokenConfig.contractAddress;
+  }
+
   getChain(): string {
     return this.tokenConfig.type;
   }

--- a/modules/sdk-coin-hbar/test/unit/hbarToken.ts
+++ b/modules/sdk-coin-hbar/test/unit/hbarToken.ts
@@ -26,5 +26,9 @@ describe('Hedera Hashgraph Token', function () {
     token.coin.should.equal('thbar');
     token.network.should.equal('Testnet');
     token.decimalPlaces.should.equal(6);
+    token.nodeAccountId.should.equal('0.0.3');
+    token.tokenId.should.equal('0.0.13078');
+    token.contractAddress.should.equal('0.0.13078');
+    token.tokenId.should.equal(token.contractAddress);
   });
 });

--- a/modules/statics/src/account.ts
+++ b/modules/statics/src/account.ts
@@ -284,7 +284,7 @@ export class HederaToken extends AccountCoinToken {
     });
 
     this.nodeAccountId = options.nodeAccountId;
-    this.tokenId = options.tokenId;
+    this.tokenId = options.contractAddress;
     this.contractAddress = options.contractAddress;
   }
 }

--- a/modules/statics/src/tokenConfig.ts
+++ b/modules/statics/src/tokenConfig.ts
@@ -455,6 +455,9 @@ const formattedHbarTokens = coins.reduce((acc: HbarTokenConfig[], coin) => {
       network: coin.network.type === NetworkType.MAINNET ? 'Mainnet' : 'Testnet',
       name: coin.fullName,
       decimalPlaces: coin.decimalPlaces,
+      nodeAccountId: coin.nodeAccountId,
+      tokenId: coin.tokenId,
+      contractAddress: coin.contractAddress,
     });
   }
   return acc;

--- a/modules/statics/src/tokenConfig.ts
+++ b/modules/statics/src/tokenConfig.ts
@@ -67,7 +67,11 @@ export type OfcTokenConfig = BaseTokenConfig & {
   isFiat: boolean;
 };
 
-export type HbarTokenConfig = BaseNetworkConfig;
+export type HbarTokenConfig = BaseNetworkConfig & {
+  nodeAccountId: string;
+  tokenId: string;
+  contractAddress: string;
+};
 
 export type XrpTokenConfig = BaseNetworkConfig & {
   issuerAddress: string;


### PR DESCRIPTION
## Description

We want to use `contractAddress` field to populate `tokenId`, and eventually we will only use the `contractAddress` being passed from statics and then finally Asset Metadata Service.

## Issue Number

WIN-4533

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Test Cases added.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [x] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
