### PR TITLE
feat(sdk-hmac): normalize HTTP methods and updated calculateHMAC types

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -65,6 +65,7 @@ module.exports = {
         'COIN-',
         'FIAT-',
         'ME-',
+        'ANT-',
         '#', // Prefix used by GitHub issues
       ],
     },

--- a/modules/sdk-hmac/src/hmac.ts
+++ b/modules/sdk-hmac/src/hmac.ts
@@ -1,4 +1,4 @@
-import { createHmac } from 'crypto';
+import { type BinaryLike, createHmac, type KeyObject } from 'crypto';
 import * as urlLib from 'url';
 import * as sjcl from '@bitgo/sjcl';
 import {
@@ -16,7 +16,7 @@ import {
  * @param message {String} - the actual message to HMAC
  * @returns {*} - the result of the HMAC operation
  */
-export function calculateHMAC(key: string, message: string): string {
+export function calculateHMAC(key: string | BinaryLike | KeyObject, message: string | BinaryLike): string {
   return createHmac('sha256', key).update(message).digest('hex');
 }
 
@@ -37,6 +37,10 @@ export function calculateHMACSubject({
   method,
   authVersion,
 }: CalculateHmacSubjectOptions): string {
+  /* Normalize legacy 'del' to 'delete' for backward compatibility */
+  if (method === 'del') {
+    method = 'delete';
+  }
   const urlDetails = urlLib.parse(urlPath);
   const queryPath = urlDetails.query && urlDetails.query.length > 0 ? urlDetails.path : urlDetails.pathname;
   if (statusCode !== undefined && isFinite(statusCode) && Number.isInteger(statusCode)) {

--- a/modules/sdk-hmac/src/types.ts
+++ b/modules/sdk-hmac/src/types.ts
@@ -1,4 +1,4 @@
-export const supportedRequestMethods = ['get', 'post', 'put', 'del', 'patch', 'options'] as const;
+export const supportedRequestMethods = ['get', 'post', 'put', 'del', 'patch', 'options', 'delete'] as const;
 
 export type AuthVersion = 2 | 3;
 

--- a/modules/sdk-hmac/test/hmac.ts
+++ b/modules/sdk-hmac/test/hmac.ts
@@ -8,6 +8,7 @@ import {
   verifyResponse,
 } from '../src/hmac';
 import * as sjcl from '@bitgo/sjcl';
+import { createSecretKey } from 'crypto';
 
 // Mock Date.now for consistent timestamp values
 const MOCK_TIMESTAMP = 1672531200000; // Example timestamp (e.g., Jan 1, 2023, 00:00:00 UTC)
@@ -29,6 +30,20 @@ describe('HMAC Utility Functions', () => {
       const message = 'test-message';
       const expectedHmac = 'f8c2bb87c17608c9038eab4e92ef2775e42629c939d6fd3390d42f80af6bb712';
       expect(calculateHMAC(key, message)).to.equal(expectedHmac);
+    });
+
+    it('should accept a Buffer key (BinaryLike) and match the string result', () => {
+      const keyBuffer = Buffer.from('test-key', 'utf8');
+      const message = Buffer.from('test-message');
+      const expectedHmac = 'f8c2bb87c17608c9038eab4e92ef2775e42629c939d6fd3390d42f80af6bb712';
+      expect(calculateHMAC(keyBuffer, message)).to.equal(expectedHmac);
+    });
+
+    it('should accept a KeyObject key and match the string result', () => {
+      const keyObject = createSecretKey(Buffer.from('test-key', 'utf8'));
+      const message = 'test-message';
+      const expectedHmac = 'f8c2bb87c17608c9038eab4e92ef2775e42629c939d6fd3390d42f80af6bb712';
+      expect(calculateHMAC(keyObject, message)).to.equal(expectedHmac);
     });
   });
 


### PR DESCRIPTION
## Description

Enhances calculateHMAC in the sdk-hmac module to support all key and message types accepted by crypto.createHmac. Adds `delete` to the list of supported HTTP methods and normalizes `del` to `delete` for improved backward compatibility with legacy request methods.

## Issue Number
TICKET: ANT-1025

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit Test
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
