### PR TITLE
feat(ci): move dependency audit step to code quality matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,6 @@ jobs:
       - name: Check In-Repo Package Versions
         run: yarn run check-versions
 
-      - name: Dependency Audit
-        run: yarn run improved-yarn-audit --min-severity high
-
       - name: build packages
         env:
           # Workaround for https://github.com/nodejs/node/issues/51555
@@ -86,7 +83,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        check: ['lint', 'format', 'commit-lint', 'dependencies']
+        check: ['lint', 'format', 'commit-lint', 'dependencies', 'audit']
 
     steps:
       - uses: actions/checkout@v4
@@ -128,6 +125,10 @@ jobs:
       - name: Check Package Dependencies
         if: matrix.check == 'dependencies'
         run: yarn run check-deps
+
+      - name: Audit Dependencies
+        if: matrix.check == 'audit'
+        run: yarn run improved-yarn-audit --min-severity high
 
   browser-test:
     runs-on: ubuntu-22.04


### PR DESCRIPTION

Move the dependency audit step from its own workflow into the 
code quality matrix to streamline our CI process and reduce 
overall build time.

Issue: BTC-0