### PR TITLE
fix: replaced vulnerable request with axios

### DIFF
--- a/modules/bitgo/package.json
+++ b/modules/bitgo/package.json
@@ -154,9 +154,7 @@
     "keccak": "3.0.3",
     "libsodium-wrappers-sumo": "^0.7.9",
     "puppeteer": "2.1.1",
-    "q": "^1.1.2",
-    "request": "^2.88.0",
-    "request-promise": "^4.2.2"
+    "q": "^1.1.2"
   },
   "optionalDependencies": {
     "@ethereumjs/common": "^2.6.5",

--- a/modules/bitgo/test/unit/bitgo.ts
+++ b/modules/bitgo/test/unit/bitgo.ts
@@ -11,7 +11,7 @@ import { common, generateGPGKeyPair } from '@bitgo/sdk-core';
 import { bip32, ECPair } from '@bitgo/utxo-lib';
 import * as _ from 'lodash';
 import * as BitGoJS from '../../src/index';
-const rp = require('request-promise');
+import axios from 'axios';
 
 import { TestBitGo } from '@bitgo/sdk-test';
 import { BitGo } from '../../src/bitgo';
@@ -473,27 +473,25 @@ describe('BitGo Prototype Methods', function () {
           timestamp: '1521590532925',
         });
 
-      const responseData = (await rp({
-        uri: url,
-        method: 'GET',
+      const response = await axios.get(url, {
         headers: requestHeaders,
-        transform: (body, response) => {
-          // verify the response headers
-          const url = response.request.href;
-          const hmac = response.headers.hmac;
-          const timestamp = response.headers.timestamp;
-          const statusCode = response.statusCode;
-          const verificationParams = {
-            url,
-            hmac,
-            timestamp,
-            token,
-            statusCode,
-            text: body,
-          };
-          return bitgo.verifyResponse(verificationParams);
-        },
-      })) as any;
+      });
+
+      const finalUrl = response.request.responseURL || url;
+      const hmac = response.headers.hmac;
+      const timestamp = response.headers.timestamp;
+      const statusCode = response.status;
+
+      const verificationParams = {
+        url: finalUrl,
+        hmac,
+        timestamp,
+        token,
+        statusCode,
+        text: response.data,
+      };
+
+      const responseData = bitgo.verifyResponse(verificationParams) as any;
       responseData.signatureSubject.should.equal(
         '1521590532925|/api/v2/tltc/wallet/5941b202b42fcbc707170d5b597491d9/address/QNc4RFAcbvqmtrR1kR2wbGLCx6tEvojFYE?segwit=1|200|{"id":"5a7ca8bcaf52c8e807c575fb692609ec","address":"QNc4RFAcbvqmtrR1kR2wbGLCx6tEvojFYE","chain":0,"index":2,"coin":"tltc","wallet":"5941b202b42fcbc707170d5b597491d9","coinSpecific":{"redeemScript":"522102835bcfd130f7a56f72c905b782d90b66e22f88ad3309cf72af5138a7d44be8b3210322c7f42a1eb212868eab78db7ba64846075d98c7f4c7aa25a02e57871039e0cd210265825be0d5bf957fb72abd7c23bf0836a78a15f951a073467cd5c99e03ce7ab753ae"},"balance":{"updated":"2018-02-28T23:48:07.341Z","numTx":1,"numUnspents":1,"totalReceived":20000000}}'
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -18046,24 +18046,7 @@ request-progress@^3.0.0:
   dependencies:
     throttleit "^1.0.0"
 
-request-promise-core@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz"
-  integrity sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==
-  dependencies:
-    lodash "^4.17.19"
-
-request-promise@^4.2.2:
-  version "4.2.6"
-  resolved "https://registry.npmjs.org/request-promise/-/request-promise-4.2.6.tgz"
-  integrity sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==
-  dependencies:
-    bluebird "^3.5.0"
-    request-promise-core "1.1.4"
-    stealthy-require "^1.1.1"
-    tough-cookie "^2.3.3"
-
-request@^2.79.0, request@^2.88.0:
+request@^2.79.0:
   version "2.88.2"
   resolved "https://registry.npmjs.org/request/-/request-2.88.2.tgz"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -19197,11 +19180,6 @@ statuses@2.0.1:
   resolved "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
-stealthy-require@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz"
-  integrity sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==
-
 stellar-base@^8.2.2:
   version "8.2.2"
   resolved "https://registry.npmjs.org/stellar-base/-/stellar-base-8.2.2.tgz"
@@ -19988,20 +19966,20 @@ tonweb@^0.0.62:
     node-fetch "2.6.7"
     tweetnacl "1.0.3"
 
-tough-cookie@^2.3.3, tough-cookie@~2.5.0:
-  version "2.5.0"
-  resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz"
-  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
-  dependencies:
-    psl "^1.1.28"
-    punycode "^2.1.1"
-
 tough-cookie@^5.0.0:
   version "5.1.2"
   resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz"
   integrity sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==
   dependencies:
     tldts "^6.1.32"
+
+tough-cookie@~2.5.0:
+  version "2.5.0"
+  resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz"
+  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
+  dependencies:
+    psl "^1.1.28"
+    punycode "^2.1.1"
 
 tr46@~0.0.3:
   version "0.0.3"


### PR DESCRIPTION
TICKET: DX-1558

The tests in the "bitgo" module used the request package, which is deprecated and vulnerable to GHSA-p8p7-x288-28g6. This PR attempts to replace the request with a more modern HTTP client library, Axios. Axios is taken as an alternative to a first party HTTP client like fetch because it has a cleaner migration from request-promise. 

Another PR under this ticket will address the request package being transitively depended on. 

Note: the unit-tests failing happen in modules/bitgo were happening prior to this commit. 


