### PR TITLE
feat(utxo): add ESM build support for UTXO modules

### DIFF
--- a/modules/abstract-utxo/package.json
+++ b/modules/abstract-utxo/package.json
@@ -2,16 +2,33 @@
   "name": "@bitgo/abstract-utxo",
   "version": "10.6.0",
   "description": "BitGo SDK coin library for UTXO base implementation",
-  "main": "./dist/src/index.js",
-  "types": "./dist/src/index.d.ts",
+  "main": "./dist/cjs/src/index.js",
+  "module": "./dist/esm/index.js",
+  "browser": "./dist/esm/index.js",
+  "types": "./dist/cjs/src/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/src/index.d.ts",
+        "default": "./dist/cjs/src/index.js"
+      }
+    }
+  },
   "files": [
-    "dist/src"
+    "dist/cjs",
+    "dist/esm"
   ],
   "scripts": {
-    "build": "yarn tsc --build --incremental --verbose .",
+    "build": "npm run build:cjs && npm run build:esm",
+    "build:cjs": "yarn tsc --build --incremental --verbose .",
+    "build:esm": "yarn tsc --project tsconfig.esm.json",
     "fmt": "prettier --write .",
     "check-fmt": "prettier --check '**/*.{ts,js,json}'",
-    "clean": "rm -r ./dist",
+    "clean": "rm -rf ./dist",
     "lint": "eslint --quiet .",
     "prepare": "npm run build",
     "test": "npm run unit-test",

--- a/modules/abstract-utxo/tsconfig.esm.json
+++ b/modules/abstract-utxo/tsconfig.esm.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/esm",
+    "rootDir": "./src",
+    "module": "ES2020",
+    "target": "ES2020",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM"],
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "test", "dist"],
+  "references": []
+}
+

--- a/modules/abstract-utxo/tsconfig.json
+++ b/modules/abstract-utxo/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist",
+    "outDir": "./dist/cjs",
     "rootDir": "./",
     "strictPropertyInitialization": false,
     "esModuleInterop": true,

--- a/modules/babylonlabs-io-btc-staking-ts/package.json
+++ b/modules/babylonlabs-io-btc-staking-ts/package.json
@@ -11,7 +11,9 @@
     "require": "./dist/index.cjs"
   },
   "scripts": {
-    "generate-types": "dts-bundle-generator -o ./dist/index.d.cts ./src/index.ts --no-check",
+    "generate-types:cjs": "dts-bundle-generator -o ./dist/index.d.cts ./src/index.ts --no-check",
+    "generate-types:esm": "dts-bundle-generator -o ./dist/index.d.ts ./src/index.ts --no-check",
+    "generate-types": "npm run generate-types:cjs && npm run generate-types:esm",
     "build": "node build.js && npm run generate-types",
     "prepare": "husky",
     "prepublishOnly": "npm run build",

--- a/modules/utxo-core/package.json
+++ b/modules/utxo-core/package.json
@@ -2,25 +2,60 @@
   "name": "@bitgo/utxo-core",
   "version": "1.23.0",
   "description": "BitGo UTXO Core types",
-  "main": "./dist/src/index.js",
-  "types": "./dist/src/index.d.ts",
+  "main": "./dist/cjs/src/index.js",
+  "module": "./dist/esm/index.js",
+  "browser": "./dist/esm/index.js",
+  "types": "./dist/cjs/src/index.d.ts",
   "files": [
-    "dist/src"
+    "dist/cjs",
+    "dist/esm"
   ],
   "exports": {
-    ".": "./dist/src/index.js",
-    "./descriptor": "./dist/src/descriptor/index.js",
-    "./testutil": "./dist/src/testutil/index.js",
-    "./testutil/descriptor": "./dist/src/testutil/descriptor/index.js"
-  },
-  "browser": {
-    ".": "./dist/src/index.js",
-    "./descriptor": "./dist/src/descriptor/index.js",
-    "./testutil": "./dist/src/testutil/index.js",
-    "./testutil/descriptor": "./dist/src/testutil/descriptor/index.js"
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/src/index.d.ts",
+        "default": "./dist/cjs/src/index.js"
+      }
+    },
+    "./descriptor": {
+      "import": {
+        "types": "./dist/esm/descriptor/index.d.ts",
+        "default": "./dist/esm/descriptor/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/src/descriptor/index.d.ts",
+        "default": "./dist/cjs/src/descriptor/index.js"
+      }
+    },
+    "./testutil": {
+      "import": {
+        "types": "./dist/esm/testutil/index.d.ts",
+        "default": "./dist/esm/testutil/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/src/testutil/index.d.ts",
+        "default": "./dist/cjs/src/testutil/index.js"
+      }
+    },
+    "./testutil/descriptor": {
+      "import": {
+        "types": "./dist/esm/testutil/descriptor/index.d.ts",
+        "default": "./dist/esm/testutil/descriptor/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/src/testutil/descriptor/index.d.ts",
+        "default": "./dist/cjs/src/testutil/descriptor/index.js"
+      }
+    }
   },
   "scripts": {
-    "build": "yarn tsc --build --incremental --verbose .",
+    "build": "npm run build:cjs && npm run build:esm",
+    "build:cjs": "yarn tsc --build --incremental --verbose .",
+    "build:esm": "yarn tsc --project tsconfig.esm.json",
     "fmt": "prettier --write .",
     "check-fmt": "prettier --check '**/*.{ts,js,json}'",
     "clean": "rm -r ./dist",
@@ -45,7 +80,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "type": "commonjs",
   "nyc": {
     "extension": [
       ".ts"

--- a/modules/utxo-core/tsconfig.esm.json
+++ b/modules/utxo-core/tsconfig.esm.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/esm",
+    "rootDir": "./src",
+    "module": "ES2020",
+    "target": "ES2020",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM"],
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "test", "dist"],
+  "references": []
+}

--- a/modules/utxo-core/tsconfig.json
+++ b/modules/utxo-core/tsconfig.json
@@ -1,11 +1,13 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist",
+    "outDir": "./dist/cjs",
     "rootDir": "./",
     "esModuleInterop": true,
     "allowJs": false,
-    "strict": true
+    "strict": true,
+    "moduleResolution": "node16",
+    "module": "node16"
   },
   "include": ["src/**/*", "test/**/*"],
   "exclude": ["node_modules"],

--- a/modules/utxo-staking/package.json
+++ b/modules/utxo-staking/package.json
@@ -2,13 +2,30 @@
   "name": "@bitgo/utxo-staking",
   "version": "1.25.0",
   "description": "BitGo SDK for build UTXO staking transactions",
-  "main": "./dist/src/index.js",
-  "types": "./dist/src/index.d.ts",
+  "main": "./dist/cjs/src/index.js",
+  "module": "./dist/esm/index.js",
+  "browser": "./dist/esm/index.js",
+  "types": "./dist/cjs/src/index.d.ts",
   "files": [
-    "dist/src"
+    "dist/cjs",
+    "dist/esm"
   ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/src/index.d.ts",
+        "default": "./dist/cjs/src/index.js"
+      }
+    }
+  },
   "scripts": {
-    "build": "yarn tsc --build --incremental --verbose .",
+    "build": "npm run build:cjs && npm run build:esm",
+    "build:cjs": "yarn tsc --build --incremental --verbose .",
+    "build:esm": "yarn tsc --project tsconfig.esm.json",
     "fmt": "prettier --write .",
     "check-fmt": "prettier --check '**/*.{ts,js,json}'",
     "clean": "rm -r ./dist",
@@ -41,7 +58,6 @@
       ".ts"
     ]
   },
-  "type": "commonjs",
   "dependencies": {
     "@babylonlabs-io/babylon-proto-ts": "1.7.2",
     "@bitgo/babylonlabs-io-btc-staking-ts": "^3.1.0",

--- a/modules/utxo-staking/tsconfig.esm.json
+++ b/modules/utxo-staking/tsconfig.esm.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/esm",
+    "rootDir": "./src",
+    "module": "ES2020",
+    "target": "ES2020",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM"],
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*", "src/babylon/*.json"],
+  "exclude": ["node_modules", "test", "dist", "scripts"],
+  "references": []
+}

--- a/modules/utxo-staking/tsconfig.json
+++ b/modules/utxo-staking/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist",
+    "outDir": "./dist/cjs",
     "rootDir": ".",
     "typeRoots": ["./node_modules/@types", "../../node_modules/@types"],
     "allowJs": false,


### PR DESCRIPTION

This PR adds ESM build support for several UTXO-related modules while 
maintaining CommonJS compatibility. The implementation enables dual-format
output that works across browser and Node.js environments.

Key changes:
- Add ESM build configuration for abstract-utxo, utxo-core, and utxo-staking
- Update package.json files with proper export conditions
- Create browser-specific TypeScript configs for ESM output
- Adjust directory structure for dual-format support
- Fix dist tags script to properly handle modules not in package.json
- Add comprehensive documentation for the dual module format support

BTC-2732