### PR TITLE
chore: adding the missing evm chain api tokens in the Bitgo api options

### DIFF
--- a/modules/sdk-api/src/types.ts
+++ b/modules/sdk-api/src/types.ts
@@ -36,6 +36,16 @@ export interface BitGoAPIOptions {
   optimisticEtherscanApiToken?: string;
   zksyncExplorerApiToken?: string;
   bscscanApiToken?: string;
+  coredaoExplorerApiToken?: string;
+  oasExplorerApiToken?: string;
+  sgbExplorerApiToken?: string;
+  flrExplorerApiToken?: string;
+  xdcExplorerApiToken?: string;
+  wemixExplorerApiToken?: string;
+  monExplorerApiToken?: string;
+  worldExplorerApiToken?: string;
+  somniaExplorerApiToken?: string;
+  soneiumExplorerApiToken?: string;
   hmacVerification?: boolean;
   customProxyAgent?: Agent;
   refreshToken?: string;


### PR DESCRIPTION
Ticket: COIN-4971

Add missing optional properties to BitGoAPIOptions interface to match
runtime implementation in bitgoAPI.ts:

- coredaoExplorerApiToken
- oasExplorerApiToken  
- sgbExplorerApiToken
- flrExplorerApiToken
- xdcExplorerApiToken
- wemixExplorerApiToken
- monExplorerApiToken
- worldExplorerApiToken
- somniaExplorerApiToken
- soneiumExplorerApiToken

