### PR TITLE
Dx 1800 automate bumping public types

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,27 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>BitGo/gha-renovate-bot//presets/onboarding#v1.15.1"],
   "baseBranches": ["master"],
-  "enabledManagers": ["github-actions", "regex"],
+  "enabledManagers": ["github-actions", "regex", "nix", "pre-commit", "npm"],
+  "schedule": ["on monday"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["@bitgo/public-types"],
+      "automerge": false,
+      "prTitle": "chore(deps): update @bitgo/public-types to {{newVersion}}",
+      "schedule": ["at any time"],
+      "prCreation": "immediate",
+      "reviewersFromCodeOwners": true,
+      "branchPrefix": "renovate/public-types/",
+      "semanticCommits": "enabled",
+      "separateMinorPatch": false,
+      "groupName": "BitGo Public Types",
+      "addLabels": ["auto-dependency-update"],
+      "assigneesFromCodeOwners": true,
+      "platformAutomerge": false,
+      "commitMessageAction": "chore",
+      "commitMessageTopic": "(deps): bump up @bitgo/public-types",
+      "commitMessageExtra": "to {{newVersion}}",
+      "commitBody": "This commit is part of an automated dependency update to minimize change lead time."
+    }
+  ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>BitGo/gha-renovate-bot//presets/onboarding#v1.15.1"],
+  "extends": ["github>BitGo/gha-renovate-bot//presets/onboarding#v3.104.1"],
   "baseBranches": ["master"],
-  "enabledManagers": ["github-actions", "regex", "nix", "pre-commit", "npm"],
+  "enabledManagers": ["github-actions", "regex", "pre-commit", "npm"],
   "schedule": ["on monday"],
   "packageRules": [
     {


### PR DESCRIPTION
The ticket provides automatic bumping of the BitGo public types dependency, which solves the issue of [change lead time](https://jellyfish.co/library/change-lead-time/#:~:text=Change%20lead%20time%20refers%20to,efficiency%20of%20the%20delivery%20pipeline.). It runs weekly using Renovate Bot and operates having the bot create PR (auto assigning reviewers) with all the latest dependency updates.  

Ticket: DX-1800
