### PR TITLE
fix(sdk-coin-avaxp): update utxo selection to also check STAKEABLE_LOCK_OUT

### DIFF
--- a/modules/sdk-coin-avaxp/src/lib/atomicTransactionBuilder.ts
+++ b/modules/sdk-coin-avaxp/src/lib/atomicTransactionBuilder.ts
@@ -11,7 +11,7 @@ import {
 } from 'avalanche/dist/apis/platformvm';
 import { Credential } from 'avalanche/dist/common';
 import { BuildTransactionError } from '@bitgo/sdk-core';
-import { SECP256K1_Transfer_Output } from './iface';
+import { SECP256K1_STAKEABLE_LOCK_OUT, SECP256K1_Transfer_Output } from './iface';
 
 /**
  * Cross-chain transactions (export and import) are atomic operations.
@@ -104,7 +104,10 @@ export abstract class AtomicTransactionBuilder extends DeprecatedTransactionBuil
     });
 
     this.transaction._utxos.forEach((utxo, i) => {
-      if (utxo.outputID === SECP256K1_Transfer_Output) {
+      if (
+        utxo.outputID === SECP256K1_Transfer_Output ||
+        (utxo.outputID === SECP256K1_STAKEABLE_LOCK_OUT && utxo.locktime === '0')
+      ) {
         const txidBuf = utils.cb58Decode(utxo.txid);
         const amt: BN = new BN(utxo.amount);
         const outputidx = utils.outputidxNumberToBuffer(utxo.outputidx);

--- a/modules/sdk-coin-avaxp/src/lib/delegatorTxBuilder.ts
+++ b/modules/sdk-coin-avaxp/src/lib/delegatorTxBuilder.ts
@@ -16,7 +16,7 @@ import {
   UnsignedTx,
 } from 'avalanche/dist/apis/platformvm';
 import { BinTools, BN } from 'avalanche';
-import { SECP256K1_Transfer_Output, DeprecatedTx, DeprecatedBaseTx } from './iface';
+import { SECP256K1_Transfer_Output, DeprecatedTx, DeprecatedBaseTx, SECP256K1_STAKEABLE_LOCK_OUT } from './iface';
 import utils from './utils';
 import { Credential } from 'avalanche/dist/common';
 import { deprecatedRecoverUtxos } from './utxoEngine';
@@ -309,7 +309,10 @@ export class DelegatorTxBuilder extends DeprecatedTransactionBuilder {
     const buildOutputs = this.transaction._utxos[0].addresses.length !== 0;
 
     this.transaction._utxos.forEach((utxo, i) => {
-      if (utxo.outputID === SECP256K1_Transfer_Output) {
+      if (
+        utxo.outputID === SECP256K1_Transfer_Output ||
+        (utxo.outputID === SECP256K1_STAKEABLE_LOCK_OUT && utxo.locktime === '0')
+      ) {
         const txidBuf = utils.cb58Decode(utxo.txid);
         const amt: BN = new BN(utxo.amount);
         const outputidx = utils.outputidxNumberToBuffer(utxo.outputidx);

--- a/modules/sdk-coin-avaxp/src/lib/iface.ts
+++ b/modules/sdk-coin-avaxp/src/lib/iface.ts
@@ -50,6 +50,7 @@ export interface TxData {
  */
 export type DecodedUtxoObj = {
   outputID: number;
+  locktime?: string;
   amount: string;
   txid: string;
   outputidx: string;
@@ -61,9 +62,14 @@ export type DecodedUtxoObj = {
 /**
  * TypeId value for SECP256K1 Transfer Output
  *
- * {@link https://docs.avax.network/specs/platform-transaction-serialization#secp256k1-transfer-output-example }
+ * {@link https://build.avax.network/docs/api-reference/p-chain/txn-format#secp256k1-transfer-output }
  */
 export const SECP256K1_Transfer_Output = 7;
+/**
+ * TypeId value for Stakeable Lock Output
+ * {@link https://build.avax.network/docs/api-reference/p-chain/txn-format#stakeablelockout }
+ */
+export const SECP256K1_STAKEABLE_LOCK_OUT = 22;
 
 export const ADDRESS_SEPARATOR = '~';
 export const INPUT_SEPARATOR = ':';

--- a/modules/sdk-coin-avaxp/src/lib/transactionBuilder.ts
+++ b/modules/sdk-coin-avaxp/src/lib/transactionBuilder.ts
@@ -131,21 +131,12 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
     return this;
   }
 
-  // TODO(CR-1073):
-  // Implement:
-  //  buildImplementation
-  //  signImplementation
-  //  get transaction
-  //  set transaction
-  //  validateRawTransaction
-
   /** @inheritdoc */
   protected fromImplementation(rawTransaction: string): Transaction {
     const [tx] = pvmSerial.AddPermissionlessValidatorTx.fromBytes(
       Buffer.from(rawTransaction, 'hex'),
       avmSerial.getAVMManager().getDefaultCodec()
     );
-    // TODO(CR-1073): check if initBuilder can only use UnsignedTx and pvmSerial.BaseTx is not required
     this.initBuilder(tx);
     return this._transaction;
   }

--- a/modules/sdk-coin-avaxp/src/lib/utxoEngine.ts
+++ b/modules/sdk-coin-avaxp/src/lib/utxoEngine.ts
@@ -1,4 +1,4 @@
-import { DecodedUtxoObj, SECP256K1_Transfer_Output } from './iface';
+import { DecodedUtxoObj, SECP256K1_STAKEABLE_LOCK_OUT, SECP256K1_Transfer_Output } from './iface';
 import { BN, Buffer as BufferAvax } from 'avalanche';
 import { Signature } from 'avalanche/dist/common';
 import utils from './utils';
@@ -98,7 +98,12 @@ export function utxoToInput(
   let currentTotal: BN = new BN(0);
 
   const inputs = utxos
-    .filter((utxo) => utxo && utxo.outputID === SECP256K1_Transfer_Output)
+    .filter(
+      (utxo) =>
+        utxo &&
+        (utxo.outputID === SECP256K1_Transfer_Output ||
+          (utxo.outputID === SECP256K1_STAKEABLE_LOCK_OUT && utxo.locktime === '0'))
+    )
     .map((utxo) => {
       // validate the utxos
       const utxoAddresses: BufferAvax[] = utxo.addresses.map((a) => utils.parseAddress(a));

--- a/modules/sdk-coin-avaxp/test/resources/avaxp.ts
+++ b/modules/sdk-coin-avaxp/test/resources/avaxp.ts
@@ -622,7 +622,7 @@ export const BUILD_AND_SIGN_ADD_PERMISSIONLESS_VALIDATOR_SAMPLE = {
     '0xa94d6182edbd953516b262f17565a65d98f5741549cd70d2423abff750bb4b8d982d482376b189142ff8aa4705615fee14be6174610860e9c003aa4aeaa613b1732abf3cd0c9c42fa5856345644068c0d1f9fa1d9af32e20b14fca02983260bc',
   utxos: [
     {
-      outputID: 7,
+      outputID: 22,
       amount: '98000000',
       txid: 's92SjoZQemgG97HocX9GgyFy6ZKmapgcgqQ3y5J2uwP3qWBUy',
       threshold: 2,


### PR DESCRIPTION

noticed that some utxo will be of type 22 with locktim 0 those are eligible to be used for transactions


TICKET: SC-3257

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
