### PR TITLE
feat(sdk-api): update sdk to support Non-JSON response

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -28,6 +28,7 @@ module.exports = {
         'CR-',
         'CS-',
         'CSI-',
+        'DE-',
         'DES-',
         'DO-',
         'DOS-',

--- a/modules/sdk-api/src/api.ts
+++ b/modules/sdk-api/src/api.ts
@@ -50,7 +50,13 @@ export function handleResponseResult<ResponseResultType>(
 ): (res: superagent.Response) => ResponseResultType {
   return function (res: superagent.Response): ResponseResultType {
     if (_.isNumber(res.status) && res.status >= 200 && res.status < 300) {
-      return optionalField ? res.body[optionalField] : res.body;
+      return (
+        // If there's an optional field and the body is non-nullish with that property, return it;
+        // otherwise return the body if available; if not, return the text; and finally fallback to the entire response.
+        (optionalField && res.body && res.body[optionalField] !== undefined ? res.body[optionalField] : res.body) ??
+        res.text ??
+        res
+      );
     }
     throw errFromResponse(res);
   };


### PR DESCRIPTION
Ticket: DE-1849

The `/api/v2/admin/reports/${reportId}/document` wallet platform api that downloads a report does not a return a json response. Instead, it directly returns the report data with a `Content-Type` of either 'application/pdf' or 'text/csv'. When calling this API using the BitGo SDK, the response can’t be decoded properly because it is missing a `body` field.

To address this, we are updating the API SDK to support this type of response.

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
