### PR TITLE
fix: add alias for algo testnet tokens

### DIFF
--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -2060,7 +2060,7 @@ export const coins = CoinMap.fromCoins([
   talgoToken(
     '0e20b757-3e62-4400-887d-caff117481c8',
     'talgo:USDC-10458941',
-    undefined,
+    'talgo:10458941',
     'USDC',
     6,
     UnderlyingAsset['talgo:USDC-10458941'],
@@ -2071,7 +2071,7 @@ export const coins = CoinMap.fromCoins([
   talgoToken(
     'dd48a295-4f59-4a36-bc40-801998b9ff90',
     'talgo:USDt-180447',
-    undefined,
+    'talgo:180447',
     'Testnet Algorand USDT',
     6,
     UnderlyingAsset['talgo:USDt-180447'],
@@ -2082,7 +2082,7 @@ export const coins = CoinMap.fromCoins([
   talgoToken(
     '3cfccea1-9946-4de1-abe2-f9ab6411a14b',
     'talgo:USON-16026728',
-    undefined,
+    'talgo:16026728',
     'Unison',
     2,
     UnderlyingAsset['talgo:USON-16026728'],
@@ -2093,7 +2093,7 @@ export const coins = CoinMap.fromCoins([
   talgoToken(
     '02f2ed81-83ba-4c6c-931e-2ce1aacfd57f',
     'talgo:SPRW-16026732',
-    undefined,
+    'talgo:16026732',
     'Sparrow',
     4,
     UnderlyingAsset['talgo:SPRW-16026732'],
@@ -2104,7 +2104,7 @@ export const coins = CoinMap.fromCoins([
   talgoToken(
     '0c642b43-157a-475b-b6dc-d20ae76c71fc',
     'talgo:KAL-16026733',
-    undefined,
+    'talgo:16026733',
     'Kalki',
     8,
     UnderlyingAsset['talgo:KAL-16026733'],
@@ -2115,7 +2115,7 @@ export const coins = CoinMap.fromCoins([
   talgoToken(
     '857994b1-3198-4649-a7a0-724a8620eb67',
     'talgo:JPT-162085446',
-    undefined,
+    'talgo:162085446',
     'JPT',
     6,
     UnderlyingAsset['talgo:JPT-162085446'],


### PR DESCRIPTION
TICKET: COIN-3859


Adding alias to algo tesnet tokens so that they don't error out in OVC while signing and dont throw the error 
`Error: coin 'talgo:10458941' is not defined`
<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
