### PR TITLE
fix(utxo-lib): clarify musig2 implementation notes

### DIFF
--- a/modules/utxo-lib/src/taproot.ts
+++ b/modules/utxo-lib/src/taproot.ts
@@ -1,6 +1,11 @@
 // Taproot-specific key aggregation and taptree logic as defined in:
 // https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
 // https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki
+//
+// The implementation here is unfortunately not the same as the final Musig2
+// implementation. It is a variant of an earlier version that aggregates the
+// x-only 32-byte pubkeys instead of the plain 33-byte pubkeys.
+// See https://github.com/OttoAllmendinger/bips/blob/musig-bitgo/bip-musig2/reference.py for details.
 
 import { TapTree as PsbtTapTree, TapLeaf as PsbtTapLeaf } from 'bip174/src/lib/interfaces';
 import assert = require('assert');

--- a/modules/utxo-lib/test/taproot.spec.ts
+++ b/modules/utxo-lib/test/taproot.spec.ts
@@ -7,9 +7,13 @@ const ECPair: ECPairAPI = ECPairFactory(ecc);
 
 describe('taproot utils', () => {
   describe('musig key aggregation', () => {
-    // Expected values for the test cases assertions below are derived from the
+    // Expected values for the test cases assertions below are derived from a
     // MuSig2 implementation example code in secp256k1-zkp.
-    // https://github.com/jonasnick/secp256k1-zkp/blob/musig2/src/modules/musig/example.c
+    // https://github.com/jonasnick/secp256k1-zkp/blob/musig2/src/modules/musig/example.c (link defunct)
+    //
+    // Reconstruction of the code in the above link:
+    // https://github.com/OttoAllmendinger/bips/commit/3683cc46e0cf4fc101f1c06492eb1f9f2ab9e450
+    // https://github.com/OttoAllmendinger/bips/blob/musig-bitgo/bip-musig2/reference.py
 
     it('aggregates 2 pubkeys', () => {
       const aggregatePubkey = taproot.aggregateMuSigPubkeys(ecc, [


### PR DESCRIPTION

The current implementation is not the final Musig2 spec but an earlier
variant that aggregates x-only pubkeys. Added reference to specific
implementation details and updated test comments.

Issue: BTC-2651