### PR TITLE
feat(abstract-utxo): remove unused addressType param

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -530,6 +530,7 @@ export abstract class AbstractUtxoCoin
   }
 
   /**
+   * @deprecated - will be removed when we drop support for utxolib
    * Determine an address' type based on its witness and redeem script presence
    * @param addressDetails
    */
@@ -703,7 +704,6 @@ export abstract class AbstractUtxoCoin
       address,
       keychains,
       format: params.format ?? 'base58',
-      addressType: params.addressType,
       chain,
       index,
     });

--- a/modules/abstract-utxo/src/address/fixedScript.ts
+++ b/modules/abstract-utxo/src/address/fixedScript.ts
@@ -24,7 +24,6 @@ export interface FixedScriptAddressCoinSpecific {
 }
 
 export interface GenerateAddressOptions {
-  addressType?: ScriptType2Of3;
   chain?: number;
   index?: number;
   segwit?: boolean;
@@ -62,7 +61,6 @@ export function generateAddressWithChainAndIndex(
 
 /**
  * Generate an address for a wallet based on a set of configurations
- * @param params.addressType {string}   Deprecated
  * @param params.keychains   {[object]} Array of objects with xpubs
  * @param params.threshold   {number}   Minimum number of signatures
  * @param params.chain       {number}   Derivation chain (see https://github.com/BitGo/unspents/blob/master/src/codes.ts for
@@ -98,7 +96,7 @@ export function generateAddress(coinName: UtxoCoinName, params: GenerateFixedScr
     }
   }
 
-  const addressType = normalizeScriptType(params.addressType || convertFlagsToAddressType());
+  const addressType = normalizeScriptType(convertFlagsToAddressType());
 
   if (addressType !== fixedScriptWallet.ChainCode.scriptType(derivationChain)) {
     throw new AddressTypeChainMismatchError(addressType, derivationChain);
@@ -146,14 +144,12 @@ export function assertFixedScriptWalletAddress(
     index,
     keychains,
     format,
-    addressType,
     address,
   }: {
     chain: number | undefined;
     index: number;
     keychains: Keychain[];
     format: CreateAddressFormat;
-    addressType: string | undefined;
     address: string;
   }
 ): void {
@@ -169,7 +165,6 @@ export function assertFixedScriptWalletAddress(
 
   const expectedAddress = generateAddress(coinName, {
     format,
-    addressType: addressType as ScriptType2Of3,
     keychains,
     chain,
     index,


### PR DESCRIPTION

Remove redundant addressType parameter that was previously being passed
around in address verification functions. The parameter was not needed
since the address type can be determined from the chain code.

Issue: BTC-2668