### PR TITLE
fix: Remove Validation of coin/subnet while building move stake transaction

### DIFF
--- a/modules/sdk-coin-tao/src/lib/moveStakeTransaction.ts
+++ b/modules/sdk-coin-tao/src/lib/moveStakeTransaction.ts
@@ -1,5 +1,5 @@
 import { Interface as SubstrateInterface, Transaction as SubstrateTransaction } from '@bitgo/abstract-substrate';
-import { InvalidTransactionError, TransactionRecipient } from '@bitgo/sdk-core';
+import { InvalidTransactionError } from '@bitgo/sdk-core';
 import { decode } from '@substrate/txwrapper-polkadot';
 import { MoveStakeTxData } from './iface';
 import utils from './utils';
@@ -42,33 +42,24 @@ export class MoveStakeTransaction extends SubstrateTransaction {
     this._inputs.push({
       address: txMethod.originHotkey,
       value: txMethod.alphaAmount,
-      coin: utils.getTaoTokenBySubnetId(txMethod.originNetuid).name,
     });
 
     this._outputs.push({
       address: txMethod.destinationHotkey,
       value: txMethod.alphaAmount,
-      coin: utils.getTaoTokenBySubnetId(txMethod.destinationNetuid).name,
     });
   }
 
   /** @inheritdoc */
   explainTransaction(): SubstrateInterface.TransactionExplanation {
-    const result = this.toJson();
-    const outputs: TransactionRecipient[] = this._outputs.map((output) => {
-      return {
-        address: output.address,
-        amount: output.value,
-        tokenName: output.coin,
-      };
-    });
+    const result = this.toJson() as MoveStakeTxData;
 
     const explanationResult: SubstrateInterface.TransactionExplanation = {
       id: result.id,
-      outputAmount: result.amount?.toString() || '0',
+      outputAmount: result.alphaAmount?.toString() || '0',
       changeAmount: '0',
       changeOutputs: [],
-      outputs,
+      outputs: [],
       fee: {
         fee: result.tip?.toString() || '',
         type: 'tip',

--- a/modules/sdk-coin-tao/test/unit/transactionBuilder/moveStakeBuilder.ts
+++ b/modules/sdk-coin-tao/test/unit/transactionBuilder/moveStakeBuilder.ts
@@ -107,13 +107,7 @@ describe('Tao Move Stake Builder', function () {
 
       // Verify transaction explanation
       const explanation = tx.explainTransaction();
-      explanation.should.have.properties(['outputs', 'outputAmount', 'changeAmount', 'fee']);
-      explanation.outputs.should.have.length(1);
-      explanation.outputs[0].should.deepEqual({
-        address: '5Ffp1wJCPu4hzVDTo7XaMLqZSvSadyUQmxWPDw74CBjECSoq',
-        amount: '9007199254740995',
-        tokenName: utils.getTaoTokenBySubnetId('1').name,
-      });
+      explanation.should.have.properties(['outputAmount', 'changeAmount', 'fee']);
     });
 
     it('should validate required fields', function () {
@@ -154,9 +148,6 @@ describe('Tao Move Stake Builder', function () {
       txJson.originNetuid.should.equal('1');
       txJson.destinationNetuid.should.equal('2');
       txJson.alphaAmount.should.equal('1000000000000');
-
-      const explanation = tx.explainTransaction();
-      explanation.outputs[0].tokenName.should.equal('ttao:onion');
     });
   });
 
@@ -468,11 +459,8 @@ describe('Tao Move Stake Builder', function () {
       const tx = await builder.build();
       const explanation = tx.explainTransaction();
 
-      explanation.should.have.properties(['outputs', 'outputAmount', 'changeAmount', 'fee', 'type']);
-      explanation.outputs.should.have.length(1);
-      explanation.outputs[0].should.have.properties(['address', 'amount', 'tokenName']);
-      explanation.outputs[0].address.should.equal('5Ffp1wJCPu4hzVDTo7XaMLqZSvSadyUQmxWPDw74CBjECSoq');
-      explanation.outputs[0].amount.should.equal('1000000000000');
+      explanation.should.have.properties(['outputAmount', 'changeAmount', 'fee', 'type']);
+      explanation.outputAmount.should.equal('1000000000000');
       explanation.changeAmount.should.equal('0');
       explanation.fee.should.have.properties(['fee', 'type']);
       explanation.fee.type.should.equal('tip');
@@ -495,7 +483,7 @@ describe('Tao Move Stake Builder', function () {
       const explanation = tx.explainTransaction();
 
       explanation.fee.fee.should.equal('0');
-      explanation.outputAmount.should.equal('0');
+      explanation.outputAmount.should.equal('500000000');
     });
   });
 


### PR DESCRIPTION
Ticket: SC-3247
Description: The necessity of passing the coin name/ the check the subnet and coin association is not required for tao move stake functionality.

Move stake transactions are about redistributing existing stake between hotkeys/subnets, not transferring different coin types. The transaction operates within the same TAO ecosystem.
