### PR TITLE
Revert "Revert "feat(sdk-coin-apt): send many: addition of recipients (single recipient)""

### DIFF
--- a/modules/sdk-coin-apt/src/lib/iface.ts
+++ b/modules/sdk-coin-apt/src/lib/iface.ts
@@ -16,6 +16,7 @@ export interface TxData {
   id: string;
   sender: string;
   recipient: TransactionRecipient;
+  recipients: TransactionRecipient[];
   sequenceNumber: number;
   maxGasAmount: number;
   gasUnitPrice: number;

--- a/modules/sdk-coin-apt/src/lib/transaction/digitalAssetTransfer.ts
+++ b/modules/sdk-coin-apt/src/lib/transaction/digitalAssetTransfer.ts
@@ -37,19 +37,20 @@ export class DigitalAssetTransfer extends Transaction {
       throw new InvalidTransactionError('Invalid transaction payload');
     }
     const entryFunction = payload.entryFunction;
-    if (!this._recipient) {
-      this._recipient = {} as TransactionRecipient;
-    }
     this._assetId = entryFunction.args[0].toString();
-    this._recipient.address = entryFunction.args[1].toString();
-    this._recipient.amount = DIGITAL_ASSET_TRANSFER_AMOUNT;
+    this.recipients = [
+      {
+        address: entryFunction.args[1].toString(),
+        amount: DIGITAL_ASSET_TRANSFER_AMOUNT,
+      },
+    ] as TransactionRecipient[];
   }
 
   protected async buildRawTransaction(): Promise<void> {
     const network: Network = this._coinConfig.network.type === NetworkType.MAINNET ? Network.MAINNET : Network.TESTNET;
     const aptos = new Aptos(new AptosConfig({ network }));
     const senderAddress = AccountAddress.fromString(this._sender);
-    const recipientAddress = AccountAddress.fromString(this._recipient.address);
+    const recipientAddress = AccountAddress.fromString(this.recipients[0].address);
     const digitalAssetAddress = AccountAddress.fromString(this._assetId);
 
     const transferDigitalAssetAbi: EntryFunctionABI = {

--- a/modules/sdk-coin-apt/src/lib/transaction/fungibleAssetTransfer.ts
+++ b/modules/sdk-coin-apt/src/lib/transaction/fungibleAssetTransfer.ts
@@ -32,21 +32,21 @@ export class FungibleAssetTransfer extends Transaction {
       throw new InvalidTransactionError('Invalid transaction payload');
     }
     const entryFunction = payload.entryFunction;
-    if (!this._recipient) {
-      this._recipient = {} as TransactionRecipient;
-    }
     this._assetId = entryFunction.args[0].toString();
-    this._recipient.address = entryFunction.args[1].toString();
-    this._recipient.amount = utils.getAmountFromPayloadArgs(entryFunction.args[2].bcsToBytes());
+    this.recipients = [
+      {
+        address: entryFunction.args[1].toString(),
+        amount: utils.getAmountFromPayloadArgs(entryFunction.args[2].bcsToBytes()),
+      },
+    ] as TransactionRecipient[];
   }
 
   protected async buildRawTransaction(): Promise<void> {
     const network: Network = this._coinConfig.network.type === NetworkType.MAINNET ? Network.MAINNET : Network.TESTNET;
     const aptos = new Aptos(new AptosConfig({ network }));
     const senderAddress = AccountAddress.fromString(this._sender);
-    const recipientAddress = AccountAddress.fromString(this._recipient.address);
+    const recipientAddress = AccountAddress.fromString(this.recipients[0].address);
     const fungibleTokenAddress = this._assetId;
-
     const faTransferAbi: EntryFunctionABI = {
       typeParameters: [{ constraints: [] }],
       parameters: [parseTypeTag('0x1::object::Object'), new TypeTagAddress(), new TypeTagU64()],
@@ -57,7 +57,7 @@ export class FungibleAssetTransfer extends Transaction {
       data: {
         function: FUNGIBLE_ASSET_TRANSFER_FUNCTION,
         typeArguments: [FUNGIBLE_ASSET_TYPE_ARGUMENT],
-        functionArguments: [fungibleTokenAddress, recipientAddress, this.recipient.amount],
+        functionArguments: [fungibleTokenAddress, recipientAddress, this.recipients[0].amount],
         abi: faTransferAbi,
       },
       options: {

--- a/modules/sdk-coin-apt/src/lib/transactionBuilder/transactionBuilder.ts
+++ b/modules/sdk-coin-apt/src/lib/transactionBuilder/transactionBuilder.ts
@@ -63,10 +63,22 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
     return this;
   }
 
+  /**
+   * @deprecated - use `recipients()`.
+   */
   recipient(recipient: Recipient): this {
     this.validateAddress({ address: recipient.address });
     this.validateValue(new BigNumber(recipient.amount));
-    this.transaction.recipient = recipient;
+    this.transaction.recipients = [recipient];
+    return this;
+  }
+
+  recipients(recipients: Recipient[]): this {
+    for (const recipient of recipients) {
+      this.validateAddress({ address: recipient.address });
+      this.validateValue(new BigNumber(recipient.amount));
+    }
+    this.transaction.recipients = recipients;
     return this;
   }
 
@@ -143,8 +155,10 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
       throw new Error('transaction not defined');
     }
     this.validateAddress({ address: transaction.sender });
-    this.validateAddress({ address: transaction.recipient.address });
-    this.validateValue(new BigNumber(transaction.recipient.amount));
+    for (const recipient of transaction.recipients) {
+      this.validateAddress({ address: recipient.address });
+      this.validateValue(new BigNumber(recipient.amount));
+    }
   }
 
   isValidRawTransaction(rawTransaction: string): boolean {

--- a/modules/sdk-coin-apt/test/unit/transactionBuilder/digitalAssetTransferBuilder.ts
+++ b/modules/sdk-coin-apt/test/unit/transactionBuilder/digitalAssetTransferBuilder.ts
@@ -12,7 +12,7 @@ describe('Apt Digital Asset Transfer Builder', () => {
     const digitalAssetTransfer = new DigitalAssetTransfer(coins.get('tapt'));
     const txBuilder = factory.getDigitalAssetTransactionBuilder(digitalAssetTransfer);
     txBuilder.sender(testData.sender2.address);
-    txBuilder.recipient(testData.digitalTokenRecipients[0]);
+    txBuilder.recipients(testData.digitalTokenRecipients);
     txBuilder.gasData({
       maxGasAmount: 200000,
       gasUnitPrice: 100,
@@ -23,6 +23,7 @@ describe('Apt Digital Asset Transfer Builder', () => {
     txBuilder.addFeePayerAddress(testData.feePayer.address);
     const tx = (await txBuilder.build()) as DigitalAssetTransfer;
     should.equal(tx.sender, testData.sender2.address);
+    should.equal(tx.recipients[0].address, testData.digitalTokenRecipients[0].address);
     should.equal(tx.recipient.address, testData.digitalTokenRecipients[0].address);
     should.equal(tx.assetId, testData.digitalAssetAddress);
     should.equal(tx.maxGasAmount, 200000);
@@ -80,7 +81,7 @@ describe('Apt Digital Asset Transfer Builder', () => {
     const transaction = new DigitalAssetTransfer(coins.get('tapt'));
     const txBuilder = factory.getDigitalAssetTransactionBuilder(transaction);
     txBuilder.sender(testData.sender2.address);
-    txBuilder.recipient(testData.digitalTokenRecipients[0]);
+    txBuilder.recipients([testData.digitalTokenRecipients[0]]);
     txBuilder.gasData({
       maxGasAmount: 200000,
       gasUnitPrice: 100,
@@ -101,7 +102,7 @@ describe('Apt Digital Asset Transfer Builder', () => {
     const transaction = new DigitalAssetTransfer(coins.get('tapt'));
     const txBuilder = factory.getDigitalAssetTransactionBuilder(transaction);
     txBuilder.sender(testData.sender2.address);
-    txBuilder.recipient(testData.digitalTokenRecipients[0]);
+    txBuilder.recipients([testData.digitalTokenRecipients[0]]);
     txBuilder.gasData({
       maxGasAmount: 200000,
       gasUnitPrice: 100,
@@ -113,6 +114,12 @@ describe('Apt Digital Asset Transfer Builder', () => {
     const tx = (await txBuilder.build()) as DigitalAssetTransfer;
     const toJson = tx.toJson();
     should.equal(toJson.sender, testData.sender2.address);
+    should.deepEqual(toJson.recipients, [
+      {
+        address: testData.digitalTokenRecipients[0].address,
+        amount: testData.digitalTokenRecipients[0].amount,
+      },
+    ]);
     should.deepEqual(toJson.recipient, {
       address: testData.digitalTokenRecipients[0].address,
       amount: testData.digitalTokenRecipients[0].amount,
@@ -131,6 +138,12 @@ describe('Apt Digital Asset Transfer Builder', () => {
     const toJson = tx.toJson();
     should.equal(toJson.id, '0x3a97bbf538a73f98625b65c770bbf69d032ac18cd028b871182a127f10ab5666');
     should.equal(toJson.sender, testData.sender2.address);
+    should.deepEqual(toJson.recipients, [
+      {
+        address: testData.digitalTokenRecipients[0].address,
+        amount: testData.digitalTokenRecipients[0].amount.toString(),
+      },
+    ]);
     should.deepEqual(toJson.recipient, {
       address: testData.digitalTokenRecipients[0].address,
       amount: testData.digitalTokenRecipients[0].amount.toString(),
@@ -140,5 +153,99 @@ describe('Apt Digital Asset Transfer Builder', () => {
     should.equal(toJson.maxGasAmount, 200000);
     should.equal(toJson.gasUnitPrice, 100);
     should.equal(toJson.expirationTime, 1738041170);
+  });
+
+  describe('should test for deprecated field recipient in building transaction, without usage of recipients', () => {
+    it('should build a digital asset transfer', async function () {
+      const digitalAssetTransfer = new DigitalAssetTransfer(coins.get('tapt'));
+      const txBuilder = factory.getDigitalAssetTransactionBuilder(digitalAssetTransfer);
+      txBuilder.sender(testData.sender2.address);
+      txBuilder.recipient(testData.digitalTokenRecipients[0]);
+      txBuilder.gasData({
+        maxGasAmount: 200000,
+        gasUnitPrice: 100,
+      });
+      txBuilder.assetId(testData.digitalAssetAddress);
+      txBuilder.sequenceNumber(14);
+      txBuilder.expirationTime(1736246155);
+      txBuilder.addFeePayerAddress(testData.feePayer.address);
+      const tx = (await txBuilder.build()) as DigitalAssetTransfer;
+      should.equal(tx.sender, testData.sender2.address);
+      should.equal(tx.recipient.address, testData.digitalTokenRecipients[0].address);
+      should.equal(tx.assetId, testData.digitalAssetAddress);
+      should.equal(tx.maxGasAmount, 200000);
+      should.equal(tx.gasUnitPrice, 100);
+      should.equal(tx.sequenceNumber, 14);
+      should.equal(tx.expirationTime, 1736246155);
+      should.equal(tx.type, TransactionType.SendNFT);
+      tx.inputs.length.should.equal(1);
+      tx.inputs[0].should.deepEqual({
+        address: testData.sender2.address,
+        value: testData.digitalTokenRecipients[0].amount,
+        coin: 'tapt',
+      });
+      tx.outputs.length.should.equal(1);
+      tx.outputs[0].should.deepEqual({
+        address: testData.digitalTokenRecipients[0].address,
+        value: testData.digitalTokenRecipients[0].amount,
+        coin: 'tapt',
+      });
+      const rawTx = tx.toBroadcastFormat();
+      should.equal(txBuilder.isValidRawTransaction(rawTx), true);
+      rawTx.should.equal(
+        '0x1aed808916ab9b1b30b07abb53561afd46847285ce28651221d406173a3724490e00000000000000020000000000000000000000000000000000000000000000000000000000000001066f626a656374087472616e736665720107000000000000000000000000000000000000000000000000000000000000000405746f6b656e05546f6b656e0002202e356062777469d39ca5d9b72512ce2d5713d7938ed6ca9193d4fc2016a819fd20f7405c28a02cf5bab4ea4498240bb3579db45951794eb1c843bef0534c093ad9400d03000000000064000000000000008b037d670000000002030020000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000dbc87a1c816d9bcd06b683c37e80c7162e4d48da7812198b830e4d5d8e0629f2002000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+      );
+      const toJson = tx.toJson();
+      should.equal(toJson.sender, testData.sender2.address);
+      should.deepEqual(toJson.recipient, {
+        address: testData.digitalTokenRecipients[0].address,
+        amount: testData.digitalTokenRecipients[0].amount,
+      });
+      should.equal(toJson.sequenceNumber, 14);
+      should.equal(tx.assetId, testData.digitalAssetAddress);
+      should.equal(toJson.maxGasAmount, 200000);
+      should.equal(toJson.gasUnitPrice, 100);
+      should.equal(toJson.expirationTime, 1736246155);
+      should.equal(toJson.feePayer, testData.feePayer.address);
+    });
+
+    it('should build and send a signed tx', async function () {
+      const txBuilder = factory.from(testData.DIGITAL_ASSET_TRANSFER);
+      const tx = (await txBuilder.build()) as DigitalAssetTransfer;
+      should.equal(tx.type, TransactionType.SendNFT);
+      tx.inputs.length.should.equal(1);
+      tx.inputs[0].should.deepEqual({
+        address: testData.sender2.address,
+        value: testData.digitalTokenRecipients[0].amount,
+        coin: 'tapt',
+      });
+      tx.outputs.length.should.equal(1);
+      tx.outputs[0].should.deepEqual({
+        address: testData.digitalTokenRecipients[0].address,
+        value: testData.digitalTokenRecipients[0].amount,
+        coin: 'tapt',
+      });
+      should.equal(tx.id, '0x3a97bbf538a73f98625b65c770bbf69d032ac18cd028b871182a127f10ab5666');
+      should.equal(tx.maxGasAmount, 200000);
+      should.equal(tx.gasUnitPrice, 100);
+      should.equal(tx.sequenceNumber, 171);
+      should.equal(tx.expirationTime, 1738041170);
+      should.equal(tx.type, TransactionType.SendNFT);
+      const rawTx = tx.toBroadcastFormat();
+      should.equal(txBuilder.isValidRawTransaction(rawTx), true);
+      should.equal(rawTx, testData.DIGITAL_ASSET_TRANSFER);
+      const toJson = tx.toJson();
+      should.equal(toJson.id, '0x3a97bbf538a73f98625b65c770bbf69d032ac18cd028b871182a127f10ab5666');
+      should.equal(toJson.sender, testData.sender2.address);
+      should.deepEqual(toJson.recipient, {
+        address: testData.digitalTokenRecipients[0].address,
+        amount: testData.digitalTokenRecipients[0].amount.toString(),
+      });
+      should.equal(tx.assetId, testData.digitalAssetAddress);
+      should.equal(toJson.sequenceNumber, 171);
+      should.equal(toJson.maxGasAmount, 200000);
+      should.equal(toJson.gasUnitPrice, 100);
+      should.equal(toJson.expirationTime, 1738041170);
+    });
   });
 });

--- a/modules/sdk-coin-apt/test/unit/transactionBuilder/fungibleAssetTransferBuilder.ts
+++ b/modules/sdk-coin-apt/test/unit/transactionBuilder/fungibleAssetTransferBuilder.ts
@@ -14,7 +14,7 @@ describe('Apt Token Transfer Builder', () => {
       const fungibleTokenTransfer = new FungibleAssetTransfer(coins.get('tapt:usdt'));
       const txBuilder = factory.getFungibleAssetTransactionBuilder(fungibleTokenTransfer);
       txBuilder.sender(testData.sender2.address);
-      txBuilder.recipient(testData.fungibleTokenRecipients[0]);
+      txBuilder.recipients([testData.fungibleTokenRecipients[0]]);
       txBuilder.gasData({
         maxGasAmount: 200000,
         gasUnitPrice: 100,
@@ -25,7 +25,9 @@ describe('Apt Token Transfer Builder', () => {
       txBuilder.addFeePayerAddress(testData.feePayer.address);
       const tx = (await txBuilder.build()) as FungibleAssetTransfer;
       should.equal(tx.sender, testData.sender2.address);
+      should.equal(tx.recipients[0].address, testData.fungibleTokenRecipients[0].address);
       should.equal(tx.recipient.address, testData.fungibleTokenRecipients[0].address);
+      should.equal(tx.recipients[0].amount, testData.fungibleTokenRecipients[0].amount);
       should.equal(tx.recipient.amount, testData.fungibleTokenRecipients[0].amount);
       should.equal(tx.assetId, testData.fungibleTokenAddress.usdt);
       should.equal(tx.maxGasAmount, 200000);
@@ -82,7 +84,7 @@ describe('Apt Token Transfer Builder', () => {
       const transaction = new FungibleAssetTransfer(coins.get('tapt'));
       const txBuilder = factory.getFungibleAssetTransactionBuilder(transaction);
       txBuilder.sender(testData.sender2.address);
-      txBuilder.recipient(testData.fungibleTokenRecipients[0]);
+      txBuilder.recipients([testData.fungibleTokenRecipients[0]]);
       txBuilder.gasData({
         maxGasAmount: 200000,
         gasUnitPrice: 100,
@@ -103,7 +105,7 @@ describe('Apt Token Transfer Builder', () => {
       const transaction = new FungibleAssetTransfer(coins.get('tapt'));
       const txBuilder = factory.getFungibleAssetTransactionBuilder(transaction);
       txBuilder.sender(testData.sender2.address);
-      txBuilder.recipient(testData.fungibleTokenRecipients[0]);
+      txBuilder.recipients([testData.fungibleTokenRecipients[0]]);
       txBuilder.gasData({
         maxGasAmount: 200000,
         gasUnitPrice: 100,
@@ -115,6 +117,12 @@ describe('Apt Token Transfer Builder', () => {
       const tx = (await txBuilder.build()) as FungibleAssetTransfer;
       const toJson = tx.toJson();
       should.equal(toJson.sender, testData.sender2.address);
+      should.deepEqual(toJson.recipients, [
+        {
+          address: testData.fungibleTokenRecipients[0].address,
+          amount: testData.fungibleTokenRecipients[0].amount,
+        },
+      ]);
       should.deepEqual(toJson.recipient, {
         address: testData.fungibleTokenRecipients[0].address,
         amount: testData.fungibleTokenRecipients[0].amount,
@@ -133,6 +141,12 @@ describe('Apt Token Transfer Builder', () => {
       const toJson = tx.toJson();
       should.equal(toJson.id, '0x271da92f3dcd673a0bd28d26f8b49c1f0c6ead0f5be0fbab3e9412972e96d80b');
       should.equal(toJson.sender, testData.sender2.address);
+      should.deepEqual(toJson.recipients, [
+        {
+          address: testData.fungibleTokenRecipients[0].address,
+          amount: testData.fungibleTokenRecipients[0].amount.toString(),
+        },
+      ]);
       should.deepEqual(toJson.recipient, {
         address: testData.fungibleTokenRecipients[0].address,
         amount: testData.fungibleTokenRecipients[0].amount.toString(),
@@ -154,9 +168,9 @@ describe('Apt Token Transfer Builder', () => {
 
     it('should fail for invalid recipient', async function () {
       const builder = factory.getTransferBuilder();
-      should(() => builder.recipient(testData.invalidRecipients[0])).throwError('Invalid address randomString');
-      should(() => builder.recipient(testData.invalidRecipients[1])).throwError('Value cannot be less than zero');
-      should(() => builder.recipient(testData.invalidRecipients[2])).throwError('Invalid amount format');
+      should(() => builder.recipients([testData.invalidRecipients[0]])).throwError('Invalid address randomString');
+      should(() => builder.recipients([testData.invalidRecipients[1]])).throwError('Value cannot be less than zero');
+      should(() => builder.recipients([testData.invalidRecipients[2]])).throwError('Invalid amount format');
     });
     it('should fail for invalid gas amount', async function () {
       const builder = factory.getTransferBuilder();
@@ -171,6 +185,100 @@ describe('Apt Token Transfer Builder', () => {
       const transaction = new FungibleAssetTransfer(coins.get('tapt'));
       const txBuilder = factory.getFungibleAssetTransactionBuilder(transaction);
       should(() => txBuilder.assetId('randomString')).throwError('Invalid address randomString');
+    });
+  });
+
+  describe('should test for deprecated field recipient in building transaction, without usage of recipients', () => {
+    it('should build a token transfer', async function () {
+      const fungibleTokenTransfer = new FungibleAssetTransfer(coins.get('tapt:usdt'));
+      const txBuilder = factory.getFungibleAssetTransactionBuilder(fungibleTokenTransfer);
+      txBuilder.sender(testData.sender2.address);
+      txBuilder.recipient(testData.fungibleTokenRecipients[0]);
+      txBuilder.gasData({
+        maxGasAmount: 200000,
+        gasUnitPrice: 100,
+      });
+      txBuilder.assetId(testData.fungibleTokenAddress.usdt);
+      txBuilder.sequenceNumber(14);
+      txBuilder.expirationTime(1736246155);
+      txBuilder.addFeePayerAddress(testData.feePayer.address);
+      const tx = (await txBuilder.build()) as FungibleAssetTransfer;
+      should.equal(tx.sender, testData.sender2.address);
+      should.equal(tx.recipient.address, testData.fungibleTokenRecipients[0].address);
+      should.equal(tx.recipient.amount, testData.fungibleTokenRecipients[0].amount);
+      should.equal(tx.assetId, testData.fungibleTokenAddress.usdt);
+      should.equal(tx.maxGasAmount, 200000);
+      should.equal(tx.gasUnitPrice, 100);
+      should.equal(tx.sequenceNumber, 14);
+      should.equal(tx.expirationTime, 1736246155);
+      should.equal(tx.type, TransactionType.SendToken);
+      tx.inputs.length.should.equal(1);
+      tx.inputs[0].should.deepEqual({
+        address: testData.sender2.address,
+        value: testData.fungibleTokenRecipients[0].amount,
+        coin: 'tapt:usdt',
+      });
+      tx.outputs.length.should.equal(1);
+      tx.outputs[0].should.deepEqual({
+        address: testData.fungibleTokenRecipients[0].address,
+        value: testData.fungibleTokenRecipients[0].amount,
+        coin: 'tapt:usdt',
+      });
+      const rawTx = tx.toBroadcastFormat();
+      should.equal(txBuilder.isValidRawTransaction(rawTx), true);
+      rawTx.should.equal(
+        '0x1aed808916ab9b1b30b07abb53561afd46847285ce28651221d406173a3724490e00000000000000020000000000000000000000000000000000000000000000000000000000000001167072696d6172795f66756e6769626c655f73746f7265087472616e73666572010700000000000000000000000000000000000000000000000000000000000000010e66756e6769626c655f6173736574084d65746164617461000320d5d0d561493ea2b9410f67da804653ae44e793c2423707d4f11edb2e3819205020f7405c28a02cf5bab4ea4498240bb3579db45951794eb1c843bef0534c093ad9080100000000000000400d03000000000064000000000000008b037d670000000002030020000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000dbc87a1c816d9bcd06b683c37e80c7162e4d48da7812198b830e4d5d8e0629f2002000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+      );
+      const toJson = tx.toJson();
+      should.equal(toJson.sender, testData.sender2.address);
+      should.deepEqual(toJson.recipient, {
+        address: testData.fungibleTokenRecipients[0].address,
+        amount: testData.fungibleTokenRecipients[0].amount,
+      });
+      should.equal(toJson.sequenceNumber, 14);
+      should.equal(tx.assetId, testData.fungibleTokenAddress.usdt);
+      should.equal(toJson.maxGasAmount, 200000);
+      should.equal(toJson.gasUnitPrice, 100);
+      should.equal(toJson.expirationTime, 1736246155);
+      should.equal(toJson.feePayer, testData.feePayer.address);
+    });
+
+    it('should build and send a signed tx', async function () {
+      const txBuilder = factory.from(testData.FUNGIBLE_TOKEN_TRANSFER);
+      const tx = (await txBuilder.build()) as FungibleAssetTransfer;
+      tx.inputs.length.should.equal(1);
+      tx.inputs[0].should.deepEqual({
+        address: testData.sender2.address,
+        value: testData.fungibleTokenRecipients[0].amount,
+        coin: 'tapt:usdt',
+      });
+      tx.outputs.length.should.equal(1);
+      tx.outputs[0].should.deepEqual({
+        address: testData.fungibleTokenRecipients[0].address,
+        value: testData.fungibleTokenRecipients[0].amount,
+        coin: 'tapt:usdt',
+      });
+      should.equal(tx.id, '0x271da92f3dcd673a0bd28d26f8b49c1f0c6ead0f5be0fbab3e9412972e96d80b');
+      should.equal(tx.maxGasAmount, 200000);
+      should.equal(tx.gasUnitPrice, 100);
+      should.equal(tx.sequenceNumber, 167);
+      should.equal(tx.expirationTime, 1737893604);
+      should.equal(tx.type, TransactionType.SendToken);
+      const rawTx = tx.toBroadcastFormat();
+      should.equal(txBuilder.isValidRawTransaction(rawTx), true);
+      should.equal(rawTx, testData.FUNGIBLE_TOKEN_TRANSFER);
+      const toJson = tx.toJson();
+      should.equal(toJson.id, '0x271da92f3dcd673a0bd28d26f8b49c1f0c6ead0f5be0fbab3e9412972e96d80b');
+      should.equal(toJson.sender, testData.sender2.address);
+      should.deepEqual(toJson.recipient, {
+        address: testData.fungibleTokenRecipients[0].address,
+        amount: testData.fungibleTokenRecipients[0].amount.toString(),
+      });
+      should.equal(tx.assetId, testData.fungibleTokenAddress.usdt);
+      should.equal(toJson.sequenceNumber, 167);
+      should.equal(toJson.maxGasAmount, 200000);
+      should.equal(toJson.gasUnitPrice, 100);
+      should.equal(toJson.expirationTime, 1737893604);
     });
   });
 });

--- a/modules/sdk-coin-apt/test/unit/transactionBuilder/transferBuilder.ts
+++ b/modules/sdk-coin-apt/test/unit/transactionBuilder/transferBuilder.ts
@@ -6,14 +6,13 @@ import should from 'should';
 
 describe('Apt Transfer Transaction', () => {
   const factory = new TransactionBuilderFactory(coins.get('tapt'));
-
   describe('Aptos Coin Transfer Transaction', () => {
     describe('Succeed', () => {
       it('should build a transfer tx', async function () {
         const transaction = new TransferTransaction(coins.get('tapt'));
         const txBuilder = factory.getTransferBuilder(transaction);
         txBuilder.sender(testData.sender2.address);
-        txBuilder.recipient(testData.recipients[0]);
+        txBuilder.recipients(testData.recipients);
         txBuilder.gasData({
           maxGasAmount: 200000,
           gasUnitPrice: 100,
@@ -24,7 +23,10 @@ describe('Apt Transfer Transaction', () => {
         txBuilder.setIsSimulateTxn(true);
         const tx = (await txBuilder.build()) as TransferTransaction;
         should.equal(tx.sender, testData.sender2.address);
+        should.equal(tx.recipients[0].address, testData.recipients[0].address);
+        should.equal(tx.recipients[0].amount, testData.recipients[0].amount);
         should.equal(tx.recipient.address, testData.recipients[0].address);
+        should.equal(tx.recipients[0].amount, testData.recipients[0].amount);
         should.equal(tx.recipient.amount, testData.recipients[0].amount);
         should.equal(tx.maxGasAmount, 200000);
         should.equal(tx.gasUnitPrice, 100);
@@ -83,7 +85,7 @@ describe('Apt Transfer Transaction', () => {
         const transaction = new TransferTransaction(coins.get('tapt'));
         const txBuilder = factory.getTransferBuilder(transaction);
         txBuilder.sender(testData.sender2.address);
-        txBuilder.recipient(testData.recipients[0]);
+        txBuilder.recipients(testData.recipients);
         txBuilder.gasData({
           maxGasAmount: 200000,
           gasUnitPrice: 100,
@@ -103,7 +105,7 @@ describe('Apt Transfer Transaction', () => {
         const transaction = new TransferTransaction(coins.get('tapt'));
         const txBuilder = factory.getTransferBuilder(transaction);
         txBuilder.sender(testData.sender2.address);
-        txBuilder.recipient(testData.recipients[0]);
+        txBuilder.recipients(testData.recipients);
         txBuilder.gasData({
           maxGasAmount: 200000,
           gasUnitPrice: 100,
@@ -114,6 +116,12 @@ describe('Apt Transfer Transaction', () => {
         const tx = (await txBuilder.build()) as TransferTransaction;
         const toJson = tx.toJson();
         should.equal(toJson.sender, testData.sender2.address);
+        should.deepEqual(toJson.recipients, [
+          {
+            address: testData.recipients[0].address,
+            amount: testData.recipients[0].amount,
+          },
+        ]);
         should.deepEqual(toJson.recipient, {
           address: testData.recipients[0].address,
           amount: testData.recipients[0].amount,
@@ -131,6 +139,12 @@ describe('Apt Transfer Transaction', () => {
         const toJson = tx.toJson();
         should.equal(toJson.id, '0x249289a8178e4b9cdb89fad6e8e436ccc435753e4ea3c9d50e0c8b525582e90d');
         should.equal(toJson.sender, '0x1aed808916ab9b1b30b07abb53561afd46847285ce28651221d406173a372449');
+        should.deepEqual(toJson.recipients, [
+          {
+            address: '0xf7405c28a02cf5bab4ea4498240bb3579db45951794eb1c843bef0534c093ad9',
+            amount: '1000',
+          },
+        ]);
         should.deepEqual(toJson.recipient, {
           address: '0xf7405c28a02cf5bab4ea4498240bb3579db45951794eb1c843bef0534c093ad9',
           amount: '1000',
@@ -151,9 +165,9 @@ describe('Apt Transfer Transaction', () => {
 
       it('should fail for invalid recipient', async function () {
         const builder = factory.getTransferBuilder();
-        should(() => builder.recipient(testData.invalidRecipients[0])).throwError('Invalid address randomString');
-        should(() => builder.recipient(testData.invalidRecipients[1])).throwError('Value cannot be less than zero');
-        should(() => builder.recipient(testData.invalidRecipients[2])).throwError('Invalid amount format');
+        should(() => builder.recipients([testData.invalidRecipients[0]])).throwError('Invalid address randomString');
+        should(() => builder.recipients([testData.invalidRecipients[1]])).throwError('Value cannot be less than zero');
+        should(() => builder.recipients([testData.invalidRecipients[2]])).throwError('Invalid amount format');
       });
       it('should fail for invalid gas amount', async function () {
         const builder = factory.getTransferBuilder();
@@ -172,7 +186,7 @@ describe('Apt Transfer Transaction', () => {
       const transaction = new TransferTransaction(coins.get('tapt'));
       const txBuilder = factory.getTransferBuilder(transaction);
       txBuilder.sender(testData.sender2.address);
-      txBuilder.recipient(testData.recipients[0]);
+      txBuilder.recipients(testData.recipients);
       txBuilder.gasData({
         maxGasAmount: 200000,
         gasUnitPrice: 100,
@@ -184,8 +198,8 @@ describe('Apt Transfer Transaction', () => {
       txBuilder.setIsSimulateTxn(true);
       const tx = (await txBuilder.build()) as TransferTransaction;
       should.equal(tx.sender, testData.sender2.address);
-      should.equal(tx.recipient.address, testData.recipients[0].address);
-      should.equal(tx.recipient.amount, testData.recipients[0].amount);
+      should.equal(tx.recipients[0].address, testData.recipients[0].address);
+      should.equal(tx.recipients[0].amount, testData.recipients[0].amount);
       should.equal(tx.maxGasAmount, 200000);
       should.equal(tx.gasUnitPrice, 100);
       should.equal(tx.sequenceNumber, 14);
@@ -214,7 +228,7 @@ describe('Apt Transfer Transaction', () => {
       const transaction = new TransferTransaction(coins.get('tapt'));
       const txBuilder = factory.getTransferBuilder(transaction);
       txBuilder.sender(testData.sender2.address);
-      txBuilder.recipient(testData.recipients[0]);
+      txBuilder.recipients(testData.recipients);
       txBuilder.gasData({
         maxGasAmount: 200000,
         gasUnitPrice: 100,
@@ -235,7 +249,7 @@ describe('Apt Transfer Transaction', () => {
       const transaction = new TransferTransaction(coins.get('tapt'));
       const txBuilder = factory.getTransferBuilder(transaction);
       txBuilder.sender(testData.sender2.address);
-      txBuilder.recipient(testData.recipients[0]);
+      txBuilder.recipients(testData.recipients);
       txBuilder.gasData({
         maxGasAmount: 200000,
         gasUnitPrice: 100,
@@ -247,6 +261,62 @@ describe('Apt Transfer Transaction', () => {
       const tx = (await txBuilder.build()) as TransferTransaction;
       const toJson = tx.toJson();
       should.equal(toJson.sender, testData.sender2.address);
+      should.deepEqual(toJson.recipients, [
+        {
+          address: testData.recipients[0].address,
+          amount: testData.recipients[0].amount,
+        },
+      ]);
+      should.equal(toJson.sequenceNumber, 14);
+      should.equal(toJson.maxGasAmount, 200000);
+      should.equal(toJson.gasUnitPrice, 100);
+      should.equal(toJson.expirationTime, 1736246155);
+      should.equal(toJson.feePayer, testData.feePayer.address);
+    });
+  });
+
+  describe('should test for deprecated field recipient in building transaction, without usage of recipients', () => {
+    it('should build a transfer tx', async function () {
+      const transaction = new TransferTransaction(coins.get('tapt'));
+      const txBuilder = factory.getTransferBuilder(transaction);
+      txBuilder.sender(testData.sender2.address);
+      txBuilder.recipient(testData.recipients[0]);
+      txBuilder.gasData({
+        maxGasAmount: 200000,
+        gasUnitPrice: 100,
+      });
+      txBuilder.sequenceNumber(14);
+      txBuilder.expirationTime(1736246155);
+      txBuilder.addFeePayerAddress(testData.feePayer.address);
+      txBuilder.setIsSimulateTxn(true);
+      const tx = (await txBuilder.build()) as TransferTransaction;
+      should.equal(tx.sender, testData.sender2.address);
+      should.equal(tx.recipient.address, testData.recipients[0].address);
+      should.equal(tx.recipient.amount, testData.recipients[0].amount);
+      should.equal(tx.maxGasAmount, 200000);
+      should.equal(tx.gasUnitPrice, 100);
+      should.equal(tx.sequenceNumber, 14);
+      should.equal(tx.expirationTime, 1736246155);
+      should.equal(tx.type, TransactionType.Send);
+      tx.inputs.length.should.equal(1);
+      tx.inputs[0].should.deepEqual({
+        address: testData.sender2.address,
+        value: testData.recipients[0].amount,
+        coin: 'tapt',
+      });
+      tx.outputs.length.should.equal(1);
+      tx.outputs[0].should.deepEqual({
+        address: testData.recipients[0].address,
+        value: testData.recipients[0].amount,
+        coin: 'tapt',
+      });
+      const rawTx = tx.toBroadcastFormat();
+      should.equal(txBuilder.isValidRawTransaction(rawTx), true);
+      rawTx.should.equal(
+        '0x1aed808916ab9b1b30b07abb53561afd46847285ce28651221d406173a3724490e000000000000000200000000000000000000000000000000000000000000000000000000000000010d6170746f735f6163636f756e740e7472616e736665725f636f696e73010700000000000000000000000000000000000000000000000000000000000000010a6170746f735f636f696e094170746f73436f696e000220f7405c28a02cf5bab4ea4498240bb3579db45951794eb1c843bef0534c093ad908e803000000000000400d03000000000064000000000000008b037d67000000000203040000dbc87a1c816d9bcd06b683c37e80c7162e4d48da7812198b830e4d5d8e0629f204'
+      );
+      const toJson = tx.toJson();
+      should.equal(toJson.sender, testData.sender2.address);
       should.deepEqual(toJson.recipient, {
         address: testData.recipients[0].address,
         amount: testData.recipients[0].amount,
@@ -256,6 +326,46 @@ describe('Apt Transfer Transaction', () => {
       should.equal(toJson.gasUnitPrice, 100);
       should.equal(toJson.expirationTime, 1736246155);
       should.equal(toJson.feePayer, testData.feePayer.address);
+    });
+
+    it('should build and send a signed tx', async function () {
+      const txBuilder = factory.from(testData.TRANSACTION_USING_TRANSFER_COINS);
+      txBuilder.getSequenceNumber().should.equal(146);
+
+      const tx = (await txBuilder.build()) as TransferTransaction;
+      should.equal(tx.type, TransactionType.Send);
+      tx.inputs.length.should.equal(1);
+      tx.inputs[0].should.deepEqual({
+        address: testData.sender2.address,
+        value: testData.recipients[0].amount,
+        coin: 'tapt',
+      });
+      tx.outputs.length.should.equal(1);
+      tx.outputs[0].should.deepEqual({
+        address: testData.recipients[0].address,
+        value: testData.recipients[0].amount,
+        coin: 'tapt',
+      });
+      should.equal(tx.id, '0x249289a8178e4b9cdb89fad6e8e436ccc435753e4ea3c9d50e0c8b525582e90d');
+      should.equal(tx.maxGasAmount, 200000);
+      should.equal(tx.gasUnitPrice, 100);
+      should.equal(tx.sequenceNumber, 146);
+      should.equal(tx.expirationTime, 1737528215);
+      should.equal(tx.type, TransactionType.Send);
+      const rawTx = tx.toBroadcastFormat();
+      should.equal(txBuilder.isValidRawTransaction(rawTx), true);
+      should.equal(rawTx, testData.TRANSACTION_USING_TRANSFER_COINS);
+      const toJson = tx.toJson();
+      should.equal(toJson.id, '0x249289a8178e4b9cdb89fad6e8e436ccc435753e4ea3c9d50e0c8b525582e90d');
+      should.equal(toJson.sender, '0x1aed808916ab9b1b30b07abb53561afd46847285ce28651221d406173a372449');
+      should.deepEqual(toJson.recipient, {
+        address: '0xf7405c28a02cf5bab4ea4498240bb3579db45951794eb1c843bef0534c093ad9',
+        amount: '1000',
+      });
+      should.equal(toJson.sequenceNumber, 146);
+      should.equal(toJson.maxGasAmount, 200000);
+      should.equal(toJson.gasUnitPrice, 100);
+      should.equal(toJson.expirationTime, 1737528215);
     });
   });
 });


### PR DESCRIPTION
Reverts BitGo/BitGoJS#5821

**Background**
Aptos withdrawals on the testnet were failing during broadcasting with the following error:
`Invalid transaction: Type: InvariantViolation Code: UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION`

Since we couldn't immediately identify the root cause, we initially reverted related PRs, including #5809, as it introduced changes to the transaction structure and was a potential suspect.

**Root Cause**
Upon further investigation, we discovered that the issue was not caused by the changes in #5809. 
Instead, it stemmed from our **Aptos testnet fullnode running an outdated version**, which prevented it from broadcasting transactions properly.

**Resolution**
Now that we have identified the actual cause, we are reverting the previous revert, as #5821 had no impact on the failure.