### PR TITLE
feat: use wasm-utxo for address generation on testnets

### DIFF
--- a/modules/abstract-utxo/test/unit/util/unspents.ts
+++ b/modules/abstract-utxo/test/unit/util/unspents.ts
@@ -1,5 +1,6 @@
 import * as utxolib from '@bitgo/utxo-lib';
 import { getSeed } from '@bitgo/sdk-test';
+import * as wasmUtxo from '@bitgo/wasm-utxo';
 
 import { getReplayProtectionAddresses } from '../../../src';
 
@@ -31,6 +32,9 @@ export function getWalletAddress(
   chain = defaultChain,
   index = 0
 ): string {
+  if (utxolib.isTestnet(network)) {
+    return wasmUtxo.fixedScriptWallet.address(walletKeys, chain, index, network);
+  }
   return utxolib.address.fromOutputScript(getOutputScript(walletKeys, chain, index).scriptPubKey, network);
 }
 
@@ -49,8 +53,7 @@ export function mockWalletUnspent<TNumber extends number | bigint = number>(
   if (chain === undefined) {
     throw new Error(`unspent chain must be set`);
   }
-  const derived = getOutputScript(walletKeys, chain, index);
-  const deriveAddress = utxolib.address.fromOutputScript(derived.scriptPubKey, network);
+  const deriveAddress = getWalletAddress(network, walletKeys, chain, index);
   if (address) {
     if (address !== deriveAddress) {
       throw new Error(`derivedAddress mismatch: ${address} derived=${deriveAddress}`);


### PR DESCRIPTION
Use wasm-utxo's fixedScriptWallet.address for testnets instead of utxo-lib's address derivation. This improves compatibility with the native implementation.

Co-authored-by: llm-git <llm-git@ttll.de>

Ticket: BTC-2720

TICKET: BTC-2720

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
