### PR TITLE
fix: mitigate CVE-2024-48930 by validating secp256k1 curve points, enforce secp256k1 v5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,5 +143,21 @@
     "terser": "^5.14.2",
     "tmp": "^0.2.3"
   },
+  "overrides": {
+    "ethereum-cryptography": {
+      "secp256k1": "5.0.1"
+    },
+    "hdkey": {
+      "secp256k1": "5.0.1"
+    },
+    "eccrypto": {
+      "secp256k1": "5.0.1"
+    },
+    "bip322-js": {
+      "bitcoinjs-message": {
+        "secp256k1": "5.0.1"
+      }
+    }
+  },
   "packageManager": "yarn@1.22.22"
 }

--- a/scripts/check-package-dependencies.ts
+++ b/scripts/check-package-dependencies.ts
@@ -34,6 +34,7 @@ const options = {
     'sass-loader',
     'style-loader',
     'ts-loader',
+    'secp256k1',
   ],
   specials: [
     depcheck.special.babel,


### PR DESCRIPTION
TICKET: DX-1569

This PR adds overrides to enforce secp256k1 v5.0.1. It also adds some additional curve validation.

# Testing
`yarn run unit-test` passes
`npm ls secp256k1` no longer shows conflicts

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
