### PR TITLE
feat(abstract-utxo): remove deprecated API and make `network` private

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -392,7 +392,7 @@ export abstract class AbstractUtxoCoin
    * @deprecated - will be removed when we drop support for utxolib
    * Use `name` property instead.
    */
-  get network(): utxolib.Network {
+  private get network(): utxolib.Network {
     return getNetworkFromCoinName(this.name);
   }
 


### PR DESCRIPTION

Remove static validAddressTypes getter which was marked as deprecated,
and make the `network` getter private to enforce deprecation in favor of 
the `name` property.

Issue: BTC-2916