### PR TITLE
feat(abstract-utxo): bump wasm-utxo to 1.32.0

### DIFF
--- a/modules/abstract-utxo/package.json
+++ b/modules/abstract-utxo/package.json
@@ -68,7 +68,7 @@
     "@bitgo/utxo-core": "^1.32.0",
     "@bitgo/utxo-lib": "^11.20.0",
     "@bitgo/utxo-ord": "^1.25.0",
-    "@bitgo/wasm-utxo": "^1.29.0",
+    "@bitgo/wasm-utxo": "^1.32.0",
     "@types/lodash": "^4.14.121",
     "@types/superagent": "4.1.15",
     "bignumber.js": "^9.0.2",

--- a/modules/abstract-utxo/src/recovery/backupKeyRecovery.ts
+++ b/modules/abstract-utxo/src/recovery/backupKeyRecovery.ts
@@ -417,7 +417,7 @@ export async function backupKeyRecovery(
     if (psbt instanceof utxolib.bitgo.UtxoPsbt) {
       txInfo.transactionHex = psbt.extractTransaction().toBuffer().toString('hex');
     } else if (psbt instanceof fixedScriptWallet.BitGoPsbt) {
-      txInfo.transactionHex = Buffer.from(psbt.extractTransaction()).toString('hex');
+      txInfo.transactionHex = Buffer.from(psbt.extractTransaction().toBytes()).toString('hex');
     } else {
       throw new Error('expected a UtxoPsbt or BitGoPsbt object');
     }

--- a/modules/abstract-utxo/src/transaction/fixedScript/signTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/signTransaction.ts
@@ -112,7 +112,7 @@ export async function signTransaction<
     );
     if (isLastSignature) {
       signedPsbt.finalizeAllInputs();
-      return Buffer.from(signedPsbt.extractTransaction());
+      return Buffer.from(signedPsbt.extractTransaction().toBytes());
     }
     return signedPsbt;
   }

--- a/modules/utxo-bin/package.json
+++ b/modules/utxo-bin/package.json
@@ -31,7 +31,7 @@
     "@bitgo/unspents": "^0.51.0",
     "@bitgo/utxo-core": "^1.32.0",
     "@bitgo/utxo-lib": "^11.20.0",
-    "@bitgo/wasm-utxo": "^1.29.0",
+    "@bitgo/wasm-utxo": "^1.32.0",
     "@noble/curves": "1.8.1",
     "archy": "^1.0.0",
     "bech32": "^2.0.0",

--- a/modules/utxo-core/package.json
+++ b/modules/utxo-core/package.json
@@ -81,7 +81,7 @@
     "@bitgo/secp256k1": "^1.10.0",
     "@bitgo/unspents": "^0.51.0",
     "@bitgo/utxo-lib": "^11.20.0",
-    "@bitgo/wasm-utxo": "^1.29.0",
+    "@bitgo/wasm-utxo": "^1.32.0",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
     "fast-sha256": "^1.3.0"
   },

--- a/modules/utxo-ord/package.json
+++ b/modules/utxo-ord/package.json
@@ -45,7 +45,7 @@
     "directory": "modules/utxo-ord"
   },
   "dependencies": {
-    "@bitgo/wasm-utxo": "^1.29.0"
+    "@bitgo/wasm-utxo": "^1.32.0"
   },
   "devDependencies": {
     "@bitgo/utxo-lib": "^11.20.0"

--- a/modules/utxo-ord/test/psbt.ts
+++ b/modules/utxo-ord/test/psbt.ts
@@ -129,8 +129,8 @@ describe('OutputLayout to PSBT conversion', function () {
       assertValidPsbt(psbt, rootWalletKeys, signerXprvs, expectedOutputs, expectedResult.feeOutput);
       assertValidPsbt(psbt1, rootWalletKeys, signerXprvs, expectedOutputs, expectedResult.feeOutput);
       assert.strictEqual(
-        Buffer.from(psbt.extractTransaction()).toString('hex'),
-        Buffer.from(psbt1.extractTransaction()).toString('hex')
+        Buffer.from(psbt.extractTransaction().toBytes()).toString('hex'),
+        Buffer.from(psbt1.extractTransaction().toBytes()).toString('hex')
       );
     });
   }

--- a/modules/utxo-staking/package.json
+++ b/modules/utxo-staking/package.json
@@ -63,7 +63,7 @@
     "@bitgo/babylonlabs-io-btc-staking-ts": "^3.4.0",
     "@bitgo/utxo-core": "^1.32.0",
     "@bitgo/utxo-lib": "^11.20.0",
-    "@bitgo/wasm-utxo": "^1.29.0",
+    "@bitgo/wasm-utxo": "^1.32.0",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
     "bip322-js": "^2.0.0",
     "bitcoinjs-lib": "^6.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -996,10 +996,10 @@
     monocle-ts "^2.3.13"
     newtype-ts "^0.3.5"
 
-"@bitgo/wasm-utxo@^1.29.0":
-  version "1.29.0"
-  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-1.29.0.tgz#75be3668bd972a3ff9aae07aed84916bfceb870d"
-  integrity sha512-eWYM7/me8bg+oqw6lEVMdmR1eUVuGzOoyKgSm1QAZUe41qR8IjMyyWjtWI1s5XExfAOXnZuSss/8QJEPOjXhzg==
+"@bitgo/wasm-utxo@^1.32.0":
+  version "1.32.0"
+  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-1.32.0.tgz#fc7e7803eb584ba8ad16aeb0a2805d6905d287d3"
+  integrity sha512-fqUGh8XOrzbPcTxK3lhS9UjqKxx3UaN6L+eS3vocBeWHbQvl6jm9xPPQ+TDkeiUuZdxaj0+7ca4Algt9vyiXHg==
 
 "@brandonblack/musig@^0.0.1-alpha.0":
   version "0.0.1-alpha.1"


### PR DESCRIPTION

Update wasm-utxo version to 1.32.0 across multiple modules and fix
transaction extraction call to use toBytes() method.

Issue: BTC-2866