### PR TITLE
feat(utxo-core): add verification func for to_sign txs

### DIFF
--- a/modules/utxo-core/src/bip322/index.ts
+++ b/modules/utxo-core/src/bip322/index.ts
@@ -1,3 +1,4 @@
 export * from './toSpend';
 export * from './toSign';
 export * from './utils';
+export * from './verify';

--- a/modules/utxo-core/src/bip322/verify.ts
+++ b/modules/utxo-core/src/bip322/verify.ts
@@ -1,0 +1,53 @@
+import assert from 'assert';
+
+import * as utxolib from '@bitgo/utxo-lib';
+
+import { buildToSpendTransaction } from './toSpend';
+
+export type VerificationInfo = {
+  message: string;
+  address: string;
+};
+
+/**
+ *
+ * @param toSignTx
+ * @param verificationInfo
+ * @param network
+ */
+export function verifyFixedScriptToSignTxWithInfo(
+  toSignTx: utxolib.Transaction<bigint>,
+  verificationInfo: VerificationInfo[],
+  network: utxolib.Network
+): void {
+  assert.deepStrictEqual(
+    toSignTx.ins.length,
+    verificationInfo.length,
+    'to_sign transaction must have one input per message'
+  );
+
+  // Verify the transaction structure
+  assert.deepStrictEqual(toSignTx.version, 0, 'to_sign transaction version must be 0');
+  assert.deepStrictEqual(toSignTx.locktime, 0, 'to_sign transaction locktime must be 0');
+  assert.deepStrictEqual(toSignTx.outs.length, 1, 'to_sign transaction must have one output');
+  assert.deepStrictEqual(toSignTx.outs[0].value, BigInt(0), 'to_sign transaction output value must be 0');
+  assert.deepStrictEqual(
+    toSignTx.outs[0].script.toString('hex'),
+    '6a',
+    'to_sign transaction output script must be OP_RETURN'
+  );
+
+  // Verify the messages against the transaction inputs
+  toSignTx.ins.forEach((input, inputIndex) => {
+    // Check that the expected to_spend transaction matches
+    const scriptPubKey = utxolib.address.toOutputScript(verificationInfo[inputIndex].address, network);
+    const toSpendTx = buildToSpendTransaction(scriptPubKey, verificationInfo[inputIndex].message);
+    assert.deepStrictEqual(
+      utxolib.bitgo.getOutputIdForInput(toSignTx.ins[inputIndex]).txid,
+      toSpendTx.getId(),
+      'to_sign transaction input must reference the to_spend transaction'
+    );
+    assert.deepStrictEqual(input.index, 0, `to_sign transaction input ${inputIndex} index must be 0`);
+    assert.deepStrictEqual(input.sequence, 0, `to_sign transaction input ${inputIndex} sequence must be 0`);
+  });
+}

--- a/modules/utxo-core/test/bip322/verify.ts
+++ b/modules/utxo-core/test/bip322/verify.ts
@@ -1,0 +1,48 @@
+import assert from 'assert';
+
+import * as utxolib from '@bitgo/utxo-lib';
+
+import * as bip322 from '../../src/bip322';
+import { addBip322InputWithChainAndIndex, VerificationInfo, verifyFixedScriptToSignTxWithInfo } from '../../src/bip322';
+
+describe('Verify BIP322 to_sign transactions', function () {
+  it('should verify a correctly signed BIP322 to_sign transaction with multiple messages', function () {
+    function createMessage(messageBase: string, index: number): string {
+      return messageBase + index.toString();
+    }
+
+    const rootWalletKeys = utxolib.testutil.getDefaultWalletKeys();
+    const network = utxolib.networks.bitcoin;
+    const messageBase = 'I can believe it is not butter ';
+
+    const toSignPsbt = bip322.createBaseToSignPsbt(rootWalletKeys);
+
+    const verificationInfo: VerificationInfo[] = [];
+    utxolib.bitgo.chainCodes
+      .filter((chain) => chain !== 30 && chain !== 31)
+      .forEach((chain, index) => {
+        const message = createMessage(messageBase, index);
+        const walletKeys = rootWalletKeys.deriveForChainAndIndex(chain, index);
+        const address = utxolib.address.fromOutputScript(
+          utxolib.bitgo.outputScripts.createOutputScript2of3(
+            walletKeys.publicKeys,
+            utxolib.bitgo.scriptTypeForChain(chain),
+            network
+          ).scriptPubKey,
+          network
+        );
+        verificationInfo.push({ message, address });
+        addBip322InputWithChainAndIndex(toSignPsbt, message, rootWalletKeys, { chain, index });
+      });
+    toSignPsbt.setAllInputsMusig2NonceHD(rootWalletKeys.user);
+    toSignPsbt.setAllInputsMusig2NonceHD(rootWalletKeys.bitgo);
+    toSignPsbt.signAllInputsHD(rootWalletKeys.user);
+    toSignPsbt.signAllInputsHD(rootWalletKeys.bitgo);
+
+    const tx = toSignPsbt.finalizeAllInputs().extractTransaction();
+
+    assert.doesNotThrow(() => {
+      verifyFixedScriptToSignTxWithInfo(tx, verificationInfo, network);
+    });
+  });
+});


### PR DESCRIPTION
Add function to verify BIP322 to_sign transaction structure and that inputs reference the correct to_spend transactions for given addresses and messages. Includes test coverage for verifying multiple messages.

TICKET: BTC-2375

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
