### PR TITLE
feat: enable intent handling for all EVM chains with TSS support

### DIFF
--- a/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
@@ -191,7 +191,7 @@ export abstract class MpcUtils {
       isTestTransaction: params.isTestTransaction,
     };
 
-    if (['eth', 'polygon', 'bsc', 'coredao', 'seievm'].includes(baseCoin.getFamily())) {
+    if (baseCoin.isEVM() && baseCoin.supportsTss()) {
       switch (params.intentType) {
         case 'payment':
         case 'transferToken':


### PR DESCRIPTION
## Summary
- Replaced hardcoded EVM chain list with dynamic check using `baseCoin.isEVM() && baseCoin.supportsTss()`
- Enables intent handling for all EVM chains that support TSS/MPC automatically
- Improves maintainability by removing need to update hardcoded chain lists for new EVM chains

## Test plan
- [ ] Verify existing EVM chains (eth, polygon, bsc, coredao, seievm) continue to work
- [ ] Test that new EVM chains with TSS support are automatically enabled
- [ ] Ensure non-EVM chains or EVM chains without TSS are not affected

CLOSES TICKET: COIN-7464