### PR TITLE
Dx 1558 replace vulnerable request package with axios

### DIFF
--- a/modules/bitgo/package.json
+++ b/modules/bitgo/package.json
@@ -154,9 +154,7 @@
     "keccak": "3.0.3",
     "libsodium-wrappers-sumo": "^0.7.9",
     "puppeteer": "2.1.1",
-    "q": "^1.1.2",
-    "request": "^2.88.0",
-    "request-promise": "^4.2.2"
+    "q": "^1.1.2"
   },
   "optionalDependencies": {
     "@ethereumjs/common": "^2.6.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18046,24 +18046,7 @@ request-progress@^3.0.0:
   dependencies:
     throttleit "^1.0.0"
 
-request-promise-core@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz"
-  integrity sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==
-  dependencies:
-    lodash "^4.17.19"
-
-request-promise@^4.2.2:
-  version "4.2.6"
-  resolved "https://registry.npmjs.org/request-promise/-/request-promise-4.2.6.tgz"
-  integrity sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==
-  dependencies:
-    bluebird "^3.5.0"
-    request-promise-core "1.1.4"
-    stealthy-require "^1.1.1"
-    tough-cookie "^2.3.3"
-
-request@^2.79.0, request@^2.88.0:
+request@^2.79.0:
   version "2.88.2"
   resolved "https://registry.npmjs.org/request/-/request-2.88.2.tgz"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -19197,11 +19180,6 @@ statuses@2.0.1:
   resolved "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
-stealthy-require@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz"
-  integrity sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==
-
 stellar-base@^8.2.2:
   version "8.2.2"
   resolved "https://registry.npmjs.org/stellar-base/-/stellar-base-8.2.2.tgz"
@@ -19988,20 +19966,20 @@ tonweb@^0.0.62:
     node-fetch "2.6.7"
     tweetnacl "1.0.3"
 
-tough-cookie@^2.3.3, tough-cookie@~2.5.0:
-  version "2.5.0"
-  resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz"
-  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
-  dependencies:
-    psl "^1.1.28"
-    punycode "^2.1.1"
-
 tough-cookie@^5.0.0:
   version "5.1.2"
   resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz"
   integrity sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==
   dependencies:
     tldts "^6.1.32"
+
+tough-cookie@~2.5.0:
+  version "2.5.0"
+  resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz"
+  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
+  dependencies:
+    psl "^1.1.28"
+    punycode "^2.1.1"
 
 tr46@~0.0.3:
   version "0.0.3"


### PR DESCRIPTION
TICKET: [DX-1558](https://bitgoinc.atlassian.net/browse/DX-1558)

The tests in the "bitgo" module used the request package, which is deprecated and vulnerable to https://github.com/advisories/GHSA-p8p7-x288-28g6. This PR attempts to replace the request with a more modern HTTP client library, Axios. Axios is taken as an alternative to a first party HTTP client like fetch because it has a cleaner migration from request-promise.

`npm ls request` was ran to confirm that this PR resolved all direct dependencies on the vulnerable request package.

We can have more confidence it works because this change was to the unit tests for modules/bitgo. If the changes were to be broken, the Unit tests in the CI checks would have also failed.

Another PR under this ticket will address the request package being transitively depended on, and after this point, the security vulnerabilities for the request package will disappear.  


[DX-1558]: https://bitgoinc.atlassian.net/browse/DX-1558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ