### PR TITLE
feat(sdk-core): generate Go account wallet

### DIFF
--- a/examples/ts/create-go-account.ts
+++ b/examples/ts/create-go-account.ts
@@ -1,0 +1,67 @@
+/**
+ * Create a Go Account wallet at BitGo.
+ * This makes use of the convenience function generateWallet with type: 'trading'
+ *
+ * IMPORTANT: You must backup the encrypted private key and encrypted wallet passphrase!
+ *
+ * Copyright 2025, BitGo, Inc.  All Rights Reserved.
+ */
+
+import { BitGoAPI } from '@bitgo/sdk-api';
+import { coins } from 'bitgo';
+require('dotenv').config({ path: '../../.env' });
+
+const bitgo = new BitGoAPI({
+  accessToken: process.env.TESTNET_ACCESS_TOKEN,
+  env: 'test', // Change this to env: 'production' when you are ready for production
+});
+
+// Go Accounts use the 'ofc' (Off-Chain) coin
+const coin = 'ofc';
+bitgo.register(coin, coins.Ofc.createInstance);
+
+// TODO: set a label for your new Go Account here
+const label = 'Example Go Account Wallet';
+
+// TODO: set your passphrase for your new wallet here (encrypts the private key)
+const passphrase = 'go_account_wallet_passphrase';
+
+// TODO: set your passcode encryption code here (encrypts the passphrase itself)
+const passcodeEncryptionCode = 'encryption_code_for_passphrase';
+
+// TODO: set your enterprise ID for your new wallet here
+const enterprise = 'your_enterprise_id';
+
+async function main() {
+  const response = await bitgo.coin(coin).wallets().generateWallet({
+    label,
+    passphrase,
+    passcodeEncryptionCode,
+    enterprise,
+    type: 'trading', // Required for Go Accounts
+  });
+
+  // Type guard to ensure we got a Go Account response
+  if (!('userKeychain' in response)) {
+    throw new Error('Go account missing required user keychain');
+  }
+
+  const { wallet, userKeychain, encryptedWalletPassphrase } = response;
+
+  console.log(`Wallet ID: ${wallet.id()}`);
+
+  console.log('BACKUP THE FOLLOWING INFORMATION: ');
+  console.log('User Keychain:');
+  console.log(`Keychain ID: ${userKeychain.id}`);
+  console.log(`Public Key: ${userKeychain.pub}`);
+  console.log(`Encrypted Private Key: ${userKeychain.encryptedPrv}`);
+
+  console.log(`Encrypted Wallet Passphrase: ${encryptedWalletPassphrase}`);
+
+  // Create receive address for Go Account
+  const receiveAddress = await wallet.createAddress();
+  console.log('Go Account Receive Address:', receiveAddress.address);
+}
+
+main().catch((e) => console.error('Error creating Go Account:', e));
+

--- a/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
@@ -219,7 +219,7 @@ export interface SupplementGenerateWalletOptions {
   rootPrivateKey?: string;
   disableKRSEmail?: boolean;
   multisigType?: 'tss' | 'onchain' | 'blsdkg';
-  type: 'hot' | 'cold' | 'custodial' | 'advanced';
+  type: 'hot' | 'cold' | 'custodial' | 'advanced' | 'trading';
   subType?: 'lightningCustody' | 'lightningSelfCustody' | 'onPrem';
   coinSpecific?: { [coinName: string]: unknown };
   evmKeyRingReferenceWalletId?: string;

--- a/modules/sdk-core/src/bitgo/keychain/iKeychains.ts
+++ b/modules/sdk-core/src/bitgo/keychain/iKeychains.ts
@@ -46,6 +46,8 @@ export interface Keychain {
   coinSpecific?: { [coinName: string]: unknown };
   // Alternative encryptedPrv using webauthn and the prf extension
   webauthnDevices?: KeychainWebauthnDevice[];
+  // Ethereum address derived from xpub
+  ethAddress?: string;
 }
 
 export type OptionalKeychainEncryptedKey = Pick<Keychain, 'encryptedPrv' | 'webauthnDevices'>;

--- a/modules/sdk-core/src/bitgo/wallet/iWallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallets.ts
@@ -2,6 +2,7 @@ import * as t from 'io-ts';
 
 import { IRequestTracer } from '../../api';
 import { KeychainsTriplet, LightningKeychainsTriplet } from '../baseCoin';
+import { Keychain } from '../keychain';
 import { IWallet, PaginationOptions, WalletShare } from './iWallet';
 import { Wallet } from './wallet';
 
@@ -15,6 +16,14 @@ export interface WalletWithKeychains extends KeychainsTriplet {
 export interface LightningWalletWithKeychains extends LightningKeychainsTriplet {
   responseType: 'LightningWalletWithKeychains';
   wallet: IWallet;
+  warning?: string;
+  encryptedWalletPassphrase?: string;
+}
+
+export interface GoAccountWalletWithUserKeychain {
+  responseType: 'GoAccountWalletWithUserKeychain';
+  wallet: IWallet;
+  userKeychain: Keychain;
   warning?: string;
   encryptedWalletPassphrase?: string;
 }
@@ -68,7 +77,7 @@ export interface GenerateWalletOptions {
   isDistributedCustody?: boolean;
   bitgoKeyId?: string;
   commonKeychain?: string;
-  type?: 'hot' | 'cold' | 'custodial';
+  type?: 'hot' | 'cold' | 'custodial' | 'trading';
   subType?: 'lightningCustody' | 'lightningSelfCustody';
   evmKeyRingReferenceWalletId?: string;
 }
@@ -85,6 +94,19 @@ export const GenerateLightningWalletOptionsCodec = t.strict(
 );
 
 export type GenerateLightningWalletOptions = t.TypeOf<typeof GenerateLightningWalletOptionsCodec>;
+
+export const GenerateGoAccountWalletOptionsCodec = t.strict(
+  {
+    label: t.string,
+    passphrase: t.string,
+    enterprise: t.string,
+    passcodeEncryptionCode: t.string,
+    type: t.literal('trading'),
+  },
+  'GenerateGoAccountWalletOptions'
+);
+
+export type GenerateGoAccountWalletOptions = t.TypeOf<typeof GenerateGoAccountWalletOptionsCodec>;
 
 export interface GetWalletByAddressOptions {
   address?: string;
@@ -214,7 +236,9 @@ export interface IWallets {
   get(params?: GetWalletOptions): Promise<Wallet>;
   list(params?: ListWalletOptions): Promise<{ wallets: IWallet[] }>;
   add(params?: AddWalletOptions): Promise<any>;
-  generateWallet(params?: GenerateWalletOptions): Promise<WalletWithKeychains | LightningWalletWithKeychains>;
+  generateWallet(
+    params?: GenerateWalletOptions
+  ): Promise<WalletWithKeychains | LightningWalletWithKeychains | GoAccountWalletWithUserKeychain>;
   listShares(params?: Record<string, unknown>): Promise<any>;
   getShare(params?: { walletShareId?: string }): Promise<any>;
   updateShare(params?: UpdateShareOptions): Promise<any>;


### PR DESCRIPTION
TICKET: CAAS-491

- Streamlining the [CaaS Go Account creation](https://developers.bitgo.com/guides/crypto-as-a-service/go-accounts) by extending the generate wallet endpoint to support Go account wallets
- Add a separate sub-handler to create Go account wallet
- Create new `GoAccountWalletWithUserKeychain` type since Go accounts operate with 1 key - the user key
- Extended the KeyChain type to include `ethAddress` since that was missing from the types but various wallet types has an ethAddress derived from the xpub key in the keychain (checked it out with Go, lightning btc, and hot self-custody)
- added go account creation example script and unit test 
- Tested this locally on testnet and created a Go account successfully
