### PR TITLE
Refactor: Centralize signature ordering logic in FLRP transaction builders

### DIFF
--- a/modules/sdk-coin-flrp/test/unit/lib/exportInPTxBuilder.ts
+++ b/modules/sdk-coin-flrp/test/unit/lib/exportInPTxBuilder.ts
@@ -200,5 +200,190 @@ describe('Flrp Export In P Tx Builder', () => {
       rawTx.should.equal(signedExportHex);
       tx.id.should.equal('ka8at5CinmpUc6QMVr33dyUJi156LKMdodrJM59kS6EWr3vHg');
     });
+
+    it('should FAIL with unsorted UTXO addresses - demonstrates AddressMap mismatch issue for export in P-chain tx', async () => {
+      // This test uses UTXO addresses in UNSORTED order to demonstrate the issue.
+      // With unsorted addresses, the current implementation will create AddressMaps incorrectly
+      // because it uses sorted addresses, not UTXO address order.
+      //
+      // Expected: AddressMap should map addresses to signature slots based on UTXO order (sigIndicies)
+      // Current (WRONG): AddressMap uses sorted addresses with sequential slots
+      //
+      // This test WILL FAIL with current implementation because AddressMaps don't match sigIndicies
+
+      // UTXO addresses in UNSORTED order (different from sorted)
+      // Sorted would be: [0x12cb... (smallest), 0xa6e0... (middle), 0xc386... (largest)]
+      // Unsorted: [0xc386... (largest), 0x12cb... (smallest), 0xa6e0... (middle)]
+      const unsortedUtxoAddresses = [
+        '0xc386d58d09a9ae77cf1cf07bf1c9de44ebb0c9f3', // Largest (would be index 2 if sorted)
+        '0x12cb32eaf92553064db98d271b56cba079ec78f5', // Smallest (would be index 0 if sorted)
+        '0xa6e0c1abd0132f70efb77e2274637ff336a29a57', // Middle (would be index 1 if sorted)
+      ];
+
+      // Corresponding P-chain addresses (in same order as UTXO)
+      const pAddresses = [
+        'P-costwo15msvr27szvhhpmah0c38gcml7vm29xjh7tcek8', // Maps to 0xc386... (UTXO index 0)
+        'P-costwo1zt9n96hey4fsvnde35n3k4kt5pu7c784dzewzd', // Maps to 0x12cb... (UTXO index 1)
+        'P-costwo1cwrdtrgf4xh80ncu7palrjw7gn4mpj0n4dxghh', // Maps to 0xa6e0... (UTXO index 2)
+      ];
+
+      // Create UTXO with UNSORTED addresses
+      // Amount must cover export amount + fee
+      const exportAmount = '50000000';
+      const fee = '1261000';
+      const utxoAmount = (BigInt(exportAmount) + BigInt(fee)).toString(); // amount + fee
+
+      const utxo: DecodedUtxoObj = {
+        outputID: 0,
+        amount: utxoAmount,
+        txid: 'zstyYq5riDKYDSR3fUYKKkuXKJ1aJCe8WNrXKqEBJD4CGwzFw',
+        outputidx: '0',
+        addresses: unsortedUtxoAddresses, // UNSORTED order
+        threshold: 2,
+      };
+
+      // Build transaction
+      const txBuilder = factory
+        .getExportInPBuilder()
+        .threshold(2)
+        .locktime(0)
+        .fromPubKey(pAddresses)
+        .externalChainId(testData.sourceChainId)
+        .amount(exportAmount)
+        .fee(fee)
+        .utxos([utxo]);
+
+      // Build unsigned transaction
+      const unsignedTx = await txBuilder.build();
+      const unsignedHex = unsignedTx.toBroadcastFormat();
+
+      // Parse it back to inspect AddressMaps and sigIndicies
+      const parsedBuilder = factory.from(unsignedHex);
+      const parsedTx = await parsedBuilder.build();
+      const flareTx = (parsedTx as any)._flareTransaction;
+
+      // Get the input to check sigIndicies
+      const exportTx = flareTx.tx as any;
+      const input = exportTx.baseTx.inputs[0];
+      const transferInput = input.input;
+      const sigIndicies = transferInput.sigIndicies();
+
+      // sigIndicies tells us: sigIndicies[slotIndex] = utxoAddressIndex
+      // For threshold=2, we need signatures for first 2 addresses in UTXO order
+      // UTXO order: [0xc386... (index 0), 0x12cb... (index 1), 0xa6e0... (index 2)]
+      // So sigIndicies should be [0, 1] meaning: slot 0 = UTXO index 0, slot 1 = UTXO index 1
+
+      // Verify sigIndicies are [0, 1] (first 2 addresses in UTXO order, NOT sorted order)
+      sigIndicies.length.should.equal(2);
+      sigIndicies[0].should.equal(0, 'First signature slot should be UTXO address index 0 (0xc386...)');
+      sigIndicies[1].should.equal(1, 'Second signature slot should be UTXO address index 1 (0x12cb...)');
+
+      // The critical test: Verify that signature slots have embedded addresses based on UTXO order
+      // With unsorted UTXO addresses, this will FAIL if AddressMaps don't match UTXO order
+      //
+      // sigIndicies tells us: sigIndicies[slotIndex] = utxoAddressIndex
+      // For threshold=2, we need signatures for first 2 addresses in UTXO order
+      // UTXO order: [0xc386... (index 0), 0x12cb... (index 1), 0xa6e0... (index 2)]
+      // So sigIndicies should be [0, 1] meaning: slot 0 = UTXO index 0, slot 1 = UTXO index 1
+
+      // Parse the credential to see which slots have which embedded addresses
+      const credential = flareTx.credentials[0];
+      const signatures = credential.getSignatures();
+
+      // Helper function to check if signature has embedded address (same logic as transaction.ts)
+      const testUtils2 = require('../../../src/lib/utils').default;
+      const isEmptySignature = (signature: string): boolean => {
+        return !!signature && testUtils2.removeHexPrefix(signature).startsWith('0'.repeat(90));
+      };
+
+      const hasEmbeddedAddress = (signature: string): boolean => {
+        if (!isEmptySignature(signature)) return false;
+        const cleanSig = testUtils2.removeHexPrefix(signature);
+        if (cleanSig.length < 130) return false;
+        const embeddedPart = cleanSig.substring(90, 130);
+        // Check if embedded part is not all zeros
+        return embeddedPart !== '0'.repeat(40);
+      };
+
+      // Extract embedded addresses from signature slots
+      const embeddedAddresses: string[] = [];
+
+      signatures.forEach((sig: string, slotIndex: number) => {
+        if (hasEmbeddedAddress(sig)) {
+          // Extract embedded address (after position 90, 40 chars = 20 bytes)
+          const cleanSig = testUtils2.removeHexPrefix(sig);
+          const embeddedAddr = cleanSig.substring(90, 130).toLowerCase();
+          embeddedAddresses[slotIndex] = '0x' + embeddedAddr;
+        }
+      });
+
+      // Verify: Credentials only embed ONE address (user/recovery), not both
+      // The embedded address should be based on addressesIndex logic, not sorted order
+      //
+      // Compute addressesIndex to determine expected signature order
+      const utxoAddressBytes = unsortedUtxoAddresses.map((addr) => testUtils2.parseAddress(addr));
+      const pAddressBytes = pAddresses.map((addr) => testUtils2.parseAddress(addr));
+
+      const addressesIndex: number[] = [];
+      pAddressBytes.forEach((pAddr) => {
+        const utxoIndex = utxoAddressBytes.findIndex(
+          (uAddr) => Buffer.compare(Buffer.from(uAddr), Buffer.from(pAddr)) === 0
+        );
+        addressesIndex.push(utxoIndex);
+      });
+
+      // firstIndex = 0 (user), bitgoIndex = 1
+      const firstIndex = 0;
+      const bitgoIndex = 1;
+
+      // Determine expected signature order based on addressesIndex
+      const userComesFirst = addressesIndex[bitgoIndex] > addressesIndex[firstIndex];
+
+      // Expected credential structure:
+      // - If user comes first: [userAddress, zeros]
+      // - If bitgo comes first: [zeros, userAddress]
+      const userAddressHex = Buffer.from(pAddressBytes[firstIndex]).toString('hex').toLowerCase();
+      const expectedUserAddr = '0x' + userAddressHex;
+
+      if (userComesFirst) {
+        // Expected: [userAddress, zeros]
+        // Slot 0 should have user address (pAddr0 = 0xc386... = UTXO index 0)
+        if (embeddedAddresses[0]) {
+          embeddedAddresses[0]
+            .toLowerCase()
+            .should.equal(
+              expectedUserAddr,
+              `Slot 0 should have user address (${expectedUserAddr}) because user comes first in UTXO order`
+            );
+        } else {
+          throw new Error(`Slot 0 should have embedded user address, but is empty`);
+        }
+        // Slot 1 should be zeros (no embedded address)
+        if (embeddedAddresses[1]) {
+          throw new Error(`Slot 1 should be zeros, but has embedded address: ${embeddedAddresses[1]}`);
+        }
+      } else {
+        // Expected: [zeros, userAddress]
+        // Slot 0 should be zeros
+        if (embeddedAddresses[0]) {
+          throw new Error(`Slot 0 should be zeros, but has embedded address: ${embeddedAddresses[0]}`);
+        }
+        // Slot 1 should have user address
+        if (embeddedAddresses[1]) {
+          embeddedAddresses[1]
+            .toLowerCase()
+            .should.equal(
+              expectedUserAddr,
+              `Slot 1 should have user address (${expectedUserAddr}) because bitgo comes first in UTXO order`
+            );
+        } else {
+          throw new Error(`Slot 1 should have embedded user address, but is empty`);
+        }
+      }
+
+      // The key verification: AddressMaps should match the credential order
+      // With the fix, AddressMaps are created using the same addressesIndex logic as credentials
+      // This ensures signing works correctly even with unsorted UTXO addresses
+    });
   });
 });

--- a/modules/sdk-coin-flrp/test/unit/lib/importInPTxBuilder.ts
+++ b/modules/sdk-coin-flrp/test/unit/lib/importInPTxBuilder.ts
@@ -4,6 +4,7 @@ import { IMPORT_IN_P as testData } from '../../resources/transactionData/importI
 import { TransactionBuilderFactory, DecodedUtxoObj, Transaction } from '../../../src/lib';
 import { coins, FlareNetwork } from '@bitgo/statics';
 import signFlowTest from './signFlowTestSuit';
+import testUtils from '../../../src/lib/utils';
 
 describe('Flrp Import In P Tx Builder', () => {
   const coinConfig = coins.get('tflrp');
@@ -139,6 +140,228 @@ describe('Flrp Import In P Tx Builder', () => {
       const rawTx = tx.toBroadcastFormat();
       rawTx.should.equal(signedImportHex);
       tx.id.should.equal('2vwvuXp47dsUmqb4vkaMk7UsukrZNapKXT2ruZhVibbjMDpqr9');
+    });
+
+    it('should FAIL with unsorted UTXO addresses - demonstrates AddressMap mismatch issue', async () => {
+      // This test uses UTXO addresses in UNSORTED order to demonstrate the issue.
+      // With unsorted addresses, the current implementation will create AddressMaps incorrectly
+      // because it uses sorted addresses, not UTXO address order.
+      //
+      // Expected: AddressMap should map addresses to signature slots based on UTXO order (sigIndicies)
+      // Current (WRONG): AddressMap uses sorted addresses with sequential slots
+      //
+      // This test WILL FAIL with current implementation because AddressMaps don't match sigIndicies
+
+      // UTXO addresses in UNSORTED order (different from sorted)
+      // Sorted would be: [0x12cb... (smallest), 0xa6e0... (middle), 0xc386... (largest)]
+      // Unsorted: [0xc386... (largest), 0x12cb... (smallest), 0xa6e0... (middle)]
+      const unsortedUtxoAddresses = [
+        '0xc386d58d09a9ae77cf1cf07bf1c9de44ebb0c9f3', // Largest (would be index 2 if sorted)
+        '0x12cb32eaf92553064db98d271b56cba079ec78f5', // Smallest (would be index 0 if sorted)
+        '0xa6e0c1abd0132f70efb77e2274637ff336a29a57', // Middle (would be index 1 if sorted)
+      ];
+
+      // Corresponding P-chain addresses (in same order as UTXO)
+      const pAddresses = [
+        'P-costwo15msvr27szvhhpmah0c38gcml7vm29xjh7tcek8', // Maps to 0xc386... (UTXO index 0)
+        'P-costwo1zt9n96hey4fsvnde35n3k4kt5pu7c784dzewzd', // Maps to 0x12cb... (UTXO index 1)
+        'P-costwo1cwrdtrgf4xh80ncu7palrjw7gn4mpj0n4dxghh', // Maps to 0xa6e0... (UTXO index 2)
+      ];
+
+      // Create UTXO with UNSORTED addresses
+      const utxo: DecodedUtxoObj = {
+        outputID: 0,
+        amount: '50000000',
+        txid: 'zstyYq5riDKYDSR3fUYKKkuXKJ1aJCe8WNrXKqEBJD4CGwzFw',
+        outputidx: '0',
+        addresses: unsortedUtxoAddresses, // UNSORTED order
+        threshold: 2,
+      };
+
+      // Build transaction
+      const txBuilder = factory
+        .getImportInPBuilder()
+        .threshold(2)
+        .locktime(0)
+        .fromPubKey(pAddresses)
+        .externalChainId(testData.sourceChainId)
+        .fee('1261000')
+        .utxos([utxo]);
+
+      // Build unsigned transaction
+      const unsignedTx = await txBuilder.build();
+      const unsignedHex = unsignedTx.toBroadcastFormat();
+
+      // Parse it back to inspect AddressMaps and sigIndicies
+      const parsedBuilder = factory.from(unsignedHex);
+      const parsedTx = await parsedBuilder.build();
+      const flareTx = (parsedTx as any)._flareTransaction;
+
+      // Get the input to check sigIndicies
+      const importTx = flareTx.tx as any;
+      const input = importTx.ins[0];
+      const transferInput = input.input;
+      const sigIndicies = transferInput.sigIndicies();
+
+      // sigIndicies tells us: sigIndicies[slotIndex] = utxoAddressIndex
+      // For threshold=2, we need signatures for first 2 addresses in UTXO order
+      // UTXO order: [0xc386... (index 0), 0x12cb... (index 1), 0xa6e0... (index 2)]
+      // So sigIndicies should be [0, 1] meaning: slot 0 = UTXO index 0, slot 1 = UTXO index 1
+
+      // Verify sigIndicies are [0, 1] (first 2 addresses in UTXO order, NOT sorted order)
+      sigIndicies.length.should.equal(2);
+      sigIndicies[0].should.equal(0, 'First signature slot should be UTXO address index 0 (0xc386...)');
+      sigIndicies[1].should.equal(1, 'Second signature slot should be UTXO address index 1 (0x12cb...)');
+
+      // Now the key test: AddressMap should map addresses based on sigIndicies (UTXO order)
+      // NOT based on sorted order
+      //
+      // Current implementation (WRONG):
+      // - Sorts addresses: [0x12cb... (smallest), 0xa6e0... (middle), 0xc386... (largest)]
+      // - Maps: sorted[0] -> slot 0, sorted[1] -> slot 1
+      // - This means: 0x12cb... -> slot 0, 0xa6e0... -> slot 1 (WRONG!)
+      //
+      // Expected (CORRECT):
+      // - Uses UTXO order via sigIndicies: sigIndicies[0]=0, sigIndicies[1]=1
+      // - Maps: address at UTXO index 0 (0xc386...) -> slot 0, address at UTXO index 1 (0x12cb...) -> slot 1
+      // - This means: 0xc386... -> slot 0, 0x12cb... -> slot 1 (CORRECT!)
+
+      // Parse addresses
+      // Address at UTXO index 0 (0xc386...) should map to signature slot 0
+      const pAddr0Bytes = testUtils.parseAddress(pAddresses[0]); // Corresponds to UTXO index 0
+
+      // Address at UTXO index 1 (0x12cb...) should map to signature slot 1
+      const pAddr1Bytes = testUtils.parseAddress(pAddresses[1]); // Corresponds to UTXO index 1
+
+      // Get addresses from AddressMap
+      const addressesInMap = flareTx.getAddresses();
+
+      // Verify addresses are in the map
+      const addr0InMap = addressesInMap.some((addr) => Buffer.compare(Buffer.from(addr), pAddr0Bytes) === 0);
+      const addr1InMap = addressesInMap.some((addr) => Buffer.compare(Buffer.from(addr), pAddr1Bytes) === 0);
+
+      addr0InMap.should.be.true('Address at UTXO index 0 should be in AddressMap');
+      addr1InMap.should.be.true('Address at UTXO index 1 should be in AddressMap');
+
+      // The critical assertion: AddressMap should map addresses to signature slots based on sigIndicies
+      // Since we can't directly access individual AddressMap instances, we verify the behavior
+      // by checking that the transaction structure is correct.
+      //
+      // With current implementation (WRONG):
+      // - AddressMap maps sorted addresses: 0x12cb... -> slot 0, 0xa6e0... -> slot 1
+      // - But sigIndicies say: slot 0 = UTXO index 0 (0xc386...), slot 1 = UTXO index 1 (0x12cb...)
+      // - Mismatch! AddressMap says 0x12cb... -> slot 0, but sigIndicies say slot 0 = 0xc386...
+      //
+      // This mismatch will cause signing to fail because:
+      // - Signing logic uses AddressMap to find which slot to sign
+      // - But credentials expect signatures in slots based on sigIndicies (UTXO order)
+      // - Result: "wrong signature" error on-chain
+
+      // The critical test: Verify that signature slots have embedded addresses based on UTXO order
+      // With unsorted UTXO addresses, this will FAIL if AddressMaps don't match UTXO order
+      //
+      // sigIndicies tells us: sigIndicies[slotIndex] = utxoAddressIndex
+      // For threshold=2, we need signatures for first 2 addresses in UTXO order
+      // UTXO order: [0xc386... (index 0), 0x12cb... (index 1), 0xa6e0... (index 2)]
+      // So sigIndicies should be [0, 1] meaning: slot 0 = UTXO index 0, slot 1 = UTXO index 1
+
+      // Parse the credential to see which slots have which embedded addresses
+      const credential = flareTx.credentials[0];
+      const signatures = credential.getSignatures();
+
+      // Extract embedded addresses from signature slots
+      const embeddedAddresses: string[] = [];
+
+      // Helper function to check if signature has embedded address (same logic as transaction.ts)
+      const isEmptySignature = (signature: string): boolean => {
+        return !!signature && testUtils.removeHexPrefix(signature).startsWith('0'.repeat(90));
+      };
+
+      const hasEmbeddedAddress = (signature: string): boolean => {
+        if (!isEmptySignature(signature)) return false;
+        const cleanSig = testUtils.removeHexPrefix(signature);
+        if (cleanSig.length < 130) return false;
+        const embeddedPart = cleanSig.substring(90, 130);
+        // Check if embedded part is not all zeros
+        return embeddedPart !== '0'.repeat(40);
+      };
+
+      signatures.forEach((sig: string, slotIndex: number) => {
+        if (hasEmbeddedAddress(sig)) {
+          // Extract embedded address (after position 90, 40 chars = 20 bytes)
+          const cleanSig = testUtils.removeHexPrefix(sig);
+          const embeddedAddr = cleanSig.substring(90, 130).toLowerCase();
+          embeddedAddresses[slotIndex] = '0x' + embeddedAddr;
+        }
+      });
+
+      // Verify: Credentials only embed ONE address (user/recovery), not both
+      // The embedded address should be based on addressesIndex logic, not sorted order
+      //
+      // Compute addressesIndex to determine expected signature order
+      const utxoAddressBytes = unsortedUtxoAddresses.map((addr) => testUtils.parseAddress(addr));
+      const pAddressBytes = pAddresses.map((addr) => testUtils.parseAddress(addr));
+
+      const addressesIndex: number[] = [];
+      pAddressBytes.forEach((pAddr) => {
+        const utxoIndex = utxoAddressBytes.findIndex(
+          (uAddr) => Buffer.compare(Buffer.from(uAddr), Buffer.from(pAddr)) === 0
+        );
+        addressesIndex.push(utxoIndex);
+      });
+
+      // firstIndex = 0 (user), bitgoIndex = 1
+      const firstIndex = 0;
+      const bitgoIndex = 1;
+
+      // Determine expected signature order based on addressesIndex
+      const userComesFirst = addressesIndex[bitgoIndex] > addressesIndex[firstIndex];
+
+      // Expected credential structure:
+      // - If user comes first: [userAddress, zeros]
+      // - If bitgo comes first: [zeros, userAddress]
+      const userAddressHex = Buffer.from(pAddressBytes[firstIndex]).toString('hex').toLowerCase();
+      const expectedUserAddr = '0x' + userAddressHex;
+
+      if (userComesFirst) {
+        // Expected: [userAddress, zeros]
+        // Slot 0 should have user address (pAddr0 = 0xc386... = UTXO index 0)
+        if (embeddedAddresses[0]) {
+          embeddedAddresses[0]
+            .toLowerCase()
+            .should.equal(
+              expectedUserAddr,
+              `Slot 0 should have user address (${expectedUserAddr}) because user comes first in UTXO order`
+            );
+        } else {
+          throw new Error(`Slot 0 should have embedded user address, but is empty`);
+        }
+        // Slot 1 should be zeros (no embedded address)
+        if (embeddedAddresses[1]) {
+          throw new Error(`Slot 1 should be zeros, but has embedded address: ${embeddedAddresses[1]}`);
+        }
+      } else {
+        // Expected: [zeros, userAddress]
+        // Slot 0 should be zeros
+        if (embeddedAddresses[0]) {
+          throw new Error(`Slot 0 should be zeros, but has embedded address: ${embeddedAddresses[0]}`);
+        }
+        // Slot 1 should have user address
+        if (embeddedAddresses[1]) {
+          embeddedAddresses[1]
+            .toLowerCase()
+            .should.equal(
+              expectedUserAddr,
+              `Slot 1 should have user address (${expectedUserAddr}) because bitgo comes first in UTXO order`
+            );
+        } else {
+          throw new Error(`Slot 1 should have embedded user address, but is empty`);
+        }
+      }
+
+      // The key verification: AddressMaps should match the credential order
+      // With the fix, AddressMaps are created using the same addressesIndex logic as credentials
+      // This ensures signing works correctly even with unsorted UTXO addresses
     });
   });
 });


### PR DESCRIPTION
## Refactor: Centralize Signature Ordering Logic in FLRP Transaction Builders

### Summary

This PR centralizes the signature ordering and AddressMap creation logic in FLRP transaction builders to match avaxp's architecture pattern. This eliminates ~200+ lines of duplicated code across `ImportInPTxBuilder`, `ImportInCTxBuilder`, and `ExportInPTxBuilder`.

### Problem

FLRP had duplicated signature ordering logic scattered across each builder:
- Each builder implemented its own `addressesIndex`-based credential ordering logic
- AddressMap creation was duplicated across multiple methods (`initBuilder`, `buildFlareTransaction`, `createInputs`, etc.)
- Inconsistent with avaxp's centralized approach in `AtomicTransactionBuilder`
- Maintenance burden: changes required updates in multiple places

### Solution

Introduced two centralized helper methods in `AtomicTransactionBuilder`:
1. **`createCredentialForUtxo()`** - Creates credentials with dynamic ordering based on UTXO address positions
2. **`createAddressMapForUtxo()`** - Creates AddressMaps matching credential order

All builders now use these centralized methods, ensuring consistent behavior across all transaction types.

### Changes

**New Centralized Methods:**
- `AtomicTransactionBuilder.createCredentialForUtxo()` - Handles credential creation with UTXO-based ordering
- `AtomicTransactionBuilder.createAddressMapForUtxo()` - Handles AddressMap creation matching credential order

**Refactored Builders:**
- `ImportInPTxBuilder` - Updated `initBuilder()` and `buildFlareTransaction()` to use centralized methods
- `ImportInCTxBuilder` - Updated `initBuilder()` and `buildFlareTransaction()` to use centralized methods  
- `ExportInPTxBuilder` - Updated `initBuilder()` and `buildFlareTransaction()` to use centralized methods

### Technical Details

The signature ordering logic uses `addressesIndex` to determine the order of addresses in UTXOs:
- If `addressesIndex[bitgoIndex] < addressesIndex[firstIndex]`: Bitgo signature comes first (slot 0)
- Otherwise: User/recovery signature comes first (slot 0)

This ensures AddressMaps match credential order, preventing signature index mismatches.

### Related

- Fixes AddressMap mismatch issues for C-chain import transactions
- Aligns FLRP implementation with avaxp's proven architecture
- Part of ongoing effort to improve code consistency across coin implementations