### PR TITLE
feat: get max spendable given unspent ids

### DIFF
--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -323,6 +323,7 @@ export interface UnspentsOptions extends PaginationOptions {
   target?: number | string;
   segwit?: boolean;
   chains?: number[];
+  unspentIds?: string[];
 }
 
 export interface ManageUnspentReservationOptions {

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -641,6 +641,7 @@ export class Wallet implements IWallet {
       'prevId',
       'segwit',
       'target',
+      'unspentIds',
     ]);
 
     return this.bitgo.get(this.url('/unspents')).query(query).result();


### PR DESCRIPTION
Add support to get the maximum spendable in a transaction given a set of unspent ids.

Ticket: BTC-2052