### PR TITLE
feat(utxo-core): simplify signature process with direct message param

### DIFF
--- a/modules/utxo-core/test/bip322/bip322.utils.ts
+++ b/modules/utxo-core/test/bip322/bip322.utils.ts
@@ -13,6 +13,6 @@ export const BIP322_FIXTURE_HELLO_WORLD_TOSPEND_TX = buildToSpendTransaction(
   Buffer.from('Hello World')
 );
 
-export const BIP322_FIXTURE_HELLOW_WORLD_TOSIGN_PSBT = buildToSignPsbt(BIP322_FIXTURE_HELLO_WORLD_TOSPEND_TX, {
+export const BIP322_FIXTURE_HELLO_WORLD_TOSIGN_PSBT = buildToSignPsbt('Hello World', {
   scriptPubKey: BIP322_PAYMENT_P2WPKH_FIXTURE.output as Buffer,
 });

--- a/modules/utxo-core/test/bip322/toSign.ts
+++ b/modules/utxo-core/test/bip322/toSign.ts
@@ -23,11 +23,9 @@ describe('BIP322 toSign', function () {
 
     fixtures.forEach(({ message, txid }) => {
       it(`should build a to_sign PSBT for message "${message}"`, function () {
-        const toSpendTx = bip322.buildToSpendTransaction(scriptPubKey, Buffer.from(message));
-        const addressDetails = {
+        const result = bip322.buildToSignPsbt(message, {
           scriptPubKey,
-        };
-        const result = bip322.buildToSignPsbt(toSpendTx, addressDetails);
+        });
         const computedTxid = result
           .signAllInputs(prv, [utxolib.Transaction.SIGHASH_ALL])
           .finalizeAllInputs()
@@ -41,13 +39,6 @@ describe('BIP322 toSign', function () {
   describe('buildToSignPsbtForChainAndIndex', function () {
     const rootWalletKeys = utxolib.testutil.getDefaultWalletKeys();
 
-    it('should fail when scriptPubKey of to_spend is different than to_sign', function () {
-      const toSpendTx = bip322.buildToSpendTransaction(BIP322_PAYMENT_P2WPKH_FIXTURE.output as Buffer, 'Hello World');
-      assert.throws(() => {
-        bip322.buildToSignPsbtForChainAndIndex(toSpendTx, rootWalletKeys, 0, 0);
-      }, /Output scriptPubKey does not match the expected output script for the chain and index./);
-    });
-
     function run(chain: utxolib.bitgo.ChainCode, shouldFail: boolean, index: number) {
       it(`should${
         shouldFail ? ' fail to' : ''
@@ -60,7 +51,7 @@ describe('BIP322 toSign', function () {
           return;
         }
         const toSpendTx = bip322.buildToSpendTransactionFromChainAndIndex(rootWalletKeys, chain, index, message);
-        const toSignPsbt = bip322.buildToSignPsbtForChainAndIndex(toSpendTx, rootWalletKeys, chain, index);
+        const toSignPsbt = bip322.buildToSignPsbtForChainAndIndex(message, rootWalletKeys, chain, index);
 
         const derivedKeys = rootWalletKeys.deriveForChainAndIndex(chain, index);
         const prv1 = derivedKeys.triple[0];

--- a/modules/utxo-core/test/bip322/utils.ts
+++ b/modules/utxo-core/test/bip322/utils.ts
@@ -2,27 +2,24 @@ import assert from 'assert';
 
 import * as utxolib from '@bitgo/utxo-lib';
 
-import { addBip322ProofMessage, getBip322ProofInputIndex, psbtIsBip322Proof } from '../../src/bip322';
+import { getBip322ProofInputIndex, psbtIsBip322Proof } from '../../src/bip322';
 
-import { BIP322_FIXTURE_HELLOW_WORLD_TOSIGN_PSBT } from './bip322.utils';
+import { BIP322_FIXTURE_HELLO_WORLD_TOSIGN_PSBT } from './bip322.utils';
 
 describe('BIP322 Proof utils', function () {
   it('should add a BIP322 proof message to a PSBT input', function () {
     const psbt = utxolib.bitgo.createPsbtFromBuffer(
-      BIP322_FIXTURE_HELLOW_WORLD_TOSIGN_PSBT.toBuffer(),
+      BIP322_FIXTURE_HELLO_WORLD_TOSIGN_PSBT.toBuffer(),
       utxolib.networks.bitcoin
     );
-    const inputIndex = 0;
-    const message = Buffer.from('Hello World');
-    addBip322ProofMessage(psbt, inputIndex, message);
 
-    const proprietaryKeyVals = utxolib.bitgo.getPsbtInputProprietaryKeyVals(psbt.data.inputs[inputIndex], {
+    const proprietaryKeyVals = utxolib.bitgo.getPsbtInputProprietaryKeyVals(psbt.data.inputs[0], {
       identifier: utxolib.bitgo.PSBT_PROPRIETARY_IDENTIFIER,
       subtype: utxolib.bitgo.ProprietaryKeySubtype.BIP322_MESSAGE,
     });
 
     assert.ok(proprietaryKeyVals.length === 1);
-    assert.ok(proprietaryKeyVals[0].value.equals(message));
+    assert.ok(proprietaryKeyVals[0].value.equals(Buffer.from('Hello World')));
     assert.ok(proprietaryKeyVals[0].key.keydata.length === 0); // keydata should be empty
     assert.ok(proprietaryKeyVals[0].key.identifier === utxolib.bitgo.PSBT_PROPRIETARY_IDENTIFIER);
     assert.ok(proprietaryKeyVals[0].key.subtype === utxolib.bitgo.ProprietaryKeySubtype.BIP322_MESSAGE);
@@ -30,17 +27,12 @@ describe('BIP322 Proof utils', function () {
 
   it('should return the input index of a BIP322 proof message', function () {
     const psbt = utxolib.bitgo.createPsbtFromBuffer(
-      BIP322_FIXTURE_HELLOW_WORLD_TOSIGN_PSBT.toBuffer(),
+      BIP322_FIXTURE_HELLO_WORLD_TOSIGN_PSBT.toBuffer(),
       utxolib.networks.bitcoin
     );
-    assert.ok(!psbtIsBip322Proof(psbt)); // initially should not be a BIP322 proof
-
-    const inputIndex = 0;
-    const message = Buffer.from('Hello World');
-    addBip322ProofMessage(psbt, inputIndex, message);
 
     const resultIndex = getBip322ProofInputIndex(psbt);
-    assert.strictEqual(resultIndex, inputIndex);
+    assert.strictEqual(resultIndex, 0);
     assert.ok(psbtIsBip322Proof(psbt));
   });
 });


### PR DESCRIPTION
Refactor buildToSignPsbt to accept message directly instead of a toSpendTx parameter. This simplifies the API by internally generating the toSpend transaction and storing the message in the PSBT for later verification.

Also adds message to the PSBT as proprietary data so it can be verified during the validation process.

Issue: BTC-2375

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
