### PR TITLE
feat: wallet ownership validation for eth-like, ada, apt, vet, icp

### DIFF
--- a/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
+++ b/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
@@ -2748,20 +2748,20 @@ export abstract class AbstractEthLikeNewCoins extends AbstractEthLikeCoin {
     let expectedAddress;
     let actualAddress;
 
-    const { address, impliedForwarderVersion } = params;
+    const { address, impliedForwarderVersion, coinSpecific } = params;
+    const forwarderVersion = impliedForwarderVersion ?? coinSpecific?.forwarderVersion;
 
     if (address && !this.isValidAddress(address)) {
       throw new InvalidAddressError(`invalid address: ${address}`);
     }
     // Forwarder version 0 addresses cannot be verified because we do not store the nonce value required for address derivation.
-    if (impliedForwarderVersion === 0) {
+    if (forwarderVersion === 0) {
       return true;
     }
     // Verify MPC wallet address for wallet version 3 and 6
     if (isTssVerifyAddressOptions(params) && params.walletVersion !== 5) {
       return verifyMPCWalletAddress({ ...params, keyCurve: 'secp256k1' }, this.isValidAddress, (pubKey) => {
-        const derivedPublicKey = Buffer.from(pubKey, 'hex').subarray(0, 33).toString('hex');
-        return new KeyPairLib({ pub: derivedPublicKey }).getAddress();
+        return new KeyPairLib({ pub: pubKey }).getAddress();
       });
     } else {
       // Verify forwarder receive address

--- a/modules/sdk-coin-ada/test/unit/ada.ts
+++ b/modules/sdk-coin-ada/test/unit/ada.ts
@@ -898,4 +898,84 @@ describe('ADA', function () {
         .should.be.rejectedWith('tx outputs does not match with expected address');
     });
   });
+
+  describe('isWalletAddress', function () {
+    let keychains;
+    const commonKeychain =
+      '0c012a54ac4bcbfc322ed71f3fcba85b993f4de0377e211f8e52e539571a7b397b63db46d8f20218019681c45ff7d4ef86b4d7ee8c4dac0d8b69b7b966962258';
+
+    before(function () {
+      keychains = [
+        {
+          id: '691ce22d193ef7977224cef7f2c5736f',
+          source: 'user',
+          type: 'tss',
+          commonKeychain,
+        },
+        {
+          id: '691ce22d193ef7977224cefac9e54e33',
+          source: 'backup',
+          type: 'tss',
+          commonKeychain,
+        },
+        {
+          id: '691ce22d193ef7977224cef23e73b113',
+          source: 'bitgo',
+          type: 'tss',
+          commonKeychain,
+          isBitGo: true,
+        },
+      ];
+    });
+
+    it('should verify TSS address derivation', async function () {
+      const validAddress = 'addr_test1vrdswnnph3gh9pm9zsd2r7k9p2rek7927xqzs48cdtph5rq3fxtjf';
+      const index = 0;
+
+      const params = { address: validAddress, index, keychains };
+      const res = await basecoin.isWalletAddress(params);
+      assert.equal(res, true);
+    });
+
+    it('should return false when address does not match derived address', async function () {
+      const wrongAddress =
+        'addr_test1qqnnvptrc3rec64q2n9jh572ncu5wvdtt8uvg4g3aj96s5dwu9nj70mlahzglm9939uevupsmj8dcdqv25d5n5r8vw8sn7prey';
+      const index = 0;
+
+      const params = { address: wrongAddress, index, keychains };
+      const res = await basecoin.isWalletAddress(params);
+      assert.equal(res, false);
+    });
+
+    it('should throw error when keychains is missing', async function () {
+      const validAddress = 'addr_test1vr8rakm66rcfv4fcxqykg5lf0yv7lsyk9mvapx369jpvtcgfcuk7f';
+      const index = 0;
+
+      const params = { address: validAddress, index };
+      await basecoin.isWalletAddress(params).should.be.rejectedWith('missing required param keychains');
+    });
+
+    it('should throw error when commonKeychain is missing', async function () {
+      const validAddress = 'addr_test1vr8rakm66rcfv4fcxqykg5lf0yv7lsyk9mvapx369jpvtcgfcuk7f';
+      const index = 0;
+      const invalidKeychains = [
+        {
+          id: 'test-user',
+          source: 'user',
+          type: 'tss',
+        },
+      ];
+
+      const params = { address: validAddress, index, keychains: invalidKeychains };
+      await basecoin.isWalletAddress(params).should.be.rejectedWith('missing required param commonKeychain');
+    });
+
+    it('should throw error when address is invalid', async function () {
+      const invalidAddress = 'invalid-address';
+      const index = 0;
+
+      const params = { address: invalidAddress, index, keychains };
+      await basecoin.isWalletAddress(params).should.be.rejectedWith(`Invalid Cardano Address: ${invalidAddress}`);
+    });
+  });
 });

--- a/modules/sdk-coin-apt/src/apt.ts
+++ b/modules/sdk-coin-apt/src/apt.ts
@@ -128,9 +128,9 @@ export class Apt extends BaseCoin {
       throw new InvalidAddressError(`invalid address: ${address}`);
     }
 
-    return verifyEddsaTssWalletAddress(params, this.isValidAddress.bind(this), (publicKey: string) => {
-      return utils.getAddressFromPublicKey(publicKey.slice(0, 64));
-    });
+    return verifyEddsaTssWalletAddress(params, this.isValidAddress.bind(this), (publicKey: string) =>
+      utils.getAddressFromPublicKey(publicKey)
+    );
   }
 
   async parseTransaction(params: AptParseTransactionOptions): Promise<ParsedTransaction> {

--- a/modules/sdk-coin-apt/src/apt.ts
+++ b/modules/sdk-coin-apt/src/apt.ts
@@ -14,8 +14,9 @@ import {
   PrebuildTransactionWithIntentOptions,
   SignedTransaction,
   SignTransactionOptions,
-  VerifyAddressOptions,
   VerifyTransactionOptions,
+  TssVerifyAddressOptions,
+  verifyEddsaTssWalletAddress,
 } from '@bitgo/sdk-core';
 import { BaseCoin as StaticsBaseCoin, coins } from '@bitgo/statics';
 import { KeyPair as AptKeyPair, TransactionBuilderFactory } from './lib';
@@ -120,13 +121,16 @@ export class Apt extends BaseCoin {
     return true;
   }
 
-  async isWalletAddress(params: VerifyAddressOptions): Promise<boolean> {
-    const { address: newAddress } = params;
+  async isWalletAddress(params: TssVerifyAddressOptions): Promise<boolean> {
+    const { address } = params;
 
-    if (!this.isValidAddress(newAddress)) {
-      throw new InvalidAddressError(`invalid address: ${newAddress}`);
+    if (!this.isValidAddress(address)) {
+      throw new InvalidAddressError(`invalid address: ${address}`);
     }
-    return true;
+
+    return verifyEddsaTssWalletAddress(params, this.isValidAddress.bind(this), (publicKey: string) => {
+      return utils.getAddressFromPublicKey(publicKey.slice(0, 64));
+    });
   }
 
   async parseTransaction(params: AptParseTransactionOptions): Promise<ParsedTransaction> {

--- a/modules/sdk-coin-apt/test/unit/apt.ts
+++ b/modules/sdk-coin-apt/test/unit/apt.ts
@@ -333,7 +333,7 @@ describe('APT:', function () {
     });
 
     it('should return true for isWalletAddress with valid address for index 4', async function () {
-      const newAddress = '0x8b3c7807730d75792dd6c49732cf9f014d6984a9c77d386bdb1072a9e537d8d8';
+      const newAddress = '0x3d7a55c4f55702b0a57f0228060c78dcf612d157108d77487d1fbed45d8f656a';
       const index = 4;
 
       const params = { commonKeychain, address: newAddress, index, keychains };

--- a/modules/sdk-coin-eth/test/unit/eth.ts
+++ b/modules/sdk-coin-eth/test/unit/eth.ts
@@ -806,7 +806,7 @@ describe('ETH:', function () {
           const coin = bitgo.coin('teth') as Teth;
 
           const params = {
-            address: '0x9e7ce8c24d9f76a814e23633e61be7cb8e6e2d5e',
+            address: '0x01153f3adfe454a72589ca9ef74f013c19e54961',
             baseAddress: '0xdf07117705a9f8dc4c2a78de66b7f1797dba9d4e',
             coinSpecific: {
               forwarderVersion: 3,
@@ -824,7 +824,7 @@ describe('ETH:', function () {
           const coin = bitgo.coin('teth') as Teth;
 
           const params = {
-            address: '0x9e7ce8c24d9f76a814e23633e61be7cb8e6e2d5e',
+            address: '0x01153f3adfe454a72589ca9ef74f013c19e54961',
             baseAddress: '0xdf07117705a9f8dc4c2a78de66b7f1797dba9d4e',
             coinSpecific: {
               forwarderVersion: 5,

--- a/modules/sdk-coin-icp/test/unit/icp.ts
+++ b/modules/sdk-coin-icp/test/unit/icp.ts
@@ -233,4 +233,92 @@ describe('Internet computer', function () {
         .should.rejectedWith('generated signableHex is not equal to params.signableHex');
     });
   });
+
+  describe('isWalletAddress', function () {
+    let keychains;
+    const commonKeychain =
+      '036b38ca5e63e9800b5040af498eb6e9a9c77e244ac2858edafa4bd0926a635731c3fabde9007a5771e93621d9fcb1c879660208dc79cc609fe8ddd189f7a955ab';
+
+    before(function () {
+      keychains = [
+        {
+          id: '691ddce39d0505f43dd931570e6bd7cf',
+          source: 'user',
+          type: 'tss',
+          commonKeychain,
+        },
+        {
+          id: '691ddce3b1a977aaf2465acca73b2aef',
+          source: 'backup',
+          type: 'tss',
+          commonKeychain,
+        },
+        {
+          id: '691ddce38e366afce3f35b0778c79858',
+          source: 'bitgo',
+          type: 'tss',
+          commonKeychain,
+          isBitGo: true,
+        },
+      ];
+    });
+
+    it('should verify TSS address derivation', async function () {
+      const validAddress = 'fd3eaed3e2064bd30ab497e22e8ac5a0dcadd81fa5353879dbab64e259ec70c0';
+      const index = 0;
+
+      const params = { address: validAddress, index, keychains };
+      const res = await basecoin.isWalletAddress(params);
+      assert.equal(res, true);
+    });
+
+    it('should return false when address does not match derived address', async function () {
+      const wrongAddress = 'c3d30f404955975adaba89f2e1ebc75c1f44a6a204578afce8f3780d64fe252e';
+      const index = 0;
+
+      const params = { address: wrongAddress, index, keychains };
+      const res = await basecoin.isWalletAddress(params);
+      assert.equal(res, false);
+    });
+
+    it('should throw error when keychains is missing', async function () {
+      const validAddress = 'fd3eaed3e2064bd30ab497e22e8ac5a0dcadd81fa5353879dbab64e259ec70c0';
+      const index = 0;
+
+      const params = { address: validAddress, index };
+      await assert.rejects(async () => basecoin.isWalletAddress(params), {
+        message: 'missing required param keychains',
+      });
+    });
+
+    it('should throw error when commonKeychain is missing', async function () {
+      const validAddress = 'fd3eaed3e2064bd30ab497e22e8ac5a0dcadd81fa5353879dbab64e259ec70c0';
+      const index = 0;
+      const invalidKeychains = [
+        {
+          id: '691ddce39d0505f43dd931570e6bd7cf',
+          source: 'user',
+          type: 'tss',
+        },
+      ];
+
+      const params = { address: validAddress, index, keychains: invalidKeychains };
+      await assert.rejects(async () => basecoin.isWalletAddress(params), {
+        message: 'missing required param commonKeychain',
+      });
+    });
+
+    it('should throw error when address is invalid', async function () {
+      const invalidAddress = 'invalid-address';
+      const index = 0;
+
+      const params = { address: invalidAddress, index, keychains };
+      await assert.rejects(
+        async () => basecoin.isWalletAddress(params),
+        (err: Error) => {
+          return err.message.includes('invalid address');
+        }
+      );
+    });
+  });
 });

--- a/modules/sdk-coin-iota/src/iota.ts
+++ b/modules/sdk-coin-iota/src/iota.ts
@@ -136,7 +136,10 @@ export class Iota extends BaseCoin {
     return verifyEddsaTssWalletAddress(
       params,
       (address) => this.isValidAddress(address),
-      (publicKey) => utils.getAddressFromPublicKey(publicKey)
+      (publicKey) => {
+        const publicKeyOnly = Buffer.from(publicKey, 'hex').subarray(0, 32).toString('hex');
+        return utils.getAddressFromPublicKey(publicKeyOnly);
+      }
     );
   }
 

--- a/modules/sdk-coin-iota/src/iota.ts
+++ b/modules/sdk-coin-iota/src/iota.ts
@@ -136,10 +136,7 @@ export class Iota extends BaseCoin {
     return verifyEddsaTssWalletAddress(
       params,
       (address) => this.isValidAddress(address),
-      (publicKey) => {
-        const publicKeyOnly = Buffer.from(publicKey, 'hex').subarray(0, 32).toString('hex');
-        return utils.getAddressFromPublicKey(publicKeyOnly);
-      }
+      (publicKey) => utils.getAddressFromPublicKey(publicKey)
     );
   }
 

--- a/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
@@ -169,12 +169,23 @@ export interface TssVerifyAddressOptions {
    * For MPC wallets, the commonKeychain (combined public key from MPC key generation)
    * should be identical across all keychains (user, backup, bitgo).
    */
-  keychains: Keychain[];
+  keychains: Pick<Keychain, 'commonKeychain'>[];
   /**
    * Derivation index for the address.
    * Used to derive child addresses from the root keychain via HD derivation path: m/{index}
    */
-  index: string;
+  index: number | string;
+}
+
+export function isTssVerifyAddressOptions<T extends VerifyAddressOptions | TssVerifyAddressOptions>(
+  params: T
+): params is T & TssVerifyAddressOptions {
+  return !!(
+    'keychains' in params &&
+    'index' in params &&
+    'address' in params &&
+    params.keychains?.some((kc) => 'commonKeychain' in kc && !!kc.commonKeychain)
+  );
 }
 
 export interface TransactionParams {

--- a/modules/sdk-core/src/bitgo/utils/tss/addressVerification.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/addressVerification.ts
@@ -1,4 +1,4 @@
-import { Ecdsa } from 'modules/sdk-core/src/account-lib/mpc';
+import { Ecdsa } from '../../../account-lib/mpc';
 import { TssVerifyAddressOptions } from '../../baseCoin/iBaseCoin';
 import { InvalidAddressError } from '../../errors';
 import { EDDSAMethods } from '../../tss';
@@ -73,8 +73,7 @@ export async function verifyMPCWalletAddress(
 
   const MPC = params.keyCurve === 'secp256k1' ? new Ecdsa() : await EDDSAMethods.getInitializedMpcInstance();
   const commonKeychain = extractCommonKeychain(keychains);
-  const derivationPath = 'm/' + index;
-  const derivedPublicKey = MPC.deriveUnhardened(commonKeychain, derivationPath);
+  const derivedPublicKey = MPC.deriveUnhardened(commonKeychain, 'm/' + index);
 
   // secp256k1 expects 33 bytes; ed25519 expects 32 bytes
   const publicKeySize = params.keyCurve === 'secp256k1' ? 33 : 32;

--- a/modules/sdk-core/src/bitgo/utils/tss/addressVerification.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/addressVerification.ts
@@ -75,7 +75,12 @@ export async function verifyMPCWalletAddress(
   const commonKeychain = extractCommonKeychain(keychains);
   const derivationPath = 'm/' + index;
   const derivedPublicKey = MPC.deriveUnhardened(commonKeychain, derivationPath);
-  const expectedAddress = getAddressFromPublicKey(derivedPublicKey);
+
+  // secp256k1 expects 33 bytes; ed25519 expects 32 bytes
+  const publicKeySize = params.keyCurve === 'secp256k1' ? 33 : 32;
+  const publicKeyOnly = Buffer.from(derivedPublicKey, 'hex').subarray(0, publicKeySize).toString('hex');
+
+  const expectedAddress = getAddressFromPublicKey(publicKeyOnly);
 
   return address === expectedAddress;
 }

--- a/modules/sdk-core/src/index.ts
+++ b/modules/sdk-core/src/index.ts
@@ -10,6 +10,7 @@ import { EcdsaUtils } from './bitgo/utils/tss/ecdsa/ecdsa';
 export { EcdsaUtils };
 import { EcdsaMPCv2Utils } from './bitgo/utils/tss/ecdsa/ecdsaMPCv2';
 export { EcdsaMPCv2Utils };
+export { verifyEddsaTssWalletAddress, verifyMPCWalletAddress } from './bitgo/utils/tss/addressVerification';
 export { GShare, SignShare, YShare } from './account-lib/mpc/tss/eddsa/types';
 export { TssEcdsaStep1ReturnMessage, TssEcdsaStep2ReturnMessage } from './bitgo/tss/types';
 export { SShare } from './bitgo/tss/ecdsa/types';


### PR DESCRIPTION
Fix `AbstractEthLikeNewCoins.isWalletAddress` forwarder version bypass
   - Remove unconditional `return true` for versions 0, 3, 5
   - Implement validation for these versions

Fix partial implementations for `ada`, `apt`, `icp`, `vet`
   - add wallet address verification for these coins, previously they were only format checks  

ticket: WP-6461