### PR TITLE
refactor(utxo-core): enhance BIP322 with support for multiple inputs

### DIFF
--- a/modules/utxo-core/src/bip322/toSign.ts
+++ b/modules/utxo-core/src/bip322/toSign.ts
@@ -8,9 +8,35 @@ export type AddressDetails = {
   witnessScript?: Buffer;
   scriptPubKey: Buffer;
 };
+export const MAX_NUM_BIP322_INPUTS = 200;
 
 /**
- * Construct the toSign PSBT for a BIP322 verification.
+ * Create the base PSBT for the to_sign transaction for BIP322 signing.
+ * There will be ever 1 output.
+ */
+export function createBaseToSignPsbt(rootWalletKeys?: bitgo.RootWalletKeys): Psbt {
+  // Create PSBT object for constructing the transaction
+  const psbt = new Psbt();
+  // Set default value for nVersion and nLockTime
+  psbt.setVersion(0); // nVersion = 0
+  psbt.setLocktime(0); // nLockTime = 0
+
+  // Set the output
+  psbt.addOutput({
+    value: BigInt(0), // vout[0].nValue = 0
+    script: Buffer.from([0x6a]), // vout[0].scriptPubKey = OP_RETURN
+  });
+
+  // If rootWalletKeys are provided, add them to the PSBT as global xpubs
+  if (rootWalletKeys) {
+    bitgo.addXpubsToPsbt(psbt, rootWalletKeys);
+  }
+
+  return psbt;
+}
+
+/**
+ * Add a BIP322 input to the PSBT.
  * Source implementation:
  * https://github.com/bitcoin/bips/blob/master/bip-0322.mediawiki#full
  *
@@ -19,44 +45,38 @@ export type AddressDetails = {
  * @param {string} [tag=BIP322_TAG] - The tag to use for hashing, defaults to BIP322_TAG.
  * @returns {Psbt} - The hex representation of the constructed PSBT.
  */
-export function buildToSignPsbt(message: string, addressDetails: AddressDetails, tag = BIP322_TAG): Psbt {
+export function addBip322Input(psbt: Psbt, message: string, addressDetails: AddressDetails, tag = BIP322_TAG): void {
   const toSpendTx = buildToSpendTransaction(addressDetails.scriptPubKey, message, tag);
+  if (psbt.data.inputs.length >= MAX_NUM_BIP322_INPUTS) {
+    throw new Error(`Exceeded maximum number of BIP322 inputs (${MAX_NUM_BIP322_INPUTS})`);
+  }
 
-  // Create PSBT object for constructing the transaction
-  const psbt = new Psbt();
-  // Set default value for nVersion and nLockTime
-  psbt.setVersion(0); // nVersion = 0
-  psbt.setLocktime(0); // nLockTime = 0
-  // Set the input
   psbt.addInput({
     hash: toSpendTx.getId(), // vin[0].prevout.hash = to_spend.txid
     index: 0, // vin[0].prevout.n = 0
     sequence: 0, // vin[0].nSequence = 0
     nonWitnessUtxo: toSpendTx.toBuffer(), // previous transaction for us to rebuild later to verify
   });
-  psbt.updateInput(0, {
+  const inputIndex = psbt.data.inputs.length - 1;
+  psbt.updateInput(inputIndex, {
     witnessUtxo: { value: BigInt(0), script: addressDetails.scriptPubKey },
   });
 
   if (addressDetails.redeemScript) {
-    psbt.updateInput(0, { redeemScript: addressDetails.redeemScript });
+    psbt.updateInput(inputIndex, { redeemScript: addressDetails.redeemScript });
   }
   if (addressDetails.witnessScript) {
-    psbt.updateInput(0, { witnessScript: addressDetails.witnessScript });
+    psbt.updateInput(inputIndex, {
+      witnessScript: addressDetails.witnessScript,
+    });
   }
 
   // Add the message as a proprietary key value to the PSBT so we can verify it later
-  addBip322ProofMessage(psbt, 0, Buffer.from(message));
-
-  // Set the output
-  psbt.addOutput({
-    value: BigInt(0), // vout[0].nValue = 0
-    script: Buffer.from([0x6a]), // vout[0].scriptPubKey = OP_RETURN
-  });
-  return psbt;
+  addBip322ProofMessage(psbt, inputIndex, Buffer.from(message));
 }
 
-export function buildToSignPsbtForChainAndIndex(
+export function addBip322InputWithChainAndIndex(
+  psbt: Psbt,
   message: string,
   rootWalletKeys: bitgo.RootWalletKeys,
   chain: bitgo.ChainCode,
@@ -68,17 +88,17 @@ export function buildToSignPsbtForChainAndIndex(
   const walletKeys = rootWalletKeys.deriveForChainAndIndex(chain, index);
   const output = bitgo.outputScripts.createOutputScript2of3(walletKeys.publicKeys, bitgo.scriptTypeForChain(chain));
 
-  const psbt = buildToSignPsbt(message, {
+  addBip322Input(psbt, message, {
     scriptPubKey: output.scriptPubKey,
     redeemScript: output.redeemScript,
     witnessScript: output.witnessScript,
   });
 
+  const inputIndex = psbt.data.inputs.length - 1;
   psbt.updateInput(
-    0,
+    inputIndex,
     bitgo.getPsbtBip32DerivationOutputUpdate(rootWalletKeys, walletKeys, bitgo.scriptTypeForChain(chain))
   );
-  bitgo.addXpubsToPsbt(psbt, rootWalletKeys);
 
   return psbt;
 }

--- a/modules/utxo-core/test/bip322/bip322.utils.ts
+++ b/modules/utxo-core/test/bip322/bip322.utils.ts
@@ -1,6 +1,6 @@
 import { payments, ECPair } from '@bitgo/utxo-lib';
 
-import { buildToSignPsbt, buildToSpendTransaction } from '../../src/bip322';
+import { addBip322Input, createBaseToSignPsbt, buildToSpendTransaction } from '../../src/bip322';
 
 export const BIP322_WIF_FIXTURE = 'L3VFeEujGtevx9w18HD1fhRbCH67Az2dpCymeRE1SoPK6XQtaN2k';
 export const BIP322_PRV_FIXTURE = ECPair.fromWIF(BIP322_WIF_FIXTURE);
@@ -13,6 +13,7 @@ export const BIP322_FIXTURE_HELLO_WORLD_TOSPEND_TX = buildToSpendTransaction(
   Buffer.from('Hello World')
 );
 
-export const BIP322_FIXTURE_HELLO_WORLD_TOSIGN_PSBT = buildToSignPsbt('Hello World', {
+export const BIP322_FIXTURE_HELLO_WORLD_TOSIGN_PSBT = createBaseToSignPsbt();
+addBip322Input(BIP322_FIXTURE_HELLO_WORLD_TOSIGN_PSBT, 'Hello World', {
   scriptPubKey: BIP322_PAYMENT_P2WPKH_FIXTURE.output as Buffer,
 });

--- a/modules/utxo-core/test/bip322/toSign.ts
+++ b/modules/utxo-core/test/bip322/toSign.ts
@@ -23,7 +23,8 @@ describe('BIP322 toSign', function () {
 
     fixtures.forEach(({ message, txid }) => {
       it(`should build a to_sign PSBT for message "${message}"`, function () {
-        const result = bip322.buildToSignPsbt(message, {
+        const result = bip322.createBaseToSignPsbt();
+        bip322.addBip322Input(result, message, {
           scriptPubKey,
         });
         const computedTxid = result
@@ -51,7 +52,8 @@ describe('BIP322 toSign', function () {
           return;
         }
         const toSpendTx = bip322.buildToSpendTransactionFromChainAndIndex(rootWalletKeys, chain, index, message);
-        const toSignPsbt = bip322.buildToSignPsbtForChainAndIndex(message, rootWalletKeys, chain, index);
+        const toSignPsbt = bip322.createBaseToSignPsbt(rootWalletKeys);
+        bip322.addBip322InputWithChainAndIndex(toSignPsbt, message, rootWalletKeys, chain, index);
 
         // Can sign the PSBT with the keys
         // Should be able to use HD because we have the bip32Derivation information


### PR DESCRIPTION
Refactor BIP322 implementation to support multiple inputs in one PSBT. This change allows for a more flexible approach where we can batch multiple message signature requests into a single transaction.

- Create a base PSBT for to_sign transactions
- Add method to add inputs incrementally
- Add limit of maximum inputs (200)
- Update tests to use the new API

TICKET: BTC-2385

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
