### PR TITLE
feat(abstract-utxo): enhance output handling and fix address comparison

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -592,19 +592,6 @@ export abstract class AbstractUtxoCoin
     return this.decodeTransaction(string, decodeWith);
   }
 
-  toCanonicalTransactionRecipient(output: { valueString: string; address?: string }): {
-    amount: bigint;
-    address: string;
-  } {
-    const amount = BigInt(output.valueString);
-    assertValidTransactionRecipient({ amount, address: output.address });
-    assert(output.address, 'address is required');
-    if (isScriptRecipient(output.address)) {
-      return { amount, address: output.address };
-    }
-    return { amount, address: this.canonicalAddress(output.address) };
-  }
-
   /**
    * Extract and fill transaction details such as internal/change spend, external spend (explicit vs. implicit), etc.
    * @param params

--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -479,7 +479,11 @@ export abstract class AbstractUtxoCoin
     }
   }
 
-  preprocessBuildParams(params: Record<string, any>): Record<string, any> {
+  /**
+   * This is called before crafting the HTTP request to the BitGo API.
+   * It converts the recipient address `scriptPubKey:...` to { script: string } | { address: string }.
+   */
+  override preprocessBuildParams(params: Record<string, any>): Record<string, any> {
     if (params.recipients !== undefined) {
       params.recipients =
         params.recipients instanceof Array

--- a/modules/abstract-utxo/src/transaction/fixedScript/parseOutput.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/parseOutput.ts
@@ -14,6 +14,7 @@ import {
 
 import { AbstractUtxoCoin } from '../../abstractUtxoCoin';
 import { Output, FixedScriptWalletOutput } from '../types';
+import { fromExtendedAddressFormatToScript } from '../recipient';
 
 const debug = debugLib('bitgo:v2:parseoutput');
 
@@ -284,7 +285,9 @@ export async function parseOutput({
      */
     if (txParams.recipients !== undefined && txParams.recipients.length > RECIPIENT_THRESHOLD) {
       const isCurrentAddressInRecipients = txParams.recipients.some((recipient) =>
-        recipient.address.includes(currentAddress)
+        fromExtendedAddressFormatToScript(recipient.address, coin.name).equals(
+          fromExtendedAddressFormatToScript(currentAddress, coin.name)
+        )
       );
 
       if (isCurrentAddressInRecipients) {

--- a/modules/abstract-utxo/src/transaction/fixedScript/parseTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/parseTransaction.ts
@@ -183,7 +183,7 @@ export async function parseTransaction<TNumber extends bigint | number>(
         keychainArray: toKeychainTriple(keychains),
         wallet,
         txParams: {
-          recipients: expectedOutputs,
+          recipients: txParams.recipients ?? [],
           changeAddress: txParams.changeAddress,
         },
         customChange,

--- a/modules/abstract-utxo/src/transaction/outputDifference.ts
+++ b/modules/abstract-utxo/src/transaction/outputDifference.ts
@@ -7,7 +7,10 @@ export type ComparableOutput<TValue> = {
 export type ActualOutput = ComparableOutput<bigint>;
 
 /** Expected outputs can have a fixed value or 'max'. */
-export type ExpectedOutput = ComparableOutput<bigint | 'max'>;
+export type ExpectedOutput = ComparableOutput<bigint | 'max'> & {
+  /** When true, the output is not required to be present in the transaction. */
+  optional?: boolean;
+};
 
 /**
  * @param a
@@ -40,6 +43,13 @@ export function outputDifference<A extends ActualOutput | ExpectedOutput, B exte
   return first;
 }
 
+export function getMissingOutputs<A extends ActualOutput, B extends ExpectedOutput>(
+  actualOutputs: A[],
+  expectedOutputs: B[]
+): B[] {
+  return outputDifference(expectedOutputs, actualOutputs).filter((o) => !o.optional);
+}
+
 export type OutputDifferenceWithExpected<TActual extends ActualOutput, TExpected extends ExpectedOutput> = {
   /** These are the external outputs that were expected and found in the transaction. */
   explicitOutputs: TActual[];
@@ -65,7 +75,7 @@ export function outputDifferencesWithExpected<TActual extends ActualOutput, TExp
 ): OutputDifferenceWithExpected<TActual, TExpected> {
   const implicitOutputs = outputDifference(actualOutputs, expectedOutputs);
   const explicitOutputs = outputDifference(actualOutputs, implicitOutputs);
-  const missingOutputs = outputDifference(expectedOutputs, actualOutputs);
+  const missingOutputs = getMissingOutputs(actualOutputs, expectedOutputs);
   return {
     explicitOutputs,
     implicitOutputs,

--- a/modules/abstract-utxo/src/transaction/recipient.ts
+++ b/modules/abstract-utxo/src/transaction/recipient.ts
@@ -33,6 +33,19 @@ export function fromExtendedAddressFormatToScript(extendedAddress: string, coinN
   return utxolib.addressFormat.toOutputScriptTryFormats(result.address, network);
 }
 
+export function toOutputScript(v: string | { address: string } | { script: string }, coinName: UtxoCoinName): Buffer {
+  if (typeof v === 'string') {
+    return fromExtendedAddressFormatToScript(v, coinName);
+  }
+  if ('script' in v) {
+    return Buffer.from(v.script, 'hex');
+  }
+  if ('address' in v) {
+    return fromExtendedAddressFormatToScript(v.address, coinName);
+  }
+  throw new Error('invalid input');
+}
+
 /**
  * Convert a script or address to the extended address format.
  * @param script

--- a/modules/abstract-utxo/test/unit/transaction/outputDifference.ts
+++ b/modules/abstract-utxo/test/unit/transaction/outputDifference.ts
@@ -6,7 +6,7 @@ import {
   matchingOutput,
   outputDifference,
   outputDifferencesWithExpected,
-} from '../../../../src/transaction/outputDifference';
+} from '../../../src/transaction/outputDifference';
 
 describe('outputDifference', function () {
   function output(script: string, value: bigint | number): ActualOutput;

--- a/modules/abstract-utxo/test/unit/transaction/outputDifference.ts
+++ b/modules/abstract-utxo/test/unit/transaction/outputDifference.ts
@@ -10,8 +10,8 @@ import {
 } from '../../../src/transaction/outputDifference';
 
 describe('outputDifference', function () {
-  function output(script: string, value: bigint | number): ActualOutput;
-  function output(script: string, value: 'max'): ExpectedOutput;
+  function output(script: string, value: bigint | number, optional?: boolean): ActualOutput;
+  function output(script: string, value: 'max', optional?: boolean): ExpectedOutput;
   function output(script: string, value: bigint | number | 'max', optional?: boolean): ActualOutput | ExpectedOutput {
     const scriptBuffer = Buffer.from(script, 'hex');
     if (scriptBuffer.toString('hex') !== script) {


### PR DESCRIPTION

This PR adds optional expected outputs support and fixes several issues in 
address handling and transaction parsing:

- Add optional flag to ExpectedOutput type for outputs that can be excluded
- Normalize address comparison in parseOutput for accurate matching
- Fix handling of allowExternalChangeAddress parameter in transaction verification
- Move toCanonicalTransactionRecipient to parseTransaction module
- Add missing override keyword to preprocessBuildParams method
- Move outputDifference tests to correct directory

Issue: BTC-2962