### PR TITLE
feat(utxo-ord): improve inscription reveal and postage handling

### DIFF
--- a/modules/utxo-ord/src/inscriptions.ts
+++ b/modules/utxo-ord/src/inscriptions.ts
@@ -21,6 +21,9 @@ import { PreparedInscriptionRevealData } from '@bitgo/sdk-core';
 
 const OPS = bscript.OPS;
 const MAX_LENGTH_TAP_DATA_PUSH = 520;
+// default "postage" amount
+// https://github.com/ordinals/ord/blob/0.24.2/src/lib.rs#L149
+const DEFAULT_POSTAGE_AMOUNT = BigInt(10_000);
 
 /**
  * The max size of an individual OP_PUSH in a Taproot script is 520 bytes. This
@@ -100,7 +103,7 @@ function getInscriptionRevealSize(
       },
     ],
   });
-  psbt.addOutput({ script: commitOutput, value: BigInt(10_000) });
+  psbt.addOutput({ script: commitOutput, value: DEFAULT_POSTAGE_AMOUNT });
 
   psbt.signTaprootInput(
     0,

--- a/modules/utxo-ord/test/inscription.ts
+++ b/modules/utxo-ord/test/inscription.ts
@@ -9,7 +9,7 @@ function createCommitTransactionPsbt(commitAddress: string, walletKeys: utxolib.
 
   commitTransactionPsbt.addOutput({
     script: commitTransactionOutputScript,
-    value: BigInt(42),
+    value: BigInt(10_000),
   });
 
   const walletUnspent = testutil.mockWalletUnspent(networks.testnet, BigInt(20_000), { keys: walletKeys });
@@ -64,7 +64,7 @@ describe('inscriptions', () => {
     });
   });
 
-  xdescribe('Inscription Reveal Data', () => {
+  describe('Inscription Reveal Data', () => {
     it('should sign reveal transaction and validate reveal size', () => {
       const walletKeys = testutil.getDefaultWalletKeys();
       const inscriptionData = Buffer.from('And Desert You', 'ascii');
@@ -76,11 +76,13 @@ describe('inscriptions', () => {
       );
 
       const commitTransactionPsbt = createCommitTransactionPsbt(address, walletKeys);
+      // Use the commit address (P2TR) as recipient to match the output script size
+      // used in getInscriptionRevealSize estimation
       const fullySignedRevealTransaction = inscriptions.signRevealTransaction(
         walletKeys.user.privateKey as Buffer,
         tapLeafScript,
         address,
-        '2N9R3mMCv6UfVbWEUW3eXJgxDeg4SCUVsu9',
+        address,
         commitTransactionPsbt.getUnsignedTx().toBuffer(),
         networks.testnet
       );
@@ -88,7 +90,6 @@ describe('inscriptions', () => {
       fullySignedRevealTransaction.finalizeTapInputWithSingleLeafScriptAndSignature(0);
       const actualVirtualSize = fullySignedRevealTransaction.extractTransaction(true).virtualSize();
 
-      // TODO(BG-70861): figure out why size is slightly different and re-enable test
       assert.strictEqual(revealTransactionVSize, actualVirtualSize);
     });
   });


### PR DESCRIPTION

This PR includes two changes to the utxo-ord module:

1. Fix the inscription reveal size test by using the same output address in 
   both estimation and actual transaction. Also increases commit value for 
   more realistic testing.

2. Add a default postage amount constant based on the ord reference 
   implementation, replacing hardcoded values for better readability and 
   maintainability.

BTC-2936