### PR TITLE
feat(utxo-staking): add test fixture normalization helper

### DIFF
--- a/modules/utxo-staking/test/fixtures/babylon/txTree.testnet.json
+++ b/modules/utxo-staking/test/fixtures/babylon/txTree.testnet.json
@@ -30,29 +30,49 @@
       "data": {
         "inputs": [
           {
-            "unknownKeyVals": [],
-            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
             "witnessUtxo": {
-              "value": 55555,
-              "script": "5120f1871fc2ac3050b53dc35d502a9d94388f6f373b86f3905667945a8430cbd639"
+              "script": "5120f1871fc2ac3050b53dc35d502a9d94388f6f373b86f3905667945a8430cbd639",
+              "value": "55555"
             },
             "tapLeafScript": [
               {
-                "leafVersion": 192,
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac01e1d2e84c4fc6bdddf3b8018065cf5ca8405988579188585f382c51c088e882696962cb69242e00941e0a6197b7ecdb83ab8bb0490dbfd23fa4b8d26b75989eb",
                 "script": "207b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9ad021027b2",
-                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac01e1d2e84c4fc6bdddf3b8018065cf5ca8405988579188585f382c51c088e882696962cb69242e00941e0a6197b7ecdb83ab8bb0490dbfd23fa4b8d26b75989eb"
+                "leafVersion": 192
               }
-            ]
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
           }
         ],
         "outputs": [
-          {
-            "unknownKeyVals": []
-          }
+          {}
         ],
         "globalMap": {
-          "unsignedTx": {}
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "64da14050ffd0e6186c68a59f371a0adc95cc84b0502fe0915be7eba3f771bb3",
+                  "index": 0,
+                  "script": "",
+                  "sequence": 10000,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "55267",
+                  "script": "0014896f1ba65deaeb045bb3121e20e5744e66ca0e48"
+                }
+              ]
+            }
+          }
         }
+      },
+      "opts": {
+        "maximumFeeRate": 5000
       }
     },
     "fee": 288
@@ -84,29 +104,49 @@
       "data": {
         "inputs": [
           {
-            "unknownKeyVals": [],
-            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
             "witnessUtxo": {
-              "value": 53555,
-              "script": "51204dcea0c802236110602d7b1cc2e76ef5f1f05170b058685b4caf4367ac849d6b"
+              "script": "51204dcea0c802236110602d7b1cc2e76ef5f1f05170b058685b4caf4367ac849d6b",
+              "value": "53555"
             },
             "tapLeafScript": [
               {
-                "leafVersion": 192,
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac096962cb69242e00941e0a6197b7ecdb83ab8bb0490dbfd23fa4b8d26b75989eb",
                 "script": "207b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9ad02f003b2",
-                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac096962cb69242e00941e0a6197b7ecdb83ab8bb0490dbfd23fa4b8d26b75989eb"
+                "leafVersion": 192
               }
-            ]
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
           }
         ],
         "outputs": [
-          {
-            "unknownKeyVals": []
-          }
+          {}
         ],
         "globalMap": {
-          "unsignedTx": {}
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "c047c5904542017cfee57fdb350d6bf776a5ef8c46bc033f454a64b496d0ab9d",
+                  "index": 0,
+                  "script": "",
+                  "sequence": 1008,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "53267",
+                  "script": "0014896f1ba65deaeb045bb3121e20e5744e66ca0e48"
+                }
+              ]
+            }
+          }
         }
+      },
+      "opts": {
+        "maximumFeeRate": 5000
       }
     },
     "fee": 288
@@ -116,32 +156,54 @@
       "data": {
         "inputs": [
           {
-            "unknownKeyVals": [],
-            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
             "witnessUtxo": {
-              "value": 53555,
-              "script": "51204dcea0c802236110602d7b1cc2e76ef5f1f05170b058685b4caf4367ac849d6b"
+              "script": "51204dcea0c802236110602d7b1cc2e76ef5f1f05170b058685b4caf4367ac849d6b",
+              "value": "53555"
             },
             "tapLeafScript": [
               {
-                "leafVersion": 192,
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac04dc5f7d3676ac2eabc7c787dfd6084ec280ab8d971de668a83be41700def7f2b",
                 "script": "207b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9ad20d23c2c25e1fcf8fd1c21b9a402c19e2e309e531e45e92fb1e9805b6056b0cc76ad200aee0509b16db71c999238a4827db945526859b13c95487ab46725357c9a9f25ac20113c3a32a9d320b72190a04a020a0db3976ef36972673258e9a38a364f3dc3b0ba2017921cf156ccb4e73d428f996ed11b245313e37e27c978ac4d2cc21eca4672e4ba203bb93dfc8b61887d771f3630e9a63e97cbafcfcc78556a474df83a31a0ef899cba2040afaf47c4ffa56de86410d8e47baa2bb6f04b604f4ea24323737ddc3fe092dfba2079a71ffd71c503ef2e2f91bccfc8fcda7946f4653cef0d9f3dde20795ef3b9f0ba20d21faf78c6751a0d38e6bd8028b907ff07e9a869a43fc837d6b3f8dff6119a36ba20f5199efae3f28bb82476163a7e458c7ad445d9bffb0682d10d3bdb2cb41f8e8eba20fa9d882d45f4060bdb8042183828cd87544f1ea997380e586cab77d5fd698737ba569c",
-                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac04dc5f7d3676ac2eabc7c787dfd6084ec280ab8d971de668a83be41700def7f2b"
+                "leafVersion": 192
               }
-            ]
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
           }
         ],
         "outputs": [
-          {
-            "unknownKeyVals": []
-          },
-          {
-            "unknownKeyVals": []
-          }
+          {},
+          {}
         ],
         "globalMap": {
-          "unsignedTx": {}
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "c047c5904542017cfee57fdb350d6bf776a5ef8c46bc033f454a64b496d0ab9d",
+                  "index": 0,
+                  "script": "",
+                  "sequence": 4294967295,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "2677",
+                  "script": "00145be12624d08a2b424095d7c07221c33450d14bf1"
+                },
+                {
+                  "value": "45878",
+                  "script": "5120d5238530e223ef1bd34a8a98ee1708f6a8a87e7a2589d88de6700b9973ffff46"
+                }
+              ]
+            }
+          }
         }
+      },
+      "opts": {
+        "maximumFeeRate": 5000
       }
     },
     "fee": 5000
@@ -151,32 +213,54 @@
       "data": {
         "inputs": [
           {
-            "unknownKeyVals": [],
-            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
             "witnessUtxo": {
-              "value": 55555,
-              "script": "5120f1871fc2ac3050b53dc35d502a9d94388f6f373b86f3905667945a8430cbd639"
+              "script": "5120f1871fc2ac3050b53dc35d502a9d94388f6f373b86f3905667945a8430cbd639",
+              "value": "55555"
             },
             "tapLeafScript": [
               {
-                "leafVersion": 192,
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0407e9ef753fc7908376c525371a0e4be9fcd492d714118e5917a5512a697bc6d",
                 "script": "207b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9ad20d23c2c25e1fcf8fd1c21b9a402c19e2e309e531e45e92fb1e9805b6056b0cc76ad200aee0509b16db71c999238a4827db945526859b13c95487ab46725357c9a9f25ac20113c3a32a9d320b72190a04a020a0db3976ef36972673258e9a38a364f3dc3b0ba2017921cf156ccb4e73d428f996ed11b245313e37e27c978ac4d2cc21eca4672e4ba203bb93dfc8b61887d771f3630e9a63e97cbafcfcc78556a474df83a31a0ef899cba2040afaf47c4ffa56de86410d8e47baa2bb6f04b604f4ea24323737ddc3fe092dfba2079a71ffd71c503ef2e2f91bccfc8fcda7946f4653cef0d9f3dde20795ef3b9f0ba20d21faf78c6751a0d38e6bd8028b907ff07e9a869a43fc837d6b3f8dff6119a36ba20f5199efae3f28bb82476163a7e458c7ad445d9bffb0682d10d3bdb2cb41f8e8eba20fa9d882d45f4060bdb8042183828cd87544f1ea997380e586cab77d5fd698737ba569c",
-                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0407e9ef753fc7908376c525371a0e4be9fcd492d714118e5917a5512a697bc6d"
+                "leafVersion": 192
               }
-            ]
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
           }
         ],
         "outputs": [
-          {
-            "unknownKeyVals": []
-          },
-          {
-            "unknownKeyVals": []
-          }
+          {},
+          {}
         ],
         "globalMap": {
-          "unsignedTx": {}
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "64da14050ffd0e6186c68a59f371a0adc95cc84b0502fe0915be7eba3f771bb3",
+                  "index": 0,
+                  "script": "",
+                  "sequence": 4294967295,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "2777",
+                  "script": "00145be12624d08a2b424095d7c07221c33450d14bf1"
+                },
+                {
+                  "value": "47778",
+                  "script": "5120d5238530e223ef1bd34a8a98ee1708f6a8a87e7a2589d88de6700b9973ffff46"
+                }
+              ]
+            }
+          }
         }
+      },
+      "opts": {
+        "maximumFeeRate": 5000
       }
     },
     "fee": 5000

--- a/modules/utxo-staking/test/fixtures/babylon/txTree.testnetMock.json
+++ b/modules/utxo-staking/test/fixtures/babylon/txTree.testnetMock.json
@@ -30,29 +30,49 @@
       "data": {
         "inputs": [
           {
-            "unknownKeyVals": [],
-            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
             "witnessUtxo": {
-              "value": 55555,
-              "script": "5120788d73d75d7dd88d3612f7a91d5b3d6ad4778d8b49176f9539d322980b2f4fd7"
+              "script": "5120788d73d75d7dd88d3612f7a91d5b3d6ad4778d8b49176f9539d322980b2f4fd7",
+              "value": "55555"
             },
             "tapLeafScript": [
               {
-                "leafVersion": 192,
+                "controlBlock": "c150929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac068cc9790c0627bc8f28afd009b31974a2fce5ea4fe2ed4dd8b65c8feda196875c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552",
                 "script": "207b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9ad021027b2",
-                "controlBlock": "c150929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac068cc9790c0627bc8f28afd009b31974a2fce5ea4fe2ed4dd8b65c8feda196875c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552"
+                "leafVersion": 192
               }
-            ]
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
           }
         ],
         "outputs": [
-          {
-            "unknownKeyVals": []
-          }
+          {}
         ],
         "globalMap": {
-          "unsignedTx": {}
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "a999d7bc6af1a17cd4e70d0fd875a1734152dfb55f9166240f35965c79fa36c2",
+                  "index": 0,
+                  "script": "",
+                  "sequence": 10000,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "55267",
+                  "script": "0014896f1ba65deaeb045bb3121e20e5744e66ca0e48"
+                }
+              ]
+            }
+          }
         }
+      },
+      "opts": {
+        "maximumFeeRate": 5000
       }
     },
     "fee": 288
@@ -84,29 +104,49 @@
       "data": {
         "inputs": [
           {
-            "unknownKeyVals": [],
-            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
             "witnessUtxo": {
-              "value": 53555,
-              "script": "5120dec7bc887b110e2c10f1c9a2212cd961e95184870c91d88c9a3727f4ef4c303c"
+              "script": "5120dec7bc887b110e2c10f1c9a2212cd961e95184870c91d88c9a3727f4ef4c303c",
+              "value": "53555"
             },
             "tapLeafScript": [
               {
-                "leafVersion": 192,
+                "controlBlock": "c150929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552",
                 "script": "207b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9ad02f003b2",
-                "controlBlock": "c150929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552"
+                "leafVersion": 192
               }
-            ]
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
           }
         ],
         "outputs": [
-          {
-            "unknownKeyVals": []
-          }
+          {}
         ],
         "globalMap": {
-          "unsignedTx": {}
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "4c2a294c5e31886937d0985e69e65314419e8866e5ab859cb2903cbe420a555a",
+                  "index": 0,
+                  "script": "",
+                  "sequence": 1008,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "53267",
+                  "script": "0014896f1ba65deaeb045bb3121e20e5744e66ca0e48"
+                }
+              ]
+            }
+          }
         }
+      },
+      "opts": {
+        "maximumFeeRate": 5000
       }
     },
     "fee": 288
@@ -116,32 +156,54 @@
       "data": {
         "inputs": [
           {
-            "unknownKeyVals": [],
-            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
             "witnessUtxo": {
-              "value": 53555,
-              "script": "5120dec7bc887b110e2c10f1c9a2212cd961e95184870c91d88c9a3727f4ef4c303c"
+              "script": "5120dec7bc887b110e2c10f1c9a2212cd961e95184870c91d88c9a3727f4ef4c303c",
+              "value": "53555"
             },
             "tapLeafScript": [
               {
-                "leafVersion": 192,
+                "controlBlock": "c150929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac04dc5f7d3676ac2eabc7c787dfd6084ec280ab8d971de668a83be41700def7f2b",
                 "script": "207b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9ad20850854d26df93570748d94e3da361f134c522f7970bd7f8701a164547308a900ad2004e2b2468fe224659eb9dc5bd0a9cc1b4878b64f40c67c951610320bce78dfd1ac202f3432bf9054e482041b890e084bc1a34cfbc0b63aded113bfa36b6f2402832bba204d7e91e4a0ab0526a387684db1628b535e6b66046aaa7d1b583b93c5a16e1ac7ba205e14742c0943fa66799f699a0ef98cf2b7cd223ddbb61f6878999182bbcc4700ba2064d55d591c5d416f713df9e15afd32e9ff2441cf276b2f90e5b3085163ca7a6bba206672282496e17eccaae560aac4d9fe85d8c166a4aa43f51fa8963c80a165831fba207939bcf0084cff0fe5c88a1748c1d97d63ff9ae6423a98dca65d974bb9123ce0ba209f66599cde7f3c3fefb6b96509e472f8a9e2caf8793b9b673fcb4067ef888f50ba20f0638e4817559347e67a07b56a6cb824d455fba42a8c8c95171c397540c51789ba569c",
-                "controlBlock": "c150929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac04dc5f7d3676ac2eabc7c787dfd6084ec280ab8d971de668a83be41700def7f2b"
+                "leafVersion": 192
               }
-            ]
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
           }
         ],
         "outputs": [
-          {
-            "unknownKeyVals": []
-          },
-          {
-            "unknownKeyVals": []
-          }
+          {},
+          {}
         ],
         "globalMap": {
-          "unsignedTx": {}
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "4c2a294c5e31886937d0985e69e65314419e8866e5ab859cb2903cbe420a555a",
+                  "index": 0,
+                  "script": "",
+                  "sequence": 4294967295,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "2677",
+                  "script": "00145be12624d08a2b424095d7c07221c33450d14bf1"
+                },
+                {
+                  "value": "45878",
+                  "script": "5120d5238530e223ef1bd34a8a98ee1708f6a8a87e7a2589d88de6700b9973ffff46"
+                }
+              ]
+            }
+          }
         }
+      },
+      "opts": {
+        "maximumFeeRate": 5000
       }
     },
     "fee": 5000
@@ -151,29 +213,49 @@
       "data": {
         "inputs": [
           {
-            "unknownKeyVals": [],
-            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
             "witnessUtxo": {
-              "value": 45878,
-              "script": "5120d5238530e223ef1bd34a8a98ee1708f6a8a87e7a2589d88de6700b9973ffff46"
+              "script": "5120d5238530e223ef1bd34a8a98ee1708f6a8a87e7a2589d88de6700b9973ffff46",
+              "value": "45878"
             },
             "tapLeafScript": [
               {
-                "leafVersion": 192,
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
                 "script": "207b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9ad02f003b2",
-                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
+                "leafVersion": 192
               }
-            ]
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
           }
         ],
         "outputs": [
-          {
-            "unknownKeyVals": []
-          }
+          {}
         ],
         "globalMap": {
-          "unsignedTx": {}
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "264b3381598865054722ba6679f12405e06305dc4dd5ad1a6f7c330c28670163",
+                  "index": 1,
+                  "script": "",
+                  "sequence": 1008,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "45590",
+                  "script": "0014896f1ba65deaeb045bb3121e20e5744e66ca0e48"
+                }
+              ]
+            }
+          }
         }
+      },
+      "opts": {
+        "maximumFeeRate": 5000
       }
     },
     "fee": 288
@@ -183,32 +265,54 @@
       "data": {
         "inputs": [
           {
-            "unknownKeyVals": [],
-            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
             "witnessUtxo": {
-              "value": 55555,
-              "script": "5120788d73d75d7dd88d3612f7a91d5b3d6ad4778d8b49176f9539d322980b2f4fd7"
+              "script": "5120788d73d75d7dd88d3612f7a91d5b3d6ad4778d8b49176f9539d322980b2f4fd7",
+              "value": "55555"
             },
             "tapLeafScript": [
               {
-                "leafVersion": 192,
+                "controlBlock": "c150929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac04e9d38ba2696952c3a326cd821c319173cbe70ff9393f732b44d13aee3add4c0",
                 "script": "207b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9ad20850854d26df93570748d94e3da361f134c522f7970bd7f8701a164547308a900ad2004e2b2468fe224659eb9dc5bd0a9cc1b4878b64f40c67c951610320bce78dfd1ac202f3432bf9054e482041b890e084bc1a34cfbc0b63aded113bfa36b6f2402832bba204d7e91e4a0ab0526a387684db1628b535e6b66046aaa7d1b583b93c5a16e1ac7ba205e14742c0943fa66799f699a0ef98cf2b7cd223ddbb61f6878999182bbcc4700ba2064d55d591c5d416f713df9e15afd32e9ff2441cf276b2f90e5b3085163ca7a6bba206672282496e17eccaae560aac4d9fe85d8c166a4aa43f51fa8963c80a165831fba207939bcf0084cff0fe5c88a1748c1d97d63ff9ae6423a98dca65d974bb9123ce0ba209f66599cde7f3c3fefb6b96509e472f8a9e2caf8793b9b673fcb4067ef888f50ba20f0638e4817559347e67a07b56a6cb824d455fba42a8c8c95171c397540c51789ba569c",
-                "controlBlock": "c150929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac04e9d38ba2696952c3a326cd821c319173cbe70ff9393f732b44d13aee3add4c0"
+                "leafVersion": 192
               }
-            ]
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
           }
         ],
         "outputs": [
-          {
-            "unknownKeyVals": []
-          },
-          {
-            "unknownKeyVals": []
-          }
+          {},
+          {}
         ],
         "globalMap": {
-          "unsignedTx": {}
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "a999d7bc6af1a17cd4e70d0fd875a1734152dfb55f9166240f35965c79fa36c2",
+                  "index": 0,
+                  "script": "",
+                  "sequence": 4294967295,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "2777",
+                  "script": "00145be12624d08a2b424095d7c07221c33450d14bf1"
+                },
+                {
+                  "value": "47778",
+                  "script": "5120d5238530e223ef1bd34a8a98ee1708f6a8a87e7a2589d88de6700b9973ffff46"
+                }
+              ]
+            }
+          }
         }
+      },
+      "opts": {
+        "maximumFeeRate": 5000
       }
     },
     "fee": 5000
@@ -218,29 +322,49 @@
       "data": {
         "inputs": [
           {
-            "unknownKeyVals": [],
-            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
             "witnessUtxo": {
-              "value": 47778,
-              "script": "5120d5238530e223ef1bd34a8a98ee1708f6a8a87e7a2589d88de6700b9973ffff46"
+              "script": "5120d5238530e223ef1bd34a8a98ee1708f6a8a87e7a2589d88de6700b9973ffff46",
+              "value": "47778"
             },
             "tapLeafScript": [
               {
-                "leafVersion": 192,
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
                 "script": "207b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9ad02f003b2",
-                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
+                "leafVersion": 192
               }
-            ]
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
           }
         ],
         "outputs": [
-          {
-            "unknownKeyVals": []
-          }
+          {}
         ],
         "globalMap": {
-          "unsignedTx": {}
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "afdab314f4798317b427a227da4767e0a1c46a37cc14e33e34979aa1eff10ccd",
+                  "index": 1,
+                  "script": "",
+                  "sequence": 1008,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "47490",
+                  "script": "0014896f1ba65deaeb045bb3121e20e5744e66ca0e48"
+                }
+              ]
+            }
+          }
         }
+      },
+      "opts": {
+        "maximumFeeRate": 5000
       }
     },
     "fee": 288

--- a/modules/utxo-staking/test/unit/babylon/transactions.ts
+++ b/modules/utxo-staking/test/unit/babylon/transactions.ts
@@ -8,6 +8,7 @@ import { createAddressFromDescriptor, toWrappedPsbt } from '@bitgo/utxo-core/des
 import { getFixture, getKey, toPlainObject } from '@bitgo/utxo-core/testutil';
 
 import { BabylonDescriptorBuilder, finalityBabylonProvider0, testnetStakingParams } from '../../../src/babylon';
+import { normalize } from '../fixtures.utils';
 
 import * as vendor from './vendor/btc-staking-ts/src';
 import * as vendorStaking from './vendor/btc-staking-ts/src/staking';
@@ -206,7 +207,7 @@ async function assertScriptsEqualFixture(
 }
 
 async function assertTransactionEqualsFixture(fixtureName: string, tx: unknown): Promise<void> {
-  await assertEqualsFixture(fixtureName, toPlainObject(tx));
+  await assertEqualsFixture(fixtureName, normalize(tx));
 }
 
 function assertEqualsMiniscript(script: Buffer, miniscript: ast.MiniscriptNode): void {

--- a/modules/utxo-staking/test/unit/fixtures.utils.ts
+++ b/modules/utxo-staking/test/unit/fixtures.utils.ts
@@ -1,0 +1,32 @@
+import { Descriptor } from '@bitgo/wasm-miniscript';
+import * as utxolib from '@bitgo/utxo-lib';
+import * as bitcoinjslib from 'bitcoinjs-lib';
+import { toPlainObjectFromTx, toPlainObjectFromPsbt } from '@bitgo/utxo-core/testutil/descriptor';
+
+export function normalize(v: unknown): unknown {
+  if (typeof v === 'bigint') {
+    return v.toString();
+  }
+  if (v instanceof Descriptor) {
+    return v.toString();
+  }
+  if (v instanceof Buffer) {
+    return v.toString('hex');
+  }
+  if (v instanceof bitcoinjslib.Psbt) {
+    v = utxolib.Psbt.fromBuffer(v.toBuffer());
+  }
+  if (v instanceof utxolib.Psbt) {
+    return toPlainObjectFromPsbt(v);
+  }
+  if (v instanceof utxolib.Transaction) {
+    return toPlainObjectFromTx(v);
+  }
+  if (Array.isArray(v)) {
+    return v.map(normalize);
+  }
+  if (typeof v === 'object' && v !== null) {
+    return Object.fromEntries(Object.entries(v).flatMap(([k, v]) => (v === undefined ? [] : [[k, normalize(v)]])));
+  }
+  return v;
+}


### PR DESCRIPTION

Add helper function to normalize test fixture data, including bigint,
descriptors, buffers, and transaction types.

Issue: BTC-1826