### PR TITLE
fix(sdk-coin-ada): use derivedFromParentWithSeed in address verification

### DIFF
--- a/modules/sdk-coin-ada/src/ada.ts
+++ b/modules/sdk-coin-ada/src/ada.ts
@@ -174,9 +174,11 @@ export class Ada extends BaseCoin {
     }
 
     const commonKeychain = extractCommonKeychain(keychains);
+    const derivationSeed = (keychains[0] as { derivedFromParentWithSeed?: string })?.derivedFromParentWithSeed;
     const { address: derivedAddress } = await this.getAdaAddressAndAccountId({
       bitgoKey: commonKeychain,
       index: indexNumber,
+      seed: derivationSeed,
     });
 
     return address === derivedAddress;

--- a/modules/sdk-coin-ada/test/unit/ada.ts
+++ b/modules/sdk-coin-ada/test/unit/ada.ts
@@ -1010,6 +1010,86 @@ describe('ADA', function () {
         })
         .should.be.rejectedWith('all keychains must have the same commonKeychain for MPC coins');
     });
+
+    it('should verify address when derivedFromParentWithSeed is present', async function () {
+      const derivedFromParentWithSeed = 'testDerivationSeed123';
+
+      const keychains = [
+        {
+          id: '1',
+          commonKeychain: commonKeychain,
+          derivedFromParentWithSeed: derivedFromParentWithSeed,
+          type: 'tss' as const,
+          source: 'user' as const,
+        },
+        {
+          id: '2',
+          commonKeychain: commonKeychain,
+          derivedFromParentWithSeed: derivedFromParentWithSeed,
+          type: 'tss' as const,
+          source: 'backup' as const,
+        },
+        {
+          id: '3',
+          commonKeychain: commonKeychain,
+          derivedFromParentWithSeed: derivedFromParentWithSeed,
+          type: 'tss' as const,
+          source: 'bitgo' as const,
+        },
+      ];
+
+      const { address: expectedAddress } = await (basecoin as any).getAdaAddressAndAccountId({
+        bitgoKey: commonKeychain,
+        index: 0,
+        seed: derivedFromParentWithSeed,
+      });
+
+      const isValid = await basecoin.isWalletAddress({
+        address: expectedAddress,
+        keychains,
+        index: 0,
+      });
+
+      isValid.should.equal(true);
+    });
+
+    it('should fail verification when derivedFromParentWithSeed is missing but address was created with seed', async function () {
+      const derivedFromParentWithSeed = 'testDerivationSeed123';
+      const { address: addressWithSeed } = await (basecoin as any).getAdaAddressAndAccountId({
+        bitgoKey: commonKeychain,
+        index: 0,
+        seed: derivedFromParentWithSeed,
+      });
+
+      const keychainsWithoutSeed = [
+        {
+          id: '1',
+          commonKeychain: commonKeychain,
+          type: 'tss' as const,
+          source: 'user' as const,
+        },
+        {
+          id: '2',
+          commonKeychain: commonKeychain,
+          type: 'tss' as const,
+          source: 'backup' as const,
+        },
+        {
+          id: '3',
+          commonKeychain: commonKeychain,
+          type: 'tss' as const,
+          source: 'bitgo' as const,
+        },
+      ];
+
+      const isValid = await basecoin.isWalletAddress({
+        address: addressWithSeed,
+        keychains: keychainsWithoutSeed,
+        index: 0,
+      });
+
+      isValid.should.equal(false);
+    });
   });
 
   describe('Verify token consolidation transaction:', () => {


### PR DESCRIPTION
Address verification was failing for wallets created with existing keys because isWalletAddress was not using the derivedFromParentWithSeed property to compute the correct derivation path. This fix extracts the seed from the keychain and passes it to getAdaAddressAndAccountId.

TICKET: COIN-7254

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
