### PR TITLE
chore: fix decimalPlaces value and add test cases

### DIFF
--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -912,7 +912,7 @@ export const ofcCoins = [
     '6fd31137-ab29-441e-9136-8b4bad4f0477',
     'ofctsol:usdc',
     'testnet USD Coin',
-    6,
+    9,
     UnderlyingAsset['tsol:usdc'],
     SOL_TOKEN_FEATURES
   ),
@@ -979,7 +979,7 @@ export const ofcCoins = [
   ofcTronToken('d953a72b-b7b9-4c8d-97bd-f03394e30608', 'ofctrx:trxs', 'Staked TRX', 18, UnderlyingAsset['trx:trxs']),
   ofcXrpToken('6a173023-5faf-4a0a-af38-b8be98abe94f', 'ofcxrp:rlusd', 'Ripple USD', 15, UnderlyingAsset['xrp:rlusd']),
   tofcXrpToken('bd406dab-3b55-4ab5-b0a5-74b9f94268a3', 'ofctxrp:rlusd', 'RLUSD', 15, UnderlyingAsset['txrp:rlusd']),
-  ofcXrpToken('eb3c02de-7221-4fde-9235-5cc576eb7c8b', 'ofcxrp:xsgd', 'XSGD', 6, UnderlyingAsset['xrp:xsgd']),
+  ofcXrpToken('eb3c02de-7221-4fde-9235-5cc576eb7c8b', 'ofcxrp:xsgd', 'XSGD', 15, UnderlyingAsset['xrp:xsgd']),
   ofcXrpToken(
     '46c75216-5498-4417-b73c-a08c11d693ad',
     'ofcxrp:tbill',

--- a/modules/statics/test/unit/ofcCoinParity.ts
+++ b/modules/statics/test/unit/ofcCoinParity.ts
@@ -13,6 +13,11 @@ const EXCLUDED_ASSETS = new Set<string>([
   'tgbp', // confusion with the fiat version
 ]);
 
+const EXCLUDED_ASSETS_FOR_DECIMAL_CHECK = new Set<string>([
+  'ofctusd', // Not sure why decimalPlaces is set to 2 instead of 18.
+  'ofctgbp', // Not sure why decimalPlaces is set to 2 instead of 18.
+]);
+
 describe('OFC Coin parity tests', function () {
   it('should have parity with OFC for ERC20 tokens', function () {
     const ofcCoinsWithInvalidAssets = ofcErc20Coins
@@ -50,4 +55,33 @@ describe('OFC Coin parity tests', function () {
       // should(addedOfcErc20s.length).equal(0, 'Missing OFC ERC20s');
     }
   });
+
+  it('validate the decimalPlaces for ofc token', function () {
+    const ofcCoins = coins.filter((coin) => coin.family === 'ofc');
+    ofcCoins.forEach((ofcCoin) => {
+      const baseTokenName = ofcCoin.name.replace(/^ofc/, '');
+      const baseCoin = getCoin(baseTokenName);
+      if (
+        baseCoin &&
+        !EXCLUDED_ASSETS_FOR_DECIMAL_CHECK.has(ofcCoin.name) &&
+        baseCoin.decimalPlaces !== ofcCoin.decimalPlaces
+      ) {
+        baseCoin.decimalPlaces.should.equal(ofcCoin.decimalPlaces);
+      }
+    });
+  });
+
+  function getCoin(coinName: string) {
+    try {
+      {
+        const coin = coins.get(coinName);
+        if (!coin) {
+          return undefined;
+        }
+        return coin;
+      }
+    } catch (e) {
+      return undefined;
+    }
+  }
 });


### PR DESCRIPTION
The decimalPlaces for OFC tokens should always match the actual decimal places of the underlying coin.

Ticket: WIN-6149

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
