### PR TITLE
docs: cleaning up the readme verbiage dx-2014

### DIFF
--- a/examples/js/trx/consolidate-account-balances.js
+++ b/examples/js/trx/consolidate-account-balances.js
@@ -2,7 +2,7 @@
  * Tron wallet can't send funds from their receive addresses.
  * Account balance consolidation is used to sweep funds from the
  * receive addresses into the wallet's base address for sending.
- * @see {@link https://app.bitgo.com/docs/#operation/v2.wallet.consolidateaccount.build}
+ * @see {@link https://developers.bitgo.com/reference/v2walletconsolidateaccountbuild#/}
  */
 const BitGoJS = require('bitgo');
 

--- a/examples/js/xtz/consolidate-account-balances.js
+++ b/examples/js/xtz/consolidate-account-balances.js
@@ -2,7 +2,7 @@
  * Tezos wallet can't send funds from their receive addresses.
  * Account balance consolidation is used to sweep funds from the
  * receive addresses into the wallet's base address for sending.
- * @see {@link https://app.bitgo.com/docs/#operation/v2.wallet.consolidateaccount.build}
+ * @see {@link https://developers.bitgo.com/reference/v2walletconsolidateaccountbuild#/}
  */
 const BitGoJS = require('bitgo');
 const Promise = require('bluebird');

--- a/examples/ts/trx/consolidate-hot-account-balances.ts
+++ b/examples/ts/trx/consolidate-hot-account-balances.ts
@@ -2,7 +2,7 @@
  * Tron wallets can't send funds from their receive addresses.
  * Account balance consolidation is used to sweep funds from the
  * receive addresses into the wallet's base address for sending.
- * @see {@link https://app.bitgo.com/docs/#operation/v2.wallet.consolidateaccount.build}
+ * @see {@link https://developers.bitgo.com/reference/v2walletconsolidateaccountbuild#/}
  */
 import { BitGo, WalletCoinSpecific } from 'bitgo';
 

--- a/examples/ts/xtz/consolidate-account-balances.ts
+++ b/examples/ts/xtz/consolidate-account-balances.ts
@@ -2,7 +2,7 @@
  * Tezos wallet can't send funds from their receive addresses.
  * Account balance consolidation is used to sweep funds from the
  * receive addresses into the wallet's base address for sending.
- * @see {@link https://app.bitgo.com/docs/#operation/v2.wallet.consolidateaccount.build}
+ * @see {@link https://developers.bitgo.com/reference/v2walletconsolidateaccountbuild#/}
  */
 import { BitGo, WalletCoinSpecific } from 'bitgo';
 

--- a/modules/bitgo/README.md
+++ b/modules/bitgo/README.md
@@ -1,39 +1,39 @@
 # BitGo JavaScript SDK
 
-The BitGo Platform and SDK makes it easy to build multi-signature crypto-currency applications today with support for Bitcoin, Ethereum and many other coins.
-The SDK is fully integrated with the BitGo co-signing service for managing all of your BitGo wallets.
+The BitGo Platform enables you to build multisignature and MPC cryptocurrency applications for over a thousand digital assets. You can view all BitGo supported assets on the [Developer Portal](https://assets.bitgo.com/coins). The SDK is fully integrated with the BitGo co-signing service for managing all of your BitGo wallets.
 
-Included in the SDK are examples for how to use the API to manage your multi-signature wallets.
+The SDK includes examples for how to use the API to manage your wallets.
 
-Please email us at support@bitgo.com if you have questions or comments about this API.
+If you have questions or comments about this API, email support@bitgo.com.
 
 [![Known Vulnerabilities](https://snyk.io/test/github/BitGo/BitGoJS/badge.svg)](https://snyk.io/test/github/BitGo/BitGoJS)
 [![BitGo SDK](https://github.com/BitGo/BitGoJS/actions/workflows/ci.yml/badge.svg)](https://github.com/BitGo/BitGoJS/actions/workflows/ci.yml)
 
 # Installation
 
-Please make sure you are running at least Node version 20 (the latest LTS release is recommended) and NPM version 10.
-We recommend using `nvm`, the [Node Version Manager](https://github.com/creationix/nvm/blob/master/README.markdown#installation), for setting your Node version.
+Ensure you're running Node version 20 or higher (preferably the latest LTS release) and NPM version 10.
+For setting your Node version, we recommend using `nvm` - the [Node Version Manager](https://github.com/creationix/nvm/blob/master/README.markdown#installation).
 
 `npm install --save bitgo`
 
 # Full Documentation
 
-For more general information about the BitGo API and various integration guides, please see our [Developer Portal](https://developers.bitgo.com/).
+For more comprehensive information about the BitGo API, including integration guides, see the BitGo [Developer Portal](https://developers.bitgo.com/).
 
 # Release Notes
 
-You can find the complete release notes (since version 4.44.0) [here](https://github.com/BitGo/BitGoJS/blob/master/modules/bitgo/CHANGELOG.md).
+- [API changelog](https://github.com/BitGo/api-changelog/)
+- [SDK changelog](https://github.com/BitGo/BitGoJS/blob/master/modules/bitgo/CHANGELOG.md) (since version 4.44.0)
 
 # Example Usage
 
-Examples and integration guides for BitGoJS or BitGo Express can be found in the [Developer Portal](https://developers.bitgo.com/guides/get-started/intro) or the [examples directory](https://github.com/BitGo/BitGoJS/tree/master/examples).
+You can view examples in the [examples directory](https://github.com/BitGo/BitGoJS/tree/master/examples). You can view integration guides in the [Developer Portal](https://developers.bitgo.com/guides/get-started/intro).
 
 # Enabling additional debugging output
 
 `bitgo` uses the `debug` package to emit extra information, which can be useful when debugging issues with BitGoJS or BitGo Express.
 
-When using the `bitgo` npm package, the easiest way to enable debug output is by setting the `DEBUG` environment variable to one or more of the debug namespaces in the table below. Multiple debug namespaces can be enabled by giving a comma-separated list or by using `*` as a wildcard. See the [debug package documentation](https://github.com/visionmedia/debug#readme) for more details.
+When using the `bitgo` npm package, the easiest way to enable debug output is to set the `DEBUG` environment variable to one or more of the debug namespaces in the table below. You can enable multiple debug namespaces by using a comma-separated list or by using `*` as a wildcard. See the [debug package documentation](https://github.com/visionmedia/debug#readme) for more details.
 
 ## Available Debug Namespaces
 
@@ -47,18 +47,18 @@ When using the `bitgo` npm package, the easiest way to enable debug output is by
 | `bitgo:v2:eth`              | Ethereum specific output. Currently only failures to require the optional Ethereum libraries are reported                            |
 | `bitgo:v2:util`             | SDK utilities specific output. Currently only failures to require the optional Ethereum libraries are reported                       |
 
-Another debug namespace which is not provided by BitGoJS but is helpful nonetheless is the `superagent` namespace, which will output all HTTP requests and responses (only the URL, not bodies).
+Another debug namespace that BitGoJS doesn't provide but is helpful nonetheless is the `superagent` namespace. This outputs all HTTP requests and responses (only the URL, not bodies).
 
 ## Example
 
-To run an SDK script with debug output enabled, export the DEBUG environment variable before running.
+To run an SDK script with debug output enabled, export the `DEBUG` environment variable before running.
 
 ```shell script
 export DEBUG='bitgo:*' # enable all bitgo debug namespaces
 node myScript.js
 ```
 
-To set debug namespaces in the browser, you should set `localStorage.debug` property instead of the `DEBUG` environment variable using your browser's development tools console.
+To set debug namespaces in a browser, set the `localStorage.debug` property instead of the `DEBUG` environment variable using your browser's development tools console.
 
 ```js
 localStorage.debug = 'bitgo:*'; // enable all bitgo debug namespaces
@@ -66,13 +66,13 @@ localStorage.debug = 'bitgo:*'; // enable all bitgo debug namespaces
 
 # Using with TypeScript
 
-`bitgo` is not yet compatible with the `noImplicitAny` compiler option. If you want to use this option in your project (and we recommend that you do), you must set the `skipLibCheck` option to supress errors about missing type definitions for dependencies of `bitgo`.
+`bitgo` is not yet compatible with the `noImplicitAny` compiler option. To use this option in your project (and we recommend that you do), you must set the `skipLibCheck` option to suppress errors about missing type definitions for dependencies of `bitgo`.
 
-# Usage in Browser
+# Usage in browser
 
-Since version 6, `bitgo` includes a minified, browser-compatible bundle by default at `dist/browser/BitGoJS.min.js`. It can be copied from there directly into your project.
+Since version 6, `bitgo` includes a minified, browser-compatible bundle by default at `dist/browser/BitGoJS.min.js`. You can copy the bundle from there and paste it directly into your project.
 
-BitGoJS can also be bundled with any module bundler. There is a Webpack configuration file already included, which can be triggered with package scripts.
+You can also bundle BitGoJS with any module bundler. There's a Webpack configuration file already included, which you can use to trigger with package scripts.
 
 For a production build: `npm run-script compile`
 

--- a/modules/express/README.md
+++ b/modules/express/README.md
@@ -1,19 +1,18 @@
-# BitGo Express Local Signing Server (REST API)
+# BitGo Express local signing server (REST API)
 
-Suitable for developers working in a language without an official BitGo SDK.
+BitGo Express is suitable for developers working in a language without an official BitGo SDK.
 
-BitGo Express runs as a service in your own datacenter, and handles the client-side operations involving your own keys, such as partially signing transactions before submitting to BitGo.
-This ensures your keys never leave your network, and are not seen by BitGo. BitGo Express can also proxy the standard BitGo REST APIs, providing a unified interface to BitGo through a single REST API.
+BitGo Express runs as a service in your own datacenter, and handles the client-side operations involving your own keys, such as partially signing transactions before submitting to BitGo. This ensures your keys never leave your network, and are not seen by BitGo. BitGo Express can also proxy the standard BitGo REST APIs, providing a unified interface to BitGo through a single REST API.
 
 # Documentation
 
-Comprehensive documentation on the APIs provided by BitGo Express can be found at our [Platform API Reference](https://app.bitgo.com/docs/#tag/Express).
+View comprehensive documentation on the BitGo [Developer Portal](https://developers.bitgo.com/docs/get-started-express-install/).
 
 # Running BitGo Express
 
 ## Docker
 
-For most users, we recommend running BitGo Express as a docker container, since this is the most secure way to run BitGo Express.
+For most users, we recommend running BitGo Express as a Docker container, since this's the most secure way to run BitGo Express.
 
 > Deprecation Warning: bitgosdk/express will no longer receive updates. Please use the official bitgo/express images.
 
@@ -73,13 +72,13 @@ $ openssl req -newkey rsa:2048 -nodes -keyout cert.key -x509 -days 3650 -out cer
 
 This will output a key file `cert.key` and certificate file `cert.crt`
 
-Finally you can run your docker container like this (note, replace `/path/to` with the full path to your `certs` folder):
+Finally you can run your Docker container like this (note, replace `/path/to` with the full path to your `certs` folder):
 
 ```bash
 $ docker run -it --volume /path/to/certs:/private -p 4000:4000 bitgo/express:latest -p 4000 -k /private/cert.key -c /private/cert.crt -e prod
 ```
 
-An alternative way to provide the ssl certification is to export them as environment variables.
+An alternative way to provide the SSL certification is to export them as environment variables.
 
 ```bash
 $ export BITGO_SSL_KEY=$(cat /private/cert.key)
@@ -98,9 +97,9 @@ Environment: prod
 Base URI: https://0.0.0.0:4000
 ```
 
-### Building the docker container
+### Building the Docker container
 
-If you'd like to build the BitGo Express docker container yourself from the source code, first check out the latest **master** branch, then run `docker build` from the project root. Here's the commands:
+To build the BitGo Express Docker container yourself from the source code, check out the latest **master** branch and run `docker build` from the project root.
 
 ```bash
 $ git clone https://github.com/bitgo/bitgojs
@@ -109,7 +108,7 @@ $ docker build -t bitgo-express:latest .
 $ docker run -it bitgo-express:latest
 ```
 
-Another way to build the BitGo Express docker container if you have `yarn` installed:
+You can also build the BitGo Express Docker container using `yarn`:
 
 ```bash
 $ git clone https://github.com/bitgo/bitgojs
@@ -120,17 +119,15 @@ $ docker run -it bitgo-express:latest
 
 ## From source
 
-For users who are unable to run BitGo Express as a docker container, we recommend building and running from the source code.
+For users who are unable to run BitGo Express as a Docker container, we recommend building and running from the source code.
 
 ### Prerequisites
 
-Please make sure you are running at least Node version 16.
-We recommend using `nvm`, the [Node Version Manager](https://github.com/creationix/nvm/blob/master/README.markdown#installation), for setting your Node version.
-BitGo Express has become a first class citizen of the monorepo so we recommend using `yarn` for local setup.
+Ensure you're running at least Node version 16. We recommend using `nvm`, the [Node Version Manager](https://github.com/creationix/nvm/blob/master/README.markdown#installation), for setting your Node version. BitGo Express has become a first class citizen of the monorepo so we recommend using `yarn` for local setup.
 
 ### Cloning the repository and installing dependencies
 
-First, clone the latest **master** branch, then run `yarn install` in the project root directory.
+Clone the latest **master** branch and run `yarn install` in the project root directory.
 
 ```bash
 $ git clone https://github.com/bitgo/bitgojs
@@ -140,7 +137,7 @@ $ yarn install --frozen-lockfile && yarn install --production --frozen-lockfile 
 
 ### Running BitGo Express
 
-From the express module folder (`modules/express`), run this command:
+From the Express module folder (`modules/express`), run this command:
 
 ```bash
 $ yarn run start
@@ -235,7 +232,7 @@ BitGo Express is able to take configuration options from either command line arg
 | N/A             | --disableproxy                  | `BITGO_DISABLE_PROXY` <sup>0</sup>        | N/A           | Disable proxying of routes not explicitly handled by bitgo-express                                                                                                                                                                                                                                                                                   |
 | N/A             | --disableenvcheck               | `BITGO_DISABLE_ENV_CHECK` <sup>0</sup>    | N/A           | Disable checking for correct `NODE_ENV` environment variable when running against BitGo production environment.                                                                                                                                                                                                                                      |
 | -i              | --ipc                           | `BITGO_IPC`                               | N/A           | If set, bind to the given IPC (unix domain) socket. Binding to an IPC socket can be useful if the caller of bitgo-express resides on the same host as the bitgo-express instance itself, since the socket can be secured using normal file permissions and ownership semantics. Note: This is not supported on Windows platforms.                    |
-| N/A             | --authversion                   | `BITGO_AUTH_VERSION`                      | 2             | BitGo Authentication scheme version which should be used form making requests to the BitGo server. Please see the [BitGo API documentation](https://app.bitgo.com/docs) for more info on authentication scheme versions.                                                                                                                             |
+| N/A             | --authversion                   | `BITGO_AUTH_VERSION`                      | 2             | BitGo Authentication scheme version which should be used form making requests to the BitGo server. For more info on authentication scheme versions, view the API reference on the BitGo [Developer Portal](https://developers.bitgo.com/reference/overview#/).                                                                                                                             |
 | N/A             | --externalSignerUrl             | `BITGO_EXTERNAL_SIGNER_URL`               | N/A           | URL specifying the external API to call for remote signing.                                                                                                                                                                                                                                                                                          |
 | N/A             | --signerMode                    | `BITGO_SIGNER_MODE `                      | N/A           | If set, run Express as a remote signer.                                                                                                                                                                                                                                                                                                              |
 | N/A             | --signerFileSystemPath          | `BITGO_SIGNER_FILE_SYSTEM_PATH `          | N/A           | Local path specifying where an Express signer machine keeps the encrypted user private keys. Required when signerMode is set.                                                                                                                                                                                                                        |

--- a/modules/sdk-coin-iota/README.md
+++ b/modules/sdk-coin-iota/README.md
@@ -36,4 +36,4 @@ const iota = sdk.coin('iota');
 
 ## Documentation
 
-For detailed API documentation, see the [BitGo API reference](https://app.bitgo.com/docs/).
+For detailed API documentation, view the BitGo [Developer Portal](https://developers.bitgo.com/reference/overview#/).


### PR DESCRIPTION
Went looking for public-facing links to old/deprecated doc pages and couldn't stop myself from doing some copy editing for style and verbiage along the way.

Resolves DX-2014.