### PR TITLE
chore: onboard new strx token win-6000

### DIFF
--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -2681,6 +2681,7 @@ export enum UnderlyingAsset {
   'trx:usdt' = 'trx:usdt',
   'trx:usd1' = 'trx:usd1',
   'trx:nft' = 'trx:nft',
+  'trx:strx' = 'trx:strx',
 
   // TRX testnet tokens
   'ttrx:usdt' = 'ttrx:usdt',

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -2029,6 +2029,14 @@ export const coins = CoinMap.fromCoins([
     'TPFqcBAaaUMCSVRCqPaQ9QnzKhmuoLR6Rc',
     UnderlyingAsset['trx:usd1']
   ),
+  tronToken(
+    '35b44b0f-272c-4e13-8056-3bbab3fd609e',
+    'trx:strx',
+    'Staked TRX',
+    18,
+    'TU3kjFuhtEo42tsCBtfYUAZxoqQ4yuSLQ5',
+    UnderlyingAsset['trx:strx']
+  ),
   algoToken(
     'bf444e89-e762-48a9-a27d-8efa2aed7867',
     'algo:USDC-31566704',

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -834,6 +834,7 @@ export const ofcCoins = [
   ),
   ofcTronToken('94b00b66-68a4-45ed-b772-77e5bca1e34c', 'ofctrx:usdt', 'Tether USD', 6, UnderlyingAsset['trx:usdt']),
   ofcTronToken('486dca06-5709-45ee-8b35-677e3d27509f', 'ofctrx:usd1', 'USD1 Token', 18, UnderlyingAsset['trx:usd1']),
+  ofcTronToken('d953a72b-b7b9-4c8d-97bd-f03394e30608', 'ofctrx:strx', 'Staked TRX', 18, UnderlyingAsset['trx:strx']),
   ofcXrpToken('6a173023-5faf-4a0a-af38-b8be98abe94f', 'ofcxrp:rlusd', 'Ripple USD', 15, UnderlyingAsset['xrp:rlusd']),
   tofcXrpToken('bd406dab-3b55-4ab5-b0a5-74b9f94268a3', 'ofctxrp:rlusd', 'RLUSD', 15, UnderlyingAsset['txrp:rlusd']),
   ofcXrpToken('eb3c02de-7221-4fde-9235-5cc576eb7c8b', 'ofcxrp:xsgd', 'XSGD', 6, UnderlyingAsset['xrp:xsgd']),


### PR DESCRIPTION
TICKET: [WIN-6000](https://bitgoinc.atlassian.net/browse/WIN-6000)

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->


[WIN-6000]: https://bitgoinc.atlassian.net/browse/WIN-6000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ