### PR TITLE
ci: update publish workflow to use .nvmrc

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 18
+          node-version-file: .nvmrc
 
       - name: Install BitGoJS
         run: yarn install --with-frozen-lockfile


### PR DESCRIPTION
## Summary
- Update GitHub Actions publish workflow to use node version from .nvmrc file instead of hardcoded version 18

Ticket: VL-3418