### PR TITLE
fix(sdk-coin-hbar): remove tokenid from statics

### DIFF
--- a/modules/statics/src/account.ts
+++ b/modules/statics/src/account.ts
@@ -86,7 +86,6 @@ export interface HederaCoinConstructorOptions extends AccountConstructorOptions 
 
 export interface HederaTokenConstructorOptions extends AccountConstructorOptions {
   nodeAccountId: string;
-  tokenId: string;
   contractAddress: string;
 }
 
@@ -1369,7 +1368,6 @@ export function hederaToken(
   network: AccountNetwork,
   decimalPlaces: number,
   asset: UnderlyingAsset,
-  tokenId: string,
   contractAddress: string,
   features: CoinFeature[] = AccountCoin.DEFAULT_FEATURES,
   prefix = '',
@@ -1384,7 +1382,6 @@ export function hederaToken(
       decimalPlaces,
       asset,
       nodeAccountId: HEDERA_NODE_ACCCOUNT_ID,
-      tokenId,
       contractAddress,
       features,
       prefix,

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -1471,7 +1471,6 @@ export const coins = CoinMap.fromCoins([
     6,
     UnderlyingAsset.USDC,
     '0.0.456858',
-    '0.0.456858',
     AccountCoin.DEFAULT_FEATURES
   ),
 
@@ -1483,7 +1482,6 @@ export const coins = CoinMap.fromCoins([
     6,
     UnderlyingAsset.XSGD,
     '0.0.1985922',
-    '0.0.1985922',
     AccountCoin.DEFAULT_FEATURES
   ),
   hederaToken(
@@ -1493,7 +1491,6 @@ export const coins = CoinMap.fromCoins([
     Networks.main.hedera,
     2,
     UnderlyingAsset.BCT,
-    '0.0.1958126',
     '0.0.1958126',
     AccountCoin.DEFAULT_FEATURES
   ),
@@ -1505,7 +1502,6 @@ export const coins = CoinMap.fromCoins([
     6,
     UnderlyingAsset.CLXY,
     '0.0.859814',
-    '0.0.859814',
     AccountCoin.DEFAULT_FEATURES
   ),
   hederaToken(
@@ -1515,7 +1511,6 @@ export const coins = CoinMap.fromCoins([
     Networks.main.hedera,
     8,
     UnderlyingAsset['hbar:karate'],
-    '0.0.2283230',
     '0.0.2283230',
     AccountCoin.DEFAULT_FEATURES
   ),
@@ -1527,7 +1522,6 @@ export const coins = CoinMap.fromCoins([
     6,
     UnderlyingAsset['hbar:sauce'],
     '0.0.731861',
-    '0.0.731861',
     AccountCoin.DEFAULT_FEATURES
   ),
   hederaToken(
@@ -1537,7 +1531,6 @@ export const coins = CoinMap.fromCoins([
     Networks.main.hedera,
     8,
     UnderlyingAsset['hbar:dovu'],
-    '0.0.3716059',
     '0.0.3716059',
     AccountCoin.DEFAULT_FEATURES
   ),
@@ -1549,7 +1542,6 @@ export const coins = CoinMap.fromCoins([
     6,
     UnderlyingAsset['hbar:pack'],
     '0.0.4794920',
-    '0.0.4794920',
     AccountCoin.DEFAULT_FEATURES
   ),
   hederaToken(
@@ -1559,7 +1551,6 @@ export const coins = CoinMap.fromCoins([
     Networks.main.hedera,
     8,
     UnderlyingAsset['hbar:jam'],
-    '0.0.127877',
     '0.0.127877',
     AccountCoin.DEFAULT_FEATURES
   ),
@@ -1571,7 +1562,6 @@ export const coins = CoinMap.fromCoins([
     6,
     UnderlyingAsset['hbar:berry'],
     '0.0.7496578',
-    '0.0.7496578',
     AccountCoin.DEFAULT_FEATURES
   ),
   hederaToken(
@@ -1582,7 +1572,6 @@ export const coins = CoinMap.fromCoins([
     6,
     UnderlyingAsset.USDC,
     '0.0.13078',
-    '0.0.13078',
     AccountCoin.DEFAULT_FEATURES
   ),
   hederaToken(
@@ -1592,7 +1581,6 @@ export const coins = CoinMap.fromCoins([
     Networks.test.hedera,
     6,
     UnderlyingAsset.USDC,
-    '0.0.5894751',
     '0.0.5894751',
     AccountCoin.DEFAULT_FEATURES
   ),


### PR DESCRIPTION
## Description

I am removing the redundant static parameter which is replaced by `contractAddress` previously in this PR - #5530 
The `tokenId` variable is used across in downstream applications, so I am not touching that, and all such applications don't need any change whatsoever and can continue using the `tokenId`

We simply are removing parameter which we are not using anymore.

## Issue Number

TICKET: WIN-4533

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The tests were in the same older pull request. If the tests are successful in this PR, means this change doesn't break the existing functionality.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [x] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
