### PR TITLE
feat(descriptor): auto-detect descriptor types

### DIFF
--- a/modules/abstract-utxo/package.json
+++ b/modules/abstract-utxo/package.json
@@ -48,7 +48,7 @@
     "@bitgo/unspents": "^0.47.19",
     "@bitgo/utxo-core": "^1.4.0",
     "@bitgo/utxo-lib": "^11.2.3",
-    "@bitgo/wasm-miniscript": "2.0.0-beta.6",
+    "@bitgo/wasm-miniscript": "2.0.0-beta.7",
     "@types/bluebird": "^3.5.25",
     "@types/lodash": "^4.14.121",
     "@types/superagent": "4.1.15",

--- a/modules/utxo-bin/package.json
+++ b/modules/utxo-bin/package.json
@@ -30,7 +30,7 @@
     "@bitgo/statics": "^51.1.0",
     "@bitgo/unspents": "^0.47.19",
     "@bitgo/utxo-lib": "^11.2.3",
-    "@bitgo/wasm-miniscript": "2.0.0-beta.6",
+    "@bitgo/wasm-miniscript": "2.0.0-beta.7",
     "@noble/curves": "1.8.1",
     "archy": "^1.0.0",
     "bech32": "^2.0.0",

--- a/modules/utxo-core/package.json
+++ b/modules/utxo-core/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@bitgo/unspents": "^0.47.19",
     "@bitgo/utxo-lib": "^11.2.3",
-    "@bitgo/wasm-miniscript": "2.0.0-beta.6",
+    "@bitgo/wasm-miniscript": "2.0.0-beta.7",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4"
   },
   "gitHead": "18e460ddf02de2dbf13c2aa243478188fb539f0c"

--- a/modules/utxo-core/src/descriptor/DescriptorMap.ts
+++ b/modules/utxo-core/src/descriptor/DescriptorMap.ts
@@ -6,9 +6,6 @@ export type DescriptorMap = Map<string, Descriptor>;
 /** Convert an array of descriptor name-value pairs to a descriptor map */
 export function toDescriptorMap(descriptors: { name: string; value: Descriptor | string }[]): DescriptorMap {
   return new Map(
-    descriptors.map((d) => [
-      d.name,
-      d.value instanceof Descriptor ? d.value : Descriptor.fromString(d.value, 'derivable'),
-    ])
+    descriptors.map((d) => [d.name, d.value instanceof Descriptor ? d.value : Descriptor.fromStringDetectType(d.value)])
   );
 }

--- a/modules/utxo-core/src/testutil/descriptor/descriptors.ts
+++ b/modules/utxo-core/src/testutil/descriptor/descriptors.ts
@@ -134,21 +134,12 @@ function getDescriptorNode(
   throw new Error(`Unknown descriptor template: ${template}`);
 }
 
-function getDescriptorType(template: DescriptorTemplate): 'derivable' | 'definite' {
-  switch (template) {
-    case 'Tr1Of3-NoKeyPath-Tree-Plain':
-      return 'definite';
-    default:
-      return 'derivable';
-  }
-}
-
 export function getDescriptor(
   template: DescriptorTemplate,
   keys: KeyTriple | string[] = getDefaultXPubs(),
   path = '0/*'
 ): Descriptor {
-  return Descriptor.fromString(ast.formatNode(getDescriptorNode(template, keys, path)), getDescriptorType(template));
+  return Descriptor.fromStringDetectType(ast.formatNode(getDescriptorNode(template, keys, path)));
 }
 
 export function getDescriptorMap(

--- a/modules/utxo-staking/package.json
+++ b/modules/utxo-staking/package.json
@@ -42,7 +42,7 @@
     "@bitgo/unspents": "^0.47.19",
     "@bitgo/utxo-core": "^1.4.0",
     "@bitgo/utxo-lib": "^11.2.3",
-    "@bitgo/wasm-miniscript": "2.0.0-beta.6"
+    "@bitgo/wasm-miniscript": "2.0.0-beta.7"
   },
   "devDependencies": {
     "bip174": "=2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -867,10 +867,10 @@
     monocle-ts "^2.3.13"
     newtype-ts "^0.3.5"
 
-"@bitgo/wasm-miniscript@2.0.0-beta.6":
-  version "2.0.0-beta.6"
-  resolved "https://registry.npmjs.org/@bitgo/wasm-miniscript/-/wasm-miniscript-2.0.0-beta.6.tgz#821dac1eb7d334aa8846d035a2b841ab45bab985"
-  integrity sha512-QmBu9PgKVxFVNpcLSNvhQZhsSZSxAcn/1ONCr+XvZypIDRBHcVCwAdpiqMPbGAwz8r8w2JjZxoiJ768hY+PYYQ==
+"@bitgo/wasm-miniscript@2.0.0-beta.7":
+  version "2.0.0-beta.7"
+  resolved "https://registry.npmjs.org/@bitgo/wasm-miniscript/-/wasm-miniscript-2.0.0-beta.7.tgz#53eb0e87295ad5f2df0933c3b3b519e90bb4d2f1"
+  integrity sha512-cXHEpksbl/myUVkOUJJFXhvPYLLLt8iujrNK00csGyLYTRafwaO2U2txhwt8nUV2CnZXGsmxci/ZsLGLfdJ/8A==
 
 "@brandonblack/musig@^0.0.1-alpha.0":
   version "0.0.1-alpha.1"


### PR DESCRIPTION

Adds automated type detection for `Descriptor.fromString`, removing the need
for manual type specification. The feature relies on the latest version of
wasm-miniscript (2.0.0-beta.7).

Issue: BTC-1826