### PR TITLE
fix: remove stale advisories from .iyarc

### DIFF
--- a/.iyarc
+++ b/.iyarc
@@ -1,6 +1,1 @@
-GHSA-3h5v-q93c-6h6q
-GHSA-8hc4-vh64-cxmj
-GHSA-9wv6-86v2-598j
 GHSA-3gc7-fjrx-p6mg
-GHSA-cpj6-fhp6-mr6j
-GHSA-f46r-rw29-r322

--- a/package.json
+++ b/package.json
@@ -104,8 +104,7 @@
   ],
   "scripts": {
     "postinstall": "test -n \"$NOYARNPOSTINSTALL\" || lerna run build --stream",
-    "audit": "yarn audit --group dependencies optionalDependencies peerDependencies ; test $? -lt 8",
-    "audit-dev": "yarn audit --group devDependencies ; test $? -lt 8",
+    "audit-high": "improved-yarn-audit --min-severity high",
     "lint": "lerna run lint --stream",
     "lint-changed": "lerna run lint --since origin/${GITHUB_REPO_BRANCH:-master}..HEAD --stream",
     "unit-test-changed": "lerna run unit-test --since $(git merge-base HEAD~ origin/${GITHUB_REPO_BRANCH:-master}) --stream",


### PR DESCRIPTION
The only applicable advisory is for bigint-buffer which has no patch.

https://github.com/advisories/GHSA-3gc7-fjrx-p6mg

to use:

```
yarn run audit-high
```

TICKET: VL-3487

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
