### PR TITLE
feat(scripts): amend script to fetch TRX balance to be consolidated

### DIFF
--- a/examples/ts/trx/fetch-addresses-with-trx-balance-for-consolidation.ts
+++ b/examples/ts/trx/fetch-addresses-with-trx-balance-for-consolidation.ts
@@ -1,9 +1,10 @@
 /**
- * Copyright 2024, BitGo, Inc.  All Rights Reserved.
+ * Copyright 2025, BitGo, Inc.  All Rights Reserved.
  */
 import { BitGoAPI } from '@bitgo/sdk-api';
 import { Trx } from '@bitgo/sdk-coin-trx';
 import * as fs from 'fs';
+import BigNumber from 'bignumber.js';
 require('dotenv').config({ path: '../../.env' });
 
 const bitgo = new BitGoAPI({
@@ -16,6 +17,8 @@ bitgo.register(coin, Trx.createInstance);
 
 const walletId = '';
 
+// This script is used for fetching the amount of TRX that can be consolidated
+// specifically for wallets which use gas tank to fund addresses in case of token deposit (we block 36 trx for each unique token that is present in the address)
 async function main() {
   const wallet = await bitgo.coin(coin).wallets().get({ id: walletId });
   let prevId = undefined;
@@ -27,20 +30,31 @@ async function main() {
 
     for (const { address, balance, needsConsolidation, tokenConsolidationState } of addresses.addresses) {
       const { tokens, spendableBalanceString } = balance;
-      const usdtBalance = tokens['trx:usdt']?.spendableBalanceString;
-
+      let tokenCounter = 0;
       console.log(`Address ${index}: ${address}`);
-      console.log('USDT token balance: ', usdtBalance || 'Does not have USDT balance');
-      console.log('TRX balance: ', spendableBalanceString);
+      const trxSpendableBalance = new BigNumber(spendableBalanceString || '0');
+      console.log('TRX balance: ', trxSpendableBalance);
 
-      if (usdtBalance > 0 && spendableBalanceString > 36000000) {
-        const data = `${address}, USDT balance: ${usdtBalance}, TRX balance: ${spendableBalanceString}, V1: ${needsConsolidation}, V2: ${tokenConsolidationState['trx']}\n`;
-        fs.appendFileSync('addresses-with-usdt-balance-and-trx-greater-than-36.txt', data);
+      // Process token balances if any
+      for (const key in tokens) {
+        const tokenSpendableBalance = new BigNumber(tokens[key]?.spendableBalanceString || '0');
+        console.log(`Token: ${key}, Token spendable balance: ${tokenSpendableBalance}`);
+        if (tokenSpendableBalance.isGreaterThan(0)) {
+          tokenCounter += 1;
+        }  
       }
 
-      if ((!usdtBalance || usdtBalance <= 0) && spendableBalanceString > 1000000) {
-        const data = `${address}, USDT balance: ${usdtBalance}, TRX balance: ${spendableBalanceString}, V1: ${needsConsolidation}, V2: ${tokenConsolidationState['trx']}\n`;
-        fs.appendFileSync('addresses-without-usdt-and-trx-greater-than-1.txt', data);
+      if (tokenCounter > 0 && trxSpendableBalance.isGreaterThanOrEqualTo(0)) {
+        // This is for enteprises which use gas tank for funding receive addresses with TRX on token deposit
+        // we block 36 TRX for each unique token that needs to be consolidated and arrive at the amout of TRX that can be consolidated
+        const trxBalanceThatCanBeConsolidated = BigNumber.max(trxSpendableBalance.minus(tokenCounter * 36000000), 0);
+        const data = `${address}, No of tokens: ${tokenCounter}, TRX balance: ${trxSpendableBalance}, TRX balance that can be consolidated: ${trxBalanceThatCanBeConsolidated}, V1 flag: ${needsConsolidation}, V2 flag: ${tokenConsolidationState['trx']}\n`;
+        fs.appendFileSync('addresses-with-token-balance-and-trx-to-be-consolidated.txt', data);
+      } else if (tokenCounter == 0 && trxSpendableBalance.isGreaterThanOrEqualTo(0)) {
+        // if address does not have any tokens and has more than 1 TRX, then we need to subtract 1 TRX from it (min TRX thats left in the address)
+        const trxBalanceThatCanBeConsolidated = BigNumber.max(trxSpendableBalance.minus(1000000), 0);
+        const data = `${address}, No of tokens: ${tokenCounter}, TRX balance: ${trxSpendableBalance}, TRX balance that can be consolidated: ${trxBalanceThatCanBeConsolidated}, V1 flag: ${needsConsolidation}, V2 flag: ${tokenConsolidationState['trx']}\n`;
+        fs.appendFileSync('addresses-without-token-balance-and-trx-to-be-consolidated.txt', data);
       }
 
       index += 1;


### PR DESCRIPTION
Ticket: SC-2558

Amending script to be more robust and find out TRX that can be consolidated (for enterprises which use gas tank for funding TRX incase of token deposit):
- find out addresses having token balances and amount of TRX that can be consolidated (after subtracting 36 TRX * no of tokens)
- find out addresses without any token balances and amount of TRX that can be consolidated (after subtracting 1 TRX)