### PR TITLE
fix: creating transfer before sending tx

### DIFF
--- a/modules/abstract-lightning/src/wallet/lightning.ts
+++ b/modules/abstract-lightning/src/wallet/lightning.ts
@@ -292,6 +292,16 @@ export class LightningWallet implements ILightningWallet {
       };
     }
 
+    const transfer: { id: string } = await this.wallet.bitgo
+      .post(
+        this.wallet.bitgo.url(
+          '/wallet/' + this.wallet.id() + '/txrequests/' + transactionRequestCreate.txRequestId + '/transfers',
+          2
+        )
+      )
+      .send()
+      .result();
+
     const transactionRequestSend = await commonTssMethods.sendTxRequest(
       this.wallet.bitgo,
       this.wallet.id(),
@@ -301,17 +311,15 @@ export class LightningWallet implements ILightningWallet {
     );
 
     const coinSpecific = transactionRequestSend.transactions?.[0]?.unsignedTx?.coinSpecific;
-    let transfer;
-    if (coinSpecific && coinSpecific.paymentHash && typeof coinSpecific.paymentHash === 'string') {
-      transfer = await this.wallet.getTransfer({ id: coinSpecific.paymentHash });
-    }
+    const updatedTransfer = await this.wallet.getTransfer({ id: transfer.id });
+
     return {
       txRequestId: transactionRequestCreate.txRequestId,
       txRequestState: transactionRequestSend.state,
       paymentStatus: coinSpecific
         ? t.exact(LndCreatePaymentResponse).encode(coinSpecific as LndCreatePaymentResponse)
         : undefined,
-      transfer,
+      transfer: updatedTransfer,
     };
   }
 
@@ -344,6 +352,16 @@ export class LightningWallet implements ILightningWallet {
       };
     }
 
+    const transfer: { id: string } = await this.wallet.bitgo
+      .post(
+        this.wallet.bitgo.url(
+          '/wallet/' + this.wallet.id() + '/txrequests/' + transactionRequestCreate.txRequestId + '/transfers',
+          2
+        )
+      )
+      .send()
+      .result();
+
     const transactionRequestSend = await commonTssMethods.sendTxRequest(
       this.wallet.bitgo,
       this.wallet.id(),
@@ -352,9 +370,12 @@ export class LightningWallet implements ILightningWallet {
       reqId
     );
 
+    const updatedTransfer = await this.wallet.getTransfer({ id: transfer.id });
+
     return {
       txRequestId: transactionRequestCreate.txRequestId,
       txRequestState: transactionRequestSend.state,
+      transfer: updatedTransfer,
     };
   }
 

--- a/modules/sdk-core/src/bitgo/pendingApproval/pendingApproval.ts
+++ b/modules/sdk-core/src/bitgo/pendingApproval/pendingApproval.ts
@@ -435,6 +435,17 @@ export class PendingApproval implements IPendingApproval {
             assert(this._pendingApproval.txRequestId, 'Missing txRequestId');
             // this.populateWallet is called before this so we should be good here
             assert(this.wallet?.id(), 'Missing wallet id');
+            // todo: add test case for this
+            // add new transfer before sending tx
+            await this.bitgo
+              .post(
+                this.bitgo.url(
+                  '/wallet/' + this.wallet?.id() + '/txrequests/' + this._pendingApproval.txRequestId + '/transfers',
+                  2
+                )
+              )
+              .send()
+              .result();
             await sendTxRequest(
               this.bitgo,
               this.wallet?.id() as string,


### PR DESCRIPTION
Currently we are creating transfer during sendTx. This flow has 2 problems: 
- Flow different from the regular 2 of 3 wallets.
- After sendTx there is no proper way to get the transfer to return back to the client especially in withdraw flow.
So we will be creating the transfer in BitGoJS before sending the sendTx and removing the logic of creating in sendTx from WP.

TICKET: BTC-2146
