### PR TITLE
fix: resolve store2 vulnerability via yarn resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
     "**/ethers/**/ws": "7.5.10",
     "**/swarm-js/**/ws": "5.2.4",
     "serialize-javascript": "^6.0.2",
-    "@grpc/grpc-js": "^1.12.6"
+    "@grpc/grpc-js": "^1.12.6",
+    "**/avalanche/store2": "2.14.4"
   },
   "workspaces": [
     "modules/*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19268,10 +19268,10 @@ stop-iteration-iterator@^1.1.0:
     es-errors "^1.3.0"
     internal-slot "^1.1.0"
 
-store2@2.13.2:
-  version "2.13.2"
-  resolved "https://registry.npmjs.org/store2/-/store2-2.13.2.tgz"
-  integrity sha512-CMtO2Uneg3SAz/d6fZ/6qbqqQHi2ynq6/KzMD/26gTkiEShCcpqFfTHgOxsE0egAq6SX3FmN4CeSqn8BzXQkJg==
+store2@2.13.2, store2@2.14.4:
+  version "2.14.4"
+  resolved "https://registry.npmjs.org/store2/-/store2-2.14.4.tgz#81b313abaddade4dcd7570c5cc0e3264a8f7a242"
+  integrity sha512-srTItn1GOvyvOycgxjAnPA63FZNwy0PTyUBFMHRM+hVFltAeoh0LmNBz9SZqUS9mMqGk8rfyWyXn3GH5ReJ8Zw==
 
 str2buf@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
## Description
Applied targeted resolution to pin `store2` to 2.14.4 for avalanche package. This addresses GHSA-w5hq-hm5m-4548, a low-severity XSS vulnerability.

The ticket requested updating `avalanche` to a version with `store2` 2.14.4+, however the latest `avalanche` version (3.16.0) only includes `store2` 2.14.2. Used resolution to force `avalanche@3.15.3` to use `store2@2.14.4` instead of vulnerable 2.13.2.

**Direct store2 usage audit**: No direct `store2.get()` operations found in codebase
- Searched for `store2.get` and `store.get`

**localStorage XSS vectors review**: No vulnerable patterns found
- All localStorage usage is safe (documentation examples only)

**Input validation**: N/A (No user-controlled data used in store operations)

## Issue Number

Ticket: DX-1562

# How Has This Been Tested?

- `yarn audit` - GHSA-w5hq-hm5m-4548 resolved, no store2 vulnerabilities
- `yarn unit-test` - All tests successful