### PR TITLE
fix: bump up follow-redirects version

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "body-parser": "1.20.3",
     "degenerator": "5.0.0",
     "eventsource": "2.0.2",
-    "follow-redirects": "1.15.4",
+    "follow-redirects": "^1.15.6",
     "io-ts": "npm:@bitgo-forks/io-ts@2.1.4",
     "isbinaryfile": "5.0.0",
     "minimist": "1.2.6",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "body-parser": "1.20.3",
     "degenerator": "5.0.0",
     "eventsource": "2.0.2",
-    "follow-redirects": "^1.15.6",
+    "follow-redirects": "1.15.11",
     "io-ts": "npm:@bitgo-forks/io-ts@2.1.4",
     "isbinaryfile": "5.0.0",
     "minimist": "1.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11790,10 +11790,10 @@ flux@^4.0.1:
     fbemitter "^3.0.0"
     fbjs "^3.0.1"
 
-follow-redirects@1.15.4, follow-redirects@^1.0.0, follow-redirects@^1.15.6:
-  version "1.15.4"
-  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz#cdc7d308bf6493126b17ea2191ea0ccf3e535adf"
-  integrity sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==
+follow-redirects@^1.0.0, follow-redirects@^1.15.6:
+  version "1.15.11"
+  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
+  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
 
 for-each@^0.3.3, for-each@^0.3.5, for-each@~0.3.3:
   version "0.3.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11790,7 +11790,7 @@ flux@^4.0.1:
     fbemitter "^3.0.0"
     fbjs "^3.0.1"
 
-follow-redirects@^1.0.0, follow-redirects@^1.15.6:
+follow-redirects@1.15.11, follow-redirects@^1.0.0, follow-redirects@^1.15.6:
   version "1.15.11"
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
   integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==


### PR DESCRIPTION
TICKET: DX-1554

<img width="619" height="219" alt="Screenshot 2025-09-11 at 2 44 30 PM" src="https://github.com/user-attachments/assets/de4b7acd-90f0-498f-b62a-ceaa70c40944" />

NOTE: we actually use version 1.15.11 not ^1.15.6.