### PR TITLE
fix(abstract-lightning): correct derivation index computation

### DIFF
--- a/modules/abstract-lightning/src/lightning/lightningUtils.ts
+++ b/modules/abstract-lightning/src/lightning/lightningUtils.ts
@@ -228,11 +228,14 @@ export function deriveTatSharedSecret(coinName: 'lnbtc' | 'tlnbtc', xprv: string
 
 /**
  * Given a seed, compute a BIP32 derivation index.
- * 0 <= index < 4294967295 (largest 4 byte number)
+ * 0 <= index < 2147483648 (largest 31 bit number). This needs to be 2^31 - 1 so that the bip32 library
+ * can derive the hardened key.
  * @param seed (optional) If nothing provided, we will generate one randomly
  */
 export function computeBip32DerivationIndexFromSeed(seed?: string): number {
-  return Buffer.from(utxolib.crypto.sha256(Buffer.from(seed ?? randomBytes(32).toString('hex'), 'utf8'))).readUint32BE(
-    0
+  return (
+    (Buffer.from(utxolib.crypto.sha256(Buffer.from(seed ?? randomBytes(32).toString('hex'), 'utf8'))).readUint32BE(0) %
+      Math.pow(2, 31)) -
+    1
   );
 }


### PR DESCRIPTION
Change the BIP32 derivation index computation to ensure it's within a valid range for hardened keys, using 2^31 - 1 as max value instead of 2^32.

BTC-2196

Co-authored-by: llm-git <llm-git@ttll.de>

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
