### PR TITLE
feat(abstract-utxo): enforce groupwise descriptor validation

### DIFF
--- a/modules/abstract-utxo/src/descriptor/NamedDescriptor.ts
+++ b/modules/abstract-utxo/src/descriptor/NamedDescriptor.ts
@@ -1,5 +1,5 @@
 import * as t from 'io-ts';
-import { Descriptor } from '@bitgo/wasm-miniscript';
+import { Descriptor, DescriptorPkType } from '@bitgo/wasm-miniscript';
 import { BIP32Interface, networks } from '@bitgo/utxo-lib';
 import { signMessage, verifyMessage } from '@bitgo/sdk-core';
 
@@ -22,6 +22,8 @@ export type NamedDescriptor<T = string> = {
   signatures?: string[];
 };
 
+export type NamedDescriptorNative = NamedDescriptor<Descriptor>;
+
 export function createNamedDescriptorWithSignature(
   name: string,
   descriptor: string | Descriptor,
@@ -33,6 +35,10 @@ export function createNamedDescriptorWithSignature(
   const value = descriptor.toString();
   const signature = signMessage(value, signingKey, networks.bitcoin).toString('hex');
   return { name, value, signatures: [signature] };
+}
+
+export function toNamedDescriptorNative(e: NamedDescriptor, pkType: DescriptorPkType): NamedDescriptorNative {
+  return { ...e, value: Descriptor.fromString(e.value, pkType) };
 }
 
 export function hasValidSignature(descriptor: string | Descriptor, key: BIP32Interface, signatures: string[]): boolean {

--- a/modules/abstract-utxo/src/descriptor/index.ts
+++ b/modules/abstract-utxo/src/descriptor/index.ts
@@ -1,7 +1,13 @@
 export { Miniscript, Descriptor } from '@bitgo/wasm-miniscript';
 export { DescriptorMap } from '@bitgo/utxo-core/descriptor';
 export { assertDescriptorWalletAddress } from './assertDescriptorWalletAddress';
-export { NamedDescriptor, createNamedDescriptorWithSignature, hasValidSignature } from './NamedDescriptor';
+export {
+  NamedDescriptor,
+  createNamedDescriptorWithSignature,
+  hasValidSignature,
+  NamedDescriptorNative,
+  toNamedDescriptorNative,
+} from './NamedDescriptor';
 export { isDescriptorWallet, getDescriptorMapFromWallet } from './descriptorWallet';
 export { getPolicyForEnv } from './validatePolicy';
 export * as createWallet from './createWallet';

--- a/modules/abstract-utxo/src/descriptor/validatePolicy.ts
+++ b/modules/abstract-utxo/src/descriptor/validatePolicy.ts
@@ -1,16 +1,16 @@
-import { Descriptor } from '@bitgo/wasm-miniscript';
 import { EnvironmentName, Triple } from '@bitgo/sdk-core';
 import * as utxolib from '@bitgo/utxo-lib';
 import { DescriptorMap, toDescriptorMap } from '@bitgo/utxo-core/descriptor';
 
 import { parseDescriptor } from './builder';
-import { hasValidSignature, NamedDescriptor } from './NamedDescriptor';
+import { hasValidSignature, NamedDescriptor, NamedDescriptorNative, toNamedDescriptorNative } from './NamedDescriptor';
 
 export type KeyTriple = Triple<utxolib.BIP32Interface>;
 
 export interface DescriptorValidationPolicy {
   name: string;
-  validate(d: Descriptor, walletKeys: KeyTriple, signatures: string[]): boolean;
+
+  validate(arr: NamedDescriptorNative[], walletKeys: KeyTriple): boolean;
 }
 
 export const policyAllowAll: DescriptorValidationPolicy = {
@@ -21,13 +21,15 @@ export const policyAllowAll: DescriptorValidationPolicy = {
 export function getValidatorDescriptorTemplate(name: string): DescriptorValidationPolicy {
   return {
     name: 'descriptorTemplate(' + name + ')',
-    validate(d: Descriptor, walletKeys: KeyTriple): boolean {
-      const parsed = parseDescriptor(d);
-      return (
-        parsed.name === name &&
-        parsed.keys.length === walletKeys.length &&
-        parsed.keys.every((k, i) => k.toBase58() === walletKeys[i].neutered().toBase58())
-      );
+    validate(arr: NamedDescriptorNative[], walletKeys: KeyTriple): boolean {
+      return arr.every((d) => {
+        const parsed = parseDescriptor(d.value);
+        return (
+          parsed.name === name &&
+          parsed.keys.length === walletKeys.length &&
+          parsed.keys.every((k, i) => k.toBase58() === walletKeys[i].neutered().toBase58())
+        );
+      });
     },
   };
 }
@@ -35,8 +37,8 @@ export function getValidatorDescriptorTemplate(name: string): DescriptorValidati
 export function getValidatorEvery(validators: DescriptorValidationPolicy[]): DescriptorValidationPolicy {
   return {
     name: 'every(' + validators.map((v) => v.name).join(',') + ')',
-    validate(d: Descriptor, walletKeys: KeyTriple, signatures: string[]): boolean {
-      return validators.every((v) => v.validate(d, walletKeys, signatures));
+    validate(arr: NamedDescriptorNative[], walletKeys: KeyTriple): boolean {
+      return validators.every((v) => v.validate(arr, walletKeys));
     },
   };
 }
@@ -44,8 +46,8 @@ export function getValidatorEvery(validators: DescriptorValidationPolicy[]): Des
 export function getValidatorSome(validators: DescriptorValidationPolicy[]): DescriptorValidationPolicy {
   return {
     name: 'some(' + validators.map((v) => v.name).join(',') + ')',
-    validate(d: Descriptor, walletKeys: KeyTriple, signatures: string[]): boolean {
-      return validators.some((v) => v.validate(d, walletKeys, signatures));
+    validate(arr: NamedDescriptorNative[], walletKeys: KeyTriple): boolean {
+      return validators.some((v) => v.validate(arr, walletKeys));
     },
   };
 }
@@ -57,27 +59,26 @@ export function getValidatorOneOfTemplates(names: string[]): DescriptorValidatio
 export function getValidatorSignedByUserKey(): DescriptorValidationPolicy {
   return {
     name: 'signedByUser',
-    validate(d: Descriptor, walletKeys: KeyTriple, signatures: string[]): boolean {
+    validate(arr: NamedDescriptorNative[], walletKeys: KeyTriple): boolean {
       // the first key is the user key, by convention
-      return hasValidSignature(d, walletKeys[0], signatures);
+      return arr.every((d) => hasValidSignature(d.value, walletKeys[0], d.signatures ?? []));
     },
   };
 }
 
 export class DescriptorPolicyValidationError extends Error {
-  constructor(descriptor: Descriptor, policy: DescriptorValidationPolicy) {
-    super(`Descriptor ${descriptor.toString()} does not match policy ${policy.name}`);
+  constructor(ds: NamedDescriptorNative[], policy: DescriptorValidationPolicy) {
+    super(`Descriptors ${ds.map((d) => d.value.toString())} does not match policy ${policy.name}`);
   }
 }
 
 export function assertDescriptorPolicy(
-  descriptor: Descriptor,
+  descriptors: NamedDescriptorNative[],
   policy: DescriptorValidationPolicy,
-  walletKeys: KeyTriple,
-  signatures: string[]
+  walletKeys: KeyTriple
 ): void {
-  if (!policy.validate(descriptor, walletKeys, signatures)) {
-    throw new DescriptorPolicyValidationError(descriptor, policy);
+  if (!policy.validate(descriptors, walletKeys)) {
+    throw new DescriptorPolicyValidationError(descriptors, policy);
   }
 }
 
@@ -86,13 +87,11 @@ export function toDescriptorMapValidate(
   walletKeys: KeyTriple,
   policy: DescriptorValidationPolicy
 ): DescriptorMap {
-  return toDescriptorMap(
-    descriptors.map((namedDescriptor) => {
-      const d = Descriptor.fromString(namedDescriptor.value, 'derivable');
-      assertDescriptorPolicy(d, policy, walletKeys, namedDescriptor.signatures ?? []);
-      return { name: namedDescriptor.name, value: d };
-    })
+  const namedDescriptorsNative: NamedDescriptorNative[] = descriptors.map((v) =>
+    toNamedDescriptorNative(v, 'derivable')
   );
+  assertDescriptorPolicy(namedDescriptorsNative, policy, walletKeys);
+  return toDescriptorMap(namedDescriptorsNative);
 }
 
 export function getPolicyForEnv(env: EnvironmentName): DescriptorValidationPolicy {
@@ -101,7 +100,7 @@ export function getPolicyForEnv(env: EnvironmentName): DescriptorValidationPolic
     case 'prod':
       return getValidatorSome([
         // allow all 2-of-3-ish descriptors where the keys match the wallet keys
-        getValidatorOneOfTemplates(['Wsh2Of3', 'Wsh2Of3CltvDrop', 'ShWsh2Of3CltvDrop']),
+        getValidatorOneOfTemplates(['Wsh2Of3', 'Wsh2Of3CltvDrop']),
         // allow all descriptors signed by the user key
         getValidatorSignedByUserKey(),
       ]);

--- a/modules/abstract-utxo/src/descriptor/validatePolicy.ts
+++ b/modules/abstract-utxo/src/descriptor/validatePolicy.ts
@@ -99,8 +99,10 @@ export function getPolicyForEnv(env: EnvironmentName): DescriptorValidationPolic
     case 'adminProd':
     case 'prod':
       return getValidatorSome([
-        // allow all 2-of-3-ish descriptors where the keys match the wallet keys
-        getValidatorOneOfTemplates(['Wsh2Of3', 'Wsh2Of3CltvDrop']),
+        // allow 2-of-3-ish descriptor groups where the keys match the wallet keys
+        getValidatorDescriptorTemplate('Wsh2Of3'),
+        // allow descriptor groups where all keys match the wallet keys plus OP_DROP (coredao staking)
+        getValidatorDescriptorTemplate('Wsh2Of3CltvDrop'),
         // allow all descriptors signed by the user key
         getValidatorSignedByUserKey(),
       ]);

--- a/modules/abstract-utxo/test/transaction/descriptor/validatePolicy.ts
+++ b/modules/abstract-utxo/test/transaction/descriptor/validatePolicy.ts
@@ -1,11 +1,10 @@
 import assert from 'assert';
 
-import { Descriptor } from '@bitgo/wasm-miniscript';
 import { Triple } from '@bitgo/sdk-core';
 import { BIP32Interface } from '@bitgo/utxo-lib';
 import { getKeyTriple } from '@bitgo/utxo-core/testutil';
 
-import { DescriptorTemplate, getDescriptor } from '../../../../utxo-core/src/testutil/descriptor/descriptors';
+import { DescriptorTemplate, getDescriptor } from '../../../../utxo-core/src/testutil/descriptor';
 import {
   assertDescriptorPolicy,
   DescriptorPolicyValidationError,
@@ -13,15 +12,20 @@ import {
   getPolicyForEnv,
   getValidatorDescriptorTemplate,
 } from '../../../src/descriptor/validatePolicy';
-import { NamedDescriptor, createNamedDescriptorWithSignature } from '../../../src/descriptor';
+import { NamedDescriptor, createNamedDescriptorWithSignature, toNamedDescriptorNative } from '../../../src/descriptor';
 
 function testAssertDescriptorPolicy(
-  d: NamedDescriptor<string>,
+  ds: NamedDescriptor<string>[],
   p: DescriptorValidationPolicy,
   k: Triple<BIP32Interface>,
   expectedError: DescriptorPolicyValidationError | null
 ) {
-  const f = () => assertDescriptorPolicy(Descriptor.fromString(d.value, 'derivable'), p, k, d.signatures ?? []);
+  const f = () =>
+    assertDescriptorPolicy(
+      ds.map((d) => toNamedDescriptorNative(d, 'derivable')),
+      p,
+      k
+    );
   if (expectedError) {
     assert.throws(f);
   } else {
@@ -39,21 +43,24 @@ describe('assertDescriptorPolicy', function () {
   }
 
   it('has expected result', function () {
-    testAssertDescriptorPolicy(getNamedDescriptor('Wsh2Of3'), getValidatorDescriptorTemplate('Wsh2Of3'), keys, null);
+    testAssertDescriptorPolicy([getNamedDescriptor('Wsh2Of3')], getValidatorDescriptorTemplate('Wsh2Of3'), keys, null);
 
     // prod does only allow Wsh2Of3-ish descriptors
-    testAssertDescriptorPolicy(getNamedDescriptor('Wsh2Of3'), getPolicyForEnv('prod'), keys, null);
+    testAssertDescriptorPolicy([getNamedDescriptor('Wsh2Of3')], getPolicyForEnv('prod'), keys, null);
 
     // prod only allows other descriptors if they are signed by the user key
-    testAssertDescriptorPolicy(getNamedDescriptor('Wsh2Of2'), getPolicyForEnv('prod'), keys, null);
+    testAssertDescriptorPolicy([getNamedDescriptor('Wsh2Of2')], getPolicyForEnv('prod'), keys, null);
     testAssertDescriptorPolicy(
-      stripSignature(getNamedDescriptor('Wsh2Of2')),
+      [stripSignature(getNamedDescriptor('Wsh2Of2'))],
       getPolicyForEnv('prod'),
       keys,
-      new DescriptorPolicyValidationError(getDescriptor('Wsh2Of2'), getPolicyForEnv('prod'))
+      new DescriptorPolicyValidationError(
+        [toNamedDescriptorNative(getNamedDescriptor('Wsh2Of2'), 'derivable')],
+        getPolicyForEnv('prod')
+      )
     );
 
     // test is very permissive by default
-    testAssertDescriptorPolicy(stripSignature(getNamedDescriptor('Wsh2Of2')), getPolicyForEnv('test'), keys, null);
+    testAssertDescriptorPolicy([stripSignature(getNamedDescriptor('Wsh2Of2'))], getPolicyForEnv('test'), keys, null);
   });
 });


### PR DESCRIPTION

Add validation for multiple descriptors and prevent mixed descriptor types
in production. Split validation for 2-of-3 descriptors to ensure they
belong to the same type group, preventing potential security issues with
mixed regular and staking descriptors.

Refactor descriptor handling to support native descriptor types and add
type conversion helpers.

Issue: BTC-1843