### PR TITLE
feat(abstract-utxo): update wasm-utxo and optimize tx signing

### DIFF
--- a/modules/abstract-utxo/package.json
+++ b/modules/abstract-utxo/package.json
@@ -68,7 +68,7 @@
     "@bitgo/utxo-core": "^1.31.0",
     "@bitgo/utxo-lib": "^11.19.1",
     "@bitgo/utxo-ord": "^1.24.1",
-    "@bitgo/wasm-utxo": "^1.27.0",
+    "@bitgo/wasm-utxo": "^1.29.0",
     "@types/lodash": "^4.14.121",
     "@types/superagent": "4.1.15",
     "bignumber.js": "^9.0.2",

--- a/modules/abstract-utxo/src/transaction/fixedScript/SigningError.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/SigningError.ts
@@ -28,6 +28,13 @@ export class InputSigningError<TNumber extends number | bigint = number> extends
   }
 }
 
+export class BulkSigningError extends Error {
+  constructor(public reason: Error | string) {
+    const reasonMessage = reason instanceof Error ? reason.message : reason;
+    super(`bulk signing error: ${reasonMessage}`);
+  }
+}
+
 export class TransactionSigningError<TNumber extends number | bigint = number> extends Error {
   constructor(signErrors: InputSigningError<TNumber>[], verifyError: InputSigningError<TNumber>[]) {
     super(

--- a/modules/utxo-bin/package.json
+++ b/modules/utxo-bin/package.json
@@ -31,7 +31,7 @@
     "@bitgo/unspents": "^0.50.14",
     "@bitgo/utxo-core": "^1.31.0",
     "@bitgo/utxo-lib": "^11.19.1",
-    "@bitgo/wasm-utxo": "^1.27.0",
+    "@bitgo/wasm-utxo": "^1.29.0",
     "@noble/curves": "1.8.1",
     "archy": "^1.0.0",
     "bech32": "^2.0.0",

--- a/modules/utxo-core/package.json
+++ b/modules/utxo-core/package.json
@@ -81,7 +81,7 @@
     "@bitgo/secp256k1": "^1.9.0",
     "@bitgo/unspents": "^0.50.14",
     "@bitgo/utxo-lib": "^11.19.1",
-    "@bitgo/wasm-utxo": "^1.27.0",
+    "@bitgo/wasm-utxo": "^1.29.0",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
     "fast-sha256": "^1.3.0"
   },

--- a/modules/utxo-ord/package.json
+++ b/modules/utxo-ord/package.json
@@ -45,7 +45,7 @@
     "directory": "modules/utxo-ord"
   },
   "dependencies": {
-    "@bitgo/wasm-utxo": "^1.27.0"
+    "@bitgo/wasm-utxo": "^1.29.0"
   },
   "devDependencies": {
     "@bitgo/utxo-lib": "^11.19.1"

--- a/modules/utxo-staking/package.json
+++ b/modules/utxo-staking/package.json
@@ -63,7 +63,7 @@
     "@bitgo/babylonlabs-io-btc-staking-ts": "^3.3.0",
     "@bitgo/utxo-core": "^1.31.0",
     "@bitgo/utxo-lib": "^11.19.1",
-    "@bitgo/wasm-utxo": "^1.27.0",
+    "@bitgo/wasm-utxo": "^1.29.0",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
     "bip322-js": "^2.0.0",
     "bitcoinjs-lib": "^6.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -996,10 +996,10 @@
     monocle-ts "^2.3.13"
     newtype-ts "^0.3.5"
 
-"@bitgo/wasm-utxo@^1.27.0":
-  version "1.27.0"
-  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-1.27.0.tgz#c8ebe108ce8b55d3df70cd3968211a6ef3001bef"
-  integrity sha512-gX0YemHbSBOKQ/nKaBsZKI3cJzgkrLXFWuMsPJ7t2oDzE3ggfgVF3ulGFsuaQ8WQT4rOsZ7FZz2f+C9mStXAeA==
+"@bitgo/wasm-utxo@^1.29.0":
+  version "1.29.0"
+  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-1.29.0.tgz#75be3668bd972a3ff9aae07aed84916bfceb870d"
+  integrity sha512-eWYM7/me8bg+oqw6lEVMdmR1eUVuGzOoyKgSm1QAZUe41qR8IjMyyWjtWI1s5XExfAOXnZuSss/8QJEPOjXhzg==
 
 "@brandonblack/musig@^0.0.1-alpha.0":
   version "0.0.1-alpha.1"


### PR DESCRIPTION

Update wasm-utxo dependency across multiple modules from 1.27.0 to 1.29.0.

Implement bulk signing approach for transaction inputs to optimize the
signing process. Instead of signing each input individually, all inputs
are now signed in a single operation, improving performance.

Added BulkSigningError class to provide better error reporting when
bulk signing operations fail.

Issue: BTC-2980