### PR TITLE
feat(sdk-core): lightning wallet sharing support

### DIFF
--- a/modules/sdk-core/src/bitgo/lightning/lightningWalletUtil.ts
+++ b/modules/sdk-core/src/bitgo/lightning/lightningWalletUtil.ts
@@ -1,0 +1,29 @@
+import { Wallet } from '../wallet';
+import { KeychainWithEncryptedPrv } from '../keychain';
+
+/**
+ * Get the lightning auth key for the given purpose
+ */
+export async function getLightningAuthKey(
+  wallet: Wallet,
+  purpose: 'userAuth' | 'nodeAuth'
+): Promise<KeychainWithEncryptedPrv> {
+  if (wallet.baseCoin.getFamily() !== 'lnbtc') {
+    throw new Error(`Invalid lightning coin family: ${wallet.baseCoin.getFamily()}`);
+  }
+  const authKeyIds = wallet.coinSpecific()?.keys;
+  if (authKeyIds?.length !== 2) {
+    throw new Error(`Invalid number of auth keys in lightning wallet: ${authKeyIds?.length}`);
+  }
+  const keychains = await Promise.all(authKeyIds.map((id) => wallet.baseCoin.keychains().get({ id })));
+  const userAuthKeychain = keychains.find((v) => {
+    const coinSpecific = v?.coinSpecific?.[wallet.baseCoin.getChain()];
+    return (
+      coinSpecific && typeof coinSpecific === 'object' && 'purpose' in coinSpecific && coinSpecific.purpose === purpose
+    );
+  });
+  if (userAuthKeychain?.encryptedPrv) {
+    return userAuthKeychain as KeychainWithEncryptedPrv;
+  }
+  throw new Error(`Missing lightning ${purpose} keychain with encrypted private key`);
+}


### PR DESCRIPTION
Lightning uses user auth key instead of user key
to authorise transactions to BitGo backend.

Actual transaction signing are done using user key, but that is controlled by BitGo for custodial lightning wallets.

So user auth key from coinSpecific of a wallet
should be the one shared by the users during wallet sharings.

TICKET: BTC-1934

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
