### PR TITLE
feat(abstract-utxo): fix npm test to handle extra arguments

### DIFF
--- a/modules/abstract-utxo/package.json
+++ b/modules/abstract-utxo/package.json
@@ -31,7 +31,7 @@
     "clean": "rm -rf ./dist",
     "lint": "eslint --quiet .",
     "prepare": "npm run build",
-    "test": "npm run unit-test",
+    "test": "mocha --recursive test/unit/",
     "unit-test": "mocha --recursive test/unit/",
     "integration-test": "mocha --recursive test/integration/"
   },


### PR DESCRIPTION

Update test script to directly call mocha so that extra arguments can be
properly passed through (e.g., npm test -- --grep pattern)

Issue: BTC-2806

Co-authored-by: llm-git <llm-git@ttll.de>