### PR TITLE
fix(statics): correct assetids for sip10 tokens

### DIFF
--- a/modules/statics/src/coins/sip10Tokens.ts
+++ b/modules/statics/src/coins/sip10Tokens.ts
@@ -2,6 +2,11 @@ import { sip10Token, tsip10Token } from '../account';
 import { UnderlyingAsset } from '../base';
 import { STX_TOKEN_FEATURES } from '../coinFeatures';
 
+// SIP10 tokens' assetId can be obtained as follows:
+// assetId = contractId::tokenName
+// contractId is the contract field and can be obtained from the token contract on explorer
+// tokenName is the name defined in the SIP10 token contract source code. Search 'define-fungible-token'
+// in the contract source code to find the tokenName
 export const sip10Tokens = [
   sip10Token(
     '6157083d-e0b5-4a77-9ace-20c4b96af9ed',
@@ -17,7 +22,7 @@ export const sip10Tokens = [
     'stx:ststx',
     'stSTX',
     6,
-    'SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.ststx-token::ststx-token',
+    'SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.ststx-token::ststx',
     UnderlyingAsset['stx:ststx'],
     STX_TOKEN_FEATURES
   ),
@@ -26,7 +31,7 @@ export const sip10Tokens = [
     'stx:alex',
     'Alex Labs',
     8,
-    'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.token-alex::token-alex',
+    'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.token-alex::alex',
     UnderlyingAsset['stx:alex'],
     STX_TOKEN_FEATURES
   ),
@@ -35,7 +40,7 @@ export const sip10Tokens = [
     'stx:aeusdc',
     'Allbridge Bridged USDC',
     6,
-    'SP3Y2ZSH8P7D50B0VBTSX11S7XSG24M1VB9YFQA4K.token-aeusdc::token-aeusdc',
+    'SP3Y2ZSH8P7D50B0VBTSX11S7XSG24M1VB9YFQA4K.token-aeusdc::aeUSDC',
     UnderlyingAsset['stx:aeusdc'],
     STX_TOKEN_FEATURES
   ),
@@ -44,7 +49,7 @@ export const sip10Tokens = [
     'stx:susdh',
     'sUSDH',
     6,
-    'SPN5AKG35QZSK2M8GAMR4AFX45659RJHDW353HSG.susdh-token-v1::susdh-token-v1',
+    'SPN5AKG35QZSK2M8GAMR4AFX45659RJHDW353HSG.susdh-token-v1::susdh',
     UnderlyingAsset['stx:susdh'],
     STX_TOKEN_FEATURES
   ),
@@ -53,7 +58,7 @@ export const sip10Tokens = [
     'stx:usdh',
     'USDH',
     8,
-    'SPN5AKG35QZSK2M8GAMR4AFX45659RJHDW353HSG.usdh-token-v1::usdh-token-v1',
+    'SPN5AKG35QZSK2M8GAMR4AFX45659RJHDW353HSG.usdh-token-v1::usdh',
     UnderlyingAsset['stx:usdh'],
     STX_TOKEN_FEATURES
   ),
@@ -62,7 +67,7 @@ export const sip10Tokens = [
     'stx:welsh',
     'Welshcorgicoin',
     6,
-    'SP3NE50GEXFG9SZGTT51P40X2CKYSZ5CC4ZTZ7A2G.welshcorgicoin-token::welshcorgicoin-token',
+    'SP3NE50GEXFG9SZGTT51P40X2CKYSZ5CC4ZTZ7A2G.welshcorgicoin-token::welshcorgicoin',
     UnderlyingAsset['stx:welsh'],
     STX_TOKEN_FEATURES
   ),


### PR DESCRIPTION
This Pr corrects the assetIds for sip10 tokens. 

COIN-3829
TICKET: COIN-3829

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
