### PR TITLE
feat: add includeBalance parameter to wallet query options

### DIFF
--- a/modules/express/test/unit/clientRoutes/lightning/lightningSignerRoutes.ts
+++ b/modules/express/test/unit/clientRoutes/lightning/lightningSignerRoutes.ts
@@ -43,7 +43,10 @@ describe('Lightning signer routes', () => {
       includingOptionalFields ? 'with' : 'without'
     } optional fields`, async () => {
       const readFileStub = sinon.stub(fs.promises, 'readFile').resolves(JSON.stringify(lightningSignerConfigs));
-      const wpWalletnock = nock(bgUrl).get(`/api/v2/tlnbtc/wallet/${apiData.wallet.id}`).reply(200, apiData.wallet);
+      const wpWalletnock = nock(bgUrl)
+        .get(`/api/v2/tlnbtc/wallet/${apiData.wallet.id}`)
+        .query({ includeBalance: false })
+        .reply(200, apiData.wallet);
 
       const wpKeychainNocks = [
         nock(bgUrl).get(`/api/v2/tlnbtc/key/${apiData.userKey.id}`).reply(200, apiData.userKey),
@@ -92,6 +95,7 @@ describe('Lightning signer routes', () => {
         const readFileStub = sinon.stub(fs.promises, 'readFile').resolves(JSON.stringify(lightningSignerConfigs));
         const wpWalletnock = nock(bgUrl)
           .get(`/api/v2/tlnbtc/wallet/${apiData.wallet.id}`)
+          .query({ includeBalance: false })
           .reply(200, {
             ...apiData.wallet,
             ...(includeWatchOnlyIp ? {} : { watchOnlyExternalIp: null }),

--- a/modules/sdk-core/src/bitgo/wallet/wallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallets.ts
@@ -926,6 +926,10 @@ export class Wallets implements IWallets {
       query.allTokens = params.allTokens;
     }
 
+    if (params.includeBalance !== undefined) {
+      query.includeBalance = params.includeBalance;
+    }
+
     this.bitgo.setRequestTracer(params.reqId || new RequestTracer());
 
     const wallet = await this.bitgo


### PR DESCRIPTION
Allow users to specify whether balance information should be included in wallet query results by adding an optional boolean parameter 'includeBalance'. Validates the parameter type and includes it in the query if provided

Ticket: BTC-1946

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
