### PR TITLE
fix(jito): remove output for staking activate

### DIFF
--- a/modules/sdk-coin-sol/src/lib/transaction.ts
+++ b/modules/sdk-coin-sol/src/lib/transaction.ts
@@ -40,6 +40,7 @@ import {
   requiresAllSignatures,
   validateRawMsgInstruction,
 } from './utils';
+import { SolStakingTypeEnum } from '@bitgo/public-types';
 
 export class Transaction extends BaseTransaction {
   protected _solTransaction: SolTransaction;
@@ -359,11 +360,13 @@ export class Transaction extends BaseTransaction {
             value: instruction.params.amount,
             coin: this._coinConfig.name,
           });
-          outputs.push({
-            address: instruction.params.stakingAddress,
-            value: instruction.params.amount,
-            coin: this._coinConfig.name,
-          });
+          if (instruction.params.stakingType !== SolStakingTypeEnum.JITO) {
+            outputs.push({
+              address: instruction.params.stakingAddress,
+              value: instruction.params.amount,
+              coin: this._coinConfig.name,
+            });
+          }
           break;
         case InstructionBuilderTypes.StakingDeactivate:
           if (instruction.params.amount && instruction.params.unstakingAddress) {

--- a/modules/sdk-coin-sol/test/unit/transactionBuilder/stakingActivateBuilder.ts
+++ b/modules/sdk-coin-sol/test/unit/transactionBuilder/stakingActivateBuilder.ts
@@ -202,12 +202,7 @@ describe('Sol Staking Activate Builder', () => {
       value: amount,
       coin: 'tsol',
     });
-    tx.outputs.length.should.equal(1);
-    tx.outputs[0].should.deepEqual({
-      address: JITO_STAKE_POOL_ADDRESS,
-      value: amount,
-      coin: 'tsol',
-    });
+    tx.outputs.length.should.equal(0);
   };
 
   describe('Succeed', () => {


### PR DESCRIPTION
## Description

This PR removes the output for StakingActivate instructions when the staking type is JITO. This is because the stake pool account (passed as `stakingAddress` and `validator`) doesn't actually receive the funds. Moreover, the user (fee payer, owner of wallet) is not the owner of the stake pool account.

## Issue Number

Ticket: SC-3015

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I updated the existing unit test. The change has to then be verified by upgrading wallet-platform and trying to reproduce the bug.
