### PR TITLE
feat(statics): onboard 11 new ungated tokens with OFC equivalents

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -3109,6 +3109,24 @@ export const allCoinsAndTokens = [
     UnderlyingAsset['baseeth:mext'],
     Networks.main.basechain
   ),
+  erc20Token(
+    '7609fc1a-c35c-4179-97fb-18c69bd3b6d3',
+    'baseeth:b3',
+    'B3',
+    18,
+    '0xb3b32f9f8827d4634fe7d973fa1034ec9fddb3b3',
+    UnderlyingAsset['baseeth:b3'],
+    Networks.main.basechain
+  ),
+  erc20Token(
+    '832db50b-6e27-4570-8455-048ead291bb0',
+    'baseeth:kaito',
+    'Kaito',
+    18,
+    '0x98d0baa52b2d063e780de12f615f963fe8537553',
+    UnderlyingAsset['baseeth:kaito'],
+    Networks.main.basechain
+  ),
 
   // XDC mainnet tokens
   xdcErc20(
@@ -4888,6 +4906,14 @@ export const allCoinsAndTokens = [
     '0x1a6b3a62391eccaaa992ade44cd4afe6bec8cff1',
     UnderlyingAsset['arbeth:uxlink']
   ),
+  arbethErc20(
+    'eb6d0a38-5497-4943-a38c-92e887b68da3',
+    'arbeth:next',
+    'Everclear',
+    18,
+    '0x58b9cb810a68a7f3e1e4f8cb45d1b9b3c79705e8',
+    UnderlyingAsset['arbeth:next']
+  ),
 
   opethErc20(
     '8d80fac6-4cbc-447c-b49b-4229cb8aa89d',
@@ -5656,6 +5682,18 @@ export const allCoinsAndTokens = [
     '0x1a8f4bc33f8ef7fbc851f156857aa65d397a6a6fd27a7ac2ca717b51f2fd9489::alkimi::ALKIMI',
     UnderlyingAsset['sui:alkimi'],
     SUI_TOKEN_FEATURES_EXCLUDE_SINGAPORE
+  ),
+  suiToken(
+    'fa2635bb-de30-41d9-8be6-c336f5bed88b',
+    'sui:dmc',
+    'DeLorean',
+    9,
+    '0x4c981f3ff786cdb9e514da897ab8a953647dae2ace9679e8358eec1e3e8871ac',
+    'dmc',
+    'DMC',
+    '0x4c981f3ff786cdb9e514da897ab8a953647dae2ace9679e8358eec1e3e8871ac::dmc::DMC',
+    UnderlyingAsset['sui:dmc'],
+    SUI_TOKEN_FEATURES
   ),
   tsuiToken(
     '0b8a7919-c37e-4be8-8338-7fc13c6c875e',

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -2371,6 +2371,10 @@ export enum UnderlyingAsset {
   'eth:turtle' = 'eth:turtle',
   'eth:order' = 'eth:order',
   'eth:puffer' = 'eth:puffer',
+  'eth:resolv' = 'eth:resolv',
+  'eth:spec' = 'eth:spec',
+  'eth:prompt' = 'eth:prompt',
+  'eth:yb' = 'eth:yb',
 
   'xlm:BST-GADDFE4R72YUP2AOEL67OHZN3GJQYPC3VE734N2XFMEGRR2L32CZ3XYZ' = 'xlm:BST-GADDFE4R72YUP2AOEL67OHZN3GJQYPC3VE734N2XFMEGRR2L32CZ3XYZ',
   'xlm:VELO-GDM4RQUQQUVSKQA7S6EM7XBZP3FCGH4Q7CL6TABQ7B2BEJ5ERARM2M5M' = 'xlm:VELO-GDM4RQUQQUVSKQA7S6EM7XBZP3FCGH4Q7CL6TABQ7B2BEJ5ERARM2M5M',
@@ -2821,6 +2825,7 @@ export enum UnderlyingAsset {
   'bsc:home' = 'bsc:home',
   'bsc:zbt' = 'bsc:zbt',
   'bsc:iost' = 'bsc:iost',
+  'bsc:sto' = 'bsc:sto',
 
   // BSC NFTs
   // generic NFTs
@@ -2904,6 +2909,7 @@ export enum UnderlyingAsset {
   'arbeth:pendle' = 'arbeth:pendle',
   'arbeth:gmx' = 'arbeth:gmx',
   'arbeth:uxlink' = 'arbeth:uxlink',
+  'arbeth:next' = 'arbeth:next',
 
   // BaseETH mainnet tokens
   'baseeth:aero' = 'baseeth:aero',
@@ -2936,6 +2942,8 @@ export enum UnderlyingAsset {
   'baseeth:argt' = 'baseeth:argt',
   'baseeth:brat' = 'baseeth:brat',
   'baseeth:mext' = 'baseeth:mext',
+  'baseeth:b3' = 'baseeth:b3',
+  'baseeth:kaito' = 'baseeth:kaito',
 
   // BaseETH testnet tokens
   'tbaseeth:usdc' = 'tbaseeth:usdc',
@@ -3291,6 +3299,8 @@ export enum UnderlyingAsset {
   'sol:home' = 'sol:home',
   'sol:oob' = 'sol:oob',
   'sol:xnet' = 'sol:xnet',
+  'sol:prcl' = 'sol:prcl',
+  'sol:asp' = 'sol:asp',
 
   'tsol:txsgd' = 'sol:txsgd',
   'tsol:txusd' = 'sol:txusd',
@@ -3347,6 +3357,7 @@ export enum UnderlyingAsset {
   'sui:xmn' = 'sui:xmn',
   'sui:xaum' = 'sui:xaum',
   'sui:alkimi' = 'sui:alkimi',
+  'sui:dmc' = 'sui:dmc',
 
   // Sui testnet tokens
   'tsui:deep' = 'tsui:deep',

--- a/modules/statics/src/coins/bscTokens.ts
+++ b/modules/statics/src/coins/bscTokens.ts
@@ -1507,4 +1507,13 @@ export const bscTokens = [
     UnderlyingAsset['bsc:iost'],
     BSC_TOKEN_FEATURES
   ),
+  bscToken(
+    '0b4a8583-8447-4099-ba49-1270d5f73346',
+    'bsc:sto',
+    'StakeStone',
+    18,
+    '0xdaf1695c41327b61b9b9965ac6a5843a3198cf07',
+    UnderlyingAsset['bsc:sto'],
+    BSC_TOKEN_FEATURES
+  ),
 ];

--- a/modules/statics/src/coins/erc20Coins.ts
+++ b/modules/statics/src/coins/erc20Coins.ts
@@ -14219,4 +14219,36 @@ export const erc20Coins = [
     '0x4d1c297d39c5c1277964d0e3f8aa901493664530',
     UnderlyingAsset['eth:puffer']
   ),
+  erc20(
+    'ad3c4a14-1a13-4c27-bdbf-214de70e25b8',
+    'eth:resolv',
+    'Resolv',
+    18,
+    '0x259338656198ec7a76c729514d3cb45dfbf768a1',
+    UnderlyingAsset['eth:resolv']
+  ),
+  erc20(
+    '05dc3d4e-8359-413f-b244-2c9fe5ecbf97',
+    'eth:spec',
+    'Spectral',
+    18,
+    '0xadf7c35560035944e805d98ff17d58cde2449389',
+    UnderlyingAsset['eth:spec']
+  ),
+  erc20(
+    'b68c736d-b8c8-4abc-8ef9-7720d0409045',
+    'eth:prompt',
+    'Wayfinder',
+    18,
+    '0x28d38df637db75533bd3f71426f3410a82041544',
+    UnderlyingAsset['eth:prompt']
+  ),
+  erc20(
+    'd54b246d-891c-4aa3-a041-c191d2e7b088',
+    'eth:yb',
+    'YieldBasis',
+    18,
+    '0x01791f726b4103694969820be083196cc7c045ff',
+    UnderlyingAsset['eth:yb']
+  ),
 ];

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -3809,4 +3809,19 @@ export const ofcCoins = [
   ),
   ofc('d45636f8-f120-4374-b717-70fe999baa43', 'ofcarc', 'Arc', 18, UnderlyingAsset.ARC, CoinKind.CRYPTO),
   tofc('bc57e64d-045e-4421-aa92-64db0c51e1d7', 'ofctarc', 'Arc Testnet', 18, UnderlyingAsset.ARC, CoinKind.CRYPTO),
+  // New BSC OFC token
+  ofcBscToken('b4200c85-f550-44d6-a6cb-a590f19773b0', 'ofcbsc:sto', 'StakeStone', 18, UnderlyingAsset['bsc:sto']),
+  // New Arbitrum OFC token
+  ofcArbethErc20(
+    'd58490c0-07d2-4642-8af7-efa2453392e9',
+    'ofcarbeth:next',
+    'Everclear',
+    18,
+    UnderlyingAsset['arbeth:next']
+  ),
+  // New SOL OFC tokens
+  ofcsolToken('0ce490e5-fba4-4f50-b059-598c151482f0', 'ofcsol:prcl', 'Parcl', 6, UnderlyingAsset['sol:prcl']),
+  ofcsolToken('ddba6928-8700-4435-8970-0e75acae7025', 'ofcsol:asp', 'Aspecta', 9, UnderlyingAsset['sol:asp']),
+  // New SUI OFC token
+  ofcSuiToken('1e01eb3d-2573-4662-aa5e-4c390e4a9b38', 'ofcsui:dmc', 'DeLorean', 9, UnderlyingAsset['sui:dmc']),
 ];

--- a/modules/statics/src/coins/ofcErc20Coins.ts
+++ b/modules/statics/src/coins/ofcErc20Coins.ts
@@ -3645,6 +3645,40 @@ export const ofcErc20Coins = [
     6,
     underlyingAssetForSymbol('mantle:ausd')
   ),
+  // New ETH OFC tokens
+  ofcerc20('a5357ba2-5a2a-4d73-8f65-e01b9158ea9c', 'ofceth:resolv', 'Resolv', 18, UnderlyingAsset['eth:resolv']),
+  ofcerc20('5485e380-c3df-49ab-98f2-9c4d3f37f2fb', 'ofceth:spec', 'Spectral', 18, UnderlyingAsset['eth:spec']),
+  ofcerc20('8e52ca73-1860-43e5-98d6-49c5f34b8da2', 'ofceth:prompt', 'Wayfinder', 18, UnderlyingAsset['eth:prompt']),
+  ofcerc20('0edacb3a-b48a-4a6e-ae28-69f8b7a84bfa', 'ofceth:yb', 'YieldBasis', 18, UnderlyingAsset['eth:yb']),
+  // New Base OFC tokens
+  ofcerc20(
+    'b096690d-92fd-4f02-83d6-e26a1ff393f3',
+    'ofcbaseeth:b3',
+    'B3',
+    18,
+    UnderlyingAsset['baseeth:b3'],
+    undefined,
+    undefined,
+    '',
+    undefined,
+    undefined,
+    true,
+    'baseeth'
+  ),
+  ofcerc20(
+    '24f6d6b1-524b-4945-8a36-15f60c3bad75',
+    'ofcbaseeth:kaito',
+    'Kaito',
+    18,
+    UnderlyingAsset['baseeth:kaito'],
+    undefined,
+    undefined,
+    '',
+    undefined,
+    undefined,
+    true,
+    'baseeth'
+  ),
 ];
 
 export const tOfcErc20Coins = [

--- a/modules/statics/src/coins/solTokens.ts
+++ b/modules/statics/src/coins/solTokens.ts
@@ -3553,4 +3553,24 @@ export const solTokens = [
     UnderlyingAsset['tsol:txusd'],
     SOL_TOKEN_FEATURES
   ),
+  solToken(
+    'bbbd68ee-57c6-4d48-a8a9-e49a6b8946fd',
+    'sol:prcl',
+    'Parcl',
+    6,
+    '4LLbsb5ReP3yEtYzmXewyGjcir5uXtKFURtaEUVC2AHs',
+    '4LLbsb5ReP3yEtYzmXewyGjcir5uXtKFURtaEUVC2AHs',
+    UnderlyingAsset['sol:prcl'],
+    SOL_TOKEN_FEATURES
+  ),
+  solToken(
+    '08a43fa6-bb7e-4bc0-b76a-144d8bab0086',
+    'sol:asp',
+    'Aspecta',
+    9,
+    'DJ7vji2BU7RjNgktPAKN4L42CiXTFHEt4Eeeyr5FiTmy',
+    'DJ7vji2BU7RjNgktPAKN4L42CiXTFHEt4Eeeyr5FiTmy',
+    UnderlyingAsset['sol:asp'],
+    SOL_TOKEN_FEATURES
+  ),
 ];


### PR DESCRIPTION
## Description

Onboard 11 new ungated tokens with their OFC equivalents across 6 chains (ETH, BSC, Arbitrum, Base, SOL, SUI).

### Tokens Added:
| Chain | Symbol | Full Name | Decimals |
|-------|--------|-----------|----------|
| ETH | `eth:resolv` | Resolv | 18 |
| ETH | `eth:spec` | Spectral | 18 |
| ETH | `eth:prompt` | Wayfinder | 18 |
| ETH | `eth:yb` | YieldBasis | 18 |
| BSC | `bsc:sto` | StakeStone | 18 |
| Arbitrum | `arbeth:next` | Everclear | 18 |
| Base | `baseeth:b3` | B3 | 18 |
| Base | `baseeth:kaito` | Kaito | 18 |
| SOL | `sol:prcl` | Parcl | 6 |
| SOL | `sol:asp` | Aspecta | 9 |
| SUI | `sui:dmc` | DeLorean | 9 |

### Changes:
- Added 11 UnderlyingAsset entries in `base.ts`
- Added token definitions in respective chain files (`erc20Coins.ts`, `bscTokens.ts`, `solTokens.ts`, `allCoinsAndTokens.ts`)
- Added 11 OFC equivalent tokens for go accounts (`ofcErc20Coins.ts`, `ofcCoins.ts`)

### Verification Done:
- Confirmed none of the tokens were already in the codebase
- All ETH contract addresses are lowercase
- SOL tokens checked on solscan.io (Token Program, not Token 2022)
- All tokens follow `<chain>:<symbol>` naming convention

## Issue Number

COIN-2681

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Verified all token symbols and contract addresses are unique in the codebase
- Confirmed no linting errors after changes
- All UUIDs are unique (no duplicates)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes