### PR TITLE
fix(sdk-coin-tao): prevent real api calls by using beforeEach for stubbing

### DIFF
--- a/modules/sdk-coin-tao/test/unit/tao.ts
+++ b/modules/sdk-coin-tao/test/unit/tao.ts
@@ -27,7 +27,7 @@ describe('Tao:', function () {
     let headerInfoCB;
     let getFeeCB;
 
-    before(function () {
+    beforeEach(function () {
       accountInfoCB = sandBox.stub(Tao.prototype, 'getAccountInfo' as keyof Tao);
       headerInfoCB = sandBox.stub(Tao.prototype, 'getHeaderInfo' as keyof Tao);
       getFeeCB = sandBox.stub(Tao.prototype, 'getFee' as keyof Tao);


### PR DESCRIPTION
TICKET: WIN-4315

Previously, stubs were created in `before`, causing real API calls when 
the sandbox was restored by other tests. This fix moves stub creation to 
`beforeEach`, ensuring each test has fresh stubs and preventing real API 
calls during test execution.