### PR TITLE
feat(abstract-utxo): enable wasm-utxo via decodeWith parameter

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -42,6 +42,7 @@ import {
   isValidPrv,
   isValidXprv,
 } from '@bitgo/sdk-core';
+import { fixedScriptWallet } from '@bitgo/wasm-utxo';
 
 import {
   backupKeyRecovery,
@@ -68,6 +69,7 @@ import {
   verifyTransaction,
 } from './transaction';
 import type { TransactionExplanation } from './transaction/fixedScript/explainTransaction';
+import { Musig2Participant } from './transaction/fixedScript/musig2';
 import {
   AggregateValidationError,
   ErrorMissingOutputs,
@@ -77,7 +79,7 @@ import { assertDescriptorWalletAddress, getDescriptorMapFromWallet, isDescriptor
 import { getChainFromNetwork, getFamilyFromNetwork, getFullNameFromNetwork } from './names';
 import { assertFixedScriptWalletAddress } from './address/fixedScript';
 import { ParsedTransaction } from './transaction/types';
-import { decodePsbtWith, stringToBufferTryFormats } from './transaction/decode';
+import { decodePsbtWith, encodeTransaction, stringToBufferTryFormats } from './transaction/decode';
 import { toBip32Triple, UtxoKeychain } from './keychains';
 import { verifyKeySignature, verifyUserPublicKey } from './verifyKey';
 import { getPolicyForEnv } from './descriptor/validatePolicy';
@@ -360,7 +362,10 @@ export interface SignPsbtResponse {
   psbt: string;
 }
 
-export abstract class AbstractUtxoCoin extends BaseCoin {
+export abstract class AbstractUtxoCoin
+  extends BaseCoin
+  implements Musig2Participant<utxolib.bitgo.UtxoPsbt>, Musig2Participant<fixedScriptWallet.BitGoPsbt>
+{
   public altScriptHash?: number;
   public supportAltScriptDestination?: boolean;
   public readonly amountType: 'number' | 'bigint';
@@ -509,7 +514,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
     if (_.isUndefined(prebuild.blockHeight)) {
       prebuild.blockHeight = (await this.getLatestBlockHeight()) as number;
     }
-    return _.extend({}, prebuild, { txHex: tx.toHex() });
+    return _.extend({}, prebuild, { txHex: encodeTransaction(tx).toString('hex') });
   }
 
   /**
@@ -541,12 +546,12 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
     }
   }
 
-  decodeTransactionAsPsbt(input: Buffer | string): utxolib.bitgo.UtxoPsbt {
+  decodeTransactionAsPsbt(input: Buffer | string): utxolib.bitgo.UtxoPsbt | fixedScriptWallet.BitGoPsbt {
     const decoded = this.decodeTransaction(input);
-    if (!(decoded instanceof utxolib.bitgo.UtxoPsbt)) {
-      throw new Error('expected psbt but got transaction');
+    if (decoded instanceof fixedScriptWallet.BitGoPsbt || decoded instanceof utxolib.bitgo.UtxoPsbt) {
+      return decoded;
     }
-    return decoded;
+    throw new Error('expected psbt but got transaction');
   }
 
   decodeTransactionFromPrebuild<TNumber extends number | bigint>(prebuild: {
@@ -720,16 +725,29 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
 
   /**
    * @returns input psbt added with deterministic MuSig2 nonce for bitgo key for each MuSig2 inputs.
-   * @param psbtHex all MuSig2 inputs should contain user MuSig2 nonce
+   * @param psbt all MuSig2 inputs should contain user MuSig2 nonce
    * @param walletId
    */
-  async getMusig2Nonces(psbt: utxolib.bitgo.UtxoPsbt, walletId: string): Promise<utxolib.bitgo.UtxoPsbt> {
-    const params: SignPsbtRequest = { psbt: psbt.toHex() };
+  async getMusig2Nonces(psbt: utxolib.bitgo.UtxoPsbt, walletId: string): Promise<utxolib.bitgo.UtxoPsbt>;
+  async getMusig2Nonces(psbt: fixedScriptWallet.BitGoPsbt, walletId: string): Promise<fixedScriptWallet.BitGoPsbt>;
+  async getMusig2Nonces<T extends utxolib.bitgo.UtxoPsbt | fixedScriptWallet.BitGoPsbt>(
+    psbt: T,
+    walletId: string
+  ): Promise<T>;
+  async getMusig2Nonces<T extends utxolib.bitgo.UtxoPsbt | fixedScriptWallet.BitGoPsbt>(
+    psbt: T,
+    walletId: string
+  ): Promise<T> {
+    const buffer = encodeTransaction(psbt);
     const response = await this.bitgo
       .post(this.url('/wallet/' + walletId + '/tx/signpsbt'))
-      .send(params)
+      .send({ psbt: buffer.toString('hex') })
       .result();
-    return this.decodeTransactionAsPsbt(response.psbt);
+    if (psbt instanceof utxolib.bitgo.UtxoPsbt) {
+      return decodePsbtWith(response.psbt, this.network, 'utxolib') as T;
+    } else {
+      return decodePsbtWith(response.psbt, this.network, 'wasm-utxo') as T;
+    }
   }
 
   /**
@@ -739,7 +757,8 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
    * @param walletId
    */
   async signPsbt(psbtHex: string, walletId: string): Promise<SignPsbtResponse> {
-    return { psbt: (await this.getMusig2Nonces(this.decodeTransactionAsPsbt(psbtHex), walletId)).toHex() };
+    const psbt = await this.getMusig2Nonces(this.decodeTransactionAsPsbt(psbtHex), walletId);
+    return { psbt: encodeTransaction(psbt).toString('hex') };
   }
 
   /**
@@ -749,11 +768,10 @@ export abstract class AbstractUtxoCoin extends BaseCoin {
   async signPsbtFromOVC(ovcJson: Record<string, unknown>): Promise<Record<string, unknown>> {
     assert(ovcJson['psbtHex'], 'ovcJson must contain psbtHex');
     assert(ovcJson['walletId'], 'ovcJson must contain walletId');
-    const psbt = await this.getMusig2Nonces(
-      this.decodeTransactionAsPsbt(ovcJson['psbtHex'] as string),
-      ovcJson['walletId'] as string
-    );
-    return _.extend(ovcJson, { txHex: psbt.toHex() });
+    const hex = ovcJson['psbtHex'] as string;
+    const walletId = ovcJson['walletId'] as string;
+    const psbt = await this.getMusig2Nonces(this.decodeTransactionAsPsbt(hex), walletId);
+    return _.extend(ovcJson, { txHex: encodeTransaction(psbt).toString('hex') });
   }
 
   /**

--- a/modules/abstract-utxo/src/transaction/decode.ts
+++ b/modules/abstract-utxo/src/transaction/decode.ts
@@ -57,3 +57,15 @@ export function decodePsbtWith(
     return fixedScriptWallet.BitGoPsbt.fromBytes(psbt, toNetworkName(network));
   }
 }
+
+export function encodeTransaction(
+  transaction: utxolib.bitgo.UtxoTransaction<bigint | number> | utxolib.bitgo.UtxoPsbt | fixedScriptWallet.BitGoPsbt
+): Buffer {
+  if (transaction instanceof utxolib.bitgo.UtxoTransaction) {
+    return transaction.toBuffer();
+  } else if (transaction instanceof utxolib.bitgo.UtxoPsbt) {
+    return transaction.toBuffer();
+  } else {
+    return Buffer.from(transaction.serialize());
+  }
+}

--- a/modules/abstract-utxo/src/transaction/signTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/signTransaction.ts
@@ -10,6 +10,7 @@ import { fetchKeychains, toBip32Triple } from '../keychains';
 
 import * as fixedScript from './fixedScript';
 import * as descriptor from './descriptor';
+import { encodeTransaction } from './decode';
 
 const debug = buildDebug('bitgo:abstract-utxo:transaction:signTransaction');
 
@@ -72,6 +73,7 @@ export async function signTransaction<TNumber extends number | bigint>(
       pubs: params.pubs,
       cosignerPub: params.cosignerPub,
     });
-    return { txHex: signedTx.toBuffer().toString('hex') };
+    const buffer = Buffer.isBuffer(signedTx) ? signedTx : encodeTransaction(signedTx);
+    return { txHex: buffer.toString('hex') };
   }
 }

--- a/modules/abstract-utxo/src/transaction/types.ts
+++ b/modules/abstract-utxo/src/transaction/types.ts
@@ -7,6 +7,10 @@ import type { CustomChangeOptions } from './fixedScript';
 
 export type SdkBackend = 'utxolib' | 'wasm-utxo';
 
+export function isSdkBackend(backend: string): backend is SdkBackend {
+  return backend === 'utxolib' || backend === 'wasm-utxo';
+}
+
 export type DecodedTransaction<TNumber extends number | bigint> =
   | utxolib.bitgo.UtxoTransaction<TNumber>
   | utxolib.bitgo.UtxoPsbt

--- a/modules/abstract-utxo/src/transaction/types.ts
+++ b/modules/abstract-utxo/src/transaction/types.ts
@@ -1,4 +1,5 @@
 import * as utxolib from '@bitgo/utxo-lib';
+import { fixedScriptWallet } from '@bitgo/wasm-utxo';
 
 import type { UtxoNamedKeychains } from '../keychains';
 
@@ -8,7 +9,8 @@ export type SdkBackend = 'utxolib' | 'wasm-utxo';
 
 export type DecodedTransaction<TNumber extends number | bigint> =
   | utxolib.bitgo.UtxoTransaction<TNumber>
-  | utxolib.bitgo.UtxoPsbt;
+  | utxolib.bitgo.UtxoPsbt
+  | fixedScriptWallet.BitGoPsbt;
 
 export interface BaseOutput<TAmount = string | number> {
   address: string;

--- a/modules/abstract-utxo/test/unit/transaction/fixedScript/signPsbt.ts
+++ b/modules/abstract-utxo/test/unit/transaction/fixedScript/signPsbt.ts
@@ -130,9 +130,9 @@ function describeSignPsbtWithMusig2Participant(
           getMockCoinWasm(acidTest.rootWalletKeys, acidTest.network),
           psbt,
           acidTest.rootWalletKeys.user,
-          wasmWalletKeys,
-          replayProtection,
+          fixedScriptWallet.RootWalletKeys.from(acidTest.rootWalletKeys),
           {
+            replayProtection,
             isLastSignature: false,
             signingStep: undefined,
             walletId: 'test-wallet-id',

--- a/modules/abstract-utxo/test/unit/transaction/fixedScript/util.ts
+++ b/modules/abstract-utxo/test/unit/transaction/fixedScript/util.ts
@@ -4,6 +4,7 @@ export function hasWasmUtxoSupport(network: utxolib.Network): boolean {
   return ![
     utxolib.networks.bitcoincash,
     utxolib.networks.bitcoingold,
+    utxolib.networks.bitcoinsv,
     utxolib.networks.ecash,
     utxolib.networks.zcash,
   ].includes(utxolib.getMainnet(network));


### PR DESCRIPTION
This PR adds comprehensive support for wasm-utxo based PSBT handling and
transaction functions to the abstract-utxo module:

- Add encodeTransaction helper function to convert transactions to Buffer
- Extend DecodedTransaction to include wasm-utxo BitGoPsbt
- Support wasm-utxo PSBTs in the getMusig2Nonces method
- Enable signing PSBTs with wasm implementation
- Add PSBT decoder selection capability with the decodeWith parameter
- Update test suite to verify wasm-utxo transaction decoding

These changes enable compatibility between different PSBT implementations
and provide flexibility in choosing the appropriate decoder based on
requirements.


We use `wasm-utxo` in the case that the `/tx/build` route replies with a property `"decodeWith": "utxo-wasm"`


Issue: BTC-2806