### PR TITLE
feat(utxo-staking): implement babylon unstaking tests

### DIFF
--- a/modules/utxo-core/src/descriptor/psbt/createPsbt.ts
+++ b/modules/utxo-core/src/descriptor/psbt/createPsbt.ts
@@ -48,15 +48,19 @@ export type PsbtParams = {
   sequence?: number;
 };
 
+export type DerivedDescriptorTransactionInput = DerivedDescriptorWalletOutput & {
+  sequence?: number;
+};
+
 export function createPsbt(
   params: PsbtParams,
-  inputs: DerivedDescriptorWalletOutput[],
+  inputs: DerivedDescriptorTransactionInput[],
   outputs: WithOptDescriptor<Output>[]
 ): utxolib.bitgo.UtxoPsbt {
   const psbt = utxolib.bitgo.UtxoPsbt.createPsbt({ network: params.network });
   psbt.setVersion(params.version ?? 2);
   psbt.setLocktime(params.locktime ?? 0);
-  psbt.addInputs(inputs.map((i) => ({ ...i, sequence: params.sequence ?? MAX_BIP125_RBF_SEQUENCE })));
+  psbt.addInputs(inputs.map((i) => ({ ...i, sequence: i.sequence ?? params.sequence ?? MAX_BIP125_RBF_SEQUENCE })));
   psbt.addOutputs(outputs);
   updateInputsWithDescriptors(
     psbt,

--- a/modules/utxo-core/src/descriptor/psbt/index.ts
+++ b/modules/utxo-core/src/descriptor/psbt/index.ts
@@ -3,3 +3,4 @@ export * from './createPsbt';
 export * from './parse';
 export * from './findDescriptors';
 export * from './wrap';
+export * from './sign';

--- a/modules/utxo-core/src/descriptor/psbt/sign.ts
+++ b/modules/utxo-core/src/descriptor/psbt/sign.ts
@@ -1,0 +1,47 @@
+import assert from 'assert';
+
+import * as utxolib from '@bitgo/utxo-lib';
+import { Psbt as WasmPsbt } from '@bitgo/wasm-miniscript';
+
+/** These can be replaced when @bitgo/wasm-miniscript is updated */
+export type SignPsbtInputResult = { Schnorr: string[] } | { Ecdsa: string[] };
+export type SignPsbtResult = {
+  [inputIndex: number]: SignPsbtInputResult;
+};
+
+/**
+ * @param signResult
+ * @return the number of new signatures created by the signResult for a single input
+ */
+export function getNewSignatureCountForInput(signResult: SignPsbtInputResult): number {
+  if ('Schnorr' in signResult) {
+    return signResult.Schnorr.length;
+  }
+  if ('Ecdsa' in signResult) {
+    return signResult.Ecdsa.length;
+  }
+  throw new Error(`Unknown signature type ${Object.keys(signResult).join(', ')}`);
+}
+
+/**
+ * @param signResult
+ * @return the number of new signatures created by the signResult
+ */
+export function getNewSignatureCount(signResult: SignPsbtResult): number {
+  return Object.values(signResult).reduce((sum, signatures) => sum + getNewSignatureCountForInput(signatures), 0);
+}
+
+type Key = Buffer | utxolib.BIP32Interface | utxolib.ECPairInterface;
+
+/** Convenience function to sign a PSBT with a key */
+export function signWithKey(psbt: WasmPsbt, key: Key): SignPsbtResult {
+  // we need to do casting here because the type definitions in wasm-miniscript are a little bit buggy
+  if (Buffer.isBuffer(key)) {
+    return psbt.signWithPrv(key) as unknown as SignPsbtResult;
+  }
+  if ('toBase58' in key) {
+    return psbt.signWithXprv(key.toBase58()) as unknown as SignPsbtResult;
+  }
+  assert(key.privateKey);
+  return psbt.signWithPrv(key.privateKey) as unknown as SignPsbtResult;
+}

--- a/modules/utxo-core/src/testutil/descriptor/mock.utils.ts
+++ b/modules/utxo-core/src/testutil/descriptor/mock.utils.ts
@@ -1,8 +1,12 @@
 import { Descriptor } from '@bitgo/wasm-miniscript';
 import * as utxolib from '@bitgo/utxo-lib';
 
-import { PsbtParams, createPsbt, createScriptPubKeyFromDescriptor } from '../../descriptor';
-import { DerivedDescriptorWalletOutput } from '../../descriptor/Output';
+import {
+  PsbtParams,
+  createPsbt,
+  createScriptPubKeyFromDescriptor,
+  DerivedDescriptorTransactionInput,
+} from '../../descriptor';
 
 import { DescriptorTemplate, getDefaultXPubs, getDescriptor } from './descriptors';
 
@@ -12,6 +16,7 @@ type BaseMockDescriptorOutputParams = {
   id?: MockOutputIdParams;
   index?: number;
   value?: bigint;
+  sequence?: number;
 };
 
 function mockOutputId(id?: MockOutputIdParams): {
@@ -26,7 +31,7 @@ function mockOutputId(id?: MockOutputIdParams): {
 export function mockDerivedDescriptorWalletOutput(
   descriptor: Descriptor,
   outputParams: BaseMockDescriptorOutputParams = {}
-): DerivedDescriptorWalletOutput {
+): DerivedDescriptorTransactionInput {
   const { value = BigInt(1e6) } = outputParams;
   const { hash, vout } = mockOutputId(outputParams.id);
   return {
@@ -37,6 +42,7 @@ export function mockDerivedDescriptorWalletOutput(
       value,
     },
     descriptor,
+    sequence: outputParams.sequence,
   };
 }
 

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Wsh2Of3-CustomInputSequence.psbtStages.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Wsh2Of3-CustomInputSequence.psbtStages.json
@@ -1,0 +1,644 @@
+{
+  "unsigned": {
+    "psbt": {
+      "data": {
+        "inputs": [
+          {
+            "witnessUtxo": {
+              "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104",
+              "value": "1000000"
+            },
+            "witnessScript": "52210285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c392102d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e21029a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de40653ae",
+            "bip32Derivation": [
+              {
+                "masterFingerprint": "86ea6d35",
+                "pubkey": "0285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
+                "path": "m/0/0"
+              },
+              {
+                "masterFingerprint": "96daa738",
+                "pubkey": "029a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de406",
+                "path": "m/0/0"
+              },
+              {
+                "masterFingerprint": "702fc808",
+                "pubkey": "02d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e",
+                "path": "m/0/0"
+              }
+            ]
+          },
+          {
+            "witnessUtxo": {
+              "script": "0020e822404ded4c14f401afdaf6aaed1cf319ef2380c3aaba8cc6e3d8895ff09d7d",
+              "value": "1000000"
+            },
+            "witnessScript": "5221024062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e742103266670018fb65f1384da4e9b9b92c79d5c42d5f51c3ceb1e516babfb7595f2432102d502c2c474f4874a96b544afa9f8a9aa49e03ca8fcf736b1a1d150a663db13a653ae",
+            "bip32Derivation": [
+              {
+                "masterFingerprint": "86ea6d35",
+                "pubkey": "024062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e74",
+                "path": "m/0/1"
+              },
+              {
+                "masterFingerprint": "96daa738",
+                "pubkey": "02d502c2c474f4874a96b544afa9f8a9aa49e03ca8fcf736b1a1d150a663db13a6",
+                "path": "m/0/1"
+              },
+              {
+                "masterFingerprint": "702fc808",
+                "pubkey": "03266670018fb65f1384da4e9b9b92c79d5c42d5f51c3ceb1e516babfb7595f243",
+                "path": "m/0/1"
+              }
+            ]
+          }
+        ],
+        "outputs": [
+          {},
+          {
+            "witnessScript": "52210285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c392102d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e21029a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de40653ae",
+            "bip32Derivation": [
+              {
+                "masterFingerprint": "86ea6d35",
+                "pubkey": "0285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
+                "path": "m/0/0"
+              },
+              {
+                "masterFingerprint": "96daa738",
+                "pubkey": "029a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de406",
+                "path": "m/0/0"
+              },
+              {
+                "masterFingerprint": "702fc808",
+                "pubkey": "02d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e",
+                "path": "m/0/0"
+              }
+            ]
+          }
+        ],
+        "globalMap": {
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 0,
+                  "script": "",
+                  "sequence": 4294967293,
+                  "witness": []
+                },
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 1,
+                  "script": "",
+                  "sequence": 123,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "400000",
+                  "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+                },
+                {
+                  "value": "400000",
+                  "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "nonceStore": {
+        "nonces": []
+      },
+      "opts": {
+        "maximumFeeRate": 5000
+      }
+    },
+    "parsed": {
+      "inputs": [
+        {
+          "address": "bc1q2yau645jl7k577lmanqn9a0ulcgcqm0wrrmx09dppd3kcwguvyzqk86umj",
+          "value": "1000000",
+          "scriptId": {
+            "descriptor": "wsh(multi(2,xpub661MyMwAqRbcGgAiE61i1eaQhbbjc4bbNGs29j3pDwR6nWEve2UsfFvNjBCVq55ou4CRNmwFJaes68he1Dv4DtZijPb1rKyCAe7QUeSNrHv/0/*,xpub661MyMwAqRbcEhTeHonWEhBz8fEB77o21PhGm6SvrbDBQfMiyLi1QP9sqoocVxmpU88J81v5DN8TQycPtZpeyATTPgfQZNz5XLCAiwjubBt/0/*,xpub661MyMwAqRbcGYdhWFrcJryS4koZw7EhwAWy8K1ohYycNketUENNBbSXB8RNLdaob7TanDsmT2Cn2Me7Bt4wBjQurPcqBaWkiCNQPQ1rVUG/0/*))#7njj32qu",
+            "index": 0
+          }
+        },
+        {
+          "address": "bc1qaq3yqn0dfs20gqd0mtm24mgu7vv77guqcw4t4rxxu0vgjhlsn47seygpq7",
+          "value": "1000000",
+          "scriptId": {
+            "descriptor": "wsh(multi(2,xpub661MyMwAqRbcGgAiE61i1eaQhbbjc4bbNGs29j3pDwR6nWEve2UsfFvNjBCVq55ou4CRNmwFJaes68he1Dv4DtZijPb1rKyCAe7QUeSNrHv/0/*,xpub661MyMwAqRbcEhTeHonWEhBz8fEB77o21PhGm6SvrbDBQfMiyLi1QP9sqoocVxmpU88J81v5DN8TQycPtZpeyATTPgfQZNz5XLCAiwjubBt/0/*,xpub661MyMwAqRbcGYdhWFrcJryS4koZw7EhwAWy8K1ohYycNketUENNBbSXB8RNLdaob7TanDsmT2Cn2Me7Bt4wBjQurPcqBaWkiCNQPQ1rVUG/0/*))#7njj32qu",
+            "index": 1
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477",
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000"
+        },
+        {
+          "address": "bc1q2yau645jl7k577lmanqn9a0ulcgcqm0wrrmx09dppd3kcwguvyzqk86umj",
+          "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104",
+          "value": "400000",
+          "scriptId": {
+            "descriptor": "wsh(multi(2,xpub661MyMwAqRbcGgAiE61i1eaQhbbjc4bbNGs29j3pDwR6nWEve2UsfFvNjBCVq55ou4CRNmwFJaes68he1Dv4DtZijPb1rKyCAe7QUeSNrHv/0/*,xpub661MyMwAqRbcEhTeHonWEhBz8fEB77o21PhGm6SvrbDBQfMiyLi1QP9sqoocVxmpU88J81v5DN8TQycPtZpeyATTPgfQZNz5XLCAiwjubBt/0/*,xpub661MyMwAqRbcGYdhWFrcJryS4koZw7EhwAWy8K1ohYycNketUENNBbSXB8RNLdaob7TanDsmT2Cn2Me7Bt4wBjQurPcqBaWkiCNQPQ1rVUG/0/*))#7njj32qu",
+            "index": 0
+          }
+        }
+      ],
+      "spendAmount": "400000",
+      "minerFee": "1200000",
+      "virtualSize": 307
+    }
+  },
+  "signedA": {
+    "psbt": {
+      "data": {
+        "inputs": [
+          {
+            "witnessUtxo": {
+              "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104",
+              "value": "1000000"
+            },
+            "partialSig": [
+              {
+                "pubkey": "0285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
+                "signature": "304402205dd8c83a46a260e607e05175d889d4cd358b24a99965a04214ca3685d0a344af02201522c9415a0ff32ea2360828afe9caf51da1fe9a2d772e281e3059d6133bf87a01"
+              }
+            ],
+            "witnessScript": "52210285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c392102d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e21029a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de40653ae",
+            "bip32Derivation": [
+              {
+                "masterFingerprint": "86ea6d35",
+                "pubkey": "0285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
+                "path": "m/0/0"
+              },
+              {
+                "masterFingerprint": "96daa738",
+                "pubkey": "029a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de406",
+                "path": "m/0/0"
+              },
+              {
+                "masterFingerprint": "702fc808",
+                "pubkey": "02d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e",
+                "path": "m/0/0"
+              }
+            ]
+          },
+          {
+            "witnessUtxo": {
+              "script": "0020e822404ded4c14f401afdaf6aaed1cf319ef2380c3aaba8cc6e3d8895ff09d7d",
+              "value": "1000000"
+            },
+            "partialSig": [
+              {
+                "pubkey": "024062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e74",
+                "signature": "30440220796346e206b6c49e4969bc9088ca417e0bacb93891187f623924883f46569593022029a34bb7ea2d734398c8281be10b53f198b636a05279b2647b9d4c326fda602701"
+              }
+            ],
+            "witnessScript": "5221024062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e742103266670018fb65f1384da4e9b9b92c79d5c42d5f51c3ceb1e516babfb7595f2432102d502c2c474f4874a96b544afa9f8a9aa49e03ca8fcf736b1a1d150a663db13a653ae",
+            "bip32Derivation": [
+              {
+                "masterFingerprint": "86ea6d35",
+                "pubkey": "024062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e74",
+                "path": "m/0/1"
+              },
+              {
+                "masterFingerprint": "96daa738",
+                "pubkey": "02d502c2c474f4874a96b544afa9f8a9aa49e03ca8fcf736b1a1d150a663db13a6",
+                "path": "m/0/1"
+              },
+              {
+                "masterFingerprint": "702fc808",
+                "pubkey": "03266670018fb65f1384da4e9b9b92c79d5c42d5f51c3ceb1e516babfb7595f243",
+                "path": "m/0/1"
+              }
+            ]
+          }
+        ],
+        "outputs": [
+          {},
+          {
+            "witnessScript": "52210285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c392102d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e21029a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de40653ae",
+            "bip32Derivation": [
+              {
+                "masterFingerprint": "86ea6d35",
+                "pubkey": "0285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
+                "path": "m/0/0"
+              },
+              {
+                "masterFingerprint": "96daa738",
+                "pubkey": "029a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de406",
+                "path": "m/0/0"
+              },
+              {
+                "masterFingerprint": "702fc808",
+                "pubkey": "02d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e",
+                "path": "m/0/0"
+              }
+            ]
+          }
+        ],
+        "globalMap": {
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 0,
+                  "script": "",
+                  "sequence": 4294967293,
+                  "witness": []
+                },
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 1,
+                  "script": "",
+                  "sequence": 123,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "400000",
+                  "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+                },
+                {
+                  "value": "400000",
+                  "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "nonceStore": {
+        "nonces": []
+      },
+      "opts": {
+        "maximumFeeRate": 5000
+      }
+    },
+    "parsed": {
+      "inputs": [
+        {
+          "address": "bc1q2yau645jl7k577lmanqn9a0ulcgcqm0wrrmx09dppd3kcwguvyzqk86umj",
+          "value": "1000000",
+          "scriptId": {
+            "descriptor": "wsh(multi(2,xpub661MyMwAqRbcGgAiE61i1eaQhbbjc4bbNGs29j3pDwR6nWEve2UsfFvNjBCVq55ou4CRNmwFJaes68he1Dv4DtZijPb1rKyCAe7QUeSNrHv/0/*,xpub661MyMwAqRbcEhTeHonWEhBz8fEB77o21PhGm6SvrbDBQfMiyLi1QP9sqoocVxmpU88J81v5DN8TQycPtZpeyATTPgfQZNz5XLCAiwjubBt/0/*,xpub661MyMwAqRbcGYdhWFrcJryS4koZw7EhwAWy8K1ohYycNketUENNBbSXB8RNLdaob7TanDsmT2Cn2Me7Bt4wBjQurPcqBaWkiCNQPQ1rVUG/0/*))#7njj32qu",
+            "index": 0
+          }
+        },
+        {
+          "address": "bc1qaq3yqn0dfs20gqd0mtm24mgu7vv77guqcw4t4rxxu0vgjhlsn47seygpq7",
+          "value": "1000000",
+          "scriptId": {
+            "descriptor": "wsh(multi(2,xpub661MyMwAqRbcGgAiE61i1eaQhbbjc4bbNGs29j3pDwR6nWEve2UsfFvNjBCVq55ou4CRNmwFJaes68he1Dv4DtZijPb1rKyCAe7QUeSNrHv/0/*,xpub661MyMwAqRbcEhTeHonWEhBz8fEB77o21PhGm6SvrbDBQfMiyLi1QP9sqoocVxmpU88J81v5DN8TQycPtZpeyATTPgfQZNz5XLCAiwjubBt/0/*,xpub661MyMwAqRbcGYdhWFrcJryS4koZw7EhwAWy8K1ohYycNketUENNBbSXB8RNLdaob7TanDsmT2Cn2Me7Bt4wBjQurPcqBaWkiCNQPQ1rVUG/0/*))#7njj32qu",
+            "index": 1
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477",
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000"
+        },
+        {
+          "address": "bc1q2yau645jl7k577lmanqn9a0ulcgcqm0wrrmx09dppd3kcwguvyzqk86umj",
+          "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104",
+          "value": "400000",
+          "scriptId": {
+            "descriptor": "wsh(multi(2,xpub661MyMwAqRbcGgAiE61i1eaQhbbjc4bbNGs29j3pDwR6nWEve2UsfFvNjBCVq55ou4CRNmwFJaes68he1Dv4DtZijPb1rKyCAe7QUeSNrHv/0/*,xpub661MyMwAqRbcEhTeHonWEhBz8fEB77o21PhGm6SvrbDBQfMiyLi1QP9sqoocVxmpU88J81v5DN8TQycPtZpeyATTPgfQZNz5XLCAiwjubBt/0/*,xpub661MyMwAqRbcGYdhWFrcJryS4koZw7EhwAWy8K1ohYycNketUENNBbSXB8RNLdaob7TanDsmT2Cn2Me7Bt4wBjQurPcqBaWkiCNQPQ1rVUG/0/*))#7njj32qu",
+            "index": 0
+          }
+        }
+      ],
+      "spendAmount": "400000",
+      "minerFee": "1200000",
+      "virtualSize": 307
+    }
+  },
+  "signedAB": {
+    "psbt": {
+      "data": {
+        "inputs": [
+          {
+            "witnessUtxo": {
+              "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104",
+              "value": "1000000"
+            },
+            "partialSig": [
+              {
+                "pubkey": "0285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
+                "signature": "304402205dd8c83a46a260e607e05175d889d4cd358b24a99965a04214ca3685d0a344af02201522c9415a0ff32ea2360828afe9caf51da1fe9a2d772e281e3059d6133bf87a01"
+              },
+              {
+                "pubkey": "02d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e",
+                "signature": "304402200b4ca990a8481f923cd1850976a0054da820c66e97f1738bceb6691afa2872ba02203b30e494ab43777d0d01fc5fbf15cecfcade2e47976a819620467c14fe97ee3101"
+              }
+            ],
+            "witnessScript": "52210285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c392102d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e21029a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de40653ae",
+            "bip32Derivation": [
+              {
+                "masterFingerprint": "86ea6d35",
+                "pubkey": "0285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
+                "path": "m/0/0"
+              },
+              {
+                "masterFingerprint": "96daa738",
+                "pubkey": "029a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de406",
+                "path": "m/0/0"
+              },
+              {
+                "masterFingerprint": "702fc808",
+                "pubkey": "02d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e",
+                "path": "m/0/0"
+              }
+            ]
+          },
+          {
+            "witnessUtxo": {
+              "script": "0020e822404ded4c14f401afdaf6aaed1cf319ef2380c3aaba8cc6e3d8895ff09d7d",
+              "value": "1000000"
+            },
+            "partialSig": [
+              {
+                "pubkey": "024062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e74",
+                "signature": "30440220796346e206b6c49e4969bc9088ca417e0bacb93891187f623924883f46569593022029a34bb7ea2d734398c8281be10b53f198b636a05279b2647b9d4c326fda602701"
+              },
+              {
+                "pubkey": "03266670018fb65f1384da4e9b9b92c79d5c42d5f51c3ceb1e516babfb7595f243",
+                "signature": "3045022100e6d8a5c6b41fe64935612277d769592eae28d2ddfe3bc21119dfb2355d75ab49022067fe21615f788fd72fd7a0952d61ddaced70afc8f9bdd6e9c05d9e17bcca077501"
+              }
+            ],
+            "witnessScript": "5221024062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e742103266670018fb65f1384da4e9b9b92c79d5c42d5f51c3ceb1e516babfb7595f2432102d502c2c474f4874a96b544afa9f8a9aa49e03ca8fcf736b1a1d150a663db13a653ae",
+            "bip32Derivation": [
+              {
+                "masterFingerprint": "86ea6d35",
+                "pubkey": "024062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e74",
+                "path": "m/0/1"
+              },
+              {
+                "masterFingerprint": "96daa738",
+                "pubkey": "02d502c2c474f4874a96b544afa9f8a9aa49e03ca8fcf736b1a1d150a663db13a6",
+                "path": "m/0/1"
+              },
+              {
+                "masterFingerprint": "702fc808",
+                "pubkey": "03266670018fb65f1384da4e9b9b92c79d5c42d5f51c3ceb1e516babfb7595f243",
+                "path": "m/0/1"
+              }
+            ]
+          }
+        ],
+        "outputs": [
+          {},
+          {
+            "witnessScript": "52210285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c392102d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e21029a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de40653ae",
+            "bip32Derivation": [
+              {
+                "masterFingerprint": "86ea6d35",
+                "pubkey": "0285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
+                "path": "m/0/0"
+              },
+              {
+                "masterFingerprint": "96daa738",
+                "pubkey": "029a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de406",
+                "path": "m/0/0"
+              },
+              {
+                "masterFingerprint": "702fc808",
+                "pubkey": "02d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e",
+                "path": "m/0/0"
+              }
+            ]
+          }
+        ],
+        "globalMap": {
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 0,
+                  "script": "",
+                  "sequence": 4294967293,
+                  "witness": []
+                },
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 1,
+                  "script": "",
+                  "sequence": 123,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "400000",
+                  "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+                },
+                {
+                  "value": "400000",
+                  "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "nonceStore": {
+        "nonces": []
+      },
+      "opts": {
+        "maximumFeeRate": 5000
+      }
+    },
+    "parsed": {
+      "inputs": [
+        {
+          "address": "bc1q2yau645jl7k577lmanqn9a0ulcgcqm0wrrmx09dppd3kcwguvyzqk86umj",
+          "value": "1000000",
+          "scriptId": {
+            "descriptor": "wsh(multi(2,xpub661MyMwAqRbcGgAiE61i1eaQhbbjc4bbNGs29j3pDwR6nWEve2UsfFvNjBCVq55ou4CRNmwFJaes68he1Dv4DtZijPb1rKyCAe7QUeSNrHv/0/*,xpub661MyMwAqRbcEhTeHonWEhBz8fEB77o21PhGm6SvrbDBQfMiyLi1QP9sqoocVxmpU88J81v5DN8TQycPtZpeyATTPgfQZNz5XLCAiwjubBt/0/*,xpub661MyMwAqRbcGYdhWFrcJryS4koZw7EhwAWy8K1ohYycNketUENNBbSXB8RNLdaob7TanDsmT2Cn2Me7Bt4wBjQurPcqBaWkiCNQPQ1rVUG/0/*))#7njj32qu",
+            "index": 0
+          }
+        },
+        {
+          "address": "bc1qaq3yqn0dfs20gqd0mtm24mgu7vv77guqcw4t4rxxu0vgjhlsn47seygpq7",
+          "value": "1000000",
+          "scriptId": {
+            "descriptor": "wsh(multi(2,xpub661MyMwAqRbcGgAiE61i1eaQhbbjc4bbNGs29j3pDwR6nWEve2UsfFvNjBCVq55ou4CRNmwFJaes68he1Dv4DtZijPb1rKyCAe7QUeSNrHv/0/*,xpub661MyMwAqRbcEhTeHonWEhBz8fEB77o21PhGm6SvrbDBQfMiyLi1QP9sqoocVxmpU88J81v5DN8TQycPtZpeyATTPgfQZNz5XLCAiwjubBt/0/*,xpub661MyMwAqRbcGYdhWFrcJryS4koZw7EhwAWy8K1ohYycNketUENNBbSXB8RNLdaob7TanDsmT2Cn2Me7Bt4wBjQurPcqBaWkiCNQPQ1rVUG/0/*))#7njj32qu",
+            "index": 1
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477",
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000"
+        },
+        {
+          "address": "bc1q2yau645jl7k577lmanqn9a0ulcgcqm0wrrmx09dppd3kcwguvyzqk86umj",
+          "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104",
+          "value": "400000",
+          "scriptId": {
+            "descriptor": "wsh(multi(2,xpub661MyMwAqRbcGgAiE61i1eaQhbbjc4bbNGs29j3pDwR6nWEve2UsfFvNjBCVq55ou4CRNmwFJaes68he1Dv4DtZijPb1rKyCAe7QUeSNrHv/0/*,xpub661MyMwAqRbcEhTeHonWEhBz8fEB77o21PhGm6SvrbDBQfMiyLi1QP9sqoocVxmpU88J81v5DN8TQycPtZpeyATTPgfQZNz5XLCAiwjubBt/0/*,xpub661MyMwAqRbcGYdhWFrcJryS4koZw7EhwAWy8K1ohYycNketUENNBbSXB8RNLdaob7TanDsmT2Cn2Me7Bt4wBjQurPcqBaWkiCNQPQ1rVUG/0/*))#7njj32qu",
+            "index": 0
+          }
+        }
+      ],
+      "spendAmount": "400000",
+      "minerFee": "1200000",
+      "virtualSize": 307
+    },
+    "psbtFinal": {
+      "data": {
+        "inputs": [
+          {
+            "witnessUtxo": {
+              "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104",
+              "value": "1000000"
+            },
+            "finalScriptWitness": "040047304402205dd8c83a46a260e607e05175d889d4cd358b24a99965a04214ca3685d0a344af02201522c9415a0ff32ea2360828afe9caf51da1fe9a2d772e281e3059d6133bf87a0147304402200b4ca990a8481f923cd1850976a0054da820c66e97f1738bceb6691afa2872ba02203b30e494ab43777d0d01fc5fbf15cecfcade2e47976a819620467c14fe97ee31016952210285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c392102d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e21029a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de40653ae"
+          },
+          {
+            "witnessUtxo": {
+              "script": "0020e822404ded4c14f401afdaf6aaed1cf319ef2380c3aaba8cc6e3d8895ff09d7d",
+              "value": "1000000"
+            },
+            "finalScriptWitness": "04004730440220796346e206b6c49e4969bc9088ca417e0bacb93891187f623924883f46569593022029a34bb7ea2d734398c8281be10b53f198b636a05279b2647b9d4c326fda602701483045022100e6d8a5c6b41fe64935612277d769592eae28d2ddfe3bc21119dfb2355d75ab49022067fe21615f788fd72fd7a0952d61ddaced70afc8f9bdd6e9c05d9e17bcca077501695221024062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e742103266670018fb65f1384da4e9b9b92c79d5c42d5f51c3ceb1e516babfb7595f2432102d502c2c474f4874a96b544afa9f8a9aa49e03ca8fcf736b1a1d150a663db13a653ae"
+          }
+        ],
+        "outputs": [
+          {},
+          {
+            "witnessScript": "52210285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c392102d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e21029a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de40653ae",
+            "bip32Derivation": [
+              {
+                "masterFingerprint": "86ea6d35",
+                "pubkey": "0285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c39",
+                "path": "m/0/0"
+              },
+              {
+                "masterFingerprint": "96daa738",
+                "pubkey": "029a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de406",
+                "path": "m/0/0"
+              },
+              {
+                "masterFingerprint": "702fc808",
+                "pubkey": "02d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e",
+                "path": "m/0/0"
+              }
+            ]
+          }
+        ],
+        "globalMap": {
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 0,
+                  "script": "",
+                  "sequence": 4294967293,
+                  "witness": []
+                },
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 1,
+                  "script": "",
+                  "sequence": 123,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "400000",
+                  "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+                },
+                {
+                  "value": "400000",
+                  "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "nonceStore": {
+        "nonces": []
+      },
+      "opts": {
+        "maximumFeeRate": 5000
+      }
+    },
+    "networkTx": {
+      "version": 2,
+      "locktime": 0,
+      "ins": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "script": "",
+          "sequence": 4294967293,
+          "witness": [
+            "",
+            "304402205dd8c83a46a260e607e05175d889d4cd358b24a99965a04214ca3685d0a344af02201522c9415a0ff32ea2360828afe9caf51da1fe9a2d772e281e3059d6133bf87a01",
+            "304402200b4ca990a8481f923cd1850976a0054da820c66e97f1738bceb6691afa2872ba02203b30e494ab43777d0d01fc5fbf15cecfcade2e47976a819620467c14fe97ee3101",
+            "52210285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c392102d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e21029a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de40653ae"
+          ]
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "script": "",
+          "sequence": 123,
+          "witness": [
+            "",
+            "30440220796346e206b6c49e4969bc9088ca417e0bacb93891187f623924883f46569593022029a34bb7ea2d734398c8281be10b53f198b636a05279b2647b9d4c326fda602701",
+            "3045022100e6d8a5c6b41fe64935612277d769592eae28d2ddfe3bc21119dfb2355d75ab49022067fe21615f788fd72fd7a0952d61ddaced70afc8f9bdd6e9c05d9e17bcca077501",
+            "5221024062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e742103266670018fb65f1384da4e9b9b92c79d5c42d5f51c3ceb1e516babfb7595f2432102d502c2c474f4874a96b544afa9f8a9aa49e03ca8fcf736b1a1d150a663db13a653ae"
+          ]
+        }
+      ],
+      "outs": [
+        {
+          "value": "400000",
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+        },
+        {
+          "value": "400000",
+          "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104"
+        }
+      ],
+      "network": {
+        "messagePrefix": "\u0018Bitcoin Signed Message:\n",
+        "bech32": "bc",
+        "bip32": {
+          "public": 76067358,
+          "private": 76066276
+        },
+        "pubKeyHash": 0,
+        "scriptHash": 5,
+        "wif": 128,
+        "coin": "btc"
+      }
+    },
+    "networkTxBuffer": "0200000000010201010101010101010101010101010101010101010101010101010101010101010000000000fdffffff010101010101010101010101010101010101010101010101010101010101010101000000007b00000002801a06000000000022002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8801a060000000000220020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104040047304402205dd8c83a46a260e607e05175d889d4cd358b24a99965a04214ca3685d0a344af02201522c9415a0ff32ea2360828afe9caf51da1fe9a2d772e281e3059d6133bf87a0147304402200b4ca990a8481f923cd1850976a0054da820c66e97f1738bceb6691afa2872ba02203b30e494ab43777d0d01fc5fbf15cecfcade2e47976a819620467c14fe97ee31016952210285f9fc63871a4f7e7877923a162c3f14fbaed12fab925e341173cff43eb93c392102d5298e6df3cc36ef883e10698e31c4d39108bdad04066111b5bb70241373cd3e21029a50a261452c3233d75f3aaa79d7187b823050b329fa1c51d7d5e1067b9de40653ae04004730440220796346e206b6c49e4969bc9088ca417e0bacb93891187f623924883f46569593022029a34bb7ea2d734398c8281be10b53f198b636a05279b2647b9d4c326fda602701483045022100e6d8a5c6b41fe64935612277d769592eae28d2ddfe3bc21119dfb2355d75ab49022067fe21615f788fd72fd7a0952d61ddaced70afc8f9bdd6e9c05d9e17bcca077501695221024062b7c830cca69d5c808306526e7a980fbdb5356a8a5c9fd6549f2d1bf76e742103266670018fb65f1384da4e9b9b92c79d5c42d5f51c3ceb1e516babfb7595f2432102d502c2c474f4874a96b544afa9f8a9aa49e03ca8fcf736b1a1d150a663db13a653ae00000000"
+  }
+}

--- a/modules/utxo-core/test/descriptor/psbt/psbt.ts
+++ b/modules/utxo-core/test/descriptor/psbt/psbt.ts
@@ -112,29 +112,24 @@ function getStages(
   );
 }
 
-function describeCreatePsbt(
-  name: string,
-  {
-    descriptorSelf,
-    psbtParams,
-    stages,
-  }: {
-    descriptorSelf: Descriptor;
-    stages: PsbtStage[];
-    psbtParams: Partial<PsbtParams>;
-  }
-) {
+type TestParams = {
+  descriptorSelf: Descriptor;
+  psbtParams: Partial<PsbtParams>;
+  stages: PsbtStage[];
+};
+
+function describeCreatePsbt(name: string, testParams: TestParams) {
   describe(`createPsbt ${name}`, function () {
     it('creates psbt with expected properties', async function () {
       const psbtUnsigned = mockPsbtDefault({
-        descriptorSelf,
+        descriptorSelf: testParams.descriptorSelf,
         descriptorOther: getDescriptor('Wsh2Of3', otherKeys),
-        params: psbtParams,
+        params: testParams.psbtParams,
       });
-      const descriptorMap = new Map([['self', descriptorSelf]]);
+      const descriptorMap = new Map([['self', testParams.descriptorSelf]]);
       const parsed = parse(psbtUnsigned, descriptorMap, utxolib.networks.bitcoin);
       assert.strictEqual(parsed.spendAmount, psbtUnsigned.txOutputs[1].value);
-      await assertEqualsFixture(name, 'psbtStages.json', getStages(psbtUnsigned, parsed, stages));
+      await assertEqualsFixture(name, 'psbtStages.json', getStages(psbtUnsigned, parsed, testParams.stages));
     });
   });
 }

--- a/modules/utxo-core/test/descriptor/psbt/psbt.ts
+++ b/modules/utxo-core/test/descriptor/psbt/psbt.ts
@@ -134,15 +134,26 @@ function describeCreatePsbt(name: string, testParams: TestParams) {
   });
 }
 
+const defaultStagesCombinedAB: PsbtStage[] = [
+  { name: 'unsigned', keys: [] },
+  { name: 'signedA', keys: selfKeys.slice(0, 1) },
+  { name: 'signedAB', keys: selfKeys.slice(0, 2), final: true },
+];
+
+function getDefaultStagesSeparateAB({ plain = false } = {}): PsbtStage[] {
+  const keys = plain ? selfKeys.map(toPlain) : selfKeys;
+  return [
+    { name: 'unsigned', keys: [] },
+    { name: 'signedA', keys: keys.slice(0, 1) },
+    { name: 'signedB', keys: keys.slice(1, 2), final: true },
+  ];
+}
+
 function describeCreatePsbt2Of3(t: DescriptorTemplate) {
   describeCreatePsbt(t, {
     descriptorSelf: getDescriptor(t, selfKeys),
     psbtParams: getPsbtParams(t),
-    stages: [
-      { name: 'unsigned', keys: [] },
-      { name: 'signedA', keys: selfKeys.slice(0, 1) },
-      { name: 'signedAB', keys: selfKeys.slice(0, 2), final: true },
-    ],
+    stages: defaultStagesCombinedAB,
   });
 }
 
@@ -152,18 +163,10 @@ describeCreatePsbt2Of3('Tr2Of3-NoKeyPath');
 describeCreatePsbt('Tr1Of3-NoKeyPath-Tree', {
   descriptorSelf: getDescriptor('Tr1Of3-NoKeyPath-Tree', selfKeys),
   psbtParams: {},
-  stages: [
-    { name: 'unsigned', keys: [] },
-    { name: 'signedA', keys: selfKeys.slice(0, 1) },
-    { name: 'signedB', keys: selfKeys.slice(1, 2), final: true },
-  ],
+  stages: getDefaultStagesSeparateAB(),
 });
 describeCreatePsbt('Tr1Of3-NoKeyPath-Tree-PlainKeys', {
   descriptorSelf: getDescriptor('Tr1Of3-NoKeyPath-Tree-Plain', selfKeys),
   psbtParams: {},
-  stages: [
-    { name: 'unsigned', keys: [] },
-    { name: 'signedA', keys: selfKeys.slice(0, 1).map(toPlain) },
-    { name: 'signedB', keys: selfKeys.slice(1, 2).map(toPlain), final: true },
-  ],
+  stages: getDefaultStagesSeparateAB({ plain: true }),
 });

--- a/modules/utxo-staking/test/fixtures/babylon/unstakingTransaction.testnet.json
+++ b/modules/utxo-staking/test/fixtures/babylon/unstakingTransaction.testnet.json
@@ -1,0 +1,37 @@
+{
+  "transaction": {
+    "version": 2,
+    "locktime": 0,
+    "ins": [
+      {
+        "hash": "64da14050ffd0e6186c68a59f371a0adc95cc84b0502fe0915be7eba3f771bb3",
+        "index": 0,
+        "script": "",
+        "sequence": 10000,
+        "witness": [
+          "34a9fb0ebbcd13f30cb8ca398bdedb23073c19cabb17b6de6ba4f45afea360bd9798b4fa5d2d886af2fd1e161f37787316fa3482e45ef4a6ca5692a619550ac0",
+          "207b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9ad021027b2",
+          "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac01e1d2e84c4fc6bdddf3b8018065cf5ca8405988579188585f382c51c088e882696962cb69242e00941e0a6197b7ecdb83ab8bb0490dbfd23fa4b8d26b75989eb"
+        ]
+      }
+    ],
+    "outs": [
+      {
+        "value": "54555",
+        "script": "0014896f1ba65deaeb045bb3121e20e5744e66ca0e48"
+      }
+    ],
+    "network": {
+      "messagePrefix": "\u0018Bitcoin Signed Message:\n",
+      "bech32": "bc",
+      "bip32": {
+        "public": 76067358,
+        "private": 76066276
+      },
+      "pubKeyHash": 0,
+      "scriptHash": 5,
+      "wif": 128,
+      "coin": "btc"
+    }
+  }
+}

--- a/modules/utxo-staking/test/fixtures/babylon/unstakingTransaction.testnetMock.json
+++ b/modules/utxo-staking/test/fixtures/babylon/unstakingTransaction.testnetMock.json
@@ -1,0 +1,37 @@
+{
+  "transaction": {
+    "version": 2,
+    "locktime": 0,
+    "ins": [
+      {
+        "hash": "a999d7bc6af1a17cd4e70d0fd875a1734152dfb55f9166240f35965c79fa36c2",
+        "index": 0,
+        "script": "",
+        "sequence": 10000,
+        "witness": [
+          "3856a8f99911738be2687076e7aa977499f9db8187ed85d574e7cbaa10520252b8d954011b35d18afb875cfac5019f937a2dcbc2e4143cf12c2c120f8250a8ab",
+          "207b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9ad021027b2",
+          "c150929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac068cc9790c0627bc8f28afd009b31974a2fce5ea4fe2ed4dd8b65c8feda196875c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552"
+        ]
+      }
+    ],
+    "outs": [
+      {
+        "value": "54555",
+        "script": "0014896f1ba65deaeb045bb3121e20e5744e66ca0e48"
+      }
+    ],
+    "network": {
+      "messagePrefix": "\u0018Bitcoin Signed Message:\n",
+      "bech32": "bc",
+      "bip32": {
+        "public": 76067358,
+        "private": 76066276
+      },
+      "pubKeyHash": 0,
+      "scriptHash": 5,
+      "wif": 128,
+      "coin": "btc"
+    }
+  }
+}


### PR DESCRIPTION

This PR Babylon unstaking tests, along with several improvements to the UTXO core library to enable
this functionality:

- Support custom input sequence numbers in transaction creation
- Implement test fixtures for both testnet and mock environments
- Add PSBT signing utilities for Schnorr and ECDSA signatures
- Extract common PSBT test configurations and parameters for improved code
  organization

Issue: BTC-1966