### PR TITLE
feat(utxo-lib): add zcash shielded components detection utility

### DIFF
--- a/modules/utxo-lib/test/bitgo/zcash/ZcashBufferutils.ts
+++ b/modules/utxo-lib/test/bitgo/zcash/ZcashBufferutils.ts
@@ -1,0 +1,76 @@
+import * as assert from 'assert';
+import { BufferWriter } from 'bitcoinjs-lib/src/bufferutils';
+
+import { hasSaplingOrOrchardShieldedComponentsFromBuffer } from '../../../src/bitgo/zcash/ZcashBufferutils';
+
+function finalize(w: BufferWriter): Buffer {
+  return w.buffer.slice(0, w.offset);
+}
+
+describe('ZcashBufferutils.hasSaplingOrOrchardShieldedComponentsFromBuffer', function () {
+  it('returns false for minimal v4 transparent-only (empty Sapling bundle)', function () {
+    const w = new BufferWriter(Buffer.alloc(256));
+    w.writeInt32((1 << 31) | 4);
+    w.writeUInt32(0x892f2085); // SAPLING_VERSION_GROUP_ID
+    w.writeVarInt(0); // vin
+    w.writeVarInt(0); // vout
+    w.writeUInt32(0); // locktime
+    w.writeUInt32(0); // expiryHeight
+    w.writeSlice(Buffer.alloc(8, 0)); // valueBalance
+    w.writeVarInt(0); // vSpendsSapling
+    w.writeVarInt(0); // vOutputsSapling
+    // JoinSplits omitted: this helper does not read them.
+    const tx = finalize(w);
+
+    assert.strictEqual(hasSaplingOrOrchardShieldedComponentsFromBuffer(tx), false);
+  });
+
+  it('returns true for v4 when Sapling bundle is non-empty', function () {
+    const w = new BufferWriter(Buffer.alloc(256));
+    w.writeInt32((1 << 31) | 4);
+    w.writeUInt32(0x892f2085);
+    w.writeVarInt(0);
+    w.writeVarInt(0);
+    w.writeUInt32(0);
+    w.writeUInt32(0);
+    w.writeSlice(Buffer.alloc(8, 0));
+    w.writeVarInt(1); // vSpendsSapling (non-empty -> readEmptySaplingBundle throws)
+    const tx = finalize(w);
+
+    assert.strictEqual(hasSaplingOrOrchardShieldedComponentsFromBuffer(tx), true);
+  });
+
+  it('returns false for minimal v5 transparent-only (empty Sapling + Orchard)', function () {
+    const w = new BufferWriter(Buffer.alloc(256));
+    w.writeInt32((1 << 31) | 5);
+    w.writeUInt32(0x26a7270a); // ZIP225_VERSION_GROUP_ID
+    w.writeUInt32(0xc2d6d0b4); // consensusBranchId (NU5; arbitrary for this test)
+    w.writeUInt32(0); // locktime
+    w.writeUInt32(0); // expiryHeight
+    w.writeVarInt(0); // vin
+    w.writeVarInt(0); // vout
+    w.writeVarInt(0); // vSpendsSapling
+    w.writeVarInt(0); // vOutputsSapling
+    w.writeUInt8(0x00); // orchard bundle empty marker
+    const tx = finalize(w);
+
+    assert.strictEqual(hasSaplingOrOrchardShieldedComponentsFromBuffer(tx), false);
+  });
+
+  it('returns true for v5 when Orchard bundle is non-empty', function () {
+    const w = new BufferWriter(Buffer.alloc(256));
+    w.writeInt32((1 << 31) | 5);
+    w.writeUInt32(0x26a7270a);
+    w.writeUInt32(0xc2d6d0b4);
+    w.writeUInt32(0);
+    w.writeUInt32(0);
+    w.writeVarInt(0);
+    w.writeVarInt(0);
+    w.writeVarInt(0);
+    w.writeVarInt(0);
+    w.writeUInt8(0x01); // orchard bundle present -> readEmptyOrchardBundle throws
+    const tx = finalize(w);
+
+    assert.strictEqual(hasSaplingOrOrchardShieldedComponentsFromBuffer(tx), true);
+  });
+});


### PR DESCRIPTION
Add a utility function `hasSaplingOrOrchardShieldedComponentsFromBuffer` to detect if a Zcash transaction buffer contains any shielded components (Sapling or Orchard). This is useful for quickly checking transaction compatibility without performing full parsing.

BTC-2887

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
