### PR TITLE
feat(sdk-core): add transaction validation for (consolidate) unspent management

### DIFF
--- a/modules/bitgo/test/v2/unit/unspents.ts
+++ b/modules/bitgo/test/v2/unit/unspents.ts
@@ -60,6 +60,7 @@ describe('Verify string type is used for value of unspent', function () {
           );
 
         sinon.stub(wallet, 'signTransaction').resolves({});
+        sinon.stub(wallet.baseCoin, 'verifyTransaction').resolves();
 
         const sendScope = nock(bgUrl)
           .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/send`, { type: manageUnspentType })

--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -1589,6 +1589,7 @@ describe('V2 Wallet:', function () {
           'unsigned'
         )
       );
+      psbts.forEach((psbt) => utxoLib.bitgo.addXpubsToPsbt(psbt, rootWalletKey));
       const txHexes = psbts.map((psbt) => ({ txHex: psbt.toHex() }));
 
       const nocks: nock.Scope[] = [];
@@ -1627,6 +1628,7 @@ describe('V2 Wallet:', function () {
         rootWalletKey,
         'unsigned'
       );
+      utxoLib.bitgo.addXpubsToPsbt(psbt, rootWalletKey);
 
       const nocks: nock.Scope[] = [];
       nocks.push(

--- a/modules/sdk-coin-btc/test/unit/btc.ts
+++ b/modules/sdk-coin-btc/test/unit/btc.ts
@@ -8,6 +8,8 @@ import { Tbtc } from '../../src';
 import { BitGoAPI } from '@bitgo/sdk-api';
 import * as utxolib from '@bitgo/utxo-lib';
 
+const { getDefaultWalletKeys, toKeychainObjects } = require('../../../bitgo/test/v2/unit/coins/utxo/util/keychains');
+
 describe('BTC:', () => {
   let bitgo: TestBitGoAPI;
 
@@ -118,10 +120,6 @@ describe('BTC:', () => {
     });
 
     it('should detect hex spoofing in BUILD_SIGN_SEND', async (): Promise<void> => {
-      const {
-        getDefaultWalletKeys,
-        toKeychainObjects,
-      } = require('../../../bitgo/test/v2/unit/coins/utxo/util/keychains');
       const rootWalletKey = getDefaultWalletKeys();
       const keysObj = toKeychainObjects(rootWalletKey, 'pass');
 
@@ -189,10 +187,6 @@ describe('BTC:', () => {
     });
 
     it('should detect hex spoofing in fanout BUILD_SIGN_SEND', async (): Promise<void> => {
-      const {
-        getDefaultWalletKeys,
-        toKeychainObjects,
-      } = require('../../../bitgo/test/v2/unit/coins/utxo/util/keychains');
       const rootWalletKey = getDefaultWalletKeys();
       const keysObj = toKeychainObjects(rootWalletKey, 'pass');
 

--- a/modules/sdk-coin-btc/test/unit/btc.ts
+++ b/modules/sdk-coin-btc/test/unit/btc.ts
@@ -107,7 +107,7 @@ describe('BTC:', () => {
     });
   });
 
-  describe('Unspent management spoofability (BUILD_SIGN_SEND)', () => {
+  describe('Unspent management spoofability - Consolidation (BUILD_SIGN_SEND)', () => {
     let coin: Tbtc;
     let bitgoTest: TestBitGoAPI;
     before(() => {
@@ -171,6 +171,77 @@ describe('BTC:', () => {
 
       await assert.rejects(
         wallet.consolidateUnspents({ walletPassphrase: 'pass' }),
+        (e: any) =>
+          typeof e?.message === 'string' &&
+          e.message.includes('prebuild attempts to spend to unintended external recipients')
+      );
+    });
+  });
+
+  describe('Unspent management spoofability - Fanout (BUILD_SIGN_SEND)', () => {
+    let coin: Tbtc;
+    let bitgoTest: TestBitGoAPI;
+    before(() => {
+      bitgoTest = TestBitGo.decorate(BitGoAPI, { env: 'test' });
+      bitgoTest.safeRegister('tbtc', Tbtc.createInstance);
+      bitgoTest.initializeTestVars();
+      coin = bitgoTest.coin('tbtc') as Tbtc;
+    });
+
+    it('should detect hex spoofing in fanout BUILD_SIGN_SEND', async (): Promise<void> => {
+      const {
+        getDefaultWalletKeys,
+        toKeychainObjects,
+      } = require('../../../bitgo/test/v2/unit/coins/utxo/util/keychains');
+      const rootWalletKey = getDefaultWalletKeys();
+      const keysObj = toKeychainObjects(rootWalletKey, 'pass');
+
+      const { Wallet } = await import('@bitgo/sdk-core');
+      const wallet = new Wallet(bitgoTest, coin, {
+        id: '5b34252f1bf349930e34020a',
+        coin: 'tbtc',
+        keys: keysObj.map((k) => k.id),
+      });
+
+      const originalPsbt = utxolib.testutil.constructPsbt(
+        [{ scriptType: 'p2wsh' as const, value: BigInt(10000) }],
+        [{ address: 'tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7', value: BigInt(9000) }],
+        coin.network,
+        rootWalletKey,
+        'unsigned' as const
+      );
+      utxolib.bitgo.addXpubsToPsbt(originalPsbt, rootWalletKey);
+
+      const spoofedPsbt = utxolib.testutil.constructPsbt(
+        [{ scriptType: 'p2wsh' as const, value: BigInt(10000) }],
+        [{ address: 'tb1pjgg9ty3s2ztp60v6lhgrw76f7hxydzuk9t9mjsndh3p2gf2ah7gs4850kn', value: BigInt(9000) }],
+        coin.network,
+        rootWalletKey,
+        'unsigned' as const
+      );
+      utxolib.bitgo.addXpubsToPsbt(spoofedPsbt, rootWalletKey);
+      const spoofedHex: string = spoofedPsbt.toHex();
+
+      const bgUrl: string = (bitgoTest as any)._baseUrl;
+      const nock = require('nock');
+
+      nock(bgUrl)
+        .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/fanoutUnspents`)
+        .reply(200, { txHex: spoofedHex, fanoutId: 'test' });
+
+      nock(bgUrl)
+        .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/send`)
+        .reply((requestBody: any) => {
+          if (requestBody?.txHex === spoofedHex) {
+            throw new Error('Spoofed transaction was sent: spoofing protection failed');
+          }
+          return [200, { txid: 'test-txid-123', status: 'signed' }];
+        });
+
+      keysObj.forEach((k, i) => nock(bgUrl).get(`/api/v2/${wallet.coin()}/key/${wallet.keyIds()[i]}`).reply(200, k));
+
+      await assert.rejects(
+        wallet.fanoutUnspents({ walletPassphrase: 'pass' }),
         (e: any) =>
           typeof e?.message === 'string' &&
           e.message.includes('prebuild attempts to spend to unintended external recipients')

--- a/modules/sdk-coin-btc/test/unit/btc.ts
+++ b/modules/sdk-coin-btc/test/unit/btc.ts
@@ -118,7 +118,10 @@ describe('BTC:', () => {
     });
 
     it('should detect hex spoofing in BUILD_SIGN_SEND', async (): Promise<void> => {
-      const { getDefaultWalletKeys, toKeychainObjects } = require('../../../bitgo/test/v2/unit/coins/utxo/util/keychains');
+      const {
+        getDefaultWalletKeys,
+        toKeychainObjects,
+      } = require('../../../bitgo/test/v2/unit/coins/utxo/util/keychains');
       const rootWalletKey = getDefaultWalletKeys();
       const keysObj = toKeychainObjects(rootWalletKey, 'pass');
 
@@ -164,9 +167,7 @@ describe('BTC:', () => {
           return [200, { txid: 'test-txid-123', status: 'signed' }];
         });
 
-      keysObj.forEach((k, i) =>
-        nock(bgUrl).get(`/api/v2/${wallet.coin()}/key/${wallet.keyIds()[i]}`).reply(200, k)
-      );
+      keysObj.forEach((k, i) => nock(bgUrl).get(`/api/v2/${wallet.coin()}/key/${wallet.keyIds()[i]}`).reply(200, k));
 
       await assert.rejects(
         wallet.consolidateUnspents({ walletPassphrase: 'pass' }),

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -735,6 +735,18 @@ export class Wallet implements IWallet {
       return buildResponse;
     }
 
+    // Validate that the platform-built transaction matches user parameters
+    const txPrebuilds = Array.isArray(buildResponse) ? buildResponse : [buildResponse];
+    for (const txPrebuild of txPrebuilds) {
+      await this.baseCoin.verifyTransaction({
+        txParams: params,
+        txPrebuild,
+        wallet: this,
+        verification: params.verification ?? {},
+        reqId,
+      });
+    }
+
     const keychains = (await this.baseCoin
       .keychains()
       .getKeysForSigning({ wallet: this, reqId })) as unknown as Keychain[];
@@ -750,8 +762,6 @@ export class Wallet implements IWallet {
       // Manually override the signing and validating to not fail.
       allowNonSegwitSigningWithoutPrevTx: !!params.bulk,
     };
-
-    const txPrebuilds = Array.isArray(buildResponse) ? buildResponse : [buildResponse];
 
     const selectParams = _.pick(params, ['comment', 'otp', 'bulk']);
 

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -742,24 +742,22 @@ export class Wallet implements IWallet {
     // Validate that the platform-built transaction matches user parameters
     const txPrebuilds = Array.isArray(buildResponse) ? buildResponse : [buildResponse];
     await Promise.all(
-      txPrebuilds
-        .filter((txPrebuild) => txPrebuild.txHex)
-        .map((txPrebuild) =>
-          this.baseCoin.verifyTransaction({
-            txParams: params,
-            txPrebuild,
-            wallet: this,
-            verification: {
-              ...(params.verification ?? {}),
-              keychains: {
-                user: keychains[0],
-                backup: keychains[1],
-                bitgo: keychains[2],
-              },
+      txPrebuilds.map((txPrebuild) =>
+        this.baseCoin.verifyTransaction({
+          txParams: params,
+          txPrebuild,
+          wallet: this,
+          verification: {
+            ...(params.verification ?? {}),
+            keychains: {
+              user: keychains[0],
+              backup: keychains[1],
+              bitgo: keychains[2],
             },
-            reqId,
-          })
-        )
+          },
+          reqId,
+        })
+      )
     );
 
     const transactionParams = {

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -737,15 +737,17 @@ export class Wallet implements IWallet {
 
     // Validate that the platform-built transaction matches user parameters
     const txPrebuilds = Array.isArray(buildResponse) ? buildResponse : [buildResponse];
-    for (const txPrebuild of txPrebuilds) {
-      await this.baseCoin.verifyTransaction({
-        txParams: params,
-        txPrebuild,
-        wallet: this,
-        verification: params.verification ?? {},
-        reqId,
-      });
-    }
+    await Promise.all(
+      txPrebuilds.map((txPrebuild) =>
+        this.baseCoin.verifyTransaction({
+          txParams: params,
+          txPrebuild,
+          wallet: this,
+          verification: params.verification ?? {},
+          reqId,
+        })
+      )
+    );
 
     const keychains = (await this.baseCoin
       .keychains()


### PR DESCRIPTION
#### Description:
- Reordered + refactored transaction prebuild validation to occur after keychain retrieval, ensuring `verifyTransaction` has access to required keychain data for proper spoofing protection (for both consolidate and fanout)
- Added unit test for consolidate unspent management spoofability protection in `test/btc.ts` (for UTXO coins)
- Verifies that platform responses are validated against user parameters and covers BUILD_SIGN_SEND flow

Ticket: WP-5945
