### PR TITLE
feat: add forward tolerance for v3 validity check

### DIFF
--- a/modules/sdk-hmac/test/hmac.ts
+++ b/modules/sdk-hmac/test/hmac.ts
@@ -249,7 +249,7 @@ describe('HMAC Utility Functions', () => {
       expect(result.isValid).to.be.false;
     });
 
-    it('should return invalid if timestamp is outside the validity window', () => {
+    it('should return invalid if timestamp is outside the validity window (backwards check)', () => {
       const result = verifyResponse({
         url: '/api/test',
         statusCode: 200,
@@ -262,6 +262,39 @@ describe('HMAC Utility Functions', () => {
       });
 
       expect(result.isInResponseValidityWindow).to.be.false;
+    });
+
+    it('should return invalid if timestamp is outside the validity window (forwards check)', () => {
+      const result = verifyResponse({
+        url: '/api/test',
+        statusCode: 200,
+        text: 'response-body',
+        timestamp: MOCK_TIMESTAMP + 1000 * 60 * 2, // 2 minutes in the future
+        token: 'test-token',
+        hmac: '8f6a2d183e4c4f2bd2023202486e1651292c84573a31b3829d394f1763a6ec6c',
+        method: 'post',
+        authVersion: 3,
+      });
+
+      expect(result.isInResponseValidityWindow).to.be.false;
+    });
+
+    it('should verify if timestamp is inside the forward validity window', () => {
+      const result = verifyResponse({
+        url: '/api/test',
+        statusCode: 200,
+        text: 'response-body',
+        timestamp: MOCK_TIMESTAMP + 1000 * 30, // 30 seconds in the future
+        token: 'test-token',
+        hmac: '5e08c494691951ee45a6fc0e3fbfce3a76fcb5b9ee37e9bf9f2ac66690466dc7',
+        method: 'post',
+        authVersion: 3,
+      });
+
+      expect(result).to.include({
+        isValid: true,
+        isInResponseValidityWindow: true,
+      });
     });
 
     it('should verify response with Buffer data', () => {


### PR DESCRIPTION
Ticket: ANT-1352

Context: during local v3 auth testing I ran into the error `server response outside response validity time window, possible man-in-the-middle-attack` which happened because the response timestamp logged was `1764777803921` and the `Date.now()` timestamp that `verifyResponse` used was `1764777803898`. So, the response timestamp was slightly ahead, even though `verifyResponse` is called after. This is likely server-client clock skew, this fix adds a forward validity check of 60s to accommodate this.

## Description

This pull request updates the HMAC utility functions to support a more flexible validity window for timestamp verification, allowing both backward and forward checks. It also adds an optional `useOriginalPath` parameter to key functions for more control over HMAC subject calculation, and expands the test suite to cover the new validity window logic.

**HMAC validity window improvements:**

* The `verifyResponse` function now checks if the timestamp is within a 5-minute backward window and a 1-minute forward window, improving support for minor clock drift between systems.
* The test suite adds cases for forward validity window checks, ensuring that timestamps up to 1 minute in the future are considered valid, and those beyond are invalid. [[1]](diffhunk://#diff-f66f4dd2801062f4e3869f89314dfafd55a9a9deb6ee3a3d029009ae2f5cdeb3R267-R299) [[2]](diffhunk://#diff-f66f4dd2801062f4e3869f89314dfafd55a9a9deb6ee3a3d029009ae2f5cdeb3L252-R252)

**API flexibility enhancements:**

* The `calculateRequestHMAC`, `calculateRequestHeaders`, and `verifyResponse` functions now accept an optional `useOriginalPath` parameter to keep them in line with `calculateHMACSubject`, allowing callers to specify whether to use the original URL path when calculating the HMAC subject. [[1]](diffhunk://#diff-4fa496a43b56a903fcd1b7054c1429ce457ce95f905760d01ff5ce6847b6bfc8L72-R76) [[2]](diffhunk://#diff-4fa496a43b56a903fcd1b7054c1429ce457ce95f905760d01ff5ce6847b6bfc8L89-R90) [[3]](diffhunk://#diff-4fa496a43b56a903fcd1b7054c1429ce457ce95f905760d01ff5ce6847b6bfc8L112-R129)

## Issue Number

ANT-1352

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [x] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
