### PR TITLE
feat(utxo-staking): add utility function to force finalize PSBTs

### DIFF
--- a/modules/utxo-staking/src/babylon/delegationMessage.ts
+++ b/modules/utxo-staking/src/babylon/delegationMessage.ts
@@ -44,6 +44,19 @@ export function getSignedPsbt(
   return bitcoinjslib.Psbt.fromBuffer(Buffer.from(wrappedPsbt.serialize()));
 }
 
+/**
+ * Utility method to work around a bug in btc-staking-ts
+ * https://github.com/babylonlabs-io/btc-staking-ts/issues/71
+ * @param buffer
+ * @param network
+ */
+export function forceFinalizePsbt(buffer: Buffer, network: BabylonNetworkLike): bitcoinjslib.Psbt {
+  const psbt = bitcoinjslib.Psbt.fromBuffer(buffer, { network: toBitcoinJsNetwork(network) });
+  // this only works with certain bitcoinjslib versions
+  psbt.finalizeAllInputs();
+  return psbt;
+}
+
 export function getBtcProviderForECKey(
   descriptorBuilder: BabylonDescriptorBuilder,
   stakerKey: utxolib.ECPairInterface


### PR DESCRIPTION

Implement workaround for a bug in btc-staking-ts library where some PSBTs
cannot be properly finalized. This function helps finalize PSBTs that
would otherwise fail due to the issue tracked in babylonlabs-io/btc-staking-ts#71.

Issue: BTC-1966