### PR TITLE
feat: add Buffer support for HMAC generation

### DIFF
--- a/modules/sdk-api/src/bitgoAPI.ts
+++ b/modules/sdk-api/src/bitgoAPI.ts
@@ -520,9 +520,9 @@ export class BitGoAPI implements BitGoBase {
    * @param timestamp request timestamp from `Date.now()`
    * @param statusCode Only set for HTTP responses, leave blank for requests
    * @param method request method
-   * @returns {string}
+   * @returns {string | Buffer}
    */
-  calculateHMACSubject(params: CalculateHmacSubjectOptions): string {
+  calculateHMACSubject<T extends string | Buffer = string>(params: CalculateHmacSubjectOptions<T>): T {
     return sdkHmac.calculateHMACSubject({ ...params, authVersion: this._authVersion });
   }
 

--- a/modules/sdk-hmac/src/types.ts
+++ b/modules/sdk-hmac/src/types.ts
@@ -2,27 +2,27 @@ export const supportedRequestMethods = ['get', 'post', 'put', 'del', 'patch', 'o
 
 export type AuthVersion = 2 | 3;
 
-export interface CalculateHmacSubjectOptions {
+export interface CalculateHmacSubjectOptions<T> {
   urlPath: string;
-  text: string;
+  text: T;
   timestamp: number;
   method: (typeof supportedRequestMethods)[number];
   statusCode?: number;
   authVersion: AuthVersion;
 }
 
-export interface CalculateRequestHmacOptions {
+export interface CalculateRequestHmacOptions<T extends string | Buffer = string> {
   url: string;
-  text: string;
+  text: T;
   timestamp: number;
   token: string;
   method: (typeof supportedRequestMethods)[number];
   authVersion: AuthVersion;
 }
 
-export interface CalculateRequestHeadersOptions {
+export interface CalculateRequestHeadersOptions<T extends string | Buffer = string> {
   url: string;
-  text: string;
+  text: T;
   token: string;
   method: (typeof supportedRequestMethods)[number];
   authVersion: AuthVersion;
@@ -34,20 +34,20 @@ export interface RequestHeaders {
   tokenHash: string;
 }
 
-export interface VerifyResponseOptions extends CalculateRequestHeadersOptions {
+export interface VerifyResponseOptions<T extends string | Buffer = string> extends CalculateRequestHeadersOptions<T> {
   hmac: string;
   url: string;
-  text: string;
+  text: T;
   timestamp: number;
   method: (typeof supportedRequestMethods)[number];
   statusCode?: number;
   authVersion: AuthVersion;
 }
 
-export interface VerifyResponseInfo {
+export interface VerifyResponseInfo<T extends string | Buffer = string> {
   isValid: boolean;
   expectedHmac: string;
-  signatureSubject: string;
+  signatureSubject: T;
   isInResponseValidityWindow: boolean;
   verificationTime: number;
 }


### PR DESCRIPTION
Ticket: ANT-1033


## Description

This change enhances the `calculateHMACSubject` function to support Buffers in addition to strings. This will allow us to pass buffers directly from WP instead of having to call `toString()` which incurs a performance cost. Existing tests pass, and new tests have been added to verify the HMAC generation/verification works with Buffers.

This change is part of the V3 auth improvements [epic](https://bitgoinc.atlassian.net/browse/ANT-1014)

## Issue Number

[ANT-1033](https://bitgoinc.atlassian.net/browse/ANT-1033)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [x] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



[ANT-1033]: https://bitgoinc.atlassian.net/browse/ANT-1033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ