### PR TITLE
fix(root): sha.js vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "yeoman-generator": "^5.6.1"
   },
   "resolutions": {
+    "**/sha.js": ">=2.4.12",
     "@ethereumjs/util": "8.0.3",
     "@types/keyv": "3.1.4",
     "@types/react": "17.0.24",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18851,13 +18851,14 @@ setprototypeof@1.2.0:
   resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-sha.js@^2.3.6, sha.js@^2.4.0, sha.js@^2.4.11, sha.js@^2.4.8, sha.js@~2.4.4:
-  version "2.4.11"
-  resolved "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
-  integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
+sha.js@>=2.4.12, sha.js@^2.3.6, sha.js@^2.4.0, sha.js@^2.4.11, sha.js@^2.4.8, sha.js@~2.4.4:
+  version "2.4.12"
+  resolved "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz#eb8b568bf383dfd1867a32c3f2b74eb52bdbf23f"
+  integrity sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==
   dependencies:
-    inherits "^2.0.1"
-    safe-buffer "^5.0.1"
+    inherits "^2.0.4"
+    safe-buffer "^5.2.1"
+    to-buffer "^1.2.0"
 
 shallow-clone@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ sha.js is missing type checks leading to hash rewind and     │
│               │ passing on crafted data                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ sha.js                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=2.4.12                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ crypto-browserify                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ crypto-browserify > create-hash > sha.js                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1106972                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ sha.js is missing type checks leading to hash rewind and     │
│               │ passing on crafted data                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ sha.js                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=2.4.12                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ crypto-browserify                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ crypto-browserify > browserify-sign > create-hash > sha.js   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1106972                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ sha.js is missing type checks leading to hash rewind and     │
│               │ passing on crafted data                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ sha.js                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=2.4.12                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ crypto-browserify                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ crypto-browserify > browserify-cipher > browserify-aes >     │
│               │ create-hash > sha.js                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1106972                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ sha.js is missing type checks leading to hash rewind and     │
│               │ passing on crafted data                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ sha.js                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=2.4.12                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ crypto-browserify                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ crypto-browserify > browserify-sign > parse-asn1 >           │
│               │ browserify-aes > create-hash > sha.js                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1106972                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ sha.js is missing type checks leading to hash rewind and     │
│               │ passing on crafted data                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ sha.js                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=2.4.12                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @bitgo/sdk-coin-avaxp                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @bitgo/sdk-coin-avaxp > avalanche > crypto-browserify >      │
│               │ browserify-cipher > browserify-aes > create-hash > sha.js    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1106972                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ sha.js is missing type checks leading to hash rewind and     │
│               │ passing on crafted data                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ sha.js                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=2.4.12                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @bitgo/sdk-coin-avaxc                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @bitgo/sdk-coin-avaxc > @bitgo/sdk-coin-avaxp > avalanche >  │
│               │ crypto-browserify > browserify-cipher > browserify-aes >     │
│               │ create-hash > sha.js                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1106972                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ sha.js is missing type checks leading to hash rewind and     │
│               │ passing on crafted data                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ sha.js                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=2.4.12                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @bitgo/account-lib                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @bitgo/account-lib > @bitgo/sdk-coin-avaxc >                 │
│               │ @bitgo/sdk-coin-avaxp > avalanche > crypto-browserify >      │
│               │ browserify-cipher > browserify-aes > create-hash > sha.js    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1106972                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ sha.js is missing type checks leading to hash rewind and     │
│               │ passing on crafted data                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ sha.js                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=2.4.12                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ bitgo                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ bitgo > @bitgo/account-lib > @bitgo/sdk-coin-avaxc >         │
│               │ @bitgo/sdk-coin-avaxp > avalanche > crypto-browserify >      │
│               │ browserify-cipher > browserify-aes > create-hash > sha.js    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1106972                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ sha.js is missing type checks leading to hash rewind and     │
│               │ passing on crafted data                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ sha.js                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=2.4.12                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @bitgo/express                                               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @bitgo/express > bitgo > @bitgo/account-lib >                │
│               │ @bitgo/sdk-coin-avaxc > @bitgo/sdk-coin-avaxp > avalanche >  │
│               │ crypto-browserify > browserify-cipher > browserify-aes >     │
│               │ create-hash > sha.js                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1106972                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ sha.js is missing type checks leading to hash rewind and     │
│               │ passing on crafted data                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ sha.js                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=2.4.12                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ bitgo                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ bitgo > @bitgo/account-lib > @bitgo/sdk-coin-celo >          │
│               │ @celo/contractkit > web3 > web3-eth > web3-eth-accounts >    │
│               │ crypto-browserify > browserify-cipher > browserify-aes >     │
│               │ create-hash > sha.js                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1106972                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ sha.js is missing type checks leading to hash rewind and     │
│               │ passing on crafted data                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ sha.js                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=2.4.12                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @bitgo/express                                               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @bitgo/express > bitgo > @bitgo/account-lib >                │
│               │ @bitgo/sdk-coin-celo > @celo/contractkit > web3 > web3-eth > │
│               │ web3-eth-accounts > crypto-browserify > browserify-cipher >  │
│               │ browserify-aes > create-hash > sha.js                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1106972                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ sha.js is missing type checks leading to hash rewind and     │
│               │ passing on crafted data                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ sha.js                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=2.4.12                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @bitgo/express                                               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @bitgo/express > bitgo > @bitgo/account-lib >                │
│               │ @bitgo/sdk-coin-celo > @celo/contractkit > web3 > web3-eth > │
│               │ web3-eth-accounts > crypto-browserify > browserify-sign >    │
│               │ parse-asn1 > browserify-aes > create-hash > sha.js           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1106972                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ sha.js is missing type checks leading to hash rewind and     │
│               │ passing on crafted data                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ sha.js                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=2.4.12                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @bitgo/express                                               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @bitgo/express > bitgo > @bitgo/account-lib >                │
│               │ @bitgo/sdk-coin-celo > @celo/contractkit > web3 > web3-eth > │
│               │ web3-eth-accounts > crypto-browserify > browserify-sign >    │
│               │ parse-asn1 > pbkdf2 > create-hmac > create-hash > sha.js     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1106972                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
```
TICKET: WP-5668


<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->