### PR TITLE
feat(sdk-api): add dynamic headers in sdk requests

### DIFF
--- a/modules/sdk-api/src/bitgoAPI.ts
+++ b/modules/sdk-api/src/bitgoAPI.ts
@@ -395,8 +395,8 @@ export class BitGoAPI implements BitGoBase {
 
       req.set('BitGo-Auth-Version', this._authVersion === 3 ? '3.0' : '2.0');
 
+      const data = serializeRequestData(req);
       if (this._token) {
-        const data = serializeRequestData(req);
         setRequestQueryString(req);
 
         const requestProperties = this.calculateRequestHeaders({
@@ -417,7 +417,6 @@ export class BitGoAPI implements BitGoBase {
       }
 
       if (this.getAdditionalHeadersCb) {
-        const data = serializeRequestData(req);
         const additionalHeaders = this.getAdditionalHeadersCb(method, url, data);
         for (const { key, value } of additionalHeaders) {
           req.set(key, value);

--- a/modules/sdk-api/src/types.ts
+++ b/modules/sdk-api/src/types.ts
@@ -1,6 +1,15 @@
 import { EnvironmentName, IRequestTracer, V1Network } from '@bitgo/sdk-core';
 import { ECPairInterface } from '@bitgo/utxo-lib';
 import { type Agent } from 'http';
+
+const patchedRequestMethods = ['get', 'post', 'put', 'del', 'patch', 'options'] as const;
+export type RequestMethods = (typeof patchedRequestMethods)[number];
+export type AdditionalHeadersCallback = (
+  method: RequestMethods,
+  url: string,
+  data?: string
+) => Array<{ key: string; value: string }>;
+
 export {
   supportedRequestMethods,
   AuthVersion,
@@ -35,6 +44,7 @@ export interface BitGoAPIOptions {
   userAgent?: string;
   validate?: boolean;
   cookiesPropagationEnabled?: boolean;
+  getAdditionalHeadersCb?: AdditionalHeadersCallback;
 }
 
 export interface AccessTokenOptions {


### PR DESCRIPTION
TICKET: [ME-178](https://bitgoinc.atlassian.net/browse/ME-178)

Provide a way to dynamically set headers in sdk requests


[ME-178]: https://bitgoinc.atlassian.net/browse/ME-178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ