### PR TITLE
feat: change error type for password error in bulkshareoption

### DIFF
--- a/modules/sdk-core/src/bitgo/errors.ts
+++ b/modules/sdk-core/src/bitgo/errors.ts
@@ -163,6 +163,12 @@ export class MissingEncryptedKeychainError extends Error {
   }
 }
 
+export class IncorrectPasswordError extends Error {
+  public constructor(message?: string) {
+    super(message || 'Incorrect password');
+  }
+}
+
 export class ApiResponseError<ResponseBodyType = any> extends BitGoJsError {
   message: string;
   status: number;

--- a/modules/sdk-core/src/bitgo/wallet/iWallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallets.ts
@@ -204,6 +204,10 @@ export interface AcceptShareResponse {
   walletShareId: string;
 }
 
+export interface BulkAcceptShareResponse {
+  acceptedWalletShares: AcceptShareResponse[];
+}
+
 export interface IWallets {
   get(params?: GetWalletOptions): Promise<Wallet>;
   list(params?: ListWalletOptions): Promise<{ wallets: IWallet[] }>;
@@ -218,6 +222,6 @@ export interface IWallets {
   getWallet(params?: GetWalletOptions): Promise<IWallet>;
   getWalletByAddress(params?: GetWalletByAddressOptions): Promise<IWallet>;
   getTotalBalances(params?: Record<string, never>): Promise<any>;
-  bulkAcceptShare(params: BulkAcceptShareOptions): Promise<AcceptShareResponse[]>;
+  bulkAcceptShare(params: BulkAcceptShareOptions): Promise<BulkAcceptShareResponse>;
   listSharesV2(): Promise<WalletShares>;
 }

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -18,7 +18,12 @@ import {
 import { makeRandomKey } from '../bitcoin';
 import { BitGoBase } from '../bitgoBase';
 import { getSharedSecret } from '../ecdh';
-import { AddressGenerationError, MethodNotImplementedError, MissingEncryptedKeychainError } from '../errors';
+import {
+  AddressGenerationError,
+  IncorrectPasswordError,
+  MethodNotImplementedError,
+  MissingEncryptedKeychainError,
+} from '../errors';
 import * as internal from '../internal/internal';
 import { drawKeycard } from '../internal';
 import { decryptKeychainPrivateKey, Keychain, KeychainWithEncryptedPrv } from '../keychain';
@@ -1685,7 +1690,7 @@ export class Wallet implements IWallet {
 
         const userPrv = decryptKeychainPrivateKey(this.bitgo, keychain, walletPassphrase);
         if (!userPrv) {
-          throw new Error('Unable to decrypt user keychain');
+          throw new IncorrectPasswordError('Password shared is incorrect for this wallet');
         }
 
         keychain.prv = userPrv;

--- a/modules/sdk-core/src/bitgo/wallet/wallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallets.ts
@@ -17,9 +17,9 @@ import { decodeOrElse, promiseProps, RequestTracer } from '../utils';
 import {
   AcceptShareOptions,
   AcceptShareOptionsRequest,
-  AcceptShareResponse,
   AddWalletOptions,
   BulkAcceptShareOptions,
+  BulkAcceptShareResponse,
   BulkUpdateWalletShareOptions,
   BulkUpdateWalletShareOptionsRequest,
   BulkUpdateWalletShareResponse,
@@ -636,9 +636,9 @@ export class Wallets implements IWallets {
   /**
    * Bulk accept wallet shares
    * @param params AcceptShareOptionsRequest[]
-   * @returns {Promise<AcceptShareResponse[]>}
+   * @returns {Promise<BulkAcceptShareResponse>}
    */
-  async bulkAcceptShareRequest(params: AcceptShareOptionsRequest[]): Promise<AcceptShareResponse[]> {
+  async bulkAcceptShareRequest(params: AcceptShareOptionsRequest[]): Promise<BulkAcceptShareResponse> {
     return await this.bitgo
       .put(this.bitgo.url('/walletshares/accept', 2))
       .send({
@@ -846,9 +846,9 @@ export class Wallets implements IWallets {
    * @param params.newWalletPassphrase - new wallet passphrase for saving the shared wallet prv.
    *                                     If left blank then the user's login password is used.
    *
-   *@returns {Promise<AcceptShareResponse[]>}
+   *@returns {Promise<BulkAcceptShareResponse>}
    */
-  async bulkAcceptShare(params: BulkAcceptShareOptions): Promise<AcceptShareResponse[]> {
+  async bulkAcceptShare(params: BulkAcceptShareOptions): Promise<BulkAcceptShareResponse> {
     common.validateParams(params, ['userLoginPassword'], ['newWalletPassphrase']);
     assert(params.walletShareIds.length > 0, 'no walletShareIds are passed');
 


### PR DESCRIPTION
this is done so that we can differentiate on UI what error message to show based on error instance.

Ticket: CSI-445
<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
