### PR TITLE
feat: Replace Generic Errors with Suspicious Transaction Errors for UTXO/EthLike Coins

### DIFF
--- a/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
+++ b/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
@@ -2775,7 +2775,7 @@ export abstract class AbstractEthLikeNewCoins extends AbstractEthLikeCoin {
 
     // Helper to throw TxIntentMismatchError with consistent context
     const throwTxMismatch = (message: string): never => {
-      throw new TxIntentMismatchError(message, '', [txParams], txPrebuild?.txHex || '');
+      throw new TxIntentMismatchError(message, undefined, [txParams], txPrebuild?.txHex);
     };
 
     if (
@@ -2849,7 +2849,7 @@ export abstract class AbstractEthLikeNewCoins extends AbstractEthLikeCoin {
 
     // Helper to throw TxIntentMismatchError with consistent context
     const throwTxMismatch = (message: string): never => {
-      throw new TxIntentMismatchError(message, '', [txParams], txPrebuild?.txHex || '');
+      throw new TxIntentMismatchError(message, undefined, [txParams], txPrebuild?.txHex);
     };
 
     if (!txParams?.recipients || !txPrebuild?.recipients || !wallet) {

--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -632,6 +632,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
    * @param params.verification.keychains Pass keychains manually rather than fetching them by id
    * @param params.verification.addresses Address details to pass in for out-of-band verification
    * @returns {boolean}
+   * @throws {TxIntentMismatchError} if transaction validation fails
    */
   async verifyTransaction<TNumber extends number | bigint = number>(
     params: VerifyTransactionOptions<TNumber>

--- a/modules/abstract-utxo/src/transaction/descriptor/verifyTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/descriptor/verifyTransaction.ts
@@ -78,9 +78,9 @@ export async function verifyTransaction(
   if (!(tx instanceof utxolib.bitgo.UtxoPsbt)) {
     throw new TxIntentMismatchError(
       'unexpected transaction type',
-      params.reqId || '',
+      params.reqId,
       [params.txParams],
-      params.txPrebuild.txHex || ''
+      params.txPrebuild.txHex
     );
   }
   assertValidTransaction(tx, descriptorMap, params.txParams.recipients ?? [], tx.network);

--- a/modules/abstract-utxo/src/transaction/descriptor/verifyTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/descriptor/verifyTransaction.ts
@@ -1,15 +1,13 @@
 import * as utxolib from '@bitgo/utxo-lib';
-import {
-  IRequestTracer,
-  ITransactionRecipient,
-  MismatchedRecipient,
-  TxIntentMismatchError,
-  TxIntentMismatchRecipientError,
-  VerifyTransactionOptions,
-} from '@bitgo/sdk-core';
+import { ITransactionRecipient, TxIntentMismatchError } from '@bitgo/sdk-core';
 import { DescriptorMap } from '@bitgo/utxo-core/descriptor';
 
-import { AbstractUtxoCoin, BaseOutput, BaseParsedTransactionOutputs } from '../../abstractUtxoCoin';
+import {
+  AbstractUtxoCoin,
+  BaseOutput,
+  BaseParsedTransactionOutputs,
+  VerifyTransactionOptions,
+} from '../../abstractUtxoCoin';
 
 import { toBaseParsedTransactionOutputsFromPsbt } from './parse';
 
@@ -65,52 +63,6 @@ export function assertValidTransaction(
 }
 
 /**
- * Convert ValidationError to TxIntentMismatchRecipientError with structured data
- *
- * This preserves the structured error information from the original ValidationError
- * by extracting the mismatched outputs and converting them to the standardized format.
- * The original error is preserved as the `cause` for debugging purposes.
- */
-function convertValidationErrorToTxIntentMismatch(
-  error: AggregateValidationError,
-  reqId: string | IRequestTracer | undefined,
-  txParams: VerifyTransactionOptions['txParams'],
-  txHex: string | undefined
-): TxIntentMismatchRecipientError {
-  const mismatchedRecipients: MismatchedRecipient[] = [];
-
-  for (const err of error.errors) {
-    if (err instanceof ErrorMissingOutputs) {
-      mismatchedRecipients.push(
-        ...err.missingOutputs.map((output) => ({
-          address: output.address,
-          amount: output.amount.toString(),
-        }))
-      );
-    } else if (err instanceof ErrorImplicitExternalOutputs) {
-      mismatchedRecipients.push(
-        ...err.implicitExternalOutputs.map((output) => ({
-          address: output.address,
-          amount: output.amount.toString(),
-        }))
-      );
-    }
-  }
-
-  const txIntentError = new TxIntentMismatchRecipientError(
-    error.message,
-    reqId,
-    [txParams],
-    txHex,
-    mismatchedRecipients
-  );
-  // Preserve the original structured error as the cause for debugging
-  // See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
-  (txIntentError as Error & { cause?: Error }).cause = error;
-  return txIntentError;
-}
-
-/**
  * Wrapper around assertValidTransaction that returns a boolean instead of throwing.
  *
  * We follow the AbstractUtxoCoin interface here which is a bit confused - the return value is a boolean but we
@@ -121,11 +73,10 @@ function convertValidationErrorToTxIntentMismatch(
  * @param descriptorMap
  * @returns {boolean} True if verification passes
  * @throws {TxIntentMismatchError} if transaction validation fails
- * @throws {TxIntentMismatchRecipientError} if transaction recipients don't match user intent
  */
-export async function verifyTransaction(
+export async function verifyTransaction<TNumber extends number | bigint>(
   coin: AbstractUtxoCoin,
-  params: VerifyTransactionOptions,
+  params: VerifyTransactionOptions<TNumber>,
   descriptorMap: DescriptorMap
 ): Promise<boolean> {
   const tx = coin.decodeTransactionFromPrebuild(params.txPrebuild);
@@ -138,14 +89,7 @@ export async function verifyTransaction(
     );
   }
 
-  try {
-    assertValidTransaction(tx, descriptorMap, params.txParams.recipients ?? [], tx.network);
-  } catch (error) {
-    if (error instanceof AggregateValidationError) {
-      throw convertValidationErrorToTxIntentMismatch(error, params.reqId, params.txParams, params.txPrebuild.txHex);
-    }
-    throw error;
-  }
+  assertValidTransaction(tx, descriptorMap, params.txParams.recipients ?? [], tx.network);
 
   return true;
 }

--- a/modules/abstract-utxo/src/transaction/fixedScript/verifyTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/verifyTransaction.ts
@@ -51,7 +51,7 @@ export async function verifyTransaction<TNumber extends bigint | number>(
 
   // Helper to throw TxIntentMismatchError with consistent context
   const throwTxMismatch = (message: string): never => {
-    throw new TxIntentMismatchError(message, reqId || '', [txParams], txPrebuild.txHex || '');
+    throw new TxIntentMismatchError(message, reqId, [txParams], txPrebuild.txHex);
   };
 
   if (!_.isUndefined(verification.disableNetworking) && !_.isBoolean(verification.disableNetworking)) {
@@ -168,7 +168,7 @@ export async function verifyTransaction<TNumber extends bigint | number>(
 
   const allOutputs = parsedTransaction.outputs;
   if (!txPrebuild.txHex) {
-    throw new TxIntentMismatchError(`txPrebuild.txHex not set`, reqId || '', [txParams], '');
+    throw new TxIntentMismatchError(`txPrebuild.txHex not set`, reqId, [txParams], undefined);
   }
   const inputs = isPsbt
     ? getPsbtTxInputs(txPrebuild.txHex, coin.network).map((v) => ({

--- a/modules/abstract-utxo/src/transaction/fixedScript/verifyTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/verifyTransaction.ts
@@ -55,11 +55,11 @@ export async function verifyTransaction<TNumber extends bigint | number>(
   };
 
   if (!_.isUndefined(verification.disableNetworking) && !_.isBoolean(verification.disableNetworking)) {
-    throwTxMismatch('verification.disableNetworking must be a boolean');
+    throw new TypeError('verification.disableNetworking must be a boolean');
   }
   const isPsbt = txPrebuild.txHex && utxolib.bitgo.isPsbt(txPrebuild.txHex);
   if (isPsbt && txPrebuild.txInfo?.unspents) {
-    throwTxMismatch('should not have unspents in txInfo for psbt');
+    throw new Error('should not have unspents in txInfo for psbt');
   }
   const disableNetworking = !!verification.disableNetworking;
   const parsedTransaction: ParsedTransaction<TNumber> = await coin.parseTransaction<TNumber>({
@@ -97,7 +97,7 @@ export async function verifyTransaction<TNumber extends bigint | number>(
     const isBackupKeySignatureValid = verify(keychains.backup, keySignatures.backupPub);
     const isBitgoKeySignatureValid = verify(keychains.bitgo, keySignatures.bitgoPub);
     if (!isBackupKeySignatureValid || !isBitgoKeySignatureValid) {
-      throwTxMismatch('secondary public key signatures invalid');
+      throw new Error('secondary public key signatures invalid');
     }
     debug('successfully verified backup and bitgo key signatures');
   } else if (!disableNetworking) {
@@ -108,11 +108,11 @@ export async function verifyTransaction<TNumber extends bigint | number>(
 
   if (parsedTransaction.needsCustomChangeKeySignatureVerification) {
     if (!keychains.user || !userPublicKeyVerified) {
-      throwTxMismatch('transaction requires verification of user public key, but it was unable to be verified');
+      throw new Error('transaction requires verification of user public key, but it was unable to be verified');
     }
     const customChangeKeySignaturesVerified = verifyCustomChangeKeySignatures(parsedTransaction, keychains.user);
     if (!customChangeKeySignaturesVerified) {
-      throwTxMismatch(
+      throw new Error(
         'transaction requires verification of custom change key signatures, but they were unable to be verified'
       );
     }
@@ -168,7 +168,7 @@ export async function verifyTransaction<TNumber extends bigint | number>(
 
   const allOutputs = parsedTransaction.outputs;
   if (!txPrebuild.txHex) {
-    throw new TxIntentMismatchError(`txPrebuild.txHex not set`, reqId, [txParams], undefined);
+    throw new Error(`txPrebuild.txHex not set`);
   }
   const inputs = isPsbt
     ? getPsbtTxInputs(txPrebuild.txHex, coin.network).map((v) => ({
@@ -185,7 +185,7 @@ export async function verifyTransaction<TNumber extends bigint | number>(
   const fee = inputAmount - outputAmount;
 
   if (fee < 0) {
-    throwTxMismatch(
+    throw new Error(
       `attempting to spend ${outputAmount} satoshis, which exceeds the input amount (${inputAmount} satoshis) by ${-fee}`
     );
   }

--- a/modules/sdk-core/src/bitgo/errors.ts
+++ b/modules/sdk-core/src/bitgo/errors.ts
@@ -253,24 +253,29 @@ export interface ContractDataPayload {
  *
  * @class TxIntentMismatchError
  * @extends {BitGoJsError}
- * @property {string | IRequestTracer} id - Transaction ID or request tracer for tracking
+ * @property {string | IRequestTracer | undefined} id - Transaction ID or request tracer for tracking
  * @property {TransactionParams[]} txParams - Array of transaction parameters that were analyzed
- * @property {string} txHex - The raw transaction in hexadecimal format
+ * @property {string | undefined} txHex - The raw transaction in hexadecimal format
  */
 export class TxIntentMismatchError extends BitGoJsError {
-  public readonly id: string | IRequestTracer;
+  public readonly id: string | IRequestTracer | undefined;
   public readonly txParams: TransactionParams[];
-  public readonly txHex: string;
+  public readonly txHex: string | undefined;
 
   /**
    * Creates an instance of TxIntentMismatchError
    *
    * @param {string} message - Error message describing the intent mismatch
-   * @param {string | IRequestTracer} id - Transaction ID or request tracer
+   * @param {string | IRequestTracer | undefined} id - Transaction ID or request tracer
    * @param {TransactionParams[]} txParams - Transaction parameters that were analyzed
-   * @param {string} txHex - Raw transaction hex string
+   * @param {string | undefined} txHex - Raw transaction hex string
    */
-  public constructor(message: string, id: string | IRequestTracer, txParams: TransactionParams[], txHex: string) {
+  public constructor(
+    message: string,
+    id: string | IRequestTracer | undefined,
+    txParams: TransactionParams[],
+    txHex: string | undefined
+  ) {
     super(message);
     this.id = id;
     this.txParams = txParams;
@@ -295,16 +300,16 @@ export class TxIntentMismatchRecipientError extends TxIntentMismatchError {
    * Creates an instance of TxIntentMismatchRecipientError
    *
    * @param {string} message - Error message describing the recipient intent mismatch
-   * @param {string | IRequestTracer} id - Transaction ID or request tracer
+   * @param {string | IRequestTracer | undefined} id - Transaction ID or request tracer
    * @param {TransactionParams[]} txParams - Transaction parameters that were analyzed
-   * @param {string} txHex - Raw transaction hex string
+   * @param {string | undefined} txHex - Raw transaction hex string
    * @param {MismatchedRecipient[]} mismatchedRecipients - Array of recipients that don't match user intent
    */
   public constructor(
     message: string,
-    id: string | IRequestTracer,
+    id: string | IRequestTracer | undefined,
     txParams: TransactionParams[],
-    txHex: string,
+    txHex: string | undefined,
     mismatchedRecipients: MismatchedRecipient[]
   ) {
     super(message, id, txParams, txHex);
@@ -329,16 +334,16 @@ export class TxIntentMismatchContractError extends TxIntentMismatchError {
    * Creates an instance of TxIntentMismatchContractError
    *
    * @param {string} message - Error message describing the contract intent mismatch
-   * @param {string | IRequestTracer} id - Transaction ID or request tracer
+   * @param {string | IRequestTracer | undefined} id - Transaction ID or request tracer
    * @param {TransactionParams[]} txParams - Transaction parameters that were analyzed
-   * @param {string} txHex - Raw transaction hex string
+   * @param {string | undefined} txHex - Raw transaction hex string
    * @param {ContractDataPayload} mismatchedDataPayload - The contract interaction data that doesn't match user intent
    */
   public constructor(
     message: string,
-    id: string | IRequestTracer,
+    id: string | IRequestTracer | undefined,
     txParams: TransactionParams[],
-    txHex: string,
+    txHex: string | undefined,
     mismatchedDataPayload: ContractDataPayload
   ) {
     super(message, id, txParams, txHex);
@@ -363,16 +368,16 @@ export class TxIntentMismatchApprovalError extends TxIntentMismatchError {
    * Creates an instance of TxIntentMismatchApprovalError
    *
    * @param {string} message - Error message describing the approval intent mismatch
-   * @param {string | IRequestTracer} id - Transaction ID or request tracer
+   * @param {string | IRequestTracer | undefined} id - Transaction ID or request tracer
    * @param {TransactionParams[]} txParams - Transaction parameters that were analyzed
-   * @param {string} txHex - Raw transaction hex string
+   * @param {string | undefined} txHex - Raw transaction hex string
    * @param {TokenApproval} tokenApproval - Details of the token approval that doesn't match user intent
    */
   public constructor(
     message: string,
-    id: string | IRequestTracer,
+    id: string | IRequestTracer | undefined,
     txParams: TransactionParams[],
-    txHex: string,
+    txHex: string | undefined,
     tokenApproval: TokenApproval
   ) {
     super(message, id, txParams, txHex);


### PR DESCRIPTION
Replace generic Error throws with `TxIntentMismatchError` in `verifyTransaction` methods for Bitcoin and other UTXO & EthLike coins to provide more specific error handling for suspicious transaction detection.
- Updated UTXO `verifyTransaction` methods
- Updated EthLike `verifyTransaction` methods

Open to comments relating to copy or if I've missed any generic error.

Ticket: WP-6189