### PR TITLE
feat(utxo-lib): introduce getScriptIdFromPath

### DIFF
--- a/modules/utxo-lib/src/bitgo/outputScripts.ts
+++ b/modules/utxo-lib/src/bitgo/outputScripts.ts
@@ -1,7 +1,9 @@
 import * as assert from 'assert';
 import * as bitcoinjs from 'bitcoinjs-lib';
 
-import { Network, p2trPayments, supportsSegwit, supportsTaproot, taproot } from '..';
+import { Network, supportsSegwit, supportsTaproot } from '../networks';
+import * as p2trPayments from '../payments';
+import * as taproot from '../taproot';
 
 import { isTriple, Triple, Tuple } from './types';
 

--- a/modules/utxo-lib/src/bitgo/parseInput.ts
+++ b/modules/utxo-lib/src/bitgo/parseInput.ts
@@ -1,10 +1,9 @@
 /* eslint no-redeclare: 0 */
 import * as opcodes from 'bitcoin-ops';
-import { TxInput, script as bscript } from 'bitcoinjs-lib';
+import { script as bscript, TxInput } from 'bitcoinjs-lib';
 
 import { isTriple } from './types';
 import { isScriptType2Of3 } from './outputScripts';
-import { ChainCode, isChainCode } from './wallet/chains';
 
 export function isPlaceholderSignature(v: number | Buffer): boolean {
   if (Buffer.isBuffer(v)) {
@@ -698,21 +697,4 @@ export function parsePubScript(
   }
 
   return result;
-}
-
-export function getChainAndIndexFromPath(path: string): { chain: ChainCode; index: number } {
-  const parts = path.split('/');
-  if (parts.length <= 2) {
-    throw new Error(`invalid path "${path}"`);
-  }
-  const chain = Number(parts[parts.length - 2]);
-  const index = Number(parts[parts.length - 1]);
-  if (!isChainCode(chain)) {
-    throw new Error(`invalid chain "${chain}"`);
-  }
-  if (!Number.isInteger(index) || index < 0) {
-    throw new Error(`invalid index "${index}"`);
-  }
-
-  return { chain, index };
 }

--- a/modules/utxo-lib/src/bitgo/parseInput.ts
+++ b/modules/utxo-lib/src/bitgo/parseInput.ts
@@ -4,6 +4,7 @@ import { TxInput, script as bscript } from 'bitcoinjs-lib';
 
 import { isTriple } from './types';
 import { isScriptType2Of3 } from './outputScripts';
+import { ChainCode, isChainCode } from './wallet/chains';
 
 export function isPlaceholderSignature(v: number | Buffer): boolean {
   if (Buffer.isBuffer(v)) {
@@ -699,18 +700,18 @@ export function parsePubScript(
   return result;
 }
 
-export function getChainAndIndexFromPath(path: string): { chain: number; index: number } {
+export function getChainAndIndexFromPath(path: string): { chain: ChainCode; index: number } {
   const parts = path.split('/');
   if (parts.length <= 2) {
     throw new Error(`invalid path "${path}"`);
   }
   const chain = Number(parts[parts.length - 2]);
   const index = Number(parts[parts.length - 1]);
-  if (isNaN(chain) || isNaN(index)) {
-    throw new Error(`Could not parse chain and index into numbers from path ${path}`);
+  if (!isChainCode(chain)) {
+    throw new Error(`invalid chain "${chain}"`);
   }
-  if (chain < 0 || index < 0) {
-    throw new Error(`chain and index must be non-negative`);
+  if (!Number.isInteger(index) || index < 0) {
+    throw new Error(`invalid index "${index}"`);
   }
 
   return { chain, index };

--- a/modules/utxo-lib/src/bitgo/wallet/ScriptId.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/ScriptId.ts
@@ -1,0 +1,21 @@
+import { ChainCode, isChainCode } from './chains';
+
+export function getChainAndIndexFromPath(path: string): {
+  chain: ChainCode;
+  index: number;
+} {
+  const parts = path.split('/');
+  if (parts.length <= 2) {
+    throw new Error(`invalid path "${path}"`);
+  }
+  const chain = Number(parts[parts.length - 2]);
+  const index = Number(parts[parts.length - 1]);
+  if (!isChainCode(chain)) {
+    throw new Error(`invalid chain "${chain}"`);
+  }
+  if (!Number.isInteger(index) || index < 0) {
+    throw new Error(`invalid index "${index}"`);
+  }
+
+  return { chain, index };
+}

--- a/modules/utxo-lib/src/bitgo/wallet/ScriptId.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/ScriptId.ts
@@ -1,9 +1,16 @@
 import { ChainCode, isChainCode } from './chains';
 
-export function getChainAndIndexFromPath(path: string): {
+export type ScriptId = {
   chain: ChainCode;
   index: number;
-} {
+};
+
+/**
+ * Get the chain and index from a bip32 path.
+ *
+ * @param path
+ */
+export function getScriptIdFromPath(path: string): ScriptId {
   const parts = path.split('/');
   if (parts.length <= 2) {
     throw new Error(`invalid path "${path}"`);
@@ -19,3 +26,6 @@ export function getChainAndIndexFromPath(path: string): {
 
   return { chain, index };
 }
+
+/** @deprecated use getScriptId */
+export const getChainAndIndexFromPath = getScriptIdFromPath;

--- a/modules/utxo-lib/src/bitgo/wallet/WalletOutput.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/WalletOutput.ts
@@ -1,11 +1,12 @@
+import * as assert from 'assert';
+
 import { Payment, taproot } from 'bitcoinjs-lib';
 import { PsbtOutput, PsbtOutputUpdate } from 'bip174/src/lib/interfaces';
 import { UtxoPsbt } from '../UtxoPsbt';
 import { RootWalletKeys, DerivedWalletKeys } from './WalletKeys';
 import { ChainCode, scriptTypeForChain } from './chains';
-import { createOutputScript2of3, createPaymentP2tr, createPaymentP2trMusig2, toXOnlyPublicKey } from '../outputScripts';
 import { getScriptIdFromPath, ScriptId } from './ScriptId';
-import * as assert from 'node:assert';
+import { createOutputScript2of3, createPaymentP2tr, createPaymentP2trMusig2, toXOnlyPublicKey } from '../outputScripts';
 
 /**
  * Get the BIP32 derivation data for a PSBT output.

--- a/modules/utxo-lib/src/bitgo/wallet/WalletOutput.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/WalletOutput.ts
@@ -1,9 +1,180 @@
-import { taproot } from 'bitcoinjs-lib';
-import { PsbtOutputUpdate } from 'bip174/src/lib/interfaces';
+import { Payment, taproot } from 'bitcoinjs-lib';
+import { PsbtOutput, PsbtOutputUpdate } from 'bip174/src/lib/interfaces';
 import { UtxoPsbt } from '../UtxoPsbt';
-import { RootWalletKeys } from './WalletKeys';
+import { RootWalletKeys, DerivedWalletKeys } from './WalletKeys';
 import { ChainCode, scriptTypeForChain } from './chains';
 import { createOutputScript2of3, createPaymentP2tr, createPaymentP2trMusig2, toXOnlyPublicKey } from '../outputScripts';
+import { getScriptIdFromPath, ScriptId } from './ScriptId';
+import * as assert from 'node:assert';
+
+/**
+ * Get the BIP32 derivation data for a PSBT output.
+ *
+ * @param rootWalletKeys root wallet keys used for master fingerprints
+ * @param walletKeys derived wallet keys for the specific chain and index
+ * @param scriptType the script type to determine whether to use regular or taproot derivation
+ * @param payment optional payment object for taproot scripts to calculate leaf hashes
+ * @returns Object containing BIP32 derivation data
+ */
+export function getPsbtBip32DerivationOutputUpdate(
+  rootWalletKeys: RootWalletKeys,
+  walletKeys: DerivedWalletKeys,
+  scriptType: string,
+  payment?: Payment
+): PsbtOutputUpdate {
+  const update: PsbtOutputUpdate = {};
+
+  if (scriptType === 'p2tr' || scriptType === 'p2trMusig2') {
+    if (!payment || !payment.redeems) {
+      throw new Error('Payment object with redeems is required for taproot derivation');
+    }
+
+    const allLeafHashes = payment.redeems.map((r) => taproot.hashTapLeaf(r.output!));
+
+    update.tapBip32Derivation = [0, 1, 2].map((idx) => {
+      const pubkey = toXOnlyPublicKey(walletKeys.triple[idx].publicKey);
+      const leafHashes: Buffer[] = [];
+
+      assert(payment.redeems);
+      payment.redeems.forEach((r: any, redeemIdx: number) => {
+        if (r.pubkeys!.find((pk: Buffer) => pk.equals(pubkey))) {
+          leafHashes.push(allLeafHashes[redeemIdx]);
+        }
+      });
+
+      return {
+        leafHashes,
+        pubkey,
+        path: walletKeys.paths[idx],
+        masterFingerprint: rootWalletKeys.triple[idx].fingerprint,
+      };
+    });
+  } else {
+    update.bip32Derivation = [0, 1, 2].map((idx) => ({
+      pubkey: walletKeys.triple[idx].publicKey,
+      path: walletKeys.paths[idx],
+      masterFingerprint: rootWalletKeys.triple[idx].fingerprint,
+    }));
+  }
+
+  return update;
+}
+
+/**
+ * Get the PSBT output update object from a PSBT output and output script.
+ *
+ * @param output the PSBT output to get update for
+ * @param outputScript the output script
+ * @param rootWalletKeys keys that will be able to spend the output
+ * @param chain chain code to use for deriving scripts (and to determine script type)
+ * @param index derivation index for the change address
+ * @returns PsbtOutputUpdate object with the required information
+ */
+export function getPsbtOutputUpdateFromPsbtOutput(
+  output: PsbtOutput,
+  outputScript: Buffer,
+  rootWalletKeys: RootWalletKeys,
+  chain: ChainCode,
+  index: number
+): PsbtOutputUpdate {
+  const walletKeys = rootWalletKeys.deriveForChainAndIndex(chain, index);
+  const scriptType = scriptTypeForChain(chain);
+  const update: PsbtOutputUpdate = {};
+
+  if (scriptType === 'p2tr' || scriptType === 'p2trMusig2') {
+    const payment =
+      scriptType === 'p2tr' ? createPaymentP2tr(walletKeys.publicKeys) : createPaymentP2trMusig2(walletKeys.publicKeys);
+    if (!payment.output || !payment.output.equals(outputScript)) {
+      throw new Error(`cannot update a p2tr output where the scripts do not match - Failing.`);
+    }
+
+    if (!output.tapTree) {
+      update.tapTree = payment.tapTree;
+    }
+    if (!output.tapInternalKey) {
+      update.tapInternalKey = payment.internalPubkey;
+    }
+
+    if (!output.tapBip32Derivation) {
+      const derivationUpdate = getPsbtBip32DerivationOutputUpdate(rootWalletKeys, walletKeys, scriptType, payment);
+      update.tapBip32Derivation = derivationUpdate.tapBip32Derivation;
+    }
+  } else {
+    const { scriptPubKey, witnessScript, redeemScript } = createOutputScript2of3(walletKeys.publicKeys, scriptType);
+    if (!scriptPubKey.equals(outputScript)) {
+      throw new Error(`cannot update an output where the scripts do not match - Failing.`);
+    }
+
+    if (!output.bip32Derivation) {
+      const derivationUpdate = getPsbtBip32DerivationOutputUpdate(rootWalletKeys, walletKeys, scriptType);
+      update.bip32Derivation = derivationUpdate.bip32Derivation;
+    }
+
+    if (!output.witnessScript && witnessScript) {
+      update.witnessScript = witnessScript;
+    }
+    if (!output.redeemScript && redeemScript) {
+      update.redeemScript = redeemScript;
+    }
+  }
+
+  return update;
+}
+
+/**
+ * Get the PSBT output update object with the required information.
+ *
+ * @param psbt the PSBT to get output update for
+ * @param rootWalletKeys keys that will be able to spend the output
+ * @param outputIndex output index where to update the output
+ * @param chain chain code to use for deriving scripts (and to determine script
+ *              type) chain is an API parameter in the BitGo API, and may be
+ *              any valid ChainCode
+ * @param index derivation index for the change address
+ * @returns PsbtOutputUpdate object with the required information
+ */
+export function getPsbtOutputUpdate(
+  psbt: UtxoPsbt,
+  rootWalletKeys: RootWalletKeys,
+  outputIndex: number,
+  chain: ChainCode,
+  index: number
+): PsbtOutputUpdate {
+  if (psbt.data.outputs.length <= outputIndex) {
+    throw new Error(
+      `outputIndex (${outputIndex}) is too large for the number of outputs (${psbt.data.outputs.length})`
+    );
+  }
+
+  const outputScript = psbt.getOutputScript(outputIndex);
+  const output = psbt.data.outputs[outputIndex];
+
+  return getPsbtOutputUpdateFromPsbtOutput(output, outputScript, rootWalletKeys, chain, index);
+}
+
+/**
+ * Update the wallet output with the required information when necessary. If the
+ * information is there already, it will skip over it.
+ *
+ * This function assumes that the output script and value have already been set.
+ *
+ * @param psbt the PSBT to update change output at
+ * @param rootWalletKeys keys that will be able to spend the output
+ * @param outputIndex output index where to update the output
+ * @param chain chain code to use for deriving scripts (and to determine script
+ *              type) chain is an API parameter in the BitGo API, and may be
+ *              any valid ChainCode
+ * @param index derivation index for the change address
+ */
+export function updateWalletOutputForPsbt(
+  psbt: UtxoPsbt,
+  rootWalletKeys: RootWalletKeys,
+  outputIndex: number,
+  chain: ChainCode,
+  index: number
+): void {
+  psbt.updateOutput(outputIndex, getPsbtOutputUpdate(psbt, rootWalletKeys, outputIndex, chain, index));
+}
 
 /**
  * Add a verifiable wallet output to the PSBT. The output and all data
@@ -39,88 +210,44 @@ export function addWalletOutputToPsbt(
 }
 
 /**
- * Update the wallet output with the required information when necessary. If the
- * information is there already, it will skip over it.
- *
- * This function assumes that the output script and value have already been set.
- *
- * @param psbt the PSBT to update change output at
- * @param rootWalletKeys keys that will be able to spend the output
- * @param outputIndex output index where to update the output
- * @param chain chain code to use for deriving scripts (and to determine script
- *              type) chain is an API parameter in the BitGo API, and may be
- *              any valid ChainCode
- * @param index derivation index for the change address
- * @param value value of the change output
+ * Fold the script ids into a single script id, if they are all the same.
+ * @param scriptIds
  */
-export function updateWalletOutputForPsbt(
-  psbt: UtxoPsbt,
-  rootWalletKeys: RootWalletKeys,
-  outputIndex: number,
-  chain: ChainCode,
-  index: number
-): void {
-  if (psbt.data.outputs.length <= outputIndex) {
-    throw new Error(
-      `outputIndex (${outputIndex}) is too large for the number of outputs (${psbt.data.outputs.length})`
-    );
+function foldScriptIds(scriptIds: ScriptId[]): ScriptId {
+  if (scriptIds.length === 0) {
+    throw new Error('cannot fold empty script ids');
   }
+  scriptIds.forEach((scriptId, i) => {
+    if (scriptId.chain !== scriptIds[0].chain) {
+      throw new Error(`chain mismatch: ${scriptId.chain} != ${scriptIds[0].chain}`);
+    }
+    if (scriptId.index !== scriptIds[0].index) {
+      throw new Error(`index mismatch: ${scriptId.index} != ${scriptIds[0].index}`);
+    }
+  });
+  return scriptIds[0];
+}
 
-  const outputScript = psbt.getOutputScript(outputIndex);
-
-  const walletKeys = rootWalletKeys.deriveForChainAndIndex(chain, index);
-  const scriptType = scriptTypeForChain(chain);
-  const output = psbt.data.outputs[outputIndex];
-  const update: PsbtOutputUpdate = {};
-  if (scriptType === 'p2tr' || scriptType === 'p2trMusig2') {
-    const payment =
-      scriptType === 'p2tr' ? createPaymentP2tr(walletKeys.publicKeys) : createPaymentP2trMusig2(walletKeys.publicKeys);
-    if (!payment.output || !payment.output.equals(outputScript)) {
-      throw new Error(`cannot update a p2tr output where the scripts do not match - Failing.`);
-    }
-    const allLeafHashes = payment.redeems!.map((r) => taproot.hashTapLeaf(r.output!));
-
-    if (!output.tapTree) {
-      update.tapTree = payment.tapTree;
-    }
-    if (!output.tapInternalKey) {
-      update.tapInternalKey = payment.internalPubkey;
-    }
-    if (!output.tapBip32Derivation) {
-      update.tapBip32Derivation = [0, 1, 2].map((idx) => {
-        const pubkey = toXOnlyPublicKey(walletKeys.triple[idx].publicKey);
-        const leafHashes: Buffer[] = [];
-        payment.redeems!.forEach((r, idx) => {
-          if (r.pubkeys!.find((pk) => pk.equals(pubkey))) {
-            leafHashes.push(allLeafHashes[idx]);
-          }
-        });
-        return {
-          leafHashes,
-          pubkey,
-          path: walletKeys.paths[idx],
-          masterFingerprint: rootWalletKeys.triple[idx].fingerprint,
-        };
-      });
-    }
-  } else {
-    const { scriptPubKey, witnessScript, redeemScript } = createOutputScript2of3(walletKeys.publicKeys, scriptType);
-    if (!scriptPubKey.equals(outputScript)) {
-      throw new Error(`cannot update an output where the scripts do not match - Failing.`);
-    }
-    if (!output.bip32Derivation) {
-      update.bip32Derivation = [0, 1, 2].map((idx) => ({
-        pubkey: walletKeys.triple[idx].publicKey,
-        path: walletKeys.paths[idx],
-        masterFingerprint: rootWalletKeys.triple[idx].fingerprint,
-      }));
-    }
-    if (!output.witnessScript && witnessScript) {
-      update.witnessScript = witnessScript;
-    }
-    if (!output.redeemScript && redeemScript) {
-      update.redeemScript = redeemScript;
-    }
+/**
+ * Get the script id from the output.
+ * The output can have either bip32Derivation or tapBip32Derivation, but not both.
+ * @param output
+ * @throws Error if neither or both bip32Derivation and tapBip32Derivation are present
+ * @throws Error if the output is empty
+ * @throws Error if we cannot fold the script ids into a single script id
+ */
+export function getScriptIdFromOutput(output: {
+  bip32Derivation?: { path: string }[];
+  tapBip32Derivation?: { path: string }[];
+}): ScriptId {
+  if (output.bip32Derivation && output.tapBip32Derivation) {
+    throw new Error('cannot get script id from output with both bip32Derivation and tapBip32Derivation');
   }
-  psbt.updateOutput(outputIndex, update);
+  if (output.bip32Derivation) {
+    return foldScriptIds(output.bip32Derivation.map((d) => getScriptIdFromPath(d.path)));
+  }
+  if (output.tapBip32Derivation) {
+    return foldScriptIds(output.tapBip32Derivation.map((d) => getScriptIdFromPath(d.path)));
+  }
+  throw new Error('cannot get script id from output without bip32Derivation or tapBip32Derivation');
 }

--- a/modules/utxo-lib/src/bitgo/wallet/index.ts
+++ b/modules/utxo-lib/src/bitgo/wallet/index.ts
@@ -7,3 +7,4 @@ export * from './WalletScripts';
 export * from './WalletKeys';
 export * from './psbt/PsbtOutputs';
 export * from './psbt/RootNodes';
+export * from './ScriptId';

--- a/modules/utxo-lib/src/testutil/keys.ts
+++ b/modules/utxo-lib/src/testutil/keys.ts
@@ -1,8 +1,8 @@
 import { BIP32API, BIP32Factory, BIP32Interface } from 'bip32';
 import * as crypto from 'crypto';
 
-import { Triple } from '../bitgo';
-import { RootWalletKeys } from '../bitgo';
+import { Triple } from '../bitgo/types';
+import { RootWalletKeys } from '../bitgo/wallet/WalletKeys';
 import { ecc, ECPair, ECPairInterface } from '../noble_ecc';
 import { networks } from '../networks';
 

--- a/modules/utxo-lib/test/bitgo/wallet/ScriptId.ts
+++ b/modules/utxo-lib/test/bitgo/wallet/ScriptId.ts
@@ -1,0 +1,26 @@
+import * as assert from 'assert';
+
+import { getChainAndIndexFromPath } from '../../../src/bitgo/wallet/ScriptId';
+
+describe('getChainAndIndexFromPath', function () {
+  it('should throw if path is not the right length', function () {
+    assert.throws(() => getChainAndIndexFromPath('/'), /invalid path/);
+    assert.throws(() => getChainAndIndexFromPath('m0000ssss'), /invalid path/);
+  });
+
+  it('should throw if the path is not a number', function () {
+    const invalidChain = [-1, 2, 'lol'];
+    const invalidIndex = [-1, 'lol'];
+    for (const chain of invalidChain) {
+      assert.throws(() => getChainAndIndexFromPath(`m/${chain}/0`), /invalid chain/);
+    }
+    for (const index of invalidIndex) {
+      assert.throws(() => getChainAndIndexFromPath(`m/0/${index}`), /invalid index/);
+    }
+  });
+
+  it('should set the chain and index correctly', function () {
+    assert.deepStrictEqual(getChainAndIndexFromPath('m/1/2'), { chain: 1, index: 2 });
+    assert.deepStrictEqual(getChainAndIndexFromPath('m/1/2/3/4/5/10/20'), { chain: 10, index: 20 });
+  });
+});

--- a/modules/utxo-lib/test/bitgo/wallet/ScriptId.ts
+++ b/modules/utxo-lib/test/bitgo/wallet/ScriptId.ts
@@ -1,26 +1,26 @@
 import * as assert from 'assert';
 
-import { getChainAndIndexFromPath } from '../../../src/bitgo/wallet/ScriptId';
+import { getScriptIdFromPath } from '../../../src/bitgo/wallet/ScriptId';
 
-describe('getChainAndIndexFromPath', function () {
+describe('getScriptId', function () {
   it('should throw if path is not the right length', function () {
-    assert.throws(() => getChainAndIndexFromPath('/'), /invalid path/);
-    assert.throws(() => getChainAndIndexFromPath('m0000ssss'), /invalid path/);
+    assert.throws(() => getScriptIdFromPath('/'), /invalid path/);
+    assert.throws(() => getScriptIdFromPath('m0000ssss'), /invalid path/);
   });
 
   it('should throw if the path is not a number', function () {
     const invalidChain = [-1, 2, 'lol'];
     const invalidIndex = [-1, 'lol'];
     for (const chain of invalidChain) {
-      assert.throws(() => getChainAndIndexFromPath(`m/${chain}/0`), /invalid chain/);
+      assert.throws(() => getScriptIdFromPath(`m/${chain}/0`), /invalid chain/);
     }
     for (const index of invalidIndex) {
-      assert.throws(() => getChainAndIndexFromPath(`m/0/${index}`), /invalid index/);
+      assert.throws(() => getScriptIdFromPath(`m/0/${index}`), /invalid index/);
     }
   });
 
   it('should set the chain and index correctly', function () {
-    assert.deepStrictEqual(getChainAndIndexFromPath('m/1/2'), { chain: 1, index: 2 });
-    assert.deepStrictEqual(getChainAndIndexFromPath('m/1/2/3/4/5/10/20'), { chain: 10, index: 20 });
+    assert.deepStrictEqual(getScriptIdFromPath('m/1/2'), { chain: 1, index: 2 });
+    assert.deepStrictEqual(getScriptIdFromPath('m/1/2/3/4/5/10/20'), { chain: 10, index: 20 });
   });
 });

--- a/modules/utxo-lib/test/bitgo/wallet/WalletOutput.ts
+++ b/modules/utxo-lib/test/bitgo/wallet/WalletOutput.ts
@@ -1,0 +1,119 @@
+import * as assert from 'assert';
+
+import { getScriptIdFromOutput, getPsbtBip32DerivationOutputUpdate } from '../../../src/bitgo/wallet/WalletOutput';
+import { getDefaultWalletKeys } from '../../../src/testutil/keys';
+
+describe('WalletOutput', function () {
+  describe('getScriptIdFromOutput', function () {
+    const rootWalletKeys = getDefaultWalletKeys();
+
+    it('should extract script id from output created with getPsbtBip32DerivationOutputUpdate for non-taproot', function () {
+      // Create a derived wallet keys for chain 10, index 20
+      const walletKeys = rootWalletKeys.deriveForChainAndIndex(10, 20);
+
+      // Get derivation data using the function we want to test against
+      const update = getPsbtBip32DerivationOutputUpdate(rootWalletKeys, walletKeys, 'p2sh');
+
+      // Extract script id from the output
+      const scriptId = getScriptIdFromOutput(update);
+
+      // Verify the extracted script id matches what we expect
+      assert.strictEqual(scriptId.chain, 10);
+      assert.strictEqual(scriptId.index, 20);
+    });
+
+    it('should extract script id from output created with getPsbtBip32DerivationOutputUpdate for taproot', function () {
+      // Create a derived wallet keys for chain 11, index 22
+      const walletKeys = rootWalletKeys.deriveForChainAndIndex(11, 22);
+
+      // Create a mock payment object with redeems property
+      const mockPayment = {
+        redeems: [
+          {
+            output: Buffer.alloc(32),
+            pubkeys: [walletKeys.triple[0].publicKey, walletKeys.triple[1].publicKey],
+          },
+        ],
+      };
+
+      // Get derivation data using the function we want to test against
+      const update = getPsbtBip32DerivationOutputUpdate(rootWalletKeys, walletKeys, 'p2tr', mockPayment);
+
+      // Extract script id from the output
+      const scriptId = getScriptIdFromOutput(update);
+
+      // Verify the extracted script id matches what we expect
+      assert.strictEqual(scriptId.chain, 11);
+      assert.strictEqual(scriptId.index, 22);
+    });
+
+    it('should extract script id from output with bip32Derivation', function () {
+      const output = {
+        bip32Derivation: [{ path: 'm/0/0' }, { path: 'm/0/0' }, { path: 'm/0/0' }],
+      };
+
+      const scriptId = getScriptIdFromOutput(output);
+      assert.strictEqual(scriptId.chain, 0);
+      assert.strictEqual(scriptId.index, 0);
+    });
+
+    it('should extract script id from output with tapBip32Derivation', function () {
+      const output = {
+        tapBip32Derivation: [{ path: 'm/0/123' }, { path: 'm/0/123' }, { path: 'm/0/123' }],
+      };
+
+      const scriptId = getScriptIdFromOutput(output);
+      assert.strictEqual(scriptId.chain, 0);
+      assert.strictEqual(scriptId.index, 123);
+    });
+
+    it('should throw error when output has both bip32Derivation and tapBip32Derivation', function () {
+      const output = {
+        bip32Derivation: [{ path: 'm/0/0' }],
+        tapBip32Derivation: [{ path: 'm/0/0' }],
+      };
+
+      assert.throws(() => {
+        getScriptIdFromOutput(output);
+      }, /cannot get script id from output with both bip32Derivation and tapBip32Derivation/);
+    });
+
+    it('should throw error when output has neither bip32Derivation nor tapBip32Derivation', function () {
+      const output = {};
+
+      assert.throws(() => {
+        getScriptIdFromOutput(output);
+      }, /cannot get script id from output without bip32Derivation or tapBip32Derivation/);
+    });
+
+    it('should throw error when paths have mismatched chain', function () {
+      const output = {
+        bip32Derivation: [{ path: 'm/0/0' }, { path: 'm/1/0' }, { path: 'm/0/0' }],
+      };
+
+      assert.throws(() => {
+        getScriptIdFromOutput(output);
+      }, /chain mismatch/);
+    });
+
+    it('should throw error when paths have mismatched index', function () {
+      const output = {
+        bip32Derivation: [{ path: 'm/0/0' }, { path: 'm/0/1' }, { path: 'm/0/0' }],
+      };
+
+      assert.throws(() => {
+        getScriptIdFromOutput(output);
+      }, /index mismatch/);
+    });
+
+    it('should throw error when derivation array is empty', function () {
+      const output = {
+        bip32Derivation: [],
+      };
+
+      assert.throws(() => {
+        getScriptIdFromOutput(output);
+      }, /cannot fold empty script ids/);
+    });
+  });
+});

--- a/modules/utxo-lib/test/bitgo/wallet/chains.ts
+++ b/modules/utxo-lib/test/bitgo/wallet/chains.ts
@@ -2,7 +2,6 @@ import * as assert from 'assert';
 import {
   ChainCode,
   chainCodes,
-  getChainAndIndexFromPath,
   getExternalChainCode,
   getInternalChainCode,
   isChainCode,
@@ -57,28 +56,5 @@ describe('chain codes', function () {
       assert.strictEqual(isExternalChainCode(c) && isInternalChainCode(c), false);
       assert.strictEqual(isExternalChainCode(c) ? getExternalChainCode(c) : getInternalChainCode(c), c);
     });
-  });
-});
-
-describe('getChainAndIndexFromPath', function () {
-  it('should throw if path is not the right length', function () {
-    assert.throws(() => getChainAndIndexFromPath('/'), /invalid path/);
-    assert.throws(() => getChainAndIndexFromPath('m0000ssss'), /invalid path/);
-  });
-
-  it('should throw if the path is not a number', function () {
-    const invalidChain = [-1, 2, 'lol'];
-    const invalidIndex = [-1, 'lol'];
-    for (const chain of invalidChain) {
-      assert.throws(() => getChainAndIndexFromPath(`m/${chain}/0`), /invalid chain/);
-    }
-    for (const index of invalidIndex) {
-      assert.throws(() => getChainAndIndexFromPath(`m/0/${index}`), /invalid index/);
-    }
-  });
-
-  it('should set the chain and index correctly', function () {
-    assert.deepStrictEqual(getChainAndIndexFromPath('m/1/2'), { chain: 1, index: 2 });
-    assert.deepStrictEqual(getChainAndIndexFromPath('m/1/2/3/4/5/10/20'), { chain: 10, index: 20 });
   });
 });

--- a/modules/utxo-lib/test/bitgo/wallet/chains.ts
+++ b/modules/utxo-lib/test/bitgo/wallet/chains.ts
@@ -67,20 +67,18 @@ describe('getChainAndIndexFromPath', function () {
   });
 
   it('should throw if the path is not a number', function () {
-    assert.throws(() => getChainAndIndexFromPath('m/0/ssss'), /Could not parse chain and index into numbers from path/);
-    assert.throws(
-      () => getChainAndIndexFromPath('//d/dd/d/d/dd/dd'),
-      /Could not parse chain and index into numbers from path/
-    );
-  });
-
-  it('should throw if chain or index is negative', function () {
-    assert.throws(() => getChainAndIndexFromPath('m/-1/0'), /chain and index must be non-negative/);
-    assert.throws(() => getChainAndIndexFromPath('m/0/-1'), /chain and index must be non-negative/);
+    const invalidChain = [-1, 2, 'lol'];
+    const invalidIndex = [-1, 'lol'];
+    for (const chain of invalidChain) {
+      assert.throws(() => getChainAndIndexFromPath(`m/${chain}/0`), /invalid chain/);
+    }
+    for (const index of invalidIndex) {
+      assert.throws(() => getChainAndIndexFromPath(`m/0/${index}`), /invalid index/);
+    }
   });
 
   it('should set the chain and index correctly', function () {
     assert.deepStrictEqual(getChainAndIndexFromPath('m/1/2'), { chain: 1, index: 2 });
-    assert.deepStrictEqual(getChainAndIndexFromPath('m/4/3/2'), { chain: 3, index: 2 });
+    assert.deepStrictEqual(getChainAndIndexFromPath('m/1/2/3/4/5/10/20'), { chain: 10, index: 20 });
   });
 });


### PR DESCRIPTION

Refactors BIP32 path handling and PSBT output processing in utxo-lib to improve
type safety and maintainability. Introduces new `getScriptIdFromPath` function
(renamed from `getChainAndIndex`) with dedicated validation, and restructures
PSBT handling into smaller, type-safe functions.

Key changes:
- Add ScriptId type and improved BIP32 path validation
- Split PSBT output handling for better maintainability
- Reorganize code structure to reduce circular dependencies
- Add comprehensive tests for script ID validation

Ref: BTC-1966