### PR TITLE
feat(utxo-staking): implement ECDSA support for Babylon BTC staking

### DIFF
--- a/modules/babylonlabs-io-btc-staking-ts/src/staking/manager.ts
+++ b/modules/babylonlabs-io-btc-staking-ts/src/staking/manager.ts
@@ -93,10 +93,10 @@ interface InclusionProof {
 }
 
 export class BabylonBtcStakingManager {
-  private stakingParams: VersionedStakingParams[];
-  private btcProvider: BtcProvider;
-  private network: networks.Network;
-  private babylonProvider: BabylonProvider;
+  protected stakingParams: VersionedStakingParams[];
+  protected btcProvider: BtcProvider;
+  protected network: networks.Network;
+  protected babylonProvider: BabylonProvider;
 
   constructor(
     network: networks.Network,
@@ -624,7 +624,8 @@ export class BabylonBtcStakingManager {
 
   /**
    * Creates a proof of possession for the staker based on ECDSA signature.
-   * @param bech32Address - The staker's bech32 address.
+   * @param bech32Address - The staker's bech32 address on the babylon chain
+   * @param stakerBtcAddress - The staker's BTC address.
    * @returns The proof of possession.
    */
   async createProofOfPossession(

--- a/modules/utxo-staking/src/babylon/stakingManager.ts
+++ b/modules/utxo-staking/src/babylon/stakingManager.ts
@@ -1,8 +1,80 @@
 import * as bitcoinjslib from 'bitcoinjs-lib';
 import * as utxolib from '@bitgo/utxo-lib';
 import * as vendor from '@bitgo/babylonlabs-io-btc-staking-ts';
+import {
+  BIP322Sig,
+  BTCSigType,
+  ProofOfPossessionBTC,
+} from '@babylonlabs-io/babylon-proto-ts/dist/generated/babylon/btcstaking/v1/pop';
 
 import { getStakingParams } from './stakingParams';
+
+/**
+ * Subclass of BabylonBtcStakingManager with the sole purpose of forcing
+ * a ECDSA signature.
+ */
+class BitGoStakingManager extends vendor.BabylonBtcStakingManager {
+  constructor(
+    network: bitcoinjslib.Network,
+    stakingParams: vendor.VersionedStakingParams[],
+    btcProvider: vendor.BtcProvider,
+    babylonProvider: vendor.BabylonProvider
+  ) {
+    super(network, stakingParams, btcProvider, babylonProvider);
+  }
+
+  /**
+   * Creates a proof of possession for the staker based on ECDSA signature.
+   *
+   * This is a parameterized version of the superclass method which infers
+   * the signature type from the stakerBtcAddress.
+   *
+   * @param bech32Address - The staker's bech32 address on the babylon network.
+   * @param stakerBtcAddress - The staker's BTC address.
+   * @param sigType - The signature type (BIP322 or ECDSA).
+   * @returns The proof of possession.
+   */
+  async createProofOfPossessionWithSigType(
+    bech32Address: string,
+    stakerBtcAddress: string,
+    sigType: BTCSigType
+  ): Promise<ProofOfPossessionBTC> {
+    const signedBabylonAddress = await this.btcProvider.signMessage(
+      vendor.SigningStep.PROOF_OF_POSSESSION,
+      bech32Address,
+      sigType === BTCSigType.BIP322 ? 'bip322-simple' : 'ecdsa'
+    );
+
+    let btcSig: Uint8Array;
+    if (sigType === BTCSigType.BIP322) {
+      const bip322Sig = BIP322Sig.fromPartial({
+        address: stakerBtcAddress,
+        sig: Buffer.from(signedBabylonAddress, 'base64'),
+      });
+      // Encode the BIP322 protobuf message to a Uint8Array
+      btcSig = BIP322Sig.encode(bip322Sig).finish();
+    } else {
+      // Encode the ECDSA signature to a Uint8Array
+      btcSig = Buffer.from(signedBabylonAddress, 'base64');
+    }
+
+    return {
+      btcSigType: sigType,
+      btcSig,
+    };
+  }
+
+  /**
+   * Creates a proof of possession for the staker based on ECDSA signature.
+   * @param bech32Address - The staker's bech32 address on the babylon network.
+   * @param stakerBtcAddress
+   * @returns The proof of possession.
+   */
+  async createProofOfPossession(bech32Address: string, stakerBtcAddress: string): Promise<ProofOfPossessionBTC> {
+    // force the ECDSA signature type
+    return this.createProofOfPossessionWithSigType(bech32Address, stakerBtcAddress, BTCSigType.ECDSA);
+  }
+}
 
 export const mockBabylonProvider: vendor.BabylonProvider = {
   signTransaction(): Promise<Uint8Array> {
@@ -31,10 +103,5 @@ export function createStakingManager(
         throw new Error('Unsupported network');
     }
   }
-  return new vendor.BabylonBtcStakingManager(
-    network,
-    stakingParams ?? getStakingParams(network),
-    btcProvider,
-    babylonProvider
-  );
+  return new BitGoStakingManager(network, stakingParams ?? getStakingParams(network), btcProvider, babylonProvider);
 }


### PR DESCRIPTION

This PR adds ECDSA signature support for Babylon BTC staking to maintain
compatibility with existing wallet functionality. The changes include:

- Create BitGoStakingManager class extending BabylonBtcStakingManager to
  use ECDSA signatures instead of BIP322
- Change class fields from private to protected in BabylonBtcStakingManager
  to enable proper inheritance
- Add proper base64 and hex string handling for Babylon protocol signatures
- Improve documentation for the createProofOfPossession method

Related: BTC-2032, BTC-2079