### PR TITLE
feat(abstract-utxo): enable wasm support for multiple UTXO coins

### DIFF
--- a/modules/abstract-utxo/package.json
+++ b/modules/abstract-utxo/package.json
@@ -68,7 +68,7 @@
     "@bitgo/utxo-core": "^1.27.0",
     "@bitgo/utxo-lib": "^11.18.0",
     "@bitgo/utxo-ord": "^1.22.19",
-    "@bitgo/wasm-utxo": "1.11.0",
+    "@bitgo/wasm-utxo": "1.14.0",
     "@types/lodash": "^4.14.121",
     "@types/superagent": "4.1.15",
     "bignumber.js": "^9.0.2",

--- a/modules/abstract-utxo/test/unit/transaction.ts
+++ b/modules/abstract-utxo/test/unit/transaction.ts
@@ -13,7 +13,7 @@ import {
   WalletSignTransactionOptions,
 } from '@bitgo/sdk-core';
 
-import { AbstractUtxoCoin, getReplayProtectionAddresses, generateAddress } from '../../src';
+import { AbstractUtxoCoin, getReplayProtectionAddresses, generateAddress, getReplayProtectionPubkeys } from '../../src';
 import { SdkBackend } from '../../src/transaction/types';
 
 import { hasWasmUtxoSupport } from './transaction/fixedScript/util';
@@ -176,7 +176,9 @@ describe(`UTXO coin signTransaction`, async function () {
     }));
     const unspentSum = inputs.reduce((prev: bigint, curr) => prev + curr.value, BigInt(0));
     const outputs: testutil.Output[] = [{ scriptType: 'p2sh', value: unspentSum - BigInt(1000) }];
-    const psbt = testutil.constructPsbt(inputs, outputs, coin.network, rootWalletKeys, 'unsigned');
+    const psbt = testutil.constructPsbt(inputs, outputs, coin.network, rootWalletKeys, 'unsigned', {
+      p2shP2pkKey: getReplayProtectionPubkeys(coin.network)[0],
+    });
 
     for (const v of [false, true]) {
       await signTransaction(psbt, v);
@@ -402,7 +404,9 @@ function run<TNumber extends number | bigint = number>(
       const outputs: testutil.Output[] = [
         { address: getOutputAddress(getWalletKeys('test')), value: unspentSum - BigInt(1000) },
       ];
-      const psbt = testutil.constructPsbt(inputs, outputs, coin.network, walletKeys, 'unsigned');
+      const psbt = testutil.constructPsbt(inputs, outputs, coin.network, walletKeys, 'unsigned', {
+        p2shP2pkKey: getReplayProtectionPubkeys(coin.network)[0],
+      });
       utxolib.bitgo.addXpubsToPsbt(psbt, walletKeys);
       return psbt;
     }

--- a/modules/abstract-utxo/test/unit/transaction/fixedScript/util.ts
+++ b/modules/abstract-utxo/test/unit/transaction/fixedScript/util.ts
@@ -1,11 +1,5 @@
 import * as utxolib from '@bitgo/utxo-lib';
 
 export function hasWasmUtxoSupport(network: utxolib.Network): boolean {
-  return ![
-    utxolib.networks.bitcoincash,
-    utxolib.networks.bitcoingold,
-    utxolib.networks.bitcoinsv,
-    utxolib.networks.ecash,
-    utxolib.networks.zcash,
-  ].includes(utxolib.getMainnet(network));
+  return utxolib.getMainnet(network) !== utxolib.networks.zcash;
 }

--- a/modules/utxo-bin/package.json
+++ b/modules/utxo-bin/package.json
@@ -31,7 +31,7 @@
     "@bitgo/unspents": "^0.50.12",
     "@bitgo/utxo-core": "^1.27.0",
     "@bitgo/utxo-lib": "^11.18.0",
-    "@bitgo/wasm-utxo": "1.11.0",
+    "@bitgo/wasm-utxo": "1.14.0",
     "@noble/curves": "1.8.1",
     "archy": "^1.0.0",
     "bech32": "^2.0.0",

--- a/modules/utxo-core/package.json
+++ b/modules/utxo-core/package.json
@@ -81,7 +81,7 @@
     "@bitgo/secp256k1": "^1.7.0",
     "@bitgo/unspents": "^0.50.12",
     "@bitgo/utxo-lib": "^11.18.0",
-    "@bitgo/wasm-utxo": "1.11.0",
+    "@bitgo/wasm-utxo": "1.14.0",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
     "bitcoinjs-message": "npm:@bitgo-forks/bitcoinjs-message@1.0.0-master.3",
     "fast-sha256": "^1.3.0"

--- a/modules/utxo-lib/src/testutil/mock.ts
+++ b/modules/utxo-lib/src/testutil/mock.ts
@@ -76,9 +76,12 @@ export function isReplayProtectionUnspent<TNumber extends bigint | number>(
 export function mockReplayProtectionUnspent<TNumber extends number | bigint>(
   network: Network,
   value: TNumber,
-  { key = replayProtectionKeyPair, vout = 0 }: { key?: BIP32Interface; vout?: number } = {}
+  { key = replayProtectionKeyPair, vout = 0 }: { key?: BIP32Interface | Buffer; vout?: number } = {}
 ): UnspentWithPrevTx<TNumber> {
-  const outputScript = createOutputScriptP2shP2pk(key.publicKey).scriptPubKey;
+  if (!Buffer.isBuffer(key)) {
+    key = key.publicKey;
+  }
+  const outputScript = createOutputScriptP2shP2pk(key).scriptPubKey;
   const prevTransaction = mockPrevTx(vout, outputScript, BigInt(value), network);
   return { ...fromOutputWithPrevTx(prevTransaction, vout), value };
 }

--- a/modules/utxo-staking/package.json
+++ b/modules/utxo-staking/package.json
@@ -63,7 +63,7 @@
     "@bitgo/babylonlabs-io-btc-staking-ts": "^3.2.1",
     "@bitgo/utxo-core": "^1.27.0",
     "@bitgo/utxo-lib": "^11.18.0",
-    "@bitgo/wasm-utxo": "1.11.0",
+    "@bitgo/wasm-utxo": "1.14.0",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
     "bip322-js": "^2.0.0",
     "bitcoinjs-lib": "^6.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -968,10 +968,10 @@
     monocle-ts "^2.3.13"
     newtype-ts "^0.3.5"
 
-"@bitgo/wasm-utxo@1.11.0":
-  version "1.11.0"
-  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-1.11.0.tgz#e6b90de37c8afac17b51d20403ba1fa102198e39"
-  integrity sha512-yLORJZR8iD96WowF9lvBIFq4su6LUlIooOuG7awX6dNaTgHStPiRUEJbbKW1cSXAzTOSscl6wNHzgTaKkxYM5A==
+"@bitgo/wasm-utxo@1.14.0":
+  version "1.14.0"
+  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-1.14.0.tgz#d4447ddf47a38b0e471ccffbf13540c1eaf30a44"
+  integrity sha512-8h0iImoUmK2Z0tdDLyfX/RfXKxb83qcRZSUhH+YFATo6SDlKpA1TpV+OjEY4Xrvte7abvVuezxU5Wq820xJcNQ==
 
 "@brandonblack/musig@^0.0.1-alpha.0":
   version "0.0.1-alpha.1"


### PR DESCRIPTION

This PR adds WASM support for BCH, BTG, BSV, and XEC networks using the
latest wasm-utxo library. It includes several improvements:

- Update @bitgo/wasm-utxo dependency from 1.11.0 to 1.14.0 across
  abstract-utxo, utxo-bin, utxo-core and utxo-staking modules
- Enable wasm-utxo support for all networks except ZCash
- Add function to generate replay protection pubkeys and use it in tests
- Allow buffer as p2shP2pk key in utxo-lib to improve reuse across
  various Bitcoin forks

BTC-2656