### PR TITLE
fix(sdk-coin-sol): remove inputs and outputs for jito deactivate

### DIFF
--- a/modules/sdk-coin-sol/src/lib/transaction.ts
+++ b/modules/sdk-coin-sol/src/lib/transaction.ts
@@ -371,7 +371,11 @@ export class Transaction extends BaseTransaction {
           }
           break;
         case InstructionBuilderTypes.StakingDeactivate:
-          if (instruction.params.amount && instruction.params.unstakingAddress) {
+          if (
+            instruction.params.amount &&
+            instruction.params.unstakingAddress &&
+            instruction.params.stakingType !== SolStakingTypeEnum.JITO
+          ) {
             inputs.push({
               address: instruction.params.stakingAddress,
               value: instruction.params.amount,

--- a/modules/sdk-coin-sol/test/unit/transactionBuilder/stakingActivateBuilder.ts
+++ b/modules/sdk-coin-sol/test/unit/transactionBuilder/stakingActivateBuilder.ts
@@ -105,18 +105,20 @@ describe('Sol Staking Activate Builder', () => {
         },
       },
     ]);
-    tx.inputs.length.should.equal(1);
-    tx.inputs[0].should.deepEqual({
-      address: wallet.pub,
-      value: amount,
-      coin: 'tsol',
-    });
-    tx.outputs.length.should.equal(1);
-    tx.outputs[0].should.deepEqual({
-      address: stakeAccount.pub,
-      value: amount,
-      coin: 'tsol',
-    });
+    tx.inputs.should.deepEqual([
+      {
+        address: wallet.pub,
+        value: amount,
+        coin: 'tsol',
+      },
+    ]);
+    tx.outputs.should.deepEqual([
+      {
+        address: stakeAccount.pub,
+        value: amount,
+        coin: 'tsol',
+      },
+    ]);
   };
 
   const signBuilderNativeOrMarinade = (txBuilder: StakingActivateBuilder) => {
@@ -203,13 +205,14 @@ describe('Sol Staking Activate Builder', () => {
     });
 
     txJson.instructionsData.should.deepEqual(expectedInstructions);
-    tx.inputs.length.should.equal(1);
-    tx.inputs[0].should.deepEqual({
-      address: wallet.pub,
-      value: amount,
-      coin: 'tsol',
-    });
-    tx.outputs.length.should.equal(0);
+    tx.inputs.should.deepEqual([
+      {
+        address: wallet.pub,
+        value: amount,
+        coin: 'tsol',
+      },
+    ]);
+    tx.outputs.should.deepEqual([]);
   };
 
   describe('Succeed', () => {

--- a/modules/sdk-coin-sol/test/unit/transactionBuilder/stakingDeactivateBuilder.ts
+++ b/modules/sdk-coin-sol/test/unit/transactionBuilder/stakingDeactivateBuilder.ts
@@ -346,6 +346,8 @@ describe('Sol Staking Deactivate Builder', () => {
                 },
               },
             ]);
+            tx.inputs.should.deepEqual([]);
+            tx.outputs.should.deepEqual([]);
           },
           knownRawTx: testData.JITO_STAKING_DEACTIVATE_SIGNED_TX,
         });


### PR DESCRIPTION
## Description

The existing inputs and outputs don't apply. There are no leftover entries that could be attributed to inputs or outputs for a Jito deactivate transaction. Therefore, 0 inputs and 0 outputs.

## Issue Number

Ticket: SC-3175

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Updated tests.