### PR TITLE
fix: Do not append text to HMAC subject if undefined

### DIFF
--- a/modules/sdk-hmac/src/hmac.ts
+++ b/modules/sdk-hmac/src/hmac.ts
@@ -57,13 +57,12 @@ export function calculateHMACSubject<T extends string | Buffer = string>({
         ? [method.toUpperCase(), timestamp, '3.0', queryPath].join('|')
         : [timestamp, queryPath].join('|');
   }
-  prefixedText += '|';
 
   const isBuffer = Buffer.isBuffer(text);
   if (isBuffer) {
-    return Buffer.concat([Buffer.from(prefixedText, 'utf-8'), text]) as T;
+    return Buffer.concat([Buffer.from(prefixedText + '|', 'utf-8'), text]) as T;
   }
-  return (prefixedText + text) as T;
+  return [prefixedText, text].join('|') as T;
 }
 
 /**

--- a/modules/sdk-hmac/test/hmac.ts
+++ b/modules/sdk-hmac/test/hmac.ts
@@ -75,6 +75,20 @@ describe('HMAC Utility Functions', () => {
       ).to.equal(expectedSubject);
     });
 
+    it('should not include undefined for a response when text is undefined', () => {
+      const expectedSubject = 'GET|1672531200000|/api/test|200|';
+      expect(
+        calculateHMACSubject({
+          urlPath: '/api/test',
+          text: undefined as unknown as string,
+          timestamp: MOCK_TIMESTAMP,
+          statusCode: 200,
+          method: 'get',
+          authVersion: 3,
+        })
+      ).to.equal(expectedSubject);
+    });
+
     it('should handle Buffer text input and return a Buffer for requests', () => {
       const buffer = Buffer.from('binary-data-content');
       const result = calculateHMACSubject({
@@ -94,6 +108,22 @@ describe('HMAC Utility Functions', () => {
       // Manually reconstruct the expected buffer to compare
       const expectedBuffer = Buffer.concat([prefixBuffer, buffer]);
       expect(result).to.deep.equal(expectedBuffer);
+    });
+
+    it('should handle Buffer undefined text input and return a Buffer for requests', () => {
+      const buffer = undefined as unknown as Buffer;
+      const result = calculateHMACSubject({
+        urlPath: '/api/test',
+        text: buffer,
+        timestamp: MOCK_TIMESTAMP,
+        method: 'get',
+        authVersion: 3,
+      });
+
+      expect(Buffer.isBuffer(result)).to.be.false;
+
+      const expectedSubject = 'GET|1672531200000|3.0|/api/test|';
+      expect(result).to.deep.equal(expectedSubject);
     });
 
     it('should handle Buffer text input and return a Buffer for responses', () => {


### PR DESCRIPTION
Ticket: ANT-1033

## Description

This PR introduces a small change that normalizes the behaviour of `calculateHMACSubject` so that it is the same as before the v3 improvements. In particular, if text was ever `undefined`, the returned subject would be `|..|..|`. Doing `prefix + text` results in `|..|..|undefined`, which is not the same behaviour. This PR fixes this and adds tests for this edge case.

## Issue Number

ANT-1033

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit test
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [x] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

