### PR TITLE
Use unit-test script for tests

### DIFF
--- a/modules/utxo-lib/package.json
+++ b/modules/utxo-lib/package.json
@@ -23,7 +23,7 @@
     "coverage-report": "nyc report --reporter=lcov",
     "coverage-html": "nyc report --reporter=html",
     "coverage": "npm run build && nyc --check-coverage mocha",
-    "test": "npm run coverage",
+    "test": "npm run unit-test",
     "unit-test": "mocha --recursive test",
     "lint": "eslint --quiet .",
     "fmt": "prettier --write '{src,test}/**/*.{ts,js}'",


### PR DESCRIPTION

Default test command now uses unit-test script. Coverage command had issues.

Closes BTC-0