### PR TITLE
feat(abstract-utxo): remove deprecated getCoinLibrary method

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -437,13 +437,6 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
   }
 
   /**
-   * @deprecated
-   */
-  getCoinLibrary() {
-    return utxolib;
-  }
-
-  /**
    * Check if an address is valid
    * @param address
    * @param param


### PR DESCRIPTION

Remove the deprecated getCoinLibrary method from the abstract-utxo
package. This method was previously marked as deprecated and is no longer
needed as part of our ongoing efforts to modernize the codebase.

BTC-2650