### PR TITLE
fix(utxo-bin): fix signature matching and add previous transaction support

### DIFF
--- a/modules/utxo-bin/src/InputParser.ts
+++ b/modules/utxo-bin/src/InputParser.ts
@@ -224,7 +224,12 @@ export class InputParser extends Parser {
             ...this.parseSignaturesWithSigners(
               parsed,
               signedBy.flatMap((v, i) => (v ? [i.toString()] : [])),
-              parsed.signatures.map((k: Buffer | 0) => (k === 0 ? -1 : signedBy.indexOf(k)))
+              parsed.signatures.map((signatureByKey: Buffer | 0) => {
+                if (signatureByKey === 0) {
+                  return -1;
+                }
+                return signedBy.findIndex((k) => k && k.equals(signatureByKey));
+              })
             )
           );
         } catch (e) {

--- a/modules/utxo-bin/src/prevTx.ts
+++ b/modules/utxo-bin/src/prevTx.ts
@@ -1,0 +1,47 @@
+import * as utxolib from '@bitgo/utxo-lib';
+import { ParserTx } from './ParserTx';
+
+function getPrevOutForOutpoint(outpoint: utxolib.bitgo.TxOutPoint, prevTx: ParserTx) {
+  if (prevTx instanceof utxolib.bitgo.UtxoTransaction) {
+    const hash = prevTx.getId();
+    if (hash !== outpoint.txid) {
+      return undefined;
+    }
+    const out = prevTx.outs[outpoint.vout];
+    if (!out) {
+      throw new Error(`vout ${outpoint.vout} not found in prevTx ${hash}`);
+    }
+    return out;
+  }
+
+  if (prevTx instanceof utxolib.bitgo.UtxoPsbt) {
+    throw new Error(`not implemented for Psbt yet`);
+  }
+
+  throw new Error(`unknown tx type`);
+}
+
+export function getPrevOutputsFromPrevTxs(tx: ParserTx, prevTxs: ParserTx[]): utxolib.TxOutput<bigint>[] | undefined {
+  if (prevTxs.length === 0) {
+    return undefined;
+  }
+  if (tx instanceof utxolib.bitgo.UtxoTransaction) {
+    const outpoints = tx.ins.map((i) => utxolib.bitgo.getOutputIdForInput(i));
+    return outpoints.map((o) => {
+      const matches = prevTxs.flatMap((t) => getPrevOutForOutpoint(o, t));
+      if (matches.length === 0) {
+        throw new Error(`no prevTx found for input ${o.txid}:${o.vout}`);
+      }
+      if (matches.length > 1) {
+        throw new Error(`more than one prevTx found for input ${o.txid}:${o.vout}`);
+      }
+      return matches[0] as utxolib.TxOutput<bigint>;
+    });
+  }
+
+  if (tx instanceof utxolib.bitgo.UtxoPsbt) {
+    throw new Error(`not implemented for Psbt yet`);
+  }
+
+  throw new Error(`unknown tx type`);
+}

--- a/modules/utxo-bin/test/fixtures/formatTransaction/p2sh_networkFullSigned_all_prevOuts.txt
+++ b/modules/utxo-bin/test/fixtures/formatTransaction/p2sh_networkFullSigned_all_prevOuts.txt
@@ -34,7 +34,8 @@ transaction: 58603ea06d55bd9dd6fec9b0d1ea5662d622f923e0f10045507723a893388e7f
 │ │     ├── signed by: [0, 2]
 │ │     ├─┬ 0
 │ │     │ ├── bytes: 3044022048a059c22437630fdd5bc3c46bd1e30438a3623a59050d5e5f2fb1a36686fd9e02202ed8206b2f2472efd3ea145bc3c52703a7874fc747bdccc97cd5b862c8d62b7401 (71 bytes)
-│ │     │ ├── valid: false
+│ │     │ ├── valid: true
+│ │     │ ├── signedBy: user
 │ │     │ ├── isCanonical: true
 │ │     │ ├── hashType: 1
 │ │     │ ├── r: 48a059c22437630fdd5bc3c46bd1e30438a3623a59050d5e5f2fb1a36686fd9e (32 bytes)
@@ -42,7 +43,8 @@ transaction: 58603ea06d55bd9dd6fec9b0d1ea5662d622f923e0f10045507723a893388e7f
 │ │     │ └── highS: false
 │ │     └─┬ 1
 │ │       ├── bytes: 30440220138087371ab51032457bdca8ef134eb566a61b16631cf6bc296c8b243f938bf70220720ab74bfa5e39f2c764d1879dd6fea9b1f287611b1ea714fe5b0928bd13d46901 (71 bytes)
-│ │       ├── valid: false
+│ │       ├── valid: true
+│ │       ├── signedBy: bitgo
 │ │       ├── isCanonical: true
 │ │       ├── hashType: 1
 │ │       ├── r: 138087371ab51032457bdca8ef134eb566a61b16631cf6bc296c8b243f938bf7 (32 bytes)
@@ -72,7 +74,8 @@ transaction: 58603ea06d55bd9dd6fec9b0d1ea5662d622f923e0f10045507723a893388e7f
 │       ├── signed by: [0, 2]
 │       ├─┬ 0
 │       │ ├── bytes: 3045022100afde55c0cfa9dc3a20fb8706c5a7f86c754efcbbaf866e09e84a18668c53148402203a7e0bb62cd5a951def97181f6a26d78b70c7ac22af79029f22b5b130785939f01 (72 bytes)
-│       │ ├── valid: false
+│       │ ├── valid: true
+│       │ ├── signedBy: user
 │       │ ├── isCanonical: true
 │       │ ├── hashType: 1
 │       │ ├── r: afde55c0cfa9dc3a20fb8706c5a7f86c754efcbbaf866e09e84a18668c531484 (32 bytes)
@@ -80,7 +83,8 @@ transaction: 58603ea06d55bd9dd6fec9b0d1ea5662d622f923e0f10045507723a893388e7f
 │       │ └── highS: false
 │       └─┬ 1
 │         ├── bytes: 3044022033ae8e7c8ef2109b804bc338e884109e5ed9e534307761aa5695a0eea3ce0615022045b4af31359339b6c696ca0f956e844baa8dd642b0e74ad2475e8fe5b4c055e801 (71 bytes)
-│         ├── valid: false
+│         ├── valid: true
+│         ├── signedBy: bitgo
 │         ├── isCanonical: true
 │         ├── hashType: 1
 │         ├── r: 33ae8e7c8ef2109b804bc338e884109e5ed9e534307761aa5695a0eea3ce0615 (32 bytes)


### PR DESCRIPTION

This PR includes two important fixes for the utxo-bin package:

1. Fixes signature matching in InputParser by replacing indexOf with 
findIndex to properly match signatures using buffer equality comparison.

2. Adds support for providing previous transaction data directly to the 
parseTx command via a new --prevTx option, eliminating the need to fetch 
from remote sources. Includes helper functions to extract previous outputs 
from these transactions.

BTC-0