### PR TITLE
feat(statics): added paygo xpub to statics for tbtc

### DIFF
--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -15,6 +15,7 @@ export abstract class BaseNetwork {
 export interface UtxoNetwork extends BaseNetwork {
   // Network name as defined in @bitgo/utxo-lib networks.ts
   utxolibName: string;
+  pubkey?: string;
 }
 
 export interface LightningNetwork extends UtxoNetwork {
@@ -342,6 +343,9 @@ class BitcoinTestnet extends Testnet implements UtxoNetwork {
   family = CoinFamily.BTC;
   utxolibName = 'testnet';
   explorerUrl = 'https://mempool.space/testnet/tx/';
+  // Add our pubkey for our paygo wallet
+  pubkey =
+    'xpub661MyMwAqRbcFU2Qx7pvGmmiQpVj8NcR7dSVpgqNChMkQyobpVWWERcrTb47WicmXwkhAY2VrC3hb29s18FDQWJf5pLm3saN6uLXAXpw1GV';
 }
 
 class BitcoinPublicSignet extends Testnet implements UtxoNetwork {

--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -15,7 +15,7 @@ export abstract class BaseNetwork {
 export interface UtxoNetwork extends BaseNetwork {
   // Network name as defined in @bitgo/utxo-lib networks.ts
   utxolibName: string;
-  pubkey?: string;
+  paygoAddressAttestationPubkey?: string;
 }
 
 export interface LightningNetwork extends UtxoNetwork {
@@ -344,7 +344,7 @@ class BitcoinTestnet extends Testnet implements UtxoNetwork {
   utxolibName = 'testnet';
   explorerUrl = 'https://mempool.space/testnet/tx/';
   // Add our pubkey for our paygo wallet
-  pubkey =
+  paygoAddressAttestationPubkey =
     'xpub661MyMwAqRbcFU2Qx7pvGmmiQpVj8NcR7dSVpgqNChMkQyobpVWWERcrTb47WicmXwkhAY2VrC3hb29s18FDQWJf5pLm3saN6uLXAXpw1GV';
 }
 


### PR DESCRIPTION
Issue: BTC-2116

TICKET: [BTC-2116](https://bitgoinc.atlassian.net/browse/BTC-2116)

<!--
# Please be aware of the following when making your pull request:

## Description
We want to add our xpub to the statics of our SDK so that we can use it to verify our paygo attestation proof later on when we have our metadata in our PSBT. This will be done in our explainTransaction method in abstract-utxo later on.

## Issue Number
[BTC-2116](https://bitgoinc.atlassian.net/browse/BTC-2116)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->


[BTC-2116]: https://bitgoinc.atlassian.net/browse/BTC-2116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BTC-2116]: https://bitgoinc.atlassian.net/browse/BTC-2116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ