### PR TITLE
fix: removed InvoiceInfo codec

### DIFF
--- a/modules/abstract-lightning/src/codecs/api/invoice.ts
+++ b/modules/abstract-lightning/src/codecs/api/invoice.ts
@@ -48,44 +48,22 @@ export const Invoice = t.intersection(
       status: InvoiceStatus,
       /** A date in ISO format representing when this invoice expires. */
       expiresAt: DateFromISOString,
+      createdAt: DateFromISOString,
+      updatedAt: DateFromISOString,
     }),
     t.partial({
       memo: t.string,
+      amtPaidMsat: BigIntFromString,
     }),
   ],
   'Invoice'
 );
 export type Invoice = t.TypeOf<typeof Invoice>;
 
-export const InvoiceInfo = t.intersection(
-  [
-    t.type({
-      valueMsat: BigIntFromString,
-      paymentHash: t.string,
-      invoice: t.string,
-      walletId: t.string,
-      status: InvoiceStatus,
-      expiresAt: DateFromISOString,
-      createdAt: DateFromISOString,
-      updatedAt: DateFromISOString,
-    }),
-    t.partial({
-      /**
-       * The number of millisats actually paid to this invoice, this may be greater
-       * than the amount requested by the invoice, since lightning allows overpaying
-       * (but not underpaying) invoices.
-       */
-      amtPaidMsat: BigIntFromString,
-    }),
-  ],
-  'InvoiceInfo'
-);
-export type InvoiceInfo = t.TypeOf<typeof InvoiceInfo>;
-
 export const ListInvoicesResponse = t.intersection(
   [
     t.type({
-      invoices: t.array(InvoiceInfo),
+      invoices: t.array(Invoice),
     }),
     t.partial({
       /**

--- a/modules/abstract-lightning/src/wallet/lightning.ts
+++ b/modules/abstract-lightning/src/wallet/lightning.ts
@@ -14,7 +14,6 @@ import { createMessageSignature, unwrapLightningCoinSpecific } from '../lightnin
 import {
   CreateInvoiceBody,
   Invoice,
-  InvoiceInfo,
   InvoiceQuery,
   LightningAuthKeychain,
   LightningKeychain,
@@ -134,10 +133,10 @@ export interface ILightningWallet {
   /**
    * Get invoice details by payment hash
    * @param {string} paymentHash - Payment hash to lookup
-   * @returns {Promise<InvoiceInfo>} Invoice details
+   * @returns {Promise<Invoice>} Invoice details
    * @throws {InvalidPaymentHash} When payment hash is not valid
    */
-  getInvoice(paymentHash: string): Promise<InvoiceInfo>;
+  getInvoice(paymentHash: string): Promise<Invoice>;
   /**
    * Lists current lightning invoices
    * @param {InvoiceQuery} params Query parameters for filtering invoices
@@ -229,11 +228,11 @@ export class LightningWallet implements ILightningWallet {
     });
   }
 
-  async getInvoice(paymentHash: string): Promise<InvoiceInfo> {
+  async getInvoice(paymentHash: string): Promise<Invoice> {
     const response = await this.wallet.bitgo
       .get(this.wallet.bitgo.url(`/wallet/${this.wallet.id()}/lightning/invoice/${paymentHash}`, 2))
       .result();
-    return decodeOrElse(InvoiceInfo.name, InvoiceInfo, response, (error) => {
+    return decodeOrElse(Invoice.name, Invoice, response, (error) => {
       throw new Error(`Invalid get invoice response ${error}`);
     });
   }

--- a/modules/bitgo/test/v2/unit/lightning/lightningWallets.ts
+++ b/modules/bitgo/test/v2/unit/lightning/lightningWallets.ts
@@ -6,7 +6,6 @@ import {
   CreateInvoiceBody,
   getLightningWallet,
   Invoice,
-  InvoiceInfo,
   InvoiceQuery,
   LndCreatePaymentResponse,
   LightningWallet,
@@ -248,7 +247,7 @@ describe('Lightning wallets', function () {
     });
 
     it('should list invoices', async function () {
-      const invoice: InvoiceInfo = {
+      const invoice: Invoice = {
         valueMsat: 1000n,
         paymentHash: 'foo',
         invoice: 'tlnfoobar',
@@ -266,7 +265,7 @@ describe('Lightning wallets', function () {
       const listInvoicesNock = nock(bgUrl)
         .get(`/api/v2/wallet/${wallet.wallet.id()}/lightning/invoice`)
         .query(InvoiceQuery.encode(query))
-        .reply(200, { invoices: [InvoiceInfo.encode(invoice)] });
+        .reply(200, { invoices: [Invoice.encode(invoice)] });
       const invoiceResponse = await wallet.listInvoices(query);
       assert.strictEqual(invoiceResponse.invoices.length, 1);
       assert.deepStrictEqual(invoiceResponse.invoices[0], invoice);
@@ -274,7 +273,7 @@ describe('Lightning wallets', function () {
     });
 
     it('should work properly with pagination while listing invoices', async function () {
-      const invoice1: InvoiceInfo = {
+      const invoice1: Invoice = {
         valueMsat: 1000n,
         paymentHash: 'foo1',
         invoice: 'tlnfoobar1',
@@ -284,17 +283,17 @@ describe('Lightning wallets', function () {
         createdAt: new Date(),
         updatedAt: new Date(),
       };
-      const invoice2: InvoiceInfo = {
+      const invoice2: Invoice = {
         ...invoice1,
         paymentHash: 'foo2',
         invoice: 'tlnfoobar2',
       };
-      const invoice3: InvoiceInfo = {
+      const invoice3: Invoice = {
         ...invoice1,
         paymentHash: 'foo3',
         invoice: 'tlnfoobar3',
       };
-      const allInvoices = [InvoiceInfo.encode(invoice1), InvoiceInfo.encode(invoice2), InvoiceInfo.encode(invoice3)];
+      const allInvoices = [Invoice.encode(invoice1), Invoice.encode(invoice2), Invoice.encode(invoice3)];
       const query = {
         status: 'open',
         startDate: new Date(),
@@ -333,6 +332,9 @@ describe('Lightning wallets', function () {
         status: 'open',
         walletId: wallet.wallet.id(),
         valueMsat: 1000n,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        memo: 'test invoice',
       };
       const createInvoiceNock = nock(bgUrl)
         .post(`/api/v2/wallet/${wallet.wallet.id()}/lightning/invoice`, CreateInvoiceBody.encode(createInvoice))

--- a/modules/express/test/unit/lightning/lightningInvoiceRoutes.test.ts
+++ b/modules/express/test/unit/lightning/lightningInvoiceRoutes.test.ts
@@ -39,6 +39,8 @@ describe('Lightning Invoice Routes', () => {
         walletId: 'testWalletId',
         status: 'open' as const,
         expiresAt: new Date('2025-02-21T10:00:00.000Z'),
+        createdAt: new Date('2025-02-21T09:00:00.000Z'),
+        updatedAt: new Date('2025-02-21T09:00:00.000Z'),
       };
 
       const createInvoiceSpy = sinon.stub().resolves(expectedResponse);


### PR DESCRIPTION
We have 2 codecs currently Invoice and InvoiceInfo.
Invoice codec is just used for createInvoice API response. Everywhere else we used InvoiceInfo (list invoices/get invoice).
To keep the response consistent and remove duplication of codecs we are merging the 2 codecs into Invoice. 

TICKET: BTC-2155

BREAKING CHANGE: create invoice response changed