### PR TITLE
feat(abstract-utxo): update backup key recovery to use standard address generation

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -815,27 +815,6 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
   }
 
   /**
-   * Create a multisig address of a given type from a list of keychains and a signing threshold
-   * @param addressType
-   * @param signatureThreshold
-   * @param keys
-   */
-  createMultiSigAddress(addressType: ScriptType2Of3, signatureThreshold: number, keys: Buffer[]): MultiSigAddress {
-    const {
-      scriptPubKey: outputScript,
-      redeemScript,
-      witnessScript,
-    } = utxolib.bitgo.outputScripts.createOutputScript2of3(keys, addressType);
-
-    return {
-      outputScript,
-      redeemScript,
-      witnessScript,
-      address: utxolib.address.fromOutputScript(outputScript, this.network),
-    };
-  }
-
-  /**
    * @deprecated - use {@see backupKeyRecovery}
    * Builds a funds recovery transaction without BitGo
    * @param params - {@see backupKeyRecovery}


### PR DESCRIPTION
Remove deprecated createMultiSigAddress function and update the backup
key recovery flow to use the standard address generation functions.
This ensures consistency with the rest of the codebase and improves
maintainability.

BTC-2668