### PR TITLE
refactor(utxo-core): trimMessagePrefix fix function

### DIFF
--- a/modules/utxo-core/src/paygo/index.ts
+++ b/modules/utxo-core/src/paygo/index.ts
@@ -1,2 +1,3 @@
 export * from './parsePayGoAttestation';
 export * from './psbt';
+export * from './trimMessagePrefix';

--- a/modules/utxo-core/src/paygo/trimMessagePrefix.ts
+++ b/modules/utxo-core/src/paygo/trimMessagePrefix.ts
@@ -2,24 +2,24 @@ import * as utxolib from '@bitgo/utxo-lib';
 
 /** We receive a proof in the form:
  * 0x18Bitcoin Signed Message:\n<varint_length><ENTROPY><ADDRESS><UUID>
- * and when verifying our message we want to exclude the 0x18Bitcoin Signed Message:\n<varint_length>
- * of the proof so that we are left with the entropy address and uuid as our message.
- * This is what we are going to be verifying.
+ * and trims the 0x18Bitcoin Signed Message:\n<varin_length> and returns
+ * our message <ENTROPY><ADDRESS><UUID> in a Buffer.
  *
  * @param proof
  * @returns
  */
 export function trimMessagePrefix(proof: Buffer): Buffer {
   const prefix = '\u0018Bitcoin Signed Message:\n';
+  const prefixBuffer = Buffer.from(prefix, 'utf-8');
   if (proof.toString().startsWith(prefix)) {
-    proof = proof.slice(Buffer.from(prefix).length);
+    proof = proof.slice(prefixBuffer.length);
     utxolib.bufferutils.varuint.decode(proof, 0);
     // Determines how many bytes were consumed during our last varuint.decode(Buffer, offset)
     // So if varuint.decode(0xfd) then varuint.decode.bytes = 3
     // varuint.decode(0xfe) then varuint.decode.bytes = 5, etc.
     const varintBytesLength = utxolib.bufferutils.varuint.decode.bytes;
 
-    proof.slice(varintBytesLength);
+    return proof.slice(varintBytesLength);
   }
   return proof;
 }

--- a/modules/utxo-core/src/testutil/index.ts
+++ b/modules/utxo-core/src/testutil/index.ts
@@ -2,4 +2,3 @@ export * from './fixtures.utils';
 export * from './key.utils';
 export * from './toPlainObject.utils';
 export * from './generatePayGoAttestationProof.utils';
-export * from './trimMessagePrefix';


### PR DESCRIPTION
TICKET: BTC-2235
Fixed the trimMessagePrefix function as it was trimming the message wrong and leaving a space in the beginning

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
