### PR TITLE
feat(express): enable esModuleInterop to align test and runtime

### DIFF
--- a/modules/express/src/enclavedExpressRoutes/enclavedExpressRoutes.ts
+++ b/modules/express/src/enclavedExpressRoutes/enclavedExpressRoutes.ts
@@ -1,5 +1,5 @@
 import * as superagent from 'superagent';
-import * as debug from 'debug';
+import debug from 'debug';
 import * as express from 'express';
 import { retryPromise } from '../retryPromise';
 

--- a/modules/express/test/integration/bitgoExpress.ts
+++ b/modules/express/test/integration/bitgoExpress.ts
@@ -7,7 +7,7 @@ import 'should-http';
 import { agent as supertest } from 'supertest';
 import { DefaultConfig } from '../../src/config';
 import { app as expressApp } from '../../src/expressApp';
-import * as nock from 'nock';
+import nock from 'nock';
 import { Environments } from '@bitgo/sdk-core';
 
 describe('Bitgo Express', function () {

--- a/modules/express/test/integration/externalSigner.ts
+++ b/modules/express/test/integration/externalSigner.ts
@@ -7,7 +7,7 @@ import * as sinon from 'sinon';
 
 import * as request from 'supertest';
 import { app as expressApp } from '../../src/expressApp';
-import * as nock from 'nock';
+import nock from 'nock';
 import { Coin, Environments } from 'bitgo';
 
 describe('Custom signing function', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "inlineSources": true,
     "lib": ["dom", "es2020"],
     "module": "commonjs",
+    "esModuleInterop": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitThis": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
Enable esModuleInterop: true to fix CommonJS default-import interop at runtime.

Context:
Unit tests run via Mocha with tsx, which implicitly provides CJS
default-import interop. This allowed `import express from 'express'`
to work in tests.The Docker image runs the compiled CJS output without
that interop, causing TypeError: (0 , express_1.    default) is not a function.
Enabling esModuleInterop makes the compiler emit CJS-compatible imports for CJS
modules like express, so  tests and the Docker runtime execute the same semantics.

Notes:
Keeps behavior consistent across tsx tests and compiled production artifacts.
No API changes; build-time only.

TICKET: WP-5759


<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->