### PR TITLE
fix(sdk-coin-sol): amend recipients type to match what WP is sending

### DIFF
--- a/modules/sdk-coin-sol/package.json
+++ b/modules/sdk-coin-sol/package.json
@@ -43,7 +43,6 @@
     "@bitgo/sdk-core": "^32.2.0",
     "@bitgo/sdk-lib-mpc": "^10.2.0",
     "@bitgo/statics": "^51.8.0",
-    "@bitgo/public-types": "4.28.1",
     "@solana/spl-token": "0.3.1",
     "@solana/web3.js": "1.92.1",
     "bignumber.js": "^9.0.0",

--- a/modules/sdk-coin-sol/src/lib/iface.ts
+++ b/modules/sdk-coin-sol/src/lib/iface.ts
@@ -1,8 +1,7 @@
-import { TransactionExplanation as BaseTransactionExplanation } from '@bitgo/sdk-core';
+import { TransactionExplanation as BaseTransactionExplanation, Recipient } from '@bitgo/sdk-core';
 import { DecodedCloseAccountInstruction } from '@solana/spl-token';
 import { Blockhash, StakeInstructionType, SystemInstructionType, TransactionSignature } from '@solana/web3.js';
 import { InstructionBuilderTypes } from './constants';
-import { RecipientEntry } from '@bitgo/public-types';
 
 // TODO(STLX-9890): Add the interfaces for validityWindow and SequenceId
 export interface SolanaKeys {
@@ -100,7 +99,7 @@ export interface StakingDeactivate {
     amount?: string;
     unstakingAddress?: string;
     isMarinade?: boolean;
-    recipients?: RecipientEntry[];
+    recipients?: Recipient[];
   };
 }
 

--- a/modules/sdk-coin-sol/src/lib/instructionParamsFactory.ts
+++ b/modules/sdk-coin-sol/src/lib/instructionParamsFactory.ts
@@ -16,8 +16,6 @@ import {
   ComputeBudgetInstruction,
 } from '@solana/web3.js';
 
-import { RecipientEntry } from '@bitgo/public-types';
-
 import { NotSupported, TransactionType } from '@bitgo/sdk-core';
 import { coins, SolCoin } from '@bitgo/statics';
 import assert from 'assert';
@@ -474,17 +472,12 @@ function parseStakingDeactivateInstructions(
         isMarinade: unstakingInstruction.deactivate === undefined,
         recipients:
           unstakingInstruction.deactivate === undefined
-            ? ([
+            ? [
                 {
-                  address: {
-                    address: unstakingInstruction.transfer?.toPubkey.toString(),
-                  },
-                  amount: {
-                    value: unstakingInstruction.transfer?.lamports.toString(),
-                    symbol: coinName,
-                  },
+                  address: unstakingInstruction.transfer?.toPubkey.toString() || '',
+                  amount: unstakingInstruction.transfer?.lamports.toString() || '',
                 },
-              ] as RecipientEntry[])
+              ]
             : undefined,
       },
     };

--- a/modules/sdk-coin-sol/src/lib/solInstructionFactory.ts
+++ b/modules/sdk-coin-sol/src/lib/solInstructionFactory.ts
@@ -253,11 +253,11 @@ function stakingDeactivateInstruction(data: StakingDeactivate): TransactionInstr
   if (isMarinade) {
     const tx = new Transaction();
     assert(recipients, 'Missing recipients param');
-    const toPubkeyAddress = new PublicKey(recipients[0].address.address || '');
+    const toPubkeyAddress = new PublicKey(recipients[0].address || '');
     const transferInstruction = SystemProgram.transfer({
       fromPubkey: new PublicKey(fromAddress),
       toPubkey: toPubkeyAddress,
-      lamports: parseInt(recipients[0].amount.value, 10),
+      lamports: parseInt(recipients[0].amount, 10),
     });
 
     tx.add(transferInstruction);

--- a/modules/sdk-coin-sol/src/lib/stakingDeactivateBuilder.ts
+++ b/modules/sdk-coin-sol/src/lib/stakingDeactivateBuilder.ts
@@ -1,13 +1,12 @@
 import { BaseCoin as CoinConfig } from '@bitgo/statics';
 import assert from 'assert';
 
-import { BuildTransactionError, TransactionType } from '@bitgo/sdk-core';
+import { BuildTransactionError, Recipient, TransactionType } from '@bitgo/sdk-core';
 import { InstructionBuilderTypes, STAKE_ACCOUNT_RENT_EXEMPT_AMOUNT } from './constants';
 import { StakingDeactivate, Transfer } from './iface';
 import { Transaction } from './transaction';
 import { TransactionBuilder } from './transactionBuilder';
 import { isValidStakingAmount, validateAddress } from './utils';
-import { RecipientEntry } from '@bitgo/public-types';
 
 export class StakingDeactivateBuilder extends TransactionBuilder {
   protected _stakingAddress: string;
@@ -15,7 +14,7 @@ export class StakingDeactivateBuilder extends TransactionBuilder {
   protected _amount?: string;
   protected _unstakingAddress: string;
   protected _isMarinade = false;
-  protected _recipients: RecipientEntry[];
+  protected _recipients: Recipient[];
 
   constructor(_coinConfig: Readonly<CoinConfig>) {
     super(_coinConfig);
@@ -108,7 +107,7 @@ export class StakingDeactivateBuilder extends TransactionBuilder {
    * @param recipients RecipientEntry[] - The recipients object
    * @returns {StakingDeactivateBuilder} This staking builder.
    */
-  recipients(recipients: RecipientEntry[]): this {
+  recipients(recipients: Recipient[]): this {
     this._recipients = recipients;
     return this;
   }

--- a/modules/sdk-coin-sol/test/unit/transactionBuilder/stakingDeactivateBuilder.ts
+++ b/modules/sdk-coin-sol/test/unit/transactionBuilder/stakingDeactivateBuilder.ts
@@ -3,9 +3,8 @@ import should from 'should';
 import { getBuilderFactory } from '../getBuilderFactory';
 import { KeyPair, Utils } from '../../../src';
 import * as testData from '../../resources/sol';
-import { TransactionType } from '@bitgo/sdk-core';
+import { Recipient, TransactionType } from '@bitgo/sdk-core';
 import * as bs58 from 'bs58';
-import { RecipientEntry } from '@bitgo/public-types';
 
 describe('Sol Staking Deactivate Builder', () => {
   const factory = getBuilderFactory('tsol');
@@ -18,15 +17,10 @@ describe('Sol Staking Deactivate Builder', () => {
   const invalidPubKey = testData.pubKeys.invalidPubKeys[0];
 
   describe('Should succeed', () => {
-    const marinadeRecipientsObject: RecipientEntry[] = [];
+    const marinadeRecipientsObject: Recipient[] = [];
     marinadeRecipientsObject.push({
-      address: {
-        address: 'opNS8ENpEMWdXcJUgJCsJTDp7arTXayoBEeBUg6UezP',
-      },
-      amount: {
-        value: '2300000',
-        symbol: 'tsol',
-      },
+      address: 'opNS8ENpEMWdXcJUgJCsJTDp7arTXayoBEeBUg6UezP',
+      amount: '2300000',
     });
     const marinadeMemo = `{\\"PrepareForRevoke\\":{\\"user\\":\\"${wallet.pub}}\\",\\"amount\\":\\"500000000000\\"}`;
 


### PR DESCRIPTION
Ticket: SC-1660


Since WP is sending recipients object with just address and amount, replacing recipients in marinade unstake flow to also accept the same


