### PR TITLE
fix: sanitize wallet object from logs

### DIFF
--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -2407,7 +2407,15 @@ export class Wallet implements IWallet {
         'transaction params:',
         _.omit(params, ['keychain', 'prv', 'passphrase', 'walletPassphrase', 'key', 'wallet'])
       );
-      console.error('transaction prebuild:', txPrebuild);
+      // Sanitize to remove _token from bitgo
+      const sanitizedPrebuild = {
+        ..._.omit(txPrebuild, ['wallet']),
+        wallet: {
+          ...this,
+          bitgo: _.omit(this.bitgo, ['_token']),
+        },
+      };
+      console.error('transaction prebuild:', sanitizedPrebuild);
       console.trace(e);
       throw e;
     }
@@ -2449,7 +2457,13 @@ export class Wallet implements IWallet {
           confirmedBalance: this.confirmedBalance(),
           spendableBalance: this.spendableBalance(),
         };
-        error.txParams = _.omit(params, ['keychain', 'prv', 'passphrase', 'walletPassphrase', 'key']);
+        error.txParams = {
+          ..._.omit(params, ['keychain', 'prv', 'passphrase', 'walletPassphrase', 'key', 'wallet']),
+          wallet: {
+            ...this,
+            bitgo: _.omit(this.bitgo, ['_token']),
+          },
+        };
       }
       throw error;
     }


### PR DESCRIPTION
When prebuildAndSignTransaction fails validation, the logged txPrebuild object, this pr aims to sanitize this for the BitGo Express logs.

**Changes:**
Sanitizing the preBuild object before logging.

TICKET: WP-7489

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
