### PR TITLE
refactor(sdk-coin-sol): token 2022 transfer hook config cleanup

### DIFF
--- a/modules/sdk-coin-sol/src/config/token2022StaticConfig.ts
+++ b/modules/sdk-coin-sol/src/config/token2022StaticConfig.ts
@@ -3,13 +3,7 @@ import type { Token2022Config } from '../lib/token2022Config';
 export const TOKEN_2022_STATIC_CONFIGS: Token2022Config[] = [
   {
     mintAddress: '4MmJVdwYN8LwvbGeCowYjSx7KoEi6BJWg8XXnW4fDDp6',
-    symbol: 'tbill',
-    name: 'OpenEden T-Bills',
-    decimals: 6,
-    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
     transferHook: {
-      programId: '48n7YGEww7fKMfJ5gJ3sQC3rM6RWGjpUsghqVfXVkR5A',
-      authority: 'CPNEkz5SaAcWqGMezXTti39ekErzMpDCtuPMGw9tt4CZ',
       extraAccountMetas: [
         {
           pubkey: '98wFF5MpMjMQbfDF2MPzo8LCGX37unZR1ohRA1mU9GmJ',
@@ -31,13 +25,7 @@ export const TOKEN_2022_STATIC_CONFIGS: Token2022Config[] = [
   },
   {
     mintAddress: '3BW95VLH2za2eUQ1PGfjxwMbpsnDFnmkA7m5LDgMKbX7',
-    symbol: 't1test',
-    name: 'T1TEST',
-    decimals: 6,
-    programId: 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
     transferHook: {
-      programId: '2Te6MFDwstRP2sZi6DLbkhVcSfaQVffmpbudN6pmvAXo',
-      authority: 'BLZvvaQgPUvL2RWoJeovudbHMhqH4S3kdenN5eg1juDr',
       extraAccountMetas: [
         {
           pubkey: 'GbQ8ZiEFzGGTeYoXwtZtcoxwPcMyUcmZDduMVNdUPKpX',

--- a/modules/sdk-coin-sol/src/lib/token2022Config.ts
+++ b/modules/sdk-coin-sol/src/lib/token2022Config.ts
@@ -16,27 +16,14 @@ export interface ExtraAccountMeta {
   isSigner: boolean;
   /** Whether the account is writable */
   isWritable: boolean;
-  /** Optional seed for PDA derivation */
-  seeds?: Array<{
-    /** Literal seed value or instruction account index reference */
-    value: string | number;
-    /** Type of seed: 'literal' for string/buffer, 'accountKey' for instruction account index */
-    type: 'literal' | 'accountKey';
-  }>;
 }
 
 /**
  * Interface for transfer hook configuration
  */
 export interface TransferHookConfig {
-  /** The transfer hook program ID */
-  programId: string;
-  /** The transfer hook authority */
-  authority: string;
   /** Extra account metas required by the transfer hook */
   extraAccountMetas: ExtraAccountMeta[];
-  /** The PDA address for extra account metas (cached) */
-  extraAccountMetasPDA?: string;
 }
 
 /**
@@ -45,34 +32,18 @@ export interface TransferHookConfig {
 export interface Token2022Config {
   /** The mint address of the token */
   mintAddress: string;
-  /** Token symbol */
-  symbol: string;
-  /** Token name */
-  name: string;
-  /** Number of decimal places */
-  decimals: number;
-  /** Program ID (TOKEN_2022_PROGRAM_ID) */
-  programId: string;
   /** Transfer hook configuration if applicable */
   transferHook?: TransferHookConfig;
-  /** Whether the token has transfer fees */
-  hasTransferFees?: boolean;
 }
 
 /**
  * Token configurations map
- * Key: mintAddress or symbol
+ * Key: mintAddress
  */
 export const TOKEN_2022_CONFIGS: Record<string, Token2022Config> = {};
 
 TOKEN_2022_STATIC_CONFIGS.forEach((config) => {
   TOKEN_2022_CONFIGS[config.mintAddress] = config;
-  TOKEN_2022_CONFIGS[config.symbol] = config;
-});
-
-// Create symbol mappings for convenience
-Object.values(TOKEN_2022_CONFIGS).forEach((config) => {
-  TOKEN_2022_CONFIGS[config.symbol] = config;
 });
 
 /**

--- a/modules/sdk-coin-sol/test/unit/solInstructionFactory.ts
+++ b/modules/sdk-coin-sol/test/unit/solInstructionFactory.ts
@@ -167,11 +167,11 @@ describe('Instruction Builder Tests: ', function () {
           fromAddress,
           toAddress,
           amount,
-          tokenName: tokenConfig!.symbol,
+          tokenName: 'tbill',
           sourceAddress,
           tokenAddress: tokenConfig!.mintAddress,
-          decimalPlaces: tokenConfig!.decimals,
-          programId: tokenConfig!.programId,
+          decimalPlaces: 6,
+          programId: TOKEN_2022_PROGRAM_ID.toString(),
         },
       };
 
@@ -187,7 +187,7 @@ describe('Instruction Builder Tests: ', function () {
         new PublicKey(toAddress),
         new PublicKey(fromAddress),
         BigInt(amount),
-        tokenConfig!.decimals,
+        6,
         [],
         TOKEN_2022_PROGRAM_ID
       );


### PR DESCRIPTION
Removed unused fields from token 2022 transfer hook configs 
Ticket: WIN-7258
