### PR TITLE
chore(sdk-coin-eos): use contractAddress to form contractName

### DIFF
--- a/modules/sdk-coin-eos/src/eosToken.ts
+++ b/modules/sdk-coin-eos/src/eosToken.ts
@@ -52,6 +52,14 @@ export class EosToken extends Eos {
     return this.tokenConfig.decimalPlaces;
   }
 
+  get contractName() {
+    return this.tokenConfig.contractName;
+  }
+
+  get contractAddress() {
+    return this.tokenConfig.contractAddress;
+  }
+
   getChain() {
     return this.tokenConfig.type;
   }

--- a/modules/sdk-coin-eos/test/unit/eosToken.ts
+++ b/modules/sdk-coin-eos/test/unit/eosToken.ts
@@ -33,6 +33,10 @@ describe('EOS Token:', function () {
     eosTokenCoin.coin.should.equal('teos');
     eosTokenCoin.decimalPlaces.should.equal(8);
     eosTokenCoin.tokenContractAddress.should.equal('testtoken113');
+    eosTokenCoin.contractName.should.equal('testtoken113');
+    eosTokenCoin.contractAddress.should.equal('testtoken113');
+    eosTokenCoin.tokenContractAddress.should.equal(eosTokenCoin.contractName);
+    eosTokenCoin.tokenContractAddress.should.equal(eosTokenCoin.contractAddress);
   });
 
   describe('verify transaction', function () {

--- a/modules/statics/src/account.ts
+++ b/modules/statics/src/account.ts
@@ -328,7 +328,7 @@ export class EosCoin extends AccountCoinToken {
       ...options,
     });
 
-    this.contractName = options.contractName;
+    this.contractName = options.contractAddress;
     this.contractAddress = options.contractAddress;
   }
 }

--- a/modules/statics/src/tokenConfig.ts
+++ b/modules/statics/src/tokenConfig.ts
@@ -44,7 +44,10 @@ export interface BaseContractAddressConfig extends BaseNetworkConfig {
 export type AvaxcTokenConfig = BaseContractAddressConfig;
 export type CeloTokenConfig = BaseContractAddressConfig;
 export type EthLikeTokenConfig = BaseContractAddressConfig;
-export type EosTokenConfig = BaseContractAddressConfig;
+export type EosTokenConfig = BaseContractAddressConfig & {
+  contractName: string;
+  contractAddress: string;
+};
 export type Erc20TokenConfig = BaseContractAddressConfig;
 export type TrxTokenConfig = BaseContractAddressConfig;
 export type StellarTokenConfig = BaseNetworkConfig;
@@ -328,6 +331,8 @@ const formattedEosTokens = coins.reduce((acc: EosTokenConfig[], coin) => {
       name: coin.fullName,
       tokenContractAddress: coin.contractName.toString().toLowerCase(),
       decimalPlaces: coin.decimalPlaces,
+      contractName: coin.contractName,
+      contractAddress: coin.contractAddress,
     });
   }
   return acc;


### PR DESCRIPTION
## Description

We want to use `contractAddress` to form the `contractName` for EOS.

## Issue Number

WIN-4530

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Test case added.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [x] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes