### PR TITLE
feat(abstract-utxo): refactor address generation and test structure

### DIFF
--- a/modules/abstract-utxo/src/address/fixedScript.ts
+++ b/modules/abstract-utxo/src/address/fixedScript.ts
@@ -1,0 +1,191 @@
+import _ from 'lodash';
+import {
+  AddressTypeChainMismatchError,
+  CreateAddressFormat,
+  InvalidAddressDerivationPropertyError,
+  UnexpectedAddressError,
+  P2shP2wshUnsupportedError,
+  P2trMusig2UnsupportedError,
+  P2trUnsupportedError,
+  P2wshUnsupportedError,
+  UnsupportedAddressTypeError,
+  sanitizeLegacyPath,
+} from '@bitgo/sdk-core';
+import * as utxolib from '@bitgo/utxo-lib';
+import { bitgo } from '@bitgo/utxo-lib';
+import { bip32 } from '@bitgo/secp256k1';
+
+type ScriptType2Of3 = bitgo.outputScripts.ScriptType2Of3;
+
+export interface FixedScriptAddressCoinSpecific {
+  outputScript?: string;
+  redeemScript?: string;
+  witnessScript?: string;
+}
+
+export interface GenerateAddressOptions {
+  addressType?: ScriptType2Of3;
+  threshold?: number;
+  chain?: number;
+  index?: number;
+  segwit?: boolean;
+  bech32?: boolean;
+}
+
+export interface GenerateFixedScriptAddressOptions extends GenerateAddressOptions {
+  format?: CreateAddressFormat;
+  keychains: { pub: string }[];
+}
+
+function canonicalAddress(network: utxolib.Network, address: string, format?: CreateAddressFormat): string {
+  if (format === 'cashaddr') {
+    const script = utxolib.addressFormat.toOutputScriptTryFormats(address, network);
+    return utxolib.addressFormat.fromOutputScriptWithFormat(script, format, network);
+  }
+  // Default to canonical format (base58 for most coins)
+  return utxolib.addressFormat.toCanonicalFormat(address, network);
+}
+
+function supportsAddressType(network: utxolib.Network, addressType: ScriptType2Of3): boolean {
+  return utxolib.bitgo.outputScripts.isSupportedScriptType(network, addressType);
+}
+
+export function generateAddressWithChainAndIndex(
+  network: utxolib.Network,
+  keychains: { pub: string }[],
+  chain: bitgo.ChainCode,
+  index: number,
+  format: CreateAddressFormat | undefined
+): string {
+  const path = '0/0/' + chain + '/' + index;
+  const hdNodes = keychains.map(({ pub }) => bip32.fromBase58(pub));
+  const derivedKeys = hdNodes.map((hdNode) => hdNode.derivePath(sanitizeLegacyPath(path)).publicKey);
+  const addressType = bitgo.scriptTypeForChain(chain);
+
+  const { scriptPubKey: outputScript } = utxolib.bitgo.outputScripts.createOutputScript2of3(derivedKeys, addressType);
+
+  const address = utxolib.address.fromOutputScript(outputScript, network);
+
+  return canonicalAddress(network, address, format);
+}
+
+/**
+ * Generate an address for a wallet based on a set of configurations
+ * @param params.addressType {string}   Deprecated
+ * @param params.keychains   {[object]} Array of objects with xpubs
+ * @param params.threshold   {number}   Minimum number of signatures
+ * @param params.chain       {number}   Derivation chain (see https://github.com/BitGo/unspents/blob/master/src/codes.ts for
+ *                                                 the corresponding address type of a given chain code)
+ * @param params.index       {number}   Derivation index
+ * @param params.segwit      {boolean}  Deprecated
+ * @param params.bech32      {boolean}  Deprecated
+ * @returns {string} The generated address
+ */
+export function generateAddress(network: utxolib.Network, params: GenerateFixedScriptAddressOptions): string {
+  let derivationIndex = 0;
+  if (_.isInteger(params.index) && (params.index as number) > 0) {
+    derivationIndex = params.index as number;
+  }
+
+  const { keychains, threshold, chain, segwit = false, bech32 = false } = params as GenerateFixedScriptAddressOptions;
+
+  let derivationChain = bitgo.getExternalChainCode('p2sh');
+  if (_.isNumber(chain) && _.isInteger(chain) && bitgo.isChainCode(chain)) {
+    derivationChain = chain;
+  }
+
+  function convertFlagsToAddressType(): ScriptType2Of3 {
+    if (bitgo.isChainCode(chain)) {
+      return bitgo.scriptTypeForChain(chain);
+    }
+    if (_.isBoolean(segwit) && segwit) {
+      return 'p2shP2wsh';
+    } else if (_.isBoolean(bech32) && bech32) {
+      return 'p2wsh';
+    } else {
+      return 'p2sh';
+    }
+  }
+
+  const addressType = params.addressType || convertFlagsToAddressType();
+
+  if (addressType !== utxolib.bitgo.scriptTypeForChain(derivationChain)) {
+    throw new AddressTypeChainMismatchError(addressType, derivationChain);
+  }
+
+  if (!supportsAddressType(network, addressType)) {
+    switch (addressType) {
+      case 'p2sh':
+        throw new Error(`internal error: p2sh should always be supported`);
+      case 'p2shP2wsh':
+        throw new P2shP2wshUnsupportedError();
+      case 'p2wsh':
+        throw new P2wshUnsupportedError();
+      case 'p2tr':
+        throw new P2trUnsupportedError();
+      case 'p2trMusig2':
+        throw new P2trMusig2UnsupportedError();
+      default:
+        throw new UnsupportedAddressTypeError();
+    }
+  }
+
+  let signatureThreshold = 2;
+  if (_.isInteger(threshold)) {
+    signatureThreshold = threshold as number;
+    if (signatureThreshold <= 0) {
+      throw new Error('threshold has to be positive');
+    }
+    if (signatureThreshold > keychains.length) {
+      throw new Error('threshold cannot exceed number of keys');
+    }
+  }
+
+  return generateAddressWithChainAndIndex(network, keychains, derivationChain, derivationIndex, params.format);
+}
+
+type Keychain = {
+  pub: string;
+};
+
+export function assertFixedScriptWalletAddress(
+  network: utxolib.Network,
+  {
+    chain,
+    index,
+    keychains,
+    format,
+    addressType,
+    address,
+  }: {
+    chain: number | undefined;
+    index: number;
+    keychains: Keychain[];
+    format: CreateAddressFormat;
+    addressType: string | undefined;
+    address: string;
+  }
+): void {
+  if ((_.isUndefined(chain) && _.isUndefined(index)) || !(_.isFinite(chain) && _.isFinite(index))) {
+    throw new InvalidAddressDerivationPropertyError(
+      `address validation failure: invalid chain (${chain}) or index (${index})`
+    );
+  }
+
+  if (!keychains) {
+    throw new Error('missing required param keychains');
+  }
+
+  const expectedAddress = generateAddress(network, {
+    format,
+    addressType: addressType as ScriptType2Of3,
+    keychains,
+    threshold: 2,
+    chain,
+    index,
+  });
+
+  if (expectedAddress !== address) {
+    throw new UnexpectedAddressError(`address validation failure: expected ${expectedAddress} but got ${address}`);
+  }
+}

--- a/modules/abstract-utxo/src/address/fixedScript.ts
+++ b/modules/abstract-utxo/src/address/fixedScript.ts
@@ -25,14 +25,13 @@ export interface FixedScriptAddressCoinSpecific {
 
 export interface GenerateAddressOptions {
   addressType?: ScriptType2Of3;
-  threshold?: number;
   chain?: number;
   index?: number;
   segwit?: boolean;
   bech32?: boolean;
 }
 
-export interface GenerateFixedScriptAddressOptions extends GenerateAddressOptions {
+interface GenerateFixedScriptAddressOptions extends GenerateAddressOptions {
   format?: CreateAddressFormat;
   keychains: { pub: string }[];
 }
@@ -169,7 +168,6 @@ export function assertFixedScriptWalletAddress(
     format,
     addressType: addressType as ScriptType2Of3,
     keychains,
-    threshold: 2,
     chain,
     index,
   });

--- a/modules/abstract-utxo/src/address/fixedScript.ts
+++ b/modules/abstract-utxo/src/address/fixedScript.ts
@@ -87,7 +87,7 @@ export function generateAddress(network: utxolib.Network, params: GenerateFixedS
     derivationIndex = params.index as number;
   }
 
-  const { keychains, threshold, chain, segwit = false, bech32 = false } = params as GenerateFixedScriptAddressOptions;
+  const { keychains, chain, segwit = false, bech32 = false } = params as GenerateFixedScriptAddressOptions;
 
   let derivationChain = bitgo.getExternalChainCode('p2sh');
   if (_.isNumber(chain) && _.isInteger(chain) && bitgo.isChainCode(chain)) {
@@ -127,17 +127,6 @@ export function generateAddress(network: utxolib.Network, params: GenerateFixedS
         throw new P2trMusig2UnsupportedError();
       default:
         throw new UnsupportedAddressTypeError();
-    }
-  }
-
-  let signatureThreshold = 2;
-  if (_.isInteger(threshold)) {
-    signatureThreshold = threshold as number;
-    if (signatureThreshold <= 0) {
-      throw new Error('threshold has to be positive');
-    }
-    if (signatureThreshold > keychains.length) {
-      throw new Error('threshold cannot exceed number of keys');
     }
   }
 

--- a/modules/abstract-utxo/src/address/index.ts
+++ b/modules/abstract-utxo/src/address/index.ts
@@ -1,0 +1,6 @@
+export {
+  generateAddress,
+  generateAddressWithChainAndIndex,
+  assertFixedScriptWalletAddress,
+  FixedScriptAddressCoinSpecific,
+} from './fixedScript';

--- a/modules/abstract-utxo/src/index.ts
+++ b/modules/abstract-utxo/src/index.ts
@@ -1,4 +1,5 @@
 export * from './abstractUtxoCoin';
+export * from './address';
 export * from './config';
 export * from './recovery';
 export * from './replayProtection';

--- a/modules/abstract-utxo/test/unit/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/test/unit/abstractUtxoCoin.ts
@@ -3,7 +3,7 @@ import should = require('should');
 import * as sinon from 'sinon';
 import { Wallet, UnexpectedAddressError, VerificationOptions, Triple } from '@bitgo/sdk-core';
 
-import { UtxoWallet, Output, TransactionExplanation, TransactionParams, generateAddress } from '../../src';
+import { UtxoWallet, Output, TransactionExplanation, TransactionParams } from '../../src';
 
 import { bip322Fixtures } from './fixtures/bip322/fixtures';
 import { psbtTxHex } from './fixtures/psbtHexProof';
@@ -113,137 +113,6 @@ describe('Abstract UTXO Coin:', () => {
       return runClassifyOutputsTest(externalAddress, verification, true, {
         recipients: [{ address: externalAddress, amount: outputAmount }],
       });
-    });
-  });
-
-  describe('Custom Change Wallets', () => {
-    const coin = getUtxoCoin('tbtc');
-
-    const keys = {
-      send: {
-        user: { id: '0', key: coin.keychains().create() },
-        backup: { id: '1', key: coin.keychains().create() },
-        bitgo: { id: '2', key: coin.keychains().create() },
-      },
-      change: {
-        user: { id: '3', key: coin.keychains().create() },
-        backup: { id: '4', key: coin.keychains().create() },
-        bitgo: { id: '5', key: coin.keychains().create() },
-      },
-    };
-
-    const customChangeKeySignatures = {
-      user: '',
-      backup: '',
-      bitgo: '',
-    };
-
-    const addressData = {
-      chain: 11,
-      index: 1,
-      addressType: 'p2shP2wsh' as const,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      keychains: [
-        { pub: keys.change.user.key.pub! },
-        { pub: keys.change.backup.key.pub! },
-        { pub: keys.change.bitgo.key.pub! },
-      ],
-      threshold: 2,
-    };
-
-    const { address: changeAddress, coinSpecific } = generateAddress(coin.network, coin.getChain(), addressData);
-
-    const changeWalletId = 'changeWalletId';
-    const stubData = {
-      signedSendingWallet: {
-        keyIds: sinon.stub().returns([keys.send.user.id, keys.send.backup.id, keys.send.bitgo.id]),
-        coinSpecific: sinon.stub().returns({ customChangeWalletId: changeWalletId }),
-      },
-      changeWallet: {
-        keyIds: sinon.stub().returns([keys.change.user.id, keys.change.backup.id, keys.change.bitgo.id]),
-        createAddress: sinon.stub().resolves(changeAddress),
-      },
-    };
-
-    before(async () => {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const sign = async ({ key }) =>
-        (await coin.signMessage({ prv: keys.send.user.key.prv }, key.pub!)).toString('hex');
-      customChangeKeySignatures.user = await sign(keys.change.user);
-      customChangeKeySignatures.backup = await sign(keys.change.backup);
-      customChangeKeySignatures.bitgo = await sign(keys.change.bitgo);
-    });
-
-    it('should consider addresses derived from the custom change keys as internal spends', async () => {
-      const signedSendingWallet = sinon.createStubInstance(Wallet, stubData.signedSendingWallet as any);
-      const changeWallet = sinon.createStubInstance(Wallet, stubData.changeWallet as any);
-
-      sinon.stub(coin, 'keychains').returns({
-        get: sinon.stub().callsFake(({ id }) => {
-          switch (id) {
-            case keys.send.user.id:
-              return Promise.resolve({ id, ...keys.send.user.key });
-            case keys.send.backup.id:
-              return Promise.resolve({ id, ...keys.send.backup.key });
-            case keys.send.bitgo.id:
-              return Promise.resolve({ id, ...keys.send.bitgo.key });
-            case keys.change.user.id:
-              return Promise.resolve({ id, ...keys.change.user.key });
-            case keys.change.backup.id:
-              return Promise.resolve({ id, ...keys.change.backup.key });
-            case keys.change.bitgo.id:
-              return Promise.resolve({ id, ...keys.change.bitgo.key });
-          }
-        }),
-      } as any);
-
-      sinon.stub(coin, 'wallets').returns({
-        get: sinon.stub().callsFake(() => Promise.resolve(changeWallet)),
-      } as any);
-
-      const outputAmount = 10000;
-      const recipients = [];
-
-      sinon.stub(coin, 'explainTransaction').resolves({
-        outputs: [],
-        changeOutputs: [
-          {
-            address: changeAddress,
-            amount: outputAmount,
-          },
-        ],
-      } as any);
-
-      signedSendingWallet._wallet = signedSendingWallet._wallet || {
-        customChangeKeySignatures,
-      };
-
-      const parsedTransaction = await coin.parseTransaction({
-        txParams: { changeAddress, recipients },
-        txPrebuild: { txHex: '' },
-        wallet: signedSendingWallet as any,
-        verification: {
-          addresses: {
-            [changeAddress]: {
-              coinSpecific,
-              chain: addressData.chain,
-              index: addressData.index,
-            },
-          },
-        },
-      });
-
-      should.exist(parsedTransaction.outputs[0]);
-      parsedTransaction.outputs[0].should.deepEqual({
-        address: changeAddress,
-        amount: outputAmount,
-        external: false,
-        needsCustomChangeKeySignatureVerification: true,
-      });
-
-      (coin.explainTransaction as any).restore();
-      (coin.wallets as any).restore();
-      (coin.keychains as any).restore();
     });
   });
 

--- a/modules/abstract-utxo/test/unit/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/test/unit/abstractUtxoCoin.ts
@@ -3,7 +3,7 @@ import should = require('should');
 import * as sinon from 'sinon';
 import { Wallet, UnexpectedAddressError, VerificationOptions, Triple } from '@bitgo/sdk-core';
 
-import { UtxoWallet, Output, TransactionExplanation, TransactionParams } from '../../src';
+import { UtxoWallet, Output, TransactionExplanation, TransactionParams, generateAddress } from '../../src';
 
 import { bip322Fixtures } from './fixtures/bip322/fixtures';
 import { psbtTxHex } from './fixtures/psbtHexProof';
@@ -151,7 +151,7 @@ describe('Abstract UTXO Coin:', () => {
       threshold: 2,
     };
 
-    const { address: changeAddress, coinSpecific } = coin.generateAddress(addressData);
+    const { address: changeAddress, coinSpecific } = generateAddress(coin.network, coin.getChain(), addressData);
 
     const changeWalletId = 'changeWalletId';
     const stubData = {

--- a/modules/abstract-utxo/test/unit/address.ts
+++ b/modules/abstract-utxo/test/unit/address.ts
@@ -82,7 +82,7 @@ function run(coin: AbstractUtxoCoin) {
       const addresses = getParameters().map((p) => {
         const label = { chain: p.chain === undefined ? 'default' : p.chain };
         try {
-          return [label, generateAddress(coin.network, coin.getChain(), p)];
+          return [label, generateAddress(coin.network, p)];
         } catch (e) {
           return [label, { error: e.message }];
         }
@@ -94,23 +94,23 @@ function run(coin: AbstractUtxoCoin) {
     it('validates and verifies generated addresses', function () {
       getParameters().forEach((p) => {
         if (p.chain && !coin.supportsAddressChain(p.chain)) {
-          assert.throws(() => generateAddress(coin.network, coin.getChain(), p));
+          assert.throws(() => generateAddress(coin.network, p));
           return;
         }
 
-        const a = generateAddress(coin.network, coin.getChain(), p);
-        coin.isValidAddress(a.address).should.eql(true);
-        if (a.address !== a.address.toUpperCase()) {
-          coin.isValidAddress(a.address.toUpperCase()).should.eql(false);
+        const address = generateAddress(coin.network, p);
+        coin.isValidAddress(address).should.eql(true);
+        if (address !== address.toUpperCase()) {
+          coin.isValidAddress(address.toUpperCase()).should.eql(false);
         }
-        coin.verifyAddress({ ...a, keychains });
+        coin.verifyAddress({ address, keychains });
       });
     });
 
     it('defaults to canonical address', function () {
       getParameters().forEach((p) => {
         if (!p.chain || coin.supportsAddressChain(p.chain)) {
-          const address = generateAddress(coin.network, coin.getChain(), p).address;
+          const address = generateAddress(coin.network, p);
           coin.canonicalAddress(address).should.eql(address);
         }
       });
@@ -122,10 +122,10 @@ function run(coin: AbstractUtxoCoin) {
           if (p.chain && (!coin.supportsAddressChain(p.chain) || !otherCoin.supportsAddressChain(p.chain))) {
             return;
           }
-          const address = generateAddress(coin.network, coin.getChain(), p);
-          const otherAddress = generateAddress(otherCoin.network, otherCoin.getChain(), p);
-          (address.address === otherAddress.address).should.eql(isCompatibleAddress(coin, otherCoin));
-          coin.isValidAddress(otherAddress.address).should.eql(isCompatibleAddress(coin, otherCoin));
+          const address = generateAddress(coin.network, p);
+          const otherAddress = generateAddress(otherCoin.network, p);
+          (address === otherAddress).should.eql(isCompatibleAddress(coin, otherCoin));
+          coin.isValidAddress(otherAddress).should.eql(isCompatibleAddress(coin, otherCoin));
         });
       });
     });

--- a/modules/abstract-utxo/test/unit/customChangeWallet.ts
+++ b/modules/abstract-utxo/test/unit/customChangeWallet.ts
@@ -1,0 +1,137 @@
+import should = require('should');
+import * as sinon from 'sinon';
+import { Wallet } from '@bitgo/sdk-core';
+
+import { generateAddress } from '../../src';
+
+import { getUtxoCoin } from './util';
+
+describe('Custom Change Wallets', () => {
+  const coin = getUtxoCoin('tbtc');
+
+  const keys = {
+    send: {
+      user: { id: '0', key: coin.keychains().create() },
+      backup: { id: '1', key: coin.keychains().create() },
+      bitgo: { id: '2', key: coin.keychains().create() },
+    },
+    change: {
+      user: { id: '3', key: coin.keychains().create() },
+      backup: { id: '4', key: coin.keychains().create() },
+      bitgo: { id: '5', key: coin.keychains().create() },
+    },
+  };
+
+  const customChangeKeySignatures = {
+    user: '',
+    backup: '',
+    bitgo: '',
+  };
+
+  const addressData = {
+    chain: 11,
+    index: 1,
+    addressType: 'p2shP2wsh' as const,
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    keychains: [
+      { pub: keys.change.user.key.pub! },
+      { pub: keys.change.backup.key.pub! },
+      { pub: keys.change.bitgo.key.pub! },
+    ],
+    threshold: 2,
+  };
+
+  const { address: changeAddress, coinSpecific } = generateAddress(coin.network, coin.getChain(), addressData);
+
+  const changeWalletId = 'changeWalletId';
+  const stubData = {
+    signedSendingWallet: {
+      keyIds: sinon.stub().returns([keys.send.user.id, keys.send.backup.id, keys.send.bitgo.id]),
+      coinSpecific: sinon.stub().returns({ customChangeWalletId: changeWalletId }),
+    },
+    changeWallet: {
+      keyIds: sinon.stub().returns([keys.change.user.id, keys.change.backup.id, keys.change.bitgo.id]),
+      createAddress: sinon.stub().resolves(changeAddress),
+    },
+  };
+
+  before(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const sign = async ({ key }) => (await coin.signMessage({ prv: keys.send.user.key.prv }, key.pub!)).toString('hex');
+    customChangeKeySignatures.user = await sign(keys.change.user);
+    customChangeKeySignatures.backup = await sign(keys.change.backup);
+    customChangeKeySignatures.bitgo = await sign(keys.change.bitgo);
+  });
+
+  it('should consider addresses derived from the custom change keys as internal spends', async () => {
+    const signedSendingWallet = sinon.createStubInstance(Wallet, stubData.signedSendingWallet as any);
+    const changeWallet = sinon.createStubInstance(Wallet, stubData.changeWallet as any);
+
+    sinon.stub(coin, 'keychains').returns({
+      get: sinon.stub().callsFake(({ id }) => {
+        switch (id) {
+          case keys.send.user.id:
+            return Promise.resolve({ id, ...keys.send.user.key });
+          case keys.send.backup.id:
+            return Promise.resolve({ id, ...keys.send.backup.key });
+          case keys.send.bitgo.id:
+            return Promise.resolve({ id, ...keys.send.bitgo.key });
+          case keys.change.user.id:
+            return Promise.resolve({ id, ...keys.change.user.key });
+          case keys.change.backup.id:
+            return Promise.resolve({ id, ...keys.change.backup.key });
+          case keys.change.bitgo.id:
+            return Promise.resolve({ id, ...keys.change.bitgo.key });
+        }
+      }),
+    } as any);
+
+    sinon.stub(coin, 'wallets').returns({
+      get: sinon.stub().callsFake(() => Promise.resolve(changeWallet)),
+    } as any);
+
+    const outputAmount = 10000;
+    const recipients = [];
+
+    sinon.stub(coin, 'explainTransaction').resolves({
+      outputs: [],
+      changeOutputs: [
+        {
+          address: changeAddress,
+          amount: outputAmount,
+        },
+      ],
+    } as any);
+
+    signedSendingWallet._wallet = signedSendingWallet._wallet || {
+      customChangeKeySignatures,
+    };
+
+    const parsedTransaction = await coin.parseTransaction({
+      txParams: { changeAddress, recipients },
+      txPrebuild: { txHex: '' },
+      wallet: signedSendingWallet as any,
+      verification: {
+        addresses: {
+          [changeAddress]: {
+            coinSpecific,
+            chain: addressData.chain,
+            index: addressData.index,
+          },
+        },
+      },
+    });
+
+    should.exist(parsedTransaction.outputs[0]);
+    parsedTransaction.outputs[0].should.deepEqual({
+      address: changeAddress,
+      amount: outputAmount,
+      external: false,
+      needsCustomChangeKeySignatureVerification: true,
+    });
+
+    (coin.explainTransaction as any).restore();
+    (coin.wallets as any).restore();
+    (coin.keychains as any).restore();
+  });
+});

--- a/modules/abstract-utxo/test/unit/customChangeWallet.ts
+++ b/modules/abstract-utxo/test/unit/customChangeWallet.ts
@@ -41,7 +41,7 @@ describe('Custom Change Wallets', () => {
     threshold: 2,
   };
 
-  const { address: changeAddress, coinSpecific } = generateAddress(coin.network, coin.getChain(), addressData);
+  const { address: changeAddress } = generateAddress(coin.network, coin.getChain(), addressData);
 
   const changeWalletId = 'changeWalletId';
   const stubData = {
@@ -114,7 +114,6 @@ describe('Custom Change Wallets', () => {
       verification: {
         addresses: {
           [changeAddress]: {
-            coinSpecific,
             chain: addressData.chain,
             index: addressData.index,
           },

--- a/modules/abstract-utxo/test/unit/customChangeWallet.ts
+++ b/modules/abstract-utxo/test/unit/customChangeWallet.ts
@@ -41,7 +41,7 @@ describe('Custom Change Wallets', () => {
     threshold: 2,
   };
 
-  const { address: changeAddress } = generateAddress(coin.network, coin.getChain(), addressData);
+  const changeAddress = generateAddress(coin.network, addressData);
 
   const changeWalletId = 'changeWalletId';
   const stubData = {

--- a/modules/abstract-utxo/test/unit/fixtures/bch/addresses-by-chain.json
+++ b/modules/abstract-utxo/test/unit/fixtures/bch/addresses-by-chain.json
@@ -3,49 +3,19 @@
     {
       "chain": "default"
     },
-    {
-      "address": "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj",
-      "chain": 0,
-      "index": 0,
-      "coin": "bch",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj"
   ],
   [
     {
       "chain": 0
     },
-    {
-      "address": "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj",
-      "chain": 0,
-      "index": 0,
-      "coin": "bch",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj"
   ],
   [
     {
       "chain": 1
     },
-    {
-      "address": "37qPMKZpagdNztA82mXrE81ch2kPzYxEnH",
-      "chain": 1,
-      "index": 0,
-      "coin": "bch",
-      "coinSpecific": {
-        "outputScript": "a9144365f80ae9830dab1d9124be68c74c2fa23bbc1287",
-        "redeemScript": "522102d06c08ccf0fddefff881e869b951d4b92e936118b3360182c5b8c55f4c40bc6121030795af84ecc10252d8a894f54845beeb5624a1c24c3747cc654bd430539dee3521029b30ebe8eb23f8cec82f25a80e3b423979ec3ba1fe07d9d4ed9f6361258bc31d53ae"
-      },
-      "addressType": "p2sh"
-    }
+    "37qPMKZpagdNztA82mXrE81ch2kPzYxEnH"
   ],
   [
     {

--- a/modules/abstract-utxo/test/unit/fixtures/bcha/addresses-by-chain.json
+++ b/modules/abstract-utxo/test/unit/fixtures/bcha/addresses-by-chain.json
@@ -3,49 +3,19 @@
     {
       "chain": "default"
     },
-    {
-      "address": "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj",
-      "chain": 0,
-      "index": 0,
-      "coin": "bcha",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj"
   ],
   [
     {
       "chain": 0
     },
-    {
-      "address": "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj",
-      "chain": 0,
-      "index": 0,
-      "coin": "bcha",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj"
   ],
   [
     {
       "chain": 1
     },
-    {
-      "address": "37qPMKZpagdNztA82mXrE81ch2kPzYxEnH",
-      "chain": 1,
-      "index": 0,
-      "coin": "bcha",
-      "coinSpecific": {
-        "outputScript": "a9144365f80ae9830dab1d9124be68c74c2fa23bbc1287",
-        "redeemScript": "522102d06c08ccf0fddefff881e869b951d4b92e936118b3360182c5b8c55f4c40bc6121030795af84ecc10252d8a894f54845beeb5624a1c24c3747cc654bd430539dee3521029b30ebe8eb23f8cec82f25a80e3b423979ec3ba1fe07d9d4ed9f6361258bc31d53ae"
-      },
-      "addressType": "p2sh"
-    }
+    "37qPMKZpagdNztA82mXrE81ch2kPzYxEnH"
   ],
   [
     {

--- a/modules/abstract-utxo/test/unit/fixtures/bsv/addresses-by-chain.json
+++ b/modules/abstract-utxo/test/unit/fixtures/bsv/addresses-by-chain.json
@@ -3,49 +3,19 @@
     {
       "chain": "default"
     },
-    {
-      "address": "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj",
-      "chain": 0,
-      "index": 0,
-      "coin": "bsv",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj"
   ],
   [
     {
       "chain": 0
     },
-    {
-      "address": "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj",
-      "chain": 0,
-      "index": 0,
-      "coin": "bsv",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj"
   ],
   [
     {
       "chain": 1
     },
-    {
-      "address": "37qPMKZpagdNztA82mXrE81ch2kPzYxEnH",
-      "chain": 1,
-      "index": 0,
-      "coin": "bsv",
-      "coinSpecific": {
-        "outputScript": "a9144365f80ae9830dab1d9124be68c74c2fa23bbc1287",
-        "redeemScript": "522102d06c08ccf0fddefff881e869b951d4b92e936118b3360182c5b8c55f4c40bc6121030795af84ecc10252d8a894f54845beeb5624a1c24c3747cc654bd430539dee3521029b30ebe8eb23f8cec82f25a80e3b423979ec3ba1fe07d9d4ed9f6361258bc31d53ae"
-      },
-      "addressType": "p2sh"
-    }
+    "37qPMKZpagdNztA82mXrE81ch2kPzYxEnH"
   ],
   [
     {

--- a/modules/abstract-utxo/test/unit/fixtures/btc/addresses-by-chain.json
+++ b/modules/abstract-utxo/test/unit/fixtures/btc/addresses-by-chain.json
@@ -3,174 +3,66 @@
     {
       "chain": "default"
     },
-    {
-      "address": "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj",
-      "chain": 0,
-      "index": 0,
-      "coin": "btc",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj"
   ],
   [
     {
       "chain": 0
     },
-    {
-      "address": "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj",
-      "chain": 0,
-      "index": 0,
-      "coin": "btc",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "34TTD5CefzLXWjuiSPDjvpJJRZe3Tqu2Mj"
   ],
   [
     {
       "chain": 1
     },
-    {
-      "address": "37qPMKZpagdNztA82mXrE81ch2kPzYxEnH",
-      "chain": 1,
-      "index": 0,
-      "coin": "btc",
-      "coinSpecific": {
-        "outputScript": "a9144365f80ae9830dab1d9124be68c74c2fa23bbc1287",
-        "redeemScript": "522102d06c08ccf0fddefff881e869b951d4b92e936118b3360182c5b8c55f4c40bc6121030795af84ecc10252d8a894f54845beeb5624a1c24c3747cc654bd430539dee3521029b30ebe8eb23f8cec82f25a80e3b423979ec3ba1fe07d9d4ed9f6361258bc31d53ae"
-      },
-      "addressType": "p2sh"
-    }
+    "37qPMKZpagdNztA82mXrE81ch2kPzYxEnH"
   ],
   [
     {
       "chain": 10
     },
-    {
-      "address": "3DMWk3dd5aJmwA2UVxjKcu9KdgA7k8Homg",
-      "chain": 10,
-      "index": 0,
-      "coin": "btc",
-      "coinSpecific": {
-        "outputScript": "a9147ff13f3faeba4d439ef40604f7c127951e77eb6a87",
-        "redeemScript": "00207aad7d57b238a09b5daa10ff47c54483b7f2ad47f3f0c0aa230958b9df334260",
-        "witnessScript": "52210304fcea3fb05f6e8a8fe91db2087bdd13b18102a0b10a77c1fdbb326b0ce7cec421028242a3ea9e20d4e6b78e3f0dde21aff86a623d48322681b203b6827e22d04a9d2102ceec88b222a55ec67d1414b523bcfc0f53eb6ac012ba91744a4ed8eb448d55f753ae"
-      },
-      "addressType": "p2shP2wsh"
-    }
+    "3DMWk3dd5aJmwA2UVxjKcu9KdgA7k8Homg"
   ],
   [
     {
       "chain": 11
     },
-    {
-      "address": "3PeXf4UiyRneENKQrarZ3yt9dwTM4xgFZQ",
-      "chain": 11,
-      "index": 0,
-      "coin": "btc",
-      "coinSpecific": {
-        "outputScript": "a914f0da56d9bb06310289d808a22ad68457a760ac0387",
-        "redeemScript": "00202ce48eb68ff4a96f2742cfbdd90210ae30bc7cdbafd63fbbe368802e3c0ae800",
-        "witnessScript": "52210386b73c1c9e0d5c3370496426cdb6593bd69bb93743e135860aa5797cd04353c521022e79cdb1ee0b8cad6c9667fedafa92f8472f731f627dc8e0018571e4de9dfda42102f6d5e998e5b41e7e783c7c5c8a633cf333b86200aab31676ab07ed336e22700353ae"
-      },
-      "addressType": "p2shP2wsh"
-    }
+    "3PeXf4UiyRneENKQrarZ3yt9dwTM4xgFZQ"
   ],
   [
     {
       "chain": 20
     },
-    {
-      "address": "bc1qjpzgkka9lhs5l39shlr4d394tljw8p2v35sl88h82djvqp3mculqa08n0a",
-      "chain": 20,
-      "index": 0,
-      "coin": "btc",
-      "coinSpecific": {
-        "outputScript": "002090448b5ba5fde14fc4b0bfc756c4b55fe4e3854c8d21f39ee75364c0063bc73e",
-        "witnessScript": "522103cf858f42c759d590d80f3715ce59be999089e6b1f381d0f4338276546fd3a04e2102dca1ab8670d45f5213c7c9d66b2f89b50a4cbd33fd72db89ba18d3e82d3dd5ee210294b6dab0dc112831a0dc1e219769bd81d13eb38a8bdb938103f919d8dd7e004353ae"
-      },
-      "addressType": "p2wsh"
-    }
+    "bc1qjpzgkka9lhs5l39shlr4d394tljw8p2v35sl88h82djvqp3mculqa08n0a"
   ],
   [
     {
       "chain": 21
     },
-    {
-      "address": "bc1q5e7nvvypt2qpjxq74zwtry9klsqkcyvcee85anaa3pax7ae207gsxkxwxc",
-      "chain": 21,
-      "index": 0,
-      "coin": "btc",
-      "coinSpecific": {
-        "outputScript": "0020a67d3630815a8019181ea89cb190b6fc016c1198ce4f4ecfbd887a6f772a7f91",
-        "witnessScript": "52210391e76285ad55895309f6fa7db9fb359489daaf235bb4cb50608f9562122af1ab210285ddd6b1e84e37a9f222737d8b80a8a980a193a783b75b9e82d6e239eb52818c2103a13ee160d79d43201ef5e65b6df4e0842de3b640904d049e64daaaa84a306bb853ae"
-      },
-      "addressType": "p2wsh"
-    }
+    "bc1q5e7nvvypt2qpjxq74zwtry9klsqkcyvcee85anaa3pax7ae207gsxkxwxc"
   ],
   [
     {
       "chain": 30
     },
-    {
-      "address": "bc1p0sm0je6mv9zrzyguquzh24svlz6sgcct3qckp34nc09vj6wedn0sqhk2xu",
-      "chain": 30,
-      "index": 0,
-      "coin": "btc",
-      "coinSpecific": {
-        "outputScript": "51207c36f9675b614431111c070575560cf8b504630b883160c6b3c3cac969d96cdf"
-      },
-      "addressType": "p2tr"
-    }
+    "bc1p0sm0je6mv9zrzyguquzh24svlz6sgcct3qckp34nc09vj6wedn0sqhk2xu"
   ],
   [
     {
       "chain": 31
     },
-    {
-      "address": "bc1phk6lhy2tka2kxsx6hjd3c0z2h2e0rcrere9lr3kqsg0p6xxqe2pq2ark68",
-      "chain": 31,
-      "index": 0,
-      "coin": "btc",
-      "coinSpecific": {
-        "outputScript": "5120bdb5fb914bb7556340dabc9b1c3c4abab2f1e0791e4bf1c6c0821e1d18c0ca82"
-      },
-      "addressType": "p2tr"
-    }
+    "bc1phk6lhy2tka2kxsx6hjd3c0z2h2e0rcrere9lr3kqsg0p6xxqe2pq2ark68"
   ],
   [
     {
       "chain": 40
     },
-    {
-      "address": "bc1pxgs4mpuymvtr7hsx3u0efx5yvjd2nark5qgsg89s8p0jcdzvukgqxua6x3",
-      "chain": 40,
-      "index": 0,
-      "coin": "btc",
-      "coinSpecific": {
-        "outputScript": "512032215d8784db163f5e068f1f949a84649aa9f476a011041cb0385f2c344ce590"
-      },
-      "addressType": "p2trMusig2"
-    }
+    "bc1pxgs4mpuymvtr7hsx3u0efx5yvjd2nark5qgsg89s8p0jcdzvukgqxua6x3"
   ],
   [
     {
       "chain": 41
     },
-    {
-      "address": "bc1p8qdlmtsw6ehy9u4w8lpw4xw6shg7jknu7fhrlaclpdaqtfp0pueslfd6ul",
-      "chain": 41,
-      "index": 0,
-      "coin": "btc",
-      "coinSpecific": {
-        "outputScript": "5120381bfdae0ed66e42f2ae3fc2ea99da85d1e95a7cf26e3ff71f0b7a05a42f0f33"
-      },
-      "addressType": "p2trMusig2"
-    }
+    "bc1p8qdlmtsw6ehy9u4w8lpw4xw6shg7jknu7fhrlaclpdaqtfp0pueslfd6ul"
   ]
 ]

--- a/modules/abstract-utxo/test/unit/fixtures/btg/addresses-by-chain.json
+++ b/modules/abstract-utxo/test/unit/fixtures/btg/addresses-by-chain.json
@@ -3,115 +3,43 @@
     {
       "chain": "default"
     },
-    {
-      "address": "AJYJw2ZqTEgJEYRGswDUf5CTkeH2D2zFPC",
-      "chain": 0,
-      "index": 0,
-      "coin": "btg",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "AJYJw2ZqTEgJEYRGswDUf5CTkeH2D2zFPC"
   ],
   [
     {
       "chain": 0
     },
-    {
-      "address": "AJYJw2ZqTEgJEYRGswDUf5CTkeH2D2zFPC",
-      "chain": 0,
-      "index": 0,
-      "coin": "btg",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "AJYJw2ZqTEgJEYRGswDUf5CTkeH2D2zFPC"
   ],
   [
     {
       "chain": 1
     },
-    {
-      "address": "AMvF5Gw1Mvy9igfgUKXaxNun27PNiLLNkc",
-      "chain": 1,
-      "index": 0,
-      "coin": "btg",
-      "coinSpecific": {
-        "outputScript": "a9144365f80ae9830dab1d9124be68c74c2fa23bbc1287",
-        "redeemScript": "522102d06c08ccf0fddefff881e869b951d4b92e936118b3360182c5b8c55f4c40bc6121030795af84ecc10252d8a894f54845beeb5624a1c24c3747cc654bd430539dee3521029b30ebe8eb23f8cec82f25a80e3b423979ec3ba1fe07d9d4ed9f6361258bc31d53ae"
-      },
-      "addressType": "p2sh"
-    }
+    "AMvF5Gw1Mvy9igfgUKXaxNun27PNiLLNkc"
   ],
   [
     {
       "chain": 10
     },
-    {
-      "address": "ATSNTzzorpeYexY2wWj4MA3Uxko6YqsQmh",
-      "chain": 10,
-      "index": 0,
-      "coin": "btg",
-      "coinSpecific": {
-        "outputScript": "a9147ff13f3faeba4d439ef40604f7c127951e77eb6a87",
-        "redeemScript": "00207aad7d57b238a09b5daa10ff47c54483b7f2ad47f3f0c0aa230958b9df334260",
-        "witnessScript": "52210304fcea3fb05f6e8a8fe91db2087bdd13b18102a0b10a77c1fdbb326b0ce7cec421028242a3ea9e20d4e6b78e3f0dde21aff86a623d48322681b203b6827e22d04a9d2102ceec88b222a55ec67d1414b523bcfc0f53eb6ac012ba91744a4ed8eb448d55f753ae"
-      },
-      "addressType": "p2shP2wsh"
-    }
+    "ATSNTzzorpeYexY2wWj4MA3Uxko6YqsQmh"
   ],
   [
     {
       "chain": 11
     },
-    {
-      "address": "AdjPP1qukg8QxApyJ8rHnEnJy26KnBr2ik",
-      "chain": 11,
-      "index": 0,
-      "coin": "btg",
-      "coinSpecific": {
-        "outputScript": "a914f0da56d9bb06310289d808a22ad68457a760ac0387",
-        "redeemScript": "00202ce48eb68ff4a96f2742cfbdd90210ae30bc7cdbafd63fbbe368802e3c0ae800",
-        "witnessScript": "52210386b73c1c9e0d5c3370496426cdb6593bd69bb93743e135860aa5797cd04353c521022e79cdb1ee0b8cad6c9667fedafa92f8472f731f627dc8e0018571e4de9dfda42102f6d5e998e5b41e7e783c7c5c8a633cf333b86200aab31676ab07ed336e22700353ae"
-      },
-      "addressType": "p2shP2wsh"
-    }
+    "AdjPP1qukg8QxApyJ8rHnEnJy26KnBr2ik"
   ],
   [
     {
       "chain": 20
     },
-    {
-      "address": "btg1qjpzgkka9lhs5l39shlr4d394tljw8p2v35sl88h82djvqp3mculqn0rwlh",
-      "chain": 20,
-      "index": 0,
-      "coin": "btg",
-      "coinSpecific": {
-        "outputScript": "002090448b5ba5fde14fc4b0bfc756c4b55fe4e3854c8d21f39ee75364c0063bc73e",
-        "witnessScript": "522103cf858f42c759d590d80f3715ce59be999089e6b1f381d0f4338276546fd3a04e2102dca1ab8670d45f5213c7c9d66b2f89b50a4cbd33fd72db89ba18d3e82d3dd5ee210294b6dab0dc112831a0dc1e219769bd81d13eb38a8bdb938103f919d8dd7e004353ae"
-      },
-      "addressType": "p2wsh"
-    }
+    "btg1qjpzgkka9lhs5l39shlr4d394tljw8p2v35sl88h82djvqp3mculqn0rwlh"
   ],
   [
     {
       "chain": 21
     },
-    {
-      "address": "btg1q5e7nvvypt2qpjxq74zwtry9klsqkcyvcee85anaa3pax7ae207gsgkznkj",
-      "chain": 21,
-      "index": 0,
-      "coin": "btg",
-      "coinSpecific": {
-        "outputScript": "0020a67d3630815a8019181ea89cb190b6fc016c1198ce4f4ecfbd887a6f772a7f91",
-        "witnessScript": "52210391e76285ad55895309f6fa7db9fb359489daaf235bb4cb50608f9562122af1ab210285ddd6b1e84e37a9f222737d8b80a8a980a193a783b75b9e82d6e239eb52818c2103a13ee160d79d43201ef5e65b6df4e0842de3b640904d049e64daaaa84a306bb853ae"
-      },
-      "addressType": "p2wsh"
-    }
+    "btg1q5e7nvvypt2qpjxq74zwtry9klsqkcyvcee85anaa3pax7ae207gsgkznkj"
   ],
   [
     {

--- a/modules/abstract-utxo/test/unit/fixtures/dash/addresses-by-chain.json
+++ b/modules/abstract-utxo/test/unit/fixtures/dash/addresses-by-chain.json
@@ -3,49 +3,19 @@
     {
       "chain": "default"
     },
-    {
-      "address": "7VB63GUpUySAWWSfhztFGCHxM7URDayyVi",
-      "chain": 0,
-      "index": 0,
-      "coin": "dash",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "7VB63GUpUySAWWSfhztFGCHxM7URDayyVi"
   ],
   [
     {
       "chain": 0
     },
-    {
-      "address": "7VB63GUpUySAWWSfhztFGCHxM7URDayyVi",
-      "chain": 0,
-      "index": 0,
-      "coin": "dash",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "7VB63GUpUySAWWSfhztFGCHxM7URDayyVi"
   ],
   [
     {
       "chain": 1
     },
-    {
-      "address": "7YZ2BWqzPfj1zeh5JPCMZW1Gcaamj6AKG6",
-      "chain": 1,
-      "index": 0,
-      "coin": "dash",
-      "coinSpecific": {
-        "outputScript": "a9144365f80ae9830dab1d9124be68c74c2fa23bbc1287",
-        "redeemScript": "522102d06c08ccf0fddefff881e869b951d4b92e936118b3360182c5b8c55f4c40bc6121030795af84ecc10252d8a894f54845beeb5624a1c24c3747cc654bd430539dee3521029b30ebe8eb23f8cec82f25a80e3b423979ec3ba1fe07d9d4ed9f6361258bc31d53ae"
-      },
-      "addressType": "p2sh"
-    }
+    "7YZ2BWqzPfj1zeh5JPCMZW1Gcaamj6AKG6"
   ],
   [
     {

--- a/modules/abstract-utxo/test/unit/fixtures/doge/addresses-by-chain.json
+++ b/modules/abstract-utxo/test/unit/fixtures/doge/addresses-by-chain.json
@@ -3,49 +3,19 @@
     {
       "chain": "default"
     },
-    {
-      "address": "9uChwvGYk4DRR7HBrWtAAwvg8925VtQqDn",
-      "chain": 0,
-      "index": 0,
-      "coin": "doge",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "9uChwvGYk4DRR7HBrWtAAwvg8925VtQqDn"
   ],
   [
     {
       "chain": 0
     },
-    {
-      "address": "9uChwvGYk4DRR7HBrWtAAwvg8925VtQqDn",
-      "chain": 0,
-      "index": 0,
-      "coin": "doge",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "9uChwvGYk4DRR7HBrWtAAwvg8925VtQqDn"
   ],
   [
     {
       "chain": 1
     },
-    {
-      "address": "9xae6AdiekWGuFXbSuCGUFdzPc8RyQ9USD",
-      "chain": 1,
-      "index": 0,
-      "coin": "doge",
-      "coinSpecific": {
-        "outputScript": "a9144365f80ae9830dab1d9124be68c74c2fa23bbc1287",
-        "redeemScript": "522102d06c08ccf0fddefff881e869b951d4b92e936118b3360182c5b8c55f4c40bc6121030795af84ecc10252d8a894f54845beeb5624a1c24c3747cc654bd430539dee3521029b30ebe8eb23f8cec82f25a80e3b423979ec3ba1fe07d9d4ed9f6361258bc31d53ae"
-      },
-      "addressType": "p2sh"
-    }
+    "9xae6AdiekWGuFXbSuCGUFdzPc8RyQ9USD"
   ],
   [
     {

--- a/modules/abstract-utxo/test/unit/fixtures/ltc/addresses-by-chain.json
+++ b/modules/abstract-utxo/test/unit/fixtures/ltc/addresses-by-chain.json
@@ -3,115 +3,43 @@
     {
       "chain": "default"
     },
-    {
-      "address": "MAfbWxccd7BxKFBcYGD5kTYhkGEVTkPv3o",
-      "chain": 0,
-      "index": 0,
-      "coin": "ltc",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "MAfbWxccd7BxKFBcYGD5kTYhkGEVTkPv3o"
   ],
   [
     {
       "chain": 0
     },
-    {
-      "address": "MAfbWxccd7BxKFBcYGD5kTYhkGEVTkPv3o",
-      "chain": 0,
-      "index": 0,
-      "coin": "ltc",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "MAfbWxccd7BxKFBcYGD5kTYhkGEVTkPv3o"
   ],
   [
     {
       "chain": 1
     },
-    {
-      "address": "ME3XfCynXoUooPS28eXC3mG21jLqtXgiEr",
-      "chain": 1,
-      "index": 0,
-      "coin": "ltc",
-      "coinSpecific": {
-        "outputScript": "a9144365f80ae9830dab1d9124be68c74c2fa23bbc1287",
-        "redeemScript": "522102d06c08ccf0fddefff881e869b951d4b92e936118b3360182c5b8c55f4c40bc6121030795af84ecc10252d8a894f54845beeb5624a1c24c3747cc654bd430539dee3521029b30ebe8eb23f8cec82f25a80e3b423979ec3ba1fe07d9d4ed9f6361258bc31d53ae"
-      },
-      "addressType": "p2sh"
-    }
+    "ME3XfCynXoUooPS28eXC3mG21jLqtXgiEr"
   ],
   [
     {
       "chain": 10
     },
-    {
-      "address": "MKZf3w3b2hACjfJNbqifSYPixNkZjxBTg9",
-      "chain": 10,
-      "index": 0,
-      "coin": "ltc",
-      "coinSpecific": {
-        "outputScript": "a9147ff13f3faeba4d439ef40604f7c127951e77eb6a87",
-        "redeemScript": "00207aad7d57b238a09b5daa10ff47c54483b7f2ad47f3f0c0aa230958b9df334260",
-        "witnessScript": "52210304fcea3fb05f6e8a8fe91db2087bdd13b18102a0b10a77c1fdbb326b0ce7cec421028242a3ea9e20d4e6b78e3f0dde21aff86a623d48322681b203b6827e22d04a9d2102ceec88b222a55ec67d1414b523bcfc0f53eb6ac012ba91744a4ed8eb448d55f753ae"
-      },
-      "addressType": "p2shP2wsh"
-    }
+    "MKZf3w3b2hACjfJNbqifSYPixNkZjxBTg9"
   ],
   [
     {
       "chain": 11
     },
-    {
-      "address": "MVrfxwtgvYe52sbJxTqtsd8Yxe3nzJDCzE",
-      "chain": 11,
-      "index": 0,
-      "coin": "ltc",
-      "coinSpecific": {
-        "outputScript": "a914f0da56d9bb06310289d808a22ad68457a760ac0387",
-        "redeemScript": "00202ce48eb68ff4a96f2742cfbdd90210ae30bc7cdbafd63fbbe368802e3c0ae800",
-        "witnessScript": "52210386b73c1c9e0d5c3370496426cdb6593bd69bb93743e135860aa5797cd04353c521022e79cdb1ee0b8cad6c9667fedafa92f8472f731f627dc8e0018571e4de9dfda42102f6d5e998e5b41e7e783c7c5c8a633cf333b86200aab31676ab07ed336e22700353ae"
-      },
-      "addressType": "p2shP2wsh"
-    }
+    "MVrfxwtgvYe52sbJxTqtsd8Yxe3nzJDCzE"
   ],
   [
     {
       "chain": 20
     },
-    {
-      "address": "ltc1qjpzgkka9lhs5l39shlr4d394tljw8p2v35sl88h82djvqp3mculq7tfr4c",
-      "chain": 20,
-      "index": 0,
-      "coin": "ltc",
-      "coinSpecific": {
-        "outputScript": "002090448b5ba5fde14fc4b0bfc756c4b55fe4e3854c8d21f39ee75364c0063bc73e",
-        "witnessScript": "522103cf858f42c759d590d80f3715ce59be999089e6b1f381d0f4338276546fd3a04e2102dca1ab8670d45f5213c7c9d66b2f89b50a4cbd33fd72db89ba18d3e82d3dd5ee210294b6dab0dc112831a0dc1e219769bd81d13eb38a8bdb938103f919d8dd7e004353ae"
-      },
-      "addressType": "p2wsh"
-    }
+    "ltc1qjpzgkka9lhs5l39shlr4d394tljw8p2v35sl88h82djvqp3mculq7tfr4c"
   ],
   [
     {
       "chain": 21
     },
-    {
-      "address": "ltc1q5e7nvvypt2qpjxq74zwtry9klsqkcyvcee85anaa3pax7ae207gs9jg7ua",
-      "chain": 21,
-      "index": 0,
-      "coin": "ltc",
-      "coinSpecific": {
-        "outputScript": "0020a67d3630815a8019181ea89cb190b6fc016c1198ce4f4ecfbd887a6f772a7f91",
-        "witnessScript": "52210391e76285ad55895309f6fa7db9fb359489daaf235bb4cb50608f9562122af1ab210285ddd6b1e84e37a9f222737d8b80a8a980a193a783b75b9e82d6e239eb52818c2103a13ee160d79d43201ef5e65b6df4e0842de3b640904d049e64daaaa84a306bb853ae"
-      },
-      "addressType": "p2wsh"
-    }
+    "ltc1q5e7nvvypt2qpjxq74zwtry9klsqkcyvcee85anaa3pax7ae207gs9jg7ua"
   ],
   [
     {

--- a/modules/abstract-utxo/test/unit/fixtures/tbch/addresses-by-chain.json
+++ b/modules/abstract-utxo/test/unit/fixtures/tbch/addresses-by-chain.json
@@ -3,49 +3,19 @@
     {
       "chain": "default"
     },
-    {
-      "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
-      "chain": 0,
-      "index": 0,
-      "coin": "tbch",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn"
   ],
   [
     {
       "chain": 0
     },
-    {
-      "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
-      "chain": 0,
-      "index": 0,
-      "coin": "tbch",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn"
   ],
   [
     {
       "chain": 1
     },
-    {
-      "address": "2MyPbR4VrC98jCfnfhu9ir4zsuNxZiPS85K",
-      "chain": 1,
-      "index": 0,
-      "coin": "tbch",
-      "coinSpecific": {
-        "outputScript": "a9144365f80ae9830dab1d9124be68c74c2fa23bbc1287",
-        "redeemScript": "522102d06c08ccf0fddefff881e869b951d4b92e936118b3360182c5b8c55f4c40bc6121030795af84ecc10252d8a894f54845beeb5624a1c24c3747cc654bd430539dee3521029b30ebe8eb23f8cec82f25a80e3b423979ec3ba1fe07d9d4ed9f6361258bc31d53ae"
-      },
-      "addressType": "p2sh"
-    }
+    "2MyPbR4VrC98jCfnfhu9ir4zsuNxZiPS85K"
   ],
   [
     {

--- a/modules/abstract-utxo/test/unit/fixtures/tbcha/addresses-by-chain.json
+++ b/modules/abstract-utxo/test/unit/fixtures/tbcha/addresses-by-chain.json
@@ -3,49 +3,19 @@
     {
       "chain": "default"
     },
-    {
-      "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
-      "chain": 0,
-      "index": 0,
-      "coin": "tbcha",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn"
   ],
   [
     {
       "chain": 0
     },
-    {
-      "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
-      "chain": 0,
-      "index": 0,
-      "coin": "tbcha",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn"
   ],
   [
     {
       "chain": 1
     },
-    {
-      "address": "2MyPbR4VrC98jCfnfhu9ir4zsuNxZiPS85K",
-      "chain": 1,
-      "index": 0,
-      "coin": "tbcha",
-      "coinSpecific": {
-        "outputScript": "a9144365f80ae9830dab1d9124be68c74c2fa23bbc1287",
-        "redeemScript": "522102d06c08ccf0fddefff881e869b951d4b92e936118b3360182c5b8c55f4c40bc6121030795af84ecc10252d8a894f54845beeb5624a1c24c3747cc654bd430539dee3521029b30ebe8eb23f8cec82f25a80e3b423979ec3ba1fe07d9d4ed9f6361258bc31d53ae"
-      },
-      "addressType": "p2sh"
-    }
+    "2MyPbR4VrC98jCfnfhu9ir4zsuNxZiPS85K"
   ],
   [
     {

--- a/modules/abstract-utxo/test/unit/fixtures/tbsv/addresses-by-chain.json
+++ b/modules/abstract-utxo/test/unit/fixtures/tbsv/addresses-by-chain.json
@@ -3,49 +3,19 @@
     {
       "chain": "default"
     },
-    {
-      "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
-      "chain": 0,
-      "index": 0,
-      "coin": "tbsv",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn"
   ],
   [
     {
       "chain": 0
     },
-    {
-      "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
-      "chain": 0,
-      "index": 0,
-      "coin": "tbsv",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn"
   ],
   [
     {
       "chain": 1
     },
-    {
-      "address": "2MyPbR4VrC98jCfnfhu9ir4zsuNxZiPS85K",
-      "chain": 1,
-      "index": 0,
-      "coin": "tbsv",
-      "coinSpecific": {
-        "outputScript": "a9144365f80ae9830dab1d9124be68c74c2fa23bbc1287",
-        "redeemScript": "522102d06c08ccf0fddefff881e869b951d4b92e936118b3360182c5b8c55f4c40bc6121030795af84ecc10252d8a894f54845beeb5624a1c24c3747cc654bd430539dee3521029b30ebe8eb23f8cec82f25a80e3b423979ec3ba1fe07d9d4ed9f6361258bc31d53ae"
-      },
-      "addressType": "p2sh"
-    }
+    "2MyPbR4VrC98jCfnfhu9ir4zsuNxZiPS85K"
   ],
   [
     {

--- a/modules/abstract-utxo/test/unit/fixtures/tbtc/addresses-by-chain.json
+++ b/modules/abstract-utxo/test/unit/fixtures/tbtc/addresses-by-chain.json
@@ -3,174 +3,66 @@
     {
       "chain": "default"
     },
-    {
-      "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
-      "chain": 0,
-      "index": 0,
-      "coin": "tbtc",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn"
   ],
   [
     {
       "chain": 0
     },
-    {
-      "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
-      "chain": 0,
-      "index": 0,
-      "coin": "tbtc",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn"
   ],
   [
     {
       "chain": 1
     },
-    {
-      "address": "2MyPbR4VrC98jCfnfhu9ir4zsuNxZiPS85K",
-      "chain": 1,
-      "index": 0,
-      "coin": "tbtc",
-      "coinSpecific": {
-        "outputScript": "a9144365f80ae9830dab1d9124be68c74c2fa23bbc1287",
-        "redeemScript": "522102d06c08ccf0fddefff881e869b951d4b92e936118b3360182c5b8c55f4c40bc6121030795af84ecc10252d8a894f54845beeb5624a1c24c3747cc654bd430539dee3521029b30ebe8eb23f8cec82f25a80e3b423979ec3ba1fe07d9d4ed9f6361258bc31d53ae"
-      },
-      "addressType": "p2sh"
-    }
+    "2MyPbR4VrC98jCfnfhu9ir4zsuNxZiPS85K"
   ],
   [
     {
       "chain": 10
     },
-    {
-      "address": "2N4uionZeh2p88wf2B6MCEr8ar2NHWEnQeQ",
-      "chain": 10,
-      "index": 0,
-      "coin": "tbtc",
-      "coinSpecific": {
-        "outputScript": "a9147ff13f3faeba4d439ef40604f7c127951e77eb6a87",
-        "redeemScript": "00207aad7d57b238a09b5daa10ff47c54483b7f2ad47f3f0c0aa230958b9df334260",
-        "witnessScript": "52210304fcea3fb05f6e8a8fe91db2087bdd13b18102a0b10a77c1fdbb326b0ce7cec421028242a3ea9e20d4e6b78e3f0dde21aff86a623d48322681b203b6827e22d04a9d2102ceec88b222a55ec67d1414b523bcfc0f53eb6ac012ba91744a4ed8eb448d55f753ae"
-      },
-      "addressType": "p2shP2wsh"
-    }
+    "2N4uionZeh2p88wf2B6MCEr8ar2NHWEnQeQ"
   ],
   [
     {
       "chain": 11
     },
-    {
-      "address": "2NFCjioQkatHzS9wxXiURfvsQrHfWqT3yZj",
-      "chain": 11,
-      "index": 0,
-      "coin": "tbtc",
-      "coinSpecific": {
-        "outputScript": "a914f0da56d9bb06310289d808a22ad68457a760ac0387",
-        "redeemScript": "00202ce48eb68ff4a96f2742cfbdd90210ae30bc7cdbafd63fbbe368802e3c0ae800",
-        "witnessScript": "52210386b73c1c9e0d5c3370496426cdb6593bd69bb93743e135860aa5797cd04353c521022e79cdb1ee0b8cad6c9667fedafa92f8472f731f627dc8e0018571e4de9dfda42102f6d5e998e5b41e7e783c7c5c8a633cf333b86200aab31676ab07ed336e22700353ae"
-      },
-      "addressType": "p2shP2wsh"
-    }
+    "2NFCjioQkatHzS9wxXiURfvsQrHfWqT3yZj"
   ],
   [
     {
       "chain": 20
     },
-    {
-      "address": "tb1qjpzgkka9lhs5l39shlr4d394tljw8p2v35sl88h82djvqp3mculq283u4j",
-      "chain": 20,
-      "index": 0,
-      "coin": "tbtc",
-      "coinSpecific": {
-        "outputScript": "002090448b5ba5fde14fc4b0bfc756c4b55fe4e3854c8d21f39ee75364c0063bc73e",
-        "witnessScript": "522103cf858f42c759d590d80f3715ce59be999089e6b1f381d0f4338276546fd3a04e2102dca1ab8670d45f5213c7c9d66b2f89b50a4cbd33fd72db89ba18d3e82d3dd5ee210294b6dab0dc112831a0dc1e219769bd81d13eb38a8bdb938103f919d8dd7e004353ae"
-      },
-      "addressType": "p2wsh"
-    }
+    "tb1qjpzgkka9lhs5l39shlr4d394tljw8p2v35sl88h82djvqp3mculq283u4j"
   ],
   [
     {
       "chain": 21
     },
-    {
-      "address": "tb1q5e7nvvypt2qpjxq74zwtry9klsqkcyvcee85anaa3pax7ae207gs37spuh",
-      "chain": 21,
-      "index": 0,
-      "coin": "tbtc",
-      "coinSpecific": {
-        "outputScript": "0020a67d3630815a8019181ea89cb190b6fc016c1198ce4f4ecfbd887a6f772a7f91",
-        "witnessScript": "52210391e76285ad55895309f6fa7db9fb359489daaf235bb4cb50608f9562122af1ab210285ddd6b1e84e37a9f222737d8b80a8a980a193a783b75b9e82d6e239eb52818c2103a13ee160d79d43201ef5e65b6df4e0842de3b640904d049e64daaaa84a306bb853ae"
-      },
-      "addressType": "p2wsh"
-    }
+    "tb1q5e7nvvypt2qpjxq74zwtry9klsqkcyvcee85anaa3pax7ae207gs37spuh"
   ],
   [
     {
       "chain": 30
     },
-    {
-      "address": "tb1p0sm0je6mv9zrzyguquzh24svlz6sgcct3qckp34nc09vj6wedn0shlq9un",
-      "chain": 30,
-      "index": 0,
-      "coin": "tbtc",
-      "coinSpecific": {
-        "outputScript": "51207c36f9675b614431111c070575560cf8b504630b883160c6b3c3cac969d96cdf"
-      },
-      "addressType": "p2tr"
-    }
+    "tb1p0sm0je6mv9zrzyguquzh24svlz6sgcct3qckp34nc09vj6wedn0shlq9un"
   ],
   [
     {
       "chain": 31
     },
-    {
-      "address": "tb1phk6lhy2tka2kxsx6hjd3c0z2h2e0rcrere9lr3kqsg0p6xxqe2pqa44eqg",
-      "chain": 31,
-      "index": 0,
-      "coin": "tbtc",
-      "coinSpecific": {
-        "outputScript": "5120bdb5fb914bb7556340dabc9b1c3c4abab2f1e0791e4bf1c6c0821e1d18c0ca82"
-      },
-      "addressType": "p2tr"
-    }
+    "tb1phk6lhy2tka2kxsx6hjd3c0z2h2e0rcrere9lr3kqsg0p6xxqe2pqa44eqg"
   ],
   [
     {
       "chain": 40
     },
-    {
-      "address": "tb1pxgs4mpuymvtr7hsx3u0efx5yvjd2nark5qgsg89s8p0jcdzvukgq35t4u7",
-      "chain": 40,
-      "index": 0,
-      "coin": "tbtc",
-      "coinSpecific": {
-        "outputScript": "512032215d8784db163f5e068f1f949a84649aa9f476a011041cb0385f2c344ce590"
-      },
-      "addressType": "p2trMusig2"
-    }
+    "tb1pxgs4mpuymvtr7hsx3u0efx5yvjd2nark5qgsg89s8p0jcdzvukgq35t4u7"
   ],
   [
     {
       "chain": 41
     },
-    {
-      "address": "tb1p8qdlmtsw6ehy9u4w8lpw4xw6shg7jknu7fhrlaclpdaqtfp0puesgpm4xs",
-      "chain": 41,
-      "index": 0,
-      "coin": "tbtc",
-      "coinSpecific": {
-        "outputScript": "5120381bfdae0ed66e42f2ae3fc2ea99da85d1e95a7cf26e3ff71f0b7a05a42f0f33"
-      },
-      "addressType": "p2trMusig2"
-    }
+    "tb1p8qdlmtsw6ehy9u4w8lpw4xw6shg7jknu7fhrlaclpdaqtfp0puesgpm4xs"
   ]
 ]

--- a/modules/abstract-utxo/test/unit/fixtures/tbtc4/addresses-by-chain.json
+++ b/modules/abstract-utxo/test/unit/fixtures/tbtc4/addresses-by-chain.json
@@ -3,174 +3,66 @@
     {
       "chain": "default"
     },
-    {
-      "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
-      "chain": 0,
-      "index": 0,
-      "coin": "tbtc4",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn"
   ],
   [
     {
       "chain": 0
     },
-    {
-      "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
-      "chain": 0,
-      "index": 0,
-      "coin": "tbtc4",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn"
   ],
   [
     {
       "chain": 1
     },
-    {
-      "address": "2MyPbR4VrC98jCfnfhu9ir4zsuNxZiPS85K",
-      "chain": 1,
-      "index": 0,
-      "coin": "tbtc4",
-      "coinSpecific": {
-        "outputScript": "a9144365f80ae9830dab1d9124be68c74c2fa23bbc1287",
-        "redeemScript": "522102d06c08ccf0fddefff881e869b951d4b92e936118b3360182c5b8c55f4c40bc6121030795af84ecc10252d8a894f54845beeb5624a1c24c3747cc654bd430539dee3521029b30ebe8eb23f8cec82f25a80e3b423979ec3ba1fe07d9d4ed9f6361258bc31d53ae"
-      },
-      "addressType": "p2sh"
-    }
+    "2MyPbR4VrC98jCfnfhu9ir4zsuNxZiPS85K"
   ],
   [
     {
       "chain": 10
     },
-    {
-      "address": "2N4uionZeh2p88wf2B6MCEr8ar2NHWEnQeQ",
-      "chain": 10,
-      "index": 0,
-      "coin": "tbtc4",
-      "coinSpecific": {
-        "outputScript": "a9147ff13f3faeba4d439ef40604f7c127951e77eb6a87",
-        "redeemScript": "00207aad7d57b238a09b5daa10ff47c54483b7f2ad47f3f0c0aa230958b9df334260",
-        "witnessScript": "52210304fcea3fb05f6e8a8fe91db2087bdd13b18102a0b10a77c1fdbb326b0ce7cec421028242a3ea9e20d4e6b78e3f0dde21aff86a623d48322681b203b6827e22d04a9d2102ceec88b222a55ec67d1414b523bcfc0f53eb6ac012ba91744a4ed8eb448d55f753ae"
-      },
-      "addressType": "p2shP2wsh"
-    }
+    "2N4uionZeh2p88wf2B6MCEr8ar2NHWEnQeQ"
   ],
   [
     {
       "chain": 11
     },
-    {
-      "address": "2NFCjioQkatHzS9wxXiURfvsQrHfWqT3yZj",
-      "chain": 11,
-      "index": 0,
-      "coin": "tbtc4",
-      "coinSpecific": {
-        "outputScript": "a914f0da56d9bb06310289d808a22ad68457a760ac0387",
-        "redeemScript": "00202ce48eb68ff4a96f2742cfbdd90210ae30bc7cdbafd63fbbe368802e3c0ae800",
-        "witnessScript": "52210386b73c1c9e0d5c3370496426cdb6593bd69bb93743e135860aa5797cd04353c521022e79cdb1ee0b8cad6c9667fedafa92f8472f731f627dc8e0018571e4de9dfda42102f6d5e998e5b41e7e783c7c5c8a633cf333b86200aab31676ab07ed336e22700353ae"
-      },
-      "addressType": "p2shP2wsh"
-    }
+    "2NFCjioQkatHzS9wxXiURfvsQrHfWqT3yZj"
   ],
   [
     {
       "chain": 20
     },
-    {
-      "address": "tb1qjpzgkka9lhs5l39shlr4d394tljw8p2v35sl88h82djvqp3mculq283u4j",
-      "chain": 20,
-      "index": 0,
-      "coin": "tbtc4",
-      "coinSpecific": {
-        "outputScript": "002090448b5ba5fde14fc4b0bfc756c4b55fe4e3854c8d21f39ee75364c0063bc73e",
-        "witnessScript": "522103cf858f42c759d590d80f3715ce59be999089e6b1f381d0f4338276546fd3a04e2102dca1ab8670d45f5213c7c9d66b2f89b50a4cbd33fd72db89ba18d3e82d3dd5ee210294b6dab0dc112831a0dc1e219769bd81d13eb38a8bdb938103f919d8dd7e004353ae"
-      },
-      "addressType": "p2wsh"
-    }
+    "tb1qjpzgkka9lhs5l39shlr4d394tljw8p2v35sl88h82djvqp3mculq283u4j"
   ],
   [
     {
       "chain": 21
     },
-    {
-      "address": "tb1q5e7nvvypt2qpjxq74zwtry9klsqkcyvcee85anaa3pax7ae207gs37spuh",
-      "chain": 21,
-      "index": 0,
-      "coin": "tbtc4",
-      "coinSpecific": {
-        "outputScript": "0020a67d3630815a8019181ea89cb190b6fc016c1198ce4f4ecfbd887a6f772a7f91",
-        "witnessScript": "52210391e76285ad55895309f6fa7db9fb359489daaf235bb4cb50608f9562122af1ab210285ddd6b1e84e37a9f222737d8b80a8a980a193a783b75b9e82d6e239eb52818c2103a13ee160d79d43201ef5e65b6df4e0842de3b640904d049e64daaaa84a306bb853ae"
-      },
-      "addressType": "p2wsh"
-    }
+    "tb1q5e7nvvypt2qpjxq74zwtry9klsqkcyvcee85anaa3pax7ae207gs37spuh"
   ],
   [
     {
       "chain": 30
     },
-    {
-      "address": "tb1p0sm0je6mv9zrzyguquzh24svlz6sgcct3qckp34nc09vj6wedn0shlq9un",
-      "chain": 30,
-      "index": 0,
-      "coin": "tbtc4",
-      "coinSpecific": {
-        "outputScript": "51207c36f9675b614431111c070575560cf8b504630b883160c6b3c3cac969d96cdf"
-      },
-      "addressType": "p2tr"
-    }
+    "tb1p0sm0je6mv9zrzyguquzh24svlz6sgcct3qckp34nc09vj6wedn0shlq9un"
   ],
   [
     {
       "chain": 31
     },
-    {
-      "address": "tb1phk6lhy2tka2kxsx6hjd3c0z2h2e0rcrere9lr3kqsg0p6xxqe2pqa44eqg",
-      "chain": 31,
-      "index": 0,
-      "coin": "tbtc4",
-      "coinSpecific": {
-        "outputScript": "5120bdb5fb914bb7556340dabc9b1c3c4abab2f1e0791e4bf1c6c0821e1d18c0ca82"
-      },
-      "addressType": "p2tr"
-    }
+    "tb1phk6lhy2tka2kxsx6hjd3c0z2h2e0rcrere9lr3kqsg0p6xxqe2pqa44eqg"
   ],
   [
     {
       "chain": 40
     },
-    {
-      "address": "tb1pxgs4mpuymvtr7hsx3u0efx5yvjd2nark5qgsg89s8p0jcdzvukgq35t4u7",
-      "chain": 40,
-      "index": 0,
-      "coin": "tbtc4",
-      "coinSpecific": {
-        "outputScript": "512032215d8784db163f5e068f1f949a84649aa9f476a011041cb0385f2c344ce590"
-      },
-      "addressType": "p2trMusig2"
-    }
+    "tb1pxgs4mpuymvtr7hsx3u0efx5yvjd2nark5qgsg89s8p0jcdzvukgq35t4u7"
   ],
   [
     {
       "chain": 41
     },
-    {
-      "address": "tb1p8qdlmtsw6ehy9u4w8lpw4xw6shg7jknu7fhrlaclpdaqtfp0puesgpm4xs",
-      "chain": 41,
-      "index": 0,
-      "coin": "tbtc4",
-      "coinSpecific": {
-        "outputScript": "5120381bfdae0ed66e42f2ae3fc2ea99da85d1e95a7cf26e3ff71f0b7a05a42f0f33"
-      },
-      "addressType": "p2trMusig2"
-    }
+    "tb1p8qdlmtsw6ehy9u4w8lpw4xw6shg7jknu7fhrlaclpdaqtfp0puesgpm4xs"
   ]
 ]

--- a/modules/abstract-utxo/test/unit/fixtures/tbtcsig/addresses-by-chain.json
+++ b/modules/abstract-utxo/test/unit/fixtures/tbtcsig/addresses-by-chain.json
@@ -3,174 +3,66 @@
     {
       "chain": "default"
     },
-    {
-      "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
-      "chain": 0,
-      "index": 0,
-      "coin": "tbtcsig",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn"
   ],
   [
     {
       "chain": 0
     },
-    {
-      "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
-      "chain": 0,
-      "index": 0,
-      "coin": "tbtcsig",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn"
   ],
   [
     {
       "chain": 1
     },
-    {
-      "address": "2MyPbR4VrC98jCfnfhu9ir4zsuNxZiPS85K",
-      "chain": 1,
-      "index": 0,
-      "coin": "tbtcsig",
-      "coinSpecific": {
-        "outputScript": "a9144365f80ae9830dab1d9124be68c74c2fa23bbc1287",
-        "redeemScript": "522102d06c08ccf0fddefff881e869b951d4b92e936118b3360182c5b8c55f4c40bc6121030795af84ecc10252d8a894f54845beeb5624a1c24c3747cc654bd430539dee3521029b30ebe8eb23f8cec82f25a80e3b423979ec3ba1fe07d9d4ed9f6361258bc31d53ae"
-      },
-      "addressType": "p2sh"
-    }
+    "2MyPbR4VrC98jCfnfhu9ir4zsuNxZiPS85K"
   ],
   [
     {
       "chain": 10
     },
-    {
-      "address": "2N4uionZeh2p88wf2B6MCEr8ar2NHWEnQeQ",
-      "chain": 10,
-      "index": 0,
-      "coin": "tbtcsig",
-      "coinSpecific": {
-        "outputScript": "a9147ff13f3faeba4d439ef40604f7c127951e77eb6a87",
-        "redeemScript": "00207aad7d57b238a09b5daa10ff47c54483b7f2ad47f3f0c0aa230958b9df334260",
-        "witnessScript": "52210304fcea3fb05f6e8a8fe91db2087bdd13b18102a0b10a77c1fdbb326b0ce7cec421028242a3ea9e20d4e6b78e3f0dde21aff86a623d48322681b203b6827e22d04a9d2102ceec88b222a55ec67d1414b523bcfc0f53eb6ac012ba91744a4ed8eb448d55f753ae"
-      },
-      "addressType": "p2shP2wsh"
-    }
+    "2N4uionZeh2p88wf2B6MCEr8ar2NHWEnQeQ"
   ],
   [
     {
       "chain": 11
     },
-    {
-      "address": "2NFCjioQkatHzS9wxXiURfvsQrHfWqT3yZj",
-      "chain": 11,
-      "index": 0,
-      "coin": "tbtcsig",
-      "coinSpecific": {
-        "outputScript": "a914f0da56d9bb06310289d808a22ad68457a760ac0387",
-        "redeemScript": "00202ce48eb68ff4a96f2742cfbdd90210ae30bc7cdbafd63fbbe368802e3c0ae800",
-        "witnessScript": "52210386b73c1c9e0d5c3370496426cdb6593bd69bb93743e135860aa5797cd04353c521022e79cdb1ee0b8cad6c9667fedafa92f8472f731f627dc8e0018571e4de9dfda42102f6d5e998e5b41e7e783c7c5c8a633cf333b86200aab31676ab07ed336e22700353ae"
-      },
-      "addressType": "p2shP2wsh"
-    }
+    "2NFCjioQkatHzS9wxXiURfvsQrHfWqT3yZj"
   ],
   [
     {
       "chain": 20
     },
-    {
-      "address": "tb1qjpzgkka9lhs5l39shlr4d394tljw8p2v35sl88h82djvqp3mculq283u4j",
-      "chain": 20,
-      "index": 0,
-      "coin": "tbtcsig",
-      "coinSpecific": {
-        "outputScript": "002090448b5ba5fde14fc4b0bfc756c4b55fe4e3854c8d21f39ee75364c0063bc73e",
-        "witnessScript": "522103cf858f42c759d590d80f3715ce59be999089e6b1f381d0f4338276546fd3a04e2102dca1ab8670d45f5213c7c9d66b2f89b50a4cbd33fd72db89ba18d3e82d3dd5ee210294b6dab0dc112831a0dc1e219769bd81d13eb38a8bdb938103f919d8dd7e004353ae"
-      },
-      "addressType": "p2wsh"
-    }
+    "tb1qjpzgkka9lhs5l39shlr4d394tljw8p2v35sl88h82djvqp3mculq283u4j"
   ],
   [
     {
       "chain": 21
     },
-    {
-      "address": "tb1q5e7nvvypt2qpjxq74zwtry9klsqkcyvcee85anaa3pax7ae207gs37spuh",
-      "chain": 21,
-      "index": 0,
-      "coin": "tbtcsig",
-      "coinSpecific": {
-        "outputScript": "0020a67d3630815a8019181ea89cb190b6fc016c1198ce4f4ecfbd887a6f772a7f91",
-        "witnessScript": "52210391e76285ad55895309f6fa7db9fb359489daaf235bb4cb50608f9562122af1ab210285ddd6b1e84e37a9f222737d8b80a8a980a193a783b75b9e82d6e239eb52818c2103a13ee160d79d43201ef5e65b6df4e0842de3b640904d049e64daaaa84a306bb853ae"
-      },
-      "addressType": "p2wsh"
-    }
+    "tb1q5e7nvvypt2qpjxq74zwtry9klsqkcyvcee85anaa3pax7ae207gs37spuh"
   ],
   [
     {
       "chain": 30
     },
-    {
-      "address": "tb1p0sm0je6mv9zrzyguquzh24svlz6sgcct3qckp34nc09vj6wedn0shlq9un",
-      "chain": 30,
-      "index": 0,
-      "coin": "tbtcsig",
-      "coinSpecific": {
-        "outputScript": "51207c36f9675b614431111c070575560cf8b504630b883160c6b3c3cac969d96cdf"
-      },
-      "addressType": "p2tr"
-    }
+    "tb1p0sm0je6mv9zrzyguquzh24svlz6sgcct3qckp34nc09vj6wedn0shlq9un"
   ],
   [
     {
       "chain": 31
     },
-    {
-      "address": "tb1phk6lhy2tka2kxsx6hjd3c0z2h2e0rcrere9lr3kqsg0p6xxqe2pqa44eqg",
-      "chain": 31,
-      "index": 0,
-      "coin": "tbtcsig",
-      "coinSpecific": {
-        "outputScript": "5120bdb5fb914bb7556340dabc9b1c3c4abab2f1e0791e4bf1c6c0821e1d18c0ca82"
-      },
-      "addressType": "p2tr"
-    }
+    "tb1phk6lhy2tka2kxsx6hjd3c0z2h2e0rcrere9lr3kqsg0p6xxqe2pqa44eqg"
   ],
   [
     {
       "chain": 40
     },
-    {
-      "address": "tb1pxgs4mpuymvtr7hsx3u0efx5yvjd2nark5qgsg89s8p0jcdzvukgq35t4u7",
-      "chain": 40,
-      "index": 0,
-      "coin": "tbtcsig",
-      "coinSpecific": {
-        "outputScript": "512032215d8784db163f5e068f1f949a84649aa9f476a011041cb0385f2c344ce590"
-      },
-      "addressType": "p2trMusig2"
-    }
+    "tb1pxgs4mpuymvtr7hsx3u0efx5yvjd2nark5qgsg89s8p0jcdzvukgq35t4u7"
   ],
   [
     {
       "chain": 41
     },
-    {
-      "address": "tb1p8qdlmtsw6ehy9u4w8lpw4xw6shg7jknu7fhrlaclpdaqtfp0puesgpm4xs",
-      "chain": 41,
-      "index": 0,
-      "coin": "tbtcsig",
-      "coinSpecific": {
-        "outputScript": "5120381bfdae0ed66e42f2ae3fc2ea99da85d1e95a7cf26e3ff71f0b7a05a42f0f33"
-      },
-      "addressType": "p2trMusig2"
-    }
+    "tb1p8qdlmtsw6ehy9u4w8lpw4xw6shg7jknu7fhrlaclpdaqtfp0puesgpm4xs"
   ]
 ]

--- a/modules/abstract-utxo/test/unit/fixtures/tdash/addresses-by-chain.json
+++ b/modules/abstract-utxo/test/unit/fixtures/tdash/addresses-by-chain.json
@@ -3,49 +3,19 @@
     {
       "chain": "default"
     },
-    {
-      "address": "8hBtzbNgcWpnxorvnFtCia7KEdFFLmoiFj",
-      "chain": 0,
-      "index": 0,
-      "coin": "tdash",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "8hBtzbNgcWpnxorvnFtCia7KEdFFLmoiFj"
   ],
   [
     {
       "chain": 0
     },
-    {
-      "address": "8hBtzbNgcWpnxorvnFtCia7KEdFFLmoiFj",
-      "chain": 0,
-      "index": 0,
-      "coin": "tdash",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "8hBtzbNgcWpnxorvnFtCia7KEdFFLmoiFj"
   ],
   [
     {
       "chain": 1
     },
-    {
-      "address": "8kZq8qjrXD7eSx7LNeCK1spdW6Mbun1sYn",
-      "chain": 1,
-      "index": 0,
-      "coin": "tdash",
-      "coinSpecific": {
-        "outputScript": "a9144365f80ae9830dab1d9124be68c74c2fa23bbc1287",
-        "redeemScript": "522102d06c08ccf0fddefff881e869b951d4b92e936118b3360182c5b8c55f4c40bc6121030795af84ecc10252d8a894f54845beeb5624a1c24c3747cc654bd430539dee3521029b30ebe8eb23f8cec82f25a80e3b423979ec3ba1fe07d9d4ed9f6361258bc31d53ae"
-      },
-      "addressType": "p2sh"
-    }
+    "8kZq8qjrXD7eSx7LNeCK1spdW6Mbun1sYn"
   ],
   [
     {

--- a/modules/abstract-utxo/test/unit/fixtures/tdoge/addresses-by-chain.json
+++ b/modules/abstract-utxo/test/unit/fixtures/tdoge/addresses-by-chain.json
@@ -3,49 +3,19 @@
     {
       "chain": "default"
     },
-    {
-      "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
-      "chain": 0,
-      "index": 0,
-      "coin": "tdoge",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn"
   ],
   [
     {
       "chain": 0
     },
-    {
-      "address": "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn",
-      "chain": 0,
-      "index": 0,
-      "coin": "tdoge",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "2Mv1fGp8gHSqsiXYG7WqcYmHZdurDGVtUbn"
   ],
   [
     {
       "chain": 1
     },
-    {
-      "address": "2MyPbR4VrC98jCfnfhu9ir4zsuNxZiPS85K",
-      "chain": 1,
-      "index": 0,
-      "coin": "tdoge",
-      "coinSpecific": {
-        "outputScript": "a9144365f80ae9830dab1d9124be68c74c2fa23bbc1287",
-        "redeemScript": "522102d06c08ccf0fddefff881e869b951d4b92e936118b3360182c5b8c55f4c40bc6121030795af84ecc10252d8a894f54845beeb5624a1c24c3747cc654bd430539dee3521029b30ebe8eb23f8cec82f25a80e3b423979ec3ba1fe07d9d4ed9f6361258bc31d53ae"
-      },
-      "addressType": "p2sh"
-    }
+    "2MyPbR4VrC98jCfnfhu9ir4zsuNxZiPS85K"
   ],
   [
     {

--- a/modules/abstract-utxo/test/unit/fixtures/tltc/addresses-by-chain.json
+++ b/modules/abstract-utxo/test/unit/fixtures/tltc/addresses-by-chain.json
@@ -3,115 +3,43 @@
     {
       "chain": "default"
     },
-    {
-      "address": "QPNRPpzvJYtxriJJjcsddTiznJJ35u6Chk",
-      "chain": 0,
-      "index": 0,
-      "coin": "tltc",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "QPNRPpzvJYtxriJJjcsddTiznJJ35u6Chk"
   ],
   [
     {
       "chain": 0
     },
-    {
-      "address": "QPNRPpzvJYtxriJJjcsddTiznJJ35u6Chk",
-      "chain": 0,
-      "index": 0,
-      "coin": "tltc",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "QPNRPpzvJYtxriJJjcsddTiznJJ35u6Chk"
   ],
   [
     {
       "chain": 1
     },
-    {
-      "address": "QSkMY5N6DFBpLrYiL1BjvmSK3mQPb8W877",
-      "chain": 1,
-      "index": 0,
-      "coin": "tltc",
-      "coinSpecific": {
-        "outputScript": "a9144365f80ae9830dab1d9124be68c74c2fa23bbc1287",
-        "redeemScript": "522102d06c08ccf0fddefff881e869b951d4b92e936118b3360182c5b8c55f4c40bc6121030795af84ecc10252d8a894f54845beeb5624a1c24c3747cc654bd430539dee3521029b30ebe8eb23f8cec82f25a80e3b423979ec3ba1fe07d9d4ed9f6361258bc31d53ae"
-      },
-      "addressType": "p2sh"
-    }
+    "QSkMY5N6DFBpLrYiL1BjvmSK3mQPb8W877"
   ],
   [
     {
       "chain": 10
     },
-    {
-      "address": "QYGUvoRti8sDH8R4oCPDKYa1zQp7UWCfAA",
-      "chain": 10,
-      "index": 0,
-      "coin": "tltc",
-      "coinSpecific": {
-        "outputScript": "a9147ff13f3faeba4d439ef40604f7c127951e77eb6a87",
-        "redeemScript": "00207aad7d57b238a09b5daa10ff47c54483b7f2ad47f3f0c0aa230958b9df334260",
-        "witnessScript": "52210304fcea3fb05f6e8a8fe91db2087bdd13b18102a0b10a77c1fdbb326b0ce7cec421028242a3ea9e20d4e6b78e3f0dde21aff86a623d48322681b203b6827e22d04a9d2102ceec88b222a55ec67d1414b523bcfc0f53eb6ac012ba91744a4ed8eb448d55f753ae"
-      },
-      "addressType": "p2shP2wsh"
-    }
+    "QYGUvoRti8sDH8R4oCPDKYa1zQp7UWCfAA"
   ],
   [
     {
       "chain": 11
     },
-    {
-      "address": "QiZVqpGzbzM5aLi19pWSkdJqzg7LkJqXZ9",
-      "chain": 11,
-      "index": 0,
-      "coin": "tltc",
-      "coinSpecific": {
-        "outputScript": "a914f0da56d9bb06310289d808a22ad68457a760ac0387",
-        "redeemScript": "00202ce48eb68ff4a96f2742cfbdd90210ae30bc7cdbafd63fbbe368802e3c0ae800",
-        "witnessScript": "52210386b73c1c9e0d5c3370496426cdb6593bd69bb93743e135860aa5797cd04353c521022e79cdb1ee0b8cad6c9667fedafa92f8472f731f627dc8e0018571e4de9dfda42102f6d5e998e5b41e7e783c7c5c8a633cf333b86200aab31676ab07ed336e22700353ae"
-      },
-      "addressType": "p2shP2wsh"
-    }
+    "QiZVqpGzbzM5aLi19pWSkdJqzg7LkJqXZ9"
   ],
   [
     {
       "chain": 20
     },
-    {
-      "address": "tltc1qjpzgkka9lhs5l39shlr4d394tljw8p2v35sl88h82djvqp3mculq4yda2d",
-      "chain": 20,
-      "index": 0,
-      "coin": "tltc",
-      "coinSpecific": {
-        "outputScript": "002090448b5ba5fde14fc4b0bfc756c4b55fe4e3854c8d21f39ee75364c0063bc73e",
-        "witnessScript": "522103cf858f42c759d590d80f3715ce59be999089e6b1f381d0f4338276546fd3a04e2102dca1ab8670d45f5213c7c9d66b2f89b50a4cbd33fd72db89ba18d3e82d3dd5ee210294b6dab0dc112831a0dc1e219769bd81d13eb38a8bdb938103f919d8dd7e004353ae"
-      },
-      "addressType": "p2wsh"
-    }
+    "tltc1qjpzgkka9lhs5l39shlr4d394tljw8p2v35sl88h82djvqp3mculq4yda2d"
   ],
   [
     {
       "chain": 21
     },
-    {
-      "address": "tltc1q5e7nvvypt2qpjxq74zwtry9klsqkcyvcee85anaa3pax7ae207gswavqrg",
-      "chain": 21,
-      "index": 0,
-      "coin": "tltc",
-      "coinSpecific": {
-        "outputScript": "0020a67d3630815a8019181ea89cb190b6fc016c1198ce4f4ecfbd887a6f772a7f91",
-        "witnessScript": "52210391e76285ad55895309f6fa7db9fb359489daaf235bb4cb50608f9562122af1ab210285ddd6b1e84e37a9f222737d8b80a8a980a193a783b75b9e82d6e239eb52818c2103a13ee160d79d43201ef5e65b6df4e0842de3b640904d049e64daaaa84a306bb853ae"
-      },
-      "addressType": "p2wsh"
-    }
+    "tltc1q5e7nvvypt2qpjxq74zwtry9klsqkcyvcee85anaa3pax7ae207gswavqrg"
   ],
   [
     {

--- a/modules/abstract-utxo/test/unit/fixtures/tzec/addresses-by-chain.json
+++ b/modules/abstract-utxo/test/unit/fixtures/tzec/addresses-by-chain.json
@@ -3,49 +3,19 @@
     {
       "chain": "default"
     },
-    {
-      "address": "t29KFG5ivWmjVf5YMJZ2ucFarni4J3NXbWB",
-      "chain": 0,
-      "index": 0,
-      "coin": "tzec",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "t29KFG5ivWmjVf5YMJZ2ucFarni4J3NXbWB"
   ],
   [
     {
       "chain": 0
     },
-    {
-      "address": "t29KFG5ivWmjVf5YMJZ2ucFarni4J3NXbWB",
-      "chain": 0,
-      "index": 0,
-      "coin": "tzec",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "t29KFG5ivWmjVf5YMJZ2ucFarni4J3NXbWB"
   ],
   [
     {
       "chain": 1
     },
-    {
-      "address": "t2ChBQL66RU2M9DnktwM1uZJB4BAeZTVZAQ",
-      "chain": 1,
-      "index": 0,
-      "coin": "tzec",
-      "coinSpecific": {
-        "outputScript": "a9144365f80ae9830dab1d9124be68c74c2fa23bbc1287",
-        "redeemScript": "522102d06c08ccf0fddefff881e869b951d4b92e936118b3360182c5b8c55f4c40bc6121030795af84ecc10252d8a894f54845beeb5624a1c24c3747cc654bd430539dee3521029b30ebe8eb23f8cec82f25a80e3b423979ec3ba1fe07d9d4ed9f6361258bc31d53ae"
-      },
-      "addressType": "p2sh"
-    }
+    "t2ChBQL66RU2M9DnktwM1uZJB4BAeZTVZAQ"
   ],
   [
     {

--- a/modules/abstract-utxo/test/unit/fixtures/zec/addresses-by-chain.json
+++ b/modules/abstract-utxo/test/unit/fixtures/zec/addresses-by-chain.json
@@ -3,49 +3,19 @@
     {
       "chain": "default"
     },
-    {
-      "address": "t3ML4DQcneK887NxcNp2s4dQDgDq8G5XTpD",
-      "chain": 0,
-      "index": 0,
-      "coin": "zec",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "t3ML4DQcneK887NxcNp2s4dQDgDq8G5XTpD"
   ],
   [
     {
       "chain": 0
     },
-    {
-      "address": "t3ML4DQcneK887NxcNp2s4dQDgDq8G5XTpD",
-      "chain": 0,
-      "index": 0,
-      "coin": "zec",
-      "coinSpecific": {
-        "outputScript": "a9141e57a925dd863a86af341037e700862bf66bf7b687",
-        "redeemScript": "5221037acffd52bb7c39a4ac3d4c01af33ce0367afec45347e332edca63a38d1fb2e472102658831a87322b3583515ca8725841335505755ada53ee133c70a6b4b8d3978702102641ee6557561c9038242cafa7f538070d7646a969bcf6169f9950abfcfefd6b853ae"
-      },
-      "addressType": "p2sh"
-    }
+    "t3ML4DQcneK887NxcNp2s4dQDgDq8G5XTpD"
   ],
   [
     {
       "chain": 1
     },
-    {
-      "address": "t3QhzMeyxZ1QybXD1yCLyMw7XwgwUjsvcvH",
-      "chain": 1,
-      "index": 0,
-      "coin": "zec",
-      "coinSpecific": {
-        "outputScript": "a9144365f80ae9830dab1d9124be68c74c2fa23bbc1287",
-        "redeemScript": "522102d06c08ccf0fddefff881e869b951d4b92e936118b3360182c5b8c55f4c40bc6121030795af84ecc10252d8a894f54845beeb5624a1c24c3747cc654bd430539dee3521029b30ebe8eb23f8cec82f25a80e3b423979ec3ba1fe07d9d4ed9f6361258bc31d53ae"
-      },
-      "addressType": "p2sh"
-    }
+    "t3QhzMeyxZ1QybXD1yCLyMw7XwgwUjsvcvH"
   ],
   [
     {

--- a/modules/abstract-utxo/test/unit/recovery/crossChainRecovery.ts
+++ b/modules/abstract-utxo/test/unit/recovery/crossChainRecovery.ts
@@ -63,7 +63,6 @@ type Address = {
   address: string;
   chain: number;
   index: number;
-  coinSpecific: unknown;
 };
 
 function nockWalletAddress(coin: AbstractUtxoCoin, walletId: string, address: Address): nock.Scope {
@@ -75,7 +74,6 @@ function nockWalletAddress(coin: AbstractUtxoCoin, walletId: string, address: Ad
       index: address.index,
       coin: coin.getChain(),
       wallet: walletId,
-      coinSpecific: address.coinSpecific,
     })
     .persist();
 }
@@ -100,14 +98,19 @@ function run<TNumber extends number | bigint = number>(sourceCoin: AbstractUtxoC
     const walletKeys = getDefaultWalletKeys();
     const recoveryWalletId = '5abacebe28d72fbd07e0b8cbba0ff39e';
     // the address the accidental deposit went to, in both sourceCoin and addressCoin formats
-    const [depositAddressSourceCoin, depositAddressRecoveryCoin] = [sourceCoin, recoveryCoin].map((coin) =>
-      generateAddress(coin.network, coin.getChain(), { keychains: keychainsBase58, index: 0 })
-    );
+    const [depositAddressSourceCoin, depositAddressRecoveryCoin] = [sourceCoin, recoveryCoin].map((coin) => ({
+      address: generateAddress(coin.network, { keychains: keychainsBase58, chain: 0, index: 0 }),
+      chain: 0,
+      index: 0,
+    }));
+    const chain = 0;
+    const index = 1;
     // the address where we want to recover our funds to
-    const recoveryAddress = generateAddress(sourceCoin.network, sourceCoin.getChain(), {
+    const recoveryAddress = generateAddress(sourceCoin.network, {
       keychains: keychainsBase58,
-      index: 1,
-    }).address;
+      chain,
+      index,
+    });
     const nocks: nock.Scope[] = [];
 
     let depositTx: utxolib.bitgo.UtxoTransaction<TNumber>;
@@ -142,8 +145,8 @@ function run<TNumber extends number | bigint = number>(sourceCoin: AbstractUtxoC
         {
           id: depositTx.getId(),
           address: depositAddressSourceCoin.address,
-          chain: depositAddressSourceCoin.chain as utxolib.bitgo.ChainCode,
-          index: depositAddressSourceCoin.index,
+          chain: chain,
+          index: index,
           value: depositTx.outs[0].value,
         },
       ];

--- a/modules/abstract-utxo/test/unit/recovery/crossChainRecovery.ts
+++ b/modules/abstract-utxo/test/unit/recovery/crossChainRecovery.ts
@@ -13,6 +13,7 @@ import {
   CrossChainRecoveryUnsigned,
   getWallet,
   supportedCrossChainRecoveries,
+  generateAddress,
 } from '../../../src';
 import {
   getFixture,
@@ -100,10 +101,13 @@ function run<TNumber extends number | bigint = number>(sourceCoin: AbstractUtxoC
     const recoveryWalletId = '5abacebe28d72fbd07e0b8cbba0ff39e';
     // the address the accidental deposit went to, in both sourceCoin and addressCoin formats
     const [depositAddressSourceCoin, depositAddressRecoveryCoin] = [sourceCoin, recoveryCoin].map((coin) =>
-      coin.generateAddress({ keychains: keychainsBase58, index: 0 })
+      generateAddress(coin.network, coin.getChain(), { keychains: keychainsBase58, index: 0 })
     );
     // the address where we want to recover our funds to
-    const recoveryAddress = sourceCoin.generateAddress({ keychains: keychainsBase58, index: 1 }).address;
+    const recoveryAddress = generateAddress(sourceCoin.network, sourceCoin.getChain(), {
+      keychains: keychainsBase58,
+      index: 1,
+    }).address;
     const nocks: nock.Scope[] = [];
 
     let depositTx: utxolib.bitgo.UtxoTransaction<TNumber>;

--- a/modules/abstract-utxo/test/unit/transaction.ts
+++ b/modules/abstract-utxo/test/unit/transaction.ts
@@ -311,9 +311,9 @@ function run<TNumber extends number | bigint = number>(
     }
 
     function getOutputAddress(rootWalletKeys: utxolib.bitgo.RootWalletKeys): string {
-      return generateAddress(coin.network, coin.getChain(), {
+      return generateAddress(coin.network, {
         keychains: rootWalletKeys.triple.map((k) => ({ pub: k.neutered().toBase58() })),
-      }).address;
+      });
     }
 
     function getSignParams(

--- a/modules/abstract-utxo/test/unit/transaction.ts
+++ b/modules/abstract-utxo/test/unit/transaction.ts
@@ -13,7 +13,7 @@ import {
   WalletSignTransactionOptions,
 } from '@bitgo/sdk-core';
 
-import { AbstractUtxoCoin, getReplayProtectionAddresses } from '../../src';
+import { AbstractUtxoCoin, getReplayProtectionAddresses, generateAddress } from '../../src';
 
 import {
   utxoCoins,
@@ -311,7 +311,7 @@ function run<TNumber extends number | bigint = number>(
     }
 
     function getOutputAddress(rootWalletKeys: utxolib.bitgo.RootWalletKeys): string {
-      return coin.generateAddress({
+      return generateAddress(coin.network, coin.getChain(), {
         keychains: rootWalletKeys.triple.map((k) => ({ pub: k.neutered().toBase58() })),
       }).address;
     }


### PR DESCRIPTION

The earlier `generateAddress` class method was unnecessary and had a return type that was too
complex. We actually only need the address string and don't care about the rest.

Issue: BTC-2652