### PR TITLE
feat(sdk-core): add ESM build support

### DIFF
--- a/modules/sdk-core/package.json
+++ b/modules/sdk-core/package.json
@@ -2,15 +2,32 @@
   "name": "@bitgo/sdk-core",
   "version": "36.22.0",
   "description": "core library functions for BitGoJS",
-  "main": "./dist/src/index.js",
-  "types": "./dist/src/index.d.ts",
+  "main": "./dist/cjs/src/index.js",
+  "module": "./dist/esm/index.js",
+  "browser": "./dist/esm/index.js",
+  "types": "./dist/cjs/src/index.d.ts",
   "files": [
-    "dist"
+    "dist/cjs",
+    "dist/esm"
   ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/src/index.d.ts",
+        "default": "./dist/cjs/src/index.js"
+      }
+    }
+  },
   "scripts": {
     "test": "yarn unit-test",
     "unit-test": "nyc -- mocha --recursive test",
-    "build": "yarn tsc --build --incremental --verbose .",
+    "build": "yarn build:cjs && yarn build:esm",
+    "build:cjs": "yarn tsc --build --incremental --verbose .",
+    "build:esm": "yarn tsc --project tsconfig.esm.json",
     "fmt": "prettier --write .",
     "check-fmt": "prettier --check '**/*.{ts,js,json}'",
     "clean": "rm -r ./dist",

--- a/modules/sdk-core/src/bitgo/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/bitgo/tss/eddsa/eddsa.ts
@@ -23,7 +23,7 @@ import {
 } from '../../utils';
 import { BaseTransaction } from '../../../account-lib';
 import { Ed25519Bip32HdTree } from '@bitgo/sdk-lib-mpc';
-import _ = require('lodash');
+import _ from 'lodash';
 import { commonVerifyWalletSignature, getTxRequest, sendSignatureShare } from '../common';
 import { IRequestTracer } from '../../../api';
 

--- a/modules/sdk-core/tsconfig.esm.json
+++ b/modules/sdk-core/tsconfig.esm.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/esm",
+    "rootDir": "./src",
+    "module": "ES2020",
+    "target": "ES2020",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM"],
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "test", "dist"],
+  "references": []
+}

--- a/modules/sdk-core/tsconfig.json
+++ b/modules/sdk-core/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist",
+    "outDir": "./dist/cjs",
     "rootDir": "./",
+    "module": "node16",
+    "moduleResolution": "node16",
     "strictPropertyInitialization": false,
     "esModuleInterop": true,
     "typeRoots": ["../../types", "./node_modules/@types", "../../node_modules/@types"]


### PR DESCRIPTION
Ticket: SCAAS-2084

## Summary

- Add dual CJS/ESM build to `@bitgo/sdk-core` to enable Turbopack compatibility  in Next.js(_bitgo-ui_)
- Follows the same pattern as `@bitgo/utxo-core` (commit `36c3cd47`)
- Fixes issue where Turbopack fails to load WASM modules from `@bitgo/wasm-utxo` due to CJS-only exports
- Slack thread reference: https://bitgo.slack.com/archives/C04LYHERBMF/p1764688935096539

## Changes

- **tsconfig.esm.json** (new): ESM build configuration with `module: ES2020` and `moduleResolution: bundler`
- **tsconfig.json**: Updated to output to `dist/cjs` with `module: node16`
- **package.json**: Added `module`, `browser`, and conditional `exports` fields for dual build
- **eddsa.ts**: Fixed lodash import syntax for ESM compatibility

## Backward Compatibility

These changes are backward compatible:
- `require('@bitgo/sdk-core')` still works (routes to CJS)
- `import from '@bitgo/sdk-core'` now uses ESM
- Types are preserved for both formats
