### PR TITLE
feat(abstract-utxo): migrate to wasm-utxo and use coin name instead of network

### DIFF
--- a/modules/abstract-utxo/src/address/fixedScript.ts
+++ b/modules/abstract-utxo/src/address/fixedScript.ts
@@ -12,18 +12,15 @@ import {
   isTriple,
   Triple,
 } from '@bitgo/sdk-core';
-import { bitgo } from '@bitgo/utxo-lib';
 import { fixedScriptWallet } from '@bitgo/wasm-utxo';
 
-import { getNetworkFromCoinName, UtxoCoinName } from '../names';
+import { UtxoCoinName } from '../names';
 
 type ScriptType2Of3 = fixedScriptWallet.OutputScriptType;
 type ChainCode = fixedScriptWallet.ChainCode;
 
 export interface FixedScriptAddressCoinSpecific {
   outputScript?: string;
-  redeemScript?: string;
-  witnessScript?: string;
 }
 
 export interface GenerateAddressOptions {
@@ -43,9 +40,16 @@ function supportsAddressType(coinName: UtxoCoinName, addressType: ScriptType2Of3
   return fixedScriptWallet.supportsScriptType(coinName, addressType);
 }
 
+/**
+ * Normalize script type aliases. "p2tr" is an alias for "p2trLegacy".
+ */
+function normalizeScriptType(scriptType: ScriptType2Of3 | 'p2tr'): ScriptType2Of3 {
+  return scriptType === 'p2tr' ? 'p2trLegacy' : scriptType;
+}
+
 export function generateAddressWithChainAndIndex(
   coinName: UtxoCoinName,
-  keychains: fixedScriptWallet.RootWalletKeys | bitgo.RootWalletKeys | Triple<string>,
+  keychains: fixedScriptWallet.WalletKeysArg | Triple<string>,
   chain: ChainCode,
   index: number,
   format: CreateAddressFormat | undefined
@@ -53,8 +57,7 @@ export function generateAddressWithChainAndIndex(
   // Convert CreateAddressFormat to AddressFormat for wasm-utxo
   // 'base58' -> 'default', 'cashaddr' -> 'cashaddr'
   const wasmFormat = format === 'base58' ? 'default' : format;
-  const network = getNetworkFromCoinName(coinName);
-  return fixedScriptWallet.address(keychains, chain, index, network, wasmFormat);
+  return fixedScriptWallet.address(keychains, chain, index, coinName, wasmFormat);
 }
 
 /**
@@ -95,7 +98,7 @@ export function generateAddress(coinName: UtxoCoinName, params: GenerateFixedScr
     }
   }
 
-  const addressType = params.addressType || convertFlagsToAddressType();
+  const addressType = normalizeScriptType(params.addressType || convertFlagsToAddressType());
 
   if (addressType !== fixedScriptWallet.ChainCode.scriptType(derivationChain)) {
     throw new AddressTypeChainMismatchError(addressType, derivationChain);
@@ -110,6 +113,7 @@ export function generateAddress(coinName: UtxoCoinName, params: GenerateFixedScr
       case 'p2wsh':
         throw new P2wshUnsupportedError();
       case 'p2tr':
+      case 'p2trLegacy':
         throw new P2trUnsupportedError();
       case 'p2trMusig2':
         throw new P2trMusig2UnsupportedError();

--- a/modules/abstract-utxo/test/unit/coins.ts
+++ b/modules/abstract-utxo/test/unit/coins.ts
@@ -2,14 +2,19 @@ import * as assert from 'assert';
 
 import * as utxolib from '@bitgo/utxo-lib';
 
-import { getMainnetCoinName, utxoCoinsMainnet, utxoCoinsTestnet } from '../../src/names';
+import { getMainnetCoinName, getNetworkFromCoinName, utxoCoinsMainnet, utxoCoinsTestnet } from '../../src/names';
 
 import { getUtxoCoinForNetwork, utxoCoins } from './util';
 
 describe('utxoCoins', function () {
   it('has expected chain/network values for items', function () {
     assert.deepStrictEqual(
-      utxoCoins.map((c) => [c.getChain(), c.getFamily(), c.getFullName(), utxolib.getNetworkName(c.network)]),
+      utxoCoins.map((c) => [
+        c.getChain(),
+        c.getFamily(),
+        c.getFullName(),
+        utxolib.getNetworkName(getNetworkFromCoinName(c.name)),
+      ]),
       [
         ['btc', 'btc', 'Bitcoin', 'bitcoin'],
         ['tbtc', 'btc', 'Testnet Bitcoin', 'testnet'],

--- a/modules/abstract-utxo/test/unit/descriptorAddress.ts
+++ b/modules/abstract-utxo/test/unit/descriptorAddress.ts
@@ -1,17 +1,16 @@
 import * as assert from 'node:assert';
 
 import * as utxolib from '@bitgo/utxo-lib';
+import { address as wasmAddress, CoinName } from '@bitgo/wasm-utxo';
 import { IWallet, WalletCoinSpecific } from '@bitgo/sdk-core';
 
 import { descriptor as utxod } from '../../src';
 
 import { getUtxoCoin } from './util';
 
-export function getDescriptorAddress(d: string, index: number, network: utxolib.Network): string {
-  const derivedScript = Buffer.from(
-    utxod.Descriptor.fromString(d, 'derivable').atDerivationIndex(index).scriptPubkey()
-  );
-  return utxolib.address.fromOutputScript(derivedScript, network);
+export function getDescriptorAddress(d: string, index: number, coinName: CoinName): string {
+  const derivedScript = utxod.Descriptor.fromString(d, 'derivable').atDerivationIndex(index).scriptPubkey();
+  return wasmAddress.fromOutputScriptWithCoin(derivedScript, coinName);
 }
 
 describe('descriptor wallets', function () {
@@ -40,9 +39,9 @@ describe('descriptor wallets', function () {
 
   const descFoo = getNamedDescriptor2Of2('foo', xpubs[0], xpubs[1]);
   const descBar = getNamedDescriptor2Of2('bar', xpubs[1], xpubs[0]);
-  const addressFoo0 = getDescriptorAddress(descFoo.value, 0, coin.network);
-  const addressFoo1 = getDescriptorAddress(descFoo.value, 1, coin.network);
-  const addressBar0 = getDescriptorAddress(descBar.value, 0, coin.network);
+  const addressFoo0 = getDescriptorAddress(descFoo.value, 0, coin.name);
+  const addressFoo1 = getDescriptorAddress(descFoo.value, 1, coin.name);
+  const addressBar0 = getDescriptorAddress(descBar.value, 0, coin.name);
 
   it('has expected values', function () {
     assert.deepStrictEqual(

--- a/modules/abstract-utxo/test/unit/prebuildAndSign.ts
+++ b/modules/abstract-utxo/test/unit/prebuildAndSign.ts
@@ -6,6 +6,7 @@ import { common, HalfSignedUtxoTransaction, Wallet } from '@bitgo/sdk-core';
 import { getSeed } from '@bitgo/sdk-test';
 
 import { AbstractUtxoCoin, getReplayProtectionAddresses } from '../../src';
+import { getMainnetCoinName } from '../../src/names';
 
 import { defaultBitGo, encryptKeychain, getDefaultWalletKeys, getUtxoWallet, keychainsBase58, utxoCoins } from './util';
 
@@ -295,7 +296,7 @@ function run(coin: AbstractUtxoCoin, inputScripts: ScriptType[], txFormat: TxFor
 }
 
 utxoCoins
-  .filter((coin) => utxolib.getMainnet(coin.network) !== utxolib.networks.bitcoinsv)
+  .filter((coin) => getMainnetCoinName(coin.name) !== 'bsv')
   .forEach((coin) => {
     scriptTypes
       // Don't iterate over p2shP2pk - in no scenario would a wallet spend two p2shP2pk inputs as these

--- a/modules/abstract-utxo/test/unit/recovery/backupKeyRecovery.ts
+++ b/modules/abstract-utxo/test/unit/recovery/backupKeyRecovery.ts
@@ -8,7 +8,7 @@ import { BIP32Interface } from '@bitgo/utxo-lib';
 import * as utxolib from '@bitgo/utxo-lib';
 import { Config, krsProviders, Triple } from '@bitgo/sdk-core';
 import { Dimensions } from '@bitgo/unspents';
-import { fixedScriptWallet } from '@bitgo/wasm-utxo';
+import { address as wasmAddress, fixedScriptWallet } from '@bitgo/wasm-utxo';
 
 import {
   AbstractUtxoCoin,
@@ -17,6 +17,7 @@ import {
   CoingeckoApi,
   FormattedOfflineVaultTxInfo,
 } from '../../../src';
+import { getCoinName } from '../../../src/names';
 import {
   defaultBitGo,
   encryptKeychain,
@@ -319,7 +320,9 @@ function run(
     it((params.hasKrsOutput ? 'has' : 'has no') + ' key recovery service output', function () {
       const outs = recoveryTx instanceof utxolib.bitgo.UtxoPsbt ? recoveryTx.getUnsignedTx().outs : recoveryTx.outs;
       outs.length.should.eql(1);
-      const outputAddresses = outs.map((o) => utxolib.address.fromOutputScript(o.script, recoveryTx.network));
+      const outputAddresses = outs.map((o) =>
+        wasmAddress.fromOutputScriptWithCoin(o.script, getCoinName(recoveryTx.network))
+      );
       outputAddresses
         .includes(keyRecoveryServiceAddress)
         .should.eql(!!params.hasKrsOutput && params.krsProvider === 'keyternal');

--- a/modules/abstract-utxo/test/unit/recovery/crossChainRecovery.ts
+++ b/modules/abstract-utxo/test/unit/recovery/crossChainRecovery.ts
@@ -16,6 +16,7 @@ import {
   generateAddress,
   convertLtcAddressToLegacyFormat,
 } from '../../../src';
+import { isMainnetCoin, isTestnetCoin } from '../../../src/names';
 import {
   getFixture,
   keychainsBase58,
@@ -265,8 +266,8 @@ utxoCoins.forEach((coin) => {
       (otherCoin) =>
         coin !== otherCoin &&
         isSupportedCrossChainRecovery(coin, otherCoin) &&
-        ((utxolib.isMainnet(coin.network) && utxolib.isMainnet(otherCoin.network)) ||
-          (utxolib.isTestnet(coin.network) && utxolib.isTestnet(otherCoin.network)))
+        ((isMainnetCoin(coin.name) && isMainnetCoin(otherCoin.name)) ||
+          (isTestnetCoin(coin.name) && isTestnetCoin(otherCoin.name)))
     )
     .forEach((otherCoin) => {
       if (coin.amountType === 'bigint') {

--- a/modules/abstract-utxo/test/unit/recovery/mock.ts
+++ b/modules/abstract-utxo/test/unit/recovery/mock.ts
@@ -1,6 +1,7 @@
 import { bitgo } from '@bitgo/utxo-lib';
 import { AddressInfo, TransactionIO } from '@bitgo/blockapis';
 import * as utxolib from '@bitgo/utxo-lib';
+import { address as wasmAddress, AddressFormat } from '@bitgo/wasm-utxo';
 
 import { AbstractUtxoCoin, RecoveryProvider } from '../../../src';
 import { Bch } from '../../../src/impl/bch';
@@ -51,7 +52,7 @@ export class MockRecoveryProvider implements RecoveryProvider {
 }
 export class MockCrossChainRecoveryProvider<TNumber extends number | bigint> implements RecoveryProvider {
   private addressVersion: 'cashaddr' | 'base58';
-  private addressFormat: utxolib.addressFormat.AddressFormat;
+  private addressFormat: AddressFormat;
   constructor(
     public coin: AbstractUtxoCoin,
     public unspents: Unspent<TNumber>[],
@@ -65,7 +66,7 @@ export class MockCrossChainRecoveryProvider<TNumber extends number | bigint> imp
 
   async getUnspentsForAddresses(addresses: string[]): Promise<Unspent[]> {
     return this.tx.outs.map((o, vout: number) => {
-      let address = utxolib.addressFormat.fromOutputScriptWithFormat(o.script, this.addressFormat, this.coin.network);
+      let address = wasmAddress.fromOutputScriptWithCoin(o.script, this.coin.name, this.addressFormat);
       if (address.includes(':')) {
         [, address] = address.split(':');
       }
@@ -91,7 +92,7 @@ export class MockCrossChainRecoveryProvider<TNumber extends number | bigint> imp
         };
       }),
       outputs: this.tx.outs.map((o) => {
-        let address = utxolib.addressFormat.fromOutputScriptWithFormat(o.script, this.addressFormat, this.coin.network);
+        let address = wasmAddress.fromOutputScriptWithCoin(o.script, this.coin.name, this.addressFormat);
         if (address.includes(':')) {
           [, address] = address.split(':');
         }

--- a/modules/abstract-utxo/test/unit/transaction.ts
+++ b/modules/abstract-utxo/test/unit/transaction.ts
@@ -5,6 +5,7 @@ import * as _ from 'lodash';
 import * as utxolib from '@bitgo/utxo-lib';
 import nock = require('nock');
 import { BIP32Interface, bitgo, testutil } from '@bitgo/utxo-lib';
+import { address as wasmAddress } from '@bitgo/wasm-utxo';
 import {
   common,
   FullySignedTransaction,
@@ -507,7 +508,7 @@ function run<TNumber extends number | bigint = number>(
           : getUnspents();
       const prevOutputs = unspents.map(
         (u): utxolib.TxOutput<TNumber> => ({
-          script: utxolib.address.toOutputScript(u.address, coin.network),
+          script: Buffer.from(wasmAddress.toOutputScriptWithCoin(u.address, coin.name)),
           value: u.value,
         })
       );

--- a/modules/abstract-utxo/test/unit/transaction/fixedScript/parsePsbt.ts
+++ b/modules/abstract-utxo/test/unit/transaction/fixedScript/parsePsbt.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import * as sinon from 'sinon';
 import * as utxolib from '@bitgo/utxo-lib';
 import { Wallet, VerificationOptions, ITransactionRecipient, Triple } from '@bitgo/sdk-core';
-import { fixedScriptWallet } from '@bitgo/wasm-utxo';
+import { address as wasmAddress, fixedScriptWallet } from '@bitgo/wasm-utxo';
 
 import { parseTransaction } from '../../../../src/transaction/fixedScript/parseTransaction';
 import { ParsedTransaction } from '../../../../src/transaction/types';
@@ -63,7 +63,7 @@ function getChangeInfoFromPsbt(psbt: utxolib.bitgo.UtxoPsbt): ChangeAddressInfo[
       const path = derivations[0].path;
       const { chain, index } = utxolib.bitgo.getChainAndIndexFromPath(path);
       return {
-        address: utxolib.address.fromOutputScript(psbt.txOutputs[i].script, psbt.network),
+        address: wasmAddress.fromOutputScriptWithCoin(psbt.txOutputs[i].script, getCoinName(psbt.network)),
         chain,
         index,
       };

--- a/modules/abstract-utxo/test/unit/util/nockIndexerAPI.ts
+++ b/modules/abstract-utxo/test/unit/util/nockIndexerAPI.ts
@@ -1,5 +1,6 @@
 import nock = require('nock');
 import * as utxolib from '@bitgo/utxo-lib';
+import { address as wasmAddress } from '@bitgo/wasm-utxo';
 
 import { AbstractUtxoCoin } from '../../../src';
 
@@ -19,7 +20,7 @@ export function nockBitGoPublicTransaction<TNumber extends number | bigint = num
 ): nock.Scope {
   const payload = {
     input: unspents.map((u) => ({ address: u.address })),
-    outputs: tx.outs.map((o) => ({ address: utxolib.address.fromOutputScript(o.script, coin.network) })),
+    outputs: tx.outs.map((o) => ({ address: wasmAddress.fromOutputScriptWithCoin(o.script, coin.name) })),
   };
   return nockBitGo().get(`/api/v2/${coin.getChain()}/public/tx/${tx.getId()}`).reply(200, payload);
 }
@@ -33,7 +34,7 @@ export function nockBitGoPublicAddressUnspents<TNumber extends number | bigint =
   const payload: ImsUnspent[] = outputs.map(
     (o, vout: number): ImsUnspent => ({
       id: `${txid}:${vout}`,
-      address: utxolib.address.fromOutputScript(o.script, coin.network),
+      address: wasmAddress.fromOutputScriptWithCoin(o.script, coin.name),
       value: Number(o.value),
       valueString: coin.amountType === 'bigint' ? o.value.toString() : undefined,
     })

--- a/modules/abstract-utxo/test/unit/util/transaction.ts
+++ b/modules/abstract-utxo/test/unit/util/transaction.ts
@@ -1,4 +1,7 @@
 import * as utxolib from '@bitgo/utxo-lib';
+import { address as wasmAddress } from '@bitgo/wasm-utxo';
+
+import { getCoinName } from '../../../src/names';
 const { isWalletUnspent, signInputWithUnspent } = utxolib.bitgo;
 type RootWalletKeys = utxolib.bitgo.RootWalletKeys;
 type Unspent<TNumber extends number | bigint = number> = utxolib.bitgo.Unspent<TNumber>;
@@ -22,7 +25,7 @@ function toTxOutput<TNumber extends number | bigint = number>(
   network: utxolib.Network
 ): utxolib.TxOutput<TNumber> {
   return {
-    script: utxolib.address.toOutputScript(u.address, network),
+    script: Buffer.from(wasmAddress.toOutputScriptWithCoin(u.address, getCoinName(network))),
     value: u.value,
   };
 }

--- a/modules/abstract-utxo/test/unit/util/unspents.ts
+++ b/modules/abstract-utxo/test/unit/util/unspents.ts
@@ -36,7 +36,10 @@ export function getWalletAddress(
   if (utxolib.isTestnet(network)) {
     return wasmUtxo.fixedScriptWallet.address(walletKeys, chain, index, network);
   }
-  return utxolib.address.fromOutputScript(getOutputScript(walletKeys, chain, index).scriptPubKey, network);
+  return wasmUtxo.address.fromOutputScriptWithCoin(
+    getOutputScript(walletKeys, chain, index).scriptPubKey,
+    getCoinName(network)
+  );
 }
 
 function mockOutputIdForAddress(address: string) {


### PR DESCRIPTION

This PR includes two main changes to the abstract-utxo module:

1. Migrating from utxolib to wasm-utxo address module:
   - Updates address functionality to use @bitgo/wasm-utxo address module
   - Adapts function signatures to work with CoinName instead of Network
   - Maintains compatibility with existing test cases
   - Reduces dependency on legacy utxolib code

2. Refactoring chain determination to use coin name instead of deprecated
   direct network usage:
   - This approach is more consistent
   - Avoids accessing internal network objects directly

BTC-2916