### PR TITLE
feat(sdk-core): improve ParsedTransaction interface type

### DIFF
--- a/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
@@ -277,8 +277,14 @@ export interface ParseTransactionOptions {
   [index: string]: unknown;
 }
 
-// TODO (SDKT-9): reverse engineer and add options
+/**
+ * This is only used for determining the PayGo fee of a transaction which is only relevant for UTXO coins.
+ * Some coins return various other fields here, but they are only used internally by the respective coins.
+ */
 export interface ParsedTransaction {
+  // the callsite assumes that this is the PayGo amount
+  implicitExternalSpendAmount?: number | bigint;
+  // coins may add internal fields
   [index: string]: unknown;
 }
 

--- a/modules/sdk-core/src/bitgo/pendingApproval/pendingApproval.ts
+++ b/modules/sdk-core/src/bitgo/pendingApproval/pendingApproval.ts
@@ -304,16 +304,16 @@ export class PendingApproval implements IPendingApproval {
     prebuildParams = _.extend({}, prebuildParams, { reqId: reqId });
     const signedTransaction = await this.wallet.prebuildAndSignTransaction(prebuildParams);
     // compare PAYGo fees
-    const originalParsedTransaction = (await this.baseCoin.parseTransaction({
+    const originalParsedTransaction = await this.baseCoin.parseTransaction({
       txParams: prebuildParams,
       wallet: this.wallet,
       txPrebuild: originalPrebuild,
-    })) as any;
-    const recreatedParsedTransaction = (await this.baseCoin.parseTransaction({
+    });
+    const recreatedParsedTransaction = await this.baseCoin.parseTransaction({
       txParams: prebuildParams,
       wallet: this.wallet,
       txPrebuild: signedTransaction,
-    })) as any;
+    });
 
     if (_.isUndefined(recreatedParsedTransaction.implicitExternalSpendAmount)) {
       return signedTransaction;


### PR DESCRIPTION

Document the main purpose of ParsedTransaction and make the key field
implicitExternalSpendAmount explicit in the interface. Remove unnecessary
type assertions in pendingApproval.ts that are now handled by the improved
type definition.

BTC-2732