### PR TITLE
feat(abstract-utxo): refactor coin name handling and improve type safety

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -77,8 +77,8 @@ import {
 } from './transaction/descriptor/verifyTransaction';
 import { assertDescriptorWalletAddress, getDescriptorMapFromWallet, isDescriptorWallet } from './descriptor';
 import {
-  getFamilyFromNetwork,
   getFullNameFromNetwork,
+  getMainnetCoinName,
   getNetworkFromCoinName,
   UtxoCoinName,
   UtxoCoinNameMainnet,
@@ -397,7 +397,7 @@ export abstract class AbstractUtxoCoin
   }
 
   getFamily(): UtxoCoinNameMainnet {
-    return getFamilyFromNetwork(this.network);
+    return getMainnetCoinName(this.name);
   }
 
   getFullName(): string {

--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -77,7 +77,7 @@ import {
 } from './transaction/descriptor/verifyTransaction';
 import { assertDescriptorWalletAddress, getDescriptorMapFromWallet, isDescriptorWallet } from './descriptor';
 import {
-  getFullNameFromNetwork,
+  getFullNameFromCoinName,
   getMainnetCoinName,
   getNetworkFromCoinName,
   UtxoCoinName,
@@ -401,7 +401,7 @@ export abstract class AbstractUtxoCoin
   }
 
   getFullName(): string {
-    return getFullNameFromNetwork(this.network);
+    return getFullNameFromCoinName(this.name);
   }
 
   /** Indicates whether the coin supports a block target */

--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -76,7 +76,13 @@ import {
   ErrorImplicitExternalOutputs,
 } from './transaction/descriptor/verifyTransaction';
 import { assertDescriptorWalletAddress, getDescriptorMapFromWallet, isDescriptorWallet } from './descriptor';
-import { getCoinName, getFamilyFromNetwork, getFullNameFromNetwork, UtxoCoinName, UtxoCoinNameMainnet } from './names';
+import {
+  getFamilyFromNetwork,
+  getFullNameFromNetwork,
+  getNetworkFromCoinName,
+  UtxoCoinName,
+  UtxoCoinNameMainnet,
+} from './names';
 import { assertFixedScriptWalletAddress } from './address/fixedScript';
 import { isSdkBackend, ParsedTransaction, SdkBackend } from './transaction/types';
 import { decodePsbtWith, encodeTransaction, stringToBufferTryFormats } from './transaction/decode';
@@ -369,31 +375,21 @@ export abstract class AbstractUtxoCoin
   extends BaseCoin
   implements Musig2Participant<utxolib.bitgo.UtxoPsbt>, Musig2Participant<fixedScriptWallet.BitGoPsbt>
 {
+  abstract name: UtxoCoinName;
+
   public altScriptHash?: number;
   public supportAltScriptDestination?: boolean;
   public defaultSdkBackend: SdkBackend = 'utxolib';
   public readonly amountType: 'number' | 'bigint';
-  private readonly _network: utxolib.Network;
 
-  protected constructor(bitgo: BitGoBase, network: utxolib.Network, amountType: 'number' | 'bigint' = 'number') {
+  protected constructor(bitgo: BitGoBase, amountType: 'number' | 'bigint' = 'number') {
     super(bitgo);
-    if (!utxolib.isValidNetwork(network)) {
-      throw new Error(
-        'invalid network: please make sure to use the same version of ' +
-          '@bitgo/utxo-lib as this library when initializing an instance of this class'
-      );
-    }
     this.amountType = amountType;
-    this._network = network;
   }
 
   /** @deprecated - will be removed when we drop support for utxolib */
   get network(): utxolib.Network {
-    return this._network;
-  }
-
-  get name(): UtxoCoinName {
-    return getCoinName(this.network);
+    return getNetworkFromCoinName(this.name);
   }
 
   getChain(): UtxoCoinName {

--- a/modules/abstract-utxo/src/impl/bch/bch.ts
+++ b/modules/abstract-utxo/src/impl/bch/bch.ts
@@ -1,12 +1,15 @@
 import { BitGoBase } from '@bitgo/sdk-core';
 import * as utxolib from '@bitgo/utxo-lib';
 
-import { AbstractUtxoCoin, UtxoNetwork } from '../../abstractUtxoCoin';
+import { AbstractUtxoCoin } from '../../abstractUtxoCoin';
+import { UtxoCoinName } from '../../names';
 import { isScriptRecipient } from '../../transaction';
 
 export class Bch extends AbstractUtxoCoin {
-  protected constructor(bitgo: BitGoBase, network?: UtxoNetwork) {
-    super(bitgo, network || utxolib.networks.bitcoincash);
+  readonly name: UtxoCoinName = 'bch';
+
+  protected constructor(bitgo: BitGoBase) {
+    super(bitgo);
   }
 
   static createInstance(bitgo: BitGoBase): Bch {

--- a/modules/abstract-utxo/src/impl/bch/tbch.ts
+++ b/modules/abstract-utxo/src/impl/bch/tbch.ts
@@ -2,13 +2,16 @@
  * @prettier
  */
 import { BitGoBase } from '@bitgo/sdk-core';
-import * as bitcoin from '@bitgo/utxo-lib';
+
+import { UtxoCoinName } from '../../names';
 
 import { Bch } from './bch';
 
 export class Tbch extends Bch {
+  readonly name: UtxoCoinName = 'tbch';
+
   constructor(bitgo: BitGoBase) {
-    super(bitgo, bitcoin.networks.bitcoincashTestnet);
+    super(bitgo);
   }
 
   static createInstance(bitgo: BitGoBase): Tbch {

--- a/modules/abstract-utxo/src/impl/bcha/bcha.ts
+++ b/modules/abstract-utxo/src/impl/bcha/bcha.ts
@@ -1,12 +1,13 @@
 import { BitGoBase } from '@bitgo/sdk-core';
-import * as utxolib from '@bitgo/utxo-lib';
 
 import { Bch } from '../bch/bch';
-import { UtxoNetwork } from '../../abstractUtxoCoin';
+import { UtxoCoinName } from '../../names';
 
 export class Bcha extends Bch {
-  constructor(bitgo: BitGoBase, network?: UtxoNetwork) {
-    super(bitgo, network || utxolib.networks.ecash);
+  readonly name: UtxoCoinName = 'bcha';
+
+  constructor(bitgo: BitGoBase) {
+    super(bitgo);
   }
 
   static createInstance(bitgo: BitGoBase): Bcha {

--- a/modules/abstract-utxo/src/impl/bcha/tbcha.ts
+++ b/modules/abstract-utxo/src/impl/bcha/tbcha.ts
@@ -2,13 +2,16 @@
  * @prettier
  */
 import { BitGoBase } from '@bitgo/sdk-core';
-import * as utxolib from '@bitgo/utxo-lib';
+
+import { UtxoCoinName } from '../../names';
 
 import { Bcha } from './bcha';
 
 export class Tbcha extends Bcha {
+  readonly name: UtxoCoinName = 'tbcha';
+
   constructor(bitgo: BitGoBase) {
-    super(bitgo, utxolib.networks.ecashTest);
+    super(bitgo);
   }
 
   static createInstance(bitgo: BitGoBase): Tbcha {

--- a/modules/abstract-utxo/src/impl/bsv/bsv.ts
+++ b/modules/abstract-utxo/src/impl/bsv/bsv.ts
@@ -1,12 +1,13 @@
 import { BitGoBase } from '@bitgo/sdk-core';
-import * as utxolib from '@bitgo/utxo-lib';
 
-import { UtxoNetwork } from '../../abstractUtxoCoin';
 import { Bch } from '../bch/bch';
+import { UtxoCoinName } from '../../names';
 
 export class Bsv extends Bch {
-  constructor(bitgo: BitGoBase, network?: UtxoNetwork) {
-    super(bitgo, network || utxolib.networks.bitcoinsv);
+  readonly name: UtxoCoinName = 'bsv';
+
+  constructor(bitgo: BitGoBase) {
+    super(bitgo);
   }
 
   static createInstance(bitgo: BitGoBase): Bsv {

--- a/modules/abstract-utxo/src/impl/bsv/tbsv.ts
+++ b/modules/abstract-utxo/src/impl/bsv/tbsv.ts
@@ -2,13 +2,16 @@
  * @prettier
  */
 import { BitGoBase } from '@bitgo/sdk-core';
-import * as utxolib from '@bitgo/utxo-lib';
+
+import { UtxoCoinName } from '../../names';
 
 import { Bsv } from './bsv';
 
 export class Tbsv extends Bsv {
+  readonly name: UtxoCoinName = 'tbsv';
+
   constructor(bitgo: BitGoBase) {
-    super(bitgo, utxolib.networks.bitcoinsvTestnet);
+    super(bitgo);
   }
 
   static createInstance(bitgo: BitGoBase): Tbsv {

--- a/modules/abstract-utxo/src/impl/btc/btc.ts
+++ b/modules/abstract-utxo/src/impl/btc/btc.ts
@@ -3,9 +3,9 @@ import {
   VerifyRecoveryTransactionOptions as BaseVerifyRecoveryTransactionOptions,
   Wallet,
 } from '@bitgo/sdk-core';
-import * as utxolib from '@bitgo/utxo-lib';
 
-import { AbstractUtxoCoin, UtxoNetwork } from '../../abstractUtxoCoin';
+import { AbstractUtxoCoin } from '../../abstractUtxoCoin';
+import { UtxoCoinName } from '../../names';
 
 import { InscriptionBuilder } from './inscriptionBuilder';
 
@@ -14,8 +14,10 @@ export interface VerifyRecoveryTransactionOptions extends BaseVerifyRecoveryTran
 }
 
 export class Btc extends AbstractUtxoCoin {
-  constructor(bitgo: BitGoBase, network?: UtxoNetwork) {
-    super(bitgo, network || utxolib.networks.bitcoin);
+  readonly name: UtxoCoinName = 'btc';
+
+  constructor(bitgo: BitGoBase) {
+    super(bitgo);
   }
 
   static createInstance(bitgo: BitGoBase): Btc {

--- a/modules/abstract-utxo/src/impl/btc/tbtc.ts
+++ b/modules/abstract-utxo/src/impl/btc/tbtc.ts
@@ -2,13 +2,16 @@
  * @prettier
  */
 import { BitGoBase } from '@bitgo/sdk-core';
-import * as utxolib from '@bitgo/utxo-lib';
+
+import { UtxoCoinName } from '../../names';
 
 import { Btc } from './btc';
 
 export class Tbtc extends Btc {
+  readonly name: UtxoCoinName = 'tbtc';
+
   constructor(bitgo: BitGoBase) {
-    super(bitgo, utxolib.networks.testnet);
+    super(bitgo);
   }
 
   static createInstance(bitgo: BitGoBase): Tbtc {

--- a/modules/abstract-utxo/src/impl/btc/tbtc4.ts
+++ b/modules/abstract-utxo/src/impl/btc/tbtc4.ts
@@ -2,13 +2,16 @@
  * @prettier
  */
 import { BitGoBase } from '@bitgo/sdk-core';
-import * as utxolib from '@bitgo/utxo-lib';
+
+import { UtxoCoinName } from '../../names';
 
 import { Btc } from './btc';
 
 export class Tbtc4 extends Btc {
+  readonly name: UtxoCoinName = 'tbtc4';
+
   constructor(bitgo: BitGoBase) {
-    super(bitgo, utxolib.networks.bitcoinTestnet4);
+    super(bitgo);
   }
 
   static createInstance(bitgo: BitGoBase): Tbtc4 {

--- a/modules/abstract-utxo/src/impl/btc/tbtcbgsig.ts
+++ b/modules/abstract-utxo/src/impl/btc/tbtcbgsig.ts
@@ -2,13 +2,16 @@
  * @prettier
  */
 import { BitGoBase } from '@bitgo/sdk-core';
-import * as utxolib from '@bitgo/utxo-lib';
+
+import { UtxoCoinName } from '../../names';
 
 import { Btc } from './btc';
 
 export class Tbtcbgsig extends Btc {
+  readonly name: UtxoCoinName = 'tbtcbgsig';
+
   constructor(bitgo: BitGoBase) {
-    super(bitgo, utxolib.networks.bitcoinBitGoSignet);
+    super(bitgo);
   }
 
   static createInstance(bitgo: BitGoBase): Tbtcbgsig {

--- a/modules/abstract-utxo/src/impl/btc/tbtcsig.ts
+++ b/modules/abstract-utxo/src/impl/btc/tbtcsig.ts
@@ -2,13 +2,16 @@
  * @prettier
  */
 import { BitGoBase } from '@bitgo/sdk-core';
-import * as utxolib from '@bitgo/utxo-lib';
+
+import { UtxoCoinName } from '../../names';
 
 import { Btc } from './btc';
 
 export class Tbtcsig extends Btc {
+  readonly name: UtxoCoinName = 'tbtcsig';
+
   constructor(bitgo: BitGoBase) {
-    super(bitgo, utxolib.networks.bitcoinPublicSignet);
+    super(bitgo);
   }
 
   static createInstance(bitgo: BitGoBase): Tbtcsig {

--- a/modules/abstract-utxo/src/impl/btg/btg.ts
+++ b/modules/abstract-utxo/src/impl/btg/btg.ts
@@ -1,11 +1,13 @@
 import { BitGoBase } from '@bitgo/sdk-core';
-import * as utxolib from '@bitgo/utxo-lib';
 
-import { AbstractUtxoCoin, UtxoNetwork } from '../../abstractUtxoCoin';
+import { AbstractUtxoCoin } from '../../abstractUtxoCoin';
+import { UtxoCoinName } from '../../names';
 
 export class Btg extends AbstractUtxoCoin {
-  constructor(bitgo: BitGoBase, network?: UtxoNetwork) {
-    super(bitgo, network || utxolib.networks.bitcoingold);
+  readonly name: UtxoCoinName = 'btg';
+
+  constructor(bitgo: BitGoBase) {
+    super(bitgo);
   }
 
   static createInstance(bitgo: BitGoBase): Btg {

--- a/modules/abstract-utxo/src/impl/dash/dash.ts
+++ b/modules/abstract-utxo/src/impl/dash/dash.ts
@@ -1,11 +1,13 @@
 import { BitGoBase } from '@bitgo/sdk-core';
-import * as utxolib from '@bitgo/utxo-lib';
 
-import { AbstractUtxoCoin, UtxoNetwork } from '../../abstractUtxoCoin';
+import { AbstractUtxoCoin } from '../../abstractUtxoCoin';
+import { UtxoCoinName } from '../../names';
 
 export class Dash extends AbstractUtxoCoin {
-  constructor(bitgo: BitGoBase, network?: UtxoNetwork) {
-    super(bitgo, network || utxolib.networks.dash);
+  readonly name: UtxoCoinName = 'dash';
+
+  constructor(bitgo: BitGoBase) {
+    super(bitgo);
   }
 
   static createInstance(bitgo: BitGoBase): Dash {

--- a/modules/abstract-utxo/src/impl/dash/tdash.ts
+++ b/modules/abstract-utxo/src/impl/dash/tdash.ts
@@ -2,13 +2,16 @@
  * @prettier
  */
 import { BitGoBase } from '@bitgo/sdk-core';
-import * as utxolib from '@bitgo/utxo-lib';
+
+import { UtxoCoinName } from '../../names';
 
 import { Dash } from './dash';
 
 export class Tdash extends Dash {
+  readonly name: UtxoCoinName = 'tdash';
+
   constructor(bitgo: BitGoBase) {
-    super(bitgo, utxolib.networks.dashTest);
+    super(bitgo);
   }
   static createInstance(bitgo: BitGoBase): Tdash {
     return new Tdash(bitgo);

--- a/modules/abstract-utxo/src/impl/doge/doge.ts
+++ b/modules/abstract-utxo/src/impl/doge/doge.ts
@@ -1,9 +1,8 @@
 import { BitGoBase, HalfSignedUtxoTransaction, SignedTransaction } from '@bitgo/sdk-core';
-import { bitgo, networks } from '@bitgo/utxo-lib';
+import { bitgo } from '@bitgo/utxo-lib';
 
 import {
   AbstractUtxoCoin,
-  UtxoNetwork,
   SignTransactionOptions,
   ExplainTransactionOptions,
   ParseTransactionOptions,
@@ -12,6 +11,7 @@ import {
   TransactionInfo,
   TransactionPrebuild,
 } from '../../abstractUtxoCoin';
+import { UtxoCoinName } from '../../names';
 import { ParsedTransaction } from '../../transaction/types';
 import type { TransactionExplanation } from '../../transaction/fixedScript/explainTransaction';
 import type { CrossChainRecoverySigned, CrossChainRecoveryUnsigned } from '../../recovery/crossChainRecovery';
@@ -56,8 +56,10 @@ function parseTransactionPrebuild<TNumber extends number | bigint>(
 }
 
 export class Doge extends AbstractUtxoCoin {
-  constructor(bitgo: BitGoBase, network?: UtxoNetwork) {
-    super(bitgo, network || networks.dogecoin, 'bigint');
+  readonly name: UtxoCoinName = 'doge';
+
+  constructor(bitgo: BitGoBase) {
+    super(bitgo, 'bigint');
   }
 
   static createInstance(bitgo: BitGoBase): Doge {

--- a/modules/abstract-utxo/src/impl/doge/tdoge.ts
+++ b/modules/abstract-utxo/src/impl/doge/tdoge.ts
@@ -2,13 +2,16 @@
  * @prettier
  */
 import { BitGoBase } from '@bitgo/sdk-core';
-import * as utxolib from '@bitgo/utxo-lib';
+
+import { UtxoCoinName } from '../../names';
 
 import { Doge } from './doge';
 
 export class Tdoge extends Doge {
+  readonly name: UtxoCoinName = 'tdoge';
+
   constructor(bitgo: BitGoBase) {
-    super(bitgo, utxolib.networks.dogecoinTest);
+    super(bitgo);
   }
   static createInstance(bitgo: BitGoBase): Tdoge {
     return new Tdoge(bitgo);

--- a/modules/abstract-utxo/src/impl/ltc/ltc.ts
+++ b/modules/abstract-utxo/src/impl/ltc/ltc.ts
@@ -1,11 +1,14 @@
 import { BitGoBase } from '@bitgo/sdk-core';
 import * as utxolib from '@bitgo/utxo-lib';
 
-import { AbstractUtxoCoin, UtxoNetwork } from '../../abstractUtxoCoin';
+import { AbstractUtxoCoin } from '../../abstractUtxoCoin';
+import { UtxoCoinName } from '../../names';
 
 export class Ltc extends AbstractUtxoCoin {
-  constructor(bitgo: BitGoBase, network?: UtxoNetwork) {
-    super(bitgo, network || utxolib.networks.litecoin);
+  readonly name: UtxoCoinName = 'ltc';
+
+  constructor(bitgo: BitGoBase) {
+    super(bitgo);
     // use legacy script hash version, which is the current Bitcoin one
     this.altScriptHash = utxolib.networks.bitcoin.scriptHash;
     // do not support alt destinations in prod

--- a/modules/abstract-utxo/src/impl/ltc/tltc.ts
+++ b/modules/abstract-utxo/src/impl/ltc/tltc.ts
@@ -1,11 +1,15 @@
 import { BitGoBase } from '@bitgo/sdk-core';
 import * as utxolib from '@bitgo/utxo-lib';
 
+import { UtxoCoinName } from '../../names';
+
 import { Ltc } from './ltc';
 
 export class Tltc extends Ltc {
+  readonly name: UtxoCoinName = 'tltc';
+
   constructor(bitgo: BitGoBase) {
-    super(bitgo, utxolib.networks.litecoinTest);
+    super(bitgo);
     this.altScriptHash = utxolib.networks.testnet.scriptHash;
     // support alt destinations on test
     this.supportAltScriptDestination = false;

--- a/modules/abstract-utxo/src/impl/zec/tzec.ts
+++ b/modules/abstract-utxo/src/impl/zec/tzec.ts
@@ -1,11 +1,14 @@
 import { BitGoBase } from '@bitgo/sdk-core';
-import * as utxolib from '@bitgo/utxo-lib';
+
+import { UtxoCoinName } from '../../names';
 
 import { Zec } from './zec';
 
 export class Tzec extends Zec {
+  readonly name: UtxoCoinName = 'tzec';
+
   constructor(bitgo: BitGoBase) {
-    super(bitgo, utxolib.networks.zcashTest);
+    super(bitgo);
   }
 
   static createInstance(bitgo: BitGoBase): Tzec {

--- a/modules/abstract-utxo/src/impl/zec/zec.ts
+++ b/modules/abstract-utxo/src/impl/zec/zec.ts
@@ -2,13 +2,15 @@
  * @prettier
  */
 import { BitGoBase } from '@bitgo/sdk-core';
-import * as utxolib from '@bitgo/utxo-lib';
 
-import { AbstractUtxoCoin, UtxoNetwork } from '../../abstractUtxoCoin';
+import { AbstractUtxoCoin } from '../../abstractUtxoCoin';
+import { UtxoCoinName } from '../../names';
 
 export class Zec extends AbstractUtxoCoin {
-  constructor(bitgo: BitGoBase, network?: UtxoNetwork) {
-    super(bitgo, network || utxolib.networks.zcash);
+  readonly name: UtxoCoinName = 'zec';
+
+  constructor(bitgo: BitGoBase) {
+    super(bitgo);
   }
 
   static createInstance(bitgo: BitGoBase): Zec {

--- a/modules/abstract-utxo/src/names.ts
+++ b/modules/abstract-utxo/src/names.ts
@@ -55,6 +55,7 @@ function getNetworkName(n: utxolib.Network): utxolib.NetworkName {
 }
 
 /**
+ * @deprecated - will be removed when we drop support for utxolib
  * @param n
  * @returns the family name for a network. Testnets and mainnets of the same coin share the same family name.
  */
@@ -146,60 +147,49 @@ export function getNetworkFromCoinName(coinName: string): utxolib.Network {
 /** @deprecated - use getNetworkFromCoinName instead */
 export const getNetworkFromChain = getNetworkFromCoinName;
 
-export function getFullNameFromNetwork(n: utxolib.Network): string {
-  const name = getNetworkName(n);
+function getBaseNameFromMainnet(coinName: UtxoCoinNameMainnet): string {
+  switch (coinName) {
+    case 'btc':
+      return 'Bitcoin';
+    case 'bch':
+      return 'Bitcoin Cash';
+    case 'bcha':
+      return 'Bitcoin ABC';
+    case 'btg':
+      return 'Bitcoin Gold';
+    case 'bsv':
+      return 'Bitcoin SV';
+    case 'dash':
+      return 'Dash';
+    case 'doge':
+      return 'Dogecoin';
+    case 'ltc':
+      return 'Litecoin';
+    case 'zec':
+      return 'ZCash';
+  }
+}
 
+export function getFullNameFromCoinName(coinName: UtxoCoinName): string {
   let prefix: string;
-  switch (name) {
-    case 'bitcoinTestnet4':
+  switch (coinName) {
+    case 'tbtc4':
       prefix = 'Testnet4 ';
       break;
-    case 'bitcoinPublicSignet':
+    case 'tbtcsig':
       prefix = 'Public Signet ';
       break;
-    case 'bitcoinBitGoSignet':
+    case 'tbtcbgsig':
       prefix = 'BitGo Signet ';
       break;
     default:
-      if (utxolib.isTestnet(n)) {
-        prefix = 'Testnet ';
-      } else {
-        prefix = '';
-      }
+      prefix = isUtxoCoinNameTestnet(coinName) ? 'Testnet ' : '';
   }
 
-  switch (name) {
-    case 'bitcoin':
-    case 'testnet':
-    case 'bitcoinTestnet4':
-    case 'bitcoinPublicSignet':
-    case 'bitcoinBitGoSignet':
-      return prefix + 'Bitcoin';
-    case 'bitcoincash':
-    case 'bitcoincashTestnet':
-      return prefix + 'Bitcoin Cash';
-    case 'ecash':
-    case 'ecashTest':
-      return prefix + 'Bitcoin ABC';
-    case 'bitcoingold':
-    case 'bitcoingoldTestnet':
-      return prefix + 'Bitcoin Gold';
-    case 'bitcoinsv':
-    case 'bitcoinsvTestnet':
-      return prefix + 'Bitcoin SV';
-    case 'dash':
-    case 'dashTest':
-      return prefix + 'Dash';
-    case 'dogecoin':
-    case 'dogecoinTest':
-      return prefix + 'Dogecoin';
-    case 'litecoin':
-    case 'litecoinTest':
-      return prefix + 'Litecoin';
-    case 'zcash':
-    case 'zcashTest':
-      return prefix + 'ZCash';
-    default:
-      throw new Error('Unknown network');
-  }
+  return prefix + getBaseNameFromMainnet(getMainnetCoinName(coinName));
+}
+
+/** @deprecated - use getFullNameFromCoinName instead */
+export function getFullNameFromNetwork(n: utxolib.Network): string {
+  return getFullNameFromCoinName(getCoinName(n));
 }

--- a/modules/abstract-utxo/src/names.ts
+++ b/modules/abstract-utxo/src/names.ts
@@ -1,21 +1,9 @@
 import * as utxolib from '@bitgo/utxo-lib';
 
 export const utxoCoinsMainnet = ['btc', 'bch', 'bcha', 'bsv', 'btg', 'dash', 'doge', 'ltc', 'zec'] as const;
-export const utxoCoinsTestnet = [
-  'tbtc',
-  'tbch',
-  'tbsv',
-  'tdash',
-  'tdoge',
-  'tltc',
-  'tzec',
-  'tbtcsig',
-  'tbtc4',
-  'tbtcbgsig',
-] as const;
 
 export type UtxoCoinNameMainnet = (typeof utxoCoinsMainnet)[number];
-export type UtxoCoinNameTestnet = (typeof utxoCoinsTestnet)[number];
+export type UtxoCoinNameTestnet = `t${UtxoCoinNameMainnet}` | 'tbtcsig' | 'tbtc4' | 'tbtcbgsig';
 export type UtxoCoinName = UtxoCoinNameMainnet | UtxoCoinNameTestnet;
 
 export function isUtxoCoinNameMainnet(coinName: string): coinName is UtxoCoinNameMainnet {
@@ -23,7 +11,7 @@ export function isUtxoCoinNameMainnet(coinName: string): coinName is UtxoCoinNam
 }
 
 export function isUtxoCoinNameTestnet(coinName: string): coinName is UtxoCoinNameTestnet {
-  return utxoCoinsTestnet.includes(coinName as UtxoCoinNameTestnet);
+  return isUtxoCoinNameMainnet(coinName.slice(1)) && coinName.startsWith('t');
 }
 
 export function isUtxoCoinName(coinName: string): coinName is UtxoCoinName {

--- a/modules/abstract-utxo/src/names.ts
+++ b/modules/abstract-utxo/src/names.ts
@@ -66,10 +66,11 @@ export function getFamilyFromNetwork(n: utxolib.Network): UtxoCoinNameMainnet {
 }
 
 /**
+ * @deprecated - will be removed when we drop support for utxolib
  * Get the chain name for a network.
  * The chain is different for every network.
  */
-export function getChainFromNetwork(n: utxolib.Network): string {
+export function getCoinName(n: utxolib.Network): UtxoCoinName {
   switch (getNetworkName(n)) {
     case 'bitcoinPublicSignet':
       return 'tbtcsig';
@@ -101,17 +102,21 @@ export function getChainFromNetwork(n: utxolib.Network): string {
 }
 
 /**
+ * @deprecated - will be removed when we drop support for utxolib
  * @param coinName - the name of the coin (e.g. 'btc', 'bch', 'ltc'). Also called 'chain' in some contexts.
  * @returns the network for a coin. This is the mainnet network for the coin.
  */
-export function getNetworkFromChain(coinName: string): utxolib.Network {
+export function getNetworkFromCoinName(coinName: string): utxolib.Network {
   for (const network of utxolib.getNetworkList()) {
-    if (getChainFromNetwork(network) === coinName) {
+    if (getCoinName(network) === coinName) {
       return network;
     }
   }
-  throw new Error(`Unknown chain ${coinName}`);
+  throw new Error(`Unknown coin name ${coinName}`);
 }
+
+/** @deprecated - use getNetworkFromCoinName instead */
+export const getNetworkFromChain = getNetworkFromCoinName;
 
 export function getFullNameFromNetwork(n: utxolib.Network): string {
   const name = getNetworkName(n);

--- a/modules/abstract-utxo/src/names.ts
+++ b/modules/abstract-utxo/src/names.ts
@@ -1,6 +1,20 @@
 import * as utxolib from '@bitgo/utxo-lib';
 
 export const utxoCoinsMainnet = ['btc', 'bch', 'bcha', 'bsv', 'btg', 'dash', 'doge', 'ltc', 'zec'] as const;
+export const utxoCoinsTestnet = [
+  'tbtc',
+  'tbtc4',
+  'tbtcsig',
+  'tbtcbgsig',
+  'tbch',
+  'tbcha',
+  'tbsv',
+  'tbtg',
+  'tdash',
+  'tdoge',
+  'tltc',
+  'tzec',
+] as const;
 
 export type UtxoCoinNameMainnet = (typeof utxoCoinsMainnet)[number];
 export type UtxoCoinNameTestnet = `t${UtxoCoinNameMainnet}` | 'tbtcsig' | 'tbtc4' | 'tbtcbgsig';
@@ -11,11 +25,25 @@ export function isUtxoCoinNameMainnet(coinName: string): coinName is UtxoCoinNam
 }
 
 export function isUtxoCoinNameTestnet(coinName: string): coinName is UtxoCoinNameTestnet {
-  return isUtxoCoinNameMainnet(coinName.slice(1)) && coinName.startsWith('t');
+  return utxoCoinsTestnet.includes(coinName as UtxoCoinNameTestnet);
 }
 
 export function isUtxoCoinName(coinName: string): coinName is UtxoCoinName {
   return isUtxoCoinNameMainnet(coinName) || isUtxoCoinNameTestnet(coinName);
+}
+
+export function getMainnetCoinName(coinName: UtxoCoinName): UtxoCoinNameMainnet {
+  if (isUtxoCoinNameMainnet(coinName)) {
+    return coinName;
+  }
+  switch (coinName) {
+    case 'tbtc4':
+    case 'tbtcsig':
+    case 'tbtcbgsig':
+      return 'btc';
+    default:
+      return coinName.slice(1) as UtxoCoinNameMainnet;
+  }
 }
 
 function getNetworkName(n: utxolib.Network): utxolib.NetworkName {

--- a/modules/abstract-utxo/src/wallet.ts
+++ b/modules/abstract-utxo/src/wallet.ts
@@ -13,7 +13,7 @@ export interface UtxoWalletData extends WalletData {
 }
 
 export function isUtxoWalletData(obj: WalletData): obj is UtxoWalletData {
-  return isUtxoCoinName(obj.coin);
+  return typeof obj.coin === 'string' && isUtxoCoinName(obj.coin);
 }
 
 export interface UtxoWallet extends Wallet {

--- a/modules/abstract-utxo/test/unit/coins.ts
+++ b/modules/abstract-utxo/test/unit/coins.ts
@@ -2,6 +2,8 @@ import * as assert from 'assert';
 
 import * as utxolib from '@bitgo/utxo-lib';
 
+import { getMainnetCoinName, utxoCoinsMainnet, utxoCoinsTestnet } from '../../src/names';
+
 import { getUtxoCoinForNetwork, utxoCoins } from './util';
 
 describe('utxoCoins', function () {
@@ -67,5 +69,24 @@ describe('utxoCoins', function () {
         ['zcashTest', 'tzec'],
       ]
     );
+  });
+
+  it('getMainnetCoinName returns correct mainnet coin name', function () {
+    // Mainnet coins return themselves
+    for (const coin of utxoCoinsMainnet) {
+      assert.strictEqual(getMainnetCoinName(coin), coin);
+    }
+
+    // Testnet coins return their mainnet counterpart
+    for (const coin of utxoCoinsTestnet) {
+      const mainnet = getMainnetCoinName(coin);
+      assert.ok(utxoCoinsMainnet.includes(mainnet), `${coin} -> ${mainnet} should be a mainnet coin`);
+    }
+
+    // Verify specific mappings for special Bitcoin testnet variants
+    assert.strictEqual(getMainnetCoinName('tbtc'), 'btc');
+    assert.strictEqual(getMainnetCoinName('tbtc4'), 'btc');
+    assert.strictEqual(getMainnetCoinName('tbtcsig'), 'btc');
+    assert.strictEqual(getMainnetCoinName('tbtcbgsig'), 'btc');
   });
 });

--- a/modules/abstract-utxo/test/unit/transaction/fixedScript/parsePsbt.ts
+++ b/modules/abstract-utxo/test/unit/transaction/fixedScript/parsePsbt.ts
@@ -14,7 +14,7 @@ import type {
   TransactionExplanation,
   ChangeAddressInfo,
 } from '../../../../src/transaction/fixedScript/explainTransaction';
-import { getChainFromNetwork } from '../../../../src/names';
+import { getCoinName } from '../../../../src/names';
 import { TransactionPrebuild } from '../../../../src/abstractUtxoCoin';
 
 import { hasWasmUtxoSupport } from './util';
@@ -110,7 +110,7 @@ function describeParseTransactionWith(
     let stubExplainTransaction: sinon.SinonStub;
 
     before('prepare', async function () {
-      const coinName = getChainFromNetwork(acidTest.network);
+      const coinName = getCoinName(acidTest.network);
       coin = getUtxoCoin(coinName);
 
       // Create PSBT and explanation


### PR DESCRIPTION

This PR refactors how coin names are handled in the abstract-utxo module, 
significantly improving type safety and simplifying the codebase.

Key changes:
- Define coin name directly in coin class instead of deriving from network
- Use type unions with template literals for testnet coin names
- Add explicit testnet coin array and mapping functions to mainnet variants
- Replace network-based helper functions with direct coin name operations
- Improve type checking in wallet data validation
- Add proper return type annotations for better IDE support

This is part of the effort to get rid of utxolib

BTC-2909