### PR TITLE
fix(key-card): upgrade jspdf to 4.0.0 to resolve critical security bug/vulnerability

### DIFF
--- a/modules/key-card/package.json
+++ b/modules/key-card/package.json
@@ -36,7 +36,7 @@
     "@bitgo/sdk-api": "^1.72.2",
     "@bitgo/sdk-core": "^36.25.0",
     "@bitgo/statics": "^58.19.0",
-    "jspdf": "^3.0.2",
+    "jspdf": "^4.0.0",
     "qrcode": "^1.5.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -872,7 +872,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/runtime@7.6.0", "@babel/runtime@^7.0.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.6", "@babel/runtime@^7.20.13", "@babel/runtime@^7.25.0", "@babel/runtime@^7.26.9", "@babel/runtime@^7.28.2", "@babel/runtime@^7.7.6":
+"@babel/runtime@7.6.0", "@babel/runtime@^7.0.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.6", "@babel/runtime@^7.20.13", "@babel/runtime@^7.25.0", "@babel/runtime@^7.28.2", "@babel/runtime@^7.28.4", "@babel/runtime@^7.7.6":
   version "7.28.4"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz#a70226016fabe25c5783b2f22d3e1c9bc5ca3326"
   integrity sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==
@@ -14044,12 +14044,12 @@ jsonpointer@^5.0.0:
   resolved "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz"
   integrity sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==
 
-jspdf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/jspdf/-/jspdf-3.0.2.tgz"
-  integrity sha512-G0fQDJ5fAm6UW78HG6lNXyq09l0PrA1rpNY5i+ly17Zb1fMMFSmS+3lw4cnrAPGyouv2Y0ylujbY2Ieq3DSlKA==
+jspdf@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/jspdf/-/jspdf-4.0.0.tgz#3731c0a1a7d8afe28c681891236f8ad4a662d893"
+  integrity sha512-w12U97Z6edKd2tXDn3LzTLg7C7QLJlx0BPfM3ecjK2BckUl9/81vZ+r5gK4/3KQdhAcEZhENUxRhtgYBj75MqQ==
   dependencies:
-    "@babel/runtime" "^7.26.9"
+    "@babel/runtime" "^7.28.4"
     fast-png "^6.2.0"
     fflate "^0.8.1"
   optionalDependencies:


### PR DESCRIPTION
TICKET: WIN-0000

Upgrades jspdf from ^3.0.2 to ^4.0.0 to address GHSA-f8cm-6447-x5h2, a critical path traversal vulnerability (CVSS 9.2) that could allow local file inclusion in the node.js build.
