### PR TITLE
feat(sdk-coin-flrp): implement UTXO address sorting to ensure signature verification

### DIFF
--- a/modules/sdk-coin-flrp/src/lib/ExportInPTxBuilder.ts
+++ b/modules/sdk-coin-flrp/src/lib/ExportInPTxBuilder.ts
@@ -233,18 +233,4 @@ export class ExportInPTxBuilder extends AtomicTransactionBuilder {
       return utxo;
     });
   }
-
-  private computeAddressesIndexFromParsed(): void {
-    const sender = this.transaction._fromAddresses;
-    if (!sender || sender.length === 0) return;
-
-    this.transaction._utxos.forEach((utxo) => {
-      if (utxo.addresses && utxo.addresses.length > 0) {
-        const utxoAddresses = utxo.addresses.map((a) => utils.parseAddress(a));
-        utxo.addressesIndex = sender.map((senderAddr) =>
-          utxoAddresses.findIndex((utxoAddr) => Buffer.compare(Buffer.from(utxoAddr), Buffer.from(senderAddr)) === 0)
-        );
-      }
-    });
-  }
 }

--- a/modules/sdk-coin-flrp/src/lib/ImportInCTxBuilder.ts
+++ b/modules/sdk-coin-flrp/src/lib/ImportInCTxBuilder.ts
@@ -230,18 +230,4 @@ export class ImportInCTxBuilder extends AtomicInCTransactionBuilder {
       };
     });
   }
-
-  private computeAddressesIndexFromParsed(): void {
-    const sender = this.transaction._fromAddresses;
-    if (!sender || sender.length === 0) return;
-
-    this.transaction._utxos.forEach((utxo) => {
-      if (utxo.addresses && utxo.addresses.length > 0) {
-        const utxoAddresses = utxo.addresses.map((a) => utils.parseAddress(a));
-        utxo.addressesIndex = sender.map((senderAddr) =>
-          utxoAddresses.findIndex((utxoAddr) => Buffer.compare(Buffer.from(utxoAddr), Buffer.from(senderAddr)) === 0)
-        );
-      }
-    });
-  }
 }

--- a/modules/sdk-coin-flrp/src/lib/ImportInPTxBuilder.ts
+++ b/modules/sdk-coin-flrp/src/lib/ImportInPTxBuilder.ts
@@ -268,27 +268,4 @@ export class ImportInPTxBuilder extends AtomicTransactionBuilder {
       return utxo;
     });
   }
-
-  /**
-   * Compute proper addressesIndex from parsed transaction's sigIndicies.
-   * Following AVAX P approach: addressesIndex[senderIdx] = position of sender in UTXO addresses.
-   *
-   * For parsed transactions:
-   * - sigIndicies tells us which UTXO positions need to sign for each slot
-   * - We use output addresses as proxy for UTXO addresses
-   * - We compute addressesIndex as sender -> utxo position mapping
-   */
-  private computeAddressesIndexFromParsed(): void {
-    const sender = this.transaction._fromAddresses;
-    if (!sender || sender.length === 0) return;
-
-    this.transaction._utxos.forEach((utxo) => {
-      if (utxo.addresses && utxo.addresses.length > 0) {
-        const utxoAddresses = utxo.addresses.map((a) => utils.parseAddress(a));
-        utxo.addressesIndex = sender.map((senderAddr) =>
-          utxoAddresses.findIndex((utxoAddr) => Buffer.compare(Buffer.from(utxoAddr), Buffer.from(senderAddr)) === 0)
-        );
-      }
-    });
-  }
 }

--- a/modules/sdk-coin-flrp/test/unit/lib/exportInPTxBuilder.ts
+++ b/modules/sdk-coin-flrp/test/unit/lib/exportInPTxBuilder.ts
@@ -148,6 +148,141 @@ describe('Flrp Export In P Tx Builder', () => {
       });
   });
 
+  describe('UTXO address sorting fix - addresses in non-sorted order for ExportInP', () => {
+    /**
+     * This test suite verifies the fix for the address ordering bug in ExportInP.
+     *
+     * The issue: When the API returns UTXO addresses in a different order than how they're
+     * stored on-chain (lexicographically sorted by byte value), the sigIndices would be
+     * computed incorrectly, causing signature verification to fail.
+     *
+     * The fix: Sort UTXO addresses before computing addressesIndex to match on-chain order.
+     */
+
+    // Helper to create UTXO with specific address order
+    const createUtxoWithAddressOrder = (utxo: (typeof testData.utxos)[0], addresses: string[]) => ({
+      ...utxo,
+      addresses: addresses,
+    });
+
+    it('should correctly sort UTXO addresses when building ExportInP transaction', async () => {
+      // Create UTXOs with addresses in reversed order (simulating API returning unsorted)
+      const reversedUtxos = testData.utxos.map((utxo) =>
+        createUtxoWithAddressOrder(utxo, [...utxo.addresses].reverse())
+      );
+
+      const txBuilder = factory
+        .getExportInPBuilder()
+        .threshold(testData.threshold)
+        .locktime(testData.locktime)
+        .fromPubKey(testData.pAddresses)
+        .amount(testData.amount)
+        .externalChainId(testData.sourceChainId)
+        .feeState(testData.feeState)
+        .context(testData.context)
+        .decodedUtxos(reversedUtxos);
+
+      // Should not throw - the fix ensures addresses are sorted before computing sigIndices
+      const tx = await txBuilder.build();
+      const txJson = tx.toJson();
+
+      txJson.type.should.equal(22); // Export In P type
+      txJson.threshold.should.equal(2);
+    });
+
+    it('should produce same transaction hex regardless of input UTXO address order for ExportInP', async () => {
+      // Build with original address order
+      const txBuilder1 = factory
+        .getExportInPBuilder()
+        .threshold(testData.threshold)
+        .locktime(testData.locktime)
+        .fromPubKey(testData.pAddresses)
+        .amount(testData.amount)
+        .externalChainId(testData.sourceChainId)
+        .feeState(testData.feeState)
+        .context(testData.context)
+        .decodedUtxos(testData.utxos);
+
+      const tx1 = await txBuilder1.build();
+      const hex1 = tx1.toBroadcastFormat();
+
+      // Build with reversed address order in UTXOs
+      const reversedUtxos = testData.utxos.map((utxo) =>
+        createUtxoWithAddressOrder(utxo, [...utxo.addresses].reverse())
+      );
+
+      const txBuilder2 = factory
+        .getExportInPBuilder()
+        .threshold(testData.threshold)
+        .locktime(testData.locktime)
+        .fromPubKey(testData.pAddresses)
+        .amount(testData.amount)
+        .externalChainId(testData.sourceChainId)
+        .feeState(testData.feeState)
+        .context(testData.context)
+        .decodedUtxos(reversedUtxos);
+
+      const tx2 = await txBuilder2.build();
+      const hex2 = tx2.toBroadcastFormat();
+
+      // Both should produce the same hex since addresses get sorted
+      hex1.should.equal(hex2);
+    });
+
+    it('should handle signing correctly with unsorted UTXO addresses for ExportInP', async () => {
+      const reversedUtxos = testData.utxos.map((utxo) =>
+        createUtxoWithAddressOrder(utxo, [...utxo.addresses].reverse())
+      );
+
+      const txBuilder = factory
+        .getExportInPBuilder()
+        .threshold(testData.threshold)
+        .locktime(testData.locktime)
+        .fromPubKey(testData.pAddresses)
+        .amount(testData.amount)
+        .externalChainId(testData.sourceChainId)
+        .feeState(testData.feeState)
+        .context(testData.context)
+        .decodedUtxos(reversedUtxos);
+
+      txBuilder.sign({ key: testData.privateKeys[2] });
+      txBuilder.sign({ key: testData.privateKeys[0] });
+
+      const tx = await txBuilder.build();
+      const txJson = tx.toJson();
+
+      // Should have signatures after signing (count depends on UTXO thresholds)
+      txJson.signatures.length.should.be.greaterThan(0);
+      tx.toBroadcastFormat().should.be.a.String();
+    });
+
+    it('should produce valid signed transaction matching expected output with unsorted addresses for ExportInP', async () => {
+      const reversedUtxos = testData.utxos.map((utxo) =>
+        createUtxoWithAddressOrder(utxo, [...utxo.addresses].reverse())
+      );
+
+      const txBuilder = factory
+        .getExportInPBuilder()
+        .threshold(testData.threshold)
+        .locktime(testData.locktime)
+        .fromPubKey(testData.pAddresses)
+        .amount(testData.amount)
+        .externalChainId(testData.sourceChainId)
+        .feeState(testData.feeState)
+        .context(testData.context)
+        .decodedUtxos(reversedUtxos);
+
+      txBuilder.sign({ key: testData.privateKeys[2] });
+      txBuilder.sign({ key: testData.privateKeys[0] });
+
+      const tx = await txBuilder.build();
+
+      // The signed tx should match the expected fullSigntxHex from testData
+      tx.toBroadcastFormat().should.equal(testData.fullSigntxHex);
+      tx.id.should.equal(testData.txhash);
+    });
+  });
+
   describe('addressesIndex extraction and signature ordering', () => {
     it('should extract addressesIndex from parsed transaction inputs', async () => {
       const txBuilder = factory.from(testData.halfSigntxHex);

--- a/modules/sdk-coin-flrp/test/unit/lib/importInCTxBuilder.ts
+++ b/modules/sdk-coin-flrp/test/unit/lib/importInCTxBuilder.ts
@@ -209,6 +209,141 @@ describe('Flrp Import In C Tx Builder', () => {
     });
   });
 
+  describe('UTXO address sorting fix - addresses in non-sorted order for ImportInC', () => {
+    /**
+     * This test suite verifies the fix for the address ordering bug in ImportInC.
+     *
+     * The issue: When the API returns UTXO addresses in a different order than how they're
+     * stored on-chain (lexicographically sorted by byte value), the sigIndices would be
+     * computed incorrectly, causing signature verification to fail.
+     *
+     * The fix: Sort UTXO addresses before computing addressesIndex to match on-chain order.
+     */
+
+    // Helper to create UTXO with specific address order
+    const createUtxoWithAddressOrder = (utxo: (typeof testData.utxos)[0], addresses: string[]) => ({
+      ...utxo,
+      addresses: addresses,
+    });
+
+    it('should correctly sort UTXO addresses when building ImportInC transaction', async () => {
+      // Create UTXOs with addresses in reversed order (simulating API returning unsorted)
+      const reversedUtxos = testData.utxos.map((utxo) =>
+        createUtxoWithAddressOrder(utxo, [...utxo.addresses].reverse())
+      );
+
+      const txBuilder = factory
+        .getImportInCBuilder()
+        .threshold(testData.threshold)
+        .locktime(testData.locktime)
+        .fromPubKey(testData.pAddresses)
+        .to(testData.to)
+        .externalChainId(testData.sourceChainId)
+        .fee(testData.fee)
+        .context(testData.context)
+        .decodedUtxos(reversedUtxos);
+
+      // Should not throw - the fix ensures addresses are sorted before computing sigIndices
+      const tx = await txBuilder.build();
+      const txJson = tx.toJson();
+
+      // Verify transaction built successfully
+      txJson.threshold.should.equal(2);
+      tx.toBroadcastFormat().should.be.a.String();
+    });
+
+    it('should produce same transaction hex regardless of input UTXO address order for ImportInC', async () => {
+      // Build with original address order
+      const txBuilder1 = factory
+        .getImportInCBuilder()
+        .threshold(testData.threshold)
+        .locktime(testData.locktime)
+        .fromPubKey(testData.pAddresses)
+        .to(testData.to)
+        .externalChainId(testData.sourceChainId)
+        .fee(testData.fee)
+        .context(testData.context)
+        .decodedUtxos(testData.utxos);
+
+      const tx1 = await txBuilder1.build();
+      const hex1 = tx1.toBroadcastFormat();
+
+      // Build with reversed address order in UTXOs
+      const reversedUtxos = testData.utxos.map((utxo) =>
+        createUtxoWithAddressOrder(utxo, [...utxo.addresses].reverse())
+      );
+
+      const txBuilder2 = factory
+        .getImportInCBuilder()
+        .threshold(testData.threshold)
+        .locktime(testData.locktime)
+        .fromPubKey(testData.pAddresses)
+        .to(testData.to)
+        .externalChainId(testData.sourceChainId)
+        .fee(testData.fee)
+        .context(testData.context)
+        .decodedUtxos(reversedUtxos);
+
+      const tx2 = await txBuilder2.build();
+      const hex2 = tx2.toBroadcastFormat();
+
+      // Both should produce the same hex since addresses get sorted
+      hex1.should.equal(hex2);
+    });
+
+    it('should handle signing correctly with unsorted UTXO addresses for ImportInC', async () => {
+      const reversedUtxos = testData.utxos.map((utxo) =>
+        createUtxoWithAddressOrder(utxo, [...utxo.addresses].reverse())
+      );
+
+      const txBuilder = factory
+        .getImportInCBuilder()
+        .threshold(testData.threshold)
+        .locktime(testData.locktime)
+        .fromPubKey(testData.pAddresses)
+        .to(testData.to)
+        .externalChainId(testData.sourceChainId)
+        .fee(testData.fee)
+        .context(testData.context)
+        .decodedUtxos(reversedUtxos);
+
+      txBuilder.sign({ key: testData.privateKeys[2] });
+      txBuilder.sign({ key: testData.privateKeys[0] });
+
+      const tx = await txBuilder.build();
+      const txJson = tx.toJson();
+
+      // Should have 2 signatures after signing
+      txJson.signatures.length.should.equal(2);
+    });
+
+    it('should produce valid signed transaction matching expected output with unsorted addresses for ImportInC', async () => {
+      const reversedUtxos = testData.utxos.map((utxo) =>
+        createUtxoWithAddressOrder(utxo, [...utxo.addresses].reverse())
+      );
+
+      const txBuilder = factory
+        .getImportInCBuilder()
+        .threshold(testData.threshold)
+        .locktime(testData.locktime)
+        .fromPubKey(testData.pAddresses)
+        .to(testData.to)
+        .externalChainId(testData.sourceChainId)
+        .fee(testData.fee)
+        .context(testData.context)
+        .decodedUtxos(reversedUtxos);
+
+      txBuilder.sign({ key: testData.privateKeys[2] });
+      txBuilder.sign({ key: testData.privateKeys[0] });
+
+      const tx = await txBuilder.build();
+
+      // The signed tx should match the expected fullSigntxHex from testData
+      tx.toBroadcastFormat().should.equal(testData.fullSigntxHex);
+      tx.id.should.equal(testData.txhash);
+    });
+  });
+
   describe('fresh build with different UTXO address order for ImportInC', () => {
     it('should correctly complete full sign flow with different UTXO address order for ImportInC', async () => {
       const builder1 = new TransactionBuilderFactory(coins.get('tflrp')).from(testData.unsignedHex);


### PR DESCRIPTION
- Added `sortAddressesByHex` and `sortAddressBuffersByHex` utility functions to sort addresses lexicographically by byte value.
- Updated `AtomicTransactionBuilder` to sort UTXO addresses before computing `addressesIndex`, ensuring alignment with on-chain storage order.
- Introduced `computeAddressesIndexFromParsed` method for consistent address indexing when parsing existing transactions.
- Removed redundant `computeAddressesIndexFromParsed` methods from `ExportInPTxBuilder` and `ImportInCTxBuilder`.
- Added unit tests to verify address sorting functionality and its impact on transaction building for both `ExportInP` and `ImportInC` transactions.