### PR TITLE
fix: revert running test in /dist

### DIFF
--- a/modules/utxo-core/package.json
+++ b/modules/utxo-core/package.json
@@ -27,7 +27,7 @@
     "lint": "eslint --quiet .",
     "prepare": "npm run build",
     "test": "npm run unit-test",
-    "unit-test": "mocha --recursive \"dist/test/**/*.js\""
+    "unit-test": "mocha --recursive test"
   },
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
@@ -45,7 +45,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "type": "commonjs",
   "nyc": {
     "extension": [
       ".ts"

--- a/modules/utxo-core/test/bip32utils.ts
+++ b/modules/utxo-core/test/bip32utils.ts
@@ -21,7 +21,12 @@ describe('bip32utils', function () {
             const expectValid = message === otherMessage && key === otherKey;
             assert.strictEqual(verifyMessage(otherMessage, otherKey, signature, utxolib.networks.bitcoin), expectValid);
             assert.strictEqual(
-              verifyMessage(Buffer.from(otherMessage), otherKey, signature, utxolib.networks.bitcoin),
+              verifyMessage(
+                typeof otherMessage === 'string' ? Buffer.from(otherMessage) : otherMessage,
+                otherKey,
+                signature,
+                utxolib.networks.bitcoin
+              ),
               expectValid
             );
           });

--- a/modules/utxo-core/test/descriptor/parse/PatternMatcher.ts
+++ b/modules/utxo-core/test/descriptor/parse/PatternMatcher.ts
@@ -32,13 +32,25 @@ function taprootScriptOnlyFromAst(n: ast.TapTreeNode): Descriptor {
 }
 
 class StakingDescriptorBuilder {
+  public userKey: Buffer;
+  public providerKeys: Buffer[];
+  public guardianKeys: Buffer[];
+  public guardianThreshold: number;
+  public stakingTimeLock: number;
+
   constructor(
-    public userKey: Buffer,
-    public providerKeys: Buffer[],
-    public guardianKeys: Buffer[],
-    public guardianThreshold: number,
-    public stakingTimeLock: number
-  ) {}
+    userKey: Buffer,
+    providerKeys: Buffer[],
+    guardianKeys: Buffer[],
+    guardianThreshold: number,
+    stakingTimeLock: number
+  ) {
+    this.userKey = userKey;
+    this.providerKeys = providerKeys;
+    this.guardianKeys = guardianKeys;
+    this.guardianThreshold = guardianThreshold;
+    this.stakingTimeLock = stakingTimeLock;
+  }
 
   getTimelockMiniscriptNode(): ast.MiniscriptNode {
     return { and_v: [pk(this.userKey), { older: this.stakingTimeLock }] };

--- a/modules/utxo-core/test/descriptor/psbt/psbt.ts
+++ b/modules/utxo-core/test/descriptor/psbt/psbt.ts
@@ -45,7 +45,7 @@ function normalize(v: unknown): unknown {
 }
 
 async function assertEqualsFixture(t: string, filename: string, value: unknown) {
-  filename = __dirname + '/../../../../test/descriptor/psbt/fixtures/' + t + '.' + filename;
+  filename = __dirname + '/fixtures/' + t + '.' + filename;
   const nv = normalize(value);
   assert.deepStrictEqual(nv, await getFixture(filename, nv));
 }

--- a/modules/utxo-staking/package.json
+++ b/modules/utxo-staking/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint --quiet .",
     "prepare": "npm run build",
     "coverage": "nyc -- npm run unit-test",
-    "unit-test": "mocha --recursive \"dist/test/**/*.js\""
+    "unit-test": "mocha --recursive test"
   },
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
@@ -41,7 +41,6 @@
       ".ts"
     ]
   },
-  "type": "commonjs",
   "dependencies": {
     "@babylonlabs-io/babylon-proto-ts": "1.0.0",
     "@bitgo/babylonlabs-io-btc-staking-ts": "^2.4.0",

--- a/modules/utxo-staking/test/unit/babylon/bug71.ts
+++ b/modules/utxo-staking/test/unit/babylon/bug71.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import assert from 'assert';
+import path from 'path';
 
 import * as bitcoinjs from 'bitcoinjs-lib';
 import * as utxolib from '@bitgo/utxo-lib';
@@ -9,8 +10,9 @@ import * as wasmMiniscript from '@bitgo/wasm-miniscript';
 describe('btc-staking-ts bug #71', function () {
   let buf: Buffer;
   before('load half-signed transaction', async function () {
+    const __dirname = path.dirname(__filename);
     const fixture = JSON.parse(
-      await fs.promises.readFile(__dirname + '/../../../../test/fixtures/babylon/txTree.testnet.json', 'utf-8')
+      await fs.promises.readFile(__dirname + '/../../fixtures/babylon/txTree.testnet.json', 'utf-8')
     );
     const base64 = fixture.slashingSignedBase64;
     assert(typeof base64 === 'string');

--- a/modules/utxo-staking/test/unit/babylon/undelegation.ts
+++ b/modules/utxo-staking/test/unit/babylon/undelegation.ts
@@ -28,7 +28,7 @@ type BtcDelegation = t.TypeOf<typeof BtcDelegation>;
 async function getFixture(txid: string): Promise<BtcDelegation> {
   // As returned by https://babylon.nodes.guru/api#/Query/BTCDelegation
   const BtcDelegationResponse = t.type({ btc_delegation: BtcDelegation }, 'BtcDelegationResponse');
-  const filename = __dirname + `/../../../../test/fixtures/babylon/rpc/btc_delegation/testnet.${txid}.json`;
+  const filename = __dirname + `/../../fixtures/babylon/rpc/btc_delegation/testnet.${txid}.json`;
   const data = JSON.parse(await fs.readFile(filename, 'utf8'));
   const result = BtcDelegationResponse.decode(data);
   if (isLeft(result)) {


### PR DESCRIPTION
Reverting the changes done by this [pr](https://github.com/BitGo/BitGoJS/pull/6529), fixing the strip-only errors instead of running in `/dist`

TICKET: CAAS-325

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
