### PR TITLE
feat: added evmKeyRingReferenceWalletId in GenerateWalletBody

### DIFF
--- a/modules/express/src/typedRoutes/api/v2/generateWallet.ts
+++ b/modules/express/src/typedRoutes/api/v2/generateWallet.ts
@@ -43,6 +43,8 @@ export const GenerateWalletBody = {
   bitgoKeyId: optional(t.string),
   /** Common keychain for self-managed cold MPC wallets */
   commonKeychain: optional(t.string),
+  /** Reference wallet ID for creating EVM keyring child wallets. When provided, the new wallet inherits keys and properties from the reference wallet, enabling unified addresses across EVM chains. */
+  evmKeyRingReferenceWalletId: optional(t.string),
 } as const;
 
 export const GenerateWalletResponse200 = t.union([


### PR DESCRIPTION
TICKET: COIN-6822

This pull request introduces support for generating EVM keyring child wallets by allowing a reference wallet ID to be specified during wallet creation. This enables unified addresses across EVM chains and extends both the API and its test coverage.

### EVM Keyring Child Wallet Support

* Added the optional `evmKeyRingReferenceWalletId` property to the `GenerateWalletBody` type, allowing new wallets to inherit keys and properties from a reference wallet for unified EVM addresses.

### Test Coverage

* Added a unit test to ensure that wallets can be generated with the new `evmKeyRingReferenceWalletId` property, verifying correct behavior and API response.

