### PR TITLE
fix: add BooleanFromString codec to openapi-generator config

### DIFF
--- a/modules/express/openapi-generator.rc.js
+++ b/modules/express/openapi-generator.rc.js
@@ -14,6 +14,7 @@ module.exports = (E) => {
       NonEmptyString: () => E.right({ type: 'string', minLength: 1 }),
       DateFromISOString: () => E.right({ type: 'string', format: 'date-time' }),
       BigIntFromString: () => E.right({ type: 'string' }),
+      BooleanFromString: () => E.right({ type: 'string', enum: ['true', 'false'] }),
     },
     'io-ts-bigint': {
       BigIntFromString: () => E.right({ type: 'string' }),


### PR DESCRIPTION
[WP-6671](https://bitgoinc.atlassian.net/browse/WP-6671)

Fixes the openapi-generator parsing error for `ExpressWalletManagementApiSpec` by adding the missing `BooleanFromString` codec definition to the openapi-generator configuration.

[Issue](https://github.com/BitGo/build-system/actions/runs/19151387743/job/54742294195): Error when parsing ExpressWalletManagementApiSpec: Cannot find external codec 'BooleanFromString' from module 'io-ts-types'.



[WP-6671]: https://bitgoinc.atlassian.net/browse/WP-6671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ