### PR TITLE
feat(utxo): add output utilities for transaction building

### DIFF
--- a/modules/utxo-core/.eslintrc.js
+++ b/modules/utxo-core/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
   extends: ['../../.eslintrc.json'],
   rules: {
+    '@typescript-eslint/ban-types': 'off',
     'import/order': ['error', { 'newlines-between': 'always' }],
     'import/no-internal-modules': 'off',
   },

--- a/modules/utxo-core/src/descriptor/Output.ts
+++ b/modules/utxo-core/src/descriptor/Output.ts
@@ -3,10 +3,74 @@ import { Descriptor } from '@bitgo/wasm-miniscript';
 import { DescriptorMap } from './DescriptorMap';
 import { createScriptPubKeyFromDescriptor } from './address';
 
-export type Output = {
+export type Output<TValue = bigint> = {
   script: Buffer;
-  value: bigint;
+  value: TValue;
 };
+
+export type MaxOutput = Output<'max'>;
+
+type ValueBigInt = { value: bigint };
+type ValueMax = { value: 'max' };
+
+/**
+ * @return true if the output is a max output
+ */
+export function isMaxOutput<A extends ValueBigInt, B extends ValueMax>(output: A | B): output is B {
+  return output.value === 'max';
+}
+
+/**
+ * @return the max output if there is one
+ * @throws if there are multiple max outputs
+ */
+export function getMaxOutput<A extends ValueBigInt, B extends ValueMax>(outputs: (A | B)[]): B | undefined {
+  const max = outputs.filter(isMaxOutput<A, B>);
+  if (max.length === 0) {
+    return undefined;
+  }
+  if (max.length > 1) {
+    throw new Error('Multiple max outputs');
+  }
+  return max[0];
+}
+
+/**
+ * @return the sum of the outputs
+ */
+export function getOutputSum(outputs: ValueBigInt[]): bigint {
+  return outputs.reduce((sum, output) => sum + output.value, 0n);
+}
+
+/**
+ * @return the sum of the outputs that are not 'max'
+ */
+export function getFixedOutputSum(outputs: (ValueBigInt | ValueMax)[]): bigint {
+  return getOutputSum(outputs.filter((o): o is Output => !isMaxOutput(o)));
+}
+
+/**
+ * @param outputs
+ * @param params
+ * @return the outputs with the 'max' output replaced with the max amount
+ */
+export function toFixedOutputs<A extends ValueBigInt, B extends ValueMax>(
+  outputs: (A | B)[],
+  params: { maxAmount: bigint }
+): A[] {
+  // assert that there is at most one max output
+  const maxOutput = getMaxOutput<A, B>(outputs);
+  return outputs.map((output): A => {
+    if (isMaxOutput(output)) {
+      if (output !== maxOutput) {
+        throw new Error('illegal state');
+      }
+      return { ...output, value: params.maxAmount };
+    } else {
+      return output;
+    }
+  });
+}
 
 export type WithDescriptor<T> = T & {
   descriptor: Descriptor;
@@ -15,6 +79,22 @@ export type WithDescriptor<T> = T & {
 export type WithOptDescriptor<T> = T & {
   descriptor?: Descriptor;
 };
+
+export function isInternalOutput<T extends object>(output: T | WithDescriptor<T>): output is WithDescriptor<T> {
+  return 'descriptor' in output && output.descriptor !== undefined;
+}
+
+export function isExternalOutput<T extends object>(output: T | WithDescriptor<T>): output is T {
+  return !isInternalOutput(output);
+}
+
+/**
+ * @return the sum of the external outputs that are not 'max'
+ * @param outputs
+ */
+export function getExternalFixedAmount(outputs: WithOptDescriptor<Output | MaxOutput>[]): bigint {
+  return getFixedOutputSum(outputs.filter(isExternalOutput));
+}
 
 export type PrevOutput = {
   hash: string;
@@ -40,7 +120,9 @@ export function toDerivedDescriptorWalletOutput(
   const derivedDescriptor = descriptor.atDerivationIndex(output.descriptorIndex);
   const script = createScriptPubKeyFromDescriptor(derivedDescriptor);
   if (!script.equals(output.witnessUtxo.script)) {
-    throw new Error(`Script mismatch: descriptor ${output.descriptorName} ${descriptor.toString()} script=${script}`);
+    throw new Error(
+      `Script mismatch: descriptor ${output.descriptorName} ${descriptor.toString()} script=${script.toString('hex')}`
+    );
   }
   return {
     hash: output.hash,

--- a/modules/utxo-core/test/descriptor/Output.ts
+++ b/modules/utxo-core/test/descriptor/Output.ts
@@ -1,0 +1,68 @@
+import * as assert from 'assert';
+
+import { Descriptor } from '@bitgo/wasm-miniscript';
+
+import {
+  getMaxOutput,
+  isMaxOutput,
+  getOutputSum,
+  getFixedOutputSum,
+  toFixedOutputs,
+  isInternalOutput,
+  isExternalOutput,
+} from '../../src/descriptor/Output';
+
+describe('Output', function () {
+  const oBigInt = { value: 1n };
+  const oBigInt2 = { value: 2n };
+  const oMax = { value: 'max' } as const;
+  const mockDescriptor = {} as Descriptor;
+
+  it('getMaxOutput returns expected values', function () {
+    assert.strictEqual(getMaxOutput([oBigInt]), undefined);
+    assert.strictEqual(getMaxOutput([oBigInt, oBigInt]), undefined);
+    assert.strictEqual(getMaxOutput([oBigInt, oMax]), oMax);
+    assert.throws(() => getMaxOutput([oMax, oMax]), /Multiple max outputs/);
+  });
+
+  it('isMaxOutput correctly identifies max outputs', function () {
+    assert.strictEqual(isMaxOutput(oBigInt), false);
+    assert.strictEqual(isMaxOutput(oMax), true);
+  });
+
+  it('getOutputSum calculates sum correctly', function () {
+    assert.strictEqual(getOutputSum([]), 0n);
+    assert.strictEqual(getOutputSum([oBigInt]), 1n);
+    assert.strictEqual(getOutputSum([oBigInt, oBigInt2]), 3n);
+  });
+
+  it('getFixedOutputSum handles mixed outputs', function () {
+    assert.strictEqual(getFixedOutputSum([]), 0n);
+    assert.strictEqual(getFixedOutputSum([oBigInt]), 1n);
+    assert.strictEqual(getFixedOutputSum([oBigInt, oMax]), 1n);
+    assert.strictEqual(getFixedOutputSum([oBigInt, oBigInt2, oMax]), 3n);
+  });
+
+  it('toFixedOutputs converts max outputs correctly', function () {
+    const maxAmount = 10n;
+    assert.deepStrictEqual(toFixedOutputs([oBigInt], { maxAmount }), [oBigInt]);
+    assert.deepStrictEqual(toFixedOutputs([oMax], { maxAmount }), [{ ...oMax, value: maxAmount }]);
+    assert.throws(() => toFixedOutputs([oMax, oMax], { maxAmount }), /Multiple max outputs/);
+  });
+
+  it('isInternalOutput correctly identifies internal outputs', function () {
+    const internalOutput = { value: 1n, descriptor: mockDescriptor };
+    const externalOutput = { value: 1n };
+
+    assert.strictEqual(isInternalOutput(internalOutput), true);
+    assert.strictEqual(isInternalOutput(externalOutput), false);
+  });
+
+  it('isExternalOutput correctly identifies external outputs', function () {
+    const internalOutput = { value: 1n, descriptor: mockDescriptor };
+    const externalOutput = { value: 1n };
+
+    assert.strictEqual(isExternalOutput(internalOutput), false);
+    assert.strictEqual(isExternalOutput(externalOutput), true);
+  });
+});


### PR DESCRIPTION

Add utilities to help building bitcoin transactions with multiple outputs.
Simplifies output classification and value calculations.

Issue: BTC-1826