### PR TITLE
feat(statics): add RESTRICTED coin feature for internal tokens

### DIFF
--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -451,6 +451,11 @@ export enum CoinFeature {
    * This coin is an EVM compatible coin and should use common EVM logic in WP
    */
   EVM_COMPATIBLE_WP = 'evm-compatible-wp',
+
+  /**
+   * This token is internal and shouldn't be exposed to users
+   */
+  RESTRICTED = 'restricted',
 }
 
 /**

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -2621,13 +2621,15 @@ export const coins = CoinMap.fromCoins([
     '30d034ae-41fd-4da2-bbb2-05fe1e301108',
     'erc721:unsteth',
     'Lido: stETH Withdrawal NFT',
-    '0x889edc2edab5f40e902b864ad4d7ade8e412f9b1'
+    '0x889edc2edab5f40e902b864ad4d7ade8e412f9b1',
+    [...AccountCoin.DEFAULT_FEATURES, CoinFeature.RESTRICTED]
   ),
   terc721(
     '05ce9121-45e0-4e9c-941b-1aa95bedfcc5',
     'terc721:unsteth',
     'Test Lido: stETH Withdrawal NFT',
-    '0xfe56573178f1bcdf53f01a6e9977670dcbbd9186'
+    '0xfe56573178f1bcdf53f01a6e9977670dcbbd9186',
+    [...AccountCoin.DEFAULT_FEATURES, CoinFeature.RESTRICTED]
   ),
   terc721(
     'e795fc78-b8a7-47a1-8294-5ecbe8a74c3a',


### PR DESCRIPTION
TICKET: SC-2604

This PR adds a new CoinFeature (RESTRICTED) which, when enabled, avoids exposing certain coins/tokens to the user. This is necessary for erc721:unsteth for LIDO, as it prevents UI and API users from withdrawing or seeing an unnecessary NFT, which can disrupt the unstaking flow.