### PR TITLE
feat(utxo-core): add eslint config, fix imports

### DIFF
--- a/modules/utxo-core/.eslintignore
+++ b/modules/utxo-core/.eslintignore
@@ -1,0 +1,6 @@
+node_modules
+.idea
+public
+dist
+test/unit/babylon/vendor
+

--- a/modules/utxo-core/.eslintrc.js
+++ b/modules/utxo-core/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: ['../../.eslintrc.json'],
+  rules: {
+    'import/order': ['error', { 'newlines-between': 'always' }],
+    'import/no-internal-modules': 'off',
+  },
+};

--- a/modules/utxo-core/src/testutil/descriptor/mock.utils.ts
+++ b/modules/utxo-core/src/testutil/descriptor/mock.utils.ts
@@ -1,7 +1,9 @@
 import { Descriptor } from '@bitgo/wasm-miniscript';
 import * as utxolib from '@bitgo/utxo-lib';
+
 import { PsbtParams, createPsbt, createScriptPubKeyFromDescriptor } from '../../descriptor';
 import { DerivedDescriptorWalletOutput } from '../../descriptor/Output';
+
 import { DescriptorTemplate, getDefaultXPubs, getDescriptor } from './descriptors';
 
 type MockOutputIdParams = { hash?: string; vout?: number };

--- a/modules/utxo-core/test/descriptor/psbt/createPsbt.ts
+++ b/modules/utxo-core/test/descriptor/psbt/createPsbt.ts
@@ -7,7 +7,6 @@ import { DescriptorTemplate, getPsbtParams } from '../../../src/testutil/descrip
 import { getFixture } from '../../../src/testutil/fixtures.utils';
 import { finalizePsbt } from '../../../src/descriptor';
 import { getKeyTriple } from '../../../src/testutil/key.utils';
-
 import { mockPsbtDefaultWithDescriptorTemplate } from '../../../src/testutil/descriptor/mock.utils';
 import { toPlainObjectFromPsbt, toPlainObjectFromTx } from '../../../src/testutil/descriptor/psbt.utils';
 

--- a/modules/utxo-core/test/descriptor/psbt/findDescriptors.ts
+++ b/modules/utxo-core/test/descriptor/psbt/findDescriptors.ts
@@ -2,7 +2,6 @@ import * as assert from 'assert';
 
 import { DescriptorTemplate, getDefaultXPubs, getDescriptor } from '../../../src/testutil/descriptor/descriptors';
 import { findDescriptorForInput, findDescriptorForOutput } from '../../../src/descriptor/psbt/findDescriptors';
-
 import { mockPsbt } from '../../../src/testutil/descriptor/mock.utils';
 
 function describeWithTemplates(templateSelf: DescriptorTemplate, templateOther: DescriptorTemplate) {

--- a/modules/utxo-core/test/descriptor/psbt/parse.ts
+++ b/modules/utxo-core/test/descriptor/psbt/parse.ts
@@ -7,7 +7,6 @@ import { DescriptorTemplate, getDefaultXPubs, getDescriptorMap } from '../../../
 import { getFixture } from '../../../src/testutil/fixtures.utils';
 import { ParsedDescriptorTransaction } from '../../../src/descriptor/psbt/parse';
 import { toPlainObject } from '../../../src/testutil/toPlainObject.utils';
-
 import { mockPsbtDefaultWithDescriptorTemplate } from '../../../src/testutil/descriptor/mock.utils';
 
 function normalize(parsed: ParsedDescriptorTransaction) {


### PR DESCRIPTION

Add .eslintrc.js and .eslintignore files to utxo-core module to enforce 
consistent code style and fix import statements according to new rules.

Issue: BTC-1829