### PR TITLE
feat(utxo-core): modernize bip32utils module

### DIFF
--- a/modules/utxo-core/package.json
+++ b/modules/utxo-core/package.json
@@ -55,11 +55,7 @@
     "@bitgo/utxo-lib": "^11.6.1",
     "@bitgo/wasm-miniscript": "2.0.0-beta.7",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
-    "bitcoinjs-message": "npm:@bitgo-forks/bitcoinjs-message@1.0.0-master.3",
-    "lodash": "^4.17.15"
-  },
-  "devDependencies": {
-    "@types/lodash": "^4.14.151"
+    "bitcoinjs-message": "npm:@bitgo-forks/bitcoinjs-message@1.0.0-master.3"
   },
   "gitHead": "18e460ddf02de2dbf13c2aa243478188fb539f0c"
 }

--- a/modules/utxo-core/src/bip32utils.ts
+++ b/modules/utxo-core/src/bip32utils.ts
@@ -6,7 +6,7 @@ import { BIP32Interface } from '@bitgo/utxo-lib';
  * @see {bitcoinMessage.sign}
  */
 export function signMessage(
-  message: string,
+  message: string | Buffer,
   privateKey: BIP32Interface | Buffer,
   network: { messagePrefix: string }
 ): Buffer {
@@ -28,7 +28,7 @@ export function signMessage(
  * @see {bitcoinMessage.verify}
  */
 export function verifyMessage(
-  message: string,
+  message: string | Buffer,
   publicKey: BIP32Interface | Buffer,
   signature: Buffer,
   network: { messagePrefix: string }

--- a/modules/utxo-core/src/bip32utils.ts
+++ b/modules/utxo-core/src/bip32utils.ts
@@ -1,5 +1,4 @@
 import * as utxolib from '@bitgo/utxo-lib';
-import * as _ from 'lodash';
 import * as bitcoinMessage from 'bitcoinjs-message';
 import { BIP32Interface } from '@bitgo/utxo-lib';
 /**
@@ -17,7 +16,7 @@ export function signMessage(
       throw new Error(`must provide privateKey`);
     }
   }
-  if (!_.isObject(network) || !_.isString(network.messagePrefix)) {
+  if (network === null || typeof network !== 'object' || typeof network.messagePrefix !== 'string') {
     throw new Error(`invalid argument 'network'`);
   }
   const compressed = true;
@@ -37,7 +36,7 @@ export function verifyMessage(
   if (!Buffer.isBuffer(publicKey)) {
     publicKey = publicKey.publicKey;
   }
-  if (!_.isObject(network) || !_.isString(network.messagePrefix)) {
+  if (network === null || typeof network !== 'object' || typeof network.messagePrefix !== 'string') {
     throw new Error(`invalid argument 'network'`);
   }
 

--- a/modules/utxo-core/test/bip32utils.ts
+++ b/modules/utxo-core/test/bip32utils.ts
@@ -1,7 +1,7 @@
 import * as crypto from 'crypto';
+import * as assert from 'assert';
 
 import * as utxolib from '@bitgo/utxo-lib';
-import 'should';
 
 import { signMessage, verifyMessage } from '../src/bip32utils';
 
@@ -18,7 +18,8 @@ describe('bip32utils', function () {
 
         keys.forEach((otherKey) => {
           messages.forEach((otherMessage) => {
-            verifyMessage(otherMessage, otherKey, signature, utxolib.networks.bitcoin).should.eql(
+            assert.strictEqual(
+              verifyMessage(otherMessage, otherKey, signature, utxolib.networks.bitcoin),
               message === otherMessage && key === otherKey
             );
           });

--- a/modules/utxo-core/test/bip32utils.ts
+++ b/modules/utxo-core/test/bip32utils.ts
@@ -11,16 +11,18 @@ describe('bip32utils', function () {
   }
   it('signMessage/verifyMessage', function () {
     const keys = getSeedBuffers(4).map((seed) => utxolib.bip32.fromSeed(seed));
-    const messages = ['hello', 'goodbye'];
+    const messages = ['hello', 'goodbye', Buffer.from('\x01\x02\x03'), Buffer.from('')];
     keys.forEach((key) => {
       messages.forEach((message) => {
         const signature = signMessage(message, key, utxolib.networks.bitcoin);
 
         keys.forEach((otherKey) => {
           messages.forEach((otherMessage) => {
+            const expectValid = message === otherMessage && key === otherKey;
+            assert.strictEqual(verifyMessage(otherMessage, otherKey, signature, utxolib.networks.bitcoin), expectValid);
             assert.strictEqual(
-              verifyMessage(otherMessage, otherKey, signature, utxolib.networks.bitcoin),
-              message === otherMessage && key === otherKey
+              verifyMessage(Buffer.from(otherMessage), otherKey, signature, utxolib.networks.bitcoin),
+              expectValid
             );
           });
         });

--- a/modules/utxo-core/test/bip32utils.ts
+++ b/modules/utxo-core/test/bip32utils.ts
@@ -1,19 +1,16 @@
-/**
- * @prettier
- */
-import { signMessage, verifyMessage } from '@bitgo/sdk-core';
 import * as crypto from 'crypto';
-import { bip32 } from '@bitgo/utxo-lib';
-import 'should';
 
 import * as utxolib from '@bitgo/utxo-lib';
+import 'should';
 
-describe('bip32util', function () {
+import { signMessage, verifyMessage } from '../src/bip32utils';
+
+describe('bip32utils', function () {
   function getSeedBuffers(length: number) {
     return Array.from({ length }).map((_, i) => crypto.createHash('sha256').update(`${i}`).digest());
   }
   it('signMessage/verifyMessage', function () {
-    const keys = getSeedBuffers(4).map((seed) => bip32.fromSeed(seed));
+    const keys = getSeedBuffers(4).map((seed) => utxolib.bip32.fromSeed(seed));
     const messages = ['hello', 'goodbye'];
     keys.forEach((key) => {
       messages.forEach((message) => {


### PR DESCRIPTION

This PR includes several improvements to the bip32utils module:

- Move bip32utils tests from bitgo to utxo-core
- Replace should.js with assert in tests for modern testing practices
- Replace lodash type checks with native JavaScript equivalents
- Remove lodash dependency completely
- Add support for Buffer message type in signMessage/verifyMessage for
  enhanced flexibility

BTC-0