### PR TITLE
refactor: use AST types for descriptor building

### DIFF
--- a/modules/utxo-core/package.json
+++ b/modules/utxo-core/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@bitgo/unspents": "^0.47.17",
     "@bitgo/utxo-lib": "^11.2.1",
-    "@bitgo/wasm-miniscript": "^2.0.0-beta.3",
+    "@bitgo/wasm-miniscript": "^2.0.0-beta.4",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4"
   },
   "gitHead": "18e460ddf02de2dbf13c2aa243478188fb539f0c"

--- a/modules/utxo-core/src/testutil/descriptor/descriptors.ts
+++ b/modules/utxo-core/src/testutil/descriptor/descriptors.ts
@@ -1,4 +1,6 @@
-import { Descriptor } from '@bitgo/wasm-miniscript';
+import assert from 'assert';
+
+import { Descriptor, ast } from '@bitgo/wasm-miniscript';
 import { BIP32Interface } from '@bitgo/utxo-lib';
 
 import { DescriptorMap, PsbtParams } from '../../descriptor';
@@ -47,20 +49,14 @@ export type DescriptorTemplate =
    */
   | 'ShWsh2Of3CltvDrop';
 
-function toXPub(k: BIP32Interface | string): string {
+function toXPub(k: BIP32Interface | string, path: string): string {
   if (typeof k === 'string') {
-    return k;
+    return k + '/' + path;
   }
-  return k.neutered().toBase58();
+  return k.neutered().toBase58() + '/' + path;
 }
 
-function multi(
-  prefix: 'multi' | 'multi_a',
-  m: number,
-  n: number,
-  keys: BIP32Interface[] | string[],
-  path: string
-): string {
+function multiArgs(m: number, n: number, keys: BIP32Interface[] | string[], path: string): [number, ...string[]] {
   if (n < m) {
     throw new Error(`Cannot create ${m} of ${n} multisig`);
   }
@@ -68,15 +64,7 @@ function multi(
     throw new Error(`Not enough keys for ${m} of ${n} multisig: keys.length=${keys.length}`);
   }
   keys = keys.slice(0, n);
-  return prefix + `(${m},${keys.map((k) => `${toXPub(k)}/${path}`).join(',')})`;
-}
-
-function multiWsh(m: number, n: number, keys: BIP32Interface[] | string[], path: string): string {
-  return multi('multi', m, n, keys, path);
-}
-
-function multiTap(m: number, n: number, keys: BIP32Interface[] | string[], path: string): string {
-  return multi('multi_a', m, n, keys, path);
+  return [m, ...keys.map((k) => toXPub(k, path))];
 }
 
 export function getPsbtParams(t: DescriptorTemplate): Partial<PsbtParams> {
@@ -90,21 +78,34 @@ export function getPsbtParams(t: DescriptorTemplate): Partial<PsbtParams> {
   }
 }
 
-export function getDescriptorString(
+function getDescriptorNode(
   template: DescriptorTemplate,
   keys: KeyTriple | string[] = getDefaultXPubs(),
   path = '0/*'
-): string {
+): ast.DescriptorNode {
   switch (template) {
     case 'Wsh2Of3':
-      return `wsh(${multiWsh(2, 3, keys, path)})`;
+      return {
+        wsh: { multi: multiArgs(2, 3, keys, path) },
+      };
     case 'ShWsh2Of3CltvDrop':
       const { locktime } = getPsbtParams(template);
-      return `sh(wsh(and_v(r:after(${locktime}),${multiWsh(2, 3, keys, path)})))`;
+      assert(locktime);
+      return {
+        sh: {
+          wsh: {
+            and_v: [{ 'r:after': locktime }, { multi: multiArgs(2, 3, keys, path) }],
+          },
+        },
+      };
     case 'Wsh2Of2':
-      return `wsh(${multiWsh(2, 2, keys, path)})`;
+      return {
+        wsh: { multi: multiArgs(2, 2, keys, path) },
+      };
     case 'Tr2Of3-NoKeyPath':
-      return `tr(${getUnspendableKey()},${multiTap(2, 3, keys, path)})`;
+      return {
+        tr: [getUnspendableKey(), { multi_a: multiArgs(2, 3, keys, path) }],
+      };
   }
   throw new Error(`Unknown descriptor template: ${template}`);
 }
@@ -114,7 +115,7 @@ export function getDescriptor(
   keys: KeyTriple | string[] = getDefaultXPubs(),
   path = '0/*'
 ): Descriptor {
-  return Descriptor.fromString(getDescriptorString(template, keys, path), 'derivable');
+  return Descriptor.fromString(ast.formatNode(getDescriptorNode(template, keys, path)), 'derivable');
 }
 
 export function getDescriptorMap(

--- a/modules/utxo-staking/package.json
+++ b/modules/utxo-staking/package.json
@@ -42,7 +42,7 @@
     "@bitgo/utxo-core": "^1.1.0",
     "@bitgo/unspents": "^0.47.17",
     "@bitgo/utxo-lib": "^11.2.1",
-    "@bitgo/wasm-miniscript": "^2.0.0-beta.3"
+    "@bitgo/wasm-miniscript": "^2.0.0-beta.4"
   },
   "devDependencies": {
     "bitcoinjs-lib": "^6.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -891,6 +891,11 @@
   resolved "https://registry.npmjs.org/@bitgo/wasm-miniscript/-/wasm-miniscript-2.0.0-beta.3.tgz#f52f9fa411f4f13527c960842f81729133aa6810"
   integrity sha512-9JWfizfdpSExQ5qDkMlZAR0UbonKILPwDXM+iqiBKIRGwlYak071lX9sfGPWoRuo7g72gU//s7AiZc6kZqgetw==
 
+"@bitgo/wasm-miniscript@^2.0.0-beta.4":
+  version "2.0.0-beta.4"
+  resolved "https://registry.npmjs.org/@bitgo/wasm-miniscript/-/wasm-miniscript-2.0.0-beta.4.tgz#6897327a0e6007cfa02081a02cba8b442e318dc5"
+  integrity sha512-lZCSo3NY/vb1hagU3J7fIdv7GhCGYb/INCdAi6ogDXBzWDl3tloviCZ9DXCNPXc7lbj8mVr3GR8zAFkPTQ0xEw==
+
 "@brandonblack/musig@^0.0.1-alpha.0":
   version "0.0.1-alpha.1"
   resolved "https://registry.npmjs.org/@brandonblack/musig/-/musig-0.0.1-alpha.1.tgz"
@@ -7160,7 +7165,7 @@ bindings@^1.3.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-bip174@^2.1.1:
+bip174@=2.1.1, bip174@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/bip174/-/bip174-2.1.1.tgz"
   integrity sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ==
@@ -7213,6 +7218,18 @@ bitcoinjs-lib@^6.0.0:
   version "6.1.6"
   resolved "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.6.tgz"
   integrity sha512-Fk8+Vc+e2rMoDU5gXkW9tD+313rhkm5h6N9HfZxXvYU9LedttVvmXKTgd9k5rsQJjkSfsv6XRM8uhJv94SrvcA==
+  dependencies:
+    "@noble/hashes" "^1.2.0"
+    bech32 "^2.0.0"
+    bip174 "^2.1.1"
+    bs58check "^3.0.1"
+    typeforce "^1.11.3"
+    varuint-bitcoin "^1.1.2"
+
+bitcoinjs-lib@^6.1.7:
+  version "6.1.7"
+  resolved "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.7.tgz#0f98dec1333d658574eefa455295668cfae38bb0"
+  integrity sha512-tlf/r2DGMbF7ky1MgUqXHzypYHakkEnm0SZP23CJKIqNY/5uNAnMbFhMJdhjrL/7anfb/U8+AlpdjPWjPnAalg==
   dependencies:
     "@noble/hashes" "^1.2.0"
     bech32 "^2.0.0"


### PR DESCRIPTION

Use AST nodes and types instead of string manipulation for building test 
descriptors. Update both utxo-core and utxo-staking packages to use the 
correct AST types and methods for tap tree script descriptors.

Ticket: BTC-1829