### PR TITLE
refactor(utxo-core): Pay Go Functions prefix

### DIFF
--- a/modules/utxo-core/src/paygo/parsePayGoAttestation.ts
+++ b/modules/utxo-core/src/paygo/parsePayGoAttestation.ts
@@ -3,7 +3,8 @@ import assert from 'assert';
 import { bufferutils } from '@bitgo/utxo-lib';
 
 // The signed address will always have the following structure:
-// <varint_length><ENTROPY><ADDRESS><UUID>
+// 0x18Bitcoin Signed Message:\n<varint_length><ENTROPY><ADDRESS><UUID>
+export const Prefix = Buffer.from('\u0018Bitcoin Signed Message:\n', 'utf-8');
 
 // UUID has the structure 00000000-0000-0000-0000-000000000000, and after
 // we Buffer.from and get it's length its 36.
@@ -32,6 +33,9 @@ export function parsePayGoAttestation(message: Buffer): {
   // This generates the first part before the varint length so that we can
   // determine how many bytes this is and iterate through the Buffer.
   let offset = 0;
+  if (message.toString('hex').startsWith(Prefix.toString('hex'))) {
+    offset = Prefix.length;
+  }
 
   // we decode the varint of the message which is uint32
   // https://en.bitcoin.it/wiki/Protocol_documentation

--- a/modules/utxo-core/test/paygo/parsePayGoAttestation.ts
+++ b/modules/utxo-core/test/paygo/parsePayGoAttestation.ts
@@ -2,46 +2,54 @@ import * as assert from 'assert';
 
 import { parsePayGoAttestation } from '../../src/paygo';
 import { generatePayGoAttestationProof } from '../../src/testutil';
+import { NIL_UUID } from '../../src/paygo/attestation';
 
 const addressFromPubKeyBase58 = 'bitgoAddressToExtract';
 const bufferAddressPubKeyB58 = Buffer.from(addressFromPubKeyBase58);
 
-describe('extractAddressBufferFromPayGoAttestationProof', () => {
-  it('should extractAddressBufferFromPayGoAttestationProof properly', () => {
-    const paygoAttestationProof = generatePayGoAttestationProof(
-      '00000000-0000-0000-0000-000000000000',
-      bufferAddressPubKeyB58
-    );
+describe('parsePayGoAttestationProof with prefix', () => {
+  it('should extractAddressBufferFromPayGoAttestationProof properly', function () {
+    const paygoAttestationProof = generatePayGoAttestationProof(NIL_UUID, bufferAddressPubKeyB58);
     const { entropy, address, uuid } = parsePayGoAttestation(paygoAttestationProof);
-    assert.deepStrictEqual(Buffer.compare(address, bufferAddressPubKeyB58), 0);
-    assert.deepStrictEqual(uuid.toString(), '00000000-0000-0000-0000-000000000000');
+    assert.ok(address.equals(bufferAddressPubKeyB58));
+    assert.deepStrictEqual(uuid.toString(), NIL_UUID);
     assert.deepStrictEqual(entropy.length, 64);
   });
 
-  it('should extract the paygo address paygo attestation proof given a non nilUUID', () => {
+  it('should extract the paygo address paygo attestation proof given a non nilUUID', function () {
     const paygoAttestationProof = generatePayGoAttestationProof(
       '12345678-1234-4567-6890-231928472123',
       bufferAddressPubKeyB58
     );
     const { entropy, address, uuid } = parsePayGoAttestation(paygoAttestationProof);
-    assert.deepStrictEqual(Buffer.compare(address, bufferAddressPubKeyB58), 0);
-    assert.deepStrictEqual(uuid.toString(), '12345678-1234-4567-6890-231928472123');
+    assert.ok(address.equals(bufferAddressPubKeyB58));
+    assert.deepStrictEqual(uuid.toString('utf-8'), '12345678-1234-4567-6890-231928472123');
     assert.deepStrictEqual(entropy.length, 64);
   });
 
-  it('should not extract the correct address given a uuid of wrong format', () => {
+  it('should not extract the correct address given a uuid of wrong format', function () {
     const paygoAttestationProof = generatePayGoAttestationProof(
       '000000000000000-000000-0000000-000000-0000000000000000',
       bufferAddressPubKeyB58
     );
     const { address } = parsePayGoAttestation(paygoAttestationProof);
-    assert.notDeepStrictEqual(Buffer.compare(address, bufferAddressPubKeyB58), 0);
+    assert.ok(!address.equals(bufferAddressPubKeyB58));
   });
 
-  it('should throw an error if the paygo attestation proof is too short', () => {
+  it('should throw an error if the paygo attestation proof is too short', function () {
     assert.throws(
-      () => parsePayGoAttestation(Buffer.from('shortproof-shrug')),
+      () => parsePayGoAttestation(Buffer.from('shortproof-shrug', 'utf-8')),
       'PayGo attestation proof is too short to contain a valid address.'
     );
+  });
+});
+
+describe('parsePayGoAttestation without prefix', function () {
+  it('should extract the parts of the proof without the prefix automatically', function () {
+    const payGoAttestationProof = generatePayGoAttestationProof(NIL_UUID, bufferAddressPubKeyB58, false);
+    const { entropy, address, uuid } = parsePayGoAttestation(payGoAttestationProof);
+    assert.ok(address.equals(bufferAddressPubKeyB58));
+    assert.deepStrictEqual(uuid.toString(), NIL_UUID);
+    assert.deepStrictEqual(entropy.length, 64);
   });
 });


### PR DESCRIPTION
TICKET: BTC-2251

This pr is to add automatic parsing on our PayGo proof, so that if the prefix `\x18Bitcoin Signed Message:\n` is in/not in our proof and will automatically parse accordingly into its parts `{ entropy, address, uuid }`.

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
