### PR TITLE
feat(abstract-utxo): deprecate 'legacy' txFormat on btc testnets

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -96,6 +96,12 @@ class ErrorInvalidTxFormat extends Error {
   }
 }
 
+class ErrorDeprecatedTxFormat extends Error {
+  constructor(txFormat: unknown) {
+    super(`Deprecated txFormat: ${txFormat} for this network`);
+  }
+}
+
 type UtxoCustomSigningFunction<TNumber extends number | bigint> = {
   (params: {
     coin: IBaseCoin;
@@ -996,6 +1002,14 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
     if (utxolib.isTestnet(this.network)) {
       if (requestedTxFormat !== undefined && !isTxFormat(requestedTxFormat)) {
         throw new ErrorInvalidTxFormat(requestedTxFormat);
+      }
+
+      if (utxolib.getMainnet(this.network) === utxolib.networks.bitcoin) {
+        if (requestedTxFormat === 'legacy') {
+          throw new ErrorDeprecatedTxFormat(requestedTxFormat);
+        }
+
+        return 'psbt-lite';
       }
     }
 


### PR DESCRIPTION

This PR implements several improvements to the transaction format handling 
in the abstract-utxo module:

- Add new 'psbt-lite' format type, a lightweight version of PSBT for 
  transaction signing
- Refactor transaction format decision logic into a dedicated method for 
  better maintainability
- Implement validation of txFormat parameters on testnet networks
- Update format priority to respect explicitly requested formats
- Force PSBT format for Bitcoin Testnet hot wallets, while handling Zcash 
  separately
- Force PSBT for testnet Bitcoin by rejecting 'legacy' format and 
  defaulting to 'psbt-lite'
- Add new error classes for handling validation and deprecated formats

Issue: BTC-2732