### PR TITLE
feat(abstract-utxo): improve transaction format selection with PSBT defaults

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -971,6 +971,10 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       return requestedFormat;
     }
 
+    if (getMainnet(this.network) === utxolib.networks.zcash) {
+      return undefined;
+    }
+
     const walletFlagMusigKp = wallet.flag('musigKp') === 'true';
     const isHotWallet = wallet.type() === 'hot';
 
@@ -978,10 +982,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
     const shouldDefaultToPsbt =
       wallet.subType() === 'distributedCustody' ||
       // default to testnet for all utxo coins except zcash
-      (isTestnet(this.network) &&
-        // FIXME(BTC-1322): fix zcash PSBT support
-        getMainnet(this.network) !== utxolib.networks.zcash &&
-        isHotWallet) ||
+      (isTestnet(this.network) && isHotWallet) ||
       // if mainnet, only default to psbt for btc hot wallets
       (isMainnet(this.network) && getMainnet(this.network) === utxolib.networks.bitcoin && isHotWallet) ||
       // default to psbt if it has the wallet flag

--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -84,6 +84,8 @@ import { isDescriptorWalletData } from './descriptor/descriptorWallet';
 
 import ScriptType2Of3 = utxolib.bitgo.outputScripts.ScriptType2Of3;
 
+export type TxFormat = 'legacy' | 'psbt';
+
 type UtxoCustomSigningFunction<TNumber extends number | bigint> = {
   (params: {
     coin: IBaseCoin;
@@ -957,36 +959,43 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
     };
   }
 
-  private shouldDefaultToPsbtTxFormat(buildParams: ExtraPrebuildParamsOptions & { wallet: Wallet }) {
-    const walletFlagMusigKp = buildParams.wallet.flag('musigKp') === 'true';
-    const isHotWallet = buildParams.wallet.type() === 'hot';
+  /**
+   * Determines the default transaction format based on wallet properties and network
+   * @param wallet - The wallet to check
+   * @param requestedFormat - Optional explicitly requested format
+   * @returns The transaction format to use, or undefined if no default applies
+   */
+  getDefaultTxFormat(wallet: Wallet, requestedFormat?: TxFormat): TxFormat | undefined {
+    // If format is explicitly requested, use it
+    if (requestedFormat !== undefined) {
+      return requestedFormat;
+    }
 
-    // if not txFormat is already specified figure out if we should default to psbt format
-    return (
-      buildParams.txFormat === undefined &&
-      (buildParams.wallet.subType() === 'distributedCustody' ||
-        // default to testnet for all utxo coins except zcash
-        (isTestnet(this.network) &&
-          // FIXME(BTC-1322): fix zcash PSBT support
-          getMainnet(this.network) !== utxolib.networks.zcash &&
-          isHotWallet) ||
-        // if mainnet, only default to psbt for btc hot wallets
-        (isMainnet(this.network) && getMainnet(this.network) === utxolib.networks.bitcoin && isHotWallet) ||
-        // default to psbt if it has the wallet flag
-        walletFlagMusigKp)
-    );
+    const walletFlagMusigKp = wallet.flag('musigKp') === 'true';
+    const isHotWallet = wallet.type() === 'hot';
+
+    // Determine if we should default to psbt format
+    const shouldDefaultToPsbt =
+      wallet.subType() === 'distributedCustody' ||
+      // default to testnet for all utxo coins except zcash
+      (isTestnet(this.network) &&
+        // FIXME(BTC-1322): fix zcash PSBT support
+        getMainnet(this.network) !== utxolib.networks.zcash &&
+        isHotWallet) ||
+      // if mainnet, only default to psbt for btc hot wallets
+      (isMainnet(this.network) && getMainnet(this.network) === utxolib.networks.bitcoin && isHotWallet) ||
+      // default to psbt if it has the wallet flag
+      walletFlagMusigKp;
+
+    return shouldDefaultToPsbt ? 'psbt' : undefined;
   }
 
   async getExtraPrebuildParams(buildParams: ExtraPrebuildParamsOptions & { wallet: Wallet }): Promise<{
-    txFormat?: 'legacy' | 'psbt';
+    txFormat?: TxFormat;
     changeAddressType?: ScriptType2Of3[] | ScriptType2Of3;
   }> {
-    let txFormat = buildParams.txFormat as 'legacy' | 'psbt' | undefined;
+    const txFormat = this.getDefaultTxFormat(buildParams.wallet, buildParams.txFormat as TxFormat | undefined);
     let changeAddressType = buildParams.changeAddressType as ScriptType2Of3[] | ScriptType2Of3 | undefined;
-
-    if (this.shouldDefaultToPsbtTxFormat(buildParams)) {
-      txFormat = 'psbt';
-    }
 
     // if the addressType is not specified, we need to default to p2trMusig2 for testnet hot wallets for staged rollout of p2trMusig2
     if (

--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -84,7 +84,18 @@ import { isDescriptorWalletData } from './descriptor/descriptorWallet';
 
 import ScriptType2Of3 = utxolib.bitgo.outputScripts.ScriptType2Of3;
 
-export type TxFormat = 'legacy' | 'psbt';
+export type TxFormat =
+  // This is a legacy transaction format based around the bitcoinjs-lib serialization of unsigned transactions
+  // does not include prevOut data and is a bit painful to work with
+  // going to be deprecated in favor of psbt
+  // @deprecated
+  | 'legacy'
+  // This is the standard psbt format, including the full prevTx data for legacy transactions.
+  // This will remain supported but is not the default, since the data sizes can become prohibitively large.
+  | 'psbt'
+  // This is a nonstandard psbt version where legacy inputs are serialized as if they were segwit inputs.
+  // While this prevents us to fully verify the transaction fee, we have other checks in place to ensure the fee is within bounds.
+  | 'psbt-lite';
 
 type UtxoCustomSigningFunction<TNumber extends number | bigint> = {
   (params: {
@@ -972,7 +983,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
     }
 
     if (isTestnet(this.network)) {
-      return 'psbt';
+      return 'psbt-lite';
     }
 
     const walletFlagMusigKp = wallet.flag('musigKp') === 'true';

--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -975,14 +975,16 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       return undefined;
     }
 
+    if (isTestnet(this.network)) {
+      return 'psbt';
+    }
+
     const walletFlagMusigKp = wallet.flag('musigKp') === 'true';
     const isHotWallet = wallet.type() === 'hot';
 
     // Determine if we should default to psbt format
     const shouldDefaultToPsbt =
       wallet.subType() === 'distributedCustody' ||
-      // default to testnet for all utxo coins except zcash
-      (isTestnet(this.network) && isHotWallet) ||
       // if mainnet, only default to psbt for btc hot wallets
       (isMainnet(this.network) && getMainnet(this.network) === utxolib.networks.bitcoin && isHotWallet) ||
       // default to psbt if it has the wallet flag

--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -971,10 +971,6 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
       return requestedFormat;
     }
 
-    if (getMainnet(this.network) === utxolib.networks.zcash) {
-      return undefined;
-    }
-
     if (isTestnet(this.network)) {
       return 'psbt';
     }

--- a/modules/abstract-utxo/test/unit/prebuildAndSign.ts
+++ b/modules/abstract-utxo/test/unit/prebuildAndSign.ts
@@ -214,7 +214,8 @@ function run(coin: AbstractUtxoCoin, inputScripts: ScriptType[], txFormat: TxFor
 
     [true, false].forEach((useWebauthn) => {
       it(`should succeed with ${useWebauthn ? 'webauthn encryptedPrv' : 'encryptedPrv'}`, async function () {
-        const txCoins = ['tzec', 'zec', 'ltc', 'bcha', 'doge', 'dash', 'btg', 'bch'];
+        // Check if this wallet/coin combination defaults to psbt
+        const defaultTxFormat = coin.getDefaultTxFormat(wallet);
         const nocks = createNocks({
           bgUrl,
           wallet,
@@ -223,7 +224,7 @@ function run(coin: AbstractUtxoCoin, inputScripts: ScriptType[], txFormat: TxFor
           recipient,
           addressInfo,
           nockOutputAddresses: txFormat !== 'psbt',
-          txFormat: !txCoins.includes(coin.getChain()) ? 'psbt' : undefined,
+          txFormat: defaultTxFormat,
         });
 
         // call prebuild and sign, nocks should be consumed
@@ -261,7 +262,8 @@ function run(coin: AbstractUtxoCoin, inputScripts: ScriptType[], txFormat: TxFor
       it(`should be able to build, sign, & verify a replacement transaction with selfSend: ${selfSend}`, async function () {
         const rbfTxIds = ['tx-to-be-replaced'],
           feeMultiplier = 1.5;
-        const txCoins = ['tzec', 'zec', 'ltc', 'bcha', 'doge', 'dash', 'btg', 'bch'];
+        // Check if this wallet/coin combination defaults to psbt
+        const defaultTxFormat = coin.getDefaultTxFormat(wallet);
         const nocks = createNocks({
           bgUrl,
           wallet,
@@ -273,7 +275,7 @@ function run(coin: AbstractUtxoCoin, inputScripts: ScriptType[], txFormat: TxFor
           feeMultiplier,
           selfSend,
           nockOutputAddresses: txFormat !== 'psbt',
-          txFormat: !txCoins.includes(coin.getChain()) ? 'psbt' : undefined,
+          txFormat: defaultTxFormat,
         });
 
         // call prebuild and sign, nocks should be consumed

--- a/modules/abstract-utxo/test/unit/txFormat.ts
+++ b/modules/abstract-utxo/test/unit/txFormat.ts
@@ -98,11 +98,16 @@ describe('txFormat', function () {
         utxolib.isMainnet(coin.network) && utxolib.getMainnet(coin.network) !== utxolib.networks.bitcoin,
     });
 
-    // Cold wallets do NOT default to PSBT
+    // Cold wallets default to PSBT
     runTest({
-      description: 'should not default to psbt for cold wallets',
+      description: 'should default to psbt for testnet cold wallets as well',
       walletOptions: { type: 'cold' },
-      expectedTxFormat: undefined,
+      coinFilter: (coin) => utxolib.isTestnet(coin.network),
+      expectedTxFormat: (coin) => {
+        const isZcash = utxolib.getMainnet(coin.network) === utxolib.networks.zcash;
+        // ZCash is excluded from PSBT default due to PSBT support issues (BTC-1322)
+        return isZcash ? undefined : 'psbt';
+      },
     });
 
     // DistributedCustody wallets default to PSBT

--- a/modules/abstract-utxo/test/unit/txFormat.ts
+++ b/modules/abstract-utxo/test/unit/txFormat.ts
@@ -103,26 +103,17 @@ function runTest(params: {
 
 describe('txFormat', function () {
   describe('getDefaultTxFormat', function () {
-    // ZCash never defaults to PSBT
+    // All testnet wallets default to PSBT
     runTest({
-      description: 'should never return psbt for zcash',
-      coinFilter: (coin) => utxolib.getMainnet(coin.network) === utxolib.networks.zcash,
-      expectedTxFormat: undefined,
-    });
-
-    // All non-ZCash testnet wallets default to PSBT
-    runTest({
-      description: 'should always return psbt for testnet (non-zcash)',
-      coinFilter: (coin) =>
-        utxolib.isTestnet(coin.network) && utxolib.getMainnet(coin.network) !== utxolib.networks.zcash,
+      description: 'should always return psbt for testnet',
+      coinFilter: (coin) => utxolib.isTestnet(coin.network),
       expectedTxFormat: 'psbt',
     });
 
     // DistributedCustody wallets default to PSBT (mainnet only, testnet already covered)
     runTest({
       description: 'should return psbt for distributedCustody wallets on mainnet',
-      coinFilter: (coin) =>
-        utxolib.isMainnet(coin.network) && utxolib.getMainnet(coin.network) !== utxolib.networks.zcash,
+      coinFilter: (coin) => utxolib.isMainnet(coin.network),
       walletFilter: (w) => w.options.subType === 'distributedCustody',
       expectedTxFormat: 'psbt',
     });
@@ -130,8 +121,7 @@ describe('txFormat', function () {
     // MuSig2 wallets default to PSBT (mainnet only, testnet already covered)
     runTest({
       description: 'should return psbt for wallets with musigKp flag on mainnet',
-      coinFilter: (coin) =>
-        utxolib.isMainnet(coin.network) && utxolib.getMainnet(coin.network) !== utxolib.networks.zcash,
+      coinFilter: (coin) => utxolib.isMainnet(coin.network),
       walletFilter: (w) => Boolean(w.options.walletFlags?.some((f) => f.name === 'musigKp' && f.value === 'true')),
       expectedTxFormat: 'psbt',
     });
@@ -148,8 +138,7 @@ describe('txFormat', function () {
     // Other mainnet wallets do NOT default to PSBT
     runTest({
       description: 'should return undefined for other mainnet wallets',
-      coinFilter: (coin) =>
-        utxolib.isMainnet(coin.network) && utxolib.getMainnet(coin.network) !== utxolib.networks.zcash,
+      coinFilter: (coin) => utxolib.isMainnet(coin.network),
       walletFilter: (w) => {
         const isHotBitcoin = w.options.type === 'hot'; // This will be bitcoin hot wallets
         const isDistributedCustody = w.options.subType === 'distributedCustody';

--- a/modules/abstract-utxo/test/unit/txFormat.ts
+++ b/modules/abstract-utxo/test/unit/txFormat.ts
@@ -1,0 +1,150 @@
+import * as assert from 'assert';
+
+import * as utxolib from '@bitgo/utxo-lib';
+import { ExtraPrebuildParamsOptions, Wallet } from '@bitgo/sdk-core';
+
+import { AbstractUtxoCoin } from '../../src';
+
+import { utxoCoins, defaultBitGo } from './util';
+
+type WalletOptions = {
+  type?: 'hot' | 'cold' | 'custodial' | 'custodialPaired' | 'trading';
+  subType?: string;
+  multisigType?: string;
+  walletFlags?: Array<{ name: string; value: string }>;
+};
+
+/**
+ * Helper function to create a mock wallet for testing
+ */
+export function createMockWallet(coin: AbstractUtxoCoin, options: WalletOptions = {}): Wallet {
+  const walletData = {
+    id: '5b34252f1bf349930e34020a',
+    coin: coin.getChain(),
+    type: options.type || 'hot',
+    ...(options.subType && { subType: options.subType }),
+    ...(options.multisigType && { multisigType: options.multisigType }),
+    ...(options.walletFlags && { walletFlags: options.walletFlags }),
+  };
+  return new Wallet(defaultBitGo, coin, walletData);
+}
+
+/**
+ * Helper function to get the txFormat from a coin's getExtraPrebuildParams method
+ */
+export async function getTxFormat(
+  coin: AbstractUtxoCoin,
+  buildParams: ExtraPrebuildParamsOptions & { wallet: Wallet }
+): Promise<'legacy' | 'psbt' | undefined> {
+  const result = await coin.getExtraPrebuildParams(buildParams);
+  return result.txFormat;
+}
+
+/**
+ * Helper function to run a txFormat test with named arguments
+ */
+function runTest(params: {
+  description: string;
+  walletOptions: WalletOptions;
+  expectedTxFormat: 'legacy' | 'psbt' | undefined | ((coin: AbstractUtxoCoin) => 'legacy' | 'psbt' | undefined);
+  coinFilter?: (coin: AbstractUtxoCoin) => boolean;
+  requestedTxFormat?: 'legacy' | 'psbt';
+  extraParams?: Partial<ExtraPrebuildParamsOptions>;
+}): void {
+  it(params.description, async function () {
+    for (const coin of utxoCoins) {
+      // Skip coins that don't match the filter
+      if (params.coinFilter && !params.coinFilter(coin)) {
+        continue;
+      }
+
+      const wallet = createMockWallet(coin, params.walletOptions);
+      const buildParams: ExtraPrebuildParamsOptions & { wallet: Wallet } = {
+        wallet,
+        ...(params.requestedTxFormat && { txFormat: params.requestedTxFormat }),
+        ...params.extraParams,
+      };
+      const txFormat = await getTxFormat(coin, buildParams);
+
+      const expectedTxFormat =
+        typeof params.expectedTxFormat === 'function' ? params.expectedTxFormat(coin) : params.expectedTxFormat;
+
+      assert.strictEqual(
+        txFormat,
+        expectedTxFormat,
+        `${params.description} - ${coin.getChain()}: expected ${expectedTxFormat}, got ${txFormat}`
+      );
+    }
+  });
+}
+
+describe('txFormat', function () {
+  describe('getExtraPrebuildParams', function () {
+    // Testnet hot wallets default to PSBT (except ZCash)
+    runTest({
+      description: 'should default to psbt for testnet hot wallets (except zcash)',
+      walletOptions: { type: 'hot' },
+      expectedTxFormat: (coin) => {
+        const isZcash = utxolib.getMainnet(coin.network) === utxolib.networks.zcash;
+        // ZCash is excluded from PSBT default due to PSBT support issues (BTC-1322)
+        return isZcash ? undefined : 'psbt';
+      },
+      coinFilter: (coin) => utxolib.isTestnet(coin.network),
+    });
+
+    // Mainnet Bitcoin hot wallets default to PSBT
+    runTest({
+      description: 'should default to psbt for mainnet bitcoin hot wallets',
+      walletOptions: { type: 'hot' },
+      expectedTxFormat: 'psbt',
+      coinFilter: (coin) =>
+        utxolib.isMainnet(coin.network) && utxolib.getMainnet(coin.network) === utxolib.networks.bitcoin,
+    });
+
+    // Mainnet non-Bitcoin hot wallets do NOT default to PSBT
+    runTest({
+      description: 'should not default to psbt for mainnet non-bitcoin hot wallets',
+      walletOptions: { type: 'hot' },
+      expectedTxFormat: undefined,
+      coinFilter: (coin) =>
+        utxolib.isMainnet(coin.network) && utxolib.getMainnet(coin.network) !== utxolib.networks.bitcoin,
+    });
+
+    // Cold wallets do NOT default to PSBT
+    runTest({
+      description: 'should not default to psbt for cold wallets',
+      walletOptions: { type: 'cold' },
+      expectedTxFormat: undefined,
+    });
+
+    // DistributedCustody wallets default to PSBT
+    runTest({
+      description: 'should default to psbt for distributedCustody wallets',
+      walletOptions: { type: 'cold', multisigType: 'tss', subType: 'distributedCustody' },
+      expectedTxFormat: 'psbt',
+    });
+
+    // Wallets with musigKp flag default to PSBT
+    runTest({
+      description: 'should default to psbt for wallets with musigKp flag',
+      walletOptions: { type: 'cold', walletFlags: [{ name: 'musigKp', value: 'true' }] },
+      expectedTxFormat: 'psbt',
+    });
+
+    // Explicitly specified legacy format is respected
+    runTest({
+      description: 'should respect explicitly specified legacy txFormat',
+      walletOptions: { type: 'hot' },
+      expectedTxFormat: 'legacy',
+      requestedTxFormat: 'legacy',
+    });
+
+    // Explicitly specified psbt format is respected
+    runTest({
+      description: 'should respect explicitly specified psbt txFormat',
+      walletOptions: { type: 'cold' },
+      expectedTxFormat: 'psbt',
+      requestedTxFormat: 'psbt',
+    });
+  });
+});

--- a/modules/abstract-utxo/test/unit/txFormat.ts
+++ b/modules/abstract-utxo/test/unit/txFormat.ts
@@ -120,7 +120,11 @@ describe('txFormat', function () {
     runTest({
       description: 'should default to psbt for wallets with musigKp flag',
       walletOptions: { type: 'cold', walletFlags: [{ name: 'musigKp', value: 'true' }] },
-      expectedTxFormat: 'psbt',
+      expectedTxFormat: (coin) => {
+        const isZcash = utxolib.getMainnet(coin.network) === utxolib.networks.zcash;
+        // ZCash is excluded from PSBT default due to PSBT support issues (BTC-1322)
+        return isZcash ? undefined : 'psbt';
+      },
     });
 
     // Explicitly specified legacy format is respected

--- a/modules/abstract-utxo/test/unit/txFormat.ts
+++ b/modules/abstract-utxo/test/unit/txFormat.ts
@@ -103,11 +103,11 @@ function runTest(params: {
 
 describe('txFormat', function () {
   describe('getDefaultTxFormat', function () {
-    // All testnet wallets default to PSBT
+    // All testnet wallets default to PSBT-lite
     runTest({
-      description: 'should always return psbt for testnet',
+      description: 'should always return psbt-lite for testnet',
       coinFilter: (coin) => utxolib.isTestnet(coin.network),
-      expectedTxFormat: 'psbt',
+      expectedTxFormat: 'psbt-lite',
     });
 
     // DistributedCustody wallets default to PSBT (mainnet only, testnet already covered)
@@ -160,6 +160,12 @@ describe('txFormat', function () {
       description: 'should respect explicitly requested psbt format',
       expectedTxFormat: 'psbt',
       requestedTxFormat: 'psbt',
+    });
+
+    runTest({
+      description: 'should respect explicitly requested psbt-lite format',
+      expectedTxFormat: 'psbt-lite',
+      requestedTxFormat: 'psbt-lite',
     });
   });
 });


### PR DESCRIPTION
This PR refactors and enhances transaction format selection in abstract-utxo
with a focus on PSBT (Partially Signed Bitcoin Transaction) defaults.

## Changes
- Extract format selection logic into a dedicated `getDefaultTxFormat` function
- Default to `psbt-lite` format for all testnet coins (including ZCash testnet)
- Update transaction format selection logic for special wallet types
- Add comprehensive unit tests covering all wallet configurations
- Simplify conditional logic throughout the codebase
- Improve maintainability by replacing hardcoded lists with dynamic function calls

## Default PSBT conditions:
- All testnet coins now default to `psbt-lite` format
- Bitcoin mainnet uses PSBT for specific wallet types (distributedCustody)
- Improved test coverage across various wallet configurations

Issue: BTC-2732, BTC-1322