### PR TITLE
feat(sdk-core): skip type check for STX

### DIFF
--- a/modules/sdk-core/src/bitgo/staking/stakingWallet.ts
+++ b/modules/sdk-core/src/bitgo/staking/stakingWallet.ts
@@ -184,6 +184,10 @@ export class StakingWallet implements IStakingWallet {
     );
   }
 
+  private isStx() {
+    return this.wallet.baseCoin.getFamily() === 'stx';
+  }
+
   private isTrxStaking(transaction: StakingTransaction) {
     return this.wallet.baseCoin.getFamily() === 'trx';
   }
@@ -448,7 +452,8 @@ export class StakingWallet implements IStakingWallet {
     if (
       buildParams?.type &&
       (explainedTransaction as any).type !== undefined &&
-      TransactionType[buildParams.type] !== (explainedTransaction as any).type
+      ((this.isStx() && TransactionType.ContractCall !== (explainedTransaction as any).type) || // for STX the tx type should always ContractCall
+        (!this.isStx() && TransactionType[buildParams.type] !== (explainedTransaction as any).type))
     ) {
       mismatchErrors.push(
         `Transaction type mismatch. Expected: '${buildParams.type}', Got: '${(explainedTransaction as any).type}'`


### PR DESCRIPTION
the staking tx type will always be contract call type but the one in the staking params is staking lock
so the checks will fail
need to skip this part

SC-3403

TICKET: SC-3403

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
