### PR TITLE
feat: introduce EVM_COMPATIBLE_BGA  coin feature

### DIFF
--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -365,6 +365,10 @@ export enum CoinFeature {
   SHARED_EVM_SIGNING = 'shared-evm-signing',
 
   /**
+   * This coins is an EVM compatible coin and should use common EVM functionality
+   */
+  EVM_COMPATIBLE_BGA = 'evm-compatible-bga',
+  /**
    * This coin supports multisig wallets
    */
   MULTISIG = 'multisig',


### PR DESCRIPTION
Ticket: WIN-5514

Adds a new coin feature - EVM_COMPATIBLE_BGA, to the codebase.

This feature is intended for use in the BGA to determine whether a specific EVM-compatible coin should utilize a common configurable methods and to create a dynamic coin instance 
This change introduces the new feature flag and does not include any immediate implementation of the usage of common methods in BGA, which will be addressed in subsequent pull requests.


