### PR TITLE
feat: bump public types

### DIFF
--- a/modules/abstract-lightning/package.json
+++ b/modules/abstract-lightning/package.json
@@ -39,7 +39,7 @@
     ]
   },
   "dependencies": {
-    "@bitgo/public-types": "5.34.0",
+    "@bitgo/public-types": "5.43.1",
     "@bitgo/sdk-core": "^36.20.1",
     "@bitgo/statics": "^58.13.0",
     "@bitgo/utxo-lib": "^11.15.0",

--- a/modules/bitgo/package.json
+++ b/modules/bitgo/package.json
@@ -137,7 +137,7 @@
     "superagent": "^9.0.1"
   },
   "devDependencies": {
-    "@bitgo/public-types": "5.34.0",
+    "@bitgo/public-types": "5.43.1",
     "@bitgo/sdk-opensslbytes": "^2.1.0",
     "@bitgo/sdk-test": "^9.1.13",
     "@openpgp/web-stream-tools": "0.0.14",

--- a/modules/express/package.json
+++ b/modules/express/package.json
@@ -59,7 +59,7 @@
     "superagent": "^9.0.1"
   },
   "devDependencies": {
-    "@bitgo/public-types": "5.34.0",
+    "@bitgo/public-types": "5.43.1",
     "@bitgo/sdk-lib-mpc": "^10.8.1",
     "@bitgo/sdk-test": "^9.1.13",
     "@types/argparse": "^1.0.36",

--- a/modules/sdk-coin-sol/package.json
+++ b/modules/sdk-coin-sol/package.json
@@ -40,7 +40,7 @@
     ]
   },
   "dependencies": {
-    "@bitgo/public-types": "5.34.0",
+    "@bitgo/public-types": "5.43.1",
     "@bitgo/sdk-core": "^36.20.1",
     "@bitgo/sdk-lib-mpc": "^10.8.1",
     "@bitgo/statics": "^58.13.0",

--- a/modules/sdk-core/package.json
+++ b/modules/sdk-core/package.json
@@ -40,7 +40,7 @@
     ]
   },
   "dependencies": {
-    "@bitgo/public-types": "5.34.0",
+    "@bitgo/public-types": "5.43.1",
     "@bitgo/sdk-lib-mpc": "^10.8.1",
     "@bitgo/secp256k1": "^1.7.0",
     "@bitgo/sjcl": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -957,10 +957,10 @@
     "@scure/base" "1.1.5"
     micro-eth-signer "0.7.2"
 
-"@bitgo/public-types@5.34.0":
-  version "5.34.0"
-  resolved "https://registry.npmjs.org/@bitgo/public-types/-/public-types-5.34.0.tgz#ffd7b8ac438ca70901ce904583c9a504dc5c5b4b"
-  integrity sha512-HnCf9Mpoy3BoIDsaZvRQACBYbmLyt3tyWFIuR10T1Q3/LZnUeJYuYLIdprVp8vRAztqKwr9NRn3/V4Gg3gLccw==
+"@bitgo/public-types@5.43.1":
+  version "5.43.1"
+  resolved "https://registry.npmjs.org/@bitgo/public-types/-/public-types-5.43.1.tgz#a3ef2160748302ef73811ed9e552cfefc0c1d140"
+  integrity sha512-HfGTXNpmSCo4TKm6TWcB9fgGunxRrZdO2Tk9tubD2gSVOUzc/EDrlGlXl2ZZ3xy2ZmaFTkRej2iODa9fEZxgMg==
   dependencies:
     fp-ts "^2.0.0"
     io-ts "npm:@bitgo-forks/io-ts@2.1.4"


### PR DESCRIPTION
[CS-6317](https://bitgoinc.atlassian.net/browse/CS-6317)

Ref: https://github.com/BitGo/public-types/releases/tag/v5.43.1
 - add optional `isTestTransaction` to `txSendBody`

[CS-6317]: https://bitgoinc.atlassian.net/browse/CS-6317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ