### PR TITLE
feat: onboard new ofc testnet hoodi coin

### DIFF
--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -270,6 +270,14 @@ export const ofcCoins = [
     CoinKind.CRYPTO
   ),
   tofc(
+    '97f83379-a536-4977-a5e8-5a4dae5a3db7',
+    'ofchooditeth',
+    'Test Hoodi Ether',
+    18,
+    UnderlyingAsset.ETH,
+    CoinKind.CRYPTO
+  ),
+  tofc(
     'f43d0558-8c07-4927-af7f-33947fd310c9',
     'ofctavaxc',
     'Test Avalanche C-Chain',


### PR DESCRIPTION
Ticket: GO-1488. This is being done so that we can essentially "reset" the underlying data for HTETH without actually wiping anything. Essentially the old data will have ofchteth on it and after migration, HTETH will point to "ofchooditeth" giving us a clean slate.
