### PR TITLE
fix: move lightning routes to before the any other calls

### DIFF
--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -1677,29 +1677,6 @@ export function setupAPIRoutes(app: express.Application, config: Config): void {
     promiseWrapper(handleV2PendingApproval)
   );
 
-  // any other API v2 call
-  app.use('/api/v2/user/*', parseBody, prepareBitGo(config), promiseWrapper(handleV2UserREST));
-  app.use('/api/v2/:coin/*', parseBody, prepareBitGo(config), promiseWrapper(handleV2CoinSpecificREST));
-
-  app.post(
-    '/api/network/v1/enterprises/:enterpriseId/clients/connections',
-    parseBody,
-    prepareBitGo(config),
-    promiseWrapper(handleNetworkV1EnterpriseClientConnections)
-  );
-
-  // everything else should use the proxy handler
-  if (config.disableProxy !== true) {
-    app.use(
-      '/api/:namespace/v[12]/enterprises/:enterpriseId/*',
-      parseBody,
-      prepareBitGo(config),
-      promiseWrapper(handleProxyReq)
-    );
-
-    app.use(parseBody, prepareBitGo(config), promiseWrapper(handleProxyReq));
-  }
-
   // lightning - create invoice
   app.post(
     '/api/v2/:coin/wallet/:id/lightning/invoice',
@@ -1707,6 +1684,7 @@ export function setupAPIRoutes(app: express.Application, config: Config): void {
     prepareBitGo(config),
     promiseWrapper(handleCreateLightningInvoice)
   );
+
   // lightning - get invoice
   app.get(
     '/api/v2/:coin/wallet/:id/lightning/invoice/:paymentHash',
@@ -1755,6 +1733,29 @@ export function setupAPIRoutes(app: express.Application, config: Config): void {
 
   // lightning - backup
   app.get('/api/v2/:coin/wallet/:id/lightning/backup', prepareBitGo(config), promiseWrapper(handleGetChannelBackup));
+
+  // any other API v2 call
+  app.use('/api/v2/user/*', parseBody, prepareBitGo(config), promiseWrapper(handleV2UserREST));
+  app.use('/api/v2/:coin/*', parseBody, prepareBitGo(config), promiseWrapper(handleV2CoinSpecificREST));
+
+  app.post(
+    '/api/network/v1/enterprises/:enterpriseId/clients/connections',
+    parseBody,
+    prepareBitGo(config),
+    promiseWrapper(handleNetworkV1EnterpriseClientConnections)
+  );
+
+  // everything else should use the proxy handler
+  if (config.disableProxy !== true) {
+    app.use(
+      '/api/:namespace/v[12]/enterprises/:enterpriseId/*',
+      parseBody,
+      prepareBitGo(config),
+      promiseWrapper(handleProxyReq)
+    );
+
+    app.use(parseBody, prepareBitGo(config), promiseWrapper(handleProxyReq));
+  }
 }
 
 export function setupSigningRoutes(app: express.Application, config: Config): void {


### PR DESCRIPTION
Order matters when listing the routes. The lightning routes should come before the any `any other` logic.

Ticket: BTC-1911

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
