### PR TITLE
fix: remove tar resolution that breaks lerna

### DIFF
--- a/.iyarc
+++ b/.iyarc
@@ -1,0 +1,7 @@
+# Excluded because:
+# - Lerna requires tar v6, but no patched v6 exists (fix only in v7.5.3)
+# - Forcing tar v7.5.3 breaks lerna's packDirectory API
+# - This CVE affects archive EXTRACTION (unpacking malicious symlinks/hardlinks)
+# - Lerna only uses tar for PACKING
+GHSA-8qq5-rm4j-mr97
+

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "**/cacache/glob": "11.1.0",
     "**/pacote/glob": "11.1.0",
     "**/sha.js": ">=2.4.12",
-    "tar": ">=7.5.3",
     "jspdf": ">=4.0.0",
     "@ethereumjs/util": "8.0.3",
     "@types/keyv": "3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17817,7 +17817,7 @@ qrcode@^1.5.1:
     pngjs "^5.0.0"
     yargs "^15.3.1"
 
-qs@6.13.0, qs@6.14.0, qs@>=6.14.1, qs@^6.11.0, qs@^6.11.2, qs@^6.12.3, qs@^6.5.1:
+qs@6.13.0, qs@6.14.0, qs@6.14.1, qs@^6.11.0, qs@^6.11.2, qs@^6.12.3, qs@^6.5.1:
   version "6.14.1"
   resolved "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz#a41d85b9d3902f31d27861790506294881871159"
   integrity sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==
@@ -20003,10 +20003,22 @@ tar-stream@~2.2.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@6.2.1, tar@>=7.5.3, tar@^6.1.11, tar@^6.1.2, tar@^7.4.3:
-  version "7.5.3"
-  resolved "https://registry.npmjs.org/tar/-/tar-7.5.3.tgz#e1a41236e32446f75e63b720222112c4ffe5b3a1"
-  integrity sha512-ENg5JUHUm2rDD7IvKNFGzyElLXNjachNLp6RaGf4+JOgxXHkqA+gq81ZAMCUmtMtqBsoU62lcp6S27g1LCYGGQ==
+tar@6.2.1, tar@^6.1.11, tar@^6.1.2:
+  version "6.2.1"
+  resolved "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz"
+  integrity sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^5.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
+
+tar@^7.4.3:
+  version "7.5.1"
+  resolved "https://registry.npmjs.org/tar/-/tar-7.5.1.tgz"
+  integrity sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==
   dependencies:
     "@isaacs/fs-minipass" "^4.0.0"
     chownr "^3.0.0"


### PR DESCRIPTION
WP-7499

The resolution `"tar": ">=7.5.3"` (from this PR https://github.com/BitGo/BitGoJS/pull/7928/changes) forced all tar dependencies causing below error:

```
TypeError: Cannot read properties of undefined (reading 'create')    at packDirectory
```
https://github.com/BitGo/build-system/actions/runs/21140438376/job/60792936809

**Fix:**
* Remove the blanket `tar: >=7.5.3` resolution
* Exclude `GHSA-8qq5-rm4j-mr97` in `.iyarc`