### PR TITLE
fix(utxo-bin): fix signature matching and add support for previous tx data

### DIFF
--- a/modules/utxo-bin/src/InputParser.ts
+++ b/modules/utxo-bin/src/InputParser.ts
@@ -224,7 +224,12 @@ export class InputParser extends Parser {
             ...this.parseSignaturesWithSigners(
               parsed,
               signedBy.flatMap((v, i) => (v ? [i.toString()] : [])),
-              parsed.signatures.map((k: Buffer | 0) => (k === 0 ? -1 : signedBy.indexOf(k)))
+              parsed.signatures.map((k: Buffer | 0) => {
+                if (k === 0) {
+                  return -1;
+                }
+                return signedBy.findIndex((kk) => kk && kl.equals(k));
+              })
             )
           );
         } catch (e) {

--- a/modules/utxo-bin/src/prevTx.ts
+++ b/modules/utxo-bin/src/prevTx.ts
@@ -1,0 +1,47 @@
+import * as utxolib from '@bitgo/utxo-lib';
+import { ParserTx } from './ParserTx';
+
+function getPrevOutForOutpoint(outpoint: utxolib.bitgo.TxOutPoint, prevTx: ParserTx) {
+  if (prevTx instanceof utxolib.bitgo.UtxoTransaction) {
+    const hash = prevTx.getId();
+    if (hash !== outpoint.txid) {
+      return undefined;
+    }
+    const out = prevTx.outs[outpoint.vout];
+    if (!out) {
+      throw new Error(`vout ${outpoint.vout} not found in prevTx ${hash}`);
+    }
+    return out;
+  }
+
+  if (prevTx instanceof utxolib.bitgo.UtxoPsbt) {
+    throw new Error(`not implemented for Psbt yet`);
+  }
+
+  throw new Error(`unknown tx type`);
+}
+
+export function getPrevOutputsFromPrevTxs(tx: ParserTx, prevTxs: ParserTx[]): utxolib.TxOutput<bigint>[] | undefined {
+  if (prevTxs.length === 0) {
+    return undefined;
+  }
+  if (tx instanceof utxolib.bitgo.UtxoTransaction) {
+    const outpoints = tx.ins.map((i) => utxolib.bitgo.getOutputIdForInput(i));
+    return outpoints.map((o) => {
+      const matches = prevTxs.flatMap((t) => getPrevOutForOutpoint(o, t));
+      if (matches.length === 0) {
+        throw new Error(`no prevTx found for input ${o.txid}:${o.vout}`);
+      }
+      if (matches.length > 1) {
+        throw new Error(`more than one prevTx found for input ${o.txid}:${o.vout}`);
+      }
+      return matches[0] as utxolib.TxOutput<bigint>;
+    });
+  }
+
+  if (tx instanceof utxolib.bitgo.UtxoPsbt) {
+    throw new Error(`not implemented for Psbt yet`);
+  }
+
+  throw new Error(`unknown tx type`);
+}


### PR DESCRIPTION

This PR addresses two main issues in the utxo-bin package:

1. Fixes signature matching in InputParser by replacing indexOf with findIndex
   to properly match signatures using buffer equality comparison.

2. Adds support for providing previous transaction data directly through a 
   new --prevTx option in the parseTx command, eliminating the need to fetch
   from remote sources. Also implements helper functions to extract previous
   outputs from these transactions.

Related: BTC-0