### PR TITLE
feat(abstract-utxo): enable wasm-utxo tests for zcash

### DIFF
--- a/modules/abstract-utxo/test/unit/transaction.ts
+++ b/modules/abstract-utxo/test/unit/transaction.ts
@@ -16,7 +16,6 @@ import {
 import { AbstractUtxoCoin, getReplayProtectionAddresses, generateAddress, getReplayProtectionPubkeys } from '../../src';
 import { SdkBackend } from '../../src/transaction/types';
 
-import { hasWasmUtxoSupport } from './transaction/fixedScript/util';
 import {
   utxoCoins,
   shouldEqualJSON,
@@ -658,7 +657,7 @@ function runTestForCoin(coin: AbstractUtxoCoin) {
         run(coin, ['p2shP2pk', type], txFormat);
       }
 
-      if (txFormat === 'psbt' && hasWasmUtxoSupport(coin.network)) {
+      if (txFormat === 'psbt') {
         run(coin, [type, type], txFormat, { decodeWith: 'wasm-utxo' });
         if (getReplayProtectionAddresses(coin.network).length) {
           run(coin, ['p2shP2pk', type], txFormat, { decodeWith: 'wasm-utxo' });

--- a/modules/abstract-utxo/test/unit/transaction/fixedScript/explainPsbt.ts
+++ b/modules/abstract-utxo/test/unit/transaction/fixedScript/explainPsbt.ts
@@ -7,8 +7,6 @@ import { fixedScriptWallet, Triple } from '@bitgo/wasm-utxo';
 import type { TransactionExplanation } from '../../../../src/transaction/fixedScript/explainTransaction';
 import { explainPsbt, explainPsbtWasm } from '../../../../src/transaction/fixedScript';
 
-import { hasWasmUtxoSupport } from './util';
-
 function describeTransactionWith(acidTest: testutil.AcidTest) {
   describe(`${acidTest.name}`, function () {
     let psbt: utxolib.bitgo.UtxoPsbt;
@@ -27,9 +25,7 @@ function describeTransactionWith(acidTest: testutil.AcidTest) {
       assert(networkName);
       walletXpubs = acidTest.rootWalletKeys.triple.map((k) => k.neutered().toBase58()) as Triple<string>;
       customChangeWalletXpubs = acidTest.otherWalletKeys.triple.map((k) => k.neutered().toBase58()) as Triple<string>;
-      if (hasWasmUtxoSupport(acidTest.network)) {
-        wasmPsbt = fixedScriptWallet.BitGoPsbt.fromBytes(psbtBytes, networkName);
-      }
+      wasmPsbt = fixedScriptWallet.BitGoPsbt.fromBytes(psbtBytes, networkName);
     });
 
     it('should match the expected values for explainPsbt', function () {
@@ -59,10 +55,6 @@ function describeTransactionWith(acidTest: testutil.AcidTest) {
     });
 
     it('should match explainPsbtWasm', function () {
-      if (!hasWasmUtxoSupport(acidTest.network)) {
-        return this.skip();
-      }
-
       const wasmExplanation = explainPsbtWasm(wasmPsbt, walletXpubs, {
         replayProtection: {
           publicKeys: [acidTest.getReplayProtectionPublicKey()],

--- a/modules/abstract-utxo/test/unit/transaction/fixedScript/parsePsbt.ts
+++ b/modules/abstract-utxo/test/unit/transaction/fixedScript/parsePsbt.ts
@@ -17,8 +17,6 @@ import type {
 import { getCoinName } from '../../../../src/names';
 import { TransactionPrebuild } from '../../../../src/abstractUtxoCoin';
 
-import { hasWasmUtxoSupport } from './util';
-
 function getTxParamsFromExplanation(
   explanation: TransactionExplanation,
   { externalCustomChangeAddress }: { externalCustomChangeAddress: boolean }
@@ -316,4 +314,4 @@ function describeTransaction(
 }
 
 describeTransaction('utxolib');
-describeTransaction('wasm', (test) => hasWasmUtxoSupport(test.network));
+describeTransaction('wasm');

--- a/modules/abstract-utxo/test/unit/transaction/fixedScript/signPsbt.ts
+++ b/modules/abstract-utxo/test/unit/transaction/fixedScript/signPsbt.ts
@@ -12,8 +12,6 @@ import {
 } from '../../../../src/transaction/fixedScript/signPsbtWasm';
 import { SdkBackend } from '../../../../src/transaction/types';
 
-import { hasWasmUtxoSupport } from './util';
-
 function getMockCoinUtxolib(keys: utxolib.bitgo.RootWalletKeys): Musig2Participant<utxolib.bitgo.UtxoPsbt> {
   return {
     async getMusig2Nonces(psbt: utxolib.bitgo.UtxoPsbt, walletId: string): Promise<utxolib.bitgo.UtxoPsbt> {
@@ -153,8 +151,6 @@ describe('signPsbtWithMusig2ParticipantUtxolib', function () {
     .filter((test) => test.signStage === 'unsigned')
     .forEach((test) => {
       describeSignPsbtWithMusig2Participant(test, { decodeWith: 'utxolib' });
-      if (hasWasmUtxoSupport(test.network)) {
-        describeSignPsbtWithMusig2Participant(test, { decodeWith: 'wasm-utxo' });
-      }
+      describeSignPsbtWithMusig2Participant(test, { decodeWith: 'wasm-utxo' });
     });
 });

--- a/modules/abstract-utxo/test/unit/transaction/fixedScript/util.ts
+++ b/modules/abstract-utxo/test/unit/transaction/fixedScript/util.ts
@@ -1,5 +1,0 @@
-import * as utxolib from '@bitgo/utxo-lib';
-
-export function hasWasmUtxoSupport(network: utxolib.Network): boolean {
-  return utxolib.getMainnet(network) !== utxolib.networks.zcash;
-}


### PR DESCRIPTION

Remove hasWasmUtxoSupport utility function and enable all wasm-utxo tests
for zcash transactions. This allows testing the PSBT format with wasm-utxo
for all coins, including zcash.

Issue: BTC-0