### PR TITLE
feat(sdk-coin-flrp): enhance transaction builders with addressesIndex handling

### DIFF
--- a/modules/sdk-coin-flrp/src/lib/ImportInCTxBuilder.ts
+++ b/modules/sdk-coin-flrp/src/lib/ImportInCTxBuilder.ts
@@ -6,6 +6,7 @@ import {
   UnsignedTx,
   Credential,
   TransferableInput,
+  TransferInput,
   TransferOutput,
   Address,
   utils as FlareUtils,
@@ -186,16 +187,17 @@ export class ImportInCTxBuilder extends AtomicInCTransactionBuilder {
     return importedInputs.map((input) => {
       const txid = input.utxoID.toString();
       const outputidx = input.utxoID.outputIdx.toString();
+      const transferInput = input.input as TransferInput;
+      const addressesIndex = transferInput.sigIndicies();
 
       return {
         outputID: SECP256K1_Transfer_Output,
         amount: input.amount().toString(),
         txid: utils.cb58Encode(Buffer.from(txid, 'hex')),
         outputidx: outputidx,
-        threshold: this.transaction._threshold,
-        addresses: this.transaction._fromAddresses.map((addr) =>
-          utils.addressToString(this.transaction._network.hrp, this.transaction._network.alias, Buffer.from(addr))
-        ),
+        threshold: addressesIndex.length || this.transaction._threshold,
+        addresses: [],
+        addressesIndex,
       };
     });
   }

--- a/modules/sdk-coin-flrp/src/lib/ImportInPTxBuilder.ts
+++ b/modules/sdk-coin-flrp/src/lib/ImportInPTxBuilder.ts
@@ -198,15 +198,16 @@ export class ImportInPTxBuilder extends AtomicTransactionBuilder {
     return importedInputs.map((input) => {
       const utxoId = input.utxoID;
       const transferInput = input.input as TransferInput;
+      const addressesIndex = transferInput.sigIndicies();
+
       const utxo: DecodedUtxoObj = {
         outputID: SECP256K1_Transfer_Output,
         amount: transferInput.amount().toString(),
         txid: utils.cb58Encode(Buffer.from(utxoId.txID.toBytes())),
         outputidx: utxoId.outputIdx.value().toString(),
-        threshold: this.transaction._threshold,
-        addresses: this.transaction._fromAddresses.map((addr) =>
-          utils.addressToString(this.transaction._network.hrp, this.transaction._network.alias, Buffer.from(addr))
-        ),
+        threshold: addressesIndex.length || this.transaction._threshold,
+        addresses: [],
+        addressesIndex,
       };
       return utxo;
     });


### PR DESCRIPTION
- Added logic to utilize pre-computed addressesIndex for signature ordering in AtomicTransactionBuilder.
- Updated ImportInCTxBuilder and ImportInPTxBuilder to incorporate addressesIndex for threshold and address mapping.
- Enhanced unit tests to verify correct handling of half-signed and unsigned transactions, ensuring proper signature counts and transaction structure preservation.