### PR TITLE
fix(sdk-coin-near): bug fix in ft builder of near

### DIFF
--- a/modules/sdk-coin-near/src/lib/fungibleTokenTransferBuilder.ts
+++ b/modules/sdk-coin-near/src/lib/fungibleTokenTransferBuilder.ts
@@ -124,7 +124,11 @@ export class FungibleTokenTransferBuilder extends TransactionBuilder {
     assert(gas, new BuildTransactionError('gas is required before building fungible token transfer'));
     assert(deposit, new BuildTransactionError('deposit is required before building fungible token transfer'));
 
-    if (!this._actions || this._actions.length === 0 || this._actions[0].functionCall?.methodName !== methodName) {
+    if (
+      !this._actions ||
+      this._actions.length === 0 ||
+      (this._actions.length === 1 && this._actions[0].functionCall?.methodName !== methodName)
+    ) {
       super.action(NearAPI.transactions.functionCall(methodName, args, BigInt(gas), BigInt(deposit)));
     }
     const tx = await super.buildImplementation();


### PR DESCRIPTION
While rebuilding the transaction using the hex, we should not add the action again.
Updated the condition to add the action,
1. If there are no actions, we should add it
2. If there is only 1 action and it's method (storage deposit) not matching ft transfer then add it.

Ticket: [COIN-4580](https://bitgoinc.atlassian.net/browse/COIN-4580)


[COIN-4580]: https://bitgoinc.atlassian.net/browse/COIN-4580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ