### PR TITLE
feat(utxo-core): add support for descriptors with plain keys

### DIFF
--- a/modules/utxo-core/src/descriptor/psbt/findDescriptors.ts
+++ b/modules/utxo-core/src/descriptor/psbt/findDescriptors.ts
@@ -14,6 +14,28 @@ import { Descriptor } from '@bitgo/wasm-miniscript';
 
 import { DescriptorMap } from '../DescriptorMap';
 
+type DescriptorWithoutIndex = { descriptor: Descriptor; index: undefined };
+
+/**
+ * Find a definite descriptor in the descriptor map that matches the given script.
+ * @param script
+ * @param descriptorMap
+ */
+function findDescriptorWithoutDerivation(
+  script: Buffer,
+  descriptorMap: DescriptorMap
+): DescriptorWithoutIndex | undefined {
+  for (const descriptor of descriptorMap.values()) {
+    if (!descriptor.hasWildcard()) {
+      if (Buffer.from(descriptor.scriptPubkey()).equals(script)) {
+        return { descriptor, index: undefined };
+      }
+    }
+  }
+
+  return undefined;
+}
+
 type DescriptorWithIndex = { descriptor: Descriptor; index: number };
 
 /**
@@ -29,7 +51,7 @@ function findDescriptorForDerivationIndex(
   descriptorMap: DescriptorMap
 ): DescriptorWithIndex | undefined {
   for (const descriptor of descriptorMap.values()) {
-    if (Buffer.from(descriptor.atDerivationIndex(index).scriptPubkey()).equals(script)) {
+    if (descriptor.hasWildcard() && Buffer.from(descriptor.atDerivationIndex(index).scriptPubkey()).equals(script)) {
       return { descriptor, index };
     }
   }
@@ -92,16 +114,16 @@ function getDerivationPaths(v: WithBip32Derivation | WithTapBip32Derivation): st
 export function findDescriptorForInput(
   input: PsbtInput,
   descriptorMap: DescriptorMap
-): DescriptorWithIndex | undefined {
+): DescriptorWithIndex | DescriptorWithoutIndex | undefined {
   const script = input.witnessUtxo?.script;
   if (!script) {
     throw new Error('Missing script');
   }
-  const derivationPaths = getDerivationPaths(input);
-  if (!derivationPaths) {
-    throw new Error('Missing derivation paths');
-  }
-  return findDescriptorForAnyDerivationPath(script, derivationPaths, descriptorMap);
+  const derivationPaths = getDerivationPaths(input) ?? [];
+  return (
+    findDescriptorWithoutDerivation(script, descriptorMap) ??
+    findDescriptorForAnyDerivationPath(script, derivationPaths, descriptorMap)
+  );
 }
 
 /**

--- a/modules/utxo-core/src/descriptor/psbt/parse.ts
+++ b/modules/utxo-core/src/descriptor/psbt/parse.ts
@@ -7,7 +7,7 @@ import { getVirtualSize } from '../VirtualSize';
 import { findDescriptorForInput, findDescriptorForOutput } from './findDescriptors';
 import { assertSatisfiable } from './assertSatisfiable';
 
-export type ScriptId = { descriptor: Descriptor; index: number };
+export type ScriptId = { descriptor: Descriptor; index: number | undefined };
 
 export type ParsedInput = {
   address: string;
@@ -46,15 +46,15 @@ export function parse(
     if (!input.witnessUtxo.value) {
       throw new Error('invalid input: no value');
     }
-    const descriptorWithIndex = findDescriptorForInput(input, descriptorMap);
-    if (!descriptorWithIndex) {
+    const scriptId = findDescriptorForInput(input, descriptorMap);
+    if (!scriptId) {
       throw new Error('invalid input: no descriptor found');
     }
-    assertSatisfiable(psbt, inputIndex, descriptorWithIndex.descriptor);
+    assertSatisfiable(psbt, inputIndex, scriptId.descriptor);
     return {
       address: utxolib.address.fromOutputScript(input.witnessUtxo.script, network),
       value: input.witnessUtxo.value,
-      scriptId: descriptorWithIndex,
+      scriptId: scriptId,
     };
   });
   const outputs = psbt.txOutputs.map((output, i): ParsedOutput => {

--- a/modules/utxo-core/src/testutil/descriptor/descriptors.ts
+++ b/modules/utxo-core/src/testutil/descriptor/descriptors.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 
 import { Descriptor, ast } from '@bitgo/wasm-miniscript';
-import { BIP32Interface } from '@bitgo/utxo-lib';
+import { bip32, BIP32Interface } from '@bitgo/utxo-lib';
 
 import { DescriptorMap, PsbtParams } from '../../descriptor';
 import { getKeyTriple, Triple, KeyTriple } from '../key.utils';
@@ -41,6 +41,8 @@ function toDescriptorMap(v: Record<string, string>): DescriptorMap {
 export type DescriptorTemplate =
   | 'Wsh2Of3'
   | 'Tr1Of3-NoKeyPath-Tree'
+  // no xpubs, just plain keys
+  | 'Tr1Of3-NoKeyPath-Tree-Plain'
   | 'Tr2Of3-NoKeyPath'
   | 'Wsh2Of2'
   /*
@@ -57,6 +59,20 @@ function toXPub(k: BIP32Interface | string, path: string): string {
   return k.neutered().toBase58() + '/' + path;
 }
 
+function toPlain(k: BIP32Interface | string, { xonly = false } = {}): string {
+  if (typeof k === 'string') {
+    if (k.startsWith('xpub') || k.startsWith('xprv')) {
+      return toPlain(bip32.fromBase58(k), { xonly });
+    }
+    return k;
+  }
+  return k.publicKey.subarray(xonly ? 1 : 0).toString('hex');
+}
+
+function toXOnly(k: BIP32Interface | string): string {
+  return toPlain(k, { xonly: true });
+}
+
 function multiArgs(m: number, n: number, keys: BIP32Interface[] | string[], path: string): [number, ...string[]] {
   if (n < m) {
     throw new Error(`Cannot create ${m} of ${n} multisig`);
@@ -70,13 +86,10 @@ function multiArgs(m: number, n: number, keys: BIP32Interface[] | string[], path
 
 export function getPsbtParams(t: DescriptorTemplate): Partial<PsbtParams> {
   switch (t) {
-    case 'Wsh2Of3':
-    case 'Wsh2Of2':
-    case 'Tr1Of3-NoKeyPath-Tree':
-    case 'Tr2Of3-NoKeyPath':
-      return {};
     case 'Wsh2Of3CltvDrop':
       return { locktime: 1 };
+    default:
+      return {};
   }
 }
 
@@ -113,8 +126,21 @@ function getDescriptorNode(
           [{ pk: toXPub(keys[0], path) }, [{ pk: toXPub(keys[1], path) }, { pk: toXPub(keys[2], path) }]],
         ],
       };
+    case 'Tr1Of3-NoKeyPath-Tree-Plain':
+      return {
+        tr: [getUnspendableKey(), [{ pk: toXOnly(keys[0]) }, [{ pk: toXOnly(keys[1]) }, { pk: toXOnly(keys[2]) }]]],
+      };
   }
   throw new Error(`Unknown descriptor template: ${template}`);
+}
+
+function getDescriptorType(template: DescriptorTemplate): 'derivable' | 'definite' {
+  switch (template) {
+    case 'Tr1Of3-NoKeyPath-Tree-Plain':
+      return 'definite';
+    default:
+      return 'derivable';
+  }
 }
 
 export function getDescriptor(
@@ -122,7 +148,7 @@ export function getDescriptor(
   keys: KeyTriple | string[] = getDefaultXPubs(),
   path = '0/*'
 ): Descriptor {
-  return Descriptor.fromString(ast.formatNode(getDescriptorNode(template, keys, path)), 'derivable');
+  return Descriptor.fromString(ast.formatNode(getDescriptorNode(template, keys, path)), getDescriptorType(template));
 }
 
 export function getDescriptorMap(

--- a/modules/utxo-core/src/testutil/descriptor/mock.utils.ts
+++ b/modules/utxo-core/src/testutil/descriptor/mock.utils.ts
@@ -52,6 +52,10 @@ type MockOutput = {
   external?: boolean;
 };
 
+function tryDeriveAtIndex(descriptor: Descriptor, index: number): Descriptor {
+  return descriptor.hasWildcard() ? descriptor.atDerivationIndex(index) : descriptor;
+}
+
 export function mockPsbt(
   inputs: MockInput[],
   outputs: MockOutput[],
@@ -59,9 +63,9 @@ export function mockPsbt(
 ): utxolib.bitgo.UtxoPsbt {
   return createPsbt(
     { ...params, network: params.network ?? utxolib.networks.bitcoin },
-    inputs.map((i) => mockDerivedDescriptorWalletOutput(i.descriptor.atDerivationIndex(i.index), i)),
+    inputs.map((i) => mockDerivedDescriptorWalletOutput(tryDeriveAtIndex(i.descriptor, i.index), i)),
     outputs.map((o) => {
-      const derivedDescriptor = o.descriptor.atDerivationIndex(o.index);
+      const derivedDescriptor = tryDeriveAtIndex(o.descriptor, o.index);
       return {
         script: createScriptPubKeyFromDescriptor(derivedDescriptor),
         value: o.value,

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Tr1Of3-NoKeyPath-Tree-PlainKeys.psbtStages.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Tr1Of3-NoKeyPath-Tree-PlainKeys.psbtStages.json
@@ -1,0 +1,954 @@
+{
+  "unsigned": {
+    "psbt": {
+      "data": {
+        "inputs": [
+          {
+            "witnessUtxo": {
+              "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+              "value": "1000000"
+            },
+            "tapLeafScript": [
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac06b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9",
+                "script": "2078426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580ac",
+                "leafVersion": 192
+              },
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0a7f318e67988ceb3947e2511fd891a2fdaa83f2344f4b82e02a5c9a27ab99d61",
+                "script": "203569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebbac",
+                "leafVersion": 192
+              },
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bda7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9",
+                "script": "2028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac",
+                "leafVersion": 192
+              }
+            ],
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapMerkleRoot": "082536b1ddcb634ef1835b5935a304ab784c58636e1e8e325d8f4bbde0f945b9"
+          },
+          {
+            "witnessUtxo": {
+              "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+              "value": "1000000"
+            },
+            "tapLeafScript": [
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac06b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9",
+                "script": "2078426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580ac",
+                "leafVersion": 192
+              },
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0a7f318e67988ceb3947e2511fd891a2fdaa83f2344f4b82e02a5c9a27ab99d61",
+                "script": "203569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebbac",
+                "leafVersion": 192
+              },
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bda7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9",
+                "script": "2028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac",
+                "leafVersion": 192
+              }
+            ],
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapMerkleRoot": "082536b1ddcb634ef1835b5935a304ab784c58636e1e8e325d8f4bbde0f945b9"
+          }
+        ],
+        "outputs": [
+          {},
+          {
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapTree": {
+              "leaves": [
+                {
+                  "depth": 1,
+                  "leafVersion": 192,
+                  "script": "203569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebbac"
+                },
+                {
+                  "depth": 2,
+                  "leafVersion": 192,
+                  "script": "2028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac"
+                },
+                {
+                  "depth": 2,
+                  "leafVersion": 192,
+                  "script": "2078426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580ac"
+                }
+              ]
+            },
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ]
+          }
+        ],
+        "globalMap": {
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 0,
+                  "script": "",
+                  "sequence": 4294967293,
+                  "witness": []
+                },
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 1,
+                  "script": "",
+                  "sequence": 4294967293,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "400000",
+                  "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+                },
+                {
+                  "value": "400000",
+                  "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "nonceStore": {
+        "nonces": []
+      },
+      "opts": {
+        "maximumFeeRate": 5000
+      }
+    },
+    "parsed": {
+      "inputs": [
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "value": "1000000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
+        },
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "value": "1000000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477",
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000"
+        },
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+          "value": "400000"
+        }
+      ],
+      "spendAmount": "800000",
+      "minerFee": "1200000",
+      "virtualSize": 279
+    }
+  },
+  "signedA": {
+    "psbt": {
+      "data": {
+        "inputs": [
+          {
+            "witnessUtxo": {
+              "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+              "value": "1000000"
+            },
+            "tapScriptSig": [
+              {
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "leafHash": "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9",
+                "signature": "33f2bfd93cad0c555cd5c2eac550d7b7ababb0f524800257f17aaf88c92c8278f299cb388831d055d7c0bdbb75b7b0c56fa2ae20c1e7fbb4ccd85db6f3286d78"
+              }
+            ],
+            "tapLeafScript": [
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac06b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9",
+                "script": "2078426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580ac",
+                "leafVersion": 192
+              },
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0a7f318e67988ceb3947e2511fd891a2fdaa83f2344f4b82e02a5c9a27ab99d61",
+                "script": "203569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebbac",
+                "leafVersion": 192
+              },
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bda7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9",
+                "script": "2028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac",
+                "leafVersion": 192
+              }
+            ],
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapMerkleRoot": "082536b1ddcb634ef1835b5935a304ab784c58636e1e8e325d8f4bbde0f945b9"
+          },
+          {
+            "witnessUtxo": {
+              "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+              "value": "1000000"
+            },
+            "tapScriptSig": [
+              {
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "leafHash": "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9",
+                "signature": "62f789426299826339f9ddfbd656358483108e339d0010fefd49ae1ef1da72ea5c284958b6b5f2c2e544f36de34ddf9863d48474eaf0559cca9944d1b7f1befd"
+              }
+            ],
+            "tapLeafScript": [
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac06b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9",
+                "script": "2078426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580ac",
+                "leafVersion": 192
+              },
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0a7f318e67988ceb3947e2511fd891a2fdaa83f2344f4b82e02a5c9a27ab99d61",
+                "script": "203569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebbac",
+                "leafVersion": 192
+              },
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bda7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9",
+                "script": "2028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac",
+                "leafVersion": 192
+              }
+            ],
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapMerkleRoot": "082536b1ddcb634ef1835b5935a304ab784c58636e1e8e325d8f4bbde0f945b9"
+          }
+        ],
+        "outputs": [
+          {},
+          {
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapTree": {
+              "leaves": [
+                {
+                  "depth": 1,
+                  "leafVersion": 192,
+                  "script": "203569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebbac"
+                },
+                {
+                  "depth": 2,
+                  "leafVersion": 192,
+                  "script": "2028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac"
+                },
+                {
+                  "depth": 2,
+                  "leafVersion": 192,
+                  "script": "2078426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580ac"
+                }
+              ]
+            },
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ]
+          }
+        ],
+        "globalMap": {
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 0,
+                  "script": "",
+                  "sequence": 4294967293,
+                  "witness": []
+                },
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 1,
+                  "script": "",
+                  "sequence": 4294967293,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "400000",
+                  "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+                },
+                {
+                  "value": "400000",
+                  "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "nonceStore": {
+        "nonces": []
+      },
+      "opts": {
+        "maximumFeeRate": 5000
+      }
+    },
+    "parsed": {
+      "inputs": [
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "value": "1000000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
+        },
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "value": "1000000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477",
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000"
+        },
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+          "value": "400000"
+        }
+      ],
+      "spendAmount": "800000",
+      "minerFee": "1200000",
+      "virtualSize": 279
+    }
+  },
+  "signedB": {
+    "psbt": {
+      "data": {
+        "inputs": [
+          {
+            "witnessUtxo": {
+              "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+              "value": "1000000"
+            },
+            "tapScriptSig": [
+              {
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "leafHash": "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10",
+                "signature": "8c43a535f29c138df7f4f43b9dd93aaf8313ce59a681d7f31bda9baf9b3341972af0a46a161c8c3fc561c0e788fdc8ca80a591f168c10bf5cb9be74bf94bb53c"
+              }
+            ],
+            "tapLeafScript": [
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac06b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9",
+                "script": "2078426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580ac",
+                "leafVersion": 192
+              },
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0a7f318e67988ceb3947e2511fd891a2fdaa83f2344f4b82e02a5c9a27ab99d61",
+                "script": "203569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebbac",
+                "leafVersion": 192
+              },
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bda7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9",
+                "script": "2028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac",
+                "leafVersion": 192
+              }
+            ],
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapMerkleRoot": "082536b1ddcb634ef1835b5935a304ab784c58636e1e8e325d8f4bbde0f945b9"
+          },
+          {
+            "witnessUtxo": {
+              "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+              "value": "1000000"
+            },
+            "tapScriptSig": [
+              {
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "leafHash": "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10",
+                "signature": "013b322678f2780fca10619a562313f4c66c1101a9e3b1d9f1e19d7a5d59f5f2f23da3749cc6c2ab528dbd79138bb65b4c65fffd41426ee89e77ca53114d2f41"
+              }
+            ],
+            "tapLeafScript": [
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac06b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9",
+                "script": "2078426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580ac",
+                "leafVersion": 192
+              },
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0a7f318e67988ceb3947e2511fd891a2fdaa83f2344f4b82e02a5c9a27ab99d61",
+                "script": "203569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebbac",
+                "leafVersion": 192
+              },
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bda7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9",
+                "script": "2028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac",
+                "leafVersion": 192
+              }
+            ],
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapMerkleRoot": "082536b1ddcb634ef1835b5935a304ab784c58636e1e8e325d8f4bbde0f945b9"
+          }
+        ],
+        "outputs": [
+          {},
+          {
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapTree": {
+              "leaves": [
+                {
+                  "depth": 1,
+                  "leafVersion": 192,
+                  "script": "203569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebbac"
+                },
+                {
+                  "depth": 2,
+                  "leafVersion": 192,
+                  "script": "2028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac"
+                },
+                {
+                  "depth": 2,
+                  "leafVersion": 192,
+                  "script": "2078426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580ac"
+                }
+              ]
+            },
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ]
+          }
+        ],
+        "globalMap": {
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 0,
+                  "script": "",
+                  "sequence": 4294967293,
+                  "witness": []
+                },
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 1,
+                  "script": "",
+                  "sequence": 4294967293,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "400000",
+                  "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+                },
+                {
+                  "value": "400000",
+                  "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "nonceStore": {
+        "nonces": []
+      },
+      "opts": {
+        "maximumFeeRate": 5000
+      }
+    },
+    "parsed": {
+      "inputs": [
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "value": "1000000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
+        },
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "value": "1000000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477",
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000"
+        },
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+          "value": "400000"
+        }
+      ],
+      "spendAmount": "800000",
+      "minerFee": "1200000",
+      "virtualSize": 279
+    },
+    "psbtFinal": {
+      "data": {
+        "inputs": [
+          {
+            "witnessUtxo": {
+              "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+              "value": "1000000"
+            },
+            "finalScriptWitness": "03408c43a535f29c138df7f4f43b9dd93aaf8313ce59a681d7f31bda9baf9b3341972af0a46a161c8c3fc561c0e788fdc8ca80a591f168c10bf5cb9be74bf94bb53c222028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac61c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bda7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+          },
+          {
+            "witnessUtxo": {
+              "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+              "value": "1000000"
+            },
+            "finalScriptWitness": "0340013b322678f2780fca10619a562313f4c66c1101a9e3b1d9f1e19d7a5d59f5f2f23da3749cc6c2ab528dbd79138bb65b4c65fffd41426ee89e77ca53114d2f41222028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac61c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bda7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+          }
+        ],
+        "outputs": [
+          {},
+          {
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapTree": {
+              "leaves": [
+                {
+                  "depth": 1,
+                  "leafVersion": 192,
+                  "script": "203569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebbac"
+                },
+                {
+                  "depth": 2,
+                  "leafVersion": 192,
+                  "script": "2028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac"
+                },
+                {
+                  "depth": 2,
+                  "leafVersion": 192,
+                  "script": "2078426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580ac"
+                }
+              ]
+            },
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ]
+          }
+        ],
+        "globalMap": {
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 0,
+                  "script": "",
+                  "sequence": 4294967293,
+                  "witness": []
+                },
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 1,
+                  "script": "",
+                  "sequence": 4294967293,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "400000",
+                  "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+                },
+                {
+                  "value": "400000",
+                  "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "nonceStore": {
+        "nonces": []
+      },
+      "opts": {
+        "maximumFeeRate": 5000
+      }
+    },
+    "networkTx": {
+      "version": 2,
+      "locktime": 0,
+      "ins": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "script": "",
+          "sequence": 4294967293,
+          "witness": [
+            "8c43a535f29c138df7f4f43b9dd93aaf8313ce59a681d7f31bda9baf9b3341972af0a46a161c8c3fc561c0e788fdc8ca80a591f168c10bf5cb9be74bf94bb53c",
+            "2028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac",
+            "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bda7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+          ]
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "script": "",
+          "sequence": 4294967293,
+          "witness": [
+            "013b322678f2780fca10619a562313f4c66c1101a9e3b1d9f1e19d7a5d59f5f2f23da3749cc6c2ab528dbd79138bb65b4c65fffd41426ee89e77ca53114d2f41",
+            "2028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac",
+            "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bda7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+          ]
+        }
+      ],
+      "outs": [
+        {
+          "value": "400000",
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+        },
+        {
+          "value": "400000",
+          "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b"
+        }
+      ],
+      "network": {
+        "messagePrefix": "\u0018Bitcoin Signed Message:\n",
+        "bech32": "bc",
+        "bip32": {
+          "public": 76067358,
+          "private": 76066276
+        },
+        "pubKeyHash": 0,
+        "scriptHash": 5,
+        "wif": 128,
+        "coin": "btc"
+      }
+    },
+    "networkTxBuffer": "0200000000010201010101010101010101010101010101010101010101010101010101010101010000000000fdffffff01010101010101010101010101010101010101010101010101010101010101010100000000fdffffff02801a06000000000022002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8801a060000000000225120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b03408c43a535f29c138df7f4f43b9dd93aaf8313ce59a681d7f31bda9baf9b3341972af0a46a161c8c3fc561c0e788fdc8ca80a591f168c10bf5cb9be74bf94bb53c222028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac61c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bda7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d90340013b322678f2780fca10619a562313f4c66c1101a9e3b1d9f1e19d7a5d59f5f2f23da3749cc6c2ab528dbd79138bb65b4c65fffd41426ee89e77ca53114d2f41222028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac61c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bda7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d900000000"
+  }
+}

--- a/modules/utxo-core/test/descriptor/psbt/psbt.ts
+++ b/modules/utxo-core/test/descriptor/psbt/psbt.ts
@@ -1,7 +1,7 @@
-import * as assert from 'assert';
+import assert from 'assert';
 
 import * as utxolib from '@bitgo/utxo-lib';
-import { BIP32Interface } from '@bitgo/utxo-lib';
+import { BIP32Interface, ECPair, ECPairInterface } from '@bitgo/utxo-lib';
 import { Descriptor } from '@bitgo/wasm-miniscript';
 
 import { DescriptorTemplate, getDescriptor, getPsbtParams } from '../../../src/testutil/descriptor';
@@ -46,7 +46,22 @@ async function assertEqualsFixture(t: string, filename: string, value: unknown) 
 const selfKeys = getKeyTriple('a');
 const otherKeys = getKeyTriple('b');
 
-type PsbtStage = { name: string; keys: BIP32Interface[]; final?: boolean };
+function toPlain(k: BIP32Interface): ECPairInterface {
+  assert.ok(k.privateKey);
+  return ECPair.fromPrivateKey(k.privateKey);
+}
+
+function isBIP32Interface(k: BIP32Interface | ECPairInterface): k is BIP32Interface {
+  const { name } = k.constructor;
+  assert(name === 'BIP32' || name === 'ECPair');
+  return k.constructor.name === 'BIP32';
+}
+
+type PsbtStage = {
+  name: string;
+  keys: (BIP32Interface | ECPairInterface)[];
+  final?: boolean;
+};
 
 type FixtureStage = {
   psbt: utxolib.bitgo.UtxoPsbt;
@@ -63,7 +78,12 @@ function getStages(
     stages.map((stage) => {
       const psbtStageWrapped = toWrappedPsbt(psbt);
       for (const key of stage.keys) {
-        psbtStageWrapped.signWithXprv(key.toBase58());
+        if (isBIP32Interface(key)) {
+          psbtStageWrapped.signWithXprv(key.toBase58());
+        } else {
+          assert(key.privateKey);
+          psbtStageWrapped.signWithPrv(key.privateKey);
+        }
       }
       const psbtStage = toUtxoPsbt(psbtStageWrapped, utxolib.networks.bitcoin);
       let psbtFinal: utxolib.bitgo.UtxoPsbt | undefined;
@@ -134,10 +154,19 @@ describeCreatePsbt2Of3('Wsh2Of3CltvDrop');
 describeCreatePsbt2Of3('Tr2Of3-NoKeyPath');
 describeCreatePsbt('Tr1Of3-NoKeyPath-Tree', {
   descriptorSelf: getDescriptor('Tr1Of3-NoKeyPath-Tree', selfKeys),
-  psbtParams: getPsbtParams('Tr1Of3-NoKeyPath-Tree'),
+  psbtParams: {},
   stages: [
     { name: 'unsigned', keys: [] },
     { name: 'signedA', keys: selfKeys.slice(0, 1) },
     { name: 'signedB', keys: selfKeys.slice(1, 2), final: true },
+  ],
+});
+describeCreatePsbt('Tr1Of3-NoKeyPath-Tree-PlainKeys', {
+  descriptorSelf: getDescriptor('Tr1Of3-NoKeyPath-Tree-Plain', selfKeys),
+  psbtParams: {},
+  stages: [
+    { name: 'unsigned', keys: [] },
+    { name: 'signedA', keys: selfKeys.slice(0, 1).map(toPlain) },
+    { name: 'signedB', keys: selfKeys.slice(1, 2).map(toPlain), final: true },
   ],
 });


### PR DESCRIPTION

Add support for taproot descriptors with plain keys (no derivation) for 
taproot 1-of-3 tree signing.

Issue: BTC-1826