### PR TITLE
feat(abstract-eth): add recover consolidation for eth

### DIFF
--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -122,6 +122,8 @@ export interface EthereumNetwork extends AccountNetwork {
   readonly forwarderImplementationAddress?: string;
   readonly nativeCoinOperationHashPrefix?: string;
   readonly tokenOperationHashPrefix?: string;
+  readonly walletV4ForwarderFactoryAddress?: string;
+  readonly walletV4ForwarderImplementationAddress?: string;
 }
 
 export interface TronNetwork extends AccountNetwork {
@@ -546,6 +548,8 @@ class Ethereum extends Mainnet implements EthereumNetwork {
   forwarderImplementationAddress = '0x059ffafdc6ef594230de44f824e2bd0a51ca5ded';
   nativeCoinOperationHashPrefix = 'ETHER';
   tokenOperationHashPrefix = 'ERC20';
+  walletV4ForwarderFactoryAddress = '0x37996e762fa8b671869740c79eb33f625b3bf92a';
+  walletV4ForwarderImplementationAddress = '0xd5fe1c1f216b775dfd30638fa7164d41321ef79b';
 }
 
 class Ethereum2 extends Mainnet implements AccountNetwork {
@@ -617,6 +621,8 @@ class Holesky extends Testnet implements EthereumNetwork {
   forwarderImplementationAddress = '0x059ffafdc6ef594230de44f824e2bd0a51ca5ded';
   nativeCoinOperationHashPrefix = 'ETHER';
   tokenOperationHashPrefix = 'ERC20';
+  walletV4ForwarderFactoryAddress = '0x37996e762fa8b671869740c79eb33f625b3bf92a';
+  walletV4ForwarderImplementationAddress = '0xd5fe1c1f216b775dfd30638fa7164d41321ef79b';
 }
 
 class Hoodi extends Testnet implements EthereumNetwork {
@@ -632,6 +638,8 @@ class Hoodi extends Testnet implements EthereumNetwork {
   forwarderImplementationAddress = '0x7441f20a59be97011842404b9aefd8d85fd81aa6';
   nativeCoinOperationHashPrefix = 'ETHER';
   tokenOperationHashPrefix = 'ERC20';
+  walletV4ForwarderFactoryAddress = '0x37996e762fa8b671869740c79eb33f625b3bf92a';
+  walletV4ForwarderImplementationAddress = '0xd5fe1c1f216b775dfd30638fa7164d41321ef79b';
 }
 
 class EthereumClassic extends Mainnet implements EthereumNetwork {

--- a/modules/statics/test/unit/resources/amsTokenConfig.ts
+++ b/modules/statics/test/unit/resources/amsTokenConfig.ts
@@ -663,6 +663,8 @@ export const amsTokenConfigWithCustomToken = {
         forwarderImplementationAddress: '0x7441f20a59be97011842404b9aefd8d85fd81aa6',
         nativeCoinOperationHashPrefix: 'ETHER',
         tokenOperationHashPrefix: 'ERC20',
+        walletV4ForwarderFactoryAddress: '0x37996e762fa8b671869740c79eb33f625b3bf92a',
+        walletV4ForwarderImplementationAddress: '0xd5fe1c1f216b775dfd30638fa7164d41321ef79b',
       },
       primaryKeyCurve: 'secp256k1',
       contractAddress: '0x89a959b9184b4f8c8633646d5dfd049d2ebc983a',


### PR DESCRIPTION
Adding the recover consolidation functionality for `eth` and `hteth` which would be used for unsigned consolidation in WRW 

ticket: WIN-5700

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
