### PR TITLE
feat(bitgo): use unminified BitGoJS for browser tests

### DIFF
--- a/modules/bitgo/karma.conf.js
+++ b/modules/bitgo/karma.conf.js
@@ -15,7 +15,7 @@ module.exports = function (config) {
 
     // list of files / patterns to load in the browser
     files: [
-      'dist/browser/BitGoJS.min.js',
+      'dist/browser/BitGoJS.js',
       'test/browser/karmaHelper.js',
       { pattern: 'test/browser/**/*.ts' },
       { pattern: 'dist/browser/*.wasm', included: false, served: true, watched: false, nocache: true },

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "lint": "lerna run lint --stream",
     "lint-changed": "lerna run lint --since origin/${GITHUB_REPO_BRANCH:-master}..HEAD --stream",
     "unit-test-changed": "lerna run unit-test --since $(git merge-base HEAD~ origin/${GITHUB_REPO_BRANCH:-master}) --stream",
-    "browser-tests": "lerna run --scope bitgo compile && lerna run --scope bitgo browser-test && lerna run --scope @bitgo/web-demo test",
+    "browser-tests": "lerna run --scope bitgo compile-test && lerna run --scope bitgo browser-test && lerna run --scope @bitgo/web-demo test",
     "gen-coverage-changed": "lerna run gen-coverage --since origin/${GITHUB_REPO_BRANCH:-master}..HEAD --stream --parallel",
     "coverage-changed": "lerna run upload-coverage --since origin/${GITHUB_REPO_BRANCH:-master}..HEAD --stream --parallel --",
     "unit-test": "lerna run unit-test --stream",


### PR DESCRIPTION

Use the unminified BitGoJS.js file for browser tests to provide more
useful stack traces. Add compile-test script reference in the browser-tests
command.

Issue: BTC-2936

Co-authored-by: llm-git <llm-git@ttll.de>