### PR TITLE
feat(utxo-staking): implement unbonding functionality and descriptor parsing

### DIFF
--- a/modules/utxo-staking/src/babylon/descriptor.ts
+++ b/modules/utxo-staking/src/babylon/descriptor.ts
@@ -17,7 +17,7 @@ function pk(b: Buffer): ast.MiniscriptNode {
   return { 'v:pk': b.toString('hex') };
 }
 
-function sortedKeys(keys: Buffer[]): Buffer[] {
+export function sortedKeys(keys: Buffer[]): Buffer[] {
   return [...keys].sort((a, b) => a.compare(b));
 }
 

--- a/modules/utxo-staking/src/babylon/parseDescriptor.ts
+++ b/modules/utxo-staking/src/babylon/parseDescriptor.ts
@@ -28,6 +28,78 @@ function parseMulti(multi: unknown): [number, string[]] {
   return [threshold, keys];
 }
 
+function parseUnilateralTimelock(
+  node: ast.MiniscriptNode,
+  matcher: PatternMatcher
+): { key: string; timelock: number } | null {
+  const pattern: Pattern = {
+    and_v: [{ 'v:pk': { $var: 'key' } }, { older: { $var: 'timelock' } }],
+  };
+  const match = matcher.match(node, pattern);
+  if (!match) {
+    return null;
+  }
+  if (typeof match.key !== 'string') {
+    throw new Error('key must be a string');
+  }
+  if (typeof match.timelock !== 'number') {
+    throw new Error('timelock must be a number');
+  }
+  return { key: match.key, timelock: match.timelock };
+}
+
+function parseSlashingNode(
+  slashingNode: ast.MiniscriptNode,
+  matcher: PatternMatcher
+): {
+  stakerKey: string;
+  finalityProviderKeys: Buffer[];
+  covenantKeys: Buffer[];
+  covenantThreshold: number;
+} {
+  const slashingPattern: Pattern = {
+    and_v: [
+      {
+        and_v: [{ 'v:pk': { $var: 'stakerKey' } }, { $var: 'finalityProviderKeyOrMulti' }],
+      },
+      { multi_a: { $var: 'covenantMulti' } },
+    ],
+  };
+
+  const slashingMatch = matcher.match(slashingNode, slashingPattern);
+  if (!slashingMatch) {
+    throw new Error('Slashing node does not match expected pattern');
+  }
+
+  if (typeof slashingMatch.stakerKey !== 'string') {
+    throw new Error('stakerKey must be a string');
+  }
+
+  const [covenantThreshold, covenantKeyStrings] = parseMulti(slashingMatch.covenantMulti);
+  const covenantKeys = covenantKeyStrings.map((k) => Buffer.from(k, 'hex'));
+
+  let finalityProviderKeys: Buffer[];
+  const fpKeyOrMulti = slashingMatch.finalityProviderKeyOrMulti as ast.MiniscriptNode;
+  if ('v:pk' in fpKeyOrMulti) {
+    finalityProviderKeys = [Buffer.from(fpKeyOrMulti['v:pk'], 'hex')];
+  } else if ('v:multi_a' in fpKeyOrMulti) {
+    const [threshold, keyStrings] = parseMulti(fpKeyOrMulti['v:multi_a']);
+    if (threshold !== 1) {
+      throw new Error('Finality provider multi threshold must be 1');
+    }
+    finalityProviderKeys = keyStrings.map((k) => Buffer.from(k, 'hex'));
+  } else {
+    throw new Error('Invalid finality provider key structure');
+  }
+
+  return {
+    stakerKey: slashingMatch.stakerKey,
+    finalityProviderKeys,
+    covenantKeys,
+    covenantThreshold,
+  };
+}
+
 /**
  * @return parsed staking descriptor components or null if the descriptor does not match the expected staking pattern.
  */
@@ -52,19 +124,12 @@ export function parseStakingDescriptor(descriptor: Descriptor | ast.DescriptorNo
   const timelockNode = result.timelockMiniscriptNode as ast.MiniscriptNode;
 
   // Verify slashing node shape: and_v([and_v([pk, pk/multi_a]), multi_a])
-  const slashingPattern: Pattern = {
-    and_v: [
-      {
-        and_v: [{ 'v:pk': { $var: 'stakerKey1' } }, { $var: 'finalityProviderKeyOrMulti' }],
-      },
-      { multi_a: { $var: 'covenantMulti' } },
-    ],
-  };
-
-  const slashingMatch = matcher.match(slashingNode, slashingPattern);
-  if (!slashingMatch) {
-    throw new Error('Slashing node does not match expected pattern');
-  }
+  const {
+    stakerKey: stakerKey1,
+    finalityProviderKeys,
+    covenantKeys,
+    covenantThreshold,
+  } = parseSlashingNode(slashingNode, matcher);
 
   // Verify unbonding node shape: and_v([pk, multi_a])
   const unbondingPattern: Pattern = {
@@ -77,47 +142,19 @@ export function parseStakingDescriptor(descriptor: Descriptor | ast.DescriptorNo
   }
 
   // Verify unbonding timelock node shape: and_v([pk, older])
-  const timelockPattern: Pattern = {
-    and_v: [{ 'v:pk': { $var: 'stakerKey3' } }, { older: { $var: 'stakingTimeLock' } }],
-  };
-
-  const timelockMatch = matcher.match(timelockNode, timelockPattern);
-  if (!timelockMatch) {
-    throw new Error('Unbonding timelock node does not match expected pattern');
+  const unilateralTimelock = parseUnilateralTimelock(timelockNode, matcher);
+  if (!unilateralTimelock) {
+    return null;
   }
 
+  const { key: stakerKey3, timelock: stakingTimeLock } = unilateralTimelock;
+
   // Verify all staker keys are the same
-  if (
-    slashingMatch.stakerKey1 !== unbondingMatch.stakerKey2 ||
-    unbondingMatch.stakerKey2 !== timelockMatch.stakerKey3
-  ) {
+  if (stakerKey1 !== unbondingMatch.stakerKey2 || unbondingMatch.stakerKey2 !== stakerKey3) {
     throw new Error('Staker keys must be identical across all nodes');
   }
 
-  // Verify timelock value is a number
-  if (typeof timelockMatch.stakingTimeLock !== 'number') {
-    throw new Error('Unbonding timelock value must be a number');
-  }
-
-  const stakerKey = Buffer.from(slashingMatch.stakerKey1 as string, 'hex');
-  const stakingTimeLock = timelockMatch.stakingTimeLock as number;
-
-  const [covenantThreshold, covenantKeyStrings] = parseMulti(slashingMatch.covenantMulti);
-  const covenantKeys = covenantKeyStrings.map((k) => Buffer.from(k, 'hex'));
-
-  let finalityProviderKeys: Buffer[];
-  const fpKeyOrMulti = slashingMatch.finalityProviderKeyOrMulti as ast.MiniscriptNode;
-  if ('v:pk' in fpKeyOrMulti) {
-    finalityProviderKeys = [Buffer.from(fpKeyOrMulti['v:pk'], 'hex')];
-  } else if ('v:multi_a' in fpKeyOrMulti) {
-    const [threshold, keyStrings] = parseMulti(fpKeyOrMulti['v:multi_a']);
-    if (threshold !== 1) {
-      throw new Error('Finality provider multi threshold must be 1');
-    }
-    finalityProviderKeys = keyStrings.map((k) => Buffer.from(k, 'hex'));
-  } else {
-    throw new Error('Invalid finality provider key structure');
-  }
+  const stakerKey = Buffer.from(stakerKey1, 'hex');
 
   return {
     stakerKey,
@@ -128,5 +165,62 @@ export function parseStakingDescriptor(descriptor: Descriptor | ast.DescriptorNo
     slashingMiniscriptNode: slashingNode,
     unbondingMiniscriptNode: unbondingNode,
     timelockMiniscriptNode: timelockNode,
+  };
+}
+
+export type ParsedUnbondingDescriptor = {
+  stakerKey: Buffer;
+  finalityProviderKeys: Buffer[];
+  covenantKeys: Buffer[];
+  covenantThreshold: number;
+  unbondingTimeLock: number;
+  slashingMiniscriptNode: ast.MiniscriptNode;
+  unbondingTimelockMiniscriptNode: ast.MiniscriptNode;
+};
+
+export function parseUnbondingDescriptor(
+  descriptor: Descriptor | ast.DescriptorNode
+): ParsedUnbondingDescriptor | null {
+  const pattern: Pattern = {
+    tr: [getUnspendableKey(), [{ $var: 'slashingMiniscriptNode' }, { $var: 'unbondingTimelockMiniscriptNode' }]],
+  };
+
+  const matcher = new PatternMatcher();
+  const descriptorNode = descriptor instanceof Descriptor ? ast.fromDescriptor(descriptor) : descriptor;
+  const result = matcher.match(descriptorNode, pattern);
+
+  if (!result) {
+    return null;
+  }
+
+  const slashingNode = result.slashingMiniscriptNode as ast.MiniscriptNode;
+  const unbondingTimelockNode = result.unbondingTimelockMiniscriptNode as ast.MiniscriptNode;
+
+  const {
+    stakerKey: stakerKey1,
+    finalityProviderKeys,
+    covenantKeys,
+    covenantThreshold,
+  } = parseSlashingNode(slashingNode, matcher);
+
+  const unilateralTimelock = parseUnilateralTimelock(unbondingTimelockNode, matcher);
+  if (!unilateralTimelock) {
+    return null;
+  }
+
+  const { key: stakerKey2, timelock: unbondingTimeLock } = unilateralTimelock;
+
+  if (stakerKey1 !== stakerKey2) {
+    throw new Error('Staker keys must be identical across all nodes');
+  }
+
+  return {
+    stakerKey: Buffer.from(stakerKey1, 'hex'),
+    finalityProviderKeys,
+    covenantKeys,
+    covenantThreshold,
+    unbondingTimeLock,
+    slashingMiniscriptNode: slashingNode,
+    unbondingTimelockMiniscriptNode: unbondingTimelockNode,
   };
 }

--- a/modules/utxo-staking/src/babylon/parseDescriptor.ts
+++ b/modules/utxo-staking/src/babylon/parseDescriptor.ts
@@ -3,11 +3,30 @@ import { PatternMatcher, Pattern } from '@bitgo/utxo-core/descriptor';
 
 import { getUnspendableKey } from './descriptor';
 
-type ParsedStakingDescriptor = {
+export type ParsedStakingDescriptor = {
+  stakerKey: Buffer;
+  finalityProviderKeys: Buffer[];
+  covenantKeys: Buffer[];
+  covenantThreshold: number;
+  stakingTimeLock: number;
   slashingMiniscriptNode: ast.MiniscriptNode;
   unbondingMiniscriptNode: ast.MiniscriptNode;
   timelockMiniscriptNode: ast.MiniscriptNode;
 };
+
+function parseMulti(multi: unknown): [number, string[]] {
+  if (!Array.isArray(multi) || multi.length < 1) {
+    throw new Error('Invalid multi structure: not an array or empty');
+  }
+  const [threshold, ...keys] = multi;
+  if (typeof threshold !== 'number') {
+    throw new Error('Invalid multi structure: threshold is not a number');
+  }
+  if (!keys.every((k) => typeof k === 'string')) {
+    throw new Error('Invalid multi structure: not all keys are strings');
+  }
+  return [threshold, keys];
+}
 
 /**
  * @return parsed staking descriptor components or null if the descriptor does not match the expected staking pattern.
@@ -59,7 +78,7 @@ export function parseStakingDescriptor(descriptor: Descriptor | ast.DescriptorNo
 
   // Verify unbonding timelock node shape: and_v([pk, older])
   const timelockPattern: Pattern = {
-    and_v: [{ 'v:pk': { $var: 'stakerKey3' } }, { older: { $var: 'unbondingTimeLockValue' } }],
+    and_v: [{ 'v:pk': { $var: 'stakerKey3' } }, { older: { $var: 'stakingTimeLock' } }],
   };
 
   const timelockMatch = matcher.match(timelockNode, timelockPattern);
@@ -76,11 +95,36 @@ export function parseStakingDescriptor(descriptor: Descriptor | ast.DescriptorNo
   }
 
   // Verify timelock value is a number
-  if (typeof timelockMatch.unbondingTimeLockValue !== 'number') {
+  if (typeof timelockMatch.stakingTimeLock !== 'number') {
     throw new Error('Unbonding timelock value must be a number');
   }
 
+  const stakerKey = Buffer.from(slashingMatch.stakerKey1 as string, 'hex');
+  const stakingTimeLock = timelockMatch.stakingTimeLock as number;
+
+  const [covenantThreshold, covenantKeyStrings] = parseMulti(slashingMatch.covenantMulti);
+  const covenantKeys = covenantKeyStrings.map((k) => Buffer.from(k, 'hex'));
+
+  let finalityProviderKeys: Buffer[];
+  const fpKeyOrMulti = slashingMatch.finalityProviderKeyOrMulti as ast.MiniscriptNode;
+  if ('v:pk' in fpKeyOrMulti) {
+    finalityProviderKeys = [Buffer.from(fpKeyOrMulti['v:pk'], 'hex')];
+  } else if ('v:multi_a' in fpKeyOrMulti) {
+    const [threshold, keyStrings] = parseMulti(fpKeyOrMulti['v:multi_a']);
+    if (threshold !== 1) {
+      throw new Error('Finality provider multi threshold must be 1');
+    }
+    finalityProviderKeys = keyStrings.map((k) => Buffer.from(k, 'hex'));
+  } else {
+    throw new Error('Invalid finality provider key structure');
+  }
+
   return {
+    stakerKey,
+    finalityProviderKeys,
+    covenantKeys,
+    covenantThreshold,
+    stakingTimeLock,
     slashingMiniscriptNode: slashingNode,
     unbondingMiniscriptNode: unbondingNode,
     timelockMiniscriptNode: timelockNode,

--- a/modules/utxo-staking/test/unit/babylon/transactions.ts
+++ b/modules/utxo-staking/test/unit/babylon/transactions.ts
@@ -23,8 +23,9 @@ import {
   getStakingParams,
   toStakerInfo,
   forceFinalizePsbt,
+  sortedKeys,
 } from '../../../src/babylon';
-import { parseStakingDescriptor } from '../../../src/babylon/parseDescriptor';
+import { parseStakingDescriptor, parseUnbondingDescriptor } from '../../../src/babylon/parseDescriptor';
 import {
   normalize,
   assertEqualsFixture,
@@ -310,6 +311,32 @@ function describeWithKeys(
       assert.deepStrictEqual(parsed.slashingMiniscriptNode, descriptorBuilder.getSlashingMiniscriptNode());
       assert.deepStrictEqual(parsed.unbondingMiniscriptNode, descriptorBuilder.getUnbondingMiniscriptNode());
       assert.deepStrictEqual(parsed.timelockMiniscriptNode, descriptorBuilder.getStakingTimelockMiniscriptNode());
+
+      assert.strictEqual(parseStakingDescriptor(descriptorBuilder.getUnbondingDescriptor()), null);
+      assert.strictEqual(parseStakingDescriptor(descriptorBuilder.getUnbondingTimelockDescriptor()), null);
+    });
+
+    it('round-trip parseUnbondingDescriptor', function () {
+      const descriptor = descriptorBuilder.getUnbondingDescriptor();
+      const parsed = parseUnbondingDescriptor(descriptor);
+
+      assert(parsed);
+      assert.deepStrictEqual(parsed.slashingMiniscriptNode, descriptorBuilder.getSlashingMiniscriptNode());
+      assert.deepStrictEqual(
+        parsed.unbondingTimelockMiniscriptNode,
+        descriptorBuilder.getUnbondingTimelockMiniscriptNode()
+      );
+      assert.deepStrictEqual(parsed.stakerKey, descriptorBuilder.stakerKey);
+      assert.deepStrictEqual(
+        sortedKeys(parsed.finalityProviderKeys),
+        sortedKeys(descriptorBuilder.finalityProviderKeys)
+      );
+      assert.deepStrictEqual(sortedKeys(parsed.covenantKeys), sortedKeys(descriptorBuilder.covenantKeys));
+      assert.strictEqual(parsed.covenantThreshold, descriptorBuilder.covenantThreshold);
+      assert.strictEqual(parsed.unbondingTimeLock, descriptorBuilder.unbondingTimeLock);
+
+      assert.strictEqual(parseUnbondingDescriptor(descriptorBuilder.getStakingDescriptor()), null);
+      assert.strictEqual(parseUnbondingDescriptor(descriptorBuilder.getUnbondingTimelockDescriptor()), null);
     });
 
     describe('Transaction Sets', async function () {

--- a/modules/utxo-staking/test/unit/babylon/undelegation.ts
+++ b/modules/utxo-staking/test/unit/babylon/undelegation.ts
@@ -7,8 +7,12 @@ import * as utxolib from '@bitgo/utxo-lib';
 import { ast, Descriptor } from '@bitgo/wasm-miniscript';
 import { PartialSig } from 'bip174/src/lib/interfaces';
 
-import { toPartialSig, UndelegationResponse } from '../../../src/babylon/undelegation/UndelegationResponse';
-import { assertValidSignatures, toUnbondingPsbtWithSignatures } from '../../../src/babylon/undelegation/unbonding';
+import {
+  toPartialSig,
+  UndelegationResponse,
+  assertValidSignatures,
+  toUnbondingPsbtWithSignatures,
+} from '../../../src/babylon/undelegation';
 import { assertTransactionEqualsFixture } from '../fixtures.utils';
 
 async function getFixture(txid: string): Promise<UndelegationResponse> {

--- a/modules/utxo-staking/test/unit/babylon/undelegation.ts
+++ b/modules/utxo-staking/test/unit/babylon/undelegation.ts
@@ -27,7 +27,15 @@ async function getFixture(txid: string): Promise<UndelegationResponse> {
   return result.right.btc_delegation.undelegation_response;
 }
 
-function runTest(network: utxolib.Network, txid: string, descriptor: Descriptor | ast.DescriptorNode | string): void {
+type DescriptorLike = Descriptor | ast.DescriptorNode | string;
+
+function toDescriptor(descriptor: DescriptorLike): Descriptor {
+  return descriptor instanceof Descriptor
+    ? descriptor
+    : Descriptor.fromStringDetectType(typeof descriptor === 'string' ? descriptor : ast.formatNode(descriptor));
+}
+
+function runTest(network: utxolib.Network, txid: string, descriptor: Descriptor): void {
   describe(`Unbonding transaction ${txid}`, function () {
     it('should create a PSBT from the unbonding transaction', async function () {
       const fixture = await getFixture(txid);
@@ -36,11 +44,6 @@ function runTest(network: utxolib.Network, txid: string, descriptor: Descriptor 
         amountType: 'bigint',
       });
       const signatures = fixture.covenant_unbonding_sig_list.map((sig) => toPartialSig(sig));
-
-      descriptor =
-        descriptor instanceof Descriptor
-          ? descriptor
-          : Descriptor.fromStringDetectType(typeof descriptor === 'string' ? descriptor : ast.formatNode(descriptor));
 
       const psbt = toUnbondingPsbtWithSignatures(
         tx,
@@ -63,38 +66,21 @@ function runTest(network: utxolib.Network, txid: string, descriptor: Descriptor 
   });
 }
 
-runTest(utxolib.networks.bitcoinPublicSignet, '5d277e1b29e5589074aea95ac8c8230fd911c2ec3c58774aafdef915619b772c', {
-  tr: [
-    '50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0',
-    [
-      {
-        and_v: [
-          {
-            and_v: [
-              { 'v:pk': '1b443f34ddc1bbaef52a8c5162dfa5a84524636ec745292f949470369ee67391' },
-              { 'v:pk': 'd23c2c25e1fcf8fd1c21b9a402c19e2e309e531e45e92fb1e9805b6056b0cc76' },
-            ],
-          },
-          {
-            multi_a: [
-              6,
-              '0aee0509b16db71c999238a4827db945526859b13c95487ab46725357c9a9f25',
-              '113c3a32a9d320b72190a04a020a0db3976ef36972673258e9a38a364f3dc3b0',
-              '17921cf156ccb4e73d428f996ed11b245313e37e27c978ac4d2cc21eca4672e4',
-              '3bb93dfc8b61887d771f3630e9a63e97cbafcfcc78556a474df83a31a0ef899c',
-              '40afaf47c4ffa56de86410d8e47baa2bb6f04b604f4ea24323737ddc3fe092df',
-              '79a71ffd71c503ef2e2f91bccfc8fcda7946f4653cef0d9f3dde20795ef3b9f0',
-              'd21faf78c6751a0d38e6bd8028b907ff07e9a869a43fc837d6b3f8dff6119a36',
-              'f5199efae3f28bb82476163a7e458c7ad445d9bffb0682d10d3bdb2cb41f8e8e',
-              'fa9d882d45f4060bdb8042183828cd87544f1ea997380e586cab77d5fd698737',
-            ],
-          },
-        ],
-      },
+runTest(
+  utxolib.networks.bitcoinPublicSignet,
+  '5d277e1b29e5589074aea95ac8c8230fd911c2ec3c58774aafdef915619b772c',
+  toDescriptor({
+    tr: [
+      '50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0',
       [
         {
           and_v: [
-            { 'v:pk': '1b443f34ddc1bbaef52a8c5162dfa5a84524636ec745292f949470369ee67391' },
+            {
+              and_v: [
+                { 'v:pk': '1b443f34ddc1bbaef52a8c5162dfa5a84524636ec745292f949470369ee67391' },
+                { 'v:pk': 'd23c2c25e1fcf8fd1c21b9a402c19e2e309e531e45e92fb1e9805b6056b0cc76' },
+              ],
+            },
             {
               multi_a: [
                 6,
@@ -111,8 +97,29 @@ runTest(utxolib.networks.bitcoinPublicSignet, '5d277e1b29e5589074aea95ac8c8230fd
             },
           ],
         },
-        { and_v: [{ 'v:pk': '1b443f34ddc1bbaef52a8c5162dfa5a84524636ec745292f949470369ee67391' }, { older: 10000 }] },
+        [
+          {
+            and_v: [
+              { 'v:pk': '1b443f34ddc1bbaef52a8c5162dfa5a84524636ec745292f949470369ee67391' },
+              {
+                multi_a: [
+                  6,
+                  '0aee0509b16db71c999238a4827db945526859b13c95487ab46725357c9a9f25',
+                  '113c3a32a9d320b72190a04a020a0db3976ef36972673258e9a38a364f3dc3b0',
+                  '17921cf156ccb4e73d428f996ed11b245313e37e27c978ac4d2cc21eca4672e4',
+                  '3bb93dfc8b61887d771f3630e9a63e97cbafcfcc78556a474df83a31a0ef899c',
+                  '40afaf47c4ffa56de86410d8e47baa2bb6f04b604f4ea24323737ddc3fe092df',
+                  '79a71ffd71c503ef2e2f91bccfc8fcda7946f4653cef0d9f3dde20795ef3b9f0',
+                  'd21faf78c6751a0d38e6bd8028b907ff07e9a869a43fc837d6b3f8dff6119a36',
+                  'f5199efae3f28bb82476163a7e458c7ad445d9bffb0682d10d3bdb2cb41f8e8e',
+                  'fa9d882d45f4060bdb8042183828cd87544f1ea997380e586cab77d5fd698737',
+                ],
+              },
+            ],
+          },
+          { and_v: [{ 'v:pk': '1b443f34ddc1bbaef52a8c5162dfa5a84524636ec745292f949470369ee67391' }, { older: 10000 }] },
+        ],
       ],
     ],
-  ],
-});
+  })
+);


### PR DESCRIPTION

This PR adds support for unbonding operations in the UTXO staking system
with several key improvements:

- Add parsing support for unbonding descriptors with proper type definitions
- Export sortedKeys function for use in the unbonding withdraw flow
- Add tests that validate unbonding outputs against expected scripts
- Extract key details from parsed staking descriptors (staker key, finality 
  provider keys, covenant keys, timelock values)
- Add separate test cases for PSBT signature validation and fixture matching
- Implement toDescriptor helper and DescriptorLike type for improved code
  readability and reduced duplication

These changes provide the foundation for the unbonding transaction flow
while improving the overall code structure and testability.

Issue: BTC-2319