### PR TITLE
feat(utxo-core): export derive from descriptor index

### DIFF
--- a/modules/utxo-core/src/descriptor/index.ts
+++ b/modules/utxo-core/src/descriptor/index.ts
@@ -1,6 +1,7 @@
 export * from './psbt';
 export * from './address';
 export * from './DescriptorMap';
+export * from './derive';
 export * from './Output';
 export * from './VirtualSize';
 


### PR DESCRIPTION

Export derive from descriptor index to make it available to consumers.

BTC-1966