### PR TITLE
refactor: throw error on validation failure

### DIFF
--- a/modules/sdk-coin-sol/src/sol.ts
+++ b/modules/sdk-coin-sol/src/sol.ts
@@ -52,6 +52,7 @@ import {
   VerifyTransactionOptions,
   TssVerifyAddressOptions,
   verifyEddsaTssWalletAddress,
+  UnexpectedAddressError,
 } from '@bitgo/sdk-core';
 import { auditEddsaPrivateKey, getDerivationPath } from '@bitgo/sdk-lib-mpc';
 import { BaseNetwork, CoinFamily, coins, SolCoin, BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
@@ -603,11 +604,17 @@ export class Sol extends BaseCoin {
   }
 
   async isWalletAddress(params: TssVerifyAddressOptions): Promise<boolean> {
-    return verifyEddsaTssWalletAddress(
+    const result = await verifyEddsaTssWalletAddress(
       params,
       (address) => this.isValidAddress(address),
       (publicKey) => this.getAddressFromPublicKey(publicKey)
     );
+
+    if (!result) {
+      throw new UnexpectedAddressError(`address validation failure: ${params.address} is not a wallet address`);
+    }
+
+    return true;
   }
 
   /**

--- a/modules/sdk-coin-sol/test/unit/sol.ts
+++ b/modules/sdk-coin-sol/test/unit/sol.ts
@@ -3443,26 +3443,28 @@ describe('SOL:', function () {
       result.should.equal(true);
     });
 
-    it('should return false for address with incorrect keychain', async function () {
+    it('should throw error for address with incorrect keychain', async function () {
       const address = '7YAesfwPk41VChUgr65bm8FEep7ymWqLSW5rpYB5zZPY';
       const wrongKeychain =
         '0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000';
       const index = '1';
       const keychains = [{ id: '1', type: 'tss' as const, commonKeychain: wrongKeychain }];
 
-      const result = await basecoin.isWalletAddress({ keychains, address, index });
-      result.should.equal(false);
+      await assert.rejects(async () => await basecoin.isWalletAddress({ keychains, address, index }), {
+        message: `address validation failure: ${address} is not a wallet address`,
+      });
     });
 
-    it('should return false for address with incorrect index', async function () {
+    it('should throw error for address with incorrect index', async function () {
       const address = '7YAesfwPk41VChUgr65bm8FEep7ymWqLSW5rpYB5zZPY';
       const commonKeychain =
         '8ea32ecacfc83effbd2e2790ee44fa7c59b4d86c29a12f09fb613d8195f93f4e21875cad3b98adada40c040c54c3569467df41a020881a6184096378701862bd';
       const wrongIndex = '999';
       const keychains = [{ id: '1', type: 'tss' as const, commonKeychain }];
 
-      const result = await basecoin.isWalletAddress({ keychains, address, index: wrongIndex });
-      result.should.equal(false);
+      await assert.rejects(async () => await basecoin.isWalletAddress({ keychains, address, index: wrongIndex }), {
+        message: `address validation failure: ${address} is not a wallet address`,
+      });
     });
 
     it('should throw error for invalid address', async function () {


### PR DESCRIPTION
Standardize this function with other implementations of `isWalletAddress` to throw a error on failure.

TICKET: WP-7322

