### PR TITLE
fix(sdk-coin-vet): correct signable payload for vechain transaction

### DIFF
--- a/modules/sdk-coin-vet/src/lib/transaction/transaction.ts
+++ b/modules/sdk-coin-vet/src/lib/transaction/transaction.ts
@@ -449,7 +449,7 @@ export class Transaction extends BaseTransaction {
   }
 
   public get signablePayload(): Buffer {
-    return Buffer.from(this.rawTransaction.getTransactionHash().bytes);
+    return Buffer.from(this.rawTransaction.encoded);
   }
 
   /** @inheritdoc */

--- a/modules/sdk-coin-vet/test/transactionBuilder/transferBuilder.ts
+++ b/modules/sdk-coin-vet/test/transactionBuilder/transferBuilder.ts
@@ -90,7 +90,7 @@ describe('Vet Transfer Transaction', () => {
         const signablePayload = tx.signablePayload;
         should.equal(
           signablePayload.toString('hex'),
-          '90c5cd3e79059f65b32088c7d807b4c989c5c3051d5392827ec817ce2037c947'
+          'f72788014ead140e77bbc140e0df94e59f1cea4e0fef511e3d0f4eec44adf19c4cbeec88016345785d8a00008081808252088082faf8c101'
         );
       });
 


### PR DESCRIPTION
current signable payload does the Blake2b hashing on top of RLP encoding, which shouldn't be the case as blake2b hashing is done in the hsm-firmware after validating the fields.


Ticket: COIN-4502

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
