### PR TITLE
fix(wallet-key-share): Optimize createBulkWalletShare to Fetch Keychain Once and Prevent Rate Limiting

### DIFF
--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -645,6 +645,11 @@ export interface BulkWalletShareOptions {
 
 export type WalletShareState = 'active' | 'accepted' | 'canceled' | 'rejected' | 'pendingapproval';
 
+export interface DecryptedKeychainData {
+  prv: string;
+  pub: string;
+}
+
 export interface BulkWalletShareKeychain {
   pub: string;
   encryptedPrv: string;

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -70,6 +70,7 @@ import {
   CreatePolicyRuleOptions,
   CreateShareOptions,
   CrossChainUTXO,
+  DecryptedKeychainData,
   DeployForwardersOptions,
   DownloadKeycardOptions,
   FanoutUnspentsOptions,
@@ -1685,7 +1686,26 @@ export class Wallet implements IWallet {
     if (params.keyShareOptions.length === 0) {
       throw new Error('No share options provided');
     }
+
     const bulkCreateShareOptions: BulkCreateShareOption[] = [];
+
+    // Check if any share option needs a keychain (has 'spend' permission)
+    const anyNeedsKeychain = params.keyShareOptions.some((opt) => opt.permissions && opt.permissions.includes('spend'));
+
+    // Fetch and decrypt the keychain ONCE for all users
+    let decryptedKeychain: DecryptedKeychainData | undefined;
+
+    if (anyNeedsKeychain) {
+      try {
+        decryptedKeychain = await this.getDecryptedKeychainForSharing(params.walletPassphrase);
+      } catch (e) {
+        if (e instanceof MissingEncryptedKeychainError) {
+          decryptedKeychain = undefined;
+        } else {
+          throw e;
+        }
+      }
+    }
 
     for (const shareOption of params.keyShareOptions) {
       try {
@@ -1699,36 +1719,22 @@ export class Wallet implements IWallet {
 
       const needsKeychain = shareOption.permissions && shareOption.permissions.includes('spend');
 
-      if (needsKeychain) {
-        const sharedKeychain = await this.prepareSharedKeychain(
-          params.walletPassphrase,
+      if (needsKeychain && decryptedKeychain) {
+        const sharedKeychain = this.encryptPrvForUser(
+          decryptedKeychain.prv,
+          decryptedKeychain.pub,
           shareOption.pubKey,
           shareOption.path
         );
-        const keychain = Object.keys(sharedKeychain ?? {}).length === 0 ? undefined : sharedKeychain;
-        if (keychain) {
-          assert(keychain.pub, 'pub must be defined for sharing');
-          assert(keychain.encryptedPrv, 'encryptedPrv must be defined for sharing');
-          assert(keychain.fromPubKey, 'fromPubKey must be defined for sharing');
-          assert(keychain.toPubKey, 'toPubKey must be defined for sharing');
-          assert(keychain.path, 'path must be defined for sharing');
 
-          const bulkKeychain: BulkWalletShareKeychain = {
-            pub: keychain.pub,
-            encryptedPrv: keychain.encryptedPrv,
-            fromPubKey: keychain.fromPubKey,
-            toPubKey: keychain.toPubKey,
-            path: keychain.path,
-          };
-
-          bulkCreateShareOptions.push({
-            user: shareOption.userId,
-            permissions: shareOption.permissions,
-            keychain: bulkKeychain,
-          });
-        }
+        bulkCreateShareOptions.push({
+          user: shareOption.userId,
+          permissions: shareOption.permissions,
+          keychain: sharedKeychain,
+        });
       }
     }
+
     return await this.createBulkKeyShares(bulkCreateShareOptions);
   }
 
@@ -1776,62 +1782,107 @@ export class Wallet implements IWallet {
     }
   }
 
+  /**
+   * Fetches and decrypts the wallet keychain for sharing.
+   * This method fetches the keychain once and decrypts it, returning the decrypted
+   * private key and public key info needed for sharing with multiple users.
+   *
+   * @param walletPassphrase - The passphrase to decrypt the keychain
+   * @returns Object containing decrypted prv and pub, or undefined for cold wallets
+   */
+  async getDecryptedKeychainForSharing(
+    walletPassphrase: string | undefined
+  ): Promise<DecryptedKeychainData | undefined> {
+    const keychain = await this.getEncryptedWalletKeychainForWalletSharing();
+
+    if (!keychain.encryptedPrv) {
+      return undefined;
+    }
+
+    if (!walletPassphrase) {
+      throw new Error('Missing walletPassphrase argument');
+    }
+
+    const prv = decryptKeychainPrivateKey(this.bitgo, keychain, walletPassphrase);
+    if (!prv) {
+      throw new IncorrectPasswordError('Password shared is incorrect for this wallet');
+    }
+
+    // Only one of pub/commonPub/commonKeychain should be present in the keychain
+    let pub = keychain.pub ?? keychain.commonPub;
+    if (keychain.commonKeychain) {
+      pub =
+        this.baseCoin.getMPCAlgorithm() === 'eddsa'
+          ? EddsaUtils.getPublicKeyFromCommonKeychain(keychain.commonKeychain)
+          : EcdsaUtils.getPublicKeyFromCommonKeychain(keychain.commonKeychain);
+    }
+
+    if (!pub) {
+      throw new Error('Unable to determine public key from keychain');
+    }
+
+    return { prv, pub };
+  }
+
+  /**
+   * Encrypts a decrypted private key for sharing with a specific user.
+   * This is the pure encryption step - no API calls, no decryption.
+   *
+   * @param decryptedPrv - The already-decrypted private key
+   * @param pub - The wallet's public key
+   * @param userPubkey - The recipient user's public key
+   * @param path - The key path
+   * @returns The encrypted keychain for the recipient with all required fields
+   */
+  encryptPrvForUser(decryptedPrv: string, pub: string, userPubkey: string, path: string): BulkWalletShareKeychain {
+    const eckey = makeRandomKey();
+    const secret = getSharedSecret(eckey, Buffer.from(userPubkey, 'hex')).toString('hex');
+    const newEncryptedPrv = this.bitgo.encrypt({ password: secret, input: decryptedPrv });
+
+    const keychain: BulkWalletShareKeychain = {
+      pub,
+      encryptedPrv: newEncryptedPrv,
+      fromPubKey: eckey.publicKey.toString('hex'),
+      toPubKey: userPubkey,
+      path: path,
+    };
+
+    assert(keychain.pub, 'pub must be defined for sharing');
+    assert(keychain.encryptedPrv, 'encryptedPrv must be defined for sharing');
+    assert(keychain.fromPubKey, 'fromPubKey must be defined for sharing');
+    assert(keychain.toPubKey, 'toPubKey must be defined for sharing');
+    assert(keychain.path, 'path must be defined for sharing');
+
+    return keychain;
+  }
+
+  /**
+   * Prepares a keychain for sharing with another user.
+   * Fetches the wallet keychain, decrypts it, and encrypts it for the recipient.
+   *
+   * @param walletPassphrase - The passphrase to decrypt the keychain
+   * @param pubkey - The recipient's public key
+   * @param path - The key path
+   * @returns The encrypted keychain for the recipient
+   */
   async prepareSharedKeychain(
     walletPassphrase: string | undefined,
     pubkey: string,
     path: string
   ): Promise<SharedKeyChain> {
-    let sharedKeychain: SharedKeyChain = {};
-
     try {
-      const keychain = await this.getEncryptedWalletKeychainForWalletSharing();
-
-      // Decrypt the user key with a passphrase
-      if (keychain.encryptedPrv) {
-        if (!walletPassphrase) {
-          throw new Error('Missing walletPassphrase argument');
-        }
-
-        const userPrv = decryptKeychainPrivateKey(this.bitgo, keychain, walletPassphrase);
-        if (!userPrv) {
-          throw new IncorrectPasswordError('Password shared is incorrect for this wallet');
-        }
-
-        keychain.prv = userPrv;
-        const eckey = makeRandomKey();
-        const secret = getSharedSecret(eckey, Buffer.from(pubkey, 'hex')).toString('hex');
-        const newEncryptedPrv = this.bitgo.encrypt({
-          password: secret,
-          input: keychain.prv,
-        });
-
-        // Only one of pub/commonPub/commonKeychain should be present in the keychain
-        let pub = keychain.pub ?? keychain.commonPub;
-        if (keychain.commonKeychain) {
-          pub =
-            this.baseCoin.getMPCAlgorithm() === 'eddsa'
-              ? EddsaUtils.getPublicKeyFromCommonKeychain(keychain.commonKeychain)
-              : EcdsaUtils.getPublicKeyFromCommonKeychain(keychain.commonKeychain);
-        }
-
-        sharedKeychain = {
-          pub,
-          encryptedPrv: newEncryptedPrv,
-          fromPubKey: eckey.publicKey.toString('hex'),
-          toPubKey: pubkey,
-          path: path,
-        };
+      const decryptedKeychain = await this.getDecryptedKeychainForSharing(walletPassphrase);
+      if (!decryptedKeychain) {
+        return {};
       }
+      return this.encryptPrvForUser(decryptedKeychain.prv, decryptedKeychain.pub, pubkey, path);
     } catch (e) {
       if (e instanceof MissingEncryptedKeychainError) {
-        sharedKeychain = {};
         // ignore this error because this looks like a cold wallet
-      } else {
-        throw e;
+        return {};
       }
+      throw e;
     }
-
-    return sharedKeychain;
   }
 
   /**


### PR DESCRIPTION
Ticket: CSI-1548

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Summary

Optimizes `createBulkWalletShare` to fetch the wallet keychain only once instead of once per user, drastically reducing API calls and preventing rate limiting (HTTP 429) errors during bulk wallet sharing.

## Problem

When sharing a wallet with multiple users via `createBulkWalletShare`, the SDK was fetching the wallet keychain (`v2.key.get`) for **each user** in the share list. 

For example, sharing 26 wallets with 15 users each resulted in **390 API calls** (26 × 15), causing rate limiting errors and failures with the message: "Failed to process wallet shares after retrying with single requests." 
Check the support ticket : CSI-1569

## Solution

Refactored the code to:

1. **Extract common logic** into two new helper methods:
   - `getDecryptedKeychainForSharing()` - Fetches and decrypts the keychain once
   - `encryptPrvForUser()` - Encrypts the private key for a specific user (no API calls)

2. **Optimize `createBulkWalletShare()`** to fetch the keychain once before the loop, then reuse it for all users