### PR TITLE
fix(avac): floor gas price estimates to 1

### DIFF
--- a/modules/sdk-coin-avaxc/src/avaxc.ts
+++ b/modules/sdk-coin-avaxc/src/avaxc.ts
@@ -1103,7 +1103,8 @@ export class AvaxC extends AbstractEthLikeNewCoins {
     const feeEstimate: FeeEstimate = await this.feeEstimate(feeEstimateParams);
 
     const gasLimit = feeEstimate.gasLimitEstimate;
-    const gasPrice = Math.round(feeEstimate.feeEstimate / gasLimit);
+    // Even if `feeEstimate < gasLimit`, we shouldn't end up with `gasPrice === 0`.
+    const gasPrice = Math.max(Math.round(feeEstimate.feeEstimate / gasLimit), 1);
     const gasPriceMax = gasPrice * 5;
     // Payment id a random number so its different for every tx
     const paymentId = Math.floor(Math.random() * 10000000000).toString();

--- a/modules/sdk-coin-avaxc/test/unit/avaxc.ts
+++ b/modules/sdk-coin-avaxc/test/unit/avaxc.ts
@@ -785,6 +785,41 @@ describe('Avalanche C-Chain', function () {
     });
   });
 
+  describe('Hop Transaction Parameters', () => {
+    const sandBox = sinon.createSandbox();
+
+    afterEach(function () {
+      sandBox.restore();
+    });
+
+    it('should create hop transaction parameters with gasPriceMax > 0', async function () {
+      const mockFeeEstimate = {
+        feeEstimate: '120000',
+        gasLimitEstimate: 500000,
+      };
+      sandBox.stub(tavaxCoin, 'feeEstimate').resolves(mockFeeEstimate);
+      const recipients = [
+        {
+          address:
+            'P-fuji14xa0q4858ct3kfvpkwnw2dys3m63kt6famckf6~P-fuji1hljye3kesjtpj87m00e8vwkayg6eys6theuxfg~P-fuji1lelqx4cleh3dzk5kplstz6mwrt3duk7d7wwmpp',
+          amount: '100000000000000000',
+        },
+      ];
+
+      const result = await tavaxCoin.createHopTransactionParams({
+        recipients,
+        type: 'Export' as keyof typeof TransactionType,
+      });
+
+      result.should.have.property('hopParams');
+      result.hopParams.should.have.properties(['userReqSig', 'gasPriceMax', 'paymentId', 'gasLimit']);
+      result.hopParams.userReqSig.should.equal('0x');
+      result.hopParams.gasPriceMax.should.be.above(0);
+      result.hopParams.paymentId.should.be.a.String();
+      result.hopParams.gasLimit.should.equal(500000);
+    });
+  });
+
   describe('Explain Transaction', () => {
     it('should explain a half signed import in C transaction', async () => {
       const testData = IMPORT_C;


### PR DESCRIPTION
This was being calculated and rounded down to 0, causing the maximum gas price limit to also be calculated as 0.

Ticket: WIN-7368
