### PR TITLE
feat(sdk-coin-sui): fee payer signing support

### DIFF
--- a/modules/sdk-coin-sui/src/lib/transactionBuilder.ts
+++ b/modules/sdk-coin-sui/src/lib/transactionBuilder.ts
@@ -63,6 +63,12 @@ export abstract class TransactionBuilder<T = SuiProgrammableTransaction> extends
     this.transaction.setSerializedSig(publicKey, signature);
   }
 
+  addFeePayerSignature(publicKey: BasePublicKey, signature: Buffer): void {
+    this._signatures.push({ publicKey, signature });
+    this.transaction.addFeePayerSignature(publicKey, signature);
+    this.transaction.setSerializedFeePayerSig(publicKey, signature);
+  }
+
   /**
    * Sets the sender of this transaction.
    * This account will be responsible for paying transaction fees.

--- a/modules/sdk-coin-sui/test/resources/sui.ts
+++ b/modules/sdk-coin-sui/test/resources/sui.ts
@@ -39,6 +39,12 @@ export const sender = {
     'AETvicGY1HwWjQokRg2HgbQeu+QQZP4ejZQGjmfWvPUd2WkzBudVlaSzjiS1btS2/34Laf6rfkNKYD540crafAxzTVAmV/9J1skZyoX4AWkJM/R4Y1FfV36atFLbCwUVqQ==',
 };
 
+export const feePayer = {
+  address: '0x77291376d885efa752ed921b48d1aa1a65a389bf214ec0eab8b31970c9ab3618',
+  publicKey: 'TBP5Vc7o+A1dlVd7B/YktCMi2K4frfBqG5FoKAlSRyI=',
+  signatureHex: '0sQRp5hwfSnjOXx/hofBbzR/AOmDmeIexKYYzqf9T/xPXx8/TTGlvOS6P+fvzQhSPyCi0BV8DKPkgC0DEDqXAg==',
+};
+
 export const recipients: Recipient[] = [
   {
     address: addresses.validAddresses[0],
@@ -326,6 +332,13 @@ export const gasData = {
   budget: GAS_BUDGET,
 };
 
+export const gasDataHavingDifferentOwner = {
+  payment: coinsGasPayment,
+  owner: feePayer.address,
+  price: DUMMY_SUI_GAS_PRICE,
+  budget: GAS_BUDGET,
+};
+
 export const gasDataWithoutGasPayment = {
   owner: sender.address,
   price: DUMMY_SUI_GAS_PRICE,
@@ -384,6 +397,9 @@ export const CUSTOM_TX_PUBLIC_TRANSFER =
 
 export const UNSUPPORTED_TX =
   'AAADAQB8/cv/rmQ4SGTkEEwSbyfbLPq1wUyg1W6IvFtoo+8KqlC2vgAAAAAAICf6QebgEjDOJoW4sw5jWv5y/UufjHTKEBOHgJuTvJUiAQCxKLKh9y8GFhre5P0lgTbBRPtAyf0t8qUokHbou50E7NKapQAAAAAAIOQxj17At6WByUlaVwW8ARhUgNYg+4piw4zD/Y0NmkGkACD2MpmTSjDA8xA/Swgzt0TpPwDQMzvfr4FvB1MJAXguuAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMMc3Rha2luZ19wb29sEHNwbGl0X3N0YWtlZF9zdWkAAgEAAAEBAAEBAgAAAQIA07HNlidQ0GBG1SOg7xObuweDJ/1vEx0EdAuFFDmMwsEBG9JpdXApX73818xmw/q0XMj4sGCPGfoT7IqE5kfKbrgJAAAAAAAAACBx2foz6S5yGPqcihv4KTDtuVntp4JleEuKIOTdKq6RONOxzZYnUNBgRtUjoO8Tm7sHgyf9bxMdBHQLhRQ5jMLB6AMAAAAAAAAAypo7AAAAAAA=';
+
+export const FEE_SPONSOR_TRANSFER =
+  'AAAEAAhkAAAAAAAAAAAg+UGuPL5WRdzMFdqDRrUz9/kfICCJpVIWU8Bisv8QswQACGQAAAAAAAAAACB3w7WyESl5PEpWAiIKS5cAB8VNSplt6UHltxNxmkL4/gQCAAEBAAABAQIAAAEBAAIAAQECAAEBAgIAAQMAmIIYi6PoBwqbsGrpRGz2B5FO6O5Y7YMGo+Ov/1obu3ECCcQFIq7VS87PpINgXF2lghsXGsGqG2FZcfuN/iftE/1RBAAAAAAAACC2RGfJXC7cVwfXSDKdKwQB/rPC0/3tdlzDSomluG57sifdAOf8zch7TZW2OEtzkRm5HyqBoWuu3qf04AaOUpQ32QAAAAAAAAAgvik+0ypZjmC8kkbE4BtuQpN/FomQiDpqIFB6wsFNJyd3KRN22IXvp1LtkhtI0aoaZaOJvyFOwOq4sxlwyas2GOgDAAAAAAAAAC0xAQAAAAAA';
 
 export const invalidRecipients: Recipient[] = [
   {


### PR DESCRIPTION
This change allow sponsor/fee address signing in case of sui, currently sui fee amount is paid from sender address so there was no need set fee address and fee signature, but for new sponsored transaction we will provide fee adress and fee signature as well

TICKET: WIN-6028

<!--
# Please be aware of the following when making your pull request:

## Description

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
