### PR TITLE
feat(utxo-lib,abstract-utxo): enhance PSBT testing and transaction explanation utilities

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -200,8 +200,8 @@ export function isWalletOutput(output: Output): output is FixedScriptWalletOutpu
   );
 }
 
-export interface TransactionExplanation extends BaseTransactionExplanation<string, string> {
-  locktime: number;
+export interface TransactionExplanation<TFee = string> extends BaseTransactionExplanation<TFee, string> {
+  locktime?: number;
   /** NOTE: this actually only captures external outputs */
   outputs: Output[];
   changeOutputs: Output[];
@@ -872,7 +872,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
    */
   async explainTransaction<TNumber extends number | bigint = number>(
     params: ExplainTransactionOptions<TNumber>
-  ): Promise<TransactionExplanation> {
+  ): Promise<TransactionExplanation<string | undefined>> {
     return explainTx(this.decodeTransactionFromPrebuild(params), params, this.network);
   }
 

--- a/modules/abstract-utxo/src/impl/doge/doge.ts
+++ b/modules/abstract-utxo/src/impl/doge/doge.ts
@@ -114,7 +114,7 @@ export class Doge extends AbstractUtxoCoin {
 
   async explainTransaction<TNumber extends number | bigint = bigint>(
     params: ExplainTransactionOptions<TNumber> | (ExplainTransactionOptions<TNumber> & { txInfo: TransactionInfoJSON })
-  ): Promise<TransactionExplanation> {
+  ): Promise<TransactionExplanation<string | undefined>> {
     return super.explainTransaction({
       ...params,
       txInfo: params.txInfo ? parseTransactionInfo(params.txInfo as TransactionInfoJSON) : undefined,

--- a/modules/abstract-utxo/src/offlineVault/TransactionExplanation.ts
+++ b/modules/abstract-utxo/src/offlineVault/TransactionExplanation.ts
@@ -8,18 +8,18 @@ export interface ExplanationOutput {
   amount: string | number;
 }
 
-export interface TransactionExplanation {
+export interface TransactionExplanation<TFee> {
   outputs: ExplanationOutput[];
   changeOutputs: ExplanationOutput[];
   fee: {
     /* network fee */
-    fee: string | number;
+    fee: TFee;
     payGoFeeString: string | number | undefined;
     payGoFeeAddress: string | undefined;
   };
 }
 
-export function getTransactionExplanation(coin: string, tx: unknown): TransactionExplanation {
+export function getTransactionExplanation(coin: string, tx: unknown): TransactionExplanation<string> {
   if (!OfflineVaultSignable.is(tx)) {
     throw new Error('not a signable transaction');
   }

--- a/modules/abstract-utxo/src/offlineVault/descriptor/transaction.ts
+++ b/modules/abstract-utxo/src/offlineVault/descriptor/transaction.ts
@@ -45,7 +45,7 @@ export function getHalfSignedPsbt(
 export function getTransactionExplanationFromPsbt(
   tx: DescriptorTransaction,
   network: utxolib.Network
-): TransactionExplanation {
+): TransactionExplanation<string> {
   const psbt = utxolib.bitgo.createPsbtDecode(tx.coinSpecific.txHex, network);
   const descriptorMap = getDescriptorsFromDescriptorTransaction(tx);
   const { outputs, changeOutputs, fee } = explainPsbt(psbt, descriptorMap);

--- a/modules/abstract-utxo/src/transaction/descriptor/explainPsbt.ts
+++ b/modules/abstract-utxo/src/transaction/descriptor/explainPsbt.ts
@@ -34,7 +34,7 @@ function getInputSignatures(psbt: utxolib.bitgo.UtxoPsbt): number[] {
 export function explainPsbt(
   psbt: utxolib.bitgo.UtxoPsbt,
   descriptors: coreDescriptors.DescriptorMap
-): TransactionExplanation {
+): TransactionExplanation<string> {
   const parsedTransaction = coreDescriptors.parse(psbt, descriptors, psbt.network);
   const { inputs, outputs } = parsedTransaction;
   const externalOutputs = outputs.filter((o) => o.scriptId === undefined);

--- a/modules/abstract-utxo/src/transaction/explainTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/explainTransaction.ts
@@ -22,7 +22,7 @@ export function explainTx<TNumber extends number | bigint>(
     changeInfo?: fixedScript.ChangeAddressInfo[];
   },
   network: utxolib.Network
-): TransactionExplanation {
+): TransactionExplanation<string | undefined> {
   if (params.wallet && isDescriptorWallet(params.wallet)) {
     if (tx instanceof utxolib.bitgo.UtxoPsbt) {
       if (!params.pubs || !isTriple(params.pubs)) {

--- a/modules/abstract-utxo/src/transaction/fixedScript/explainTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/explainTransaction.ts
@@ -345,7 +345,7 @@ export function explainPsbt(
     inputSignatures: inputSignaturesCount,
     signatures: inputSignaturesCount.reduce((prev, curr) => (curr > prev ? curr : prev), 0),
     messages,
-  } as TransactionExplanation;
+  };
 }
 
 export function explainLegacyTx<TNumber extends number | bigint>(
@@ -356,12 +356,12 @@ export function explainLegacyTx<TNumber extends number | bigint>(
     changeInfo?: { address: string; chain: number; index: number }[];
   },
   network: utxolib.Network
-): TransactionExplanation {
+): TransactionExplanation<string | undefined> {
   const common = explainCommon(tx, params, network);
   const inputSignaturesCount = getTxInputSignaturesCount(tx, params, network);
   return {
     ...common,
     inputSignatures: inputSignaturesCount,
     signatures: inputSignaturesCount.reduce((prev, curr) => (curr > prev ? curr : prev), 0),
-  } as TransactionExplanation;
+  };
 }

--- a/modules/abstract-utxo/src/transaction/fixedScript/explainTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/explainTransaction.ts
@@ -295,8 +295,8 @@ function getBip322MessageInfoAndVerify(psbt: bitgo.UtxoPsbt, network: utxolib.Ne
  * Decompose a raw psbt into useful information, such as the total amounts,
  * change amounts, and transaction outputs.
  */
-export function explainPsbt<TNumber extends number | bigint, Tx extends bitgo.UtxoTransaction<bigint>>(
-  psbt: bitgo.UtxoPsbt<Tx>,
+export function explainPsbt(
+  psbt: bitgo.UtxoPsbt,
   params: {
     pubs?: bitgo.RootWalletKeys | string[];
   },
@@ -321,7 +321,7 @@ export function explainPsbt<TNumber extends number | bigint, Tx extends bitgo.Ut
 
   const messages = getBip322MessageInfoAndVerify(psbt, network);
   const changeInfo = getChangeInfo(psbt);
-  const tx = psbt.getUnsignedTx() as bitgo.UtxoTransaction<TNumber>;
+  const tx = psbt.getUnsignedTx();
   const common = explainCommon(tx, { ...params, changeInfo }, network);
   const inputSignaturesCount = getPsbtInputSignaturesCount(psbt, params);
 

--- a/modules/abstract-utxo/src/transaction/fixedScript/explainTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/explainTransaction.ts
@@ -92,7 +92,10 @@ function explainCommon<TNumber extends number | bigint>(
   return { displayOrder, id: tx.getId(), ...outputDetails, fee, locktime };
 }
 
-function getRootWalletKeys(params: { pubs?: string[] }) {
+function getRootWalletKeys(params: { pubs?: bitgo.RootWalletKeys | string[] }): bitgo.RootWalletKeys | undefined {
+  if (params.pubs instanceof bitgo.RootWalletKeys) {
+    return params.pubs;
+  }
   const keys = params.pubs?.map((xpub) => bip32.fromBase58(xpub));
   return keys && keys.length === 3 ? new bitgo.RootWalletKeys(keys as Triple<BIP32Interface>) : undefined;
 }
@@ -100,7 +103,7 @@ function getRootWalletKeys(params: { pubs?: string[] }) {
 function getPsbtInputSignaturesCount(
   psbt: bitgo.UtxoPsbt,
   params: {
-    pubs?: string[];
+    pubs?: bitgo.RootWalletKeys | string[];
   }
 ) {
   const rootWalletKeys = getRootWalletKeys(params);
@@ -113,7 +116,7 @@ function getTxInputSignaturesCount<TNumber extends number | bigint>(
   tx: bitgo.UtxoTransaction<TNumber>,
   params: {
     txInfo?: { unspents?: bitgo.Unspent<TNumber>[] };
-    pubs?: string[];
+    pubs?: bitgo.RootWalletKeys | string[];
   },
   network: utxolib.Network
 ) {
@@ -142,6 +145,152 @@ function getTxInputSignaturesCount<TNumber extends number | bigint>(
   });
 }
 
+function getChainAndIndexFromBip32Derivations(output: bitgo.PsbtOutput) {
+  const derivations = output.bip32Derivation ?? output.tapBip32Derivation ?? undefined;
+  if (!derivations) {
+    return undefined;
+  }
+  const paths = derivations.map((d) => d.path);
+  if (!paths || paths.length !== 3) {
+    throw new Error('expected 3 paths in bip32Derivation or tapBip32Derivation');
+  }
+  if (!paths.every((p) => paths[0] === p)) {
+    throw new Error('expected all paths to be the same');
+  }
+
+  paths.forEach((path) => {
+    if (paths[0] !== path) {
+      throw new Error(
+        'Unable to get a single chain and index on the output because there are different paths for different keys'
+      );
+    }
+  });
+  return utxolib.bitgo.getChainAndIndexFromPath(paths[0]);
+}
+
+function getChangeInfo(psbt: bitgo.UtxoPsbt): ChangeAddressInfo[] | undefined {
+  try {
+    return utxolib.bitgo.findInternalOutputIndices(psbt).map((i) => {
+      const derivationInformation = getChainAndIndexFromBip32Derivations(psbt.data.outputs[i]);
+      if (!derivationInformation) {
+        throw new Error('could not find derivation information on bip32Derivation or tapBip32Derivation');
+      }
+      return {
+        address: utxolib.address.fromOutputScript(psbt.txOutputs[i].script, psbt.network),
+        external: false,
+        ...derivationInformation,
+      };
+    });
+  } catch (e) {
+    if (e instanceof utxolib.bitgo.ErrorNoMultiSigInputFound) {
+      return undefined;
+    }
+    throw e;
+  }
+}
+
+/**
+ * Extract PayGo address proof information from the PSBT if present
+ * @returns Information about the PayGo proof, including the output index and address
+ */
+function getPayGoVerificationInfo(
+  psbt: bitgo.UtxoPsbt,
+  network: utxolib.Network
+): { outputIndex: number; verificationPubkey: string } | undefined {
+  let outputIndex: number | undefined = undefined;
+  let address: string | undefined = undefined;
+  // Check if this PSBT has any PayGo address proofs
+  if (!utxocore.paygo.psbtOutputIncludesPaygoAddressProof(psbt)) {
+    return undefined;
+  }
+
+  // This pulls the pubkey depending on given network
+  const verificationPubkey = getPayGoVerificationPubkey(network);
+  // find which output index that contains the PayGo proof
+  outputIndex = utxocore.paygo.getPayGoAddressProofOutputIndex(psbt);
+  if (outputIndex === undefined || !verificationPubkey) {
+    return undefined;
+  }
+  const output = psbt.txOutputs[outputIndex];
+  address = utxolib.address.fromOutputScript(output.script, network);
+  if (!address) {
+    throw new Error(`Can not derive address ${address} Pay Go Attestation.`);
+  }
+
+  return { outputIndex, verificationPubkey };
+}
+
+/**
+ * Extract the BIP322 messages and addresses from the PSBT inputs and perform
+ * verification on the transaction to ensure that it meets the BIP322 requirements.
+ * @returns An array of objects containing the message and address for each input,
+ *          or undefined if no BIP322 messages are found.
+ */
+function getBip322MessageInfoAndVerify(psbt: bitgo.UtxoPsbt, network: utxolib.Network): Bip322Message[] | undefined {
+  const bip322Messages: { message: string; address: string }[] = [];
+  for (let i = 0; i < psbt.data.inputs.length; i++) {
+    const message = bip322.getBip322ProofMessageAtIndex(psbt, i);
+    if (message) {
+      const input = psbt.data.inputs[i];
+      if (!input.witnessUtxo) {
+        throw new Error(`Missing witnessUtxo for input index ${i}`);
+      }
+      if (!input.nonWitnessUtxo) {
+        throw new Error(`Missing nonWitnessUtxo for input index ${i}`);
+      }
+      const scriptPubKey = input.witnessUtxo.script;
+
+      // Verify that the toSpend transaction can be recreated in the PSBT and is encoded correctly in the nonWitnessUtxo
+      const toSpend = bip322.buildToSpendTransaction(scriptPubKey, message);
+      const toSpendB64 = toSpend.toBuffer().toString('base64');
+      if (input.nonWitnessUtxo.toString('base64') !== toSpendB64) {
+        throw new Error(`Non-witness UTXO does not match the expected toSpend transaction at input index ${i}`);
+      }
+
+      // Verify that the toSpend transaction ID matches the input's referenced transaction ID
+      if (toSpend.getId() !== utxolib.bitgo.getOutputIdForInput(psbt.txInputs[i]).txid) {
+        throw new Error(`ToSpend transaction ID does not match the input at index ${i}`);
+      }
+
+      // Verify the input specifics
+      if (psbt.txInputs[i].sequence !== 0) {
+        throw new Error(`Unexpected sequence number at input index ${i}: ${psbt.txInputs[i].sequence}. Expected 0.`);
+      }
+      if (psbt.txInputs[i].index !== 0) {
+        throw new Error(`Unexpected input index at position ${i}: ${psbt.txInputs[i].index}. Expected 0.`);
+      }
+
+      bip322Messages.push({
+        message: message.toString('utf8'),
+        address: utxolib.address.fromOutputScript(scriptPubKey, network),
+      });
+    }
+  }
+
+  if (bip322Messages.length > 0) {
+    // If there is a BIP322 message in any input, all inputs must have one.
+    if (bip322Messages.length !== psbt.data.inputs.length) {
+      throw new Error('Inconsistent BIP322 messages across inputs.');
+    }
+
+    // Verify the transaction specifics for BIP322
+    if (psbt.version !== 0 && psbt.version !== 2) {
+      throw new Error(`Unsupported PSBT version for BIP322: ${psbt.version}. Expected 0 `);
+    }
+    if (
+      psbt.data.outputs.length !== 1 ||
+      psbt.txOutputs[0].script.toString('hex') !== '6a' ||
+      psbt.txOutputs[0].value !== 0n
+    ) {
+      throw new Error(`Invalid PSBT outputs for BIP322. Expected exactly one OP_RETURN output with zero value.`);
+    }
+
+    return bip322Messages;
+  }
+
+  return undefined;
+}
+
 /**
  * Decompose a raw psbt into useful information, such as the total amounts,
  * change amounts, and transaction outputs.
@@ -149,155 +298,12 @@ function getTxInputSignaturesCount<TNumber extends number | bigint>(
 export function explainPsbt<TNumber extends number | bigint, Tx extends bitgo.UtxoTransaction<bigint>>(
   psbt: bitgo.UtxoPsbt<Tx>,
   params: {
-    pubs?: string[];
-    txInfo?: { unspents?: bitgo.Unspent<TNumber>[] };
+    pubs?: bitgo.RootWalletKeys | string[];
   },
   network: utxolib.Network,
   { strict = false }: { strict?: boolean } = {}
 ): TransactionExplanation {
-  const txOutputs = psbt.txOutputs;
-  const txInputs = psbt.txInputs;
-
-  function getChainAndIndexFromBip32Derivations(output: bitgo.PsbtOutput) {
-    const derivations = output.bip32Derivation ?? output.tapBip32Derivation ?? undefined;
-    if (!derivations) {
-      return undefined;
-    }
-    const paths = derivations.map((d) => d.path);
-    if (!paths || paths.length !== 3) {
-      throw new Error('expected 3 paths in bip32Derivation or tapBip32Derivation');
-    }
-    if (!paths.every((p) => paths[0] === p)) {
-      throw new Error('expected all paths to be the same');
-    }
-
-    paths.forEach((path) => {
-      if (paths[0] !== path) {
-        throw new Error(
-          'Unable to get a single chain and index on the output because there are different paths for different keys'
-        );
-      }
-    });
-    return utxolib.bitgo.getChainAndIndexFromPath(paths[0]);
-  }
-
-  function getChangeInfo() {
-    try {
-      return utxolib.bitgo.findInternalOutputIndices(psbt).map((i) => {
-        const derivationInformation = getChainAndIndexFromBip32Derivations(psbt.data.outputs[i]);
-        if (!derivationInformation) {
-          throw new Error('could not find derivation information on bip32Derivation or tapBip32Derivation');
-        }
-        return {
-          address: utxolib.address.fromOutputScript(txOutputs[i].script, network),
-          external: false,
-          ...derivationInformation,
-        };
-      });
-    } catch (e) {
-      if (e instanceof utxolib.bitgo.ErrorNoMultiSigInputFound) {
-        return undefined;
-      }
-      throw e;
-    }
-  }
-
-  /**
-   * Extract PayGo address proof information from the PSBT if present
-   * @returns Information about the PayGo proof, including the output index and address
-   */
-  function getPayGoVerificationInfo(): { outputIndex: number; verificationPubkey: string } | undefined {
-    let outputIndex: number | undefined = undefined;
-    let address: string | undefined = undefined;
-    // Check if this PSBT has any PayGo address proofs
-    if (!utxocore.paygo.psbtOutputIncludesPaygoAddressProof(psbt)) {
-      return undefined;
-    }
-
-    // This pulls the pubkey depending on given network
-    const verificationPubkey = getPayGoVerificationPubkey(network);
-    // find which output index that contains the PayGo proof
-    outputIndex = utxocore.paygo.getPayGoAddressProofOutputIndex(psbt);
-    if (outputIndex === undefined || !verificationPubkey) {
-      return undefined;
-    }
-    const output = txOutputs[outputIndex];
-    address = utxolib.address.fromOutputScript(output.script, network);
-    if (!address) {
-      throw new Error(`Can not derive address ${address} Pay Go Attestation.`);
-    }
-
-    return { outputIndex, verificationPubkey };
-  }
-
-  /**
-   * Extract the BIP322 messages and addresses from the PSBT inputs and perform
-   * verification on the transaction to ensure that it meets the BIP322 requirements.
-   * @returns An array of objects containing the message and address for each input,
-   *          or undefined if no BIP322 messages are found.
-   */
-  function getBip322MessageInfoAndVerify(): Bip322Message[] | undefined {
-    const bip322Messages: { message: string; address: string }[] = [];
-    for (let i = 0; i < psbt.data.inputs.length; i++) {
-      const message = bip322.getBip322ProofMessageAtIndex(psbt, i);
-      if (message) {
-        const input = psbt.data.inputs[i];
-        if (!input.witnessUtxo) {
-          throw new Error(`Missing witnessUtxo for input index ${i}`);
-        }
-        if (!input.nonWitnessUtxo) {
-          throw new Error(`Missing nonWitnessUtxo for input index ${i}`);
-        }
-        const scriptPubKey = input.witnessUtxo.script;
-
-        // Verify that the toSpend transaction can be recreated in the PSBT and is encoded correctly in the nonWitnessUtxo
-        const toSpend = bip322.buildToSpendTransaction(scriptPubKey, message);
-        const toSpendB64 = toSpend.toBuffer().toString('base64');
-        if (input.nonWitnessUtxo.toString('base64') !== toSpendB64) {
-          throw new Error(`Non-witness UTXO does not match the expected toSpend transaction at input index ${i}`);
-        }
-
-        // Verify that the toSpend transaction ID matches the input's referenced transaction ID
-        if (toSpend.getId() !== utxolib.bitgo.getOutputIdForInput(txInputs[i]).txid) {
-          throw new Error(`ToSpend transaction ID does not match the input at index ${i}`);
-        }
-
-        // Verify the input specifics
-        if (txInputs[i].sequence !== 0) {
-          throw new Error(`Unexpected sequence number at input index ${i}: ${txInputs[i].sequence}. Expected 0.`);
-        }
-        if (txInputs[i].index !== 0) {
-          throw new Error(`Unexpected input index at position ${i}: ${txInputs[i].index}. Expected 0.`);
-        }
-
-        bip322Messages.push({
-          message: message.toString('utf8'),
-          address: utxolib.address.fromOutputScript(scriptPubKey, network),
-        });
-      }
-    }
-
-    if (bip322Messages.length > 0) {
-      // If there is a BIP322 message in any input, all inputs must have one.
-      if (bip322Messages.length !== psbt.data.inputs.length) {
-        throw new Error('Inconsistent BIP322 messages across inputs.');
-      }
-
-      // Verify the transaction specifics for BIP322
-      if (psbt.version !== 0 && psbt.version !== 2) {
-        throw new Error(`Unsupported PSBT version for BIP322: ${psbt.version}. Expected 0 `);
-      }
-      if (psbt.data.outputs.length !== 1 || txOutputs[0].script.toString('hex') !== '6a' || txOutputs[0].value !== 0n) {
-        throw new Error(`Invalid PSBT outputs for BIP322. Expected exactly one OP_RETURN output with zero value.`);
-      }
-
-      return bip322Messages;
-    }
-
-    return undefined;
-  }
-
-  const payGoVerificationInfo = getPayGoVerificationInfo();
+  const payGoVerificationInfo = getPayGoVerificationInfo(psbt, network);
   if (payGoVerificationInfo) {
     try {
       utxocore.paygo.verifyPayGoAddressProof(
@@ -313,14 +319,14 @@ export function explainPsbt<TNumber extends number | bigint, Tx extends bitgo.Ut
     }
   }
 
-  const messages = getBip322MessageInfoAndVerify();
-  const changeInfo = getChangeInfo();
+  const messages = getBip322MessageInfoAndVerify(psbt, network);
+  const changeInfo = getChangeInfo(psbt);
   const tx = psbt.getUnsignedTx() as bitgo.UtxoTransaction<TNumber>;
   const common = explainCommon(tx, { ...params, changeInfo }, network);
   const inputSignaturesCount = getPsbtInputSignaturesCount(psbt, params);
 
   // Set fee from subtracting inputs from outputs
-  const outputAmount = txOutputs.reduce((cumulative, curr) => cumulative + BigInt(curr.value), BigInt(0));
+  const outputAmount = psbt.txOutputs.reduce((cumulative, curr) => cumulative + BigInt(curr.value), BigInt(0));
   const inputAmount = psbt.txInputs.reduce((cumulative, txInput, i) => {
     const data = psbt.data.inputs[i];
     if (data.witnessUtxo) {

--- a/modules/abstract-utxo/src/transaction/fixedScript/parseTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/parseTransaction.ts
@@ -53,7 +53,7 @@ export async function parseTransaction<TNumber extends bigint | number>(
   }
 
   // obtain all outputs
-  const explanation: TransactionExplanation = await coin.explainTransaction<TNumber>({
+  const explanation: TransactionExplanation<string | undefined> = await coin.explainTransaction<TNumber>({
     txHex: txPrebuild.txHex,
     txInfo: txPrebuild.txInfo,
     pubs: keychainArray.map((k) => k.pub) as Triple<string>,

--- a/modules/abstract-utxo/test/unit/transaction/fixedScript/explainPsbt.ts
+++ b/modules/abstract-utxo/test/unit/transaction/fixedScript/explainPsbt.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+
+import { testutil } from '@bitgo/utxo-lib';
+
+import { explainPsbt } from '../../../../src/transaction/fixedScript';
+
+function describeTransactionWith(acidTest: testutil.AcidTest) {
+  describe(`explainPsbt ${acidTest.name}`, function () {
+    it('should explain the transaction', function () {
+      const psbt = acidTest.createPsbt();
+      const explanation = explainPsbt(
+        psbt,
+        { pubs: acidTest.rootWalletKeys.triple.map((k) => k.toBase58()) },
+        acidTest.network,
+        { strict: true }
+      );
+      assert.strictEqual(explanation.outputs.length, 3);
+      assert.strictEqual(explanation.outputAmount, '2700');
+      assert.strictEqual(explanation.changeOutputs.length, acidTest.outputs.length - 3);
+      explanation.changeOutputs.forEach((change) => {
+        assert.strictEqual(change.amount, '900');
+        assert.strictEqual(typeof change.address, 'string');
+      });
+      assert.strictEqual(explanation.inputSignatures.length, acidTest.inputs.length);
+      explanation.inputSignatures.forEach((signature, i) => {
+        if (acidTest.inputs[i].scriptType === 'p2shP2pk') {
+          return;
+        }
+        if (acidTest.signStage === 'unsigned') {
+          assert.strictEqual(signature, 0);
+        } else if (acidTest.signStage === 'halfsigned') {
+          assert.strictEqual(signature, 1);
+        } else if (acidTest.signStage === 'fullsigned') {
+          assert.strictEqual(signature, 2);
+        }
+      });
+    });
+  });
+}
+
+testutil.AcidTest.suite().forEach((test) => describeTransactionWith(test));

--- a/modules/abstract-utxo/test/unit/transaction/fixedScript/explainPsbt.ts
+++ b/modules/abstract-utxo/test/unit/transaction/fixedScript/explainPsbt.ts
@@ -8,12 +8,7 @@ function describeTransactionWith(acidTest: testutil.AcidTest) {
   describe(`explainPsbt ${acidTest.name}`, function () {
     it('should explain the transaction', function () {
       const psbt = acidTest.createPsbt();
-      const explanation = explainPsbt(
-        psbt,
-        { pubs: acidTest.rootWalletKeys.triple.map((k) => k.toBase58()) },
-        acidTest.network,
-        { strict: true }
-      );
+      const explanation = explainPsbt(psbt, { pubs: acidTest.rootWalletKeys }, acidTest.network, { strict: true });
       assert.strictEqual(explanation.outputs.length, 3);
       assert.strictEqual(explanation.outputAmount, '2700');
       assert.strictEqual(explanation.changeOutputs.length, acidTest.outputs.length - 3);

--- a/modules/utxo-lib/src/testutil/psbt.ts
+++ b/modules/utxo-lib/src/testutil/psbt.ts
@@ -3,6 +3,7 @@ import { ok as assert } from 'assert';
 
 import {
   createOutputScriptP2shP2pk,
+  isSupportedScriptType,
   ScriptType,
   ScriptType2Of3,
   scriptTypeP2shP2pk,
@@ -26,10 +27,12 @@ import {
   UtxoTransaction,
   verifySignatureWithUnspent,
   addXpubsToPsbt,
+  clonePsbtWithoutNonWitnessUtxo,
 } from '../bitgo';
 import { Network } from '../networks';
 import { mockReplayProtectionUnspent, mockWalletUnspent } from './mock';
 import { toOutputScript } from '../address';
+import { getDefaultWalletKeys, getWalletKeysForSeed } from './keys';
 
 /**
  * This is a bit of a misnomer, as it actually specifies the spend type of the input.
@@ -47,6 +50,8 @@ export type Input = {
   scriptType: InputScriptType;
   value: bigint;
 };
+
+export type SignStage = 'unsigned' | 'halfsigned' | 'fullsigned';
 
 /**
  * Set isInternalAddress=true for internal output address
@@ -169,7 +174,7 @@ export function constructPsbt(
   outputs: Output[],
   network: Network,
   rootWalletKeys: RootWalletKeys,
-  sign: 'unsigned' | 'halfsigned' | 'fullsigned',
+  signStage: SignStage,
   params?: {
     signers?: { signerName: KeyName; cosignerName?: KeyName };
     deterministic?: boolean;
@@ -183,6 +188,11 @@ export function constructPsbt(
   assert(totalInputAmount >= outputInputAmount, 'total output can not exceed total input');
 
   const psbt = createPsbtForNetwork({ network });
+
+  if (params?.addGlobalXPubs) {
+    addXpubsToPsbt(psbt, rootWalletKeys);
+  }
+
   const unspents = inputs.map((input, i) => toUnspent(input, i, network, rootWalletKeys));
 
   unspents.forEach((u, i) => {
@@ -226,7 +236,7 @@ export function constructPsbt(
     throw new Error('invalid output');
   });
 
-  if (sign === 'unsigned') {
+  if (signStage === 'unsigned') {
     return psbt;
   }
 
@@ -237,15 +247,90 @@ export function constructPsbt(
 
   signAllPsbtInputs(psbt, inputs, rootWalletKeys, 'halfsigned', { signers, skipNonWitnessUtxo });
 
-  if (sign === 'fullsigned') {
-    signAllPsbtInputs(psbt, inputs, rootWalletKeys, sign, { signers, deterministic, skipNonWitnessUtxo });
-  }
-
-  if (params?.addGlobalXPubs) {
-    addXpubsToPsbt(psbt, rootWalletKeys);
+  if (signStage === 'fullsigned') {
+    signAllPsbtInputs(psbt, inputs, rootWalletKeys, signStage, { signers, deterministic, skipNonWitnessUtxo });
   }
 
   return psbt;
+}
+
+export type TxFormat = 'psbt' | 'psbt-lite';
+
+/**
+ * Creates a valid PSBT with as many features as possible.
+ *
+ * - Inputs:
+ *   - All wallet script types that are supported by the network.
+ *   - A p2shP2pk input (for replay protection)
+ * - Outputs:
+ *   - All wallet script types that are supported by the network.
+ *   - A p2sh output with derivation info of a different wallet (not in the global psbt xpubs)
+ *   - A p2sh output with no derivation info (external output)
+ *   - An OP_RETURN output
+ */
+export class AcidTest {
+  public readonly network: Network;
+  public readonly signStage: SignStage;
+  public readonly txFormat: TxFormat;
+  public readonly rootWalletKeys: RootWalletKeys;
+  public readonly otherWalletKeys: RootWalletKeys;
+  public readonly inputs: Input[];
+  public readonly outputs: Output[];
+
+  constructor(
+    network: Network,
+    signStage: SignStage,
+    txFormat: TxFormat,
+    rootWalletKeys: RootWalletKeys,
+    otherWalletKeys: RootWalletKeys,
+    inputs: Input[],
+    outputs: Output[]
+  ) {
+    this.network = network;
+    this.signStage = signStage;
+    this.txFormat = txFormat;
+    this.rootWalletKeys = rootWalletKeys;
+    this.otherWalletKeys = otherWalletKeys;
+    this.inputs = inputs;
+    this.outputs = outputs;
+  }
+
+  static withDefaults(network: Network, signStage: SignStage, txFormat: TxFormat): AcidTest {
+    const rootWalletKeys = getDefaultWalletKeys();
+
+    const otherWalletKeys = getWalletKeysForSeed('too many secrets');
+    const inputs: Input[] = inputScriptTypes
+      .filter((scriptType) =>
+        scriptType === 'taprootKeyPathSpend'
+          ? isSupportedScriptType(network, 'p2trMusig2')
+          : isSupportedScriptType(network, scriptType)
+      )
+      .map((scriptType) => ({ scriptType, value: BigInt(2000) }));
+
+    const outputs: Output[] = outputScriptTypes
+      .filter((scriptType) => isSupportedScriptType(network, scriptType))
+      .map((scriptType) => ({ scriptType, value: BigInt(900) }));
+
+    // Test other wallet output (with derivation info)
+    outputs.push({ scriptType: 'p2sh', value: BigInt(900), walletKeys: otherWalletKeys });
+    // Tes non-wallet output
+    outputs.push({ scriptType: 'p2sh', value: BigInt(900), walletKeys: null });
+    // Test OP_RETURN output
+    outputs.push({ opReturn: 'setec astronomy', value: BigInt(900) });
+
+    return new AcidTest(network, signStage, txFormat, rootWalletKeys, otherWalletKeys, inputs, outputs);
+  }
+
+  createPsbt(): UtxoPsbt {
+    const psbt = constructPsbt(this.inputs, this.outputs, this.network, this.rootWalletKeys, this.signStage, {
+      deterministic: true,
+      addGlobalXPubs: true,
+    });
+    if (this.txFormat === 'psbt-lite') {
+      return clonePsbtWithoutNonWitnessUtxo(psbt);
+    }
+    return psbt;
+  }
 }
 
 /**

--- a/modules/utxo-lib/src/testutil/transaction.ts
+++ b/modules/utxo-lib/src/testutil/transaction.ts
@@ -154,8 +154,12 @@ export function constructTxnBuilder<TNumber extends number | bigint>(
   const outputInputAmount = outputs.reduce((sum, output) => sum + BigInt(output.value), BigInt(0));
   assert(totalInputAmount >= outputInputAmount, 'total output can not exceed total input');
   assert(
-    !outputs.some((o) => (o.scriptType && o.address) || (!o.scriptType && !o.address)),
-    'only either output script type or address should be provided'
+    outputs.every((o) => o.scriptType || o.address),
+    'must provide either scriptType or address for each output'
+  );
+  assert(
+    outputs.every((o) => !(o.scriptType && o.address)),
+    'cannot provide both scriptType and address for the same output'
   );
 
   const txb = createTransactionBuilderForNetwork<TNumber>(network);

--- a/modules/utxo-lib/test/bitgo/psbt/SignVerifyLegacy.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/SignVerifyLegacy.ts
@@ -1,0 +1,56 @@
+import * as assert from 'assert';
+
+import { getStrictSignatureCount, getStrictSignatureCounts } from '../../../src/bitgo';
+import { constructTxnBuilder, TxnInput } from '../../../src/testutil';
+import { AcidTest, SignStage } from '../../../src/testutil/psbt';
+import { getNetworkList, getNetworkName, isMainnet, networks } from '../../../src';
+
+const signs = ['unsigned', 'halfsigned', 'fullsigned'] as const;
+
+function signCount(signStage: SignStage) {
+  return signStage === 'unsigned' ? 0 : signStage === 'halfsigned' ? 1 : 2;
+}
+
+function runTx(acidTest: AcidTest) {
+  const coin = getNetworkName(acidTest.network);
+  const signatureCount = signCount(acidTest.signStage);
+  describe(`tx build, sign and verify for ${coin} ${acidTest.signStage}`, function () {
+    const inputs = acidTest.inputs.filter(
+      (input): input is TxnInput<bigint> =>
+        input.scriptType !== 'taprootKeyPathSpend' && input.scriptType !== 'p2trMusig2'
+    );
+    const outputs = acidTest.outputs.filter(
+      (output) =>
+        ('scriptType' in output && output.scriptType !== undefined) ||
+        ('address' in output && output.address !== undefined)
+    );
+    it(`tx signature counts ${coin} ${acidTest.signStage}`, function () {
+      const txb = constructTxnBuilder(inputs, outputs, acidTest.network, acidTest.rootWalletKeys, acidTest.signStage);
+      const tx = acidTest.signStage === 'fullsigned' ? txb.build() : txb.buildIncomplete();
+
+      const counts = getStrictSignatureCounts(tx);
+      const countsFromIns = getStrictSignatureCounts(tx.ins);
+
+      assert.strictEqual(counts.length, tx.ins.length);
+      assert.strictEqual(countsFromIns.length, tx.ins.length);
+      tx.ins.forEach((input, inputIndex) => {
+        const expectedCount = inputs[inputIndex].scriptType === 'p2shP2pk' && signatureCount > 0 ? 1 : signatureCount;
+        assert.strictEqual(
+          getStrictSignatureCount(input),
+          expectedCount,
+          `input ${inputIndex} has ${getStrictSignatureCount(input)} signatures, expected ${expectedCount}`
+        );
+        assert.strictEqual(counts[inputIndex], expectedCount);
+        assert.strictEqual(countsFromIns[inputIndex], expectedCount);
+      });
+    });
+  });
+}
+
+signs.forEach((sign) => {
+  getNetworkList()
+    .filter((v) => isMainnet(v) && v !== networks.bitcoinsv)
+    .forEach((network) => {
+      runTx(AcidTest.withDefaults(network, sign, 'psbt'));
+    });
+});

--- a/modules/utxo-lib/test/bitgo/psbt/SignVerifyLegacy.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/SignVerifyLegacy.ts
@@ -3,9 +3,7 @@ import * as assert from 'assert';
 import { getStrictSignatureCount, getStrictSignatureCounts } from '../../../src/bitgo';
 import { constructTxnBuilder, TxnInput } from '../../../src/testutil';
 import { AcidTest, SignStage } from '../../../src/testutil/psbt';
-import { getNetworkList, getNetworkName, isMainnet, networks } from '../../../src';
-
-const signs = ['unsigned', 'halfsigned', 'fullsigned'] as const;
+import { getNetworkName } from '../../../src';
 
 function signCount(signStage: SignStage) {
   return signStage === 'unsigned' ? 0 : signStage === 'halfsigned' ? 1 : 2;
@@ -47,10 +45,8 @@ function runTx(acidTest: AcidTest) {
   });
 }
 
-signs.forEach((sign) => {
-  getNetworkList()
-    .filter((v) => isMainnet(v) && v !== networks.bitcoinsv)
-    .forEach((network) => {
-      runTx(AcidTest.withDefaults(network, sign, 'psbt'));
-    });
-});
+AcidTest.suite()
+  .filter((acidTest) => acidTest.txFormat === 'psbt')
+  .forEach((acidTest) => {
+    runTx(acidTest);
+  });

--- a/modules/utxo-lib/test/bitgo/psbt/SignVerifyPsbt.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/SignVerifyPsbt.ts
@@ -12,7 +12,7 @@ import {
   UtxoPsbt,
   UtxoTransaction,
 } from '../../../src/bitgo';
-import { constructTxnBuilder, Input as TestUtilInput, TxnInput } from '../../../src/testutil';
+import { Input as TestUtilInput } from '../../../src/testutil';
 import { AcidTest, InputScriptType, SignStage } from '../../../src/testutil/psbt';
 import { getNetworkList, getNetworkName, isMainnet, networks } from '../../../src';
 import {
@@ -186,48 +186,11 @@ function runPsbt(acidTest: AcidTest) {
   });
 }
 
-function runTx(acidTest: AcidTest) {
-  const coin = getNetworkName(acidTest.network);
-  const signatureCount = signCount(acidTest.signStage);
-  describe(`tx build, sign and verify for ${coin} ${acidTest.signStage}`, function () {
-    const inputs = acidTest.inputs.filter(
-      (input): input is TxnInput<bigint> =>
-        input.scriptType !== 'taprootKeyPathSpend' && input.scriptType !== 'p2trMusig2'
-    );
-    const outputs = acidTest.outputs.filter(
-      (output) =>
-        ('scriptType' in output && output.scriptType !== undefined) ||
-        ('address' in output && output.address !== undefined)
-    );
-    it(`tx signature counts ${coin} ${acidTest.signStage}`, function () {
-      const txb = constructTxnBuilder(inputs, outputs, acidTest.network, acidTest.rootWalletKeys, acidTest.signStage);
-      const tx = acidTest.signStage === 'fullsigned' ? txb.build() : txb.buildIncomplete();
-
-      const counts = getStrictSignatureCounts(tx);
-      const countsFromIns = getStrictSignatureCounts(tx.ins);
-
-      assert.strictEqual(counts.length, tx.ins.length);
-      assert.strictEqual(countsFromIns.length, tx.ins.length);
-      tx.ins.forEach((input, inputIndex) => {
-        const expectedCount = inputs[inputIndex].scriptType === 'p2shP2pk' && signatureCount > 0 ? 1 : signatureCount;
-        assert.strictEqual(
-          getStrictSignatureCount(input),
-          expectedCount,
-          `input ${inputIndex} has ${getStrictSignatureCount(input)} signatures, expected ${expectedCount}`
-        );
-        assert.strictEqual(counts[inputIndex], expectedCount);
-        assert.strictEqual(countsFromIns[inputIndex], expectedCount);
-      });
-    });
-  });
-}
-
 signs.forEach((sign) => {
   getNetworkList()
     .filter((v) => isMainnet(v) && v !== networks.bitcoinsv)
     .forEach((network) => {
       runPsbt(AcidTest.withDefaults(network, sign, 'psbt'));
       runPsbt(AcidTest.withDefaults(network, sign, 'psbt-lite'));
-      runTx(AcidTest.withDefaults(network, sign, 'psbt'));
     });
 });

--- a/modules/utxo-lib/test/bitgo/psbt/SignVerifyPsbtAndTx.ts
+++ b/modules/utxo-lib/test/bitgo/psbt/SignVerifyPsbtAndTx.ts
@@ -3,6 +3,7 @@ import * as assert from 'assert';
 import {
   addXpubsToPsbt,
   clonePsbtWithoutNonWitnessUtxo,
+  createPsbtFromBuffer,
   getPsbtInputSignatureCount,
   getSignatureValidationArrayPsbt,
   getStrictSignatureCount,
@@ -136,9 +137,16 @@ function runPsbt(
   describe(`psbt build, sign and verify for ${coin} ${inputTypes.join('-')} ${sign}`, function () {
     let psbt: UtxoPsbt;
 
-    it(`getSignatureValidationArray with globalXpub ${coin} ${sign}`, function () {
+    before(function () {
       psbt = constructPsbt(inputs, outputs, network, rootWalletKeys, sign, { deterministic: true });
       addXpubsToPsbt(psbt, rootWalletKeysXpubs);
+    });
+
+    it('round-trip test', function () {
+      assert.deepStrictEqual(psbt.toBuffer(), createPsbtFromBuffer(psbt.toBuffer(), network).toBuffer());
+    });
+
+    it(`getSignatureValidationArray with globalXpub ${coin} ${sign}`, function () {
       psbt.data.inputs.forEach((input, inputIndex) => {
         const isP2shP2pk = inputs[inputIndex].scriptType === 'p2shP2pk';
         const expectedSigValid = getSigValidArray(inputs[inputIndex].scriptType, sign);


### PR DESCRIPTION

This PR adds comprehensive PSBT testing capabilities and refines transaction 
explanation utilities across the codebase:

## PSBT Testing Enhancements
- Add AcidTest utility for comprehensive PSBT testing across all supported 
  input/output types and networks
- Create AcidTest.suite() function to generate complete test suites
- Add round-trip PSBT buffer serialization test
- Split sign/verify tests into separate files for PSBT and legacy transactions

## Transaction Explanation Improvements
- Add tests for explainPsbt utility using the new AcidTest framework
- Refactor transaction explanation utilities for better readability
- Remove unnecessary type parameters from explainPsbt
- Make fee and locktime fields optional in transaction explanations
- Update getRootWalletKeys to handle RootWalletKeys instances properly

## Type System Improvements
- Add proper typing throughout the codebase
- Improve test organization with const arrays and type refinements

BTC-2732, BG-59313