### PR TITLE
feat(utxo-staking): implement Babylon staking utilities

### DIFF
--- a/modules/utxo-staking/src/babylon/delegationMessage.ts
+++ b/modules/utxo-staking/src/babylon/delegationMessage.ts
@@ -8,11 +8,13 @@ import * as babylonProtobuf from '@babylonlabs-io/babylon-proto-ts';
 import * as bitcoinjslib from 'bitcoinjs-lib';
 import * as utxolib from '@bitgo/utxo-lib';
 import { Descriptor } from '@bitgo/wasm-miniscript';
+import { toXOnlyPublicKey } from '@bitgo/utxo-core';
 import { toWrappedPsbt } from '@bitgo/utxo-core/descriptor';
 
 import { BabylonDescriptorBuilder } from './descriptor';
 import { createStakingManager } from './stakingManager';
 import { getStakingParams } from './stakingParams';
+import { BabylonNetworkLike, toBitcoinJsNetwork } from './network';
 
 export type ValueWithTypeUrl<T> = { typeUrl: string; value: T };
 
@@ -85,6 +87,77 @@ type Result = {
   unsignedDelegationMsg: ValueWithTypeUrl<babylonProtobuf.btcstakingtx.MsgCreateBTCDelegation>;
   stakingTx: bitcoinjslib.Transaction;
 };
+
+/**
+ * @param stakingKey - this is the single-sig key that is used for co-signing the staking output
+ * @param changeAddress - this is unrelated to the staking key and is used for the change output
+ */
+export function toStakerInfo(
+  stakingKey: utxolib.ECPairInterface | Buffer | string,
+  changeAddress: string
+): vendor.StakerInfo {
+  if (typeof stakingKey === 'object' && 'publicKey' in stakingKey) {
+    stakingKey = stakingKey.publicKey;
+  }
+  if (typeof stakingKey === 'string') {
+    stakingKey = Buffer.from(stakingKey, 'hex');
+  }
+  return {
+    publicKeyNoCoordHex: toXOnlyPublicKey(stakingKey).toString('hex'),
+    address: changeAddress,
+  };
+}
+
+export function createStaking(
+  network: BabylonNetworkLike,
+  blockHeight: number,
+  stakerBtcInfo: vendor.StakerInfo,
+  stakingInput: vendor.StakingInputs,
+  versionedParams: vendor.VersionedStakingParams[] = getStakingParams(network)
+): vendor.Staking {
+  if (blockHeight === 0) {
+    throw new Error('Babylon BTC tip height cannot be 0');
+  }
+
+  // Get the Babylon params based on the BTC tip height from Babylon chain
+  const params = vendor.getBabylonParamByBtcHeight(blockHeight, versionedParams);
+
+  return new vendor.Staking(
+    toBitcoinJsNetwork(network),
+    stakerBtcInfo,
+    params,
+    stakingInput.finalityProviderPkNoCoordHex,
+    stakingInput.stakingTimelock
+  );
+}
+
+type TransactionLike =
+  | bitcoinjslib.Psbt
+  | bitcoinjslib.Transaction
+  | utxolib.Transaction
+  | utxolib.bitgo.UtxoTransaction<bigint | number>
+  | utxolib.Psbt
+  | utxolib.bitgo.UtxoPsbt;
+
+function toStakingTransactionFromPsbt(
+  psbt: bitcoinjslib.Psbt | utxolib.Psbt | utxolib.bitgo.UtxoPsbt
+): bitcoinjslib.Transaction {
+  if (!(psbt instanceof utxolib.bitgo.UtxoPsbt)) {
+    psbt = utxolib.bitgo.createPsbtFromBuffer(psbt.toBuffer(), utxolib.networks.bitcoin);
+  }
+  if (psbt instanceof utxolib.bitgo.UtxoPsbt) {
+    // only utxolib.bitgo.UtxoPsbt has the getUnsignedTx method
+    return bitcoinjslib.Transaction.fromHex(psbt.getUnsignedTx().toHex());
+  }
+  throw new Error('illegal state');
+}
+
+export function toStakingTransaction(tx: TransactionLike): bitcoinjslib.Transaction {
+  if (tx instanceof bitcoinjslib.Psbt || tx instanceof utxolib.Psbt) {
+    return toStakingTransactionFromPsbt(tx);
+  }
+  return bitcoinjslib.Transaction.fromHex(tx.toHex());
+}
 
 /*
  * This is mostly lifted from

--- a/modules/utxo-staking/src/babylon/delegationMessage.ts
+++ b/modules/utxo-staking/src/babylon/delegationMessage.ts
@@ -1,3 +1,6 @@
+/**
+ * https://github.com/babylonlabs-io/babylon/blob/v1.99.0-snapshot.250211/x/btcstaking/types/validate_parsed_message.go
+ */
 import assert from 'assert';
 
 import * as vendor from '@bitgo/babylonlabs-io-btc-staking-ts';

--- a/modules/utxo-staking/src/babylon/descriptor.ts
+++ b/modules/utxo-staking/src/babylon/descriptor.ts
@@ -1,6 +1,7 @@
 /**
  * https://github.com/babylonlabs-io/babylon/tree/main/docs
  * https://github.com/babylonlabs-io/babylon/blob/main/docs/staking-script.md
+ * https://github.com/babylonlabs-io/babylon/blob/v1.99.0-snapshot.250211/btcstaking/staking.go
  */
 
 import { Descriptor, ast } from '@bitgo/wasm-miniscript';

--- a/modules/utxo-staking/src/babylon/descriptor.ts
+++ b/modules/utxo-staking/src/babylon/descriptor.ts
@@ -44,21 +44,6 @@ export class BabylonDescriptorBuilder {
       finalityProviderKeys: Buffer[];
     } & StakingParams
   ): BabylonDescriptorBuilder {
-    /*
-
-  const stakerKey = getECKey('staker');
-  const covenantThreshold = stakingParams.covenantQuorum;
-  const stakingTimelock = stakingParams.minStakingTimeBlocks;
-  const unbondingTimelock = stakingParams.unbondingTime;
-  const vendorBuilder = new vendor.StakingScriptData(
-    getXOnlyPubkey(stakerKey),
-    finalityProviderKeys.map(getXOnlyPubkey),
-    covenantKeys.map(getXOnlyPubkey),
-    covenantThreshold,
-    stakingTimelock,
-    unbondingTimelock
-  );
-     */
     return new BabylonDescriptorBuilder(
       params.stakerKey,
       params.finalityProviderKeys,

--- a/modules/utxo-staking/src/babylon/index.ts
+++ b/modules/utxo-staking/src/babylon/index.ts
@@ -1,3 +1,10 @@
+import { initBTCCurve } from '@bitgo/babylonlabs-io-btc-staking-ts';
+import * as bitcoinjslib from 'bitcoinjs-lib';
+import * as utxolib from '@bitgo/utxo-lib';
+
+initBTCCurve();
+bitcoinjslib.initEccLib(utxolib.ecc);
+
 export * from './delegationMessage';
 export * from './descriptor';
 export * from './stakingParams';

--- a/modules/utxo-staking/src/babylon/keyUtils.ts
+++ b/modules/utxo-staking/src/babylon/keyUtils.ts
@@ -1,5 +1,0 @@
-import { ECPairInterface } from '@bitgo/utxo-lib';
-
-export function getXOnlyPubkey(key: ECPairInterface): Buffer {
-  return key.publicKey.subarray(1);
-}

--- a/modules/utxo-staking/src/babylon/network.ts
+++ b/modules/utxo-staking/src/babylon/network.ts
@@ -1,0 +1,34 @@
+import * as bitcoinjslib from 'bitcoinjs-lib';
+import * as utxolib from '@bitgo/utxo-lib';
+
+export type BabylonNetwork = 'mainnet' | 'testnet';
+
+export type BabylonNetworkLike = bitcoinjslib.Network | utxolib.Network | BabylonNetwork;
+
+export function toBabylonNetwork(n: BabylonNetworkLike): BabylonNetwork {
+  switch (n) {
+    case bitcoinjslib.networks.bitcoin:
+    case utxolib.networks.bitcoin:
+      return 'mainnet';
+    case bitcoinjslib.networks.testnet:
+    case utxolib.networks.testnet:
+    case utxolib.networks.bitcoinPublicSignet:
+      return 'testnet';
+    case 'mainnet':
+    case 'testnet':
+      return n;
+    default:
+      throw new Error('Unsupported network');
+  }
+}
+
+export function toBitcoinJsNetwork(n: BabylonNetworkLike): bitcoinjslib.Network {
+  switch (toBabylonNetwork(n)) {
+    case 'mainnet':
+      return bitcoinjslib.networks.bitcoin;
+    case 'testnet':
+      return bitcoinjslib.networks.testnet;
+    default:
+      throw new Error('Unsupported network');
+  }
+}

--- a/modules/utxo-staking/src/babylon/stakingParams.ts
+++ b/modules/utxo-staking/src/babylon/stakingParams.ts
@@ -9,6 +9,7 @@ import {
   StakingInputs,
   VersionedStakingParams,
 } from '@bitgo/babylonlabs-io-btc-staking-ts';
+export { getBabylonParamByVersion, getBabylonParamByBtcHeight } from '@bitgo/babylonlabs-io-btc-staking-ts';
 
 import { BabylonDescriptorBuilder } from './descriptor';
 import jsonMainnetParams from './params.mainnet.json';

--- a/modules/utxo-staking/src/babylon/stakingParams.ts
+++ b/modules/utxo-staking/src/babylon/stakingParams.ts
@@ -2,7 +2,6 @@ import * as t from 'io-ts';
 import * as tt from 'io-ts-types';
 import { isLeft } from 'fp-ts/Either';
 import { PathReporter } from 'io-ts/lib/PathReporter';
-import * as bitcoinjslib from 'bitcoinjs-lib';
 import * as utxolib from '@bitgo/utxo-lib';
 import {
   getBabylonParamByVersion,
@@ -14,6 +13,7 @@ import {
 import { BabylonDescriptorBuilder } from './descriptor';
 import jsonMainnetParams from './params.mainnet.json';
 import jsonTestnetParams from './params.testnet.json';
+import { BabylonNetworkLike, toBabylonNetwork } from './network';
 
 const BabylonParamsJSON = t.type({
   covenant_pks: t.array(t.string),
@@ -66,27 +66,6 @@ function toVersionedParamsFromJson(jsonParams: unknown[]): VersionedStakingParam
       return result.right.params;
     })
   );
-}
-
-type BabylonNetwork = 'mainnet' | 'testnet';
-
-type BabylonNetworkLike = bitcoinjslib.Network | utxolib.Network | BabylonNetwork;
-
-function toBabylonNetwork(n: BabylonNetworkLike): BabylonNetwork {
-  switch (n) {
-    case bitcoinjslib.networks.bitcoin:
-    case utxolib.networks.bitcoin:
-      return 'mainnet';
-    case bitcoinjslib.networks.testnet:
-    case utxolib.networks.testnet:
-    case utxolib.networks.bitcoinPublicSignet:
-      return 'testnet';
-    case 'mainnet':
-    case 'testnet':
-      return n;
-    default:
-      throw new Error('Unsupported network');
-  }
 }
 
 export const mainnetStakingParams: readonly VersionedStakingParams[] = Object.freeze(

--- a/modules/utxo-staking/src/transaction.ts
+++ b/modules/utxo-staking/src/transaction.ts
@@ -1,5 +1,8 @@
 import * as utxolib from '@bitgo/utxo-lib';
 import { Dimensions } from '@bitgo/unspents';
+import * as bitcoinjslib from 'bitcoinjs-lib';
+
+bitcoinjslib.initEccLib(utxolib.ecc);
 
 /**
  * Build a staking transaction for a wallet that assumes 2-of-3 multisig for the inputs

--- a/modules/utxo-staking/test/unit/babylon/transactions.ts
+++ b/modules/utxo-staking/test/unit/babylon/transactions.ts
@@ -20,8 +20,6 @@ import { normalize } from '../fixtures.utils';
 import { fromXOnlyPublicKey, getECKey, getECKeys, getXOnlyPubkey } from './key.utils';
 import { getBitGoUtxoStakingMsgCreateBtcDelegation, getVendorMsgCreateBtcDelegation } from './vendor.utils';
 
-bitcoinjslib.initEccLib(utxolib.ecc);
-
 type WithFee<T> = T & { fee: number };
 type TransactionWithFee = WithFee<{ transaction: bitcoinjslib.Transaction }>;
 type PsbtWithFee = WithFee<{ psbt: bitcoinjslib.Psbt }>;

--- a/modules/utxo-staking/test/unit/babylon/transactions.ts
+++ b/modules/utxo-staking/test/unit/babylon/transactions.ts
@@ -14,6 +14,7 @@ import {
   testnetFinalityProvider0,
   getSignedPsbt,
   getStakingParams,
+  toStakerInfo,
 } from '../../../src/babylon';
 import { normalize } from '../fixtures.utils';
 
@@ -289,10 +290,7 @@ function describeWithKeys(
       it('has expected transactions (vendorStaking.Staking)', async function (this: Mocha.Context) {
         const vendorStakingTxBuilder = new vendor.Staking(
           bitcoinjslib.networks.bitcoin,
-          {
-            address: changeAddress,
-            publicKeyNoCoordHex: getXOnlyPubkey(stakerKey).toString('hex'),
-          },
+          toStakerInfo(stakerKey, changeAddress),
           stakingParams,
           getXOnlyPubkey(finalityProvider).toString('hex'),
           stakingParams.minStakingTimeBlocks


### PR DESCRIPTION

Implement core utilities for Bitcoin staking with Babylon protocol including:
- Delegation message creation from PSBT
- Network type definitions and conversion functions
- Staker info helpers and timelock parameter support
- Descriptor builder enhancements
- Babylon parameter lookup functions

Refactor delegation message creation for better composability and
extract network type definitions into separate files.

Issue: BTC-1933