### PR TITLE
fix: add --ignore-scripts argument to yarn cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           path: |
             node_modules
             modules/*/node_modules
-          key: ${{ runner.os }}-node${{matrix.node-version}}-${{ hashFiles('yarn.lock') }}-${{ hashFiles('tsconfig.packages.json') }}-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-node${{matrix.node-version}}-ignore-scripts-${{ hashFiles('yarn.lock') }}-${{ hashFiles('tsconfig.packages.json') }}-${{ hashFiles('**/package.json') }}
 
       - name: Install Packages
         if: steps.lerna-cache.outputs.cache-hit != 'true' || contains( github.event.pull_request.labels.*.name, 'SKIP_CACHE')
@@ -106,7 +106,7 @@ jobs:
           path: |
             node_modules
             modules/*/node_modules
-          key: ${{ runner.os }}-node20-${{ hashFiles('yarn.lock') }}-${{ hashFiles('tsconfig.packages.json') }}-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-node20-ignore-scripts-${{ hashFiles('yarn.lock') }}-${{ hashFiles('tsconfig.packages.json') }}-${{ hashFiles('**/package.json') }}
 
       - name: Install Packages
         if: steps.lerna-cache.outputs.cache-hit != 'true' || contains( github.event.pull_request.labels.*.name, 'SKIP_CACHE')
@@ -152,7 +152,7 @@ jobs:
           path: |
             node_modules
             modules/*/node_modules
-          key: ${{ runner.os }}-node22-${{ hashFiles('yarn.lock') }}-${{ hashFiles('tsconfig.packages.json') }}-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-node22-ignore-scripts-${{ hashFiles('yarn.lock') }}-${{ hashFiles('tsconfig.packages.json') }}-${{ hashFiles('**/package.json') }}
 
       - name: Install Packages
         if: steps.lerna-cache.outputs.cache-hit != 'true'
@@ -300,19 +300,19 @@ jobs:
         id: docker-test
         run: |
           echo "Testing Docker image bitgo/express:${{ github.sha }}"
-          
+
           CONTAINER_ID=$(docker run -d -p 3080:3080 bitgo/express:${{ github.sha }})
           echo "Started container: $CONTAINER_ID"
-          
+
           # Wait for the service to be ready with timeout
           echo "Waiting for service to be ready..."
-          
+
           for i in {1..30}; do
             if curl -f -s --max-time 5 http://localhost:3080/api/v2/ping > /dev/null 2>&1; then
               echo "✅ API health check passed"
               break
             fi
-            
+
             if [ $i -eq 30 ]; then
               echo "::error::API health check failed after 30 attempts"
               docker logs "$CONTAINER_ID"
@@ -320,18 +320,18 @@ jobs:
               docker rm "$CONTAINER_ID"
               exit 1
             fi
-            
+
             echo "Waiting for API... (attempt $i/30)"
             sleep 2
           done
-          
+
           # Check container logs for errors
           docker logs "$CONTAINER_ID"
-          
+
           # Stop the container
           docker stop "$CONTAINER_ID"
           docker rm "$CONTAINER_ID"
-          
+
           echo "✅ Docker image tests passed"
 
   dockerfile-check:
@@ -354,7 +354,7 @@ jobs:
           path: |
             node_modules
             modules/*/node_modules
-          key: ${{ runner.os }}-node22-${{ hashFiles('yarn.lock') }}-${{ hashFiles('tsconfig.packages.json')}}-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-node22-ignore-scripts-${{ hashFiles('yarn.lock') }}-${{ hashFiles('tsconfig.packages.json')}}-${{ hashFiles('**/package.json') }}
 
       - name: Install Packages
         if: steps.lerna-cache.outputs.cache-hit != 'true' || contains( github.event.pull_request.labels.*.name, 'SKIP_CACHE')


### PR DESCRIPTION
Using the `--ignore-scripts` argument will result in a different set of dependencies being installed. For example, some native dependencies won't be installed, so fallbacks will be used. I'm not sure exactly why we're using the argument sometimes and other times we aren't, so in the meantime I'm making sure that we at least account for the presence of the argument in the yarn cache key.

TICKET: VL-3710