### PR TITLE
feat(utxo-core): add selectTapLeafScript option to createPsbt

### DIFF
--- a/modules/utxo-core/src/testutil/descriptor/mock.utils.ts
+++ b/modules/utxo-core/src/testutil/descriptor/mock.utils.ts
@@ -1,4 +1,4 @@
-import { Descriptor } from '@bitgo/wasm-miniscript';
+import { Descriptor, Miniscript } from '@bitgo/wasm-miniscript';
 import * as utxolib from '@bitgo/utxo-lib';
 
 import {
@@ -17,6 +17,7 @@ type BaseMockDescriptorOutputParams = {
   index?: number;
   value?: bigint;
   sequence?: number;
+  selectTapLeafScript?: Miniscript;
 };
 
 function mockOutputId(id?: MockOutputIdParams): {
@@ -42,6 +43,7 @@ export function mockDerivedDescriptorWalletOutput(
       value,
     },
     descriptor,
+    selectTapLeafScript: outputParams.selectTapLeafScript,
     sequence: outputParams.sequence,
   };
 }
@@ -49,6 +51,7 @@ export function mockDerivedDescriptorWalletOutput(
 type MockInput = BaseMockDescriptorOutputParams & {
   index: number;
   descriptor: Descriptor;
+  selectTapLeafScript?: Miniscript;
 };
 
 type MockOutput = {

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Tr1Of3-NoKeyPath-Tree-Plain-TapLeafScript0.psbtStages.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Tr1Of3-NoKeyPath-Tree-Plain-TapLeafScript0.psbtStages.json
@@ -1,0 +1,486 @@
+{
+  "unsigned": {
+    "psbt": {
+      "data": {
+        "inputs": [
+          {
+            "witnessUtxo": {
+              "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+              "value": "1000000"
+            },
+            "tapLeafScript": [
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0a7f318e67988ceb3947e2511fd891a2fdaa83f2344f4b82e02a5c9a27ab99d61",
+                "script": "203569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebbac",
+                "leafVersion": 192
+              }
+            ],
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapMerkleRoot": "082536b1ddcb634ef1835b5935a304ab784c58636e1e8e325d8f4bbde0f945b9"
+          },
+          {
+            "witnessUtxo": {
+              "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+              "value": "1000000"
+            },
+            "tapLeafScript": [
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0a7f318e67988ceb3947e2511fd891a2fdaa83f2344f4b82e02a5c9a27ab99d61",
+                "script": "203569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebbac",
+                "leafVersion": 192
+              }
+            ],
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapMerkleRoot": "082536b1ddcb634ef1835b5935a304ab784c58636e1e8e325d8f4bbde0f945b9"
+          }
+        ],
+        "outputs": [
+          {},
+          {
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapTree": {
+              "leaves": [
+                {
+                  "depth": 1,
+                  "leafVersion": 192,
+                  "script": "203569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebbac"
+                },
+                {
+                  "depth": 2,
+                  "leafVersion": 192,
+                  "script": "2028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac"
+                },
+                {
+                  "depth": 2,
+                  "leafVersion": 192,
+                  "script": "2078426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580ac"
+                }
+              ]
+            },
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ]
+          }
+        ],
+        "globalMap": {
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 0,
+                  "script": "",
+                  "sequence": 4294967293,
+                  "witness": []
+                },
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 1,
+                  "script": "",
+                  "sequence": 4294967293,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "400000",
+                  "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+                },
+                {
+                  "value": "400000",
+                  "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "nonceStore": {
+        "nonces": []
+      },
+      "opts": {
+        "maximumFeeRate": 5000
+      }
+    },
+    "parsed": {
+      "inputs": [
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "value": "1000000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
+        },
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "value": "1000000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477",
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000"
+        },
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+          "value": "400000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
+        }
+      ],
+      "spendAmount": "400000",
+      "minerFee": "1200000",
+      "virtualSize": 279
+    }
+  },
+  "signed": {
+    "psbt": {
+      "data": {
+        "inputs": [
+          {
+            "witnessUtxo": {
+              "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+              "value": "1000000"
+            },
+            "tapScriptSig": [
+              {
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "leafHash": "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9",
+                "signature": "33f2bfd93cad0c555cd5c2eac550d7b7ababb0f524800257f17aaf88c92c8278f299cb388831d055d7c0bdbb75b7b0c56fa2ae20c1e7fbb4ccd85db6f3286d78"
+              }
+            ],
+            "tapLeafScript": [
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0a7f318e67988ceb3947e2511fd891a2fdaa83f2344f4b82e02a5c9a27ab99d61",
+                "script": "203569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebbac",
+                "leafVersion": 192
+              }
+            ],
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapMerkleRoot": "082536b1ddcb634ef1835b5935a304ab784c58636e1e8e325d8f4bbde0f945b9"
+          },
+          {
+            "witnessUtxo": {
+              "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+              "value": "1000000"
+            },
+            "tapScriptSig": [
+              {
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "leafHash": "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9",
+                "signature": "62f789426299826339f9ddfbd656358483108e339d0010fefd49ae1ef1da72ea5c284958b6b5f2c2e544f36de34ddf9863d48474eaf0559cca9944d1b7f1befd"
+              }
+            ],
+            "tapLeafScript": [
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0a7f318e67988ceb3947e2511fd891a2fdaa83f2344f4b82e02a5c9a27ab99d61",
+                "script": "203569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebbac",
+                "leafVersion": 192
+              }
+            ],
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapMerkleRoot": "082536b1ddcb634ef1835b5935a304ab784c58636e1e8e325d8f4bbde0f945b9"
+          }
+        ],
+        "outputs": [
+          {},
+          {
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapTree": {
+              "leaves": [
+                {
+                  "depth": 1,
+                  "leafVersion": 192,
+                  "script": "203569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebbac"
+                },
+                {
+                  "depth": 2,
+                  "leafVersion": 192,
+                  "script": "2028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac"
+                },
+                {
+                  "depth": 2,
+                  "leafVersion": 192,
+                  "script": "2078426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580ac"
+                }
+              ]
+            },
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ]
+          }
+        ],
+        "globalMap": {
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 0,
+                  "script": "",
+                  "sequence": 4294967293,
+                  "witness": []
+                },
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 1,
+                  "script": "",
+                  "sequence": 4294967293,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "400000",
+                  "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+                },
+                {
+                  "value": "400000",
+                  "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "nonceStore": {
+        "nonces": []
+      },
+      "opts": {
+        "maximumFeeRate": 5000
+      }
+    },
+    "parsed": {
+      "inputs": [
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "value": "1000000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
+        },
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "value": "1000000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477",
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000"
+        },
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+          "value": "400000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
+        }
+      ],
+      "spendAmount": "400000",
+      "minerFee": "1200000",
+      "virtualSize": 279
+    }
+  }
+}

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Tr1Of3-NoKeyPath-Tree-Plain-TapLeafScript1.psbtStages.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Tr1Of3-NoKeyPath-Tree-Plain-TapLeafScript1.psbtStages.json
@@ -1,0 +1,486 @@
+{
+  "unsigned": {
+    "psbt": {
+      "data": {
+        "inputs": [
+          {
+            "witnessUtxo": {
+              "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+              "value": "1000000"
+            },
+            "tapLeafScript": [
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bda7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9",
+                "script": "2028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac",
+                "leafVersion": 192
+              }
+            ],
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapMerkleRoot": "082536b1ddcb634ef1835b5935a304ab784c58636e1e8e325d8f4bbde0f945b9"
+          },
+          {
+            "witnessUtxo": {
+              "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+              "value": "1000000"
+            },
+            "tapLeafScript": [
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bda7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9",
+                "script": "2028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac",
+                "leafVersion": 192
+              }
+            ],
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapMerkleRoot": "082536b1ddcb634ef1835b5935a304ab784c58636e1e8e325d8f4bbde0f945b9"
+          }
+        ],
+        "outputs": [
+          {},
+          {
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapTree": {
+              "leaves": [
+                {
+                  "depth": 1,
+                  "leafVersion": 192,
+                  "script": "203569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebbac"
+                },
+                {
+                  "depth": 2,
+                  "leafVersion": 192,
+                  "script": "2028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac"
+                },
+                {
+                  "depth": 2,
+                  "leafVersion": 192,
+                  "script": "2078426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580ac"
+                }
+              ]
+            },
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ]
+          }
+        ],
+        "globalMap": {
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 0,
+                  "script": "",
+                  "sequence": 4294967293,
+                  "witness": []
+                },
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 1,
+                  "script": "",
+                  "sequence": 4294967293,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "400000",
+                  "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+                },
+                {
+                  "value": "400000",
+                  "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "nonceStore": {
+        "nonces": []
+      },
+      "opts": {
+        "maximumFeeRate": 5000
+      }
+    },
+    "parsed": {
+      "inputs": [
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "value": "1000000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
+        },
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "value": "1000000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477",
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000"
+        },
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+          "value": "400000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
+        }
+      ],
+      "spendAmount": "400000",
+      "minerFee": "1200000",
+      "virtualSize": 279
+    }
+  },
+  "signed": {
+    "psbt": {
+      "data": {
+        "inputs": [
+          {
+            "witnessUtxo": {
+              "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+              "value": "1000000"
+            },
+            "tapScriptSig": [
+              {
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "leafHash": "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10",
+                "signature": "8c43a535f29c138df7f4f43b9dd93aaf8313ce59a681d7f31bda9baf9b3341972af0a46a161c8c3fc561c0e788fdc8ca80a591f168c10bf5cb9be74bf94bb53c"
+              }
+            ],
+            "tapLeafScript": [
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bda7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9",
+                "script": "2028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac",
+                "leafVersion": 192
+              }
+            ],
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapMerkleRoot": "082536b1ddcb634ef1835b5935a304ab784c58636e1e8e325d8f4bbde0f945b9"
+          },
+          {
+            "witnessUtxo": {
+              "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+              "value": "1000000"
+            },
+            "tapScriptSig": [
+              {
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "leafHash": "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10",
+                "signature": "013b322678f2780fca10619a562313f4c66c1101a9e3b1d9f1e19d7a5d59f5f2f23da3749cc6c2ab528dbd79138bb65b4c65fffd41426ee89e77ca53114d2f41"
+              }
+            ],
+            "tapLeafScript": [
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bda7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9",
+                "script": "2028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac",
+                "leafVersion": 192
+              }
+            ],
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapMerkleRoot": "082536b1ddcb634ef1835b5935a304ab784c58636e1e8e325d8f4bbde0f945b9"
+          }
+        ],
+        "outputs": [
+          {},
+          {
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapTree": {
+              "leaves": [
+                {
+                  "depth": 1,
+                  "leafVersion": 192,
+                  "script": "203569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebbac"
+                },
+                {
+                  "depth": 2,
+                  "leafVersion": 192,
+                  "script": "2028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac"
+                },
+                {
+                  "depth": 2,
+                  "leafVersion": 192,
+                  "script": "2078426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580ac"
+                }
+              ]
+            },
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ]
+          }
+        ],
+        "globalMap": {
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 0,
+                  "script": "",
+                  "sequence": 4294967293,
+                  "witness": []
+                },
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 1,
+                  "script": "",
+                  "sequence": 4294967293,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "400000",
+                  "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+                },
+                {
+                  "value": "400000",
+                  "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "nonceStore": {
+        "nonces": []
+      },
+      "opts": {
+        "maximumFeeRate": 5000
+      }
+    },
+    "parsed": {
+      "inputs": [
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "value": "1000000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
+        },
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "value": "1000000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477",
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000"
+        },
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+          "value": "400000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
+        }
+      ],
+      "spendAmount": "400000",
+      "minerFee": "1200000",
+      "virtualSize": 279
+    }
+  }
+}

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Tr1Of3-NoKeyPath-Tree-Plain-TapLeafScript2.psbtStages.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Tr1Of3-NoKeyPath-Tree-Plain-TapLeafScript2.psbtStages.json
@@ -1,0 +1,486 @@
+{
+  "unsigned": {
+    "psbt": {
+      "data": {
+        "inputs": [
+          {
+            "witnessUtxo": {
+              "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+              "value": "1000000"
+            },
+            "tapLeafScript": [
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac06b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9",
+                "script": "2078426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580ac",
+                "leafVersion": 192
+              }
+            ],
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapMerkleRoot": "082536b1ddcb634ef1835b5935a304ab784c58636e1e8e325d8f4bbde0f945b9"
+          },
+          {
+            "witnessUtxo": {
+              "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+              "value": "1000000"
+            },
+            "tapLeafScript": [
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac06b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9",
+                "script": "2078426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580ac",
+                "leafVersion": 192
+              }
+            ],
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapMerkleRoot": "082536b1ddcb634ef1835b5935a304ab784c58636e1e8e325d8f4bbde0f945b9"
+          }
+        ],
+        "outputs": [
+          {},
+          {
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapTree": {
+              "leaves": [
+                {
+                  "depth": 1,
+                  "leafVersion": 192,
+                  "script": "203569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebbac"
+                },
+                {
+                  "depth": 2,
+                  "leafVersion": 192,
+                  "script": "2028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac"
+                },
+                {
+                  "depth": 2,
+                  "leafVersion": 192,
+                  "script": "2078426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580ac"
+                }
+              ]
+            },
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ]
+          }
+        ],
+        "globalMap": {
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 0,
+                  "script": "",
+                  "sequence": 4294967293,
+                  "witness": []
+                },
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 1,
+                  "script": "",
+                  "sequence": 4294967293,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "400000",
+                  "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+                },
+                {
+                  "value": "400000",
+                  "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "nonceStore": {
+        "nonces": []
+      },
+      "opts": {
+        "maximumFeeRate": 5000
+      }
+    },
+    "parsed": {
+      "inputs": [
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "value": "1000000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
+        },
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "value": "1000000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477",
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000"
+        },
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+          "value": "400000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
+        }
+      ],
+      "spendAmount": "400000",
+      "minerFee": "1200000",
+      "virtualSize": 279
+    }
+  },
+  "signed": {
+    "psbt": {
+      "data": {
+        "inputs": [
+          {
+            "witnessUtxo": {
+              "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+              "value": "1000000"
+            },
+            "tapScriptSig": [
+              {
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "leafHash": "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd",
+                "signature": "0588b5273345fdcd648edfda310afeaf06c75f5ccefbafbde59148ae3600796f1d99f40d47a5bed5cf2f83d6a7f0133d551a0e27a30432fd31d0f165a3235b2c"
+              }
+            ],
+            "tapLeafScript": [
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac06b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9",
+                "script": "2078426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580ac",
+                "leafVersion": 192
+              }
+            ],
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapMerkleRoot": "082536b1ddcb634ef1835b5935a304ab784c58636e1e8e325d8f4bbde0f945b9"
+          },
+          {
+            "witnessUtxo": {
+              "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+              "value": "1000000"
+            },
+            "tapScriptSig": [
+              {
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "leafHash": "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd",
+                "signature": "3bbed5b5fcd835c90329161388b3e243e19ab7a8ea2298e319526e1850089b73e11b0ac5976bf3bd7665e8fe462fdc44cdcd56691f2101ecd68420cd80eafbcc"
+              }
+            ],
+            "tapLeafScript": [
+              {
+                "controlBlock": "c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac06b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9",
+                "script": "2078426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580ac",
+                "leafVersion": 192
+              }
+            ],
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ],
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapMerkleRoot": "082536b1ddcb634ef1835b5935a304ab784c58636e1e8e325d8f4bbde0f945b9"
+          }
+        ],
+        "outputs": [
+          {},
+          {
+            "tapInternalKey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+            "tapTree": {
+              "leaves": [
+                {
+                  "depth": 1,
+                  "leafVersion": 192,
+                  "script": "203569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebbac"
+                },
+                {
+                  "depth": 2,
+                  "leafVersion": 192,
+                  "script": "2028fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201ac"
+                },
+                {
+                  "depth": 2,
+                  "leafVersion": 192,
+                  "script": "2078426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580ac"
+                }
+              ]
+            },
+            "tapBip32Derivation": [
+              {
+                "masterFingerprint": "4be1dd67",
+                "pubkey": "28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201",
+                "path": "m",
+                "leafHashes": [
+                  "6b043efe7f51dfe0a527139361ec95bdcd28f1ebe54b63bab7b84468c9c4de10"
+                ]
+              },
+              {
+                "masterFingerprint": "1f412747",
+                "pubkey": "3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb",
+                "path": "m",
+                "leafHashes": [
+                  "a7949f48ebc158aaf40b52b2745fbbf868c4400cd96e3ebef0b9a6af04e476d9"
+                ]
+              },
+              {
+                "masterFingerprint": "f4ac30dd",
+                "pubkey": "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+                "path": "m",
+                "leafHashes": []
+              },
+              {
+                "masterFingerprint": "a24b61e9",
+                "pubkey": "78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580",
+                "path": "m",
+                "leafHashes": [
+                  "fec90a8940a27960883c8b6e7cac3cde9b0493e98b87700b09cbb3edf5a452bd"
+                ]
+              }
+            ]
+          }
+        ],
+        "globalMap": {
+          "unsignedTx": {
+            "tx": {
+              "version": 2,
+              "locktime": 0,
+              "ins": [
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 0,
+                  "script": "",
+                  "sequence": 4294967293,
+                  "witness": []
+                },
+                {
+                  "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+                  "index": 1,
+                  "script": "",
+                  "sequence": 4294967293,
+                  "witness": []
+                }
+              ],
+              "outs": [
+                {
+                  "value": "400000",
+                  "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+                },
+                {
+                  "value": "400000",
+                  "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "nonceStore": {
+        "nonces": []
+      },
+      "opts": {
+        "maximumFeeRate": 5000
+      }
+    },
+    "parsed": {
+      "inputs": [
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "value": "1000000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
+        },
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "value": "1000000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477",
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000"
+        },
+        {
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9",
+          "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+          "value": "400000",
+          "scriptId": {
+            "descriptor": "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,{pk(3569e37b7d247ddc6500f4927c5412783e810d2bad44d8c57dffba8118e03ebb),{pk(28fa10584d2e1f7833e943827812608b9a1c5e4ec789762d6a90b4d1f1339201),pk(78426026dde1e26b926b9aa4e3efd3d9df45d594bf738748c1d0cb0a2bbf0580)}})#50gkv3dy"
+          }
+        }
+      ],
+      "spendAmount": "400000",
+      "minerFee": "1200000",
+      "virtualSize": 279
+    }
+  }
+}


### PR DESCRIPTION

Add ability to specify which tap leaf script should be used when
signing a taproot transaction. This enables selective script path
signing with specific scripts from the tap tree.

Features added:
- New findTapLeafScript function to locate a specific script in a tree
- Support for selectTapLeafScript in transaction inputs
- Test fixtures for different tap leaf script selection scenarios

BTC-2143