### PR TITLE
feat(sdk-core, abstract-utxo): enhance explainTransaction with wallet context

### DIFF
--- a/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
@@ -583,7 +583,10 @@ export interface IBaseCoin {
     backup: string;
     bitgo: string;
   }>;
-  explainTransaction(options: Record<string, any>): Promise<ITransactionExplanation<any, string | number> | undefined>;
+  explainTransaction(
+    options: Record<string, any>,
+    wallet?: IWallet
+  ): Promise<ITransactionExplanation<any, string | number> | undefined>;
   verifyTransaction(params: VerifyTransactionOptions): Promise<boolean>;
   verifyAddress(params: VerifyAddressOptions): Promise<boolean>;
   isWalletAddress(params: VerifyAddressOptions | TssVerifyAddressOptions, wallet?: IWallet): Promise<boolean>;

--- a/modules/sdk-core/src/bitgo/staking/stakingWallet.ts
+++ b/modules/sdk-core/src/bitgo/staking/stakingWallet.ts
@@ -405,7 +405,7 @@ export class StakingWallet implements IStakingWallet {
       return;
     }
 
-    const explainedTransaction = await coin.explainTransaction(result);
+    const explainedTransaction = await coin.explainTransaction(result, this.wallet);
     const mismatchErrors: string[] = [];
 
     if (buildParams?.recipients && buildParams.recipients.length > 0) {


### PR DESCRIPTION

This PR enhances the explainTransaction functionality across two packages:

1. sdk-core: Adds ability to pass wallet instance to explainTransaction for 
   additional context during transaction validation. This enables more accurate 
   verification of staking transactions by providing wallet-specific 
   information.

2. abstract-utxo: Adds automatic keychain fetching in explainTransaction when 
   a wallet is available but no keychains are explicitly provided.

These changes improve transaction validation by leveraging available wallet 
context.

Issue: BTC-2963