### PR TITLE
build(abstract-utxo): bump wasm-utxo to 1.22.0

### DIFF
--- a/modules/abstract-utxo/package.json
+++ b/modules/abstract-utxo/package.json
@@ -68,7 +68,7 @@
     "@bitgo/utxo-core": "^1.28.0",
     "@bitgo/utxo-lib": "^11.19.0",
     "@bitgo/utxo-ord": "^1.22.20",
-    "@bitgo/wasm-utxo": "^1.20.0",
+    "@bitgo/wasm-utxo": "^1.22.0",
     "@types/lodash": "^4.14.121",
     "@types/superagent": "4.1.15",
     "bignumber.js": "^9.0.2",

--- a/modules/utxo-bin/package.json
+++ b/modules/utxo-bin/package.json
@@ -31,7 +31,7 @@
     "@bitgo/unspents": "^0.50.13",
     "@bitgo/utxo-core": "^1.28.0",
     "@bitgo/utxo-lib": "^11.19.0",
-    "@bitgo/wasm-utxo": "^1.20.0",
+    "@bitgo/wasm-utxo": "^1.22.0",
     "@noble/curves": "1.8.1",
     "archy": "^1.0.0",
     "bech32": "^2.0.0",

--- a/modules/utxo-core/package.json
+++ b/modules/utxo-core/package.json
@@ -81,7 +81,7 @@
     "@bitgo/secp256k1": "^1.8.0",
     "@bitgo/unspents": "^0.50.13",
     "@bitgo/utxo-lib": "^11.19.0",
-    "@bitgo/wasm-utxo": "^1.20.0",
+    "@bitgo/wasm-utxo": "^1.22.0",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
     "fast-sha256": "^1.3.0"
   },

--- a/modules/utxo-staking/package.json
+++ b/modules/utxo-staking/package.json
@@ -63,7 +63,7 @@
     "@bitgo/babylonlabs-io-btc-staking-ts": "^3.3.0",
     "@bitgo/utxo-core": "^1.28.0",
     "@bitgo/utxo-lib": "^11.19.0",
-    "@bitgo/wasm-utxo": "^1.20.0",
+    "@bitgo/wasm-utxo": "^1.22.0",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
     "bip322-js": "^2.0.0",
     "bitcoinjs-lib": "^6.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -996,10 +996,10 @@
     monocle-ts "^2.3.13"
     newtype-ts "^0.3.5"
 
-"@bitgo/wasm-utxo@^1.20.0":
-  version "1.20.0"
-  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-1.20.0.tgz#c1051995da5f5218a7fd5f946d2f7f7b6bb3d00c"
-  integrity sha512-r9YzGu+zb0jHO+fttvG62goiNFZlUfj6sF6Cx/+ZjGK2g54heD3F64TQNj9klxJY8l6q7p4ka/v4CyIj5MEFQA==
+"@bitgo/wasm-utxo@^1.22.0":
+  version "1.22.0"
+  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-1.22.0.tgz#106cb3ddcdaf39753a513aca5c8e0508faba5dc7"
+  integrity sha512-/2jPyJvb3OwoFJ4fYI8V28zQVwj5ma6y17mByDFtMz7td0SraycPqYP6Y0B+YcVlqTMlZ0SYoEGKXBqeBqPy6w==
 
 "@brandonblack/musig@^0.0.1-alpha.0":
   version "0.0.1-alpha.1"


### PR DESCRIPTION

Update @bitgo/wasm-utxo dependency from 1.20.0 to 1.22.0 across multiple
modules to support BIP322 message signing implementation.

BTC-2916