### PR TITLE
feat: link security policy for publishing

### DIFF
--- a/modules/bitgo/SECURITY.md
+++ b/modules/bitgo/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+The BitGo team and the wider BitGo community take the security of the `BitGoJS` library seriously. We are committed to a secure and transparent vulnerability disclosure process. This policy outlines how to responsibly report security vulnerabilities in the `BitGoJS` repository and its associated ecosystem.
+
+## How to Report a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.** Public disclosure of a vulnerability can create an immediate and unmanaged risk, exposing users to a potential exploit before a fix can be implemented.
+
+Please also note that public and known vulnerabilities discoverable through dependency analysis and static analysis are considered out of scope and should not be reported.
+
+Instead, all security vulnerabilities must be reported through our official public bug bounty program. Our public bug bounty program is hosted on **Bugcrowd**. To report a vulnerability and be eligible for a bounty, please submit your findings directly to our program brief.
+
+**Link to BitGo's Public Bug Bounty Program:**
+- [https://bugcrowd.com/engagements/bitgo-mbb-og-public](https://bugcrowd.com/engagements/bitgo-mbb-og-public)
+
+## BitGo Bug Bounty Program Scope
+
+The `BitGoJS` public repository is included in the scope of our bug bounty program. For details on our Safe Harbor policy, eligibility, and other program rules, please refer to the official program brief on the Bugcrowd platform.
+
+## Supported Versions
+
+Security updates are applied to the latest major release of `BitGoJS`. While we may address critical vulnerabilities in older versions on a case-by-case basis, researchers should focus on the latest stable release for their testing efforts.
+
+## Additional Information
+
+For general inquiries or non-security-related concerns, please use the standard issue tracker. For more details on our bug bounty program rules, including reward tiers, in-scope assets, and out-of-scope issues, please refer to the official program brief on the Bugcrowd platform.
+
+Thank you for helping us keep BitGo and our users secure.


### PR DESCRIPTION
Create a symbolic link to the security policy so that it will be included in the published BitGoJS

Ticket: DX-1885

