### PR TITLE
feat(sdk-coin-btc): add option to force fee from non-ordinal unspents

### DIFF
--- a/examples/ts/btc/ordinals/move-individual-ordinal.ts
+++ b/examples/ts/btc/ordinals/move-individual-ordinal.ts
@@ -41,7 +41,9 @@ async function transferIndividualOrdinal() {
 
   // Build the transaction to send the ordinal
   // Note that you can configure the structure of the transaction by passing in additional parameters
-  const buildResult = await inscriptionBuilder.prepareTransfer(satPoint, recipient, feeRateSatKb, {});
+  const buildResult = await inscriptionBuilder.prepareTransfer(satPoint, recipient, feeRateSatKb, {
+    forceFeeFromOtherUnspent: true,
+  });
 
   const sent = await inscriptionBuilder.signAndSendTransfer(walletPassphrase, buildResult);
   console.log('sent ' + JSON.stringify(sent, null, 2));

--- a/modules/sdk-coin-btc/src/inscriptionBuilder.ts
+++ b/modules/sdk-coin-btc/src/inscriptionBuilder.ts
@@ -142,6 +142,7 @@ export class InscriptionBuilder implements IInscriptionBuilder {
       inscriptionConstraints = DefaultInscriptionConstraints,
       changeAddressType = 'p2wsh',
       txFormat = 'psbt',
+      forceFeeFromOtherUnspent = false,
     }: {
       signer?: utxolib.bitgo.KeyName;
       cosigner?: utxolib.bitgo.KeyName;
@@ -152,6 +153,7 @@ export class InscriptionBuilder implements IInscriptionBuilder {
       };
       changeAddressType?: utxolib.bitgo.outputScripts.ScriptType2Of3;
       txFormat?: 'psbt' | 'legacy';
+      forceFeeFromOtherUnspent?: boolean; // If true, will try to use unspents other than the inscription unspent to pay for the fee
     }
   ): Promise<PrebuildTransactionResult> {
     assert(isSatPoint(satPoint));
@@ -174,6 +176,9 @@ export class InscriptionBuilder implements IInscriptionBuilder {
     };
 
     for (const supplementaryUnspentsMinValue of SUPPLEMENTARY_UNSPENTS_MIN_VALUE_SATS) {
+      if (forceFeeFromOtherUnspent && supplementaryUnspentsMinValue === 0) {
+        continue; // Skip the attempt with 0
+      }
       try {
         return await this.prepareTransferWithExtraInputs(
           satPoint,


### PR DESCRIPTION
Add option `forceFeeFromOtherUnspent` to the inscription builder that ensures fees are paid from unspents other than the one containing the ordinal. This helps prevent accidentally burning ordinals when network fees are subtracted from the ordinal-containing UTXO.

Co-authored-by: llm-git <llm-git@ttll.de>

BTC-0000

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
