### PR TITLE
feat(utxo-staking): simplify params fetching and improve error handling

### DIFF
--- a/modules/utxo-staking/src/babylon/params.mainnet.json
+++ b/modules/utxo-staking/src/babylon/params.mainnet.json
@@ -1,5 +1,6 @@
 [
   {
+    "version": 0,
     "params": {
       "covenant_pks": [
         "d45c70d28f169e1f0c7f4a78e2bc73497afe585b70aa897955989068f3350aaa",
@@ -29,6 +30,7 @@
     }
   },
   {
+    "version": 1,
     "params": {
       "covenant_pks": [
         "d45c70d28f169e1f0c7f4a78e2bc73497afe585b70aa897955989068f3350aaa",
@@ -58,6 +60,7 @@
     }
   },
   {
+    "version": 2,
     "params": {
       "covenant_pks": [
         "d45c70d28f169e1f0c7f4a78e2bc73497afe585b70aa897955989068f3350aaa",
@@ -87,6 +90,7 @@
     }
   },
   {
+    "version": 3,
     "params": {
       "covenant_pks": [
         "d45c70d28f169e1f0c7f4a78e2bc73497afe585b70aa897955989068f3350aaa",
@@ -116,6 +120,7 @@
     }
   },
   {
+    "version": 4,
     "params": {
       "covenant_pks": [
         "d45c70d28f169e1f0c7f4a78e2bc73497afe585b70aa897955989068f3350aaa",

--- a/modules/utxo-staking/src/babylon/params.testnet.json
+++ b/modules/utxo-staking/src/babylon/params.testnet.json
@@ -1,5 +1,6 @@
 [
   {
+    "version": 0,
     "params": {
       "covenant_pks": [
         "49766ccd9e3cd94343e2040474a77fb37cdfd30530d05f9f1e96ae1e2102c86e",
@@ -29,6 +30,7 @@
     }
   },
   {
+    "version": 1,
     "params": {
       "covenant_pks": [
         "09585ab55a971a231c945790a0a81df754e5a07263a5c20829931cc24683bbb7",
@@ -58,6 +60,7 @@
     }
   },
   {
+    "version": 2,
     "params": {
       "covenant_pks": [
         "fa9d882d45f4060bdb8042183828cd87544f1ea997380e586cab77d5fd698737",
@@ -87,6 +90,7 @@
     }
   },
   {
+    "version": 3,
     "params": {
       "covenant_pks": [
         "fa9d882d45f4060bdb8042183828cd87544f1ea997380e586cab77d5fd698737",
@@ -116,6 +120,7 @@
     }
   },
   {
+    "version": 4,
     "params": {
       "covenant_pks": [
         "fa9d882d45f4060bdb8042183828cd87544f1ea997380e586cab77d5fd698737",
@@ -145,6 +150,7 @@
     }
   },
   {
+    "version": 5,
     "params": {
       "covenant_pks": [
         "fa9d882d45f4060bdb8042183828cd87544f1ea997380e586cab77d5fd698737",
@@ -174,6 +180,7 @@
     }
   },
   {
+    "version": 6,
     "params": {
       "covenant_pks": [
         "fa9d882d45f4060bdb8042183828cd87544f1ea997380e586cab77d5fd698737",

--- a/modules/utxo-staking/src/babylon/stakingParams.ts
+++ b/modules/utxo-staking/src/babylon/stakingParams.ts
@@ -17,6 +17,7 @@ import jsonMainnetParams from './params.mainnet.json';
 import jsonTestnetParams from './params.testnet.json';
 import { BabylonNetworkLike, toBabylonNetwork } from './network';
 
+/** @see https://docs.babylonlabs.io/api/babylon-gRPC/params/ */
 const BabylonParamsJSON = t.type({
   covenant_pks: t.array(t.string),
   covenant_quorum: t.number,
@@ -63,7 +64,7 @@ function toVersionedParamsFromJson(jsonParams: unknown[]): VersionedStakingParam
       const result = t.type({ params: BabylonParamsJSON }).decode(p);
       if (isLeft(result)) {
         const msg = PathReporter.report(result).join('\n');
-        throw new Error(`Invalid testnet params: ${msg}`);
+        throw new Error(`Invalid params: ${msg}`);
       }
       return result.right.params;
     })


### PR DESCRIPTION

Update the params fetching script to use the params_versions endpoint
instead of iterating over individual versions. Add version fields to
the local JSON files to match API structure.

Also improve error messages for invalid params by making them generic
rather than assuming testnet params.

Issue: BTC-2223