### PR TITLE
feat(account-lib): return hex broadcastable message string

### DIFF
--- a/examples/ts/build-message.ts
+++ b/examples/ts/build-message.ts
@@ -8,8 +8,9 @@
  */
 
 import {BitGoAPI} from '@bitgo/sdk-api';
+import {MessageStandardType} from "@bitgo/sdk-core";
+import {MIDNIGHT_TNC_HASH} from "@bitgo/account-lib/dist/src/utils";
 import {Hteth} from "@bitgo/sdk-coin-eth";
-import {MessageStandardType} from "@bitgo/sdk-core"; // Replace with your given coin (e.g. Ltc, Tltc)
 require('dotenv').config({ path: '../../.env' });
 
 const bitgo = new BitGoAPI({
@@ -28,9 +29,12 @@ async function main() {
   const wallet = await bitgo.coin(coin).wallets().get({ id });
   console.log(`Wallet label: ${wallet.label()}`);
 
+  const adaTestnetDestinationAddress = 'addr_test1vz7xs7ceu4xx9n5xn57lfe86vrwddqpp77vjwq5ptlkh49cqy3wur';
+  const testnetMessageRaw = `STAR 12345678 to ${adaTestnetDestinationAddress} ${MIDNIGHT_TNC_HASH}`;
+
   const txRequest = await wallet.buildSignMessageRequest({
     message: {
-      messageRaw: 'Hello, BitGo!',
+      messageRaw: testnetMessageRaw,
       messageStandardType: MessageStandardType.EIP191,
     },
   });

--- a/modules/abstract-eth/test/unit/messages/eip191/eip191Message.ts
+++ b/modules/abstract-eth/test/unit/messages/eip191/eip191Message.ts
@@ -145,7 +145,8 @@ describe('EIP191 Message', () => {
         metadata: fixtures.eip191.metadata,
       });
 
-      const broadcastString = await message.toBroadcastString();
+      const broadcastHex = await message.toBroadcastString();
+      const broadcastString = Buffer.from(broadcastHex, 'hex').toString();
       const parsedBroadcast = JSON.parse(broadcastString);
       const expectedSerializedSignatures = serializeSignatures([fixtures.eip191.signature]);
 

--- a/modules/sdk-core/src/account-lib/baseCoin/messages/baseMessage.ts
+++ b/modules/sdk-core/src/account-lib/baseCoin/messages/baseMessage.ts
@@ -160,7 +160,8 @@ export abstract class BaseMessage implements IMessage {
    */
   async toBroadcastString(): Promise<string> {
     const broadcastable = await this.toBroadcastFormat();
-    return JSON.stringify(broadcastable);
+    const broadcastableStr = JSON.stringify(broadcastable);
+    return Buffer.from(broadcastableStr).toString('hex');
   }
 
   /**

--- a/modules/sdk-core/src/account-lib/baseCoin/messages/baseMessageBuilderFactory.ts
+++ b/modules/sdk-core/src/account-lib/baseCoin/messages/baseMessageBuilderFactory.ts
@@ -44,11 +44,12 @@ export abstract class BaseMessageBuilderFactory implements IMessageBuilderFactor
 
   /**
    * Parses a broadcastable message and gets the message builder based on the message type.
-   * @param broadcastString The broadcastable message to parse
+   * @param broadcastHex The broadcastable message to parse
    * @returns A message builder instance for the parsed broadcastable message type
    */
-  fromBroadcastString(broadcastString: string): IMessageBuilder {
-    const broadcastMessage = JSON.parse(broadcastString) as BroadcastableMessage;
+  fromBroadcastString(broadcastHex: string): IMessageBuilder {
+    const broadcastStr = Buffer.from(broadcastHex).toString();
+    const broadcastMessage = JSON.parse(broadcastStr) as BroadcastableMessage;
     return this.fromBroadcastFormat(broadcastMessage);
   }
 }

--- a/modules/sdk-core/test/unit/account-lib/baseCoin/messages/baseMessage.ts
+++ b/modules/sdk-core/test/unit/account-lib/baseCoin/messages/baseMessage.ts
@@ -210,7 +210,7 @@ describe('Base Message', () => {
   });
 
   describe('toBroadcastString', () => {
-    it('should serialize the broadcastable format to JSON string', async () => {
+    it('should serialize the broadcastable format to hex string', async () => {
       const { payload, type, metadata, signers, signatures } = messageSamples.eip191;
 
       const message = new TestMessage({
@@ -230,7 +230,8 @@ describe('Base Message', () => {
         signablePayload: 'SGVsbG8gQml0R28h',
       };
 
-      const broadcastString = await message.toBroadcastString();
+      const broadcastHex = await message.toBroadcastString();
+      const broadcastString = Buffer.from(broadcastHex, 'hex').toString();
       const parsed = JSON.parse(broadcastString);
 
       should.deepEqual(parsed, expectedBroadcastString);

--- a/modules/sdk-core/test/unit/account-lib/baseCoin/messages/baseMessageBuilder.ts
+++ b/modules/sdk-core/test/unit/account-lib/baseCoin/messages/baseMessageBuilder.ts
@@ -177,7 +177,7 @@ describe('Base Message Builder', () => {
     builder.setType(MessageStandardType.EIP191).setPayload(payload).setSignatures(signatures).setSigners(signers);
 
     const message = await builder.build();
-    const broadcastString = await message.toBroadcastString();
+    const broadcastHex = await message.toBroadcastString();
 
     const expectedJson = JSON.stringify({
       type: MessageStandardType.EIP191,
@@ -187,7 +187,8 @@ describe('Base Message Builder', () => {
       metadata: { encoding: 'utf8' },
       signablePayload: 'c2VyaWFsaXplIG1l',
     });
+    const expectedHex = Buffer.from(expectedJson).toString('hex');
 
-    should.equal(broadcastString, expectedJson);
+    should.equal(broadcastHex, expectedHex);
   });
 });


### PR DESCRIPTION
1. In baseMessage.ts, the toBroadcastString() method now converts the JSON string to a hexadecimal format instead of returning the plain JSON.
2. In baseMessageBuilderFactory.ts, the fromBroadcastString() method was updated to handle the new hex format by first converting it back to a string.
3. Tests were updated in multiple files to account for this change:
    - Converting hex back to string before parsing
    - Updating test descriptions and expectations

TICKET: COIN-4755

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
