### PR TITLE
fix(sdk-coin-sol): add early validation for transaction size limits

### DIFF
--- a/modules/sdk-coin-sol/src/lib/constants.ts
+++ b/modules/sdk-coin-sol/src/lib/constants.ts
@@ -28,6 +28,18 @@ export const UNAVAILABLE_TEXT = 'UNAVAILABLE';
  */
 export const SOLANA_TRANSACTION_MAX_SIZE = 1232;
 
+/**
+ * Maximum safe recipient limits for Solana token transfers
+ *
+ * These limits are based on empirical testing to stay within SOLANA_TRANSACTION_MAX_SIZE (1232 bytes).
+ * Source: modules/sdk-coin-sol/scripts/transaction-size-benchmark-results.json
+ *
+ * With ATA Creation: Includes Associated Token Account initialization instructions
+ * Without ATA Creation: Recipients already have token accounts
+ */
+export const MAX_RECIPIENTS_WITH_ATA_CREATION = 9;
+export const MAX_RECIPIENTS_WITHOUT_ATA_CREATION = 19;
+
 export const JITO_STAKE_POOL_ADDRESS = 'Jito4APyf642JPZPx3hGc6WWJ8zPKtRbRs4P815Awbb';
 export const JITOSOL_MINT_ADDRESS = 'J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn';
 export const JITO_STAKE_POOL_RESERVE_ACCOUNT = 'BgKUXdS29YcHCFrPm5M8oLHiTzZaMDjsebggjoaQ6KFL';

--- a/modules/sdk-coin-sol/test/unit/transactionBuilder/tokenTransferBuilder.ts
+++ b/modules/sdk-coin-sol/test/unit/transactionBuilder/tokenTransferBuilder.ts
@@ -796,5 +796,89 @@ describe('Sol Token Transfer Builder', () => {
         })
       ).throwError('Invalid token name, got: ' + invalidTokenName);
     });
+
+    it('should fail with more than 9 recipients with ATA creation', async () => {
+      const txBuilder = factory.getTokenTransferBuilder();
+      txBuilder.nonce(recentBlockHash);
+      txBuilder.sender(authAccount.pub);
+
+      // Generate 10 unique recipients for ATA creation
+      const recipients: string[] = [];
+      for (let i = 0; i < 10; i++) {
+        const keypair = new KeyPair();
+        recipients.push(keypair.getKeys().pub);
+      }
+
+      for (const address of recipients) {
+        txBuilder.send({ address, amount, tokenName: nameUSDC });
+        txBuilder.createAssociatedTokenAccount({
+          ownerAddress: address,
+          tokenName: nameUSDC,
+        });
+      }
+
+      await txBuilder
+        .build()
+        .should.be.rejectedWith(
+          /Transaction too large: 10 recipients with 10 ATA creations.*maximum 9 recipients with ATA creation/
+        );
+    });
+
+    it('should fail with more than 19 recipients without ATA creation', async () => {
+      const txBuilder = factory.getTokenTransferBuilder();
+      txBuilder.nonce(recentBlockHash);
+      txBuilder.sender(authAccount.pub);
+
+      // Add 20 recipients without ATA creation (reusing addresses is fine without ATA)
+      for (let i = 0; i < 20; i++) {
+        // Only use first 3 addresses to avoid invalid address at index 3
+        const address = testData.addresses.validAddresses[i % 3];
+        txBuilder.send({ address, amount, tokenName: nameUSDC });
+      }
+
+      await txBuilder
+        .build()
+        .should.be.rejectedWith(/Transaction too large: 20 recipients.*maximum 19 recipients without ATA creation/);
+    });
+
+    it('should succeed with 9 recipients with ATA creation', async () => {
+      const txBuilder = factory.getTokenTransferBuilder();
+      txBuilder.nonce(recentBlockHash);
+      txBuilder.sender(authAccount.pub);
+
+      // Generate exactly 9 unique recipients for ATA creation
+      const recipients: string[] = [];
+      for (let i = 0; i < 9; i++) {
+        const keypair = new KeyPair();
+        recipients.push(keypair.getKeys().pub);
+      }
+
+      for (const address of recipients) {
+        txBuilder.send({ address, amount, tokenName: nameUSDC });
+        txBuilder.createAssociatedTokenAccount({
+          ownerAddress: address,
+          tokenName: nameUSDC,
+        });
+      }
+
+      const tx = await txBuilder.build();
+      tx.should.be.ok();
+    });
+
+    it('should succeed with 19 recipients without ATA creation', async () => {
+      const txBuilder = factory.getTokenTransferBuilder();
+      txBuilder.nonce(recentBlockHash);
+      txBuilder.sender(authAccount.pub);
+
+      // Add exactly 19 recipients without ATA creation (reusing addresses is fine without ATA)
+      for (let i = 0; i < 19; i++) {
+        // Only use first 3 addresses to avoid invalid address at index 3
+        const address = testData.addresses.validAddresses[i % 3];
+        txBuilder.send({ address, amount, tokenName: nameUSDC });
+      }
+
+      const tx = await txBuilder.build();
+      tx.should.be.ok();
+    });
   });
 });


### PR DESCRIPTION
TICKET: WIN-8401

Add transaction size validation to prevent buffer overflow errors when sending to too many recipients
