### PR TITLE
feat: prepare release should remove private modules

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,10 +50,7 @@ jobs:
           echo "//registry.npmjs.org/:always-auth=true" >> .npmrc
 
       - name: Prepare Release
-        run: |
-          rm -rfd ./modules/web-demo
-          rm -rfd ./modules/express
-          npx tsx ./scripts/prepare-release.ts ${{ env.preid }}
+        run: npx tsx ./scripts/prepare-release.ts ${{ env.preid }}
 
       - name: Rebuild packages
         run: yarn

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -19,7 +19,7 @@ import {
   getLernaModules,
   validateReleaseTransformations,
   replacePackageScopes,
-  incrementVersions,
+  incrementVersions, removePrivateModulesWithNoDependents,
 } from './prepareRelease';
 
 export const uninitializedModules = process.env.UNINITIALIZED_MODULES
@@ -57,7 +57,10 @@ yargs(hideBin(process.argv))
 
       try {
         // Get lerna modules directly
-        const lernaModules = await getLernaModules();
+        let lernaModules = await getLernaModules();
+        // Remove express and web-demo
+        await removePrivateModulesWithNoDependents(lernaModules);
+        lernaModules = await getLernaModules();
         // Replace package scopes
         await replacePackageScopes(rootDir, lernaModules, targetScope);
         // Increment versions

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -15,9 +15,12 @@ import path from 'path';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
-import { getLernaModules, validateReleaseTransformations } from './prepareRelease';
-import { replacePackageScopes } from './prepareRelease/mutateScope';
-import { incrementVersions } from './prepareRelease/incrementVersions';
+import {
+  getLernaModules,
+  validateReleaseTransformations,
+  replacePackageScopes,
+  incrementVersions,
+} from './prepareRelease';
 
 export const uninitializedModules = process.env.UNINITIALIZED_MODULES
   ? process.env.UNINITIALIZED_MODULES.split(',')

--- a/scripts/prepareRelease/index.ts
+++ b/scripts/prepareRelease/index.ts
@@ -3,3 +3,4 @@ export * from './lernaModules';
 export * from './walk';
 export * from './validateTransformations';
 export * from './mutateScope';
+export * from './incrementVersions';

--- a/scripts/prepareRelease/lernaModules.ts
+++ b/scripts/prepareRelease/lernaModules.ts
@@ -9,6 +9,15 @@ export type LernaModule = {
   private?: boolean;
 };
 
+export type PackageJson = {
+  name: string;
+  version: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  buildDependencies?: Record<string, string>;
+}
+
 /**
  * Create a function which can run lerna commands
  * @param {String} lernaPath - path to lerna binary
@@ -21,6 +30,37 @@ function getLernaRunner(lernaPath: string) {
   };
 }
 
+/**
+ * Removes private modules with no dependent modules (ex. express, web-demo)
+ * This should be used before any packageJson or lerna module mutations
+ * @param lernaModules
+ */
+export async function removePrivateModulesWithNoDependents(lernaModules: LernaModule[]): Promise<void> {
+  const pacakgeAllModulePackageJsons = lernaModules.map((m) => readModulePackageJson(m));
+  const privateModules = lernaModules.filter((m) => m.private);
+  const privateModulesToRemove: LernaModule[] = [];
+  // For all private modules, find the ones where the module is not a dependency for any other module
+  // For example, express and web-demo are private modules that have no dependents
+  // sdk-test is a private module, but has dependents
+  for (const m of privateModules) {
+    const moduleHasNoDependents = pacakgeAllModulePackageJsons.every((packageJson) => {
+      const moduleInDependencies = packageJson.dependencies && packageJson.dependencies[m.name];
+      const moduleInDevDependencies = packageJson.devDependencies && packageJson.devDependencies[m.name];
+      const moduleInPeerDependencies = packageJson.peerDependencies && packageJson.peerDependencies[m.name];
+      const moduleInBuildDependencies = packageJson.buildDependencies && packageJson.buildDependencies[m.name];
+      return (
+        !moduleInBuildDependencies && !moduleInDependencies && !moduleInDevDependencies && !moduleInPeerDependencies
+      );
+    });
+    if (moduleHasNoDependents) {
+      privateModulesToRemove.push(m);
+    }
+  }
+  for (const m of privateModulesToRemove) {
+    console.log(`Removing private module ${m.name}`);
+    await execa('rm', ['-rfd', m.location]);
+  }
+}
 /**
  * Get all lerna modules in the monorepo
  */
@@ -37,7 +77,7 @@ export async function getLernaModules(): Promise<LernaModule[]> {
  * @param lernaModule The module to read package.json from
  * @returns The parsed package.json content
  */
-export function readModulePackageJson(lernaModule: Pick<LernaModule, 'location'>): any {
+export function readModulePackageJson(lernaModule: Pick<LernaModule, 'location'>): PackageJson {
   return JSON.parse(
     readFileSync(path.join(lernaModule.location, 'package.json'), {
       encoding: 'utf-8',
@@ -61,12 +101,7 @@ export function writeModulePackageJson(lernaModule: LernaModule, json: any): voi
  * @param version
  */
 export function setDependencyVersion(
-  packageJson: {
-    dependencies?: Record<string, string>;
-    devDependencies?: Record<string, string>;
-    peerDependencies?: Record<string, string>;
-    buildDependencies?: Record<string, string>;
-  },
+  packageJson: PackageJson,
   dependencyName: string,
   version: string
 ): void {


### PR DESCRIPTION
This pull request updates the release preparation logic in the BitGoJS repository to ensure private modules are removed as part of the release process.

Changes
- Modified release scripts to automatically exclude/remove private packages when preparing a release.
- Adjusted relevant files to support this new behavior.
- Cleaned up code and removed redundant references to private modules.

Context:
This update streamlines the release workflow and helps avoid publishing private packages by mistake. The release workflow was tested successfully: [GitHub Actions run](https://github.com/BitGo/BitGoJS/actions/runs/17985021853).
