### PR TITLE
fix(utxo-core): improve property extraction in toPlainObject

### DIFF
--- a/modules/utxo-core/src/testutil/descriptor/psbt.utils.ts
+++ b/modules/utxo-core/src/testutil/descriptor/psbt.utils.ts
@@ -12,6 +12,7 @@ export function toPlainObjectFromPsbt(v: utxolib.Psbt): unknown {
           matchPath(path, ['__CACHE']) ||
           matchPath(path, ['opts', 'network']) ||
           matchPath(path, ['data', 'globalMap', 'unsignedTx', 'tx', 'network']) ||
+          matchPath(path, ['tx', 'network']) ||
           matchPath(path, ['network'])
         );
       },

--- a/modules/utxo-core/src/testutil/toPlainObject.utils.ts
+++ b/modules/utxo-core/src/testutil/toPlainObject.utils.ts
@@ -35,10 +35,25 @@ function toPlainEntries(
   return [[key, toPlainObject(value, opts, [...path, key])]];
 }
 
+function getAllDescriptors(v: unknown): PropertyDescriptorMap {
+  if (v === null || typeof v !== 'object') {
+    return {};
+  }
+  const descriptors: PropertyDescriptorMap = Object.getOwnPropertyDescriptors(v);
+  const proto = Object.getPrototypeOf(v);
+  if (proto) {
+    Object.assign(descriptors, getAllDescriptors(proto));
+  }
+  return descriptors;
+}
+
 function toPlainObjectFromPropertyDescriptors(v: unknown, opts: ToPlainObjectOpts, path: PathElement[]) {
-  const descriptors = Object.getOwnPropertyDescriptors(v);
+  const descriptors = getAllDescriptors(v);
   return Object.fromEntries(
     Object.entries(descriptors).flatMap(([key, descriptor]) => {
+      if (typeof descriptor.value === 'function') {
+        return [];
+      }
       if (descriptor.value !== undefined) {
         return toPlainEntries(key, descriptor.value, opts, path);
       }

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Tr1Of3-NoKeyPath-Tree-Plain-TapLeafScript0.psbtStages.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Tr1Of3-NoKeyPath-Tree-Plain-TapLeafScript0.psbtStages.json
@@ -195,7 +195,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+          "value": "400000",
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9"
+        }
+      ]
     },
     "parsed": {
       "inputs": [
@@ -444,7 +501,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+          "value": "400000",
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9"
+        }
+      ]
     },
     "parsed": {
       "inputs": [

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Tr1Of3-NoKeyPath-Tree-Plain-TapLeafScript1.psbtStages.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Tr1Of3-NoKeyPath-Tree-Plain-TapLeafScript1.psbtStages.json
@@ -195,7 +195,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+          "value": "400000",
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9"
+        }
+      ]
     },
     "parsed": {
       "inputs": [
@@ -444,7 +501,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+          "value": "400000",
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9"
+        }
+      ]
     },
     "parsed": {
       "inputs": [

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Tr1Of3-NoKeyPath-Tree-Plain-TapLeafScript2.psbtStages.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Tr1Of3-NoKeyPath-Tree-Plain-TapLeafScript2.psbtStages.json
@@ -195,7 +195,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+          "value": "400000",
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9"
+        }
+      ]
     },
     "parsed": {
       "inputs": [
@@ -444,7 +501,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+          "value": "400000",
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9"
+        }
+      ]
     },
     "parsed": {
       "inputs": [

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Tr1Of3-NoKeyPath-Tree-PlainKeys.psbtStages.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Tr1Of3-NoKeyPath-Tree-PlainKeys.psbtStages.json
@@ -215,7 +215,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+          "value": "400000",
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9"
+        }
+      ]
     },
     "parsed": {
       "inputs": [
@@ -484,7 +541,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+          "value": "400000",
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9"
+        }
+      ]
     },
     "parsed": {
       "inputs": [
@@ -753,7 +867,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+          "value": "400000",
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9"
+        }
+      ]
     },
     "parsed": {
       "inputs": [
@@ -906,7 +1077,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "5120e8f110b8eee45bf2fffc239eefec0a7cd0bdaaada8d5eca9c1c822d900e75b3b",
+          "value": "400000",
+          "address": "bc1parc3pw8wu3dl9lluyw0wlmq20ngtm24d4r27e2wpeq3djq88tvashcams9"
+        }
+      ]
     },
     "networkTx": {
       "version": 2,

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Tr1Of3-NoKeyPath-Tree.psbtStages.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Tr1Of3-NoKeyPath-Tree.psbtStages.json
@@ -215,7 +215,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "512022688df7f59f2a019f67ba1aa5d3fa7050613a7014df93938558a25848e1528f"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "512022688df7f59f2a019f67ba1aa5d3fa7050613a7014df93938558a25848e1528f",
+          "value": "400000",
+          "address": "bc1pyf5gmal4nu4qr8m8hgd2t5l6wpgxzwnszn0e8yu9tz39sj8p228st9p24e"
+        }
+      ]
     },
     "parsed": {
       "inputs": [
@@ -487,7 +544,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "512022688df7f59f2a019f67ba1aa5d3fa7050613a7014df93938558a25848e1528f"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "512022688df7f59f2a019f67ba1aa5d3fa7050613a7014df93938558a25848e1528f",
+          "value": "400000",
+          "address": "bc1pyf5gmal4nu4qr8m8hgd2t5l6wpgxzwnszn0e8yu9tz39sj8p228st9p24e"
+        }
+      ]
     },
     "parsed": {
       "inputs": [
@@ -759,7 +873,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "512022688df7f59f2a019f67ba1aa5d3fa7050613a7014df93938558a25848e1528f"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "512022688df7f59f2a019f67ba1aa5d3fa7050613a7014df93938558a25848e1528f",
+          "value": "400000",
+          "address": "bc1pyf5gmal4nu4qr8m8hgd2t5l6wpgxzwnszn0e8yu9tz39sj8p228st9p24e"
+        }
+      ]
     },
     "parsed": {
       "inputs": [
@@ -915,7 +1086,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "512022688df7f59f2a019f67ba1aa5d3fa7050613a7014df93938558a25848e1528f"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "512022688df7f59f2a019f67ba1aa5d3fa7050613a7014df93938558a25848e1528f",
+          "value": "400000",
+          "address": "bc1pyf5gmal4nu4qr8m8hgd2t5l6wpgxzwnszn0e8yu9tz39sj8p228st9p24e"
+        }
+      ]
     },
     "networkTx": {
       "version": 2,

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Tr2Of3-NoKeyPath.psbtStages.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Tr2Of3-NoKeyPath.psbtStages.json
@@ -185,7 +185,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "51201d8118efb49a67b85254e9f8c47550263cc40ea3a10021f030405903b8385bd1"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "51201d8118efb49a67b85254e9f8c47550263cc40ea3a10021f030405903b8385bd1",
+          "value": "400000",
+          "address": "bc1prkq33ma5nfnms5j5a8uvga2syc7vgr4r5yqzrupsgpvs8wpct0gswjtnh7"
+        }
+      ]
     },
     "parsed": {
       "inputs": [
@@ -427,7 +484,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "51201d8118efb49a67b85254e9f8c47550263cc40ea3a10021f030405903b8385bd1"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "51201d8118efb49a67b85254e9f8c47550263cc40ea3a10021f030405903b8385bd1",
+          "value": "400000",
+          "address": "bc1prkq33ma5nfnms5j5a8uvga2syc7vgr4r5yqzrupsgpvs8wpct0gswjtnh7"
+        }
+      ]
     },
     "parsed": {
       "inputs": [
@@ -679,7 +793,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "51201d8118efb49a67b85254e9f8c47550263cc40ea3a10021f030405903b8385bd1"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "51201d8118efb49a67b85254e9f8c47550263cc40ea3a10021f030405903b8385bd1",
+          "value": "400000",
+          "address": "bc1prkq33ma5nfnms5j5a8uvga2syc7vgr4r5yqzrupsgpvs8wpct0gswjtnh7"
+        }
+      ]
     },
     "parsed": {
       "inputs": [
@@ -825,7 +996,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "51201d8118efb49a67b85254e9f8c47550263cc40ea3a10021f030405903b8385bd1"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "51201d8118efb49a67b85254e9f8c47550263cc40ea3a10021f030405903b8385bd1",
+          "value": "400000",
+          "address": "bc1prkq33ma5nfnms5j5a8uvga2syc7vgr4r5yqzrupsgpvs8wpct0gswjtnh7"
+        }
+      ]
     },
     "networkTx": {
       "version": 2,

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Wsh2Of3-CustomInputSequence.psbtStages.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Wsh2Of3-CustomInputSequence.psbtStages.json
@@ -115,7 +115,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 123,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 123
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104",
+          "value": "400000",
+          "address": "bc1q2yau645jl7k577lmanqn9a0ulcgcqm0wrrmx09dppd3kcwguvyzqk86umj"
+        }
+      ]
     },
     "parsed": {
       "inputs": [
@@ -285,7 +342,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 123,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 123
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104",
+          "value": "400000",
+          "address": "bc1q2yau645jl7k577lmanqn9a0ulcgcqm0wrrmx09dppd3kcwguvyzqk86umj"
+        }
+      ]
     },
     "parsed": {
       "inputs": [
@@ -463,7 +577,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 123,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 123
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104",
+          "value": "400000",
+          "address": "bc1q2yau645jl7k577lmanqn9a0ulcgcqm0wrrmx09dppd3kcwguvyzqk86umj"
+        }
+      ]
     },
     "parsed": {
       "inputs": [
@@ -585,7 +756,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 123,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 123
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104",
+          "value": "400000",
+          "address": "bc1q2yau645jl7k577lmanqn9a0ulcgcqm0wrrmx09dppd3kcwguvyzqk86umj"
+        }
+      ]
     },
     "networkTx": {
       "version": 2,

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Wsh2Of3.psbtStages.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Wsh2Of3.psbtStages.json
@@ -115,7 +115,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104",
+          "value": "400000",
+          "address": "bc1q2yau645jl7k577lmanqn9a0ulcgcqm0wrrmx09dppd3kcwguvyzqk86umj"
+        }
+      ]
     },
     "parsed": {
       "inputs": [
@@ -285,7 +342,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104",
+          "value": "400000",
+          "address": "bc1q2yau645jl7k577lmanqn9a0ulcgcqm0wrrmx09dppd3kcwguvyzqk86umj"
+        }
+      ]
     },
     "parsed": {
       "inputs": [
@@ -463,7 +577,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104",
+          "value": "400000",
+          "address": "bc1q2yau645jl7k577lmanqn9a0ulcgcqm0wrrmx09dppd3kcwguvyzqk86umj"
+        }
+      ]
     },
     "parsed": {
       "inputs": [
@@ -585,7 +756,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 0,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "0020513bcd5692ffad4f7bfbecc132f5fcfe11806dee18f66795a10b636c391c6104",
+          "value": "400000",
+          "address": "bc1q2yau645jl7k577lmanqn9a0ulcgcqm0wrrmx09dppd3kcwguvyzqk86umj"
+        }
+      ]
     },
     "networkTx": {
       "version": 2,

--- a/modules/utxo-core/test/descriptor/psbt/fixtures/Wsh2Of3CltvDrop.psbtStages.json
+++ b/modules/utxo-core/test/descriptor/psbt/fixtures/Wsh2Of3CltvDrop.psbtStages.json
@@ -115,7 +115,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 1,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "00203ab8b31b07c3b64804cff426e92a4b773dc28bc744bb00b36d1b0ad5af29753b"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 1,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "00203ab8b31b07c3b64804cff426e92a4b773dc28bc744bb00b36d1b0ad5af29753b",
+          "value": "400000",
+          "address": "bc1q82utxxc8cwmyspx07snwj2jtwu7u9z78gjaspvmdrv9dttefw5asfmk40j"
+        }
+      ]
     },
     "parsed": {
       "inputs": [
@@ -285,7 +342,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 1,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "00203ab8b31b07c3b64804cff426e92a4b773dc28bc744bb00b36d1b0ad5af29753b"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 1,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "00203ab8b31b07c3b64804cff426e92a4b773dc28bc744bb00b36d1b0ad5af29753b",
+          "value": "400000",
+          "address": "bc1q82utxxc8cwmyspx07snwj2jtwu7u9z78gjaspvmdrv9dttefw5asfmk40j"
+        }
+      ]
     },
     "parsed": {
       "inputs": [
@@ -463,7 +577,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 1,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "00203ab8b31b07c3b64804cff426e92a4b773dc28bc744bb00b36d1b0ad5af29753b"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 1,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "00203ab8b31b07c3b64804cff426e92a4b773dc28bc744bb00b36d1b0ad5af29753b",
+          "value": "400000",
+          "address": "bc1q82utxxc8cwmyspx07snwj2jtwu7u9z78gjaspvmdrv9dttefw5asfmk40j"
+        }
+      ]
     },
     "parsed": {
       "inputs": [
@@ -585,7 +756,64 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "tx": {
+        "version": 2,
+        "locktime": 1,
+        "ins": [
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 0,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          },
+          {
+            "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "index": 1,
+            "script": "",
+            "sequence": 4294967293,
+            "witness": []
+          }
+        ],
+        "outs": [
+          {
+            "value": "400000",
+            "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8"
+          },
+          {
+            "value": "400000",
+            "script": "00203ab8b31b07c3b64804cff426e92a4b773dc28bc744bb00b36d1b0ad5af29753b"
+          }
+        ]
+      },
+      "inputCount": 2,
+      "version": 2,
+      "locktime": 1,
+      "txInputs": [
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 0,
+          "sequence": 4294967293
+        },
+        {
+          "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+          "index": 1,
+          "sequence": 4294967293
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "002064d5e2fcca2e107ac79ef06388fa61e93ceaf31533a8d2a8c6e95423a1b1fdb8",
+          "value": "400000",
+          "address": "bc1qvn279lx29cg843u77p3c37npay7w4uc4xw5d92xxa92z8gd3lkuq4w8477"
+        },
+        {
+          "script": "00203ab8b31b07c3b64804cff426e92a4b773dc28bc744bb00b36d1b0ad5af29753b",
+          "value": "400000",
+          "address": "bc1q82utxxc8cwmyspx07snwj2jtwu7u9z78gjaspvmdrv9dttefw5asfmk40j"
+        }
+      ]
     },
     "networkTx": {
       "version": 2,

--- a/modules/utxo-staking/test/fixtures/babylon/txTree.testnet.json
+++ b/modules/utxo-staking/test/fixtures/babylon/txTree.testnet.json
@@ -73,7 +73,24 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "inputCount": 1,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "64da14050ffd0e6186c68a59f371a0adc95cc84b0502fe0915be7eba3f771bb3",
+          "index": 0,
+          "sequence": 10000
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "0014896f1ba65deaeb045bb3121e20e5744e66ca0e48",
+          "value": "55267",
+          "address": "bc1q39h3hfjaat4sgkanzg0zpet5fenv5rjg0lhnvy"
+        }
+      ]
     },
     "fee": 288
   },
@@ -147,7 +164,24 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "inputCount": 1,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "c047c5904542017cfee57fdb350d6bf776a5ef8c46bc033f454a64b496d0ab9d",
+          "index": 0,
+          "sequence": 1008
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "0014896f1ba65deaeb045bb3121e20e5744e66ca0e48",
+          "value": "53267",
+          "address": "bc1q39h3hfjaat4sgkanzg0zpet5fenv5rjg0lhnvy"
+        }
+      ]
     },
     "fee": 288
   },
@@ -204,7 +238,29 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "inputCount": 1,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "c047c5904542017cfee57fdb350d6bf776a5ef8c46bc033f454a64b496d0ab9d",
+          "index": 0,
+          "sequence": 4294967295
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "00145be12624d08a2b424095d7c07221c33450d14bf1",
+          "value": "2678",
+          "address": "bc1qt0sjvfxs3g45ysy46lq8ygwrx3gdzjl3kjg8ln"
+        },
+        {
+          "script": "5120d5238530e223ef1bd34a8a98ee1708f6a8a87e7a2589d88de6700b9973ffff46",
+          "value": "45877",
+          "address": "bc1p653c2v8zy0h3h56232vwu9cg7652sln6ykya3r0xwq9ejulllarq0n62h9"
+        }
+      ]
     },
     "fee": 5000
   },
@@ -256,7 +312,24 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "inputCount": 1,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "ab10f226d4f6daeff01e35db4c3c643ba40ae3f29654a44543dc9e97907b991d",
+          "index": 1,
+          "sequence": 1008
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "0014896f1ba65deaeb045bb3121e20e5744e66ca0e48",
+          "value": "45589",
+          "address": "bc1q39h3hfjaat4sgkanzg0zpet5fenv5rjg0lhnvy"
+        }
+      ]
     },
     "fee": 288
   },
@@ -313,7 +386,29 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "inputCount": 1,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "64da14050ffd0e6186c68a59f371a0adc95cc84b0502fe0915be7eba3f771bb3",
+          "index": 0,
+          "sequence": 4294967295
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "00145be12624d08a2b424095d7c07221c33450d14bf1",
+          "value": "2778",
+          "address": "bc1qt0sjvfxs3g45ysy46lq8ygwrx3gdzjl3kjg8ln"
+        },
+        {
+          "script": "5120d5238530e223ef1bd34a8a98ee1708f6a8a87e7a2589d88de6700b9973ffff46",
+          "value": "47777",
+          "address": "bc1p653c2v8zy0h3h56232vwu9cg7652sln6ykya3r0xwq9ejulllarq0n62h9"
+        }
+      ]
     },
     "fee": 5000
   },
@@ -504,7 +599,29 @@
     },
     "opts": {
       "maximumFeeRate": 5000
-    }
+    },
+    "inputCount": 1,
+    "version": 2,
+    "locktime": 0,
+    "txInputs": [
+      {
+        "hash": "64da14050ffd0e6186c68a59f371a0adc95cc84b0502fe0915be7eba3f771bb3",
+        "index": 0,
+        "sequence": 4294967295
+      }
+    ],
+    "txOutputs": [
+      {
+        "script": "00145be12624d08a2b424095d7c07221c33450d14bf1",
+        "value": "2778",
+        "address": "bc1qt0sjvfxs3g45ysy46lq8ygwrx3gdzjl3kjg8ln"
+      },
+      {
+        "script": "5120d5238530e223ef1bd34a8a98ee1708f6a8a87e7a2589d88de6700b9973ffff46",
+        "value": "47777",
+        "address": "bc1p653c2v8zy0h3h56232vwu9cg7652sln6ykya3r0xwq9ejulllarq0n62h9"
+      }
+    ]
   },
   "slashingSignedBase64": "cHNidP8BAH0CAAAAAWTaFAUP/Q5hhsaKWfNxoK3JXMhLBQL+CRW+fro/dxuzAAAAAAD/////AtoKAAAAAAAAFgAUW+EmJNCKK0JAldfAciHDNFDRS/GhugAAAAAAACJRINUjhTDiI+8b00qKmO4XCPaoqH56JYnYjeZwC5lz//9GAAAAAAABASsD2QAAAAAAACJRIPGHH8KsMFC1PcNdUCqdlDiPbzc7hvOQVmeUWoQwy9Y5QRR7aghQTEYzb5haV4elQj6xjBCxSf7ynNMxathvVlzSuR4dLoTE/Gvd3zuAGAZc9cqEBZiFeRiFhfOCxRwIjogmQOjmuRNvOzG0/tFBWhWFt6nxW3JA0knlce1AaFnX6KUAhjDMxlTvEujpTevC0FwUU6/r/RHbGs4BUyyVPMxjkKVBFHtqCFBMRjNvmFpXh6VCPrGMELFJ/vKc0zFq2G9WXNK5PJTqJXcy4dmlvVUGZ10PiSI5nAKa4wsJLIm03dBQnHJAe+7QsDcnkwABrolwnOjNtP4UA/MTQ9X0oFMii47ly5bGcwiILuyV5+tS2Mhuz9NIYMDotPbn+bAulZ6HIC+IuEEUe2oIUExGM2+YWleHpUI+sYwQsUn+8pzTMWrYb1Zc0rmWliy2kkLgCUHgphl7fs24Ori7BJDb/SP6S40mt1mJ60A9pMYzIlx8wvWy23j5Emvm+JbI+PrLToqDWBlPtMJKuqbnmZI9H+a2B6r8XkWpt6GJN+PRIxp9y/wZnfMlKZ43YhXAUJKbdMGgSVS3i0tgNel6XgeKWg8o7JbVR7/ums6AOsAeHS6ExPxr3d87gBgGXPXKhAWYhXkYhYXzgsUcCI6IJpaWLLaSQuAJQeCmGXt+zbg6uLsEkNv9I/pLjSa3WYnrJyB7aghQTEYzb5haV4elQj6xjBCxSf7ynNMxathvVlzSua0CECeywGIVwFCSm3TBoElUt4tLYDXpel4HiloPKOyW1Ue/7prOgDrAPJTqJXcy4dmlvVUGZ10PiSI5nAKa4wsJLIm03dBQnHKWliy2kkLgCUHgphl7fs24Ori7BJDb/SP6S40mt1mJ6/1XASB7aghQTEYzb5haV4elQj6xjBCxSf7ynNMxathvVlzSua0gCu4FCbFttxyZkjikgn25RVJoWbE8lUh6tGclNXyanyWsIBE8OjKp0yC3IZCgSgIKDbOXbvNpcmcyWOmjijZPPcOwuiAXkhzxVsy05z1Cj5lu0RskUxPjfifJeKxNLMIeykZy5LogO7k9/IthiH13HzYw6aY+l8uvz8x4VWpHTfg6MaDviZy6IECvr0fE/6Vt6GQQ2OR7qiu28EtgT06iQyNzfdw/4JLfuiB5px/9ccUD7y4vkbzPyPzaeUb0ZTzvDZ893iB5XvO58Log0h+veMZ1Gg045r2AKLkH/wfpqGmkP8g31rP43/YRmja6IPUZnvrj8ou4JHYWOn5FjHrURdm/+waC0Q072yy0H46OuiD6nYgtRfQGC9uAQhg4KM2HVE8eqZc4Dlhsq3fV/WmHN7pWnMBCFcBQkpt0waBJVLeLS2A16XpeB4paDyjsltVHv+6azoA6wEB+nvdT/HkIN2xSU3Gg5L6fzUktcUEY5ZF6VRKml7xt/XkBIHtqCFBMRjNvmFpXh6VCPrGMELFJ/vKc0zFq2G9WXNK5rSDSPCwl4fz4/RwhuaQCwZ4uMJ5THkXpL7HpgFtgVrDMdq0gCu4FCbFttxyZkjikgn25RVJoWbE8lUh6tGclNXyanyWsIBE8OjKp0yC3IZCgSgIKDbOXbvNpcmcyWOmjijZPPcOwuiAXkhzxVsy05z1Cj5lu0RskUxPjfifJeKxNLMIeykZy5LogO7k9/IthiH13HzYw6aY+l8uvz8x4VWpHTfg6MaDviZy6IECvr0fE/6Vt6GQQ2OR7qiu28EtgT06iQyNzfdw/4JLfuiB5px/9ccUD7y4vkbzPyPzaeUb0ZTzvDZ893iB5XvO58Log0h+veMZ1Gg045r2AKLkH/wfpqGmkP8g31rP43/YRmja6IPUZnvrj8ou4JHYWOn5FjHrURdm/+waC0Q072yy0H46OuiD6nYgtRfQGC9uAQhg4KM2HVE8eqZc4Dlhsq3fV/WmHN7pWnMAhFgruBQmxbbccmZI4pIJ9uUVSaFmxPJVIerRnJTV8mp8lRQIeHS6ExPxr3d87gBgGXPXKhAWYhXkYhYXzgsUcCI6IJpaWLLaSQuAJQeCmGXt+zbg6uLsEkNv9I/pLjSa3WYnrNxxFriEWETw6MqnTILchkKBKAgoNs5du82lyZzJY6aOKNk89w7BFAh4dLoTE/Gvd3zuAGAZc9cqEBZiFeRiFhfOCxRwIjogmlpYstpJC4AlB4KYZe37NuDq4uwSQ2/0j+kuNJrdZieuheSvSIRYXkhzxVsy05z1Cj5lu0RskUxPjfifJeKxNLMIeykZy5EUCHh0uhMT8a93fO4AYBlz1yoQFmIV5GIWF84LFHAiOiCaWliy2kkLgCUHgphl7fs24Ori7BJDb/SP6S40mt1mJ64ddIsQhFju5PfyLYYh9dx82MOmmPpfLr8/MeFVqR034OjGg74mcRQIeHS6ExPxr3d87gBgGXPXKhAWYhXkYhYXzgsUcCI6IJpaWLLaSQuAJQeCmGXt+zbg6uLsEkNv9I/pLjSa3WYnrIU8Z1yEWQK+vR8T/pW3oZBDY5HuqK7bwS2BPTqJDI3N93D/gkt9FAh4dLoTE/Gvd3zuAGAZc9cqEBZiFeRiFhfOCxRwIjogmlpYstpJC4AlB4KYZe37NuDq4uwSQ2/0j+kuNJrdZietPcOmrIRZQkpt0waBJVLeLS2A16XpeB4paDyjsltVHv+6azoA6wAUA9Kww3SEWeacf/XHFA+8uL5G8z8j82nlG9GU87w2fPd4geV7zufBFAh4dLoTE/Gvd3zuAGAZc9cqEBZiFeRiFhfOCxRwIjogmlpYstpJC4AlB4KYZe37NuDq4uwSQ2/0j+kuNJrdZieve5/hlIRZ7aghQTEYzb5haV4elQj6xjBCxSf7ynNMxathvVlzSuWUDHh0uhMT8a93fO4AYBlz1yoQFmIV5GIWF84LFHAiOiCY8lOoldzLh2aW9VQZnXQ+JIjmcAprjCwksibTd0FCccpaWLLaSQuAJQeCmGXt+zbg6uLsEkNv9I/pLjSa3WYnruR4eZyEW0h+veMZ1Gg045r2AKLkH/wfpqGmkP8g31rP43/YRmjZFAh4dLoTE/Gvd3zuAGAZc9cqEBZiFeRiFhfOCxRwIjogmlpYstpJC4AlB4KYZe37NuDq4uwSQ2/0j+kuNJrdZies51OxVIRbSPCwl4fz4/RwhuaQCwZ4uMJ5THkXpL7HpgFtgVrDMdiUBlpYstpJC4AlB4KYZe37NuDq4uwSQ2/0j+kuNJrdZietrE56oIRb1GZ764/KLuCR2Fjp+RYx61EXZv/sGgtENO9sstB+OjkUCHh0uhMT8a93fO4AYBlz1yoQFmIV5GIWF84LFHAiOiCaWliy2kkLgCUHgphl7fs24Ori7BJDb/SP6S40mt1mJ60Mr21QhFvqdiC1F9AYL24BCGDgozYdUTx6plzgOWGyrd9X9aYc3RQIeHS6ExPxr3d87gBgGXPXKhAWYhXkYhYXzgsUcCI6IJpaWLLaSQuAJQeCmGXt+zbg6uLsEkNv9I/pLjSa3WYnrpfp0YAEXIFCSm3TBoElUt4tLYDXpel4HiloPKOyW1Ue/7prOgDrAARggyW6TjuYhGgUu+w0VdD8ab/vN9OV9cuZveA04tznZqWEAAAA=",
   "slashingWithdraw": {
@@ -555,7 +672,24 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "inputCount": 1,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "0808ac7143d68ebfd3d8d841cdd3cf9b9da85f8ee47b77260fd44dd2c2a4bda9",
+          "index": 1,
+          "sequence": 1008
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "0014896f1ba65deaeb045bb3121e20e5744e66ca0e48",
+          "value": "47489",
+          "address": "bc1q39h3hfjaat4sgkanzg0zpet5fenv5rjg0lhnvy"
+        }
+      ]
     },
     "fee": 288
   }

--- a/modules/utxo-staking/test/fixtures/babylon/txTree.testnetMock.json
+++ b/modules/utxo-staking/test/fixtures/babylon/txTree.testnetMock.json
@@ -73,7 +73,24 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "inputCount": 1,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "a999d7bc6af1a17cd4e70d0fd875a1734152dfb55f9166240f35965c79fa36c2",
+          "index": 0,
+          "sequence": 10000
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "0014896f1ba65deaeb045bb3121e20e5744e66ca0e48",
+          "value": "55267",
+          "address": "bc1q39h3hfjaat4sgkanzg0zpet5fenv5rjg0lhnvy"
+        }
+      ]
     },
     "fee": 288
   },
@@ -147,7 +164,24 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "inputCount": 1,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "4c2a294c5e31886937d0985e69e65314419e8866e5ab859cb2903cbe420a555a",
+          "index": 0,
+          "sequence": 1008
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "0014896f1ba65deaeb045bb3121e20e5744e66ca0e48",
+          "value": "53267",
+          "address": "bc1q39h3hfjaat4sgkanzg0zpet5fenv5rjg0lhnvy"
+        }
+      ]
     },
     "fee": 288
   },
@@ -204,7 +238,29 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "inputCount": 1,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "4c2a294c5e31886937d0985e69e65314419e8866e5ab859cb2903cbe420a555a",
+          "index": 0,
+          "sequence": 4294967295
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "00145be12624d08a2b424095d7c07221c33450d14bf1",
+          "value": "2678",
+          "address": "bc1qt0sjvfxs3g45ysy46lq8ygwrx3gdzjl3kjg8ln"
+        },
+        {
+          "script": "5120d5238530e223ef1bd34a8a98ee1708f6a8a87e7a2589d88de6700b9973ffff46",
+          "value": "45877",
+          "address": "bc1p653c2v8zy0h3h56232vwu9cg7652sln6ykya3r0xwq9ejulllarq0n62h9"
+        }
+      ]
     },
     "fee": 5000
   },
@@ -256,7 +312,24 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "inputCount": 1,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "e10ba472c29484735ceeda94f238a9a4bdbd7c9d2a228579a9c09075dc9fa8e0",
+          "index": 1,
+          "sequence": 1008
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "0014896f1ba65deaeb045bb3121e20e5744e66ca0e48",
+          "value": "45589",
+          "address": "bc1q39h3hfjaat4sgkanzg0zpet5fenv5rjg0lhnvy"
+        }
+      ]
     },
     "fee": 288
   },
@@ -313,7 +386,29 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "inputCount": 1,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "a999d7bc6af1a17cd4e70d0fd875a1734152dfb55f9166240f35965c79fa36c2",
+          "index": 0,
+          "sequence": 4294967295
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "00145be12624d08a2b424095d7c07221c33450d14bf1",
+          "value": "2778",
+          "address": "bc1qt0sjvfxs3g45ysy46lq8ygwrx3gdzjl3kjg8ln"
+        },
+        {
+          "script": "5120d5238530e223ef1bd34a8a98ee1708f6a8a87e7a2589d88de6700b9973ffff46",
+          "value": "47777",
+          "address": "bc1p653c2v8zy0h3h56232vwu9cg7652sln6ykya3r0xwq9ejulllarq0n62h9"
+        }
+      ]
     },
     "fee": 5000
   },
@@ -599,7 +694,29 @@
     },
     "opts": {
       "maximumFeeRate": 5000
-    }
+    },
+    "inputCount": 1,
+    "version": 2,
+    "locktime": 0,
+    "txInputs": [
+      {
+        "hash": "a999d7bc6af1a17cd4e70d0fd875a1734152dfb55f9166240f35965c79fa36c2",
+        "index": 0,
+        "sequence": 4294967295
+      }
+    ],
+    "txOutputs": [
+      {
+        "script": "00145be12624d08a2b424095d7c07221c33450d14bf1",
+        "value": "2778",
+        "address": "bc1qt0sjvfxs3g45ysy46lq8ygwrx3gdzjl3kjg8ln"
+      },
+      {
+        "script": "5120d5238530e223ef1bd34a8a98ee1708f6a8a87e7a2589d88de6700b9973ffff46",
+        "value": "47777",
+        "address": "bc1p653c2v8zy0h3h56232vwu9cg7652sln6ykya3r0xwq9ejulllarq0n62h9"
+      }
+    ]
   },
   "slashingSignedBase64": "cHNidP8BAH0CAAAAAamZ17xq8aF81OcND9h1oXNBUt+1X5FmJA81llx5+jbCAAAAAAD/////AtoKAAAAAAAAFgAUW+EmJNCKK0JAldfAciHDNFDRS/GhugAAAAAAACJRINUjhTDiI+8b00qKmO4XCPaoqH56JYnYjeZwC5lz//9GAAAAAAABASsD2QAAAAAAACJRIHiNc9ddfdiNNhL3qR1bPWrUd42LSRdvlTnTIpgLL0/XQRQE4rJGj+IkZZ653FvQqcwbSHi2T0DGfJUWEDILznjf0WjMl5DAYnvI8or9AJsxl0ovzl6k/i7U3YtlyP7aGWh1QLywThIfcVJzMMbCv9hW88XQAiz0qZ+qZruSxTraCrSYiuRvNDw0vESM0Kx7VkBa9Ey0FZeFZjtvh+pFagIK93lBFATiskaP4iRlnrncW9CpzBtIeLZPQMZ8lRYQMgvOeN/RwdJiz+Hzt0Yzf2dm4xhUMz03D3M72EVyeq7SuuvHpVJA1J8gl6nhvOLAjMkyxk/YERb8F/8993Jw42EJmI6oBLyaJqHUR9z4ZZKkeTJaDdC4bR5FYvX3KxRYFxCIfDdA0kEULzQyv5BU5IIEG4kOCEvBo0z7wLY63tETv6NrbyQCgytozJeQwGJ7yPKK/QCbMZdKL85epP4u1N2LZcj+2hlodUCwUPoS61nISnoauRheirk5QDNLbCl37nIPNMhGhaMweXBajARO5j5SBAkHlTw3IGRVcHAKgPZlbYT9ZaNk0KE6QRQvNDK/kFTkggQbiQ4IS8GjTPvAtjre0RO/o2tvJAKDK8HSYs/h87dGM39nZuMYVDM9Nw9zO9hFcnqu0rrrx6VSQCb5P0qOEaaMf4tHnmWHAnv7daDoFYPvs81qVQMXt8ttgFBlrBBsB8Mna/rObAjFxRPHtkIt8248B8m3Ndqj2LFBFE1+keSgqwUmo4doTbFii1Nea2YEaqp9G1g7k8WhbhrHaMyXkMBie8jyiv0AmzGXSi/OXqT+LtTdi2XI/toZaHVAUMwu1BGhpPm8OVaIGwROHBzzscvQRE5ZvkfioPPo6W6rq8d60fkrP5M0Qs1O/nVwQD/aasC1sSfF83zUttzHM0EUTX6R5KCrBSajh2hNsWKLU15rZgRqqn0bWDuTxaFuGsfB0mLP4fO3RjN/Z2bjGFQzPTcPczvYRXJ6rtK668elUkCE0krdzoQfbwTxm4Cv2IriDYiW9QdpaZfRmg1BZRtSUm/1U9czfV1gEPoxdhoVPV3R5nMlzAzY3n/5Dt8usUO0QRReFHQsCUP6ZnmfaZoO+Yzyt80iPdu2H2h4mZGCu8xHAGjMl5DAYnvI8or9AJsxl0ovzl6k/i7U3YtlyP7aGWh1QEayJ6PvWPbQ+fTQvbGReaa7UkNaB/Enz5PrrHsU5ZLeWNjtV4I+VawS3GbY9JhLDaaAVPmZXywd3YCJO6a8FD9BFF4UdCwJQ/pmeZ9pmg75jPK3zSI927YfaHiZkYK7zEcAwdJiz+Hzt0Yzf2dm4xhUMz03D3M72EVyeq7SuuvHpVJAp4T8KNUzhiiIrsyN10PR+8mr5Wxtlr67ea8kGn13eJejNvhYfAq9COvOft15jfLK3WiRx3hDpTA3FdIL8rXmqEEUZNVdWRxdQW9xPfnhWv0y6f8kQc8nay+Q5bMIUWPKemtozJeQwGJ7yPKK/QCbMZdKL85epP4u1N2LZcj+2hlodUCkJ5Mh6hpsPFTapoWnz75aISRYSQzhB+JH2X01a2//vtSbiqWyiZ40EH7hB2lNW6z3AQm4u1LmQLg0MeIHWz2lQRRk1V1ZHF1Bb3E9+eFa/TLp/yRBzydrL5DlswhRY8p6a8HSYs/h87dGM39nZuMYVDM9Nw9zO9hFcnqu0rrrx6VSQOxWVJQ1zNjxJ2LB/VFp0p4F85hjPT1CRq3uJ5G77TxbtMsXBqkFaVApXKvkfICLmkc/Pclv7PcZGi9f0Qn3WmBBFGZyKCSW4X7MquVgqsTZ/oXYwWakqkP1H6iWPIChZYMfaMyXkMBie8jyiv0AmzGXSi/OXqT+LtTdi2XI/toZaHVAplbeM3E2dnD4mEKujgBB/xk/bUOb6cfDgFWz+WWOoQNdvd+6RCSlizubEU64+ynEVxHpqqCGf777zThPcxY5Y0EUZnIoJJbhfsyq5WCqxNn+hdjBZqSqQ/UfqJY8gKFlgx/B0mLP4fO3RjN/Z2bjGFQzPTcPczvYRXJ6rtK668elUkDH0BshUsgnh9B5vkx91KRdoFjX3Vxzh++iFEarO9WRa4WI85/DnI7XyXUwRC8CwP6enZ3d8uTFkEwIPFA9kKIvQRR5ObzwCEz/D+XIihdIwdl9Y/+a5kI6mNymXZdLuRI84GjMl5DAYnvI8or9AJsxl0ovzl6k/i7U3YtlyP7aGWh1QHnDmQtOgNNGiD5olCqPjgjJNHVrLZ91TzPGIJOJtTdZC6PrEgVWf7dsa9Y6V0uu82ADe/E9HQFMOLI18RcODDlBFHk5vPAITP8P5ciKF0jB2X1j/5rmQjqY3KZdl0u5EjzgwdJiz+Hzt0Yzf2dm4xhUMz03D3M72EVyeq7SuuvHpVJAD9zATzQNe1c+Kv/82ZIHv12zDNENsIDIS8ag0rjzLK38vdayPQxyWCnNx0dbF2LHH93RiuO06peS2sOFWU/ePkEUe2oIUExGM2+YWleHpUI+sYwQsUn+8pzTMWrYb1Zc0rk8lOoldzLh2aW9VQZnXQ+JIjmcAprjCwksibTd0FCcckC908+7eXsGqYyN/TDUGbWBzYMnD66eeSX/ldA7gMJleM2/VbSjM32sRbb+AVPAx2Z3i+QJf+8wwLLDrCyXoOuQQRR7aghQTEYzb5haV4elQj6xjBCxSf7ynNMxathvVlzSuWjMl5DAYnvI8or9AJsxl0ovzl6k/i7U3YtlyP7aGWh1QED8PM4gIYjAJf637DElD9DAeUrhPhjrgWU25RQBzUtPAVVh1CLKbY9WcygMus9E3Xb2ij5WE9IcH79N1N9QqcZBFHtqCFBMRjNvmFpXh6VCPrGMELFJ/vKc0zFq2G9WXNK5wdJiz+Hzt0Yzf2dm4xhUMz03D3M72EVyeq7SuuvHpVJAJHQzfNM61g0N6EBfW+a4RMXBNRhLd6ruYjxLFR4w1TO5/4N4IdXYXpp1jHkZMkThv9P+xCIIzB7KmT8xi9d1ZkEUhQhU0m35NXB0jZTj2jYfE0xSL3lwvX+HAaFkVHMIqQDB0mLP4fO3RjN/Z2bjGFQzPTcPczvYRXJ6rtK668elUkDHlFV/NFZdBzz639ozK2C2KF9SHOovn0GiLbYRCetz2zxFFTDRliJl991+aeM95flw4HPdz3Jlg/vDniEiUx6zQRSfZlmc3n88P++2uWUJ5HL4qeLK+Hk7m2c/y0Bn74iPUGjMl5DAYnvI8or9AJsxl0ovzl6k/i7U3YtlyP7aGWh1QGJ54AgSg1eko5MNUiMPJBwIg6ibSzeeAuAxxvGB5vITZLzi6ratuPQq4MLGF6mLXvAX+x0u8PjZ3Xa7jgW4OElBFJ9mWZzefzw/77a5ZQnkcvip4sr4eTubZz/LQGfviI9QwdJiz+Hzt0Yzf2dm4xhUMz03D3M72EVyeq7SuuvHpVJAfg0V9B/HVeXlnGufAQvQ6uvvnr6Ad9kKoXQNwlri1rkjTCL6BznysXMENoghufk1scn7BhQna92PyxRZTQscd0EU8GOOSBdVk0fmege1amy4JNRV+6QqjIyVFxw5dUDFF4lozJeQwGJ7yPKK/QCbMZdKL85epP4u1N2LZcj+2hlodUA85YGfwvbla8ZsqqtXlbtxT5AQsyAN4yxHvVTVrAfZkWp02Tquk/zXlhI5bAs1zDyMbAEvE15iP1rj2QA0duYiQRTwY45IF1WTR+Z6B7VqbLgk1FX7pCqMjJUXHDl1QMUXicHSYs/h87dGM39nZuMYVDM9Nw9zO9hFcnqu0rrrx6VSQIsW/sSsA6DoYJbAEGpOx1OpcwNyIp3EBWWYAFLImCyYwYCqZmxXzkVbm1Kmrhh1B8zKR2lEGzR0JG8Hz9h4vbZiFcFQkpt0waBJVLeLS2A16XpeB4paDyjsltVHv+6azoA6wDyU6iV3MuHZpb1VBmddD4kiOZwCmuMLCSyJtN3QUJxywdJiz+Hzt0Yzf2dm4xhUMz03D3M72EVyeq7SuuvHpVL9VwEge2oIUExGM2+YWleHpUI+sYwQsUn+8pzTMWrYb1Zc0rmtIATiskaP4iRlnrncW9CpzBtIeLZPQMZ8lRYQMgvOeN/RrCAvNDK/kFTkggQbiQ4IS8GjTPvAtjre0RO/o2tvJAKDK7ogTX6R5KCrBSajh2hNsWKLU15rZgRqqn0bWDuTxaFuGse6IF4UdCwJQ/pmeZ9pmg75jPK3zSI927YfaHiZkYK7zEcAuiBk1V1ZHF1Bb3E9+eFa/TLp/yRBzydrL5DlswhRY8p6a7ogZnIoJJbhfsyq5WCqxNn+hdjBZqSqQ/UfqJY8gKFlgx+6IHk5vPAITP8P5ciKF0jB2X1j/5rmQjqY3KZdl0u5EjzguiCfZlmc3n88P++2uWUJ5HL4qeLK+Hk7m2c/y0Bn74iPULog8GOOSBdVk0fmege1amy4JNRV+6QqjIyVFxw5dUDFF4m6VpzAQhXBUJKbdMGgSVS3i0tgNel6XgeKWg8o7JbVR7/ums6AOsBOnTi6JpaVLDoybNghwxkXPL5w/5OT9zK0TROu463UwP15ASB7aghQTEYzb5haV4elQj6xjBCxSf7ynNMxathvVlzSua0ghQhU0m35NXB0jZTj2jYfE0xSL3lwvX+HAaFkVHMIqQCtIATiskaP4iRlnrncW9CpzBtIeLZPQMZ8lRYQMgvOeN/RrCAvNDK/kFTkggQbiQ4IS8GjTPvAtjre0RO/o2tvJAKDK7ogTX6R5KCrBSajh2hNsWKLU15rZgRqqn0bWDuTxaFuGse6IF4UdCwJQ/pmeZ9pmg75jPK3zSI927YfaHiZkYK7zEcAuiBk1V1ZHF1Bb3E9+eFa/TLp/yRBzydrL5DlswhRY8p6a7ogZnIoJJbhfsyq5WCqxNn+hdjBZqSqQ/UfqJY8gKFlgx+6IHk5vPAITP8P5ciKF0jB2X1j/5rmQjqY3KZdl0u5EjzguiCfZlmc3n88P++2uWUJ5HL4qeLK+Hk7m2c/y0Bn74iPULog8GOOSBdVk0fmege1amy4JNRV+6QqjIyVFxw5dUDFF4m6VpzAYhXBUJKbdMGgSVS3i0tgNel6XgeKWg8o7JbVR7/ums6AOsBozJeQwGJ7yPKK/QCbMZdKL85epP4u1N2LZcj+2hlodcHSYs/h87dGM39nZuMYVDM9Nw9zO9hFcnqu0rrrx6VSJyB7aghQTEYzb5haV4elQj6xjBCxSf7ynNMxathvVlzSua0CECeywCEWBOKyRo/iJGWeudxb0KnMG0h4tk9AxnyVFhAyC85439FFAmjMl5DAYnvI8or9AJsxl0ovzl6k/i7U3YtlyP7aGWh1wdJiz+Hzt0Yzf2dm4xhUMz03D3M72EVyeq7SuuvHpVIGs0zhIRYvNDK/kFTkggQbiQ4IS8GjTPvAtjre0RO/o2tvJAKDK0UCaMyXkMBie8jyiv0AmzGXSi/OXqT+LtTdi2XI/toZaHXB0mLP4fO3RjN/Z2bjGFQzPTcPczvYRXJ6rtK668elUmpOKfMhFk1+keSgqwUmo4doTbFii1Nea2YEaqp9G1g7k8WhbhrHRQJozJeQwGJ7yPKK/QCbMZdKL85epP4u1N2LZcj+2hlodcHSYs/h87dGM39nZuMYVDM9Nw9zO9hFcnqu0rrrx6VSGCh0MyEWUJKbdMGgSVS3i0tgNel6XgeKWg8o7JbVR7/ums6AOsAFAPSsMN0hFl4UdCwJQ/pmeZ9pmg75jPK3zSI927YfaHiZkYK7zEcARQJozJeQwGJ7yPKK/QCbMZdKL85epP4u1N2LZcj+2hlodcHSYs/h87dGM39nZuMYVDM9Nw9zO9hFcnqu0rrrx6VSYytAWSEWZNVdWRxdQW9xPfnhWv0y6f8kQc8nay+Q5bMIUWPKemtFAmjMl5DAYnvI8or9AJsxl0ovzl6k/i7U3YtlyP7aGWh1wdJiz+Hzt0Yzf2dm4xhUMz03D3M72EVyeq7SuuvHpVI40I7uIRZmcigkluF+zKrlYKrE2f6F2MFmpKpD9R+oljyAoWWDH0UCaMyXkMBie8jyiv0AmzGXSi/OXqT+LtTdi2XI/toZaHXB0mLP4fO3RjN/Z2bjGFQzPTcPczvYRXJ6rtK668elUvPcNnQhFnk5vPAITP8P5ciKF0jB2X1j/5rmQjqY3KZdl0u5EjzgRQJozJeQwGJ7yPKK/QCbMZdKL85epP4u1N2LZcj+2hlodcHSYs/h87dGM39nZuMYVDM9Nw9zO9hFcnqu0rrrx6VSPtZZvyEWe2oIUExGM2+YWleHpUI+sYwQsUn+8pzTMWrYb1Zc0rllAzyU6iV3MuHZpb1VBmddD4kiOZwCmuMLCSyJtN3QUJxyaMyXkMBie8jyiv0AmzGXSi/OXqT+LtTdi2XI/toZaHXB0mLP4fO3RjN/Z2bjGFQzPTcPczvYRXJ6rtK668elUrkeHmchFoUIVNJt+TVwdI2U49o2HxNMUi95cL1/hwGhZFRzCKkAJQHB0mLP4fO3RjN/Z2bjGFQzPTcPczvYRXJ6rtK668elUuqCCgMhFp9mWZzefzw/77a5ZQnkcvip4sr4eTubZz/LQGfviI9QRQJozJeQwGJ7yPKK/QCbMZdKL85epP4u1N2LZcj+2hlodcHSYs/h87dGM39nZuMYVDM9Nw9zO9hFcnqu0rrrx6VS29JsOyEW8GOOSBdVk0fmege1amy4JNRV+6QqjIyVFxw5dUDFF4lFAmjMl5DAYnvI8or9AJsxl0ovzl6k/i7U3YtlyP7aGWh1wdJiz+Hzt0Yzf2dm4xhUMz03D3M72EVyeq7SuuvHpVL5xghnARcgUJKbdMGgSVS3i0tgNel6XgeKWg8o7JbVR7/ums6AOsABGCBqscVriz4BegYFVev7uschrwoJjl+X1nqkqsNTXknDbQAAAA==",
   "slashingWithdraw": {
@@ -650,7 +767,24 @@
       },
       "opts": {
         "maximumFeeRate": 5000
-      }
+      },
+      "inputCount": 1,
+      "version": 2,
+      "locktime": 0,
+      "txInputs": [
+        {
+          "hash": "88934f7a4e1b28b6edf69f593ae6c03e94685083f49ce9c0357f515dfc53f8ca",
+          "index": 1,
+          "sequence": 1008
+        }
+      ],
+      "txOutputs": [
+        {
+          "script": "0014896f1ba65deaeb045bb3121e20e5744e66ca0e48",
+          "value": "47489",
+          "address": "bc1q39h3hfjaat4sgkanzg0zpet5fenv5rjg0lhnvy"
+        }
+      ]
     },
     "fee": 288
   }

--- a/modules/utxo-staking/test/fixtures/babylon/unbonding.5d27.psbt.json
+++ b/modules/utxo-staking/test/fixtures/babylon/unbonding.5d27.psbt.json
@@ -203,5 +203,41 @@
   },
   "opts": {
     "maximumFeeRate": 5000
-  }
+  },
+  "tx": {
+    "version": 2,
+    "locktime": 0,
+    "ins": [
+      {
+        "hash": "2c779b6115f9deaf4a77583cecc211d90f23c8c85aa9ae749058e5291b7e275d",
+        "index": 0,
+        "script": "",
+        "sequence": 4294967295,
+        "witness": []
+      }
+    ],
+    "outs": [
+      {
+        "value": "98000",
+        "script": "51205e319ea645643b8df9b60ecb9229a97bf318d945620c17d97a7d54e8c997e786"
+      }
+    ]
+  },
+  "inputCount": 1,
+  "version": 2,
+  "locktime": 0,
+  "txInputs": [
+    {
+      "hash": "2c779b6115f9deaf4a77583cecc211d90f23c8c85aa9ae749058e5291b7e275d",
+      "index": 0,
+      "sequence": 4294967295
+    }
+  ],
+  "txOutputs": [
+    {
+      "script": "51205e319ea645643b8df9b60ecb9229a97bf318d945620c17d97a7d54e8c997e786",
+      "value": "98000",
+      "address": "tb1ptcceafj9vsacm7dkpm9ey2df00e33k29vgxp0kt6042w3jvhu7rq8x744p"
+    }
+  ]
 }

--- a/modules/utxo-staking/test/fixtures/babylon/unbondingTransaction.testnetMock.json
+++ b/modules/utxo-staking/test/fixtures/babylon/unbondingTransaction.testnetMock.json
@@ -157,7 +157,43 @@
     },
     "opts": {
       "maximumFeeRate": 5000
-    }
+    },
+    "tx": {
+      "version": 2,
+      "locktime": 0,
+      "ins": [
+        {
+          "hash": "a999d7bc6af1a17cd4e70d0fd875a1734152dfb55f9166240f35965c79fa36c2",
+          "index": 0,
+          "script": "",
+          "sequence": 4294967293,
+          "witness": []
+        }
+      ],
+      "outs": [
+        {
+          "script": "0014896f1ba65deaeb045bb3121e20e5744e66ca0e48",
+          "value": "54555"
+        }
+      ]
+    },
+    "inputCount": 1,
+    "version": 2,
+    "locktime": 0,
+    "txInputs": [
+      {
+        "hash": "a999d7bc6af1a17cd4e70d0fd875a1734152dfb55f9166240f35965c79fa36c2",
+        "index": 0,
+        "sequence": 4294967293
+      }
+    ],
+    "txOutputs": [
+      {
+        "script": "0014896f1ba65deaeb045bb3121e20e5744e66ca0e48",
+        "value": "54555",
+        "address": "bc1q39h3hfjaat4sgkanzg0zpet5fenv5rjg0lhnvy"
+      }
+    ]
   },
   "transaction": {
     "version": 2,

--- a/modules/utxo-staking/test/fixtures/babylon/unstakingTransaction.testnet.json
+++ b/modules/utxo-staking/test/fixtures/babylon/unstakingTransaction.testnet.json
@@ -157,7 +157,43 @@
     },
     "opts": {
       "maximumFeeRate": 5000
-    }
+    },
+    "tx": {
+      "version": 2,
+      "locktime": 0,
+      "ins": [
+        {
+          "hash": "64da14050ffd0e6186c68a59f371a0adc95cc84b0502fe0915be7eba3f771bb3",
+          "index": 0,
+          "script": "",
+          "sequence": 10000,
+          "witness": []
+        }
+      ],
+      "outs": [
+        {
+          "script": "0014896f1ba65deaeb045bb3121e20e5744e66ca0e48",
+          "value": "54555"
+        }
+      ]
+    },
+    "inputCount": 1,
+    "version": 2,
+    "locktime": 0,
+    "txInputs": [
+      {
+        "hash": "64da14050ffd0e6186c68a59f371a0adc95cc84b0502fe0915be7eba3f771bb3",
+        "index": 0,
+        "sequence": 10000
+      }
+    ],
+    "txOutputs": [
+      {
+        "script": "0014896f1ba65deaeb045bb3121e20e5744e66ca0e48",
+        "value": "54555",
+        "address": "bc1q39h3hfjaat4sgkanzg0zpet5fenv5rjg0lhnvy"
+      }
+    ]
   },
   "transaction": {
     "version": 2,

--- a/modules/utxo-staking/test/fixtures/babylon/unstakingTransaction.testnetMock.json
+++ b/modules/utxo-staking/test/fixtures/babylon/unstakingTransaction.testnetMock.json
@@ -157,7 +157,43 @@
     },
     "opts": {
       "maximumFeeRate": 5000
-    }
+    },
+    "tx": {
+      "version": 2,
+      "locktime": 0,
+      "ins": [
+        {
+          "hash": "a999d7bc6af1a17cd4e70d0fd875a1734152dfb55f9166240f35965c79fa36c2",
+          "index": 0,
+          "script": "",
+          "sequence": 10000,
+          "witness": []
+        }
+      ],
+      "outs": [
+        {
+          "script": "0014896f1ba65deaeb045bb3121e20e5744e66ca0e48",
+          "value": "54555"
+        }
+      ]
+    },
+    "inputCount": 1,
+    "version": 2,
+    "locktime": 0,
+    "txInputs": [
+      {
+        "hash": "a999d7bc6af1a17cd4e70d0fd875a1734152dfb55f9166240f35965c79fa36c2",
+        "index": 0,
+        "sequence": 10000
+      }
+    ],
+    "txOutputs": [
+      {
+        "script": "0014896f1ba65deaeb045bb3121e20e5744e66ca0e48",
+        "value": "54555",
+        "address": "bc1q39h3hfjaat4sgkanzg0zpet5fenv5rjg0lhnvy"
+      }
+    ]
   },
   "transaction": {
     "version": 2,


### PR DESCRIPTION

Add tx network field to ignored paths to avoid redundant data. Enhance
getAllDescriptors to traverse the prototype chain for complete property
collection, while filtering out function values to keep serializations clean.

Issue: BTC-2143