### PR TITLE
feat(utxo-lib): preserve network when cloning PSBTs

### DIFF
--- a/modules/utxo-core/.prettierignore
+++ b/modules/utxo-core/.prettierignore
@@ -1,0 +1,1 @@
+test/descriptor/psbt/fixtures

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Tr2Of3-NoKeyPath.createPsbt.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Tr2Of3-NoKeyPath.createPsbt.json
@@ -24,19 +24,25 @@
             "masterFingerprint": "86ea6d35",
             "pubkey": "85f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
             "path": "m/0/0",
-            "leafHashes": ["649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"]
+            "leafHashes": [
+              "649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"
+            ]
           },
           {
             "masterFingerprint": "96daa738",
             "pubkey": "9a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de406",
             "path": "m/0/0",
-            "leafHashes": ["649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"]
+            "leafHashes": [
+              "649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"
+            ]
           },
           {
             "masterFingerprint": "702fc808",
             "pubkey": "d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e",
             "path": "m/0/0",
-            "leafHashes": ["649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"]
+            "leafHashes": [
+              "649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"
+            ]
           }
         ],
         "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
@@ -59,13 +65,17 @@
             "masterFingerprint": "702fc808",
             "pubkey": "266670018fb65f1384da4e9b9b92c79d5c42d5f51c3ceb1e516babfb7595f243",
             "path": "m/0/1",
-            "leafHashes": ["4b67eca4ce07266e5fa17d6276fc6fe244a384baeb087983d3500199ec8931b6"]
+            "leafHashes": [
+              "4b67eca4ce07266e5fa17d6276fc6fe244a384baeb087983d3500199ec8931b6"
+            ]
           },
           {
             "masterFingerprint": "86ea6d35",
             "pubkey": "4062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e74",
             "path": "m/0/1",
-            "leafHashes": ["4b67eca4ce07266e5fa17d6276fc6fe244a384baeb087983d3500199ec8931b6"]
+            "leafHashes": [
+              "4b67eca4ce07266e5fa17d6276fc6fe244a384baeb087983d3500199ec8931b6"
+            ]
           },
           {
             "masterFingerprint": "f4ac30dd",
@@ -77,7 +87,9 @@
             "masterFingerprint": "96daa738",
             "pubkey": "d502c2c474f4874a96b544afa9f8a9aa49e03ca8fcf736b1a1d150a663db13a6",
             "path": "m/0/1",
-            "leafHashes": ["4b67eca4ce07266e5fa17d6276fc6fe244a384baeb087983d3500199ec8931b6"]
+            "leafHashes": [
+              "4b67eca4ce07266e5fa17d6276fc6fe244a384baeb087983d3500199ec8931b6"
+            ]
           }
         ],
         "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
@@ -108,19 +120,25 @@
             "masterFingerprint": "86ea6d35",
             "pubkey": "85f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
             "path": "m/0/0",
-            "leafHashes": ["649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"]
+            "leafHashes": [
+              "649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"
+            ]
           },
           {
             "masterFingerprint": "96daa738",
             "pubkey": "9a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de406",
             "path": "m/0/0",
-            "leafHashes": ["649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"]
+            "leafHashes": [
+              "649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"
+            ]
           },
           {
             "masterFingerprint": "702fc808",
             "pubkey": "d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e",
             "path": "m/0/0",
-            "leafHashes": ["649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"]
+            "leafHashes": [
+              "649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"
+            ]
           }
         ]
       }

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Tr2Of3-NoKeyPath.createPsbtFinal.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Tr2Of3-NoKeyPath.createPsbtFinal.json
@@ -33,26 +33,32 @@
           {
             "masterFingerprint": "f4ac30dd",
             "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
-            "path": "",
+            "path": "m",
             "leafHashes": []
           },
           {
             "masterFingerprint": "86ea6d35",
             "pubkey": "85f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
-            "path": "0/0",
-            "leafHashes": ["649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"]
+            "path": "m/0/0",
+            "leafHashes": [
+              "649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"
+            ]
           },
           {
             "masterFingerprint": "96daa738",
             "pubkey": "9a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de406",
-            "path": "0/0",
-            "leafHashes": ["649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"]
+            "path": "m/0/0",
+            "leafHashes": [
+              "649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"
+            ]
           },
           {
             "masterFingerprint": "702fc808",
             "pubkey": "d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e",
-            "path": "0/0",
-            "leafHashes": ["649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"]
+            "path": "m/0/0",
+            "leafHashes": [
+              "649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"
+            ]
           }
         ]
       }
@@ -96,7 +102,6 @@
     "nonces": []
   },
   "opts": {
-    "maximumFeeRate": 5000,
-    "bip32PathsAbsolute": false
+    "maximumFeeRate": 5000
   }
 }

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Tr2Of3-NoKeyPath.createPsbtSignedA.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Tr2Of3-NoKeyPath.createPsbtSignedA.json
@@ -24,19 +24,25 @@
             "masterFingerprint": "86ea6d35",
             "pubkey": "85f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
             "path": "0/0",
-            "leafHashes": ["649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"]
+            "leafHashes": [
+              "649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"
+            ]
           },
           {
             "masterFingerprint": "96daa738",
             "pubkey": "9a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de406",
             "path": "0/0",
-            "leafHashes": ["649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"]
+            "leafHashes": [
+              "649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"
+            ]
           },
           {
             "masterFingerprint": "702fc808",
             "pubkey": "d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e",
             "path": "0/0",
-            "leafHashes": ["649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"]
+            "leafHashes": [
+              "649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"
+            ]
           }
         ],
         "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
@@ -66,13 +72,17 @@
             "masterFingerprint": "702fc808",
             "pubkey": "266670018fb65f1384da4e9b9b92c79d5c42d5f51c3ceb1e516babfb7595f243",
             "path": "0/1",
-            "leafHashes": ["4b67eca4ce07266e5fa17d6276fc6fe244a384baeb087983d3500199ec8931b6"]
+            "leafHashes": [
+              "4b67eca4ce07266e5fa17d6276fc6fe244a384baeb087983d3500199ec8931b6"
+            ]
           },
           {
             "masterFingerprint": "86ea6d35",
             "pubkey": "4062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e74",
             "path": "0/1",
-            "leafHashes": ["4b67eca4ce07266e5fa17d6276fc6fe244a384baeb087983d3500199ec8931b6"]
+            "leafHashes": [
+              "4b67eca4ce07266e5fa17d6276fc6fe244a384baeb087983d3500199ec8931b6"
+            ]
           },
           {
             "masterFingerprint": "f4ac30dd",
@@ -84,7 +94,9 @@
             "masterFingerprint": "96daa738",
             "pubkey": "d502c2c474f4874a96b544afa9f8a9aa49e03ca8fcf736b1a1d150a663db13a6",
             "path": "0/1",
-            "leafHashes": ["4b67eca4ce07266e5fa17d6276fc6fe244a384baeb087983d3500199ec8931b6"]
+            "leafHashes": [
+              "4b67eca4ce07266e5fa17d6276fc6fe244a384baeb087983d3500199ec8931b6"
+            ]
           }
         ],
         "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
@@ -122,19 +134,25 @@
             "masterFingerprint": "86ea6d35",
             "pubkey": "85f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
             "path": "0/0",
-            "leafHashes": ["649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"]
+            "leafHashes": [
+              "649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"
+            ]
           },
           {
             "masterFingerprint": "96daa738",
             "pubkey": "9a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de406",
             "path": "0/0",
-            "leafHashes": ["649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"]
+            "leafHashes": [
+              "649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"
+            ]
           },
           {
             "masterFingerprint": "702fc808",
             "pubkey": "d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e",
             "path": "0/0",
-            "leafHashes": ["649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"]
+            "leafHashes": [
+              "649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"
+            ]
           }
         ]
       }

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Tr2Of3-NoKeyPath.createPsbtSignedAB.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Tr2Of3-NoKeyPath.createPsbtSignedAB.json
@@ -24,19 +24,25 @@
             "masterFingerprint": "86ea6d35",
             "pubkey": "85f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
             "path": "0/0",
-            "leafHashes": ["649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"]
+            "leafHashes": [
+              "649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"
+            ]
           },
           {
             "masterFingerprint": "96daa738",
             "pubkey": "9a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de406",
             "path": "0/0",
-            "leafHashes": ["649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"]
+            "leafHashes": [
+              "649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"
+            ]
           },
           {
             "masterFingerprint": "702fc808",
             "pubkey": "d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e",
             "path": "0/0",
-            "leafHashes": ["649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"]
+            "leafHashes": [
+              "649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"
+            ]
           }
         ],
         "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
@@ -71,13 +77,17 @@
             "masterFingerprint": "702fc808",
             "pubkey": "266670018fb65f1384da4e9b9b92c79d5c42d5f51c3ceb1e516babfb7595f243",
             "path": "0/1",
-            "leafHashes": ["4b67eca4ce07266e5fa17d6276fc6fe244a384baeb087983d3500199ec8931b6"]
+            "leafHashes": [
+              "4b67eca4ce07266e5fa17d6276fc6fe244a384baeb087983d3500199ec8931b6"
+            ]
           },
           {
             "masterFingerprint": "86ea6d35",
             "pubkey": "4062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e74",
             "path": "0/1",
-            "leafHashes": ["4b67eca4ce07266e5fa17d6276fc6fe244a384baeb087983d3500199ec8931b6"]
+            "leafHashes": [
+              "4b67eca4ce07266e5fa17d6276fc6fe244a384baeb087983d3500199ec8931b6"
+            ]
           },
           {
             "masterFingerprint": "f4ac30dd",
@@ -89,7 +99,9 @@
             "masterFingerprint": "96daa738",
             "pubkey": "d502c2c474f4874a96b544afa9f8a9aa49e03ca8fcf736b1a1d150a663db13a6",
             "path": "0/1",
-            "leafHashes": ["4b67eca4ce07266e5fa17d6276fc6fe244a384baeb087983d3500199ec8931b6"]
+            "leafHashes": [
+              "4b67eca4ce07266e5fa17d6276fc6fe244a384baeb087983d3500199ec8931b6"
+            ]
           }
         ],
         "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
@@ -132,19 +144,25 @@
             "masterFingerprint": "86ea6d35",
             "pubkey": "85f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
             "path": "0/0",
-            "leafHashes": ["649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"]
+            "leafHashes": [
+              "649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"
+            ]
           },
           {
             "masterFingerprint": "96daa738",
             "pubkey": "9a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de406",
             "path": "0/0",
-            "leafHashes": ["649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"]
+            "leafHashes": [
+              "649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"
+            ]
           },
           {
             "masterFingerprint": "702fc808",
             "pubkey": "d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e",
             "path": "0/0",
-            "leafHashes": ["649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"]
+            "leafHashes": [
+              "649630c71a6826ae30a736fbb585330dce430fa5683c3f8a8b04cce0c4d7b416"
+            ]
           }
         ]
       }

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Wsh2Of3.createPsbtFinal.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Wsh2Of3.createPsbtFinal.json
@@ -24,17 +24,17 @@
           {
             "masterFingerprint": "86ea6d35",
             "pubkey": "0285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
-            "path": "0/0"
+            "path": "m/0/0"
           },
           {
             "masterFingerprint": "96daa738",
             "pubkey": "029a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de406",
-            "path": "0/0"
+            "path": "m/0/0"
           },
           {
             "masterFingerprint": "702fc808",
             "pubkey": "02d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e",
-            "path": "0/0"
+            "path": "m/0/0"
           }
         ]
       }
@@ -78,7 +78,6 @@
     "nonces": []
   },
   "opts": {
-    "maximumFeeRate": 5000,
-    "bip32PathsAbsolute": false
+    "maximumFeeRate": 5000
   }
 }

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Wsh2Of3CltvDrop.createPsbtFinal.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Wsh2Of3CltvDrop.createPsbtFinal.json
@@ -24,17 +24,17 @@
           {
             "masterFingerprint": "86ea6d35",
             "pubkey": "0285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
-            "path": "0/0"
+            "path": "m/0/0"
           },
           {
             "masterFingerprint": "96daa738",
             "pubkey": "029a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de406",
-            "path": "0/0"
+            "path": "m/0/0"
           },
           {
             "masterFingerprint": "702fc808",
             "pubkey": "02d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e",
-            "path": "0/0"
+            "path": "m/0/0"
           }
         ]
       }
@@ -78,7 +78,6 @@
     "nonces": []
   },
   "opts": {
-    "maximumFeeRate": 5000,
-    "bip32PathsAbsolute": false
+    "maximumFeeRate": 5000
   }
 }

--- a/modules/utxo-lib/src/bitgo/UtxoPsbt.ts
+++ b/modules/utxo-lib/src/bitgo/UtxoPsbt.ts
@@ -1321,7 +1321,7 @@ export class UtxoPsbt<Tx extends UtxoTransaction<bigint> = UtxoTransaction<bigin
   }
 
   clone(): this {
-    return super.clone() as this;
+    return UtxoPsbt.fromBuffer(this.toBuffer(), { network: this.network }) as this;
   }
 
   extractTransaction(disableFeeCheck = true): UtxoTransaction<bigint> {

--- a/modules/utxo-lib/src/bitgo/dash/DashPsbt.ts
+++ b/modules/utxo-lib/src/bitgo/dash/DashPsbt.ts
@@ -27,4 +27,8 @@ export class DashPsbt extends UtxoPsbt<DashTransaction<bigint>> {
     this.tx.extraPayload = extraPayload;
     return this;
   }
+
+  clone(): this {
+    return new DashPsbt({ network: this.network }, super.clone().data) as this;
+  }
 }

--- a/modules/utxo-lib/src/bitgo/litecoin/LitecoinPsbt.ts
+++ b/modules/utxo-lib/src/bitgo/litecoin/LitecoinPsbt.ts
@@ -15,4 +15,8 @@ export class LitecoinPsbt extends UtxoPsbt<LitecoinTransaction<bigint>> {
       data || new PsbtBase(new PsbtTransaction({ tx: new LitecoinTransaction<bigint>(opts.network) }))
     );
   }
+
+  clone(): this {
+    return new LitecoinPsbt({ network: this.network }, super.clone().data) as this;
+  }
 }

--- a/modules/utxo-lib/src/bitgo/zcash/ZcashPsbt.ts
+++ b/modules/utxo-lib/src/bitgo/zcash/ZcashPsbt.ts
@@ -157,4 +157,8 @@ export class ZcashPsbt extends UtxoPsbt<ZcashTransaction<bigint>> {
     typeforce(types.UInt32, expiryHeight);
     this.setPropertyCheckSignatures('expiryHeight', expiryHeight);
   }
+
+  clone(): this {
+    return ZcashPsbt.fromBuffer(this.toBuffer(), { network: this.network }) as this;
+  }
 }

--- a/modules/utxo-lib/test/bitgo/psbt/Psbt.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/Psbt.ts
@@ -96,14 +96,17 @@ const psbtInputs = inputScriptTypes.map((scriptType) => ({ scriptType, value: Bi
 const psbtOutputs = outputScriptTypes.map((scriptType) => ({ scriptType, value: BigInt(900) }));
 
 describe('Psbt Misc', function () {
-  it('fail to finalise p2tr sighash mismatch', function () {
-    const psbt = testutil.constructPsbt(
+  function getTestPsbt() {
+    return testutil.constructPsbt(
       [{ scriptType: 'p2tr', value: BigInt(1000) }],
       [{ scriptType: 'p2sh', value: BigInt(900) }],
       network,
       rootWalletKeys,
       'fullsigned'
     );
+  }
+  it('fail to finalise p2tr sighash mismatch', function () {
+    const psbt = getTestPsbt();
     assert(psbt.validateSignaturesOfAllInputs());
     const tapScriptSig = psbt.data.inputs[0].tapScriptSig;
     assert(tapScriptSig);
@@ -934,7 +937,11 @@ function testUtxoPsbt(coinNetwork: Network) {
 
     it('should be able to clone psbt', async function () {
       const clone = psbt.clone();
+      assert(clone instanceof psbt.constructor, `Expected clone to be instance of ${psbt.constructor.name}`);
       assert.deepStrictEqual(clone.toBuffer(), psbt.toBuffer());
+      assert.deepStrictEqual(clone.clone().toBuffer(), psbt.toBuffer());
+      assert.strictEqual(clone.network, psbt.network);
+      assert.strictEqual(clone.clone().network, psbt.network);
     });
 
     it('should be able to round-trip', async function () {


### PR DESCRIPTION

Improve cloning of PSBTs to preserve class type and network property in
deriving classes. Each subclass now correctly implements clone().

Issue: BTC-1826