### PR TITLE
fix(express): adding jsdoc

### DIFF
--- a/modules/express/src/typedRoutes/api/v1/acceptShare.ts
+++ b/modules/express/src/typedRoutes/api/v1/acceptShare.ts
@@ -3,29 +3,38 @@ import { httpRoute, httpRequest, optional } from '@api-ts/io-ts-http';
 import { BitgoExpressError } from '../../schemas/error';
 
 export const AcceptShareRequestParams = {
+  /** ID of the wallet share to accept */
   shareId: t.string,
 };
 
 export const AcceptShareRequestBody = {
+  /** User's password for authentication */
   userPassword: optional(t.string),
+  /** New passphrase to encrypt the shared wallet's keys */
   newWalletPassphrase: optional(t.string),
+  /** Optional encrypted private key to use instead of generating a new one */
   overrideEncryptedXprv: optional(t.string),
 };
 
 /**
- * Accept a wallet share
+ * Accept a Wallet Share
+ * Allows users to accept a wallet share invitation from another user.
+ * When a wallet is shared with a user, they need to accept the share to gain access
+ * to the wallet according to the permissions granted by the sharing user.
  *
  * @operationId express.v1.wallet.acceptShare
  */
 export const PostAcceptShare = httpRoute({
-  path: '/api/v1/walletshare/:shareId/acceptShare',
+  path: '/api/v1/walletshare/{shareId}/acceptShare',
   method: 'POST',
   request: httpRequest({
     params: AcceptShareRequestParams,
     body: AcceptShareRequestBody,
   }),
   response: {
+    /** Successfully accepted wallet share */
     200: t.UnknownRecord,
+    /** Error response */
     400: BitgoExpressError,
   },
 });

--- a/modules/express/src/typedRoutes/api/v1/pendingApproval.ts
+++ b/modules/express/src/typedRoutes/api/v1/pendingApproval.ts
@@ -3,33 +3,45 @@ import { httpRoute, httpRequest, optional } from '@api-ts/io-ts-http';
 import { BitgoExpressError } from '../../schemas/error';
 
 export const pendingApprovalRequestParams = {
+  /** ID of the pending approval to update */
   id: t.string,
 };
 
 export const pendingApprovalRequestBody = {
+  /** Wallet passphrase for decrypting user keys (required for transaction signing) */
   walletPassphrase: optional(t.string),
+  /** One-time password for 2FA verification */
   otp: optional(t.string),
+  /** Transaction hex to use instead of the original transaction */
   tx: optional(t.string),
+  /** Private key in string form (as an alternative to wallet passphrase) */
   xprv: optional(t.string),
+  /** If true, returns information about pending transactions without approving */
   previewPendingTxs: optional(t.boolean),
+  /** Alternative ID for the pending approval */
   pendingApprovalId: optional(t.string),
 };
 
 /**
- * Pending approval request
+ * Pending Approval Request
+ * Approve or reject a pending approval by its ID.
+ * Handles various approval scenarios including transaction approvals, policy rule changes,
+ * and user change requests.
  *
  * @operationId express.v1.pendingapprovals
  */
 
 export const PutPendingApproval = httpRoute({
-  path: '/api/v1/pendingapprovals/:id/express',
+  path: '/api/v1/pendingapprovals/{id}/express',
   method: 'PUT',
   request: httpRequest({
     params: pendingApprovalRequestParams,
     body: pendingApprovalRequestBody,
   }),
   response: {
+    /** Successfully updated pending approval */
     200: t.UnknownRecord,
+    /** Error response */
     400: BitgoExpressError,
   },
 });

--- a/modules/express/test/unit/typedRoutes/acceptShare.ts
+++ b/modules/express/test/unit/typedRoutes/acceptShare.ts
@@ -85,7 +85,7 @@ describe('AcceptShare codec tests', function () {
   describe('Edge cases', function () {
     describe('PostAcceptShare route definition', function () {
       it('should have the correct path', function () {
-        assert.strictEqual(PostAcceptShare.path, '/api/v1/walletshare/:shareId/acceptShare');
+        assert.strictEqual(PostAcceptShare.path, '/api/v1/walletshare/{shareId}/acceptShare');
       });
 
       it('should have the correct HTTP method', function () {

--- a/modules/express/test/unit/typedRoutes/pendingApproval.ts
+++ b/modules/express/test/unit/typedRoutes/pendingApproval.ts
@@ -182,7 +182,7 @@ describe('PendingApproval codec tests', function () {
 
   describe('PutPendingApproval route definition', function () {
     it('should have the correct path', function () {
-      assert.strictEqual(PutPendingApproval.path, '/api/v1/pendingapprovals/:id/express');
+      assert.strictEqual(PutPendingApproval.path, '/api/v1/pendingapprovals/{id}/express');
     });
 
     it('should have the correct HTTP method', function () {


### PR DESCRIPTION
adding jsdoc to support openapi doc gen

Ticket: WP-5643

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
