### PR TITLE
fix(sdk-coin-stx): adding contractId instead of contractAddress & contractName for SIP10 tokens

### DIFF
--- a/modules/sdk-coin-stx/src/sip10Token.ts
+++ b/modules/sdk-coin-stx/src/sip10Token.ts
@@ -36,12 +36,8 @@ export class Sip10Token extends Stx {
     return this.tokenConfig.network;
   }
 
-  get tokenContractAddress(): string {
-    return this.tokenConfig.tokenContractAddress;
-  }
-
-  get contractName(): string {
-    return this.tokenConfig.contractName;
+  get assetId(): string {
+    return this.tokenConfig.assetId;
   }
 
   get decimalPlaces(): number {

--- a/modules/statics/src/account.ts
+++ b/modules/statics/src/account.ts
@@ -131,8 +131,7 @@ export interface FiatCoinConstructorOptions extends AccountConstructorOptions {
 }
 
 export interface Sip10TokenConstructorOptions extends AccountConstructorOptions {
-  contractAddress: string;
-  contractName: string;
+  assetId: string;
 }
 
 export interface ContractAddress extends String {
@@ -531,15 +530,13 @@ export class FiatCoin extends BaseCoin {
  * the contractName on the chain.
  */
 export class Sip10Token extends AccountCoinToken {
-  public contractAddress: string;
-  public contractName: string;
+  public assetId: string;
   constructor(options: Sip10TokenConstructorOptions) {
     super({
       ...options,
     });
 
-    this.contractAddress = options.contractAddress;
-    this.contractName = options.contractName;
+    this.assetId = options.assetId;
   }
 }
 
@@ -2612,8 +2609,7 @@ export function fiat(
  * @param name unique identifier of the token
  * @param fullName Complete human-readable name of the token
  * @param decimalPlaces Number of decimal places this token supports (divisibility exponent)
- * @param contractName Contract name of this token
- * @param contractAddress Contract address of this token
+ * @param assetId A unique identifier for a token, which is in the form of contractAddress.contractName::tokenName
  * @param asset Asset which this coin represents. This is the same for both mainnet and testnet variants of a coin.
  * @param prefix? Optional token prefix. Defaults to empty string
  * @param suffix? Optional token suffix. Defaults to token name.
@@ -2626,8 +2622,7 @@ export function sip10Token(
   name: string,
   fullName: string,
   decimalPlaces: number,
-  contractName: string,
-  contractAddress: string,
+  assetId: string,
   asset: UnderlyingAsset,
   features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
   prefix = '',
@@ -2641,8 +2636,7 @@ export function sip10Token(
       name,
       fullName,
       network,
-      contractName,
-      contractAddress,
+      assetId,
       prefix,
       suffix,
       features,
@@ -2662,8 +2656,7 @@ export function sip10Token(
  * @param name unique identifier of the token
  * @param fullName Complete human-readable name of the token
  * @param decimalPlaces Number of decimal places this token supports (divisibility exponent)
- * @param contractName Contract name of this token
- * @param contractAddress Contract address of this token
+ * @param assetId A unique identifier for a token, which is in the form of contractAddress.contractName::tokenName
  * @param asset Asset which this coin represents. This is the same for both mainnet and testnet variants of a coin.
  * @param prefix? Optional token prefix. Defaults to empty string
  * @param suffix? Optional token suffix. Defaults to token name.
@@ -2675,25 +2668,12 @@ export function tsip10Token(
   name: string,
   fullName: string,
   decimalPlaces: number,
-  contractName: string,
-  contractAddress: string,
+  assetId: string,
   asset: UnderlyingAsset,
   features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
   prefix = '',
   suffix: string = name.toUpperCase(),
   network: AccountNetwork = Networks.test.stx
 ) {
-  return sip10Token(
-    id,
-    name,
-    fullName,
-    decimalPlaces,
-    contractName,
-    contractAddress,
-    asset,
-    features,
-    prefix,
-    suffix,
-    network
-  );
+  return sip10Token(id, name, fullName, decimalPlaces, assetId, asset, features, prefix, suffix, network);
 }

--- a/modules/statics/src/tokenConfig.ts
+++ b/modules/statics/src/tokenConfig.ts
@@ -96,8 +96,8 @@ export type AptTokenConfig = BaseNetworkConfig & {
   assetId: string;
 };
 
-export type Sip10TokenConfig = BaseContractAddressConfig & {
-  contractName: string;
+export type Sip10TokenConfig = BaseNetworkConfig & {
+  assetId: string;
 };
 
 export interface Tokens {
@@ -566,8 +566,7 @@ const formattedSip10Tokens = coins.reduce((acc: Sip10TokenConfig[], coin) => {
       coin: coin.network.type === NetworkType.MAINNET ? 'stx' : 'tstx',
       network: coin.network.type === NetworkType.MAINNET ? 'Mainnet' : 'Testnet',
       name: coin.fullName,
-      contractName: coin.contractName,
-      tokenContractAddress: coin.contractAddress.toString().toLowerCase(),
+      assetId: coin.assetId,
       decimalPlaces: coin.decimalPlaces,
     });
   }


### PR DESCRIPTION
Ticket: [COIN-3364](https://bitgoinc.atlassian.net/browse/COIN-3364)


[COIN-3364]: https://bitgoinc.atlassian.net/browse/COIN-3364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ