### PR TITLE
test: token naming convention for cosmos tokens

### DIFF
--- a/modules/statics/test/unit/tokenNamingConvention.ts
+++ b/modules/statics/test/unit/tokenNamingConvention.ts
@@ -1,8 +1,9 @@
 import { erc20Coins } from '../../src/coins/erc20Coins';
+import { cosmosTokens } from '../../src/coins/cosmosTokens';
 import { NetworkType } from '../../src/networks';
 
 describe('Token Naming Convention Tests', function () {
-  const allTokens = erc20Coins; //TODO: Include other token sources
+  const allTokens = [...erc20Coins, ...cosmosTokens];
 
   // Helper function to filter tokens by network type
   function getTokensByNetworkType(networkType: NetworkType) {
@@ -196,8 +197,11 @@ describe('Token Naming Convention Tests', function () {
         if (testnetVersions.length > 0 && mainnetVersions.length > 0) {
           testnetVersions.forEach((testnetVersion: any) => {
             mainnetVersions.forEach((mainnetVersion: any) => {
-              // Special case for ofcerc20 tokens which don't follow the pattern
-              if (testnetVersion.networkPrefix === 'ofct' && mainnetVersion.networkPrefix === 'ofc') {
+              // Special cases for tokens which don't follow the pattern
+              if (
+                (testnetVersion.networkPrefix === 'ofct' && mainnetVersion.networkPrefix === 'ofc') ||
+                (testnetVersion.networkPrefix === 'thash' && mainnetVersion.networkPrefix === 'hash')
+              ) {
                 return; // Skip the check for these special cases
               }
 


### PR DESCRIPTION
Ticket: [COIN-5281]

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->


[COIN-5281]: https://bitgoinc.atlassian.net/browse/COIN-5281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ