### PR TITLE
fix(coins): Validate amount as integer type in sendCoins

### DIFF
--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -4893,4 +4893,46 @@ describe('V2 Wallet:', function () {
       await wallet.approveErc20Token(walletPassphrase, tokenName).should.be.rejectedWith(sendError);
     });
   });
+
+  describe('Amount Validation for sendCoins', function () {
+    let wallet;
+    let params;
+
+    before(function () {
+      const basecoin = bitgo.coin('tbtc');
+      wallet = new Wallet(bitgo, basecoin, {
+        id: '5b34252f1bf349930e34020a',
+        coin: 'tbtc',
+        keys: ['5b3424f91bf349930e340175'],
+      });
+      params = {
+        address: '2N4Xz4itCdKKUREiytEJ1KGPoEnKHmJUIwq',
+        walletPassphrase: 'test123',
+      };
+    });
+
+    it('should reject decimal amounts in send coins', async function () {
+      params.amount = 150000000.55;
+
+      await wallet
+        .send(params)
+        .should.be.rejectedWith('invalid argument for amount - Integer greater than zero or numeric string expected');
+    });
+
+    it('should reject negative amount in send coins', async function () {
+      params.amount = '-12';
+
+      await wallet
+        .send(params)
+        .should.be.rejectedWith('invalid argument for amount - Integer greater than zero or numeric string expected');
+    });
+
+    it('should reject zero in send coins', async function () {
+      params.amount = '0';
+
+      await wallet
+        .send(params)
+        .should.be.rejectedWith('invalid argument for amount - Integer greater than zero or numeric string expected');
+    });
+  });
 });

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -2408,13 +2408,17 @@ export class Wallet implements IWallet {
     const coin = this.baseCoin;
 
     const amount = new BigNumber(params.amount);
-    if (amount.isNegative()) {
-      throw new Error('invalid argument for amount - positive number greater than zero or numeric string expected');
-    }
 
-    if (!coin.valuelessTransferAllowed() && amount.isZero()) {
-      throw new Error('invalid argument for amount - positive number greater than zero or numeric string expected');
-    }
+    const isAmountNegative = amount.isNegative();
+    const isAmountZero = amount.isZero();
+    const isAmountDecimal = !amount.isInteger();
+
+    _.some([isAmountNegative, !coin.valuelessTransferAllowed() && isAmountZero, isAmountDecimal], (condition) => {
+      if (condition) {
+        throw new Error('invalid argument for amount - Integer greater than zero or numeric string expected');
+      }
+    });
+
     const recipients: SendManyOptions['recipients'] = [
       {
         address: params.address,


### PR DESCRIPTION
Improve error message for the same
Ticket: WIN-4726

<!--
# Please be aware of the following when making your pull request:

## Description

Add validation in sendCoins api to accept the amount only as an Integer

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added Unit Test

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
