### PR TITLE
feat(abstract-utxo): ignore .cursor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ modules/**/pack-scoped/
 coverage
 /.direnv/
 .claude/
+.cursor/


### PR DESCRIPTION

Add .cursor/ to the gitignore file to prevent editor-specific files from
being tracked in version control.

Issue: BTC-2916