### PR TITLE
fix(sdk-core): include coredao family for acceleration

### DIFF
--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -3158,6 +3158,28 @@ describe('V2 Wallet:', function () {
         intent.intentType.should.equal('acceleration');
       });
 
+      it('populate intent should return valid coredao acceleration intent', async function () {
+        const mpcUtils = new ECDSAUtils.EcdsaUtils(bitgo, bitgo.coin('coredao'));
+
+        const feeOptions = {
+          maxFeePerGas: 3000000000,
+          maxPriorityFeePerGas: 2000000000,
+        };
+        const lowFeeTxid = '0x6ea07f9420f4676be6478ab1660eb92444a7c663e0e24bece929f715e882e0cf';
+
+        const intent = mpcUtils.populateIntent(bitgo.coin('coredao'), {
+          reqId,
+          intentType: 'acceleration',
+          lowFeeTxid,
+          feeOptions,
+        });
+
+        intent.should.have.property('recipients', undefined);
+        intent.feeOptions!.should.deepEqual(feeOptions);
+        intent.txid!.should.equal(lowFeeTxid);
+        intent.intentType.should.equal('acceleration');
+      });
+
       it('populate intent should return valid eth acceleration intent for receive address', async function () {
         const mpcUtils = new ECDSAUtils.EcdsaUtils(bitgo, bitgo.coin('hteth'));
 

--- a/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
@@ -191,7 +191,7 @@ export abstract class MpcUtils {
       isTestTransaction: params.isTestTransaction,
     };
 
-    if (baseCoin.getFamily() === 'eth' || baseCoin.getFamily() === 'polygon' || baseCoin.getFamily() === 'bsc') {
+    if (['eth', 'polygon', 'bsc', 'coredao'].includes(baseCoin.getFamily())) {
       switch (params.intentType) {
         case 'payment':
         case 'transferToken':


### PR DESCRIPTION
TICKET: COIN-6534

This pull request adds support for the `coredao` coin family to the intent population logic and its associated tests. The main changes ensure that `coredao` is treated similarly to other EVM-compatible chains like `eth`, `polygon`, and `bsc` when creating transaction intents.

**Support for coredao in intent population:**

* Updated the conditional in `MpcUtils.populateIntent` to include `coredao` as a supported coin family for intent creation, aligning its behavior with other EVM-compatible families (`eth`, `polygon`, `bsc`).

**Testing enhancements:**

* Added a new unit test in `wallet.ts` to validate that intent population for `coredao` acceleration works correctly, ensuring the correct structure and values in the resulting intent.

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
