### PR TITLE
refactor(utxo-core): improve descriptor handling

### DIFF
--- a/modules/utxo-core/src/Output.ts
+++ b/modules/utxo-core/src/Output.ts
@@ -1,0 +1,72 @@
+export type Output<TValue = bigint> = {
+  script: Buffer;
+  value: TValue;
+};
+export type MaxOutput = Output<'max'>;
+type ValueBigInt = { value: bigint };
+type ValueMax = { value: 'max' };
+
+/**
+ * @return true if the output is a max output
+ */
+export function isMaxOutput<A extends ValueBigInt, B extends ValueMax>(output: A | B): output is B {
+  return output.value === 'max';
+}
+
+/**
+ * @return the max output if there is one
+ * @throws if there are multiple max outputs
+ */
+export function getMaxOutput<A extends ValueBigInt, B extends ValueMax>(outputs: (A | B)[]): B | undefined {
+  const max = outputs.filter(isMaxOutput<A, B>);
+  if (max.length === 0) {
+    return undefined;
+  }
+  if (max.length > 1) {
+    throw new Error('Multiple max outputs');
+  }
+  return max[0];
+}
+
+/**
+ * @return the sum of the outputs
+ */
+export function getOutputSum(outputs: ValueBigInt[]): bigint {
+  return outputs.reduce((sum, output) => sum + output.value, 0n);
+}
+
+/**
+ * @return the sum of the outputs that are not 'max'
+ */
+export function getFixedOutputSum(outputs: (ValueBigInt | ValueMax)[]): bigint {
+  return getOutputSum(outputs.filter((o): o is Output => !isMaxOutput(o)));
+}
+
+/**
+ * @param outputs
+ * @param params
+ * @return the outputs with the 'max' output replaced with the max amount
+ */
+export function toFixedOutputs<A extends ValueBigInt, B extends ValueMax>(
+  outputs: (A | B)[],
+  params: { maxAmount: bigint }
+): A[] {
+  // assert that there is at most one max output
+  const maxOutput = getMaxOutput<A, B>(outputs);
+  return outputs.map((output): A => {
+    if (isMaxOutput(output)) {
+      if (output !== maxOutput) {
+        throw new Error('illegal state');
+      }
+      return { ...output, value: params.maxAmount };
+    } else {
+      return output;
+    }
+  });
+}
+
+export type PrevOutput = {
+  hash: string;
+  index: number;
+  witnessUtxo: Output;
+};

--- a/modules/utxo-core/src/descriptor/Output.ts
+++ b/modules/utxo-core/src/descriptor/Output.ts
@@ -1,76 +1,9 @@
 import { Descriptor } from '@bitgo/wasm-miniscript';
 
+import { getFixedOutputSum, MaxOutput, Output, PrevOutput } from '../Output';
+
 import { DescriptorMap } from './DescriptorMap';
 import { createScriptPubKeyFromDescriptor } from './address';
-
-export type Output<TValue = bigint> = {
-  script: Buffer;
-  value: TValue;
-};
-
-export type MaxOutput = Output<'max'>;
-
-type ValueBigInt = { value: bigint };
-type ValueMax = { value: 'max' };
-
-/**
- * @return true if the output is a max output
- */
-export function isMaxOutput<A extends ValueBigInt, B extends ValueMax>(output: A | B): output is B {
-  return output.value === 'max';
-}
-
-/**
- * @return the max output if there is one
- * @throws if there are multiple max outputs
- */
-export function getMaxOutput<A extends ValueBigInt, B extends ValueMax>(outputs: (A | B)[]): B | undefined {
-  const max = outputs.filter(isMaxOutput<A, B>);
-  if (max.length === 0) {
-    return undefined;
-  }
-  if (max.length > 1) {
-    throw new Error('Multiple max outputs');
-  }
-  return max[0];
-}
-
-/**
- * @return the sum of the outputs
- */
-export function getOutputSum(outputs: ValueBigInt[]): bigint {
-  return outputs.reduce((sum, output) => sum + output.value, 0n);
-}
-
-/**
- * @return the sum of the outputs that are not 'max'
- */
-export function getFixedOutputSum(outputs: (ValueBigInt | ValueMax)[]): bigint {
-  return getOutputSum(outputs.filter((o): o is Output => !isMaxOutput(o)));
-}
-
-/**
- * @param outputs
- * @param params
- * @return the outputs with the 'max' output replaced with the max amount
- */
-export function toFixedOutputs<A extends ValueBigInt, B extends ValueMax>(
-  outputs: (A | B)[],
-  params: { maxAmount: bigint }
-): A[] {
-  // assert that there is at most one max output
-  const maxOutput = getMaxOutput<A, B>(outputs);
-  return outputs.map((output): A => {
-    if (isMaxOutput(output)) {
-      if (output !== maxOutput) {
-        throw new Error('illegal state');
-      }
-      return { ...output, value: params.maxAmount };
-    } else {
-      return output;
-    }
-  });
-}
 
 export type WithDescriptor<T> = T & {
   descriptor: Descriptor;
@@ -95,12 +28,6 @@ export function isExternalOutput<T extends object>(output: T | WithDescriptor<T>
 export function getExternalFixedAmount(outputs: WithOptDescriptor<Output | MaxOutput>[]): bigint {
   return getFixedOutputSum(outputs.filter(isExternalOutput));
 }
-
-export type PrevOutput = {
-  hash: string;
-  index: number;
-  witnessUtxo: Output;
-};
 
 export type DescriptorWalletOutput = PrevOutput & {
   descriptorName: string;

--- a/modules/utxo-core/src/descriptor/address.ts
+++ b/modules/utxo-core/src/descriptor/address.ts
@@ -1,11 +1,11 @@
 import { Descriptor } from '@bitgo/wasm-miniscript';
 import * as utxolib from '@bitgo/utxo-lib';
 
-export function createScriptPubKeyFromDescriptor(descriptor: Descriptor, index?: number): Buffer {
+export function createScriptPubKeyFromDescriptor(descriptor: Descriptor, index: number | undefined): Buffer {
   if (index === undefined) {
     return Buffer.from(descriptor.scriptPubkey());
   }
-  return createScriptPubKeyFromDescriptor(descriptor.atDerivationIndex(index));
+  return createScriptPubKeyFromDescriptor(descriptor.atDerivationIndex(index), undefined);
 }
 
 export function createAddressFromDescriptor(

--- a/modules/utxo-core/src/descriptor/derive.ts
+++ b/modules/utxo-core/src/descriptor/derive.ts
@@ -1,0 +1,44 @@
+import assert from 'assert';
+
+import { Descriptor } from '@bitgo/wasm-miniscript';
+
+/**
+ * Get a descriptor at a specific derivation index.
+ * For wildcard descriptors (containing '*'), the index is required and used for derivation.
+ * For definite descriptors (not containing '*'), no index should be provided.
+ * @param descriptor - The descriptor to derive from
+ * @param index - The derivation index for wildcard descriptors
+ * @returns A new descriptor at the specified index for wildcard descriptors, or the original descriptor for definite ones
+ * @throws {Error} If index is undefined for a wildcard descriptor or if index is provided for a definite descriptor
+ */
+export function getDescriptorAtIndex(descriptor: Descriptor, index: number | undefined): Descriptor {
+  assert(descriptor instanceof Descriptor);
+  Descriptor.fromString(descriptor.toString(), 'derivable');
+  descriptor = Descriptor.fromStringDetectType(descriptor.toString());
+  if (descriptor.hasWildcard()) {
+    if (index === undefined) {
+      throw new Error('Derivable descriptor requires an index');
+    }
+    return descriptor.atDerivationIndex(index);
+  } else {
+    if (index !== undefined) {
+      throw new Error('Definite descriptor cannot be derived with index');
+    }
+    return descriptor;
+  }
+}
+
+export function getDescriptorAtIndexCheckScript(
+  descriptor: Descriptor,
+  index: number | undefined,
+  script: Buffer,
+  descriptorString = descriptor.toString()
+): Descriptor {
+  assert(descriptor instanceof Descriptor);
+  const descriptorAtIndex = getDescriptorAtIndex(descriptor, index);
+  if (!script.equals(descriptorAtIndex.scriptPubkey())) {
+    throw new Error(`Script mismatch: descriptor ${descriptorString} script=${script.toString('hex')}`);
+  }
+  assert(descriptorAtIndex instanceof Descriptor);
+  return descriptorAtIndex;
+}

--- a/modules/utxo-core/src/descriptor/index.ts
+++ b/modules/utxo-core/src/descriptor/index.ts
@@ -3,3 +3,6 @@ export * from './address';
 export * from './DescriptorMap';
 export * from './Output';
 export * from './VirtualSize';
+
+/** @deprecated - import from @bitgo/utxo-core directly instead */
+export * from '../Output';

--- a/modules/utxo-core/src/descriptor/psbt/createPsbt.ts
+++ b/modules/utxo-core/src/descriptor/psbt/createPsbt.ts
@@ -1,7 +1,8 @@
 import * as utxolib from '@bitgo/utxo-lib';
 import { Descriptor } from '@bitgo/wasm-miniscript';
 
-import { DerivedDescriptorWalletOutput, Output, WithOptDescriptor } from '../Output';
+import { DerivedDescriptorWalletOutput, WithOptDescriptor } from '../Output';
+import { Output } from '../../Output';
 
 import { toUtxoPsbt, toWrappedPsbt } from './wrap';
 import { assertSatisfiable } from './assertSatisfiable';

--- a/modules/utxo-core/src/index.ts
+++ b/modules/utxo-core/src/index.ts
@@ -2,3 +2,4 @@ export * as bip65 from './bip65';
 export * as descriptor from './descriptor';
 export * as testutil from './testutil';
 export * from './dustThreshold';
+export * from './Output';

--- a/modules/utxo-core/src/testutil/descriptor/mock.utils.ts
+++ b/modules/utxo-core/src/testutil/descriptor/mock.utils.ts
@@ -33,7 +33,7 @@ export function mockDerivedDescriptorWalletOutput(
     hash,
     index: vout,
     witnessUtxo: {
-      script: createScriptPubKeyFromDescriptor(descriptor),
+      script: createScriptPubKeyFromDescriptor(descriptor, undefined),
       value,
     },
     descriptor,
@@ -67,7 +67,7 @@ export function mockPsbt(
     outputs.map((o) => {
       const derivedDescriptor = tryDeriveAtIndex(o.descriptor, o.index);
       return {
-        script: createScriptPubKeyFromDescriptor(derivedDescriptor),
+        script: createScriptPubKeyFromDescriptor(derivedDescriptor, undefined),
         value: o.value,
         descriptor: o.external ? undefined : derivedDescriptor,
       };

--- a/modules/utxo-core/test/Output.ts
+++ b/modules/utxo-core/test/Output.ts
@@ -1,0 +1,41 @@
+import * as assert from 'assert';
+
+import { getFixedOutputSum, getMaxOutput, getOutputSum, isMaxOutput, toFixedOutputs } from '../src';
+
+describe('Output', function () {
+  const oBigInt = { value: 1n };
+  const oBigInt2 = { value: 2n };
+  const oMax = { value: 'max' } as const;
+
+  it('getMaxOutput returns expected values', function () {
+    assert.strictEqual(getMaxOutput([oBigInt]), undefined);
+    assert.strictEqual(getMaxOutput([oBigInt, oBigInt]), undefined);
+    assert.strictEqual(getMaxOutput([oBigInt, oMax]), oMax);
+    assert.throws(() => getMaxOutput([oMax, oMax]), /Multiple max outputs/);
+  });
+
+  it('isMaxOutput correctly identifies max outputs', function () {
+    assert.strictEqual(isMaxOutput(oBigInt), false);
+    assert.strictEqual(isMaxOutput(oMax), true);
+  });
+
+  it('getOutputSum calculates sum correctly', function () {
+    assert.strictEqual(getOutputSum([]), 0n);
+    assert.strictEqual(getOutputSum([oBigInt]), 1n);
+    assert.strictEqual(getOutputSum([oBigInt, oBigInt2]), 3n);
+  });
+
+  it('getFixedOutputSum handles mixed outputs', function () {
+    assert.strictEqual(getFixedOutputSum([]), 0n);
+    assert.strictEqual(getFixedOutputSum([oBigInt]), 1n);
+    assert.strictEqual(getFixedOutputSum([oBigInt, oMax]), 1n);
+    assert.strictEqual(getFixedOutputSum([oBigInt, oBigInt2, oMax]), 3n);
+  });
+
+  it('toFixedOutputs converts max outputs correctly', function () {
+    const maxAmount = 10n;
+    assert.deepStrictEqual(toFixedOutputs([oBigInt], { maxAmount }), [oBigInt]);
+    assert.deepStrictEqual(toFixedOutputs([oMax], { maxAmount }), [{ ...oMax, value: maxAmount }]);
+    assert.throws(() => toFixedOutputs([oMax, oMax], { maxAmount }), /Multiple max outputs/);
+  });
+});

--- a/modules/utxo-core/test/descriptor/Output.ts
+++ b/modules/utxo-core/test/descriptor/Output.ts
@@ -1,54 +1,11 @@
-import * as assert from 'assert';
+import assert from 'assert';
 
 import { Descriptor } from '@bitgo/wasm-miniscript';
 
-import {
-  getMaxOutput,
-  isMaxOutput,
-  getOutputSum,
-  getFixedOutputSum,
-  toFixedOutputs,
-  isInternalOutput,
-  isExternalOutput,
-} from '../../src/descriptor';
+import { isExternalOutput, isInternalOutput } from '../../src/descriptor';
 
-describe('Output', function () {
-  const oBigInt = { value: 1n };
-  const oBigInt2 = { value: 2n };
-  const oMax = { value: 'max' } as const;
+describe('decscriptor.Output', function () {
   const mockDescriptor = {} as Descriptor;
-
-  it('getMaxOutput returns expected values', function () {
-    assert.strictEqual(getMaxOutput([oBigInt]), undefined);
-    assert.strictEqual(getMaxOutput([oBigInt, oBigInt]), undefined);
-    assert.strictEqual(getMaxOutput([oBigInt, oMax]), oMax);
-    assert.throws(() => getMaxOutput([oMax, oMax]), /Multiple max outputs/);
-  });
-
-  it('isMaxOutput correctly identifies max outputs', function () {
-    assert.strictEqual(isMaxOutput(oBigInt), false);
-    assert.strictEqual(isMaxOutput(oMax), true);
-  });
-
-  it('getOutputSum calculates sum correctly', function () {
-    assert.strictEqual(getOutputSum([]), 0n);
-    assert.strictEqual(getOutputSum([oBigInt]), 1n);
-    assert.strictEqual(getOutputSum([oBigInt, oBigInt2]), 3n);
-  });
-
-  it('getFixedOutputSum handles mixed outputs', function () {
-    assert.strictEqual(getFixedOutputSum([]), 0n);
-    assert.strictEqual(getFixedOutputSum([oBigInt]), 1n);
-    assert.strictEqual(getFixedOutputSum([oBigInt, oMax]), 1n);
-    assert.strictEqual(getFixedOutputSum([oBigInt, oBigInt2, oMax]), 3n);
-  });
-
-  it('toFixedOutputs converts max outputs correctly', function () {
-    const maxAmount = 10n;
-    assert.deepStrictEqual(toFixedOutputs([oBigInt], { maxAmount }), [oBigInt]);
-    assert.deepStrictEqual(toFixedOutputs([oMax], { maxAmount }), [{ ...oMax, value: maxAmount }]);
-    assert.throws(() => toFixedOutputs([oMax, oMax], { maxAmount }), /Multiple max outputs/);
-  });
 
   it('isInternalOutput correctly identifies internal outputs', function () {
     const internalOutput = { value: 1n, descriptor: mockDescriptor };

--- a/modules/utxo-core/test/descriptor/Output.ts
+++ b/modules/utxo-core/test/descriptor/Output.ts
@@ -1,14 +1,14 @@
 import assert from 'assert';
 
-import { Descriptor } from '@bitgo/wasm-miniscript';
-
-import { isExternalOutput, isInternalOutput } from '../../src/descriptor';
+import { isExternalOutput, isInternalOutput, toDerivedDescriptorWalletOutput } from '../../src/descriptor/Output';
+import { getDescriptor } from '../../src/testutil/descriptor';
+import { createScriptPubKeyFromDescriptor } from '../../src/descriptor';
 
 describe('decscriptor.Output', function () {
-  const mockDescriptor = {} as Descriptor;
+  const descriptor = getDescriptor('Wsh2Of3');
 
   it('isInternalOutput correctly identifies internal outputs', function () {
-    const internalOutput = { value: 1n, descriptor: mockDescriptor };
+    const internalOutput = { value: 1n, descriptor };
     const externalOutput = { value: 1n };
 
     assert.strictEqual(isInternalOutput(internalOutput), true);
@@ -16,10 +16,33 @@ describe('decscriptor.Output', function () {
   });
 
   it('isExternalOutput correctly identifies external outputs', function () {
-    const internalOutput = { value: 1n, descriptor: mockDescriptor };
+    const internalOutput = { value: 1n, descriptor };
     const externalOutput = { value: 1n };
 
     assert.strictEqual(isExternalOutput(internalOutput), false);
     assert.strictEqual(isExternalOutput(externalOutput), true);
+  });
+
+  it('toDerivedDescriptorWalletOutput returns expected values', function () {
+    const derivable = descriptor;
+    const definite = derivable.atDerivationIndex(0);
+    for (const descriptor of [derivable, definite]) {
+      const descriptorIndex = descriptor === derivable ? 0 : undefined;
+      const descriptorMap = new Map([['desc', descriptor]]);
+      const descriptorWalletOutput = {
+        hash: Buffer.alloc(32).toString('hex'),
+        index: 0,
+        witnessUtxo: {
+          script: createScriptPubKeyFromDescriptor(descriptor, descriptorIndex),
+          value: 1n,
+        },
+        descriptorName: 'desc',
+        descriptorIndex,
+      };
+      assert.strictEqual(
+        toDerivedDescriptorWalletOutput(descriptorWalletOutput, descriptorMap).descriptor.toString(),
+        definite.toString()
+      );
+    }
   });
 });

--- a/modules/utxo-core/test/descriptor/derive.ts
+++ b/modules/utxo-core/test/descriptor/derive.ts
@@ -1,0 +1,25 @@
+import assert from 'assert';
+
+import { getDescriptor } from '../../src/testutil/descriptor';
+import { getDescriptorAtIndex, getDescriptorAtIndexCheckScript } from '../../src/descriptor/derive';
+
+describe('derive', function () {
+  const derivable = getDescriptor('Wsh2Of3');
+  const definite = derivable.atDerivationIndex(0);
+
+  it('getDescriptorAtIndex', function () {
+    assert(derivable.hasWildcard());
+    assert(!definite.hasWildcard());
+    assert.strictEqual(getDescriptorAtIndex(derivable, 0).toString(), definite.toString());
+    assert.strictEqual(getDescriptorAtIndex(definite, undefined).toString(), definite.toString());
+    assert.throws(() => getDescriptorAtIndex(derivable, undefined), /Derivable descriptor requires an index/);
+    assert.throws(() => getDescriptorAtIndex(definite, 0), /Definite descriptor cannot be derived with index/);
+  });
+
+  it('getDescriptorAtIndexCheckScript', function () {
+    const script0 = Buffer.from(derivable.atDerivationIndex(0).scriptPubkey());
+    const script1 = Buffer.from(derivable.atDerivationIndex(1).scriptPubkey());
+    assert.strictEqual(getDescriptorAtIndexCheckScript(derivable, 0, script0).toString(), definite.toString());
+    assert.throws(() => getDescriptorAtIndexCheckScript(derivable, 0, script1), /Script mismatch/);
+  });
+});


### PR DESCRIPTION

Split descriptor and output classes to improve separation of concerns.
Add derivation path checks for descriptor outputs.

Issue: BTC-1826