### PR TITLE
feat(utxo): refactor signing flow and improve MuSig2 support

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -59,6 +59,7 @@ import { isReplayProtectionUnspent } from './transaction/fixedScript/replayProte
 import { supportedCrossChainRecoveries } from './config';
 import {
   assertValidTransactionRecipient,
+  DecodedTransaction,
   explainTx,
   fromExtendedAddressFormat,
   isScriptRecipient,
@@ -178,9 +179,7 @@ function convertValidationErrorToTxIntentMismatch(
   return txIntentError;
 }
 
-export type DecodedTransaction<TNumber extends number | bigint> =
-  | utxolib.bitgo.UtxoTransaction<TNumber>
-  | utxolib.bitgo.UtxoPsbt;
+export type { DecodedTransaction } from './transaction/types';
 
 export type RootWalletKeys = bitgo.RootWalletKeys;
 

--- a/modules/abstract-utxo/src/transaction/fixedScript/index.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/index.ts
@@ -3,6 +3,6 @@ export { explainPsbtWasm } from './explainPsbtWasm';
 export { parseTransaction } from './parseTransaction';
 export { CustomChangeOptions } from './parseOutput';
 export { verifyTransaction } from './verifyTransaction';
-export { signTransaction } from './signTransaction';
+export { signTransaction, Musig2Participant } from './signTransaction';
 export * from './sign';
 export * from './replayProtection';

--- a/modules/abstract-utxo/src/transaction/fixedScript/signTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/signTransaction.ts
@@ -59,7 +59,7 @@ export async function signTransaction<TNumber extends number | bigint>(
         return { txHex: tx.toHex() };
       case 'cosignerNonce':
         assert(params.walletId, 'walletId is required for MuSig2 bitgo nonce');
-        return { txHex: (await coin.signPsbt(tx.toHex(), params.walletId)).psbt };
+        return { txHex: (await coin.getMusig2Nonces(tx.toHex(), params.walletId)).psbt };
       case 'signerSignature':
         const txId = tx.getUnsignedTx().getId();
         const psbt = PSBT_CACHE.get(txId);
@@ -76,7 +76,7 @@ export async function signTransaction<TNumber extends number | bigint>(
         assert(params.walletId, 'walletId is required for MuSig2 bitgo nonce');
         assert(signerKeychain);
         tx.setAllInputsMusig2NonceHD(signerKeychain);
-        const response = await coin.signPsbt(tx.toHex(), params.walletId);
+        const response = await coin.getMusig2Nonces(tx.toHex(), params.walletId);
         tx.combine(bitgo.createPsbtFromHex(response.psbt, coin.network));
         break;
     }

--- a/modules/abstract-utxo/src/transaction/fixedScript/signTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/signTransaction.ts
@@ -6,9 +6,11 @@ import { bitgo } from '@bitgo/utxo-lib';
 import * as utxolib from '@bitgo/utxo-lib';
 import { isTriple, Triple } from '@bitgo/sdk-core';
 
-import { AbstractUtxoCoin, DecodedTransaction, RootWalletKeys } from '../../abstractUtxoCoin';
+import { AbstractUtxoCoin, DecodedTransaction } from '../../abstractUtxoCoin';
 
 import { signAndVerifyPsbt, signAndVerifyWalletTransaction } from './sign';
+
+type RootWalletKeys = bitgo.RootWalletKeys;
 
 /**
  * Key Value: Unsigned tx id => PSBT

--- a/modules/abstract-utxo/src/transaction/signTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/signTransaction.ts
@@ -63,7 +63,7 @@ export async function signTransaction<TNumber extends number | bigint>(
       throw new Error('expected a UtxoPsbt object');
     }
   } else {
-    return fixedScript.signTransaction(coin, tx, getSignerKeychain(params.prv), {
+    return fixedScript.signTransaction(coin, tx, getSignerKeychain(params.prv), coin.network, {
       walletId: params.txPrebuild.walletId,
       txInfo: params.txPrebuild.txInfo,
       isLastSignature: params.isLastSignature ?? false,

--- a/modules/abstract-utxo/src/transaction/types.ts
+++ b/modules/abstract-utxo/src/transaction/types.ts
@@ -1,6 +1,12 @@
+import * as utxolib from '@bitgo/utxo-lib';
+
 import type { UtxoNamedKeychains } from '../keychains';
 
 import type { CustomChangeOptions } from './fixedScript';
+
+export type DecodedTransaction<TNumber extends number | bigint> =
+  | utxolib.bitgo.UtxoTransaction<TNumber>
+  | utxolib.bitgo.UtxoPsbt;
 
 export interface BaseOutput<TAmount = string | number> {
   address: string;

--- a/modules/abstract-utxo/test/unit/transaction/fixedScript/signPsbt.ts
+++ b/modules/abstract-utxo/test/unit/transaction/fixedScript/signPsbt.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+
+import * as utxolib from '@bitgo/utxo-lib';
+
+import { signAndVerifyPsbt } from '../../../../src/transaction/fixedScript/sign';
+
+function describeSignAndVerifyPsbt(acidTest: utxolib.testutil.AcidTest) {
+  describe(`${acidTest.name}`, function () {
+    it('should sign unsigned psbt to halfsigned', function () {
+      // Create unsigned PSBT
+      const psbt = acidTest.createPsbt();
+
+      // Set musig2 nonces for taproot inputs before signing
+      const sessionId = Buffer.alloc(32);
+      psbt.setAllInputsMusig2NonceHD(acidTest.rootWalletKeys.user, { sessionId });
+      psbt.setAllInputsMusig2NonceHD(acidTest.rootWalletKeys.bitgo, { deterministic: true });
+
+      // Sign with user key
+      const result = signAndVerifyPsbt(psbt, acidTest.rootWalletKeys.user, {
+        isLastSignature: false,
+      });
+
+      // Result should be a PSBT (not finalized)
+      assert(result instanceof utxolib.bitgo.UtxoPsbt, 'should return UtxoPsbt when not last signature');
+
+      // Verify that all wallet inputs have been signed by user key
+      result.data.inputs.forEach((input, inputIndex) => {
+        const { scriptType } = utxolib.bitgo.parsePsbtInput(input);
+
+        // Skip replay protection inputs (p2shP2pk)
+        if (scriptType === 'p2shP2pk') {
+          return;
+        }
+
+        // Verify user signature is present
+        const isValid = result.validateSignaturesOfInputHD(inputIndex, acidTest.rootWalletKeys.user);
+        assert(isValid, `input ${inputIndex} should have valid user signature`);
+      });
+    });
+  });
+}
+
+describe('signAndVerifyPsbt', function () {
+  // Create test suite with includeP2trMusig2ScriptPath set to false
+  // p2trMusig2 script path inputs are signed by user and backup keys,
+  // which is not the typical signing pattern and makes testing more complex
+  utxolib.testutil.AcidTest.suite({ includeP2trMusig2ScriptPath: false })
+    .filter((test) => test.signStage === 'unsigned')
+    .forEach((test) => {
+      describeSignAndVerifyPsbt(test);
+    });
+});


### PR DESCRIPTION
This PR includes several key improvements to the UTXO signing architecture:

- Refactors the signing flow by splitting sign.ts into smaller, focused modules
- Renames `signPsbt` to `getMusig2Nonces` to better reflect its functionality
- Updates `getMusig2Nonces` to accept UtxoPsbt objects directly for type safety
- Moves `signTransaction` away from AbstractUtxoCoin to a standalone module
- Adds configuration option to exclude p2trMusig2 script path inputs from ACID tests
- Improves error reporting by including script type in InputSigningError

The changes aim to improve code organization, reduce circular dependencies,
and enhance the developer experience when working with MuSig2 and PSBT
signing.

BTC-2806