### PR TITLE
docs(express): update canonicalAddress API docs

### DIFF
--- a/modules/express/src/typedRoutes/api/v2/canonicalAddress.ts
+++ b/modules/express/src/typedRoutes/api/v2/canonicalAddress.ts
@@ -14,9 +14,9 @@ export const CanonicalAddressRequestParams = {
  * Request body for canonical address conversion
  */
 export const CanonicalAddressRequestBody = {
-  /** Address to canonicalize - can be in any supported format (base58, cashaddr, etc.) */
+  /** Address to canonicalize - can be in any supported format (base58, cashaddr for BCH only, etc.) */
   address: t.string,
-  /** Desired address format: 'base58' or 'cashaddr' (BCH/BSV: defaults to 'base58', LTC: ignored as addresses are returned unchanged) */
+  /** Desired address format: 'base58' (supported by BCH, BSV, LTC) or 'cashaddr' (supported by BCH only). Defaults to 'base58'. LTC ignores this parameter. */
   version: optional(t.union([t.literal('base58'), t.literal('cashaddr')])),
   /** @deprecated Use version instead. Fallback parameter for version. */
   scriptHashVersion: optional(t.union([t.literal('base58'), t.literal('cashaddr')])),
@@ -30,16 +30,21 @@ export const CanonicalAddressRequestBody = {
  *
  * **Supported Coins:**
  * - **Bitcoin Cash (BCH/TBCH)**: Converts between base58 and cashaddr formats
- * - **Bitcoin SV (BSV/TBSV)**: Converts between base58 and cashaddr formats
+ * - **Bitcoin SV (BSV/TBSV)**: Supports base58 format only (cashaddr not supported)
  * - **Litecoin (LTC/TLTC)**: Returns address unchanged (included for API consistency)
  *
  * **Address Formats:**
  * - **base58**: Traditional Bitcoin-style addresses (e.g., '1BpEi6DfDAUFd7GtittLSdBeYJvcoaVggu', '3CWFddi6m4ndiGyKqzYvsFYagqDLPVMTzC')
  * - **cashaddr**: Bitcoin Cash address format with network prefix (e.g., 'bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a')
  *
- * **BCH/BSV Behavior:**
+ * **BCH Behavior:**
  * - version='base58': Converts any input format to base58 canonical format
  * - version='cashaddr': Converts any input format to cashaddr format (adds network prefix if missing)
+ * - Default (no version): Converts to base58 format
+ *
+ * **BSV Behavior (Deprecated):**
+ * - version='base58': Converts address to base58 canonical format
+ * - version='cashaddr': Not supported - will return error "unsupported address format cashaddr for network bitcoinsv"
  * - Default (no version): Converts to base58 format
  *
  * **LTC Behavior:**


### PR DESCRIPTION
- BSV supports base58 only (not cashaddr)
- Update parameter descriptions (cashaddr = BCH-only)
- Add BSV deprecation

TICKET: WP-6972

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
