### PR TITLE
feat(sdk-coin-hbar): add token enablement transaction verification

### DIFF
--- a/modules/sdk-coin-hbar/src/lib/index.ts
+++ b/modules/sdk-coin-hbar/src/lib/index.ts
@@ -7,4 +7,5 @@ export { TransferBuilder } from './transferBuilder';
 export { CoinTransferBuilder } from './coinTransferBuilder';
 export { TokenTransferBuilder } from './tokenTransferBuilder';
 export { TokenAssociateBuilder } from './tokenAssociateBuilder';
+export { Recipient } from './iface';
 export { Utils };


### PR DESCRIPTION
Add verifyTokenEnablementTransaction method to validate token associate transactions with comprehensive checks for amount, account ID, token name, and transaction type. Integrates with existing verifyTransaction flow for enhanced token enablement validation.

- Add organized validation functions for transaction structure, amount, account ID, token name, and transaction type

TICKET: WP-5746