### PR TITLE
feat(sdk-api): Add support for passing constants to the SDK as an optional parameter

### DIFF
--- a/modules/sdk-api/src/types.ts
+++ b/modules/sdk-api/src/types.ts
@@ -2,6 +2,8 @@ import { EnvironmentName, IRequestTracer, V1Network } from '@bitgo/sdk-core';
 import { ECPairInterface } from '@bitgo/utxo-lib';
 import { type Agent } from 'http';
 
+export type Constants = Record<string, any>;
+
 const patchedRequestMethods = ['get', 'post', 'put', 'del', 'patch', 'options'] as const;
 export type RequestMethods = (typeof patchedRequestMethods)[number];
 export type AdditionalHeadersCallback = (
@@ -23,6 +25,12 @@ export {
 export interface BitGoAPIOptions {
   accessToken?: string;
   authVersion?: 2 | 3;
+  clientConstants?:
+    | Record<string, any>
+    | {
+        constants: Record<string, any>;
+        ttl?: number;
+      };
   customBitcoinNetwork?: V1Network;
   customRootURI?: string;
   customSigningAddress?: string;

--- a/modules/sdk-api/test/unit/v1/wallet.ts
+++ b/modules/sdk-api/test/unit/v1/wallet.ts
@@ -22,19 +22,10 @@ nock.disableNetConnect();
 const TestBitGo = {
   TEST_WALLET1_PASSCODE: 'iVWeATjqLS1jJShrPpETti0b',
 };
-const originalFetchConstants = BitGoAPI.prototype.fetchConstants;
-BitGoAPI.prototype.fetchConstants = function (this: any) {
-  nock(this._baseUrl).get('/api/v1/client/constants').reply(200, { ttl: 3600, constants: {} });
-
-  // force client constants reload
-  BitGoAPI['_constants'] = undefined;
-
-  return originalFetchConstants.apply(this, arguments as any);
-};
 describe('Wallet Prototype Methods', function () {
   const fixtures = getFixtures();
 
-  let bitgo = new BitGoAPI({ env: 'test' });
+  let bitgo = new BitGoAPI({ env: 'test', clientConstants: { constants: {} } });
   // bitgo.initializeTestVars();
 
   const userKeypair = {
@@ -131,7 +122,7 @@ describe('Wallet Prototype Methods', function () {
 
     before(function () {
       nock.pendingMocks().should.be.empty();
-      const prodBitgo = new BitGoAPI({ env: 'prod' });
+      const prodBitgo = new BitGoAPI({ env: 'prod', clientConstants: { constants: {} } });
       // prodBitgo.initializeTestVars();
       bgUrl = common.Environments[prodBitgo.getEnv()].uri;
       fakeProdWallet = new Wallet(prodBitgo, {
@@ -364,7 +355,7 @@ describe('Wallet Prototype Methods', function () {
       const { address, redeemScript, scriptPubKey } = await getFixture<Record<string, unknown>>(
         `${__dirname}/fixtures/sign-transaction.json`
       );
-      const testBitgo = new BitGoAPI({ env: 'test' });
+      const testBitgo = new BitGoAPI({ env: 'test', clientConstants: { constants: {} } });
       const fakeTestV1SafeWallet = new Wallet(testBitgo, {
         id: address,
         private: { safe: { redeemScript } },
@@ -426,7 +417,7 @@ describe('Wallet Prototype Methods', function () {
         halfSignedTxHex,
         fullSignedTxHex,
       } = await getFixture<Record<string, unknown>>(`${__dirname}/fixtures/sign-transaction.json`);
-      const testBitgo = new BitGoAPI({ env: 'test' });
+      const testBitgo = new BitGoAPI({ env: 'test', clientConstants: { constants: {} } });
       const fakeTestV1SafeWallet = new Wallet(testBitgo, {
         id: address,
         private: { safe: { redeemScript } },
@@ -745,7 +736,7 @@ describe('Wallet Prototype Methods', function () {
     before(function accelerateTxMockedBefore() {
       nock.pendingMocks().should.be.empty();
 
-      bitgo = new BitGoAPI({ env: 'mock' });
+      bitgo = new BitGoAPI({ env: 'mock', clientConstants: { constants: {} } });
       // bitgo.initializeTestVars();
       bitgo.setValidate(false);
       wallet = new Wallet(bitgo, { id: walletId, private: { keychains: [userKeypair, backupKeypair, bitgoKey] } });


### PR DESCRIPTION
Added optional clientConstants parameter to the BitGoAPI constructor, allowing users to provide/pass constants that override server-fetched values to the SDK.
- Notably, modified `fetchConstants()` to merge server constants with client constants (client overrides take precedence).
- Unit test in `test/unit/bitgoAPI.ts` passing in a constant under this flow.

Ticket: WP-5538