### PR TITLE
fix(sdk-core): backup keychain creation to use correct privateMaterial for EcDSA MPCV2 wallets

### DIFF
--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
@@ -321,7 +321,7 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
     );
     const backupKeychainPromise = this.addBackupKeychain(
       bitgoCommonKeychain,
-      userPrivateMaterial,
+      backupPrivateMaterial,
       backupReducedPrivateMaterial,
       params.passphrase,
       params.originalPasscodeEncryptionCode


### PR DESCRIPTION


## Description
Replaces the use of userPrivateMaterial with backupPrivateMaterial when adding the backup keychain in EcdsaMPCv2Utils. This ensures the correct private material is used for backup keychain generation for EcDSA MPCV2 wallets.

## Issue Number
TICKET: WP-6057

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
