### PR TITLE
fix: change the netUID data type from number to string for Tao Staking

### DIFF
--- a/modules/sdk-core/src/bitgo/staking/iStakingWallet.ts
+++ b/modules/sdk-core/src/bitgo/staking/iStakingWallet.ts
@@ -170,7 +170,7 @@ export interface TaoStakeOptions extends StakeOptions {
   /**
    * tao staking netUID
    */
-  netUID?: number;
+  netUID?: string;
 }
 
 export interface UnstakeOptions {


### PR DESCRIPTION
Ticket: SC-3399
Resusing UI components for staking drawer which expects the value to be string.