### PR TITLE
feat(dependencies): upgrade wasm-utxo and enhance upgrade script

### DIFF
--- a/modules/abstract-utxo/package.json
+++ b/modules/abstract-utxo/package.json
@@ -68,7 +68,7 @@
     "@bitgo/utxo-core": "^1.28.0",
     "@bitgo/utxo-lib": "^11.19.0",
     "@bitgo/utxo-ord": "^1.22.20",
-    "@bitgo/wasm-utxo": "1.19.0",
+    "@bitgo/wasm-utxo": "^1.20.0",
     "@types/lodash": "^4.14.121",
     "@types/superagent": "4.1.15",
     "bignumber.js": "^9.0.2",

--- a/modules/utxo-bin/package.json
+++ b/modules/utxo-bin/package.json
@@ -31,7 +31,7 @@
     "@bitgo/unspents": "^0.50.13",
     "@bitgo/utxo-core": "^1.28.0",
     "@bitgo/utxo-lib": "^11.19.0",
-    "@bitgo/wasm-utxo": "1.19.0",
+    "@bitgo/wasm-utxo": "^1.20.0",
     "@noble/curves": "1.8.1",
     "archy": "^1.0.0",
     "bech32": "^2.0.0",

--- a/modules/utxo-core/package.json
+++ b/modules/utxo-core/package.json
@@ -81,7 +81,7 @@
     "@bitgo/secp256k1": "^1.8.0",
     "@bitgo/unspents": "^0.50.13",
     "@bitgo/utxo-lib": "^11.19.0",
-    "@bitgo/wasm-utxo": "1.19.0",
+    "@bitgo/wasm-utxo": "^1.20.0",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
     "bitcoinjs-message": "npm:@bitgo-forks/bitcoinjs-message@1.0.0-master.3",
     "fast-sha256": "^1.3.0"

--- a/modules/utxo-staking/package.json
+++ b/modules/utxo-staking/package.json
@@ -63,7 +63,7 @@
     "@bitgo/babylonlabs-io-btc-staking-ts": "^3.3.0",
     "@bitgo/utxo-core": "^1.28.0",
     "@bitgo/utxo-lib": "^11.19.0",
-    "@bitgo/wasm-utxo": "1.19.0",
+    "@bitgo/wasm-utxo": "^1.20.0",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
     "bip322-js": "^2.0.0",
     "bitcoinjs-lib": "^6.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -985,10 +985,10 @@
     monocle-ts "^2.3.13"
     newtype-ts "^0.3.5"
 
-"@bitgo/wasm-utxo@1.19.0":
-  version "1.19.0"
-  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-1.19.0.tgz#c44db54da8bfa748f3a7a24f769519ff56783236"
-  integrity sha512-M6NtRfJrWoJP68IF1bm2eNMzUdIGnIQjIDwcIMXaqJCuWXPQot8KbKHVJPe3EpdB9g4a/J5hd6JIhZRF8m7Dhw==
+"@bitgo/wasm-utxo@^1.20.0":
+  version "1.20.0"
+  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-1.20.0.tgz#c1051995da5f5218a7fd5f946d2f7f7b6bb3d00c"
+  integrity sha512-r9YzGu+zb0jHO+fttvG62goiNFZlUfj6sF6Cx/+ZjGK2g54heD3F64TQNj9klxJY8l6q7p4ka/v4CyIj5MEFQA==
 
 "@brandonblack/musig@^0.0.1-alpha.0":
   version "0.0.1-alpha.1"


### PR DESCRIPTION

This PR includes two related dependency management improvements:

1. Enhances the dependency upgrade script to allow configurable version
   prefixes (e.g., ^, ~, etc.) when adding version constraints, with
   caret (^) as the default prefix when fetching latest versions from
   the npm registry.

2. Updates the wasm-utxo dependency to v1.20.0 across all UTXO modules,
   using the caret version range for future compatibility.

Issue: BTC-0