### PR TITLE
feat(abstract-lightning): make encrypted prv key optional in get key

### DIFF
--- a/modules/abstract-lightning/src/codecs/api/wallet.ts
+++ b/modules/abstract-lightning/src/codecs/api/wallet.ts
@@ -10,26 +10,34 @@ export type KeyPurpose = t.TypeOf<typeof KeyPurpose>;
 
 export const LightningAuthKeychainCoinSpecific = getCodecPair(t.type({ purpose: KeyPurpose }));
 
-export const LightningKeychain = t.strict(
-  {
-    id: NonEmptyString,
-    pub: NonEmptyString,
-    encryptedPrv: NonEmptyString,
-    source: t.literal('user'),
-  },
+export const LightningKeychain = t.intersection(
+  [
+    t.type({
+      id: NonEmptyString,
+      pub: NonEmptyString,
+      source: t.literal('user'),
+    }),
+    t.partial({
+      encryptedPrv: NonEmptyString,
+    }),
+  ],
   'LightningKeychain'
 );
 
 export type LightningKeychain = t.TypeOf<typeof LightningKeychain>;
 
-export const LightningAuthKeychain = t.strict(
-  {
-    id: NonEmptyString,
-    pub: NonEmptyString,
-    encryptedPrv: NonEmptyString,
-    coinSpecific: LightningAuthKeychainCoinSpecific,
-    source: t.literal('user'),
-  },
+export const LightningAuthKeychain = t.intersection(
+  [
+    t.type({
+      id: NonEmptyString,
+      pub: NonEmptyString,
+      coinSpecific: LightningAuthKeychainCoinSpecific,
+      source: t.literal('user'),
+    }),
+    t.partial({
+      encryptedPrv: NonEmptyString,
+    }),
+  ],
   'LightningAuthKeychain'
 );
 

--- a/modules/abstract-lightning/src/wallet/lightning.ts
+++ b/modules/abstract-lightning/src/wallet/lightning.ts
@@ -239,9 +239,13 @@ export class LightningWallet implements ILightningWallet {
     this.wallet.bitgo.setRequestTracer(reqId);
 
     const { userAuthKey } = await getLightningAuthKeychains(this.wallet);
+    const userAuthKeyEncryptedPrv = userAuthKey.encryptedPrv;
+    if (!userAuthKeyEncryptedPrv) {
+      throw new Error(`user auth key is missing encrypted private key`);
+    }
     const signature = createMessageSignature(
       t.exact(LightningPaymentRequest).encode(params),
-      this.wallet.bitgo.decrypt({ password: params.passphrase, input: userAuthKey.encryptedPrv })
+      this.wallet.bitgo.decrypt({ password: params.passphrase, input: userAuthKeyEncryptedPrv })
     );
 
     const paymentIntent: { intent: LightningPaymentIntent } = {

--- a/modules/abstract-lightning/test/unit/lightning/codecs.ts
+++ b/modules/abstract-lightning/test/unit/lightning/codecs.ts
@@ -37,6 +37,11 @@ describe('Codecs', function () {
         encryptedPrv: 'encryptedPrv',
         source: 'user',
       },
+      {
+        id: 'id',
+        pub: 'xpub',
+        source: 'user',
+      },
     ],
     [
       null,
@@ -58,6 +63,16 @@ describe('Codecs', function () {
         id: 'id',
         pub: 'xpub',
         encryptedPrv: 'encryptedPrv',
+        source: 'user',
+        coinSpecific: {
+          lnbtc: {
+            purpose: 'userAuth',
+          },
+        },
+      },
+      {
+        id: 'id',
+        pub: 'xpub',
         source: 'user',
         coinSpecific: {
           lnbtc: {


### PR DESCRIPTION
wallet shared users control prv key of user auth key alone, not node auth and user keys.

Ticket: BTC-1934

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
