### PR TITLE
feat(sdk-core): remove dependency on inferAddressType function

### DIFF
--- a/modules/sdk-core/src/bitgo/utils/abstractUtxoCoinUtil.ts
+++ b/modules/sdk-core/src/bitgo/utils/abstractUtxoCoinUtil.ts
@@ -4,6 +4,7 @@ import * as utxolib from '@bitgo/utxo-lib';
 import ScriptType2Of3 = utxolib.bitgo.outputScripts.ScriptType2Of3;
 import { WalletType } from '../wallet';
 
+/** @deprecated - will be removed when we drop support for utxolib */
 export function inferAddressType(addressDetails: { chain: number }): ScriptType2Of3 | null {
   return utxolib.bitgo.isChainCode(addressDetails.chain)
     ? utxolib.bitgo.scriptTypeForChain(addressDetails.chain)

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -40,7 +40,6 @@ import { TradingAccount } from '../trading';
 import { getTxRequest } from '../tss';
 import {
   EddsaUnsignedTransaction,
-  inferAddressType,
   IntentOptionsForMessage,
   IntentOptionsForTypedData,
   RequestTracer,
@@ -1388,11 +1387,6 @@ export class Wallet implements IWallet {
         .post(this.baseCoin.url('/wallet/' + this._wallet.id + '/address'))
         .send(addressParams)
         .result()) as any;
-
-      // infer its address type
-      if (_.isObject(newAddress.coinSpecific)) {
-        newAddress.addressType = inferAddressType(newAddress);
-      }
 
       newAddress.keychains = keychains;
       newAddress.baseAddress = baseAddress ?? _.get(this._wallet, 'coinSpecific.baseAddress');


### PR DESCRIPTION

There is no need to infer an address type

BTC-2668