### PR TITLE
refactor(scripts): improve verify-release function readability

### DIFF
--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -15,28 +15,28 @@ let lernaModuleLocations: string[] = [];
 let TARGET_SCOPE = '@bitgo-beta';
 let filesChanged = 0;
 
-const setLernaModules = async (): Promise<void> => {
+async function setLernaModules(): Promise<void> {
   const modules = await getLernaModules();
   lernaModules = modules.map(({ name }) => name);
   lernaModuleLocations = modules.map(({ location }) => location);
-};
+}
 
-const replacePackageScopes = () => {
+function replacePackageScopes() {
   // replace all @bitgo packages & source code with alternate SCOPE
   const filePaths = [...walk(path.join(__dirname, '../', 'modules')), ...walk(path.join(__dirname, '../', 'webpack'))];
   filePaths.forEach((file) => {
     filesChanged += changeScopeInFile(file, lernaModules, TARGET_SCOPE);
   });
-};
+}
 
 // modules/bitgo is the only package we publish without an `@bitgo` prefix, so
 // we must manually set one
-const replaceBitGoPackageScope = () => {
+function replaceBitGoPackageScope() {
   const cwd = path.join(__dirname, '../', 'modules', 'bitgo');
   const json = JSON.parse(readFileSync(path.join(cwd, 'package.json'), { encoding: 'utf-8' }));
   json.name = `${TARGET_SCOPE}/bitgo`;
   writeFileSync(path.join(cwd, 'package.json'), JSON.stringify(json, null, 2) + '\n');
-};
+}
 
 /** Small version checkers in place of an npm dependency installation */
 function compareversion(version1, version2) {
@@ -73,7 +73,7 @@ function compareversion(version1, version2) {
  *
  * @param {String | undefined} preid
  */
-const incrementVersions = async (preid = 'beta') => {
+async function incrementVersions(preid = 'beta') {
   const distTags = await getDistTagsForModuleLocations(lernaModuleLocations);
   for (let i = 0; i < lernaModuleLocations.length; i++) {
     try {
@@ -118,9 +118,9 @@ const incrementVersions = async (preid = 'beta') => {
       console.warn(`Couldn't set next version for ${lernaModuleLocations[i]}`, e);
     }
   }
-};
+}
 
-const getArgs = () => {
+function getArgs() {
   const args = process.argv.slice(2) || [];
   const scopeArg = args.find((arg) => arg.startsWith('scope='));
   if (scopeArg) {
@@ -128,9 +128,9 @@ const getArgs = () => {
     TARGET_SCOPE = split[1] || TARGET_SCOPE;
   }
   console.log(`Preparing to re-target to ${TARGET_SCOPE}`);
-};
+}
 
-const main = async (preid?: string) => {
+async function main(preid?: string) {
   getArgs();
   await setLernaModules();
   replacePackageScopes();
@@ -143,6 +143,6 @@ const main = async (preid?: string) => {
     console.error('No files were changed, something must have gone wrong.');
     process.exit(1);
   }
-};
+}
 
 main(process.argv.slice(2)[0]);

--- a/scripts/verify-release.ts
+++ b/scripts/verify-release.ts
@@ -1,71 +1,41 @@
 import * as execa from 'execa';
 import { readFileSync } from 'fs';
 import * as path from 'path';
-import { get as httpGet } from 'https';
+import { getLernaModules, getDistTags } from './prepareRelease';
 
 let lernaModuleLocations: string[] = [];
 
-/**
- * Create a function which can run lerna commands
- * @param {String} lernaPath - path to lerna binary
- * @returns {function(string, string[], Object.<string, string>): Promise<string>}
- */
-function getLernaRunner(lernaPath: string) {
-  return async (command: string, args: string[] = [], options = {}) => {
-    const { stdout } = await execa(lernaPath, [command, ...args], options);
-    return stdout;
-  };
-}
-
-const getLernaModules = async (): Promise<void> => {
-  const { stdout: lernaBinary } = await execa('yarn', ['bin', 'lerna'], { cwd: process.cwd() });
-
-  const lerna = getLernaRunner(lernaBinary);
-  const modules: Array<{ name: string; location: string }> = JSON.parse(
-    await lerna('list', ['--loglevel', 'silent', '--json', '--all', '--toposort'])
-  );
-
+const getLernaModuleLocations = async (): Promise<void> => {
+  const modules = await getLernaModules();
   lernaModuleLocations = modules.map(({ location }) => location);
 };
 
-/**
- * Makes an HTTP request to fetch all the dist tags for a given package.
- */
-const getDistTags = async (packageName: string): Promise<Record<string, string>> => {
-  return new Promise((resolve) => {
-    httpGet(`https://registry.npmjs.org/-/package/${packageName}/dist-tags`, (res) => {
-      let data = '';
-      res.on('data', (d) => {
-        data += d;
-      });
-      res.on('end', () => {
-        const tags: Record<string, string> = JSON.parse(data);
-        resolve(tags);
-      });
-    });
-  });
-};
-
-const verifyPackage = async (dir: string, preid: string = 'beta'): Promise<boolean> => {
+const verifyPackage = async (dir: string, preid = 'beta'): Promise<boolean> => {
   const cwd = dir;
   const json = JSON.parse(readFileSync(path.join(cwd, 'package.json'), { encoding: 'utf-8' }));
   if (json.private) {
     return true;
   }
-  const distTags = await getDistTags(json.name);
-  if (json.version !== distTags[preid]) {
-    console.log(`${json.name} missing. Expected ${json.version}, latest is ${distTags[preid]}`);
-    const { stdout, exitCode } = await execa('npm', ['publish', '--tag', preid], { cwd });
-    console.log(stdout);
-    return exitCode === 0;
-  } else {
-    console.log(`${json.name} matches expected version ${json.version}`);
+
+  try {
+    const distTags = await getDistTags(json.name);
+    if (json.version !== distTags[preid]) {
+      console.log(`${json.name} missing. Expected ${json.version}, latest is ${distTags[preid]}`);
+      const { stdout, exitCode } = await execa('npm', ['publish', '--tag', preid], { cwd });
+      console.log(stdout);
+      return exitCode === 0;
+    } else {
+      console.log(`${json.name} matches expected version ${json.version}`);
+    }
+    return true;
+  } catch (e) {
+    console.warn(`Failed to fetch dist tags for ${json.name}`, e);
+    return false;
   }
-  return true;
 };
 
 const verify = async (preid?: string) => {
-  await getLernaModules();
+  await getLernaModuleLocations();
   for (let i = 0; i < lernaModuleLocations.length; i++) {
     const dir = lernaModuleLocations[i];
     if (!(await verifyPackage(dir, preid))) {

--- a/scripts/verify-release.ts
+++ b/scripts/verify-release.ts
@@ -5,12 +5,12 @@ import { getLernaModules, getDistTags } from './prepareRelease';
 
 let lernaModuleLocations: string[] = [];
 
-const getLernaModuleLocations = async (): Promise<void> => {
+async function getLernaModuleLocations(): Promise<void> {
   const modules = await getLernaModules();
   lernaModuleLocations = modules.map(({ location }) => location);
-};
+}
 
-const verifyPackage = async (dir: string, preid = 'beta'): Promise<boolean> => {
+async function verifyPackage(dir: string, preid = 'beta'): Promise<boolean> {
   const cwd = dir;
   const json = JSON.parse(readFileSync(path.join(cwd, 'package.json'), { encoding: 'utf-8' }));
   if (json.private) {
@@ -32,9 +32,9 @@ const verifyPackage = async (dir: string, preid = 'beta'): Promise<boolean> => {
     console.warn(`Failed to fetch dist tags for ${json.name}`, e);
     return false;
   }
-};
+}
 
-const verify = async (preid?: string) => {
+async function verify(preid?: string) {
   await getLernaModuleLocations();
   for (let i = 0; i < lernaModuleLocations.length; i++) {
     const dir = lernaModuleLocations[i];
@@ -43,7 +43,7 @@ const verify = async (preid?: string) => {
       return;
     }
   }
-};
+}
 
 // e.g. for alpha releases: `npx ts-node ./scripts/verify-beta.ts alpha`
 verify(process.argv.slice(2)[0]);


### PR DESCRIPTION

Convert arrow functions to standard named functions and reuse code in the 
verify-release script to improve maintainability and readability.

Issue: BTC-1947