### PR TITLE
feat(express): add CI check to prevent dockerfile drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,3 +276,38 @@ jobs:
 
       - name: Build BitGoJS Express Docker Image
         run: ./scripts/build-docker-express.sh
+
+  dockerfile-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup node 22
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+
+      - name: restore lerna dependencies
+        id: lerna-cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
+        with:
+          path: |
+            node_modules
+            modules/*/node_modules
+          key: ${{ runner.os }}-node22-${{ hashFiles('yarn.lock') }}-${{ hashFiles('tsconfig.packages.json') }}-${{ hashFiles('package.json') }}
+
+      - name: Install Packages
+        if: steps.lerna-cache.outputs.cache-hit != 'true' || contains( github.event.pull_request.labels.*.name, 'SKIP_CACHE')
+        run: yarn install --with-frozen-lockfile --ignore-scripts
+
+      - name: Check Dockerfile is up to date
+        run: |
+          yarn update-dockerfile
+          if ! git diff --quiet; then
+            echo "Dockerfile is not up to date. Please run 'yarn update-dockerfile' and commit the changes."
+            git diff
+            exit 1
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,6 @@ COPY --from=builder /tmp/bitgo/modules/sdk-coin-icp /var/modules/sdk-coin-icp/
 COPY --from=builder /tmp/bitgo/modules/sdk-coin-initia /var/modules/sdk-coin-initia/
 COPY --from=builder /tmp/bitgo/modules/sdk-coin-injective /var/modules/sdk-coin-injective/
 COPY --from=builder /tmp/bitgo/modules/sdk-coin-islm /var/modules/sdk-coin-islm/
-COPY --from=builder /tmp/bitgo/modules/sdk-coin-mantra /var/modules/sdk-coin-mantra/
 COPY --from=builder /tmp/bitgo/modules/sdk-coin-mon /var/modules/sdk-coin-mon/
 COPY --from=builder /tmp/bitgo/modules/sdk-coin-near /var/modules/sdk-coin-near/
 COPY --from=builder /tmp/bitgo/modules/sdk-coin-oas /var/modules/sdk-coin-oas/
@@ -185,7 +184,6 @@ cd /var/modules/sdk-coin-icp && yarn link && \
 cd /var/modules/sdk-coin-initia && yarn link && \
 cd /var/modules/sdk-coin-injective && yarn link && \
 cd /var/modules/sdk-coin-islm && yarn link && \
-cd /var/modules/sdk-coin-mantra && yarn link && \
 cd /var/modules/sdk-coin-mon && yarn link && \
 cd /var/modules/sdk-coin-near && yarn link && \
 cd /var/modules/sdk-coin-oas && yarn link && \
@@ -285,7 +283,6 @@ RUN cd /var/bitgo-express && \
     yarn link @bitgo/sdk-coin-initia && \
     yarn link @bitgo/sdk-coin-injective && \
     yarn link @bitgo/sdk-coin-islm && \
-    yarn link @bitgo/sdk-coin-mantra && \
     yarn link @bitgo/sdk-coin-mon && \
     yarn link @bitgo/sdk-coin-near && \
     yarn link @bitgo/sdk-coin-oas && \


### PR DESCRIPTION
This PR both kills the drift in the express Dockerfile and adds a CI check to ensure that drift is addressed before merging. Making sure that the Dockerfile is up-to-date at all times will ensure that any BitGoJS commit can be used to publish a new version of `bitgo/express`.

It feels a little overkill to install all the project's dependencies just for `tsx` and `execa` but apparently this is a yarn v1 limitation. I'd be happy to be proven wrong here. The new check also didn't really fit in any of the other jobs which is why I created a new job for it.

I was able to test this new CI check [here](https://github.com/BitGo/BitGoJS/actions/runs/18052593819/job/51377191316?pr=7110)

TICKET: VL-3498