### PR TITLE
feat(abstract-utxo): migrate inscription builder to wasm-utxo

### DIFF
--- a/modules/abstract-utxo/src/keychains.ts
+++ b/modules/abstract-utxo/src/keychains.ts
@@ -4,6 +4,7 @@ import * as t from 'io-ts';
 import { bitgo } from '@bitgo/utxo-lib';
 import { BIP32Interface, bip32 } from '@bitgo/secp256k1';
 import { IRequestTracer, IWallet, KeyIndices, promiseProps, Triple } from '@bitgo/sdk-core';
+import { fixedScriptWallet } from '@bitgo/wasm-utxo';
 
 import { AbstractUtxoCoin } from './abstractUtxoCoin';
 import { UtxoWallet } from './wallet';
@@ -106,6 +107,18 @@ export async function fetchKeychains(
   });
   assert(UtxoNamedKeychains.is(result));
   return result;
+}
+
+/**
+ * Fetch wallet keys as wasm-utxo RootWalletKeys
+ */
+export async function fetchWasmRootWalletKeys(
+  coin: AbstractUtxoCoin,
+  wallet: IWallet,
+  reqId?: IRequestTracer
+): Promise<fixedScriptWallet.RootWalletKeys> {
+  const keychains = await fetchKeychains(coin, wallet, reqId);
+  return fixedScriptWallet.RootWalletKeys.from([keychains.user.pub, keychains.backup.pub, keychains.bitgo.pub]);
 }
 
 export const KeySignatures = t.partial({

--- a/modules/abstract-utxo/tsconfig.json
+++ b/modules/abstract-utxo/tsconfig.json
@@ -26,6 +26,9 @@
     },
     {
       "path": "../utxo-core"
+    },
+    {
+      "path": "../utxo-ord"
     }
   ]
 }

--- a/modules/utxo-ord/package.json
+++ b/modules/utxo-ord/package.json
@@ -45,8 +45,9 @@
     "directory": "modules/utxo-ord"
   },
   "dependencies": {
-    "@bitgo/sdk-core": "^36.29.0",
-    "@bitgo/unspents": "^0.50.14",
+    "@bitgo/wasm-utxo": "^1.27.0"
+  },
+  "devDependencies": {
     "@bitgo/utxo-lib": "^11.19.1"
   },
   "lint-staged": {

--- a/modules/utxo-ord/src/SatPoint.ts
+++ b/modules/utxo-ord/src/SatPoint.ts
@@ -9,9 +9,28 @@ https://github.com/casey/ord/blob/master/bip.mediawiki#terminology-and-notation
 > `680df1e4d43016571e504b0b142ee43c5c0b83398a97bdcfd94ea6f287322d22:0:6`
 
 */
-import { bitgo } from '@bitgo/utxo-lib';
 
 export type SatPoint = `${string}:${number}:${bigint}`;
+
+/**
+ * Parse an output ID (txid:vout) into its components.
+ */
+export function parseOutputId(outputId: string): { txid: string; vout: number } {
+  const colonIndex = outputId.lastIndexOf(':');
+  if (colonIndex === -1) {
+    throw new Error(`Invalid output id format: missing colon`);
+  }
+  const txid = outputId.slice(0, colonIndex);
+  const voutStr = outputId.slice(colonIndex + 1);
+  if (txid.length !== 64 || !/^[0-9a-fA-F]+$/.test(txid)) {
+    throw new Error(`Invalid txid: must be 64 hex characters`);
+  }
+  const vout = parseInt(voutStr, 10);
+  if (isNaN(vout) || vout < 0) {
+    throw new Error(`Invalid vout: must be non-negative integer`);
+  }
+  return { txid, vout };
+}
 
 export function parseSatPoint(p: SatPoint): { txid: string; vout: number; offset: bigint } {
   const parts = p.split(':');
@@ -27,7 +46,7 @@ export function parseSatPoint(p: SatPoint): { txid: string; vout: number; offset
     throw new Error(`SatPoint offset must be positive`);
   }
   return {
-    ...bitgo.parseOutputId([txid, vout].join(':')),
+    ...parseOutputId([txid, vout].join(':')),
     offset,
   };
 }

--- a/modules/utxo-ord/src/index.ts
+++ b/modules/utxo-ord/src/index.ts
@@ -8,3 +8,5 @@ export * from './OutputLayout';
 export * from './SatPoint';
 export * from './psbt';
 export * as inscriptions from './inscriptions';
+export type { TapLeafScript, PreparedInscriptionRevealData } from './inscriptions';
+export type { WalletUnspent } from './psbt';

--- a/modules/utxo-ord/test/testutils.ts
+++ b/modules/utxo-ord/test/testutils.ts
@@ -1,0 +1,57 @@
+import * as crypto from 'crypto';
+import { fixedScriptWallet, BIP32 } from '@bitgo/wasm-utxo';
+import { WalletUnspent } from '../src';
+
+/**
+ * Create a deterministic BIP32 key from a seed string.
+ * Uses SHA256 hash of the seed as the BIP32 seed.
+ */
+export function getKey(seed: string): BIP32 {
+  return BIP32.fromSeed(crypto.createHash('sha256').update(seed).digest());
+}
+
+/**
+ * Create deterministic test wallet keys using wasm-utxo.
+ * Replicates the behavior of utxo-lib's getDefaultWalletKeys().
+ */
+export function getTestWalletKeys(seed = 'default'): {
+  rootWalletKeys: fixedScriptWallet.RootWalletKeys;
+  signerXprvs: [string, string];
+} {
+  // Create BIP32 keys from deterministic seeds (same as utxo-lib testutil)
+  const userKey = getKey(seed + '.0');
+  const backupKey = getKey(seed + '.1');
+  const bitgoKey = getKey(seed + '.2');
+
+  const rootWalletKeys = fixedScriptWallet.RootWalletKeys.fromXpubs([
+    userKey.neutered().toBase58(),
+    backupKey.neutered().toBase58(),
+    bitgoKey.neutered().toBase58(),
+  ]);
+
+  return {
+    rootWalletKeys,
+    signerXprvs: [userKey.toBase58(), bitgoKey.toBase58()],
+  };
+}
+
+/**
+ * Create a mock wallet unspent for testing.
+ * @param value - Value in satoshis
+ * @param chain - Chain code (default: 0)
+ * @param index - Derivation index (default: 0)
+ * @param vout - Output index for mock txid (default: 0)
+ */
+export function mockWalletUnspent(
+  value: bigint,
+  { chain = 0, index = 0, vout = 0 }: { chain?: number; index?: number; vout?: number } = {}
+): WalletUnspent {
+  // Create a deterministic mock txid based on vout (must be 64 hex chars)
+  const mockTxid = vout.toString(16).padStart(64, '0');
+  return {
+    id: `${mockTxid}:${vout}`,
+    value,
+    chain,
+    index,
+  };
+}


### PR DESCRIPTION

Replace utxo-lib with wasm-utxo implementation for inscription handling.
This provides a more efficient and robust way to create and sign
inscription transactions using WebAssembly.

Key changes:
- Replace utxo-lib dependency with wasm-utxo in inscription functions
- Update API to use typed arrays instead of Node Buffers
- Add coin name mapping for different Bitcoin networks
- Improve error handling and type safety

Issue: BTC-2936