### PR TITLE
fix: add missing configs

### DIFF
--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -358,7 +358,7 @@ export const ofcCoins = [
     'ofctaed',
     'Testnet United Arab Emirates Dirham',
     2,
-    UnderlyingAsset.SGD,
+    UnderlyingAsset.AED,
     CoinKind.FIAT
   ),
   tofc(
@@ -764,6 +764,14 @@ export const ofcCoins = [
     'Pump',
     6,
     UnderlyingAsset['sol:pump'],
+    SOL_OFC_TOKEN_FEATURES
+  ),
+  ofcsolToken(
+    '7d50630f-9bba-4a06-8665-4376ef1f128e',
+    'ofcsol:drift',
+    'Drift',
+    6,
+    UnderlyingAsset['sol:drift'],
     SOL_OFC_TOKEN_FEATURES
   ),
   ofcsolToken(


### PR DESCRIPTION
## Description
- fix underlying asset for tofcaed from `sgd` to `aed` [GO-1793]
- add missing ofc configs ofcsol:drift [GO-1794]


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Ticket: GO-1793


[GO-1793]: https://bitgoinc.atlassian.net/browse/GO-1793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GO-1794]: https://bitgoinc.atlassian.net/browse/GO-1794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ