### PR TITLE
chore: configure updates for public-types only

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,17 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>BitGo/gha-renovate-bot//presets/default"],
   "baseBranches": ["master"],
-  "enabledManagers": ["github-actions", "regex"]
+  "enabledManagers": ["github-actions", "regex", "npm"],
+  "packageRules": [
+    {
+      "description": "Disable all npm dependencies by default",
+      "matchManagers": ["npm"],
+      "enabled": false
+    },
+    {
+      "description": "Enable updates only for @bitgo/public-types",
+      "matchPackageNames": ["@bitgo/public-types"],
+      "enabled": true
+    }
+  ]
 }


### PR DESCRIPTION
TICKET: DX-1800

The ticket provides automatic bumping of the BitGo public types dependency, which solves the issue of [change lead time](https://jellyfish.co/library/change-lead-time/#:~:text=Change%20lead%20time%20refers%20to,efficiency%20of%20the%20delivery%20pipeline.).

**How the Package Rules Work**
This configuration uses a principle of explicitly denying and then allowing updates.

**Disable All npm Updates**: The first rule with "matchManagers": ["npm"] and "enabled": false acts as a broad sweep. It tells Renovate to ignore all npm dependencies and not to create pull requests for them. This provides a baseline of security by preventing any unexpected or potentially malicious updates from being introduced without approval.

**Enable a Specific Package**: The second, more specific rule with "matchPackageNames": ["@bitgo/public-types"] and "enabled": true overrides the previous rule. Because Renovate processes rules in order, this rule is applied after the general one. It creates an exception, allowing automated updates only for the @bitgo/public-types package. This ensures that a critical dependency receives timely updates, while all others are manually controlled.

