### PR TITLE
fix(utxo-staking): improve proof of possession validation and signature

### DIFF
--- a/modules/utxo-staking/src/babylon/stakingManager.ts
+++ b/modules/utxo-staking/src/babylon/stakingManager.ts
@@ -39,6 +39,9 @@ class BitGoStakingManager extends vendor.BabylonBtcStakingManager {
     stakerBtcAddress: string,
     sigType: BTCSigType
   ): Promise<ProofOfPossessionBTC> {
+    if (!bech32Address.startsWith('bbn1')) {
+      throw new Error('invalid bech32 babylon address, must start with bbn1');
+    }
     const signedBabylonAddress = await this.btcProvider.signMessage(
       bech32Address,
       sigType === BTCSigType.BIP322 ? 'bip322-simple' : 'ecdsa'

--- a/modules/utxo-staking/src/babylon/stakingManager.ts
+++ b/modules/utxo-staking/src/babylon/stakingManager.ts
@@ -68,11 +68,16 @@ class BitGoStakingManager extends vendor.BabylonBtcStakingManager {
 
   /**
    * Creates a proof of possession for the staker based on ECDSA signature.
+   * @param channel - The channel for which the proof of possession is created.
    * @param bech32Address - The staker's bech32 address on the babylon network.
    * @param stakerBtcAddress
    * @returns The proof of possession.
    */
-  async createProofOfPossession(bech32Address: string, stakerBtcAddress: string): Promise<ProofOfPossessionBTC> {
+  override async createProofOfPossession(
+    channel: 'delegation:create' | 'delegation:register',
+    bech32Address: string,
+    stakerBtcAddress: string
+  ): Promise<ProofOfPossessionBTC> {
     // force the ECDSA signature type
     return this.createProofOfPossessionWithSigType(bech32Address, stakerBtcAddress, BTCSigType.ECDSA);
   }


### PR DESCRIPTION

This PR includes two fixes to the proof of possession functionality in UTXO 
staking:

1. Validate babylon address by ensuring it starts with 'bbn1' prefix before 
   attempting to create proof of possession
   
2. Update createProofOfPossession method signature to add channel parameter, 
   matching the signature in the parent class

Issue: BTC-2402