### PR TITLE
feat(secp256k1): implement public key recovery in secp256k1 unit tests

### DIFF
--- a/modules/sdk-coin-flrp/test/unit/lib/utils.ts
+++ b/modules/sdk-coin-flrp/test/unit/lib/utils.ts
@@ -193,6 +193,68 @@ describe('Utils', function () {
     });
   });
 
+  describe('recoverySignature', function () {
+    it('should recover public key from valid signature', function () {
+      const network = coins.get('flrp').network as FlareNetwork;
+      const message = Buffer.from('hello world', 'utf8');
+      const privateKey = Buffer.from('0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef', 'hex');
+
+      // Create signature using the same private key
+      const signature = utils.createSignature(network, message, privateKey);
+
+      // Recover public key
+      const recoveredPubKey = utils.recoverySignature(network, message, signature);
+
+      assert.ok(recoveredPubKey instanceof Buffer);
+      assert.strictEqual(recoveredPubKey.length, 33); // Should be compressed public key (33 bytes)
+    });
+
+    it('should recover same public key for same message and signature', function () {
+      const network = coins.get('flrp').network as FlareNetwork;
+      const message = Buffer.from('hello world', 'utf8');
+      const privateKey = Buffer.from('0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef', 'hex');
+      const signature = utils.createSignature(network, message, privateKey);
+
+      const pubKey1 = utils.recoverySignature(network, message, signature);
+      const pubKey2 = utils.recoverySignature(network, message, signature);
+
+      assert.deepStrictEqual(pubKey1, pubKey2);
+    });
+
+    it('should recover public key that matches original key', function () {
+      const network = coins.get('flrp').network as FlareNetwork;
+      const message = Buffer.from('hello world', 'utf8');
+      const privateKey = Buffer.from('0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef', 'hex');
+
+      // Get original public key
+      const { ecc } = require('@bitgo/secp256k1');
+      const originalPubKey = Buffer.from(ecc.pointFromScalar(privateKey, true) as Uint8Array);
+
+      // Create signature and recover public key
+      const signature = utils.createSignature(network, message, privateKey);
+      const recoveredPubKey = utils.recoverySignature(network, message, signature);
+
+      // Convert both to hex strings for comparison
+      assert.strictEqual(recoveredPubKey.toString('hex'), originalPubKey.toString('hex'));
+    });
+
+    it('should throw error for invalid signature', function () {
+      const network = coins.get('flrp').network as FlareNetwork;
+      const message = Buffer.from('hello world', 'utf8');
+      const invalidSignature = Buffer.from('invalid signature', 'utf8');
+
+      assert.throws(() => utils.recoverySignature(network, message, invalidSignature), /Failed to recover signature/);
+    });
+
+    it('should throw error for empty message', function () {
+      const network = coins.get('flrp').network as FlareNetwork;
+      const message = Buffer.alloc(0);
+      const signature = Buffer.alloc(65); // Empty but valid length signature (65 bytes: 64 signature + 1 recovery param)
+
+      assert.throws(() => utils.recoverySignature(network, message, signature), /Failed to recover signature/);
+    });
+  });
+
   describe('address parsing utilities', function () {
     it('should handle address separator constants', function () {
       const { ADDRESS_SEPARATOR } = require('../../../src/lib/iface');

--- a/modules/secp256k1/src/index.ts
+++ b/modules/secp256k1/src/index.ts
@@ -103,6 +103,27 @@ const ecc = {
     return necc.verify(signature, h, Q, { strict });
   },
 
+  recoverPublicKey: (
+    h: Uint8Array,
+    signature: Uint8Array,
+    recovery: number,
+    compressed?: boolean
+  ): Uint8Array | null => {
+    // Message hash must be exactly 32 bytes
+    if (h.length !== 32) {
+      return null;
+    }
+    // Signature must be exactly 64 bytes (r and s components)
+    if (signature.length !== 64) {
+      return null;
+    }
+    // Recovery value must be 0 or 1
+    if (recovery !== 0 && recovery !== 1) {
+      return null;
+    }
+    return throwToNull(() => necc.recoverPublicKey(h, signature, recovery, defaultTrue(compressed)));
+  },
+
   verifySchnorr: (h: Uint8Array, Q: Uint8Array, signature: Uint8Array): boolean => {
     return necc.schnorr.verifySync(signature, h, Q);
   },


### PR DESCRIPTION
Ticket: WIN-7654

enhance signature creation and recovery with secp256k1 package for sdk-[coin-flrp](https://bitgoinc.atlassian.net/browse/COIN-flrp) and added related test cases

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
