### PR TITLE
chore: update GitHub secret reference for beta npm publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
           git checkout -b ${{ env.preid }}-$(git rev-parse --short HEAD)
           echo "email=${{ secrets.BETA_EMAIL }}" > .npmrc
           echo "@bitgo-beta:registry=https://registry.npmjs.org" >> .npmrc
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.BETA_TOKEN }}" >> .npmrc
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.BITGO_BETA_PUBLISH_TOKEN }}" >> .npmrc
           echo "//registry.npmjs.org/:always-auth=true" >> .npmrc
 
       - name: Prepare Release


### PR DESCRIPTION
## Summary
Replace `BETA_TOKEN` with `BITGO_BETA_PUBLISH_TOKEN` in the publish workflow to align with updated GitHub Actions secret naming conventions.

## Changes
- Updated `.github/workflows/publish.yml:49` to use `BITGO_BETA_PUBLISH_TOKEN` instead of `BETA_TOKEN`

## Notes
- The new GitHub Actions secret `BITGO_BETA_PUBLISH_TOKEN` must be configured in repository settings before merging
- The old `BETA_TOKEN` secret can be removed after verification

Ticket: DO-17034