### PR TITLE
Fix Docker build disk space exhaustion in CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update && apt-get install -y git python3 make g++ libtool autoconf a
 WORKDIR /tmp/bitgo
 COPY --from=filter-packages-json /tmp/bitgo .
 # (skip postinstall) https://github.com/yarnpkg/yarn/issues/4100#issuecomment-388944260
-RUN NOYARNPOSTINSTALL=1 yarn install --pure-lockfile --network-timeout 120000
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn \
+    NOYARNPOSTINSTALL=1 yarn install --pure-lockfile --network-timeout 120000
 
 COPY . .
 RUN \


### PR DESCRIPTION
Fixes disk space exhaustion during Docker builds in GitHub Actions CI by using BuildKit cache mounts for the yarn cache directory.

## Changes
- Modified Dockerfile to use `--mount=type=cache` for yarn cache
- Yarn cache is now excluded from Docker image layers
- Cache persists between builds on the same runner

## Benefits
- Fixes "no space left on device" errors in CI
- Reduces final image size (yarn cache not included)
- Maintains or improves build performance (persistent cache)

Ticket: VL-3537