### PR TITLE
feat(utxo-staking): improve test infrastructure

### DIFF
--- a/modules/utxo-core/src/testutil/fixtures.utils.ts
+++ b/modules/utxo-core/src/testutil/fixtures.utils.ts
@@ -5,7 +5,7 @@
 import * as fs from 'fs';
 import * as mpath from 'path';
 
-type FixtureEncoding = 'json' | 'hex';
+type FixtureEncoding = 'json' | 'hex' | 'txt';
 
 function isNodeJsError(e: unknown): e is NodeJS.ErrnoException {
   return e instanceof Error && typeof (e as NodeJS.ErrnoException).code === 'string';
@@ -18,6 +18,9 @@ function fixtureEncoding(path: string): FixtureEncoding {
   if (path.endsWith('.hex')) {
     return 'hex';
   }
+  if (path.endsWith('.txt')) {
+    return 'txt';
+  }
   throw new Error(`unknown fixture encoding for ${path}`);
 }
 
@@ -27,6 +30,8 @@ function decodeFixture(raw: string, encoding: FixtureEncoding): unknown {
       return JSON.parse(raw);
     case 'hex':
       return Buffer.from(raw, 'hex');
+    case 'txt':
+      return raw;
   }
 }
 
@@ -39,6 +44,11 @@ function encodeFixture(value: unknown, encoding: FixtureEncoding): string {
         throw new Error(`expected Buffer, got ${typeof value}`);
       }
       return value.toString('hex');
+    case 'txt':
+      if (typeof value !== 'string') {
+        throw new Error(`expected string, got ${typeof value}`);
+      }
+      return value;
   }
 }
 

--- a/modules/utxo-staking/.eslintrc.js
+++ b/modules/utxo-staking/.eslintrc.js
@@ -1,8 +1,7 @@
 module.exports = {
   extends: ['../../.eslintrc.json'],
   rules: {
-    // FIXME: enable
-    // 'import/order': ['error', { 'newlines-between': 'always' }],
+    'import/order': ['error', { 'newlines-between': 'always' }],
     'import/no-internal-modules': 'off',
   },
 };

--- a/modules/utxo-staking/.eslintrc.js
+++ b/modules/utxo-staking/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  extends: ['../../.eslintrc.json'],
+  rules: {
+    // FIXME: enable
+    // 'import/order': ['error', { 'newlines-between': 'always' }],
+    'import/no-internal-modules': 'off',
+  },
+};

--- a/modules/utxo-staking/.mocharc.js
+++ b/modules/utxo-staking/.mocharc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  require: 'ts-node/register',
+  extension: ['.js', '.ts'],
+};

--- a/modules/utxo-staking/.mocharc.yml
+++ b/modules/utxo-staking/.mocharc.yml
@@ -1,8 +1,0 @@
-require: 'ts-node/register'
-timeout: '60000'
-reporter: 'min'
-reporter-option:
-  - 'cdn=true'
-  - 'json=false'
-exit: true
-spec: ['test/unit/**/*.ts']

--- a/modules/utxo-staking/package.json
+++ b/modules/utxo-staking/package.json
@@ -39,6 +39,7 @@
     ]
   },
   "dependencies": {
+    "@bitgo/utxo-core": "^1.1.0",
     "@bitgo/unspents": "^0.47.17",
     "@bitgo/utxo-lib": "^11.2.1",
     "@bitgo/wasm-miniscript": "^2.0.0-beta.2"

--- a/modules/utxo-staking/package.json
+++ b/modules/utxo-staking/package.json
@@ -11,9 +11,8 @@
     "clean": "rm -r ./dist",
     "lint": "eslint --quiet .",
     "prepare": "npm run build",
-    "test": "npm run coverage",
     "coverage": "nyc -- npm run unit-test",
-    "unit-test": "mocha"
+    "unit-test": "mocha --recursive test"
   },
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",

--- a/modules/utxo-staking/test/unit/coreDao/descriptor.ts
+++ b/modules/utxo-staking/test/unit/coreDao/descriptor.ts
@@ -1,9 +1,11 @@
 import * as assert from 'assert';
+
 import * as utxolib from '@bitgo/utxo-lib';
 import { Descriptor } from '@bitgo/wasm-miniscript';
 import { getFixture } from '@bitgo/utxo-core/testutil';
 
 import { createMultiSigDescriptor, decodeTimelock } from '../../../src/coreDao';
+
 import { finalizePsbt, updateInputWithDescriptor } from './utils';
 
 describe('descriptor', function () {

--- a/modules/utxo-staking/test/unit/coreDao/descriptor.ts
+++ b/modules/utxo-staking/test/unit/coreDao/descriptor.ts
@@ -1,10 +1,10 @@
 import * as assert from 'assert';
 import * as utxolib from '@bitgo/utxo-lib';
 import { Descriptor } from '@bitgo/wasm-miniscript';
+import { getFixture } from '@bitgo/utxo-core/testutil';
 
-import { createMultiSigDescriptor } from '../../../src/coreDao/descriptor';
-import { finalizePsbt, getFixture, updateInputWithDescriptor } from './utils';
-import { decodeTimelock } from '../../../src/coreDao';
+import { createMultiSigDescriptor, decodeTimelock } from '../../../src/coreDao';
+import { finalizePsbt, updateInputWithDescriptor } from './utils';
 
 describe('descriptor', function () {
   const baseFixturePath = 'test/fixtures/coreDao/descriptor/';

--- a/modules/utxo-staking/test/unit/coreDao/opReturn.ts
+++ b/modules/utxo-staking/test/unit/coreDao/opReturn.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import assert from 'assert';
 import {
   CORE_DAO_MAINNET_CHAIN_ID,
   CORE_DAO_SATOSHI_PLUS_IDENTIFIER,
@@ -9,7 +9,7 @@ import {
   toString,
 } from '../../../src/coreDao';
 import { testutil } from '@bitgo/utxo-lib';
-import { getFixture } from './utils';
+import { getFixture } from '@bitgo/utxo-core/testutil';
 
 describe('OP_RETURN', function () {
   const validVersion = 2;

--- a/modules/utxo-staking/test/unit/coreDao/opReturn.ts
+++ b/modules/utxo-staking/test/unit/coreDao/opReturn.ts
@@ -1,4 +1,8 @@
 import assert from 'assert';
+
+import { testutil } from '@bitgo/utxo-lib';
+import { getFixture } from '@bitgo/utxo-core/testutil';
+
 import {
   CORE_DAO_MAINNET_CHAIN_ID,
   CORE_DAO_SATOSHI_PLUS_IDENTIFIER,
@@ -8,8 +12,6 @@ import {
   parseCoreDaoOpReturnOutputScript,
   toString,
 } from '../../../src/coreDao';
-import { testutil } from '@bitgo/utxo-lib';
-import { getFixture } from '@bitgo/utxo-core/testutil';
 
 describe('OP_RETURN', function () {
   const validVersion = 2;

--- a/modules/utxo-staking/test/unit/coreDao/utils.ts
+++ b/modules/utxo-staking/test/unit/coreDao/utils.ts
@@ -1,38 +1,5 @@
-import { promises as fs } from 'fs';
 import { Descriptor, Psbt } from '@bitgo/wasm-miniscript';
 import * as utxolib from '@bitgo/utxo-lib';
-
-function encode(path: string, defaultValue: unknown): string {
-  if (path.endsWith('.txt')) {
-    return String(defaultValue);
-  }
-  if (path.endsWith('.json')) {
-    return JSON.stringify(defaultValue, null, 2) + '\n';
-  }
-  throw new Error(`unrecognized path ${path}`);
-}
-
-function decode(path: string, v: string): unknown {
-  if (path.endsWith('.txt')) {
-    return v;
-  }
-  if (path.endsWith('.json')) {
-    return JSON.parse(v);
-  }
-  throw new Error(`unrecognized path ${path}`);
-}
-
-export async function getFixture(path: string, defaultValue: unknown): Promise<unknown> {
-  try {
-    return decode(path, await fs.readFile(path, 'utf8'));
-  } catch (e) {
-    if (e.code === 'ENOENT') {
-      await fs.writeFile(path, encode(path, defaultValue), 'utf8');
-      throw new Error(`wrote default value for ${path}`);
-    }
-    throw e;
-  }
-}
 
 export function updateInputWithDescriptor(psbt: utxolib.Psbt, inputIndex: number, descriptor: Descriptor): void {
   const wrappedPsbt = Psbt.deserialize(psbt.toBuffer());

--- a/modules/utxo-staking/test/unit/transaction.ts
+++ b/modules/utxo-staking/test/unit/transaction.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 
 import * as utxolib from '@bitgo/utxo-lib';
+
 import { buildFixedWalletStakingPsbt } from '../../src';
 
 describe('transactions', function () {

--- a/modules/utxo-staking/tsconfig.json
+++ b/modules/utxo-staking/tsconfig.json
@@ -6,13 +6,18 @@
     "typeRoots": ["./node_modules/@types", "../../node_modules/@types"],
     "allowJs": false,
     "strict": true,
-    "useUnknownInCatchVariables": false
+    "useUnknownInCatchVariables": false,
+    "moduleResolution": "node16",
+    "module": "node16"
   },
   "include": ["src/**/*", "bin/**/*", "test/**/*"],
   "exclude": ["node_modules"],
   "references": [
     {
       "path": "../utxo-lib"
+    },
+    {
+      "path": "../utxo-core"
     }
   ]
 }


### PR DESCRIPTION

Move fixture loading to shared utilities in utxo-core, enable import
ordering, and simplify mocha config. Add txt encoding support for fixtures.
Tests can now be run individually from IntelliJ.

Fixes: BTC-1829