### PR TITLE
fix: skip combineSigShare check for non-EIP191 message signing

### DIFF
--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -122,6 +122,7 @@ import { IRequestTracer } from '../../api';
 import { getTxRequestApiVersion, validateTxRequestApiVersion } from '../utils/txRequest';
 import { getLightningAuthKey } from '../lightning/lightningWalletUtil';
 import { SubmitTransactionResponse } from '../inscriptionBuilder';
+import { CoinFamily } from '@bitgo/statics';
 
 const debug = require('debug')('bitgo:v2:wallet');
 
@@ -3662,10 +3663,12 @@ export class Wallet implements IWallet {
         bufferToSign: Buffer.from(messageEncoded, 'hex'),
       });
       assert(signedMessageRequest.messages, 'Unable to find messages in signedMessageRequest');
-      assert(
-        signedMessageRequest.messages[0].combineSigShare,
-        'Unable to find combineSigShare in signedMessageRequest.messages'
-      );
+      if (this.baseCoin.getFamily() === CoinFamily.ETH) {
+        assert(
+          signedMessageRequest.messages[0].combineSigShare,
+          'Unable to find combineSigShare in signedMessageRequest.messages'
+        );
+      }
       assert(signedMessageRequest.messages[0].txHash, 'Unable to find txHash in signedMessageRequest.messages');
       return {
         coin: this.coin(),


### PR DESCRIPTION
This pull request introduces a minor update to the `Wallet` class to improve message signing validation for Ethereum-family coins. Specifically, it adds a check to ensure that `combineSigShare` is present in the signed message request when the coin family is Ethereum.

Validation improvements for Ethereum-family coins:

* Added a conditional check in the `Wallet` class to assert the presence of `combineSigShare` in `signedMessageRequest.messages` only for coins in the Ethereum family, using the `CoinFamily` enum.
* Imported `CoinFamily` from `@bitgo/statics` to support the new conditional logic.

TICKET: COIN-5225

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
