### PR TITLE
chore: ignore bigint-buffer overflow

### DIFF
--- a/.iyarc
+++ b/.iyarc
@@ -1,3 +1,4 @@
 GHSA-3h5v-q93c-6h6q
 GHSA-8hc4-vh64-cxmj
 GHSA-9wv6-86v2-598j
+GHSA-3gc7-fjrx-p6mg


### PR DESCRIPTION
to unblock current development so we can address this issue
asynchronously. Tracked by DX-1225.

Closes Ticket: DX-1225