### PR TITLE
refactor(abstract-lightning): move utxo-lib to peerDependencies

### DIFF
--- a/modules/abstract-lightning/package.json
+++ b/modules/abstract-lightning/package.json
@@ -42,12 +42,14 @@
     "@bitgo/public-types": "4.17.0",
     "@bitgo/sdk-core": "^31.2.1",
     "@bitgo/statics": "^51.5.0",
-    "@bitgo/utxo-lib": "^11.2.4",
     "bs58check": "^2.1.2",
     "fp-ts": "^2.12.2",
     "io-ts": "npm:@bitgo-forks/io-ts@2.1.4",
     "io-ts-types": "^0.5.16",
     "macaroon": "^3.0.4"
+  },
+  "peerDependencies": {
+    "@bitgo/utxo-lib": "^11.2.4"
   },
   "gitHead": "18e460ddf02de2dbf13c2aa243478188fb539f0c"
 }


### PR DESCRIPTION

Move utxo-lib to peerDependencies to allow consumers to provide their own
version of utxo-lib.

Issue: BTC-1947