### PR TITLE
feat(abstract-utxo): update @bitgo/wasm-utxo to 1.11.0

### DIFF
--- a/modules/abstract-utxo/package.json
+++ b/modules/abstract-utxo/package.json
@@ -68,7 +68,7 @@
     "@bitgo/utxo-core": "^1.25.0",
     "@bitgo/utxo-lib": "^11.16.1",
     "@bitgo/utxo-ord": "^1.22.15",
-    "@bitgo/wasm-utxo": "1.8.0",
+    "@bitgo/wasm-utxo": "1.11.0",
     "@types/lodash": "^4.14.121",
     "@types/superagent": "4.1.15",
     "bignumber.js": "^9.0.2",

--- a/modules/utxo-bin/package.json
+++ b/modules/utxo-bin/package.json
@@ -31,7 +31,7 @@
     "@bitgo/unspents": "^0.50.10",
     "@bitgo/utxo-core": "^1.25.0",
     "@bitgo/utxo-lib": "^11.16.1",
-    "@bitgo/wasm-utxo": "1.8.0",
+    "@bitgo/wasm-utxo": "1.11.0",
     "@noble/curves": "1.8.1",
     "archy": "^1.0.0",
     "bech32": "^2.0.0",

--- a/modules/utxo-core/package.json
+++ b/modules/utxo-core/package.json
@@ -81,7 +81,7 @@
     "@bitgo/secp256k1": "^1.7.0",
     "@bitgo/unspents": "^0.50.10",
     "@bitgo/utxo-lib": "^11.16.1",
-    "@bitgo/wasm-utxo": "1.8.0",
+    "@bitgo/wasm-utxo": "1.11.0",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
     "bitcoinjs-message": "npm:@bitgo-forks/bitcoinjs-message@1.0.0-master.3",
     "fast-sha256": "^1.3.0"

--- a/modules/utxo-staking/package.json
+++ b/modules/utxo-staking/package.json
@@ -63,7 +63,7 @@
     "@bitgo/babylonlabs-io-btc-staking-ts": "^3.2.1",
     "@bitgo/utxo-core": "^1.25.0",
     "@bitgo/utxo-lib": "^11.16.1",
-    "@bitgo/wasm-utxo": "1.8.0",
+    "@bitgo/wasm-utxo": "1.11.0",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
     "bip322-js": "^2.0.0",
     "bitcoinjs-lib": "^6.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -968,10 +968,10 @@
     monocle-ts "^2.3.13"
     newtype-ts "^0.3.5"
 
-"@bitgo/wasm-utxo@1.8.0":
-  version "1.8.0"
-  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-1.8.0.tgz#aad0099a271f61f2d6c78092650eb5ecb56b41ae"
-  integrity sha512-tDUbCo6IdpkfOgcJo41C3q4HQ8HaNSdriklHflvRKy0PhRSOvCXjyeseYHXVkL9aMhQ1k0YemdogVyjIbO05TA==
+"@bitgo/wasm-utxo@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-1.11.0.tgz#e6b90de37c8afac17b51d20403ba1fa102198e39"
+  integrity sha512-yLORJZR8iD96WowF9lvBIFq4su6LUlIooOuG7awX6dNaTgHStPiRUEJbbKW1cSXAzTOSscl6wNHzgTaKkxYM5A==
 
 "@brandonblack/musig@^0.0.1-alpha.0":
   version "0.0.1-alpha.1"


### PR DESCRIPTION

Updates wasm-utxo package to the latest version across multiple modules.

Issue: BTC-2806