### PR TITLE
refactor(utxo-core): Pay Go Util functions fix

### DIFF
--- a/modules/utxo-core/src/paygo/parsePayGoAttestation.ts
+++ b/modules/utxo-core/src/paygo/parsePayGoAttestation.ts
@@ -3,9 +3,8 @@ import assert from 'assert';
 import { bufferutils } from '@bitgo/utxo-lib';
 
 // The signed address will always have the following structure:
-// 0x18Bitcoin Signed Message:\n<varint_length><ENTROPY><ADDRESS><UUID>
+// <varint_length><ENTROPY><ADDRESS><UUID>
 
-const PrefixLength = Buffer.from([0x18]).length + Buffer.from('Bitcoin Signed Message:\n').length;
 // UUID has the structure 00000000-0000-0000-0000-000000000000, and after
 // we Buffer.from and get it's length its 36.
 const UuidBufferLength = 36;
@@ -14,7 +13,7 @@ const EntropyLen = 64;
 
 /**
  * This function takes in the attestation proof of a PayGo address of the from
- * 0x18Bitcoin Signed Message:\n<varint_length><ENTROPY><ADDRESS><UUID> and returns
+ * <varint_length><ENTROPY><ADDRESS><UUID> and returns
  * the address given its length. It is assumed that the ENTROPY is 64 bytes in the Buffer
  * so if not given an address proof length we can still extract the address from the proof.
  *
@@ -26,13 +25,13 @@ export function parsePayGoAttestation(message: Buffer): {
   address: Buffer;
   uuid: Buffer;
 } {
-  if (message.length <= PrefixLength + EntropyLen + UuidBufferLength) {
+  if (message.length <= EntropyLen + UuidBufferLength) {
     throw new Error('PayGo attestation proof is too short to contain a valid address');
   }
 
   // This generates the first part before the varint length so that we can
   // determine how many bytes this is and iterate through the Buffer.
-  let offset = PrefixLength;
+  let offset = 0;
 
   // we decode the varint of the message which is uint32
   // https://en.bitcoin.it/wiki/Protocol_documentation

--- a/modules/utxo-core/src/paygo/psbt/payGoAddressProof.ts
+++ b/modules/utxo-core/src/paygo/psbt/payGoAddressProof.ts
@@ -19,6 +19,7 @@ import {
  * @param psbt - PSBT that we need to encode our paygo address into
  * @param outputIndex - the index of the address in our output
  * @param sig - the signature that we want to encode
+ * @param entropy - the arbitrary entropy bytes from our vasp proof
  */
 export function addPayGoAddressProof(
   psbt: utxolib.bitgo.UtxoPsbt,
@@ -40,7 +41,7 @@ export function addPayGoAddressProof(
  *
  * @param psbt - PSBT we want to verify that the paygo address is in
  * @param outputIndex - we have the output index that address is in
- * @param uuid
+ * @param verificationPubkey - the pubkey signed by the HSM to verify our message
  * @returns
  */
 export function verifyPayGoAddressProof(
@@ -76,7 +77,8 @@ export function verifyPayGoAddressProof(
   // We construct our message <ENTROPY><ADDRESS><UUID>
   const message = createPayGoAttestationBuffer(addressFromOutput, entropy, psbt.network);
 
-  if (!verifyMessage(message.toString(), verificationPubkey, signature, utxolib.networks.bitcoin)) {
+  // bip32utils.verifyMessage now takes in message as a Buffer
+  if (!verifyMessage(message, verificationPubkey, signature, utxolib.networks.bitcoin)) {
     throw new ErrorPayGoAddressProofFailedVerification();
   }
 }

--- a/modules/utxo-core/src/testutil/generatePayGoAttestationProof.utils.ts
+++ b/modules/utxo-core/src/testutil/generatePayGoAttestationProof.utils.ts
@@ -12,11 +12,6 @@ import { bufferutils } from '@bitgo/utxo-lib';
  * @returns
  */
 export function generatePayGoAttestationProof(uuid: string, address: Buffer): Buffer {
-  // <0x18Bitcoin Signed Message:\n
-  const prefixByte = Buffer.from([0x18]);
-  const prefixMessage = Buffer.from('Bitcoin Signed Message:\n');
-  const prefixBuffer = Buffer.concat([prefixByte, prefixMessage]);
-
   // <ENTROPY>
   const entropyLength = 64;
   const entropy = crypto.randomBytes(entropyLength);
@@ -33,11 +28,7 @@ export function generatePayGoAttestationProof(uuid: string, address: Buffer): Bu
   const msgLengthBuffer = bufferutils.varuint.encode(msgLength);
 
   // <0x18Bitcoin Signed Message:\n<LENGTH><ENTROPY><ADDRESS><UUID>
-  const proofMessage = Buffer.concat([prefixBuffer, msgLengthBuffer, entropy, address, uuidBuffer]);
+  const proofMessage = Buffer.concat([msgLengthBuffer, entropy, address, uuidBuffer]);
 
-  // we sign this with the priv key
-  // don't know what sign function to call. Since this is just a mirrored function don't know if we need
-  // to include this part.
-  // const signedMsg = sign(attestationPrvKey, proofMessage);
   return proofMessage;
 }

--- a/modules/utxo-core/test/paygo/psbt/payGoAddressProof.ts
+++ b/modules/utxo-core/test/paygo/psbt/payGoAddressProof.ts
@@ -51,7 +51,7 @@ export const addressProofMsgBuffer = trimMessagePrefix(addressProofBuffer);
 export const addressProofEntropy = addressProofMsgBuffer.subarray(0, 65);
 
 // signature with the given msg addressProofBuffer
-export const sig = signMessage(addressProofMsgBuffer.toString(), attestationPrvKey!, network);
+export const sig = signMessage(addressProofMsgBuffer, attestationPrvKey!, network);
 
 function getTestPsbt() {
   return utxolib.testutil.constructPsbt(psbtInputs, psbtOutputs, network, rootWalletKeys, 'unsigned');


### PR DESCRIPTION
TICKET: BTC-2246

We want to keep the PayGo proof consistent when adding it to our PSBT, so we want to convert this to `hex`, another suggestion would be to modify the `bip32utils.verifyMessage` and `bip32utils.signMessage` to always convert our proof to/from `hex` so that we don't have to convert back and forth and just pass in a Buffer. Open to suggestions.

This has been done in another [PR](https://github.com/BitGo/BitGoJS/pull/6393). This PR is to modify our existing paygo util functions so that they do not account for the bitcoin prefix when signed from our keyservice. We will only be caring about the `<VARINT_LENGTH><ENTROPY><ADDRESS><UUID>` in our proof and our functions will reflect this change.
<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
