### PR TITLE
fix(utxo-core): identify internal/external output correctly

### DIFF
--- a/modules/utxo-core/src/descriptor/psbt/findDescriptors.ts
+++ b/modules/utxo-core/src/descriptor/psbt/findDescriptors.ts
@@ -136,10 +136,12 @@ export function findDescriptorForOutput(
   script: Buffer,
   output: PsbtOutput,
   descriptorMap: DescriptorMap
-): DescriptorWithIndex | undefined {
+): DescriptorWithIndex | DescriptorWithoutIndex | undefined {
   const derivationPaths = getDerivationPaths(output);
-  if (!derivationPaths) {
-    return undefined;
-  }
-  return findDescriptorForAnyDerivationPath(script, derivationPaths, descriptorMap);
+  return (
+    findDescriptorWithoutDerivation(script, descriptorMap) ??
+    (derivationPaths === undefined
+      ? undefined
+      : findDescriptorForAnyDerivationPath(script, derivationPaths, descriptorMap))
+  );
 }

--- a/modules/utxo-core/src/descriptor/psbt/parse.ts
+++ b/modules/utxo-core/src/descriptor/psbt/parse.ts
@@ -54,24 +54,24 @@ export function parse(
     return {
       address: utxolib.address.fromOutputScript(input.witnessUtxo.script, network),
       value: input.witnessUtxo.value,
-      scriptId: scriptId,
+      scriptId,
     };
   });
   const outputs = psbt.txOutputs.map((output, i): ParsedOutput => {
     if (output.value === undefined) {
       throw new Error('invalid output: no value');
     }
-    const descriptorWithIndex = findDescriptorForOutput(output.script, psbt.data.outputs[i], descriptorMap);
+    const scriptId = findDescriptorForOutput(output.script, psbt.data.outputs[i], descriptorMap);
     return {
       address: output.address,
       script: output.script,
       value: output.value,
-      scriptId: descriptorWithIndex,
+      scriptId,
     };
   });
   const inputAmount = sum(...inputs.map((input) => input.value));
   const outputSum = sum(...outputs.map((output) => output.value));
-  const spendAmount = sum(...outputs.filter((output) => !('descriptor' in output)).map((output) => output.value));
+  const spendAmount = sum(...outputs.filter((output) => !output.scriptId).map((output) => output.value));
   const minerFee = inputAmount - outputSum;
   return {
     inputs,

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Tr1Of3-NoKeyPath-Tree-PlainKeys.psbtStages.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Tr1Of3-NoKeyPath-Tree-PlainKeys.psbtStages.json
@@ -243,10 +243,13 @@
         {
           "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
           "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
-          "value": "400000"
+          "value": "400000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
         }
       ],
-      "spendAmount": "800000",
+      "spendAmount": "400000",
       "minerFee": "1200000",
       "virtualSize": 279
     }
@@ -509,10 +512,13 @@
         {
           "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
           "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
-          "value": "400000"
+          "value": "400000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
         }
       ],
-      "spendAmount": "800000",
+      "spendAmount": "400000",
       "minerFee": "1200000",
       "virtualSize": 279
     }
@@ -775,10 +781,13 @@
         {
           "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
           "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
-          "value": "400000"
+          "value": "400000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
         }
       ],
-      "spendAmount": "800000",
+      "spendAmount": "400000",
       "minerFee": "1200000",
       "virtualSize": 279
     },

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Tr1Of3-NoKeyPath-Tree.psbtStages.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Tr1Of3-NoKeyPath-Tree.psbtStages.json
@@ -252,7 +252,7 @@
           }
         }
       ],
-      "spendAmount": "800000",
+      "spendAmount": "400000",
       "minerFee": "1200000",
       "virtualSize": 279
     }
@@ -524,7 +524,7 @@
           }
         }
       ],
-      "spendAmount": "800000",
+      "spendAmount": "400000",
       "minerFee": "1200000",
       "virtualSize": 279
     }
@@ -796,7 +796,7 @@
           }
         }
       ],
-      "spendAmount": "800000",
+      "spendAmount": "400000",
       "minerFee": "1200000",
       "virtualSize": 279
     },

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Tr2Of3-NoKeyPath.psbtStages.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Tr2Of3-NoKeyPath.psbtStages.json
@@ -222,7 +222,7 @@
           }
         }
       ],
-      "spendAmount": "800000",
+      "spendAmount": "400000",
       "minerFee": "1200000",
       "virtualSize": 315
     }
@@ -464,7 +464,7 @@
           }
         }
       ],
-      "spendAmount": "800000",
+      "spendAmount": "400000",
       "minerFee": "1200000",
       "virtualSize": 315
     }
@@ -716,7 +716,7 @@
           }
         }
       ],
-      "spendAmount": "800000",
+      "spendAmount": "400000",
       "minerFee": "1200000",
       "virtualSize": 315
     },

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Wsh2Of3.psbtStages.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Wsh2Of3.psbtStages.json
@@ -152,7 +152,7 @@
           }
         }
       ],
-      "spendAmount": "800000",
+      "spendAmount": "400000",
       "minerFee": "1200000",
       "virtualSize": 307
     }
@@ -166,6 +166,12 @@
               "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104",
               "value": "1000000"
             },
+            "partialSig": [
+              {
+                "pubkey": "0285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
+                "signature": "304502210082bf9de4293adac47f9895bb781ef014521ec5627ca450f15f052035b8c795ca022062afb9278352b002676ab32c8923329db883d89d5ff55b88e922c70f190e13e601"
+              }
+            ],
             "witnessScript": "52210285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c392102d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e21029a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de40653ae",
             "bip32Derivation": [
               {
@@ -183,12 +189,6 @@
                 "pubkey": "02d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e",
                 "path": "m/0/0"
               }
-            ],
-            "partialSig": [
-              {
-                "pubkey": "0285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
-                "signature": "304502210082bf9de4293adac47f9895bb781ef014521ec5627ca450f15f052035b8c795ca022062afb9278352b002676ab32c8923329db883d89d5ff55b88e922c70f190e13e601"
-              }
             ]
           },
           {
@@ -196,6 +196,12 @@
               "script": "0020e822404ded4c14f401afdaf6aaed1cf319ef2380c3aaba8cc6e3d8895ff09d7d",
               "value": "1000000"
             },
+            "partialSig": [
+              {
+                "pubkey": "024062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e74",
+                "signature": "3045022100c6d05f74ef5f84ed1628de34e617ffd252897b88c192c893f40ae3cdf036b217022036fc634fc63506fb2b7b0b1dc41bd6e0c607f4edb1226c644fa49ceb493b690501"
+              }
+            ],
             "witnessScript": "5221024062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e742103266670018fb65f1384da4e9b9b92c79d5c42d5f51c3ceb1e516babfb7595f2432102d502c2c474f4874a96b544afa9f8a9aa49e03ca8fcf736b1a1d150a663db13a653ae",
             "bip32Derivation": [
               {
@@ -212,12 +218,6 @@
                 "masterFingerprint": "702fc808",
                 "pubkey": "03266670018fb65f1384da4e9b9b92c79d5c42d5f51c3ceb1e516babfb7595f243",
                 "path": "m/0/1"
-              }
-            ],
-            "partialSig": [
-              {
-                "pubkey": "024062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e74",
-                "signature": "3045022100c6d05f74ef5f84ed1628de34e617ffd252897b88c192c893f40ae3cdf036b217022036fc634fc63506fb2b7b0b1dc41bd6e0c607f4edb1226c644fa49ceb493b690501"
               }
             ]
           }
@@ -322,7 +322,7 @@
           }
         }
       ],
-      "spendAmount": "800000",
+      "spendAmount": "400000",
       "minerFee": "1200000",
       "virtualSize": 307
     }
@@ -336,6 +336,16 @@
               "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104",
               "value": "1000000"
             },
+            "partialSig": [
+              {
+                "pubkey": "0285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
+                "signature": "304502210082bf9de4293adac47f9895bb781ef014521ec5627ca450f15f052035b8c795ca022062afb9278352b002676ab32c8923329db883d89d5ff55b88e922c70f190e13e601"
+              },
+              {
+                "pubkey": "02d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e",
+                "signature": "3044022028ed89385ff5215417ce4ed138ca77309ec17a52ece239402e0355d3b4ba4dba02202067b68ea5b5b80fc129a7bbf30a745fa24f6f308ea088a860e8a0eeb33d990601"
+              }
+            ],
             "witnessScript": "52210285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c392102d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e21029a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de40653ae",
             "bip32Derivation": [
               {
@@ -353,16 +363,6 @@
                 "pubkey": "02d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e",
                 "path": "m/0/0"
               }
-            ],
-            "partialSig": [
-              {
-                "pubkey": "0285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
-                "signature": "304502210082bf9de4293adac47f9895bb781ef014521ec5627ca450f15f052035b8c795ca022062afb9278352b002676ab32c8923329db883d89d5ff55b88e922c70f190e13e601"
-              },
-              {
-                "pubkey": "02d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e",
-                "signature": "3044022028ed89385ff5215417ce4ed138ca77309ec17a52ece239402e0355d3b4ba4dba02202067b68ea5b5b80fc129a7bbf30a745fa24f6f308ea088a860e8a0eeb33d990601"
-              }
             ]
           },
           {
@@ -370,6 +370,16 @@
               "script": "0020e822404ded4c14f401afdaf6aaed1cf319ef2380c3aaba8cc6e3d8895ff09d7d",
               "value": "1000000"
             },
+            "partialSig": [
+              {
+                "pubkey": "024062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e74",
+                "signature": "3045022100c6d05f74ef5f84ed1628de34e617ffd252897b88c192c893f40ae3cdf036b217022036fc634fc63506fb2b7b0b1dc41bd6e0c607f4edb1226c644fa49ceb493b690501"
+              },
+              {
+                "pubkey": "03266670018fb65f1384da4e9b9b92c79d5c42d5f51c3ceb1e516babfb7595f243",
+                "signature": "3045022100e558379fdbf91b583fdeba831dd53d8c36863e1b96a768d2bd03a26d92e720f202205f0979b87df0951f3fb74999bb1b66b632429b94771ce67152070e420d23463701"
+              }
+            ],
             "witnessScript": "5221024062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e742103266670018fb65f1384da4e9b9b92c79d5c42d5f51c3ceb1e516babfb7595f2432102d502c2c474f4874a96b544afa9f8a9aa49e03ca8fcf736b1a1d150a663db13a653ae",
             "bip32Derivation": [
               {
@@ -386,16 +396,6 @@
                 "masterFingerprint": "702fc808",
                 "pubkey": "03266670018fb65f1384da4e9b9b92c79d5c42d5f51c3ceb1e516babfb7595f243",
                 "path": "m/0/1"
-              }
-            ],
-            "partialSig": [
-              {
-                "pubkey": "024062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e74",
-                "signature": "3045022100c6d05f74ef5f84ed1628de34e617ffd252897b88c192c893f40ae3cdf036b217022036fc634fc63506fb2b7b0b1dc41bd6e0c607f4edb1226c644fa49ceb493b690501"
-              },
-              {
-                "pubkey": "03266670018fb65f1384da4e9b9b92c79d5c42d5f51c3ceb1e516babfb7595f243",
-                "signature": "3045022100e558379fdbf91b583fdeba831dd53d8c36863e1b96a768d2bd03a26d92e720f202205f0979b87df0951f3fb74999bb1b66b632429b94771ce67152070e420d23463701"
               }
             ]
           }
@@ -500,7 +500,7 @@
           }
         }
       ],
-      "spendAmount": "800000",
+      "spendAmount": "400000",
       "minerFee": "1200000",
       "virtualSize": 307
     },

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Wsh2Of3CltvDrop.psbtStages.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Wsh2Of3CltvDrop.psbtStages.json
@@ -152,7 +152,7 @@
           }
         }
       ],
-      "spendAmount": "800000",
+      "spendAmount": "400000",
       "minerFee": "1200000",
       "virtualSize": 307
     }
@@ -166,6 +166,12 @@
               "script": "00203ab8b31b07c3b64804cff426e92a4b773dc28bc744bb00b36d1b0ad5af29753b",
               "value": "1000000"
             },
+            "partialSig": [
+              {
+                "pubkey": "0285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
+                "signature": "3045022100dfdf96f1f9bafa2e2d9c140a101e2c2a84636fa8d822bdc473ae3788e35eb67c02200bf5807139d168c358febb82f67c124b9ea84780c944c629c0bb4cca884a8eea01"
+              }
+            ],
             "witnessScript": "51b17552210285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c392102d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e21029a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de40653ae",
             "bip32Derivation": [
               {
@@ -183,12 +189,6 @@
                 "pubkey": "02d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e",
                 "path": "m/0/0"
               }
-            ],
-            "partialSig": [
-              {
-                "pubkey": "0285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
-                "signature": "3045022100dfdf96f1f9bafa2e2d9c140a101e2c2a84636fa8d822bdc473ae3788e35eb67c02200bf5807139d168c358febb82f67c124b9ea84780c944c629c0bb4cca884a8eea01"
-              }
             ]
           },
           {
@@ -196,6 +196,12 @@
               "script": "0020a27f0d14b1d42b029ce8fc96b3c933d45a01ffb368d0f577f0b0bb0963f399a8",
               "value": "1000000"
             },
+            "partialSig": [
+              {
+                "pubkey": "024062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e74",
+                "signature": "304402201477f123ff8a244ffdccc8a91dc04e614d7ffac913fe4ddf018adde2495952ca0220077300d6ff577d43a063aba03da799cd8f6206c3eea215f1defee2cb01fddb9901"
+              }
+            ],
             "witnessScript": "51b1755221024062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e742103266670018fb65f1384da4e9b9b92c79d5c42d5f51c3ceb1e516babfb7595f2432102d502c2c474f4874a96b544afa9f8a9aa49e03ca8fcf736b1a1d150a663db13a653ae",
             "bip32Derivation": [
               {
@@ -212,12 +218,6 @@
                 "masterFingerprint": "702fc808",
                 "pubkey": "03266670018fb65f1384da4e9b9b92c79d5c42d5f51c3ceb1e516babfb7595f243",
                 "path": "m/0/1"
-              }
-            ],
-            "partialSig": [
-              {
-                "pubkey": "024062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e74",
-                "signature": "304402201477f123ff8a244ffdccc8a91dc04e614d7ffac913fe4ddf018adde2495952ca0220077300d6ff577d43a063aba03da799cd8f6206c3eea215f1defee2cb01fddb9901"
               }
             ]
           }
@@ -322,7 +322,7 @@
           }
         }
       ],
-      "spendAmount": "800000",
+      "spendAmount": "400000",
       "minerFee": "1200000",
       "virtualSize": 307
     }
@@ -336,6 +336,16 @@
               "script": "00203ab8b31b07c3b64804cff426e92a4b773dc28bc744bb00b36d1b0ad5af29753b",
               "value": "1000000"
             },
+            "partialSig": [
+              {
+                "pubkey": "0285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
+                "signature": "3045022100dfdf96f1f9bafa2e2d9c140a101e2c2a84636fa8d822bdc473ae3788e35eb67c02200bf5807139d168c358febb82f67c124b9ea84780c944c629c0bb4cca884a8eea01"
+              },
+              {
+                "pubkey": "02d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e",
+                "signature": "3045022100c0e511293f5499900d080a2be4a4c5777435d36e60803a4465b581062152506302207cc7a388e418a88f21c137590774b2f029ea1ab1ea952a0bf75998f01e00acf101"
+              }
+            ],
             "witnessScript": "51b17552210285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c392102d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e21029a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de40653ae",
             "bip32Derivation": [
               {
@@ -353,16 +363,6 @@
                 "pubkey": "02d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e",
                 "path": "m/0/0"
               }
-            ],
-            "partialSig": [
-              {
-                "pubkey": "0285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
-                "signature": "3045022100dfdf96f1f9bafa2e2d9c140a101e2c2a84636fa8d822bdc473ae3788e35eb67c02200bf5807139d168c358febb82f67c124b9ea84780c944c629c0bb4cca884a8eea01"
-              },
-              {
-                "pubkey": "02d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e",
-                "signature": "3045022100c0e511293f5499900d080a2be4a4c5777435d36e60803a4465b581062152506302207cc7a388e418a88f21c137590774b2f029ea1ab1ea952a0bf75998f01e00acf101"
-              }
             ]
           },
           {
@@ -370,6 +370,16 @@
               "script": "0020a27f0d14b1d42b029ce8fc96b3c933d45a01ffb368d0f577f0b0bb0963f399a8",
               "value": "1000000"
             },
+            "partialSig": [
+              {
+                "pubkey": "024062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e74",
+                "signature": "304402201477f123ff8a244ffdccc8a91dc04e614d7ffac913fe4ddf018adde2495952ca0220077300d6ff577d43a063aba03da799cd8f6206c3eea215f1defee2cb01fddb9901"
+              },
+              {
+                "pubkey": "03266670018fb65f1384da4e9b9b92c79d5c42d5f51c3ceb1e516babfb7595f243",
+                "signature": "304402206f3a40d005610e221845cdb7631e68a70e9ca9e885fbae2993fb63287fa56c03022051cf70fe0cd69fb04f33c98ff1de1a4c5f8ad0872c5f70aaf9d600ca46700e4e01"
+              }
+            ],
             "witnessScript": "51b1755221024062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e742103266670018fb65f1384da4e9b9b92c79d5c42d5f51c3ceb1e516babfb7595f2432102d502c2c474f4874a96b544afa9f8a9aa49e03ca8fcf736b1a1d150a663db13a653ae",
             "bip32Derivation": [
               {
@@ -386,16 +396,6 @@
                 "masterFingerprint": "702fc808",
                 "pubkey": "03266670018fb65f1384da4e9b9b92c79d5c42d5f51c3ceb1e516babfb7595f243",
                 "path": "m/0/1"
-              }
-            ],
-            "partialSig": [
-              {
-                "pubkey": "024062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e74",
-                "signature": "304402201477f123ff8a244ffdccc8a91dc04e614d7ffac913fe4ddf018adde2495952ca0220077300d6ff577d43a063aba03da799cd8f6206c3eea215f1defee2cb01fddb9901"
-              },
-              {
-                "pubkey": "03266670018fb65f1384da4e9b9b92c79d5c42d5f51c3ceb1e516babfb7595f243",
-                "signature": "304402206f3a40d005610e221845cdb7631e68a70e9ca9e885fbae2993fb63287fa56c03022051cf70fe0cd69fb04f33c98ff1de1a4c5f8ad0872c5f70aaf9d600ca46700e4e01"
               }
             ]
           }
@@ -500,7 +500,7 @@
           }
         }
       ],
-      "spendAmount": "800000",
+      "spendAmount": "400000",
       "minerFee": "1200000",
       "virtualSize": 307
     },


### PR DESCRIPTION

Fix incorrect identification logic of internal/external outputs in the UTXO
module. This updates the matching logic to properly evaluate output types.

Issue: BTC-1826