### PR TITLE
feat(utxo-ord): add ESM support and update webpack configuration

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -12,7 +12,7 @@ module.exports = {
     'scope-enum': async () => [
       2,
       'always',
-      (await readdir('modules')).concat('root', 'deps', 'scripts', 'examples'),
+      (await readdir('modules')).concat('root', 'deps', 'scripts', 'examples', 'webpack'),
     ],
     'footer-max-line-length': [0, 'always', Infinity],
     'references-empty': [2, 'never'],

--- a/modules/utxo-ord/package.json
+++ b/modules/utxo-ord/package.json
@@ -1,11 +1,26 @@
 {
   "name": "@bitgo/utxo-ord",
   "description": "Utilities for building ordinals with BitGo utxo-lib",
-  "main": "./dist/src/index.js",
-  "types": "./dist/src/index.d.ts",
+  "main": "./dist/cjs/src/index.js",
+  "module": "./dist/esm/index.js",
+  "browser": "./dist/esm/index.js",
+  "types": "./dist/cjs/src/index.d.ts",
   "version": "1.22.22",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/src/index.d.ts",
+        "default": "./dist/cjs/src/index.js"
+      }
+    }
+  },
   "files": [
-    "dist/**/*"
+    "dist/cjs",
+    "dist/esm"
   ],
   "keywords": [
     "bitgo",
@@ -16,7 +31,9 @@
   ],
   "scripts": {
     "prepare": "npm run build",
-    "build": "yarn tsc --build --incremental --verbose .",
+    "build": "npm run build:cjs && npm run build:esm",
+    "build:cjs": "yarn tsc --build --incremental --verbose .",
+    "build:esm": "yarn tsc --project tsconfig.esm.json",
     "lint": "eslint --quiet .",
     "unit-test": "mocha --recursive test",
     "fmt": "prettier --write '{src,test}/**/*.{ts,js}'",

--- a/modules/utxo-ord/tsconfig.esm.json
+++ b/modules/utxo-ord/tsconfig.esm.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/esm",
+    "rootDir": "./src",
+    "module": "ES2020",
+    "target": "ES2020",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM"],
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "test", "dist"],
+  "references": []
+}

--- a/modules/utxo-ord/tsconfig.json
+++ b/modules/utxo-ord/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist",
+    "outDir": "./dist/cjs",
     "rootDir": ".",
     "typeRoots": ["./node_modules/@types", "../../node_modules/@types"],
     "allowJs": false,

--- a/webpack/bitgojs.config.js
+++ b/webpack/bitgojs.config.js
@@ -15,8 +15,11 @@ module.exports = {
       // use the default version here since we're webpacking ourselves
       '@bitgo/sdk-api': path.resolve('../sdk-api/dist/src/index.js'),
       async: path.resolve('../../node_modules/async/index.js'),
-      // Force ESM version of wasm-utxo for browser bundles (has proper wasm import)
+      // Force ESM versions for browser bundles - required for proper WASM initialization.
+      // Note: We can't use global `conditionNames: ['browser', 'import', ...]` because
+      // third-party packages like @solana/spl-token and @bufbuild/protobuf have broken ESM builds.
       '@bitgo/wasm-utxo': path.resolve('../../node_modules/@bitgo/wasm-utxo/dist/esm/js/index.js'),
+      '@bitgo/utxo-ord': path.resolve('../utxo-ord/dist/esm/index.js'),
     },
     fallback: {
       constants: false,


### PR DESCRIPTION

Configure ESM build alongside existing CommonJS build, updating package.json 
exports field to support both module systems. The package can now be used
with both `import` and `require` statements.

Also ensures proper import of wasm-utxo in browser environments by using the 
ESM version of utxo-ord in webpack bundles.

Issue: BTC-2936