### PR TITLE
feat(utxo-core): add toXOnlyPublicKey utility function

### DIFF
--- a/modules/utxo-core/src/index.ts
+++ b/modules/utxo-core/src/index.ts
@@ -3,3 +3,4 @@ export * as descriptor from './descriptor';
 export * as testutil from './testutil';
 export * from './dustThreshold';
 export * from './Output';
+export * from './xOnlyPubkey';

--- a/modules/utxo-core/src/xOnlyPubkey.ts
+++ b/modules/utxo-core/src/xOnlyPubkey.ts
@@ -1,0 +1,15 @@
+export function toXOnlyPublicKey(b: Buffer): Buffer {
+  if (b.length === 33) {
+    if (b[0] === 0x02 || b[0] === 0x03) {
+      return b.subarray(1);
+    } else {
+      throw new Error(`invalid pubkey leading byte ${b.subarray(0, 1).toString('hex')}`);
+    }
+  }
+
+  if (b.length === 32) {
+    return b;
+  }
+
+  throw new Error(`invalid pubkey buffer length ${b.length}`);
+}

--- a/modules/utxo-core/test/xOnlyPubkey.ts
+++ b/modules/utxo-core/test/xOnlyPubkey.ts
@@ -1,0 +1,14 @@
+import assert from 'assert';
+
+import { toXOnlyPublicKey } from '../src';
+
+describe('xOnlyPubkey', function () {
+  it('converts to X-Only pubkey', function () {
+    const buf32 = Buffer.alloc(32, 0);
+    assert.deepStrictEqual(toXOnlyPublicKey(Buffer.concat([Buffer.from([0x02]), buf32])), buf32);
+    assert.deepStrictEqual(toXOnlyPublicKey(Buffer.concat([Buffer.from([0x03]), buf32])), buf32);
+    assert.deepStrictEqual(toXOnlyPublicKey(buf32), buf32);
+    assert.throws(() => toXOnlyPublicKey(Buffer.concat([Buffer.from([0x04]), buf32])));
+    assert.throws(() => toXOnlyPublicKey(Buffer.alloc(31)));
+  });
+});


### PR DESCRIPTION

Add utility function to convert compressed public keys to x-only format
for use in taproot scripts. Includes tests for valid and invalid cases.

Issue: BTC-1933