### PR TITLE
fix: narrow down Dockerfile drift detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,19 +300,19 @@ jobs:
         id: docker-test
         run: |
           echo "Testing Docker image bitgo/express:${{ github.sha }}"
-          
+
           CONTAINER_ID=$(docker run -d -p 3080:3080 bitgo/express:${{ github.sha }})
           echo "Started container: $CONTAINER_ID"
-          
+
           # Wait for the service to be ready with timeout
           echo "Waiting for service to be ready..."
-          
+
           for i in {1..30}; do
             if curl -f -s --max-time 5 http://localhost:3080/api/v2/ping > /dev/null 2>&1; then
               echo "✅ API health check passed"
               break
             fi
-            
+
             if [ $i -eq 30 ]; then
               echo "::error::API health check failed after 30 attempts"
               docker logs "$CONTAINER_ID"
@@ -320,18 +320,18 @@ jobs:
               docker rm "$CONTAINER_ID"
               exit 1
             fi
-            
+
             echo "Waiting for API... (attempt $i/30)"
             sleep 2
           done
-          
+
           # Check container logs for errors
           docker logs "$CONTAINER_ID"
-          
+
           # Stop the container
           docker stop "$CONTAINER_ID"
           docker rm "$CONTAINER_ID"
-          
+
           echo "✅ Docker image tests passed"
 
   dockerfile-check:
@@ -363,9 +363,9 @@ jobs:
       - name: Check Dockerfile is up to date
         run: |
           yarn update-dockerfile
-          if ! git diff --quiet; then
+          if ! git diff --quiet -- . ':!yarn.lock'; then
             echo "Dockerfile is not up to date. Please run 'yarn update-dockerfile' and commit the changes."
-            git diff
+            git diff -- . ':!yarn.lock'
             exit 1
           fi
 


### PR DESCRIPTION
Using the --ignore-scripts argument will result in a different set of dependencies being installed. For example, some native dependencies won't be installed, so fallbacks will be used. I'm not sure exactly why we're using the argument sometimes and other times we aren't, so in the meantime I'm making sure that we ignore the `yarn.lock` drift when detecting drift in the `bitgo/express` Dockerfile

TICKET: VL-3710