### PR TITLE
fix: update renovate bot version for default configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>BitGo/gha-renovate-bot//presets/onboarding#v1.15.1"],
+  "extends": ["github>BitGo/gha-renovate-bot//presets/default"],
   "baseBranches": ["master"],
-  "enabledManagers": ["github-actions", "regex"],
+  "enabledManagers": ["github-actions", "regex"]
 }


### PR DESCRIPTION
TICKET: DX-1800

The ticket provides automatic bumping of the BitGo public types dependency, which solves the issue of [change lead time](https://jellyfish.co/library/change-lead-time/#:~:text=Change%20lead%20time%20refers%20to,efficiency%20of%20the%20delivery%20pipeline.). 

This initial change standardizes our renovate bot configuration without enabling any new package updates. 