### PR TITLE
feat: support original url for hmac calculation

### DIFF
--- a/modules/sdk-hmac/src/hmac.ts
+++ b/modules/sdk-hmac/src/hmac.ts
@@ -28,22 +28,23 @@ export function calculateHMAC(key: string | BinaryLike | KeyObject, message: str
  * @param statusCode Only set for HTTP responses, leave blank for requests
  * @param method request method
  * @param authVersion authentication version (2 or 3)
+ * @param useOriginalPath whether to use the original urlPath without parsing (default false)
  * @returns {string | Buffer}
  */
-export function calculateHMACSubject<T extends string | Buffer = string>({
-  urlPath,
-  text,
-  timestamp,
-  statusCode,
-  method,
-  authVersion,
-}: CalculateHmacSubjectOptions<T>): T {
+export function calculateHMACSubject<T extends string | Buffer = string>(
+  { urlPath, text, timestamp, statusCode, method, authVersion }: CalculateHmacSubjectOptions<T>,
+  useOriginalPath = false
+): T {
   /* Normalize legacy 'del' to 'delete' for backward compatibility */
   if (method === 'del') {
     method = 'delete';
   }
-  const urlDetails = urlLib.parse(urlPath);
-  const queryPath = urlDetails.query && urlDetails.query.length > 0 ? urlDetails.path : urlDetails.pathname;
+
+  let queryPath: string | null = urlPath;
+  if (!useOriginalPath) {
+    const urlDetails = urlLib.parse(urlPath);
+    queryPath = urlDetails.query && urlDetails.query.length > 0 ? urlDetails.path : urlDetails.pathname;
+  }
 
   let prefixedText: string;
   if (statusCode !== undefined && isFinite(statusCode) && Number.isInteger(statusCode)) {

--- a/modules/sdk-hmac/test/hmac.ts
+++ b/modules/sdk-hmac/test/hmac.ts
@@ -61,6 +61,35 @@ describe('HMAC Utility Functions', () => {
       ).to.equal(expectedSubject);
     });
 
+    it('should calculate the correct subject for a request with a trailing ? when useOriginalPath is true', () => {
+      const expectedSubject = 'GET|1672531200000|3.0|/api/test?|body-content';
+      expect(
+        calculateHMACSubject(
+          {
+            urlPath: '/api/test?',
+            text: 'body-content',
+            timestamp: MOCK_TIMESTAMP,
+            method: 'get',
+            authVersion: 3,
+          },
+          true
+        )
+      ).to.equal(expectedSubject);
+    });
+
+    it('should calculate the correct subject for a request with a trailing ? when useOriginalPath is false', () => {
+      const expectedSubject = 'GET|1672531200000|3.0|/api/test|body-content';
+      expect(
+        calculateHMACSubject({
+          urlPath: '/api/test?',
+          text: 'body-content',
+          timestamp: MOCK_TIMESTAMP,
+          method: 'get',
+          authVersion: 3,
+        })
+      ).to.equal(expectedSubject);
+    });
+
     it('should include statusCode for a response', () => {
       const expectedSubject = 'GET|1672531200000|/api/test|200|response-body';
       expect(


### PR DESCRIPTION
Ticket: ANT-1086

## Description

In bitgo-ui, auth-service, and WP, the original url from `x-original-uri` is used for hmac calculation with no url parsing. The url parsing typically produces the same url except in some edge cases where there is a trailing `?`. This has resulted in hmac mismatch when switching the hmac calculation to use `sdk-hmac` in these services.

To ensure existing client flows don't break, this PR adds a `useOriginalPath` parameter to `calculateHMACSubject` which will use the url passed to `calculateHMACSubject` with no parsing if it is true. The default value of this parameter is false, so as not to break existing sdk flows. In the above services, I will set it to true.

## Issue Number

ANT-1086

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [x] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
