### PR TITLE
feat(utxo-staking): add test case demonstrating bug and extend test

### DIFF
--- a/modules/utxo-staking/src/babylon/delegationMessage.ts
+++ b/modules/utxo-staking/src/babylon/delegationMessage.ts
@@ -80,11 +80,20 @@ export function getSignedPsbt(
 /**
  * Utility method to work around a bug in btc-staking-ts
  * https://github.com/babylonlabs-io/btc-staking-ts/issues/71
- * @param buffer
+ * @param v
  * @param network
  */
-export function forceFinalizePsbt(buffer: Buffer, network: BabylonNetworkLike): bitcoinjslib.Psbt {
-  const psbt = bitcoinjslib.Psbt.fromBuffer(buffer, { network: toBitcoinJsNetwork(network) });
+export function forceFinalizePsbt(
+  v: Buffer | utxolib.Psbt | bitcoinjslib.Psbt,
+  network: BabylonNetworkLike
+): bitcoinjslib.Psbt {
+  if (v instanceof utxolib.Psbt) {
+    v = v.toBuffer();
+  }
+  if (v instanceof bitcoinjslib.Psbt) {
+    v = v.toBuffer();
+  }
+  const psbt = bitcoinjslib.Psbt.fromBuffer(v, { network: toBitcoinJsNetwork(network) });
   // this only works with certain bitcoinjslib versions
   psbt.finalizeAllInputs();
   return psbt;

--- a/modules/utxo-staking/test/fixtures/babylon/txTree.testnet.json
+++ b/modules/utxo-staking/test/fixtures/babylon/txTree.testnet.json
@@ -208,6 +208,58 @@
     },
     "fee": 5000
   },
+  "unbondingSlashingWithdraw": {
+    "psbt": {
+      "data": {
+        "inputs": [
+          {
+            "witnessUtxo": {
+              "script": "5120d5238530e223ef1bd34a8a98ee1708f6a8a87e7a2589d88de6700b9973ffff46",
+              "value": "45877"
+            },
+            "tapLeafScript": [
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "script": "207b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9ad02f003b2",
+                "leafVersion": 192
+              }
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
+          }
+        ],
+        "outputs": [
+          {}
+        ],
+        "globalMap": {
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "ab10f226d4f6daeff01e35db4c3c643ba40ae3f29654a44543dc9e97907b991d",
+                  "index": 1,
+                  "script": "",
+                  "sequence": 1008,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "45589",
+                  "script": "0014896f1ba65deaeb045bb3121e20e5744e66ca0e48"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "opts": {
+        "maximumFeeRate": 5000
+      }
+    },
+    "fee": 288
+  },
   "slashing": {
     "psbt": {
       "data": {
@@ -264,5 +316,247 @@
       }
     },
     "fee": 5000
+  },
+  "slashingSigned": {
+    "data": {
+      "inputs": [
+        {
+          "witnessUtxo": {
+            "script": "5120f1871fc2ac3050b53dc35d502a9d94388f6f373b86f3905667945a8430cbd639",
+            "value": "55555"
+          },
+          "tapScriptSig": [
+            {
+              "pubkey": "7b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9",
+              "leafHash": "1e1d2e84c4fc6bdddf3b8018065cf5ca8405988579188585f382c51c088e8826",
+              "signature": "e8e6b9136f3b31b4fed1415a1585b7a9f15b7240d249e571ed406859d7e8a5008630ccc654ef12e8e94debc2d05c1453afebfd11db1ace01532c953ccc6390a5"
+            },
+            {
+              "pubkey": "7b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9",
+              "leafHash": "3c94ea257732e1d9a5bd5506675d0f8922399c029ae30b092c89b4ddd0509c72",
+              "signature": "7beed0b03727930001ae89709ce8cdb4fe1403f31343d5f4a053228b8ee5cb96c67308882eec95e7eb52d8c86ecfd34860c0e8b4f6e7f9b02e959e87202f88b8"
+            },
+            {
+              "pubkey": "7b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9",
+              "leafHash": "96962cb69242e00941e0a6197b7ecdb83ab8bb0490dbfd23fa4b8d26b75989eb",
+              "signature": "3da4c633225c7cc2f5b2db78f9126be6f896c8f8facb4e8a8358194fb4c24abaa6e799923d1fe6b607aafc5e45a9b7a18937e3d1231a7dcbfc199df325299e37"
+            }
+          ],
+          "tapLeafScript": [
+            {
+              "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac01e1d2e84c4fc6bdddf3b8018065cf5ca8405988579188585f382c51c088e882696962cb69242e00941e0a6197b7ecdb83ab8bb0490dbfd23fa4b8d26b75989eb",
+              "script": "207b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9ad021027b2",
+              "leafVersion": 192
+            },
+            {
+              "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac03c94ea257732e1d9a5bd5506675d0f8922399c029ae30b092c89b4ddd0509c7296962cb69242e00941e0a6197b7ecdb83ab8bb0490dbfd23fa4b8d26b75989eb",
+              "script": "207b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9ad200aee0509b16db71c999238a4827db945526859b13c95487ab46725357c9a9f25ac20113c3a32a9d320b72190a04a020a0db3976ef36972673258e9a38a364f3dc3b0ba2017921cf156ccb4e73d428f996ed11b245313e37e27c978ac4d2cc21eca4672e4ba203bb93dfc8b61887d771f3630e9a63e97cbafcfcc78556a474df83a31a0ef899cba2040afaf47c4ffa56de86410d8e47baa2bb6f04b604f4ea24323737ddc3fe092dfba2079a71ffd71c503ef2e2f91bccfc8fcda7946f4653cef0d9f3dde20795ef3b9f0ba20d21faf78c6751a0d38e6bd8028b907ff07e9a869a43fc837d6b3f8dff6119a36ba20f5199efae3f28bb82476163a7e458c7ad445d9bffb0682d10d3bdb2cb41f8e8eba20fa9d882d45f4060bdb8042183828cd87544f1ea997380e586cab77d5fd698737ba569c",
+              "leafVersion": 192
+            },
+            {
+              "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0407e9ef753fc7908376c525371a0e4be9fcd492d714118e5917a5512a697bc6d",
+              "script": "207b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9ad20d23c2c25e1fcf8fd1c21b9a402c19e2e309e531e45e92fb1e9805b6056b0cc76ad200aee0509b16db71c999238a4827db945526859b13c95487ab46725357c9a9f25ac20113c3a32a9d320b72190a04a020a0db3976ef36972673258e9a38a364f3dc3b0ba2017921cf156ccb4e73d428f996ed11b245313e37e27c978ac4d2cc21eca4672e4ba203bb93dfc8b61887d771f3630e9a63e97cbafcfcc78556a474df83a31a0ef899cba2040afaf47c4ffa56de86410d8e47baa2bb6f04b604f4ea24323737ddc3fe092dfba2079a71ffd71c503ef2e2f91bccfc8fcda7946f4653cef0d9f3dde20795ef3b9f0ba20d21faf78c6751a0d38e6bd8028b907ff07e9a869a43fc837d6b3f8dff6119a36ba20f5199efae3f28bb82476163a7e458c7ad445d9bffb0682d10d3bdb2cb41f8e8eba20fa9d882d45f4060bdb8042183828cd87544f1ea997380e586cab77d5fd698737ba569c",
+              "leafVersion": 192
+            }
+          ],
+          "tapBip32Derivation": [
+            {
+              "masterFingerprint": "371c45ae",
+              "pubkey": "0aee0509b16db71c999238a4827db945526859b13c95487ab46725357c9a9f25",
+              "path": "m",
+              "leafHashes": [
+                "1e1d2e84c4fc6bdddf3b8018065cf5ca8405988579188585f382c51c088e8826",
+                "96962cb69242e00941e0a6197b7ecdb83ab8bb0490dbfd23fa4b8d26b75989eb"
+              ]
+            },
+            {
+              "masterFingerprint": "a1792bd2",
+              "pubkey": "113c3a32a9d320b72190a04a020a0db3976ef36972673258e9a38a364f3dc3b0",
+              "path": "m",
+              "leafHashes": [
+                "1e1d2e84c4fc6bdddf3b8018065cf5ca8405988579188585f382c51c088e8826",
+                "96962cb69242e00941e0a6197b7ecdb83ab8bb0490dbfd23fa4b8d26b75989eb"
+              ]
+            },
+            {
+              "masterFingerprint": "875d22c4",
+              "pubkey": "17921cf156ccb4e73d428f996ed11b245313e37e27c978ac4d2cc21eca4672e4",
+              "path": "m",
+              "leafHashes": [
+                "1e1d2e84c4fc6bdddf3b8018065cf5ca8405988579188585f382c51c088e8826",
+                "96962cb69242e00941e0a6197b7ecdb83ab8bb0490dbfd23fa4b8d26b75989eb"
+              ]
+            },
+            {
+              "masterFingerprint": "214f19d7",
+              "pubkey": "3bb93dfc8b61887d771f3630e9a63e97cbafcfcc78556a474df83a31a0ef899c",
+              "path": "m",
+              "leafHashes": [
+                "1e1d2e84c4fc6bdddf3b8018065cf5ca8405988579188585f382c51c088e8826",
+                "96962cb69242e00941e0a6197b7ecdb83ab8bb0490dbfd23fa4b8d26b75989eb"
+              ]
+            },
+            {
+              "masterFingerprint": "4f70e9ab",
+              "pubkey": "40afaf47c4ffa56de86410d8e47baa2bb6f04b604f4ea24323737ddc3fe092df",
+              "path": "m",
+              "leafHashes": [
+                "1e1d2e84c4fc6bdddf3b8018065cf5ca8405988579188585f382c51c088e8826",
+                "96962cb69242e00941e0a6197b7ecdb83ab8bb0490dbfd23fa4b8d26b75989eb"
+              ]
+            },
+            {
+              "masterFingerprint": "f4ac30dd",
+              "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+              "path": "m",
+              "leafHashes": []
+            },
+            {
+              "masterFingerprint": "dee7f865",
+              "pubkey": "79a71ffd71c503ef2e2f91bccfc8fcda7946f4653cef0d9f3dde20795ef3b9f0",
+              "path": "m",
+              "leafHashes": [
+                "1e1d2e84c4fc6bdddf3b8018065cf5ca8405988579188585f382c51c088e8826",
+                "96962cb69242e00941e0a6197b7ecdb83ab8bb0490dbfd23fa4b8d26b75989eb"
+              ]
+            },
+            {
+              "masterFingerprint": "b91e1e67",
+              "pubkey": "7b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9",
+              "path": "m",
+              "leafHashes": [
+                "1e1d2e84c4fc6bdddf3b8018065cf5ca8405988579188585f382c51c088e8826",
+                "3c94ea257732e1d9a5bd5506675d0f8922399c029ae30b092c89b4ddd0509c72",
+                "96962cb69242e00941e0a6197b7ecdb83ab8bb0490dbfd23fa4b8d26b75989eb"
+              ]
+            },
+            {
+              "masterFingerprint": "39d4ec55",
+              "pubkey": "d21faf78c6751a0d38e6bd8028b907ff07e9a869a43fc837d6b3f8dff6119a36",
+              "path": "m",
+              "leafHashes": [
+                "1e1d2e84c4fc6bdddf3b8018065cf5ca8405988579188585f382c51c088e8826",
+                "96962cb69242e00941e0a6197b7ecdb83ab8bb0490dbfd23fa4b8d26b75989eb"
+              ]
+            },
+            {
+              "masterFingerprint": "6b139ea8",
+              "pubkey": "d23c2c25e1fcf8fd1c21b9a402c19e2e309e531e45e92fb1e9805b6056b0cc76",
+              "path": "m",
+              "leafHashes": [
+                "96962cb69242e00941e0a6197b7ecdb83ab8bb0490dbfd23fa4b8d26b75989eb"
+              ]
+            },
+            {
+              "masterFingerprint": "432bdb54",
+              "pubkey": "f5199efae3f28bb82476163a7e458c7ad445d9bffb0682d10d3bdb2cb41f8e8e",
+              "path": "m",
+              "leafHashes": [
+                "1e1d2e84c4fc6bdddf3b8018065cf5ca8405988579188585f382c51c088e8826",
+                "96962cb69242e00941e0a6197b7ecdb83ab8bb0490dbfd23fa4b8d26b75989eb"
+              ]
+            },
+            {
+              "masterFingerprint": "a5fa7460",
+              "pubkey": "fa9d882d45f4060bdb8042183828cd87544f1ea997380e586cab77d5fd698737",
+              "path": "m",
+              "leafHashes": [
+                "1e1d2e84c4fc6bdddf3b8018065cf5ca8405988579188585f382c51c088e8826",
+                "96962cb69242e00941e0a6197b7ecdb83ab8bb0490dbfd23fa4b8d26b75989eb"
+              ]
+            }
+          ],
+          "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+          "tapMerkleRoot": "c96e938ee6211a052efb0d15743f1a6ffbcdf4e57d72e66f780d38b739d9a961"
+        }
+      ],
+      "outputs": [
+        {},
+        {}
+      ],
+      "globalMap": {
+        "unsignedTx": {
+          "tx": {
+            "version": 2,
+            "locktime": 0,
+            "ins": [
+              {
+                "hash": "64da14050ffd0e6186c68a59f371a0adc95cc84b0502fe0915be7eba3f771bb3",
+                "index": 0,
+                "script": "",
+                "sequence": 4294967295,
+                "witness": []
+              }
+            ],
+            "outs": [
+              {
+                "value": "2778",
+                "script": "00145be12624d08a2b424095d7c07221c33450d14bf1"
+              },
+              {
+                "value": "47777",
+                "script": "5120d5238530e223ef1bd34a8a98ee1708f6a8a87e7a2589d88de6700b9973ffff46"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "opts": {
+      "maximumFeeRate": 5000
+    }
+  },
+  "slashingSignedBase64": "cHNidP8BAH0CAAAAAWTaFAUP/Q5hhsaKWfNxoK3JXMhLBQL+CRW+fro/dxuzAAAAAAD/////AtoKAAAAAAAAFgAUW+EmJNCKK0JAldfAciHDNFDRS/GhugAAAAAAACJRINUjhTDiI+8b00qKmO4XCPaoqH56JYnYjeZwC5lz//9GAAAAAAABASsD2QAAAAAAACJRIPGHH8KsMFC1PcNdUCqdlDiPbzc7hvOQVmeUWoQwy9Y5QRR7aghQTEYzb5haV4elQj6xjBCxSf7ynNMxathvVlzSuR4dLoTE/Gvd3zuAGAZc9cqEBZiFeRiFhfOCxRwIjogmQOjmuRNvOzG0/tFBWhWFt6nxW3JA0knlce1AaFnX6KUAhjDMxlTvEujpTevC0FwUU6/r/RHbGs4BUyyVPMxjkKVBFHtqCFBMRjNvmFpXh6VCPrGMELFJ/vKc0zFq2G9WXNK5PJTqJXcy4dmlvVUGZ10PiSI5nAKa4wsJLIm03dBQnHJAe+7QsDcnkwABrolwnOjNtP4UA/MTQ9X0oFMii47ly5bGcwiILuyV5+tS2Mhuz9NIYMDotPbn+bAulZ6HIC+IuEEUe2oIUExGM2+YWleHpUI+sYwQsUn+8pzTMWrYb1Zc0rmWliy2kkLgCUHgphl7fs24Ori7BJDb/SP6S40mt1mJ60A9pMYzIlx8wvWy23j5Emvm+JbI+PrLToqDWBlPtMJKuqbnmZI9H+a2B6r8XkWpt6GJN+PRIxp9y/wZnfMlKZ43YhXAUJKbdMGgSVS3i0tgNel6XgeKWg8o7JbVR7/ums6AOsAeHS6ExPxr3d87gBgGXPXKhAWYhXkYhYXzgsUcCI6IJpaWLLaSQuAJQeCmGXt+zbg6uLsEkNv9I/pLjSa3WYnrJyB7aghQTEYzb5haV4elQj6xjBCxSf7ynNMxathvVlzSua0CECeywGIVwFCSm3TBoElUt4tLYDXpel4HiloPKOyW1Ue/7prOgDrAPJTqJXcy4dmlvVUGZ10PiSI5nAKa4wsJLIm03dBQnHKWliy2kkLgCUHgphl7fs24Ori7BJDb/SP6S40mt1mJ6/1XASB7aghQTEYzb5haV4elQj6xjBCxSf7ynNMxathvVlzSua0gCu4FCbFttxyZkjikgn25RVJoWbE8lUh6tGclNXyanyWsIBE8OjKp0yC3IZCgSgIKDbOXbvNpcmcyWOmjijZPPcOwuiAXkhzxVsy05z1Cj5lu0RskUxPjfifJeKxNLMIeykZy5LogO7k9/IthiH13HzYw6aY+l8uvz8x4VWpHTfg6MaDviZy6IECvr0fE/6Vt6GQQ2OR7qiu28EtgT06iQyNzfdw/4JLfuiB5px/9ccUD7y4vkbzPyPzaeUb0ZTzvDZ893iB5XvO58Log0h+veMZ1Gg045r2AKLkH/wfpqGmkP8g31rP43/YRmja6IPUZnvrj8ou4JHYWOn5FjHrURdm/+waC0Q072yy0H46OuiD6nYgtRfQGC9uAQhg4KM2HVE8eqZc4Dlhsq3fV/WmHN7pWnMBCFcBQkpt0waBJVLeLS2A16XpeB4paDyjsltVHv+6azoA6wEB+nvdT/HkIN2xSU3Gg5L6fzUktcUEY5ZF6VRKml7xt/XkBIHtqCFBMRjNvmFpXh6VCPrGMELFJ/vKc0zFq2G9WXNK5rSDSPCwl4fz4/RwhuaQCwZ4uMJ5THkXpL7HpgFtgVrDMdq0gCu4FCbFttxyZkjikgn25RVJoWbE8lUh6tGclNXyanyWsIBE8OjKp0yC3IZCgSgIKDbOXbvNpcmcyWOmjijZPPcOwuiAXkhzxVsy05z1Cj5lu0RskUxPjfifJeKxNLMIeykZy5LogO7k9/IthiH13HzYw6aY+l8uvz8x4VWpHTfg6MaDviZy6IECvr0fE/6Vt6GQQ2OR7qiu28EtgT06iQyNzfdw/4JLfuiB5px/9ccUD7y4vkbzPyPzaeUb0ZTzvDZ893iB5XvO58Log0h+veMZ1Gg045r2AKLkH/wfpqGmkP8g31rP43/YRmja6IPUZnvrj8ou4JHYWOn5FjHrURdm/+waC0Q072yy0H46OuiD6nYgtRfQGC9uAQhg4KM2HVE8eqZc4Dlhsq3fV/WmHN7pWnMAhFgruBQmxbbccmZI4pIJ9uUVSaFmxPJVIerRnJTV8mp8lRQIeHS6ExPxr3d87gBgGXPXKhAWYhXkYhYXzgsUcCI6IJpaWLLaSQuAJQeCmGXt+zbg6uLsEkNv9I/pLjSa3WYnrNxxFriEWETw6MqnTILchkKBKAgoNs5du82lyZzJY6aOKNk89w7BFAh4dLoTE/Gvd3zuAGAZc9cqEBZiFeRiFhfOCxRwIjogmlpYstpJC4AlB4KYZe37NuDq4uwSQ2/0j+kuNJrdZieuheSvSIRYXkhzxVsy05z1Cj5lu0RskUxPjfifJeKxNLMIeykZy5EUCHh0uhMT8a93fO4AYBlz1yoQFmIV5GIWF84LFHAiOiCaWliy2kkLgCUHgphl7fs24Ori7BJDb/SP6S40mt1mJ64ddIsQhFju5PfyLYYh9dx82MOmmPpfLr8/MeFVqR034OjGg74mcRQIeHS6ExPxr3d87gBgGXPXKhAWYhXkYhYXzgsUcCI6IJpaWLLaSQuAJQeCmGXt+zbg6uLsEkNv9I/pLjSa3WYnrIU8Z1yEWQK+vR8T/pW3oZBDY5HuqK7bwS2BPTqJDI3N93D/gkt9FAh4dLoTE/Gvd3zuAGAZc9cqEBZiFeRiFhfOCxRwIjogmlpYstpJC4AlB4KYZe37NuDq4uwSQ2/0j+kuNJrdZietPcOmrIRZQkpt0waBJVLeLS2A16XpeB4paDyjsltVHv+6azoA6wAUA9Kww3SEWeacf/XHFA+8uL5G8z8j82nlG9GU87w2fPd4geV7zufBFAh4dLoTE/Gvd3zuAGAZc9cqEBZiFeRiFhfOCxRwIjogmlpYstpJC4AlB4KYZe37NuDq4uwSQ2/0j+kuNJrdZieve5/hlIRZ7aghQTEYzb5haV4elQj6xjBCxSf7ynNMxathvVlzSuWUDHh0uhMT8a93fO4AYBlz1yoQFmIV5GIWF84LFHAiOiCY8lOoldzLh2aW9VQZnXQ+JIjmcAprjCwksibTd0FCccpaWLLaSQuAJQeCmGXt+zbg6uLsEkNv9I/pLjSa3WYnruR4eZyEW0h+veMZ1Gg045r2AKLkH/wfpqGmkP8g31rP43/YRmjZFAh4dLoTE/Gvd3zuAGAZc9cqEBZiFeRiFhfOCxRwIjogmlpYstpJC4AlB4KYZe37NuDq4uwSQ2/0j+kuNJrdZies51OxVIRbSPCwl4fz4/RwhuaQCwZ4uMJ5THkXpL7HpgFtgVrDMdiUBlpYstpJC4AlB4KYZe37NuDq4uwSQ2/0j+kuNJrdZietrE56oIRb1GZ764/KLuCR2Fjp+RYx61EXZv/sGgtENO9sstB+OjkUCHh0uhMT8a93fO4AYBlz1yoQFmIV5GIWF84LFHAiOiCaWliy2kkLgCUHgphl7fs24Ori7BJDb/SP6S40mt1mJ60Mr21QhFvqdiC1F9AYL24BCGDgozYdUTx6plzgOWGyrd9X9aYc3RQIeHS6ExPxr3d87gBgGXPXKhAWYhXkYhYXzgsUcCI6IJpaWLLaSQuAJQeCmGXt+zbg6uLsEkNv9I/pLjSa3WYnrpfp0YAEXIFCSm3TBoElUt4tLYDXpel4HiloPKOyW1Ue/7prOgDrAARggyW6TjuYhGgUu+w0VdD8ab/vN9OV9cuZveA04tznZqWEAAAA=",
+  "slashingWithdraw": {
+    "psbt": {
+      "data": {
+        "inputs": [
+          {
+            "witnessUtxo": {
+              "script": "5120d5238530e223ef1bd34a8a98ee1708f6a8a87e7a2589d88de6700b9973ffff46",
+              "value": "47777"
+            },
+            "tapLeafScript": [
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "script": "207b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9ad02f003b2",
+                "leafVersion": 192
+              }
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
+          }
+        ],
+        "outputs": [
+          {}
+        ],
+        "globalMap": {
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "0808ac7143d68ebfd3d8d841cdd3cf9b9da85f8ee47b77260fd44dd2c2a4bda9",
+                  "index": 1,
+                  "script": "",
+                  "sequence": 1008,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "47489",
+                  "script": "0014896f1ba65deaeb045bb3121e20e5744e66ca0e48"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "opts": {
+        "maximumFeeRate": 5000
+      }
+    },
+    "fee": 288
   }
 }

--- a/modules/utxo-staking/test/fixtures/babylon/txTree.testnetMock.json
+++ b/modules/utxo-staking/test/fixtures/babylon/txTree.testnetMock.json
@@ -317,6 +317,291 @@
     },
     "fee": 5000
   },
+  "slashingSigned": {
+    "data": {
+      "inputs": [
+        {
+          "witnessUtxo": {
+            "script": "5120788d73d75d7dd88d3612f7a91d5b3d6ad4778d8b49176f9539d322980b2f4fd7",
+            "value": "55555"
+          },
+          "tapScriptSig": [
+            {
+              "pubkey": "04e2b2468fe224659eb9dc5bd0a9cc1b4878b64f40c67c951610320bce78dfd1",
+              "leafHash": "68cc9790c0627bc8f28afd009b31974a2fce5ea4fe2ed4dd8b65c8feda196875",
+              "signature": "bcb04e121f71527330c6c2bfd856f3c5d0022cf4a99faa66bb92c53ada0ab4988ae46f343c34bc448cd0ac7b56405af44cb4159785663b6f87ea456a020af779"
+            },
+            {
+              "pubkey": "04e2b2468fe224659eb9dc5bd0a9cc1b4878b64f40c67c951610320bce78dfd1",
+              "leafHash": "c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552",
+              "signature": "d49f2097a9e1bce2c08cc932c64fd81116fc17ff3df77270e36109988ea804bc9a26a1d447dcf86592a479325a0dd0b86d1e4562f5f72b14581710887c3740d2"
+            },
+            {
+              "pubkey": "2f3432bf9054e482041b890e084bc1a34cfbc0b63aded113bfa36b6f2402832b",
+              "leafHash": "68cc9790c0627bc8f28afd009b31974a2fce5ea4fe2ed4dd8b65c8feda196875",
+              "signature": "b050fa12eb59c84a7a1ab9185e8ab93940334b6c2977ee720f34c84685a33079705a8c044ee63e52040907953c3720645570700a80f6656d84fd65a364d0a13a"
+            },
+            {
+              "pubkey": "2f3432bf9054e482041b890e084bc1a34cfbc0b63aded113bfa36b6f2402832b",
+              "leafHash": "c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552",
+              "signature": "26f93f4a8e11a68c7f8b479e6587027bfb75a0e81583efb3cd6a550317b7cb6d805065ac106c07c3276bface6c08c5c513c7b6422df36e3c07c9b735daa3d8b1"
+            },
+            {
+              "pubkey": "4d7e91e4a0ab0526a387684db1628b535e6b66046aaa7d1b583b93c5a16e1ac7",
+              "leafHash": "68cc9790c0627bc8f28afd009b31974a2fce5ea4fe2ed4dd8b65c8feda196875",
+              "signature": "50cc2ed411a1a4f9bc3956881b044e1c1cf3b1cbd0444e59be47e2a0f3e8e96eababc77ad1f92b3f933442cd4efe7570403fda6ac0b5b127c5f37cd4b6dcc733"
+            },
+            {
+              "pubkey": "4d7e91e4a0ab0526a387684db1628b535e6b66046aaa7d1b583b93c5a16e1ac7",
+              "leafHash": "c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552",
+              "signature": "84d24addce841f6f04f19b80afd88ae20d8896f507696997d19a0d41651b52526ff553d7337d5d6010fa31761a153d5dd1e67325cc0cd8de7ff90edf2eb143b4"
+            },
+            {
+              "pubkey": "5e14742c0943fa66799f699a0ef98cf2b7cd223ddbb61f6878999182bbcc4700",
+              "leafHash": "68cc9790c0627bc8f28afd009b31974a2fce5ea4fe2ed4dd8b65c8feda196875",
+              "signature": "46b227a3ef58f6d0f9f4d0bdb19179a6bb52435a07f127cf93ebac7b14e592de58d8ed57823e55ac12dc66d8f4984b0da68054f9995f2c1ddd80893ba6bc143f"
+            },
+            {
+              "pubkey": "5e14742c0943fa66799f699a0ef98cf2b7cd223ddbb61f6878999182bbcc4700",
+              "leafHash": "c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552",
+              "signature": "a784fc28d533862888aecc8dd743d1fbc9abe56c6d96bebb79af241a7d777897a336f8587c0abd08ebce7edd798df2cadd6891c77843a5303715d20bf2b5e6a8"
+            },
+            {
+              "pubkey": "64d55d591c5d416f713df9e15afd32e9ff2441cf276b2f90e5b3085163ca7a6b",
+              "leafHash": "68cc9790c0627bc8f28afd009b31974a2fce5ea4fe2ed4dd8b65c8feda196875",
+              "signature": "a4279321ea1a6c3c54daa685a7cfbe5a212458490ce107e247d97d356b6fffbed49b8aa5b2899e34107ee107694d5bacf70109b8bb52e640b83431e2075b3da5"
+            },
+            {
+              "pubkey": "64d55d591c5d416f713df9e15afd32e9ff2441cf276b2f90e5b3085163ca7a6b",
+              "leafHash": "c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552",
+              "signature": "ec56549435ccd8f12762c1fd5169d29e05f398633d3d4246adee2791bbed3c5bb4cb1706a9056950295cabe47c808b9a473f3dc96fecf7191a2f5fd109f75a60"
+            },
+            {
+              "pubkey": "6672282496e17eccaae560aac4d9fe85d8c166a4aa43f51fa8963c80a165831f",
+              "leafHash": "68cc9790c0627bc8f28afd009b31974a2fce5ea4fe2ed4dd8b65c8feda196875",
+              "signature": "a656de3371367670f89842ae8e0041ff193f6d439be9c7c38055b3f9658ea1035dbddfba4424a58b3b9b114eb8fb29c45711e9aaa0867fbefbcd384f73163963"
+            },
+            {
+              "pubkey": "6672282496e17eccaae560aac4d9fe85d8c166a4aa43f51fa8963c80a165831f",
+              "leafHash": "c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552",
+              "signature": "c7d01b2152c82787d079be4c7dd4a45da058d7dd5c7387efa21446ab3bd5916b8588f39fc39c8ed7c97530442f02c0fe9e9d9dddf2e4c5904c083c503d90a22f"
+            },
+            {
+              "pubkey": "7939bcf0084cff0fe5c88a1748c1d97d63ff9ae6423a98dca65d974bb9123ce0",
+              "leafHash": "68cc9790c0627bc8f28afd009b31974a2fce5ea4fe2ed4dd8b65c8feda196875",
+              "signature": "79c3990b4e80d346883e68942a8f8e08c934756b2d9f754f33c6209389b537590ba3eb1205567fb76c6bd63a574baef360037bf13d1d014c38b235f1170e0c39"
+            },
+            {
+              "pubkey": "7939bcf0084cff0fe5c88a1748c1d97d63ff9ae6423a98dca65d974bb9123ce0",
+              "leafHash": "c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552",
+              "signature": "0fdcc04f340d7b573e2afffcd99207bf5db30cd10db080c84bc6a0d2b8f32cadfcbdd6b23d0c725829cdc7475b1762c71fddd18ae3b4ea9792dac385594fde3e"
+            },
+            {
+              "pubkey": "7b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9",
+              "leafHash": "3c94ea257732e1d9a5bd5506675d0f8922399c029ae30b092c89b4ddd0509c72",
+              "signature": "bdd3cfbb797b06a98c8dfd30d419b581cd83270fae9e7925ff95d03b80c26578cdbf55b4a3337dac45b6fe0153c0c766778be4097fef30c0b2c3ac2c97a0eb90"
+            },
+            {
+              "pubkey": "7b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9",
+              "leafHash": "68cc9790c0627bc8f28afd009b31974a2fce5ea4fe2ed4dd8b65c8feda196875",
+              "signature": "40fc3cce202188c025feb7ec31250fd0c0794ae13e18eb816536e51401cd4b4f015561d422ca6d8f5673280cbacf44dd76f68a3e5613d21c1fbf4dd4df50a9c6"
+            },
+            {
+              "pubkey": "7b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9",
+              "leafHash": "c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552",
+              "signature": "2474337cd33ad60d0de8405f5be6b844c5c135184b77aaee623c4b151e30d533b9ff837821d5d85e9a758c79193244e1bfd3fec42208cc1eca993f318bd77566"
+            },
+            {
+              "pubkey": "850854d26df93570748d94e3da361f134c522f7970bd7f8701a164547308a900",
+              "leafHash": "c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552",
+              "signature": "c794557f34565d073cfadfda332b60b6285f521cea2f9f41a22db61109eb73db3c451530d1962265f7dd7e69e33de5f970e073ddcf726583fbc39e2122531eb3"
+            },
+            {
+              "pubkey": "9f66599cde7f3c3fefb6b96509e472f8a9e2caf8793b9b673fcb4067ef888f50",
+              "leafHash": "68cc9790c0627bc8f28afd009b31974a2fce5ea4fe2ed4dd8b65c8feda196875",
+              "signature": "6279e008128357a4a3930d52230f241c0883a89b4b379e02e031c6f181e6f21364bce2eab6adb8f42ae0c2c617a98b5ef017fb1d2ef0f8d9dd76bb8e05b83849"
+            },
+            {
+              "pubkey": "9f66599cde7f3c3fefb6b96509e472f8a9e2caf8793b9b673fcb4067ef888f50",
+              "leafHash": "c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552",
+              "signature": "7e0d15f41fc755e5e59c6b9f010bd0eaebef9ebe8077d90aa1740dc25ae2d6b9234c22fa0739f2b17304368821b9f935b1c9fb0614276bdd8fcb14594d0b1c77"
+            },
+            {
+              "pubkey": "f0638e4817559347e67a07b56a6cb824d455fba42a8c8c95171c397540c51789",
+              "leafHash": "68cc9790c0627bc8f28afd009b31974a2fce5ea4fe2ed4dd8b65c8feda196875",
+              "signature": "3ce5819fc2f6e56bc66caaab5795bb714f9010b3200de32c47bd54d5ac07d9916a74d93aae93fcd79612396c0b35cc3c8c6c012f135e623f5ae3d9003476e622"
+            },
+            {
+              "pubkey": "f0638e4817559347e67a07b56a6cb824d455fba42a8c8c95171c397540c51789",
+              "leafHash": "c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552",
+              "signature": "8b16fec4ac03a0e86096c0106a4ec753a9730372229dc40565980052c8982c98c180aa666c57ce455b9b52a6ae187507ccca4769441b3474246f07cfd878bdb6"
+            }
+          ],
+          "tapLeafScript": [
+            {
+              "controlBlock": "c150929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac03c94ea257732e1d9a5bd5506675d0f8922399c029ae30b092c89b4ddd0509c72c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552",
+              "script": "207b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9ad2004e2b2468fe224659eb9dc5bd0a9cc1b4878b64f40c67c951610320bce78dfd1ac202f3432bf9054e482041b890e084bc1a34cfbc0b63aded113bfa36b6f2402832bba204d7e91e4a0ab0526a387684db1628b535e6b66046aaa7d1b583b93c5a16e1ac7ba205e14742c0943fa66799f699a0ef98cf2b7cd223ddbb61f6878999182bbcc4700ba2064d55d591c5d416f713df9e15afd32e9ff2441cf276b2f90e5b3085163ca7a6bba206672282496e17eccaae560aac4d9fe85d8c166a4aa43f51fa8963c80a165831fba207939bcf0084cff0fe5c88a1748c1d97d63ff9ae6423a98dca65d974bb9123ce0ba209f66599cde7f3c3fefb6b96509e472f8a9e2caf8793b9b673fcb4067ef888f50ba20f0638e4817559347e67a07b56a6cb824d455fba42a8c8c95171c397540c51789ba569c",
+              "leafVersion": 192
+            },
+            {
+              "controlBlock": "c150929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac04e9d38ba2696952c3a326cd821c319173cbe70ff9393f732b44d13aee3add4c0",
+              "script": "207b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9ad20850854d26df93570748d94e3da361f134c522f7970bd7f8701a164547308a900ad2004e2b2468fe224659eb9dc5bd0a9cc1b4878b64f40c67c951610320bce78dfd1ac202f3432bf9054e482041b890e084bc1a34cfbc0b63aded113bfa36b6f2402832bba204d7e91e4a0ab0526a387684db1628b535e6b66046aaa7d1b583b93c5a16e1ac7ba205e14742c0943fa66799f699a0ef98cf2b7cd223ddbb61f6878999182bbcc4700ba2064d55d591c5d416f713df9e15afd32e9ff2441cf276b2f90e5b3085163ca7a6bba206672282496e17eccaae560aac4d9fe85d8c166a4aa43f51fa8963c80a165831fba207939bcf0084cff0fe5c88a1748c1d97d63ff9ae6423a98dca65d974bb9123ce0ba209f66599cde7f3c3fefb6b96509e472f8a9e2caf8793b9b673fcb4067ef888f50ba20f0638e4817559347e67a07b56a6cb824d455fba42a8c8c95171c397540c51789ba569c",
+              "leafVersion": 192
+            },
+            {
+              "controlBlock": "c150929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac068cc9790c0627bc8f28afd009b31974a2fce5ea4fe2ed4dd8b65c8feda196875c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552",
+              "script": "207b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9ad021027b2",
+              "leafVersion": 192
+            }
+          ],
+          "tapBip32Derivation": [
+            {
+              "masterFingerprint": "06b34ce1",
+              "pubkey": "04e2b2468fe224659eb9dc5bd0a9cc1b4878b64f40c67c951610320bce78dfd1",
+              "path": "m",
+              "leafHashes": [
+                "68cc9790c0627bc8f28afd009b31974a2fce5ea4fe2ed4dd8b65c8feda196875",
+                "c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552"
+              ]
+            },
+            {
+              "masterFingerprint": "6a4e29f3",
+              "pubkey": "2f3432bf9054e482041b890e084bc1a34cfbc0b63aded113bfa36b6f2402832b",
+              "path": "m",
+              "leafHashes": [
+                "68cc9790c0627bc8f28afd009b31974a2fce5ea4fe2ed4dd8b65c8feda196875",
+                "c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552"
+              ]
+            },
+            {
+              "masterFingerprint": "18287433",
+              "pubkey": "4d7e91e4a0ab0526a387684db1628b535e6b66046aaa7d1b583b93c5a16e1ac7",
+              "path": "m",
+              "leafHashes": [
+                "68cc9790c0627bc8f28afd009b31974a2fce5ea4fe2ed4dd8b65c8feda196875",
+                "c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552"
+              ]
+            },
+            {
+              "masterFingerprint": "f4ac30dd",
+              "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+              "path": "m",
+              "leafHashes": []
+            },
+            {
+              "masterFingerprint": "632b4059",
+              "pubkey": "5e14742c0943fa66799f699a0ef98cf2b7cd223ddbb61f6878999182bbcc4700",
+              "path": "m",
+              "leafHashes": [
+                "68cc9790c0627bc8f28afd009b31974a2fce5ea4fe2ed4dd8b65c8feda196875",
+                "c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552"
+              ]
+            },
+            {
+              "masterFingerprint": "38d08eee",
+              "pubkey": "64d55d591c5d416f713df9e15afd32e9ff2441cf276b2f90e5b3085163ca7a6b",
+              "path": "m",
+              "leafHashes": [
+                "68cc9790c0627bc8f28afd009b31974a2fce5ea4fe2ed4dd8b65c8feda196875",
+                "c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552"
+              ]
+            },
+            {
+              "masterFingerprint": "f3dc3674",
+              "pubkey": "6672282496e17eccaae560aac4d9fe85d8c166a4aa43f51fa8963c80a165831f",
+              "path": "m",
+              "leafHashes": [
+                "68cc9790c0627bc8f28afd009b31974a2fce5ea4fe2ed4dd8b65c8feda196875",
+                "c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552"
+              ]
+            },
+            {
+              "masterFingerprint": "3ed659bf",
+              "pubkey": "7939bcf0084cff0fe5c88a1748c1d97d63ff9ae6423a98dca65d974bb9123ce0",
+              "path": "m",
+              "leafHashes": [
+                "68cc9790c0627bc8f28afd009b31974a2fce5ea4fe2ed4dd8b65c8feda196875",
+                "c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552"
+              ]
+            },
+            {
+              "masterFingerprint": "b91e1e67",
+              "pubkey": "7b6a08504c46336f985a5787a5423eb18c10b149fef29cd3316ad86f565cd2b9",
+              "path": "m",
+              "leafHashes": [
+                "3c94ea257732e1d9a5bd5506675d0f8922399c029ae30b092c89b4ddd0509c72",
+                "68cc9790c0627bc8f28afd009b31974a2fce5ea4fe2ed4dd8b65c8feda196875",
+                "c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552"
+              ]
+            },
+            {
+              "masterFingerprint": "ea820a03",
+              "pubkey": "850854d26df93570748d94e3da361f134c522f7970bd7f8701a164547308a900",
+              "path": "m",
+              "leafHashes": [
+                "c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552"
+              ]
+            },
+            {
+              "masterFingerprint": "dbd26c3b",
+              "pubkey": "9f66599cde7f3c3fefb6b96509e472f8a9e2caf8793b9b673fcb4067ef888f50",
+              "path": "m",
+              "leafHashes": [
+                "68cc9790c0627bc8f28afd009b31974a2fce5ea4fe2ed4dd8b65c8feda196875",
+                "c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552"
+              ]
+            },
+            {
+              "masterFingerprint": "f9c60867",
+              "pubkey": "f0638e4817559347e67a07b56a6cb824d455fba42a8c8c95171c397540c51789",
+              "path": "m",
+              "leafHashes": [
+                "68cc9790c0627bc8f28afd009b31974a2fce5ea4fe2ed4dd8b65c8feda196875",
+                "c1d262cfe1f3b746337f6766e31854333d370f733bd845727aaed2baebc7a552"
+              ]
+            }
+          ],
+          "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+          "tapMerkleRoot": "6ab1c56b8b3e017a060555ebfbbac721af0a098e5f97d67aa4aac3535e49c36d"
+        }
+      ],
+      "outputs": [
+        {},
+        {}
+      ],
+      "globalMap": {
+        "unsignedTx": {
+          "tx": {
+            "version": 2,
+            "locktime": 0,
+            "ins": [
+              {
+                "hash": "a999d7bc6af1a17cd4e70d0fd875a1734152dfb55f9166240f35965c79fa36c2",
+                "index": 0,
+                "script": "",
+                "sequence": 4294967295,
+                "witness": []
+              }
+            ],
+            "outs": [
+              {
+                "value": "2778",
+                "script": "00145be12624d08a2b424095d7c07221c33450d14bf1"
+              },
+              {
+                "value": "47777",
+                "script": "5120d5238530e223ef1bd34a8a98ee1708f6a8a87e7a2589d88de6700b9973ffff46"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "opts": {
+      "maximumFeeRate": 5000
+    }
+  },
+  "slashingSignedBase64": "cHNidP8BAH0CAAAAAamZ17xq8aF81OcND9h1oXNBUt+1X5FmJA81llx5+jbCAAAAAAD/////AtoKAAAAAAAAFgAUW+EmJNCKK0JAldfAciHDNFDRS/GhugAAAAAAACJRINUjhTDiI+8b00qKmO4XCPaoqH56JYnYjeZwC5lz//9GAAAAAAABASsD2QAAAAAAACJRIHiNc9ddfdiNNhL3qR1bPWrUd42LSRdvlTnTIpgLL0/XQRQE4rJGj+IkZZ653FvQqcwbSHi2T0DGfJUWEDILznjf0WjMl5DAYnvI8or9AJsxl0ovzl6k/i7U3YtlyP7aGWh1QLywThIfcVJzMMbCv9hW88XQAiz0qZ+qZruSxTraCrSYiuRvNDw0vESM0Kx7VkBa9Ey0FZeFZjtvh+pFagIK93lBFATiskaP4iRlnrncW9CpzBtIeLZPQMZ8lRYQMgvOeN/RwdJiz+Hzt0Yzf2dm4xhUMz03D3M72EVyeq7SuuvHpVJA1J8gl6nhvOLAjMkyxk/YERb8F/8993Jw42EJmI6oBLyaJqHUR9z4ZZKkeTJaDdC4bR5FYvX3KxRYFxCIfDdA0kEULzQyv5BU5IIEG4kOCEvBo0z7wLY63tETv6NrbyQCgytozJeQwGJ7yPKK/QCbMZdKL85epP4u1N2LZcj+2hlodUCwUPoS61nISnoauRheirk5QDNLbCl37nIPNMhGhaMweXBajARO5j5SBAkHlTw3IGRVcHAKgPZlbYT9ZaNk0KE6QRQvNDK/kFTkggQbiQ4IS8GjTPvAtjre0RO/o2tvJAKDK8HSYs/h87dGM39nZuMYVDM9Nw9zO9hFcnqu0rrrx6VSQCb5P0qOEaaMf4tHnmWHAnv7daDoFYPvs81qVQMXt8ttgFBlrBBsB8Mna/rObAjFxRPHtkIt8248B8m3Ndqj2LFBFE1+keSgqwUmo4doTbFii1Nea2YEaqp9G1g7k8WhbhrHaMyXkMBie8jyiv0AmzGXSi/OXqT+LtTdi2XI/toZaHVAUMwu1BGhpPm8OVaIGwROHBzzscvQRE5ZvkfioPPo6W6rq8d60fkrP5M0Qs1O/nVwQD/aasC1sSfF83zUttzHM0EUTX6R5KCrBSajh2hNsWKLU15rZgRqqn0bWDuTxaFuGsfB0mLP4fO3RjN/Z2bjGFQzPTcPczvYRXJ6rtK668elUkCE0krdzoQfbwTxm4Cv2IriDYiW9QdpaZfRmg1BZRtSUm/1U9czfV1gEPoxdhoVPV3R5nMlzAzY3n/5Dt8usUO0QRReFHQsCUP6ZnmfaZoO+Yzyt80iPdu2H2h4mZGCu8xHAGjMl5DAYnvI8or9AJsxl0ovzl6k/i7U3YtlyP7aGWh1QEayJ6PvWPbQ+fTQvbGReaa7UkNaB/Enz5PrrHsU5ZLeWNjtV4I+VawS3GbY9JhLDaaAVPmZXywd3YCJO6a8FD9BFF4UdCwJQ/pmeZ9pmg75jPK3zSI927YfaHiZkYK7zEcAwdJiz+Hzt0Yzf2dm4xhUMz03D3M72EVyeq7SuuvHpVJAp4T8KNUzhiiIrsyN10PR+8mr5Wxtlr67ea8kGn13eJejNvhYfAq9COvOft15jfLK3WiRx3hDpTA3FdIL8rXmqEEUZNVdWRxdQW9xPfnhWv0y6f8kQc8nay+Q5bMIUWPKemtozJeQwGJ7yPKK/QCbMZdKL85epP4u1N2LZcj+2hlodUCkJ5Mh6hpsPFTapoWnz75aISRYSQzhB+JH2X01a2//vtSbiqWyiZ40EH7hB2lNW6z3AQm4u1LmQLg0MeIHWz2lQRRk1V1ZHF1Bb3E9+eFa/TLp/yRBzydrL5DlswhRY8p6a8HSYs/h87dGM39nZuMYVDM9Nw9zO9hFcnqu0rrrx6VSQOxWVJQ1zNjxJ2LB/VFp0p4F85hjPT1CRq3uJ5G77TxbtMsXBqkFaVApXKvkfICLmkc/Pclv7PcZGi9f0Qn3WmBBFGZyKCSW4X7MquVgqsTZ/oXYwWakqkP1H6iWPIChZYMfaMyXkMBie8jyiv0AmzGXSi/OXqT+LtTdi2XI/toZaHVAplbeM3E2dnD4mEKujgBB/xk/bUOb6cfDgFWz+WWOoQNdvd+6RCSlizubEU64+ynEVxHpqqCGf777zThPcxY5Y0EUZnIoJJbhfsyq5WCqxNn+hdjBZqSqQ/UfqJY8gKFlgx/B0mLP4fO3RjN/Z2bjGFQzPTcPczvYRXJ6rtK668elUkDH0BshUsgnh9B5vkx91KRdoFjX3Vxzh++iFEarO9WRa4WI85/DnI7XyXUwRC8CwP6enZ3d8uTFkEwIPFA9kKIvQRR5ObzwCEz/D+XIihdIwdl9Y/+a5kI6mNymXZdLuRI84GjMl5DAYnvI8or9AJsxl0ovzl6k/i7U3YtlyP7aGWh1QHnDmQtOgNNGiD5olCqPjgjJNHVrLZ91TzPGIJOJtTdZC6PrEgVWf7dsa9Y6V0uu82ADe/E9HQFMOLI18RcODDlBFHk5vPAITP8P5ciKF0jB2X1j/5rmQjqY3KZdl0u5EjzgwdJiz+Hzt0Yzf2dm4xhUMz03D3M72EVyeq7SuuvHpVJAD9zATzQNe1c+Kv/82ZIHv12zDNENsIDIS8ag0rjzLK38vdayPQxyWCnNx0dbF2LHH93RiuO06peS2sOFWU/ePkEUe2oIUExGM2+YWleHpUI+sYwQsUn+8pzTMWrYb1Zc0rk8lOoldzLh2aW9VQZnXQ+JIjmcAprjCwksibTd0FCcckC908+7eXsGqYyN/TDUGbWBzYMnD66eeSX/ldA7gMJleM2/VbSjM32sRbb+AVPAx2Z3i+QJf+8wwLLDrCyXoOuQQRR7aghQTEYzb5haV4elQj6xjBCxSf7ynNMxathvVlzSuWjMl5DAYnvI8or9AJsxl0ovzl6k/i7U3YtlyP7aGWh1QED8PM4gIYjAJf637DElD9DAeUrhPhjrgWU25RQBzUtPAVVh1CLKbY9WcygMus9E3Xb2ij5WE9IcH79N1N9QqcZBFHtqCFBMRjNvmFpXh6VCPrGMELFJ/vKc0zFq2G9WXNK5wdJiz+Hzt0Yzf2dm4xhUMz03D3M72EVyeq7SuuvHpVJAJHQzfNM61g0N6EBfW+a4RMXBNRhLd6ruYjxLFR4w1TO5/4N4IdXYXpp1jHkZMkThv9P+xCIIzB7KmT8xi9d1ZkEUhQhU0m35NXB0jZTj2jYfE0xSL3lwvX+HAaFkVHMIqQDB0mLP4fO3RjN/Z2bjGFQzPTcPczvYRXJ6rtK668elUkDHlFV/NFZdBzz639ozK2C2KF9SHOovn0GiLbYRCetz2zxFFTDRliJl991+aeM95flw4HPdz3Jlg/vDniEiUx6zQRSfZlmc3n88P++2uWUJ5HL4qeLK+Hk7m2c/y0Bn74iPUGjMl5DAYnvI8or9AJsxl0ovzl6k/i7U3YtlyP7aGWh1QGJ54AgSg1eko5MNUiMPJBwIg6ibSzeeAuAxxvGB5vITZLzi6ratuPQq4MLGF6mLXvAX+x0u8PjZ3Xa7jgW4OElBFJ9mWZzefzw/77a5ZQnkcvip4sr4eTubZz/LQGfviI9QwdJiz+Hzt0Yzf2dm4xhUMz03D3M72EVyeq7SuuvHpVJAfg0V9B/HVeXlnGufAQvQ6uvvnr6Ad9kKoXQNwlri1rkjTCL6BznysXMENoghufk1scn7BhQna92PyxRZTQscd0EU8GOOSBdVk0fmege1amy4JNRV+6QqjIyVFxw5dUDFF4lozJeQwGJ7yPKK/QCbMZdKL85epP4u1N2LZcj+2hlodUA85YGfwvbla8ZsqqtXlbtxT5AQsyAN4yxHvVTVrAfZkWp02Tquk/zXlhI5bAs1zDyMbAEvE15iP1rj2QA0duYiQRTwY45IF1WTR+Z6B7VqbLgk1FX7pCqMjJUXHDl1QMUXicHSYs/h87dGM39nZuMYVDM9Nw9zO9hFcnqu0rrrx6VSQIsW/sSsA6DoYJbAEGpOx1OpcwNyIp3EBWWYAFLImCyYwYCqZmxXzkVbm1Kmrhh1B8zKR2lEGzR0JG8Hz9h4vbZiFcFQkpt0waBJVLeLS2A16XpeB4paDyjsltVHv+6azoA6wDyU6iV3MuHZpb1VBmddD4kiOZwCmuMLCSyJtN3QUJxywdJiz+Hzt0Yzf2dm4xhUMz03D3M72EVyeq7SuuvHpVL9VwEge2oIUExGM2+YWleHpUI+sYwQsUn+8pzTMWrYb1Zc0rmtIATiskaP4iRlnrncW9CpzBtIeLZPQMZ8lRYQMgvOeN/RrCAvNDK/kFTkggQbiQ4IS8GjTPvAtjre0RO/o2tvJAKDK7ogTX6R5KCrBSajh2hNsWKLU15rZgRqqn0bWDuTxaFuGse6IF4UdCwJQ/pmeZ9pmg75jPK3zSI927YfaHiZkYK7zEcAuiBk1V1ZHF1Bb3E9+eFa/TLp/yRBzydrL5DlswhRY8p6a7ogZnIoJJbhfsyq5WCqxNn+hdjBZqSqQ/UfqJY8gKFlgx+6IHk5vPAITP8P5ciKF0jB2X1j/5rmQjqY3KZdl0u5EjzguiCfZlmc3n88P++2uWUJ5HL4qeLK+Hk7m2c/y0Bn74iPULog8GOOSBdVk0fmege1amy4JNRV+6QqjIyVFxw5dUDFF4m6VpzAQhXBUJKbdMGgSVS3i0tgNel6XgeKWg8o7JbVR7/ums6AOsBOnTi6JpaVLDoybNghwxkXPL5w/5OT9zK0TROu463UwP15ASB7aghQTEYzb5haV4elQj6xjBCxSf7ynNMxathvVlzSua0ghQhU0m35NXB0jZTj2jYfE0xSL3lwvX+HAaFkVHMIqQCtIATiskaP4iRlnrncW9CpzBtIeLZPQMZ8lRYQMgvOeN/RrCAvNDK/kFTkggQbiQ4IS8GjTPvAtjre0RO/o2tvJAKDK7ogTX6R5KCrBSajh2hNsWKLU15rZgRqqn0bWDuTxaFuGse6IF4UdCwJQ/pmeZ9pmg75jPK3zSI927YfaHiZkYK7zEcAuiBk1V1ZHF1Bb3E9+eFa/TLp/yRBzydrL5DlswhRY8p6a7ogZnIoJJbhfsyq5WCqxNn+hdjBZqSqQ/UfqJY8gKFlgx+6IHk5vPAITP8P5ciKF0jB2X1j/5rmQjqY3KZdl0u5EjzguiCfZlmc3n88P++2uWUJ5HL4qeLK+Hk7m2c/y0Bn74iPULog8GOOSBdVk0fmege1amy4JNRV+6QqjIyVFxw5dUDFF4m6VpzAYhXBUJKbdMGgSVS3i0tgNel6XgeKWg8o7JbVR7/ums6AOsBozJeQwGJ7yPKK/QCbMZdKL85epP4u1N2LZcj+2hlodcHSYs/h87dGM39nZuMYVDM9Nw9zO9hFcnqu0rrrx6VSJyB7aghQTEYzb5haV4elQj6xjBCxSf7ynNMxathvVlzSua0CECeywCEWBOKyRo/iJGWeudxb0KnMG0h4tk9AxnyVFhAyC85439FFAmjMl5DAYnvI8or9AJsxl0ovzl6k/i7U3YtlyP7aGWh1wdJiz+Hzt0Yzf2dm4xhUMz03D3M72EVyeq7SuuvHpVIGs0zhIRYvNDK/kFTkggQbiQ4IS8GjTPvAtjre0RO/o2tvJAKDK0UCaMyXkMBie8jyiv0AmzGXSi/OXqT+LtTdi2XI/toZaHXB0mLP4fO3RjN/Z2bjGFQzPTcPczvYRXJ6rtK668elUmpOKfMhFk1+keSgqwUmo4doTbFii1Nea2YEaqp9G1g7k8WhbhrHRQJozJeQwGJ7yPKK/QCbMZdKL85epP4u1N2LZcj+2hlodcHSYs/h87dGM39nZuMYVDM9Nw9zO9hFcnqu0rrrx6VSGCh0MyEWUJKbdMGgSVS3i0tgNel6XgeKWg8o7JbVR7/ums6AOsAFAPSsMN0hFl4UdCwJQ/pmeZ9pmg75jPK3zSI927YfaHiZkYK7zEcARQJozJeQwGJ7yPKK/QCbMZdKL85epP4u1N2LZcj+2hlodcHSYs/h87dGM39nZuMYVDM9Nw9zO9hFcnqu0rrrx6VSYytAWSEWZNVdWRxdQW9xPfnhWv0y6f8kQc8nay+Q5bMIUWPKemtFAmjMl5DAYnvI8or9AJsxl0ovzl6k/i7U3YtlyP7aGWh1wdJiz+Hzt0Yzf2dm4xhUMz03D3M72EVyeq7SuuvHpVI40I7uIRZmcigkluF+zKrlYKrE2f6F2MFmpKpD9R+oljyAoWWDH0UCaMyXkMBie8jyiv0AmzGXSi/OXqT+LtTdi2XI/toZaHXB0mLP4fO3RjN/Z2bjGFQzPTcPczvYRXJ6rtK668elUvPcNnQhFnk5vPAITP8P5ciKF0jB2X1j/5rmQjqY3KZdl0u5EjzgRQJozJeQwGJ7yPKK/QCbMZdKL85epP4u1N2LZcj+2hlodcHSYs/h87dGM39nZuMYVDM9Nw9zO9hFcnqu0rrrx6VSPtZZvyEWe2oIUExGM2+YWleHpUI+sYwQsUn+8pzTMWrYb1Zc0rllAzyU6iV3MuHZpb1VBmddD4kiOZwCmuMLCSyJtN3QUJxyaMyXkMBie8jyiv0AmzGXSi/OXqT+LtTdi2XI/toZaHXB0mLP4fO3RjN/Z2bjGFQzPTcPczvYRXJ6rtK668elUrkeHmchFoUIVNJt+TVwdI2U49o2HxNMUi95cL1/hwGhZFRzCKkAJQHB0mLP4fO3RjN/Z2bjGFQzPTcPczvYRXJ6rtK668elUuqCCgMhFp9mWZzefzw/77a5ZQnkcvip4sr4eTubZz/LQGfviI9QRQJozJeQwGJ7yPKK/QCbMZdKL85epP4u1N2LZcj+2hlodcHSYs/h87dGM39nZuMYVDM9Nw9zO9hFcnqu0rrrx6VS29JsOyEW8GOOSBdVk0fmege1amy4JNRV+6QqjIyVFxw5dUDFF4lFAmjMl5DAYnvI8or9AJsxl0ovzl6k/i7U3YtlyP7aGWh1wdJiz+Hzt0Yzf2dm4xhUMz03D3M72EVyeq7SuuvHpVL5xghnARcgUJKbdMGgSVS3i0tgNel6XgeKWg8o7JbVR7/ums6AOsABGCBqscVriz4BegYFVev7uschrwoJjl+X1nqkqsNTXknDbQAAAA==",
   "slashingWithdraw": {
     "psbt": {
       "data": {

--- a/modules/utxo-staking/test/unit/babylon/bug71.ts
+++ b/modules/utxo-staking/test/unit/babylon/bug71.ts
@@ -1,0 +1,79 @@
+import * as fs from 'fs';
+import assert from 'assert';
+
+import * as bitcoinjs from 'bitcoinjs-lib';
+import * as utxolib from '@bitgo/utxo-lib';
+import * as wasmMiniscript from '@bitgo/wasm-miniscript';
+
+// demonstrate https://github.com/babylonlabs-io/btc-staking-ts/issues/71
+describe('btc-staking-ts bug #71', function () {
+  let buf: Buffer;
+  before('load half-signed transaction', async function () {
+    const fixture = JSON.parse(
+      await fs.promises.readFile(__dirname + '/../../fixtures/babylon/txTree.testnet.json', 'utf-8')
+    );
+    const base64 = fixture.slashingSignedBase64;
+    assert(typeof base64 === 'string');
+    buf = Buffer.from(base64, 'base64');
+  });
+
+  it('can finalize with bitcoinjs-lib', function () {
+    const psbt = bitcoinjs.Psbt.fromBuffer(buf);
+    // this does not throw because of a bug in bitcoinjs-lib
+    psbt.finalizeAllInputs();
+  });
+
+  it('cannot finalize with utxolib', function () {
+    const psbt = utxolib.Psbt.fromBuffer(buf);
+    assert.throws(() => {
+      psbt.finalizeAllInputs();
+    }, /Error: Can not finalize input #0/);
+  });
+
+  it('cannot finalize with wasm-miniscript', function () {
+    const psbt = wasmMiniscript.Psbt.deserialize(buf);
+    assert.throws(() => {
+      psbt.finalize();
+    }, /CouldNotSatisfyTr/);
+  });
+
+  it('cannot finalize with bitcoind', async function (this: Mocha.Context) {
+    let cookie: string;
+    try {
+      cookie = await fs.promises.readFile(process.env.HOME + '/.bitcoin/regtest/.cookie', 'utf-8');
+    } catch (e) {
+      if (e.code === 'ENOENT') {
+        console.log('No cookie file found, skipping test');
+        this.skip();
+      }
+      throw e;
+    }
+    // make regtest JSON-RPC request with cookie
+    const url = 'http://localhost:18443';
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: 'Basic ' + Buffer.from(cookie, 'utf-8').toString('base64'),
+    };
+
+    // Create the request payload for finalizepsbt RPC call
+    const body = JSON.stringify({
+      jsonrpc: '1.0',
+      id: 'bitgo-test',
+      method: 'finalizepsbt',
+      params: [buf.toString('base64')],
+    });
+
+    // Make the RPC request
+    const response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body,
+    });
+
+    assert.deepStrictEqual((await response.json()).result, {
+      // the response psbt is the same as the input psbt - not finalized
+      psbt: buf.toString('base64'),
+      complete: false,
+    });
+  });
+});


### PR DESCRIPTION
fixtures

This change adds multiple features to the codebase:
- Add a test case to demonstrate an issue where bitcoinjs-lib incorrectly
  allows finalization of an invalid transaction, while both utxolib and
  wasm-miniscript correctly reject it
- Extend test fixtures for partially-signed slashing transactions

Issue: BTC-0