### PR TITLE
feat(utxo-core): export dust threshold and virtual size utilities

### DIFF
--- a/modules/utxo-core/src/descriptor/index.ts
+++ b/modules/utxo-core/src/descriptor/index.ts
@@ -2,3 +2,4 @@ export * from './psbt';
 export * from './address';
 export * from './DescriptorMap';
 export * from './Output';
+export * from './VirtualSize';

--- a/modules/utxo-core/src/index.ts
+++ b/modules/utxo-core/src/index.ts
@@ -1,3 +1,4 @@
 export * as bip65 from './bip65';
 export * as descriptor from './descriptor';
 export * as testutil from './testutil';
+export * from './dustThreshold';


### PR DESCRIPTION

Exports dustThreshold and VirtualSize utilities from the core library for
direct access by API consumers.

Issue: BTC-1826