### PR TITLE
feat(utxo-staking): add fixtures for babylon scripts

### DIFF
--- a/modules/utxo-core/src/testutil/fixtures.utils.ts
+++ b/modules/utxo-core/src/testutil/fixtures.utils.ts
@@ -5,7 +5,7 @@
 import * as fs from 'fs';
 import * as mpath from 'path';
 
-type FixtureEncoding = 'json' | 'hex';
+type FixtureEncoding = 'json' | 'hex' | 'txt';
 
 function isNodeJsError(e: unknown): e is NodeJS.ErrnoException {
   return e instanceof Error && typeof (e as NodeJS.ErrnoException).code === 'string';
@@ -18,6 +18,9 @@ function fixtureEncoding(path: string): FixtureEncoding {
   if (path.endsWith('.hex')) {
     return 'hex';
   }
+  if (path.endsWith('.txt')) {
+    return 'txt';
+  }
   throw new Error(`unknown fixture encoding for ${path}`);
 }
 
@@ -27,6 +30,8 @@ function decodeFixture(raw: string, encoding: FixtureEncoding): unknown {
       return JSON.parse(raw);
     case 'hex':
       return Buffer.from(raw, 'hex');
+    case 'txt':
+      return raw;
   }
 }
 
@@ -39,6 +44,11 @@ function encodeFixture(value: unknown, encoding: FixtureEncoding): string {
         throw new Error(`expected Buffer, got ${typeof value}`);
       }
       return value.toString('hex');
+    case 'txt':
+      if (typeof value !== 'string') {
+        throw new Error(`expected string, got ${typeof value}`);
+      }
+      return value;
   }
 }
 

--- a/modules/utxo-staking/.eslintignore
+++ b/modules/utxo-staking/.eslintignore
@@ -2,4 +2,5 @@ node_modules
 .idea
 public
 dist
+test/unit/babylon/vendor
 

--- a/modules/utxo-staking/.eslintrc.js
+++ b/modules/utxo-staking/.eslintrc.js
@@ -1,8 +1,7 @@
 module.exports = {
   extends: ['../../.eslintrc.json'],
   rules: {
-    // FIXME: enable
-    // 'import/order': ['error', { 'newlines-between': 'always' }],
+    'import/order': ['error', { 'newlines-between': 'always' }],
     'import/no-internal-modules': 'off',
   },
 };

--- a/modules/utxo-staking/.eslintrc.js
+++ b/modules/utxo-staking/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  extends: ['../../.eslintrc.json'],
+  rules: {
+    // FIXME: enable
+    // 'import/order': ['error', { 'newlines-between': 'always' }],
+    'import/no-internal-modules': 'off',
+  },
+};

--- a/modules/utxo-staking/.mocharc.js
+++ b/modules/utxo-staking/.mocharc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  require: 'ts-node/register',
+  extension: ['.js', '.ts'],
+};

--- a/modules/utxo-staking/.mocharc.yml
+++ b/modules/utxo-staking/.mocharc.yml
@@ -1,8 +1,0 @@
-require: 'ts-node/register'
-timeout: '60000'
-reporter: 'min'
-reporter-option:
-  - 'cdn=true'
-  - 'json=false'
-exit: true
-spec: ['test/unit/**/*.ts']

--- a/modules/utxo-staking/.prettierignore
+++ b/modules/utxo-staking/.prettierignore
@@ -1,2 +1,4 @@
 .nyc_output/
 dist/
+test/fixtures/
+test/unit/babylon/vendor

--- a/modules/utxo-staking/package.json
+++ b/modules/utxo-staking/package.json
@@ -42,6 +42,6 @@
     "@bitgo/utxo-core": "^1.0.0",
     "@bitgo/unspents": "^0.47.17",
     "@bitgo/utxo-lib": "^11.2.1",
-    "@bitgo/wasm-miniscript": "^2.0.0-beta.2"
+    "@bitgo/wasm-miniscript": "^2.0.0-beta.3"
   }
 }

--- a/modules/utxo-staking/package.json
+++ b/modules/utxo-staking/package.json
@@ -39,6 +39,7 @@
     ]
   },
   "dependencies": {
+    "@bitgo/utxo-core": "^1.0.0",
     "@bitgo/unspents": "^0.47.17",
     "@bitgo/utxo-lib": "^11.2.1",
     "@bitgo/wasm-miniscript": "^2.0.0-beta.2"

--- a/modules/utxo-staking/package.json
+++ b/modules/utxo-staking/package.json
@@ -11,9 +11,8 @@
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
     "prepare": "npm run build",
-    "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",
-    "unit-test": "mocha"
+    "unit-test": "mocha --recursive test"
   },
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",

--- a/modules/utxo-staking/test/fixtures/babylon/scripts.json
+++ b/modules/utxo-staking/test/fixtures/babylon/scripts.json
@@ -1,0 +1,120 @@
+{
+  "builder": {
+    "stakerKey": "7b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9",
+    "finalityProviderKeys": [
+      "55ede96d004a0207db6495bf3c6bd406d667b835198778e4a1ae3d103de166e0"
+    ],
+    "covenantKeys": [
+      "2f3432bf9054e482041b890e084bc1a34cfbc0b63aded113bfa36b6f2402832b",
+      "4d7e91e4a0ab0526a387684db1628b535e6b66046aaa7d1b583b93c5a16e1ac7"
+    ],
+    "covenantThreshold": 2,
+    "stakingTimeLock": 100,
+    "unbondingTimeLock": 200
+  },
+  "scripts": {
+    "timelockScript": {
+      "script": "207b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9ad0164b2",
+      "miniscript": "and_v(v:pk(7b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9),older(100))",
+      "miniscriptAst": {
+        "and_v": [
+          {
+            "v:pk": "7b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9"
+          },
+          {
+            "older": 100
+          }
+        ]
+      },
+      "scriptASM": [
+        "7b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9",
+        "OP_CHECKSIGVERIFY",
+        "64",
+        "OP_CHECKSEQUENCEVERIFY"
+      ]
+    },
+    "unbondingScript": {
+      "script": "207b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9ad202f3432bf9054e482041b890e084bc1a34cfbc0b63aded113bfa36b6f2402832bac204d7e91e4a0ab0526a387684db1628b535e6b66046aaa7d1b583b93c5a16e1ac7ba529c",
+      "miniscript": "and_v(v:pk(7b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9),multi_a(2,2f3432bf9054e482041b890e084bc1a34cfbc0b63aded113bfa36b6f2402832b,4d7e91e4a0ab0526a387684db1628b535e6b66046aaa7d1b583b93c5a16e1ac7))",
+      "miniscriptAst": {
+        "and_v": [
+          {
+            "v:pk": "7b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9"
+          },
+          {
+            "multi_a": [
+              2,
+              "2f3432bf9054e482041b890e084bc1a34cfbc0b63aded113bfa36b6f2402832b",
+              "4d7e91e4a0ab0526a387684db1628b535e6b66046aaa7d1b583b93c5a16e1ac7"
+            ]
+          }
+        ]
+      },
+      "scriptASM": [
+        "7b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9",
+        "OP_CHECKSIGVERIFY",
+        "2f3432bf9054e482041b890e084bc1a34cfbc0b63aded113bfa36b6f2402832b",
+        "OP_CHECKSIG",
+        "4d7e91e4a0ab0526a387684db1628b535e6b66046aaa7d1b583b93c5a16e1ac7",
+        "OP_2",
+        "OP_NUMEQUAL"
+      ]
+    },
+    "slashingScript": {
+      "script": "207b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9ad2055ede96d004a0207db6495bf3c6bd406d667b835198778e4a1ae3d103de166e0ad202f3432bf9054e482041b890e084bc1a34cfbc0b63aded113bfa36b6f2402832bac204d7e91e4a0ab0526a387684db1628b535e6b66046aaa7d1b583b93c5a16e1ac7ba529c",
+      "miniscript": "and_v(and_v(v:pk(7b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9),v:pk(55ede96d004a0207db6495bf3c6bd406d667b835198778e4a1ae3d103de166e0)),multi_a(2,2f3432bf9054e482041b890e084bc1a34cfbc0b63aded113bfa36b6f2402832b,4d7e91e4a0ab0526a387684db1628b535e6b66046aaa7d1b583b93c5a16e1ac7))",
+      "miniscriptAst": {
+        "and_v": [
+          {
+            "and_v": [
+              {
+                "v:pk": "7b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9"
+              },
+              {
+                "v:pk": "55ede96d004a0207db6495bf3c6bd406d667b835198778e4a1ae3d103de166e0"
+              }
+            ]
+          },
+          {
+            "multi_a": [
+              2,
+              "2f3432bf9054e482041b890e084bc1a34cfbc0b63aded113bfa36b6f2402832b",
+              "4d7e91e4a0ab0526a387684db1628b535e6b66046aaa7d1b583b93c5a16e1ac7"
+            ]
+          }
+        ]
+      },
+      "scriptASM": [
+        "7b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9",
+        "OP_CHECKSIGVERIFY",
+        "55ede96d004a0207db6495bf3c6bd406d667b835198778e4a1ae3d103de166e0",
+        "OP_CHECKSIGVERIFY",
+        "2f3432bf9054e482041b890e084bc1a34cfbc0b63aded113bfa36b6f2402832b",
+        "OP_CHECKSIG",
+        "4d7e91e4a0ab0526a387684db1628b535e6b66046aaa7d1b583b93c5a16e1ac7",
+        "OP_2",
+        "OP_NUMEQUAL"
+      ]
+    },
+    "unbondingTimelockScript": {
+      "script": "207b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9ad02c800b2",
+      "miniscript": "and_v(v:pk(7b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9),older(200))",
+      "miniscriptAst": {
+        "and_v": [
+          {
+            "v:pk": "7b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9"
+          },
+          {
+            "older": 200
+          }
+        ]
+      },
+      "scriptASM": [
+        "7b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9",
+        "OP_CHECKSIGVERIFY",
+        "c800",
+        "OP_CHECKSEQUENCEVERIFY"
+      ]
+    }
+  }
+}

--- a/modules/utxo-staking/test/unit/babylon/fetchStakingScriptSource.ts
+++ b/modules/utxo-staking/test/unit/babylon/fetchStakingScriptSource.ts
@@ -1,0 +1,35 @@
+// Download and patch `stakingScript.ts` from the `btc-staking-ts` repository.
+
+import * as assert from 'node:assert';
+import * as fs from 'node:fs/promises';
+
+function getSourceUrl(tag: string): string {
+  return `https://raw.githubusercontent.com/babylonlabs-io/btc-staking-ts/${tag}/src/staking/stakingScript.ts`;
+}
+
+function patchStakingScriptSource(sourceUrl: string, source: string): string {
+  const lines = source.split('\n');
+
+  const matchLine1 = 'import { opcodes, script } from "bitcoinjs-lib";';
+  const matchLine2 = 'import { NO_COORD_PK_BYTE_LENGTH } from "../constants/keys";';
+  assert.deepStrictEqual(lines.slice(0, 2), [matchLine1, matchLine2]);
+
+  const headerInfo = `/* downloaded from ${sourceUrl} */`;
+  const subLine1 = "import { opcodes, script } from '@bitgo/utxo-lib';";
+  // apparently, our underlying bitcoinjs-lib does not include
+  // this commit https://github.com/bitcoinjs/bitcoinjs-lib/commit/e033a6ff41f31e70fcf715b5adf084be8e5880ef
+  const subLine2 = 'opcodes.OP_CHECKSIGADD = 186;';
+  const subLine3 = 'const NO_COORD_PK_BYTE_LENGTH = 32;';
+
+  return [headerInfo, subLine1, subLine2, subLine3].concat(lines.slice(2)).join('\n');
+}
+
+async function updateStakingScriptSource(tag = 'v0.4.0-rc.2'): Promise<void> {
+  const url = getSourceUrl(tag);
+  const source = await (await fetch(url)).text();
+  await fs.writeFile(__dirname + '/vendor/stakingScript.ts', patchStakingScriptSource(url, source));
+}
+
+if (require.main === module) {
+  updateStakingScriptSource().then(console.log).catch(console.error);
+}

--- a/modules/utxo-staking/test/unit/babylon/scripts.ts
+++ b/modules/utxo-staking/test/unit/babylon/scripts.ts
@@ -1,0 +1,60 @@
+import assert from 'assert';
+
+import * as utxolib from '@bitgo/utxo-lib';
+import { getFixture, getKey, toPlainObject } from '@bitgo/utxo-core/testutil';
+import { ast, Miniscript } from '@bitgo/wasm-miniscript';
+
+import { StakingScriptData } from './vendor/stakingScript';
+
+function getKeyBuffer(key: string): Buffer {
+  return getKey(key).publicKey.subarray(1);
+}
+
+function parseScript(key: string, script: unknown) {
+  if (!Buffer.isBuffer(script)) {
+    throw new Error('script must be a buffer');
+  }
+  const ms = Miniscript.fromBitcoinScript(script, 'tap');
+  return {
+    script: script.toString('hex'),
+    miniscript: ms.toString(),
+    miniscriptAst: ast.fromMiniscript(ms),
+    scriptASM: utxolib.script.toASM(script).split(/\s+/),
+  };
+}
+
+function parseScripts(scripts: unknown) {
+  if (typeof scripts !== 'object' || scripts === null) {
+    throw new Error('scripts must be an object');
+  }
+  return Object.fromEntries(Object.entries(scripts).map(([key, value]) => [key, parseScript(key, value)]));
+}
+
+async function assertEqualFixture(fixtureName: string, builder: StakingScriptData, scripts: unknown): Promise<void> {
+  const value = {
+    builder: toPlainObject(builder),
+    scripts: parseScripts(scripts),
+  };
+  // await fs.promises.unlink(fixtureName);
+  assert.deepStrictEqual(await getFixture(fixtureName, value), value);
+}
+
+describe('staking scripts', function () {
+  it('generates expected staking scripts', async function () {
+    const stakerKey = getKeyBuffer('staker');
+    const finalityProviderKeys = [getKeyBuffer('finalityProvider')];
+    const covenantKeys = [getKeyBuffer('covenant1'), getKeyBuffer('covenant2')];
+    const covenantThreshold = 2;
+    const stakingTimelock = 100;
+    const unbondingTimelock = 200;
+    const builder = new StakingScriptData(
+      stakerKey,
+      finalityProviderKeys,
+      covenantKeys,
+      covenantThreshold,
+      stakingTimelock,
+      unbondingTimelock
+    );
+    await assertEqualFixture('test/fixtures/babylon/scripts.json', builder, builder.buildScripts());
+  });
+});

--- a/modules/utxo-staking/test/unit/babylon/vendor/stakingScript.ts
+++ b/modules/utxo-staking/test/unit/babylon/vendor/stakingScript.ts
@@ -1,0 +1,313 @@
+/* downloaded from https://raw.githubusercontent.com/babylonlabs-io/btc-staking-ts/v0.4.0-rc.2/src/staking/stakingScript.ts */
+import { opcodes, script } from '@bitgo/utxo-lib';
+opcodes.OP_CHECKSIGADD = 186;
+const NO_COORD_PK_BYTE_LENGTH = 32;
+
+export const MAGIC_BYTES_LEN = 4;
+
+// Represents the staking scripts used in BTC staking.
+export interface StakingScripts {
+  timelockScript: Buffer;
+  unbondingScript: Buffer;
+  slashingScript: Buffer;
+  unbondingTimelockScript: Buffer;
+}
+
+// StakingScriptData is a class that holds the data required for the BTC Staking Script
+// and exposes methods for converting it into useful formats
+export class StakingScriptData {
+  stakerKey: Buffer;
+  finalityProviderKeys: Buffer[];
+  covenantKeys: Buffer[];
+  covenantThreshold: number;
+  stakingTimeLock: number;
+  unbondingTimeLock: number;
+
+  constructor(
+    // The `stakerKey` is the public key of the staker without the coordinate bytes.
+    stakerKey: Buffer,
+    // A list of public keys without the coordinate bytes corresponding to the finality providers
+    // the stake will be delegated to.
+    // Currently, Babylon does not support restaking, so this should contain only a single item.
+    finalityProviderKeys: Buffer[],
+    // A list of the public keys without the coordinate bytes corresponding to
+    // the covenant emulators.
+    // This is a parameter of the Babylon system and should be retrieved from there.
+    covenantKeys: Buffer[],
+    // The number of covenant emulator signatures required for a transaction
+    // to be valid.
+    // This is a parameter of the Babylon system and should be retrieved from there.
+    covenantThreshold: number,
+    // The staking period denoted as a number of BTC blocks.
+    stakingTimelock: number,
+    // The unbonding period denoted as a number of BTC blocks.
+    // This value should be more than equal than the minimum unbonding time of the
+    // Babylon system.
+    unbondingTimelock: number,
+  ) {
+    if (
+      !stakerKey ||
+      !finalityProviderKeys ||
+      !covenantKeys ||
+      !covenantThreshold ||
+      !stakingTimelock ||
+      !unbondingTimelock
+    ) {
+      throw new Error("Missing required input values");
+    }
+    this.stakerKey = stakerKey;
+    this.finalityProviderKeys = finalityProviderKeys;
+    this.covenantKeys = covenantKeys;
+    this.covenantThreshold = covenantThreshold;
+    this.stakingTimeLock = stakingTimelock;
+    this.unbondingTimeLock = unbondingTimelock;
+
+    // Run the validate method to check if the provided script data is valid
+    if (!this.validate()) {
+      throw new Error("Invalid script data provided");
+    }
+  }
+
+  /**
+   * Validates the staking script.
+   * @returns {boolean} Returns true if the staking script is valid, otherwise false.
+   */
+  validate(): boolean {
+    // check that staker key is the correct length
+    if (this.stakerKey.length != NO_COORD_PK_BYTE_LENGTH) {
+      return false;
+    }
+    // check that finalityProvider keys are the correct length
+    if (
+      this.finalityProviderKeys.some(
+        (finalityProviderKey) => finalityProviderKey.length != NO_COORD_PK_BYTE_LENGTH,
+      )
+    ) {
+      return false;
+    }
+    // check that covenant keys are the correct length
+    if (
+      this.covenantKeys.some((covenantKey) => covenantKey.length != NO_COORD_PK_BYTE_LENGTH)
+    ) {
+      return false;
+    }
+
+    // Check whether we have any duplicate keys
+    const allPks = [
+      this.stakerKey,
+      ...this.finalityProviderKeys,
+      ...this.covenantKeys,
+    ];
+    const allPksSet = new Set(allPks);
+    if (allPks.length !== allPksSet.size) {
+      return false;
+    }
+
+    // check that the threshold is above 0 and less than or equal to
+    // the size of the covenant emulators set
+    if (
+      this.covenantThreshold == 0 ||
+      this.covenantThreshold > this.covenantKeys.length
+    ) {
+      return false;
+    }
+
+    // check that maximum value for staking time is not greater than uint16 and above 0
+    if (this.stakingTimeLock == 0 || this.stakingTimeLock > 65535) {
+      return false;
+    }
+
+    // check that maximum value for unbonding time is not greater than uint16 and above 0
+    if (this.unbondingTimeLock == 0 || this.unbondingTimeLock > 65535) {
+      return false;
+    }
+
+    return true;
+  }
+
+  // The staking script allows for multiple finality provider public keys
+  // to support (re)stake to multiple finality providers
+  // Covenant members are going to have multiple keys
+
+  /**
+   * Builds a timelock script.
+   * @param timelock - The timelock value to encode in the script.
+   * @returns {Buffer} containing the compiled timelock script.
+   */
+  buildTimelockScript(timelock: number): Buffer {
+    return script.compile([
+      this.stakerKey,
+      opcodes.OP_CHECKSIGVERIFY,
+      script.number.encode(timelock),
+      opcodes.OP_CHECKSEQUENCEVERIFY,
+    ]);
+  }
+
+  /**
+   * Builds the staking timelock script.
+   * Only holder of private key for given pubKey can spend after relative lock time
+   * Creates the timelock script in the form:
+   *    <stakerPubKey>
+   *    OP_CHECKSIGVERIFY
+   *    <stakingTimeBlocks>
+   *    OP_CHECKSEQUENCEVERIFY
+   * @returns {Buffer} The staking timelock script.
+   */
+  buildStakingTimelockScript(): Buffer {
+    return this.buildTimelockScript(this.stakingTimeLock);
+  }
+
+  /**
+   * Builds the unbonding timelock script.
+   * Creates the unbonding timelock script in the form:
+   *    <stakerPubKey>
+   *    OP_CHECKSIGVERIFY
+   *    <unbondingTimeBlocks>
+   *    OP_CHECKSEQUENCEVERIFY
+   * @returns {Buffer} The unbonding timelock script.
+   */
+  buildUnbondingTimelockScript(): Buffer {
+    return this.buildTimelockScript(this.unbondingTimeLock);
+  }
+
+  /**
+   * Builds the unbonding script in the form:
+   *    buildSingleKeyScript(stakerPk, true) ||
+   *    buildMultiKeyScript(covenantPks, covenantThreshold, false)
+   *    || means combining the scripts
+   * @returns {Buffer} The unbonding script.
+   */
+  buildUnbondingScript(): Buffer {
+    return Buffer.concat([
+      this.buildSingleKeyScript(this.stakerKey, true),
+      this.buildMultiKeyScript(
+        this.covenantKeys,
+        this.covenantThreshold,
+        false,
+      ),
+    ]);
+  }
+
+  /**
+   * Builds the slashing script for staking in the form:
+   *    buildSingleKeyScript(stakerPk, true) ||
+   *    buildMultiKeyScript(finalityProviderPKs, 1, true) ||
+   *    buildMultiKeyScript(covenantPks, covenantThreshold, false)
+   *    || means combining the scripts
+   * The slashing script is a combination of single-key and multi-key scripts.
+   * The single-key script is used for staker key verification.
+   * The multi-key script is used for finality provider key verification and covenant key verification.
+   * @returns {Buffer} The slashing script as a Buffer.
+   */
+  buildSlashingScript(): Buffer {
+    return Buffer.concat([
+      this.buildSingleKeyScript(this.stakerKey, true),
+      this.buildMultiKeyScript(
+        this.finalityProviderKeys,
+        // The threshold is always 1 as we only need one
+        // finalityProvider signature to perform slashing
+        // (only one finalityProvider performs an offence)
+        1,
+        // OP_VERIFY/OP_CHECKSIGVERIFY is added at the end
+        true,
+      ),
+      this.buildMultiKeyScript(
+        this.covenantKeys,
+        this.covenantThreshold,
+        // No need to add verify since covenants are at the end of the script
+        false,
+      ),
+    ]);
+  }
+  /**
+   * Builds the staking scripts.
+   * @returns {StakingScripts} The staking scripts.
+   */
+  buildScripts(): StakingScripts {
+    return {
+      timelockScript: this.buildStakingTimelockScript(),
+      unbondingScript: this.buildUnbondingScript(),
+      slashingScript: this.buildSlashingScript(),
+      unbondingTimelockScript: this.buildUnbondingTimelockScript(),
+    };
+  }
+
+  // buildSingleKeyScript and buildMultiKeyScript allow us to reuse functionality
+  // for creating Bitcoin scripts for the unbonding script and the slashing script
+
+  /**
+   * Builds a single key script in the form:
+   * buildSingleKeyScript creates a single key script
+   *    <pk> OP_CHECKSIGVERIFY (if withVerify is true)
+   *    <pk> OP_CHECKSIG (if withVerify is false)
+   * @param pk - The public key buffer.
+   * @param withVerify - A boolean indicating whether to include the OP_CHECKSIGVERIFY opcode.
+   * @returns The compiled script buffer.
+   */
+  buildSingleKeyScript(pk: Buffer, withVerify: boolean): Buffer {
+    // Check public key length
+    if (pk.length != NO_COORD_PK_BYTE_LENGTH) {
+      throw new Error("Invalid key length");
+    }
+    return script.compile([
+      pk,
+      withVerify ? opcodes.OP_CHECKSIGVERIFY : opcodes.OP_CHECKSIG,
+    ]);
+  }
+
+  /**
+   * Builds a multi-key script in the form:
+   *    <pk1> OP_CHEKCSIG <pk2> OP_CHECKSIGADD <pk3> OP_CHECKSIGADD ... <pkN> OP_CHECKSIGADD <threshold> OP_NUMEQUAL
+   *    <withVerify -> OP_NUMEQUALVERIFY>
+   * It validates whether provided keys are unique and the threshold is not greater than number of keys
+   * If there is only one key provided it will return single key sig script
+   * @param pks - An array of public keys.
+   * @param threshold - The required number of valid signers.
+   * @param withVerify - A boolean indicating whether to include the OP_VERIFY opcode.
+   * @returns The compiled multi-key script as a Buffer.
+   * @throws {Error} If no keys are provided, if the required number of valid signers is greater than the number of provided keys, or if duplicate keys are provided.
+   */
+  buildMultiKeyScript(
+    pks: Buffer[],
+    threshold: number,
+    withVerify: boolean,
+  ): Buffer {
+    // Verify that pks is not empty
+    if (!pks || pks.length === 0) {
+      throw new Error("No keys provided");
+    }
+    // Check buffer object have expected lengths like checking pks.length
+    if (pks.some((pk) => pk.length != NO_COORD_PK_BYTE_LENGTH)) {
+      throw new Error("Invalid key length");
+    }
+    // Verify that threshold <= len(pks)
+    if (threshold > pks.length) {
+      throw new Error(
+        "Required number of valid signers is greater than number of provided keys",
+      );
+    }
+    if (pks.length === 1) {
+      return this.buildSingleKeyScript(pks[0], withVerify);
+    }
+    // keys must be sorted
+    const sortedPks = [...pks].sort(Buffer.compare);
+    // verify there are no duplicates
+    for (let i = 0; i < sortedPks.length - 1; ++i) {
+      if (sortedPks[i].equals(sortedPks[i + 1])) {
+        throw new Error("Duplicate keys provided");
+      }
+    }
+    const scriptElements = [sortedPks[0], opcodes.OP_CHECKSIG];
+    for (let i = 1; i < sortedPks.length; i++) {
+      scriptElements.push(sortedPks[i]);
+      scriptElements.push(opcodes.OP_CHECKSIGADD);
+    }
+    scriptElements.push(script.number.encode(threshold));
+    if (withVerify) {
+      scriptElements.push(opcodes.OP_NUMEQUALVERIFY);
+    } else {
+      scriptElements.push(opcodes.OP_NUMEQUAL);
+    }
+    return script.compile(scriptElements);
+  }
+}

--- a/modules/utxo-staking/test/unit/coreDao/descriptor.ts
+++ b/modules/utxo-staking/test/unit/coreDao/descriptor.ts
@@ -1,9 +1,11 @@
 import * as assert from 'assert';
+
 import * as utxolib from '@bitgo/utxo-lib';
 import { Descriptor } from '@bitgo/wasm-miniscript';
 import { getFixture } from '@bitgo/utxo-core/testutil';
 
 import { createMultiSigDescriptor, decodeTimelock } from '../../../src/coreDao';
+
 import { finalizePsbt, updateInputWithDescriptor } from './utils';
 
 describe('descriptor', function () {

--- a/modules/utxo-staking/test/unit/coreDao/descriptor.ts
+++ b/modules/utxo-staking/test/unit/coreDao/descriptor.ts
@@ -1,10 +1,10 @@
 import * as assert from 'assert';
 import * as utxolib from '@bitgo/utxo-lib';
 import { Descriptor } from '@bitgo/wasm-miniscript';
+import { getFixture } from '@bitgo/utxo-core/testutil';
 
-import { createMultiSigDescriptor } from '../../../src/coreDao/descriptor';
-import { finalizePsbt, getFixture, updateInputWithDescriptor } from './utils';
-import { decodeTimelock } from '../../../src/coreDao';
+import { createMultiSigDescriptor, decodeTimelock } from '../../../src/coreDao';
+import { finalizePsbt, updateInputWithDescriptor } from './utils';
 
 describe('descriptor', function () {
   const baseFixturePath = 'test/fixtures/coreDao/descriptor/';

--- a/modules/utxo-staking/test/unit/coreDao/opReturn.ts
+++ b/modules/utxo-staking/test/unit/coreDao/opReturn.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import assert from 'assert';
 import {
   CORE_DAO_MAINNET_CHAIN_ID,
   CORE_DAO_SATOSHI_PLUS_IDENTIFIER,
@@ -9,7 +9,7 @@ import {
   toString,
 } from '../../../src/coreDao';
 import { testutil } from '@bitgo/utxo-lib';
-import { getFixture } from './utils';
+import { getFixture } from '@bitgo/utxo-core/testutil';
 
 describe('OP_RETURN', function () {
   const validVersion = 2;

--- a/modules/utxo-staking/test/unit/coreDao/opReturn.ts
+++ b/modules/utxo-staking/test/unit/coreDao/opReturn.ts
@@ -1,4 +1,8 @@
 import assert from 'assert';
+
+import { testutil } from '@bitgo/utxo-lib';
+import { getFixture } from '@bitgo/utxo-core/testutil';
+
 import {
   CORE_DAO_MAINNET_CHAIN_ID,
   CORE_DAO_SATOSHI_PLUS_IDENTIFIER,
@@ -8,8 +12,6 @@ import {
   parseCoreDaoOpReturnOutputScript,
   toString,
 } from '../../../src/coreDao';
-import { testutil } from '@bitgo/utxo-lib';
-import { getFixture } from '@bitgo/utxo-core/testutil';
 
 describe('OP_RETURN', function () {
   const validVersion = 2;

--- a/modules/utxo-staking/test/unit/coreDao/utils.ts
+++ b/modules/utxo-staking/test/unit/coreDao/utils.ts
@@ -1,38 +1,5 @@
-import { promises as fs } from 'fs';
 import { Descriptor, Psbt } from '@bitgo/wasm-miniscript';
 import * as utxolib from '@bitgo/utxo-lib';
-
-function encode(path: string, defaultValue: unknown): string {
-  if (path.endsWith('.txt')) {
-    return String(defaultValue);
-  }
-  if (path.endsWith('.json')) {
-    return JSON.stringify(defaultValue, null, 2) + '\n';
-  }
-  throw new Error(`unrecognized path ${path}`);
-}
-
-function decode(path: string, v: string): unknown {
-  if (path.endsWith('.txt')) {
-    return v;
-  }
-  if (path.endsWith('.json')) {
-    return JSON.parse(v);
-  }
-  throw new Error(`unrecognized path ${path}`);
-}
-
-export async function getFixture(path: string, defaultValue: unknown): Promise<unknown> {
-  try {
-    return decode(path, await fs.readFile(path, 'utf8'));
-  } catch (e) {
-    if (e.code === 'ENOENT') {
-      await fs.writeFile(path, encode(path, defaultValue), 'utf8');
-      throw new Error(`wrote default value for ${path}`);
-    }
-    throw e;
-  }
-}
 
 export function updateInputWithDescriptor(psbt: utxolib.Psbt, inputIndex: number, descriptor: Descriptor): void {
   const wrappedPsbt = Psbt.deserialize(psbt.toBuffer());

--- a/modules/utxo-staking/test/unit/transaction.ts
+++ b/modules/utxo-staking/test/unit/transaction.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 
 import * as utxolib from '@bitgo/utxo-lib';
+
 import { buildFixedWalletStakingPsbt } from '../../src';
 
 describe('transactions', function () {

--- a/modules/utxo-staking/tsconfig.json
+++ b/modules/utxo-staking/tsconfig.json
@@ -6,13 +6,18 @@
     "typeRoots": ["./node_modules/@types", "../../node_modules/@types"],
     "allowJs": false,
     "strict": true,
-    "useUnknownInCatchVariables": false
+    "useUnknownInCatchVariables": false,
+    "moduleResolution": "node16",
+    "module": "node16"
   },
   "include": ["src/**/*", "bin/**/*", "test/**/*"],
   "exclude": ["node_modules"],
   "references": [
     {
       "path": "../utxo-lib"
+    },
+    {
+      "path": "../utxo-core"
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -896,6 +896,11 @@
   resolved "https://registry.npmjs.org/@bitgo/wasm-miniscript/-/wasm-miniscript-2.0.0-beta.2.tgz"
   integrity sha512-hh6R8NYTS6N1VdlgljkXAMRFNAsr2SGm1QcFjChHZ2bTotnNiCLlOlVR6EYhwtGr5eWLItye3iZG10m/li0xKA==
 
+"@bitgo/wasm-miniscript@^2.0.0-beta.3":
+  version "2.0.0-beta.3"
+  resolved "https://registry.npmjs.org/@bitgo/wasm-miniscript/-/wasm-miniscript-2.0.0-beta.3.tgz#f52f9fa411f4f13527c960842f81729133aa6810"
+  integrity sha512-9JWfizfdpSExQ5qDkMlZAR0UbonKILPwDXM+iqiBKIRGwlYak071lX9sfGPWoRuo7g72gU//s7AiZc6kZqgetw==
+
 "@brandonblack/musig@^0.0.1-alpha.0":
   version "0.0.1-alpha.1"
   resolved "https://registry.npmjs.org/@brandonblack/musig/-/musig-0.0.1-alpha.1.tgz"


### PR DESCRIPTION

Key changes:
- Add babylon script generation and fixtures
- Move test utilities to utxo-core
- Enable import ordering
- Add text encoding support for fixtures
- Simplify test configuration

Resolves: BTC-1829