### PR TITLE
feat: add  in package json to correctly resolve esm-based projects

### DIFF
--- a/modules/sdk-coin-canton/package.json
+++ b/modules/sdk-coin-canton/package.json
@@ -6,14 +6,17 @@
   "types": "./dist/src/index.d.ts",
   "exports": {
     ".": {
+      "import": "./dist/src/index.js",
       "require": "./dist/src/index.js",
       "types": "./dist/src/index.d.ts"
     },
     "./resources/proto/preparedTransaction": {
+      "import": "./dist/resources/proto/preparedTransaction.js",
       "require": "./dist/resources/proto/preparedTransaction.js",
       "types": "./dist/resources/proto/preparedTransaction.d.ts"
     },
     "./resources/hash/hash": {
+      "import": "./dist/resources/hash/hash.js",
       "require": "./dist/resources/hash/hash.js",
       "types": "./dist/resources/hash/hash.d.ts"
     }


### PR DESCRIPTION
[UI bumps](https://github.com/BitGo/bitgo-ui/pull/9071) are failing when I added the `sdk-coin-canton` dependency with error,
`Caused by: Error: Failed to resolve entry for package "@bitgo-beta/sdk-coin-canton". The package may have incorrect main/module/exports specified in its package.json: No known conditions for "." specifier in "@bitgo-beta/sdk-coin-canton" package`

To resolve this, need to add `import` in the package json exports

Ticket: [COIN-6175](https://bitgoinc.atlassian.net/browse/COIN-6175)


[COIN-6175]: https://bitgoinc.atlassian.net/browse/COIN-6175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ