### PR TITLE
fix(statics): correct berachain url

### DIFF
--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -1183,8 +1183,8 @@ class ZkSyncTestnet extends Testnet implements EthereumNetwork {
 class Berachain extends Mainnet implements EthereumNetwork {
   name = 'Bera';
   family = CoinFamily.BERA;
-  explorerUrl = 'https://80094.routescan.io/tx/';
-  accountExplorerUrl = 'https://80094.routescan.io/address/';
+  explorerUrl = 'https://berascan.com/tx/';
+  accountExplorerUrl = 'https://berascan.com/address/';
   chainId = 80094;
   nativeCoinOperationHashPrefix = '80094';
   tokenOperationHashPrefix = '80094-ERC20';


### PR DESCRIPTION
Update the berachain URL to [https://berascan.com/](http://berascan.com/)

Ticket: COIN-4730
