### PR TITLE
feat(abstract-utxo): switch descriptor wallet stack to wasm-utxo primitives

### DIFF
--- a/modules/abstract-utxo/src/descriptor/assertDescriptorWalletAddress.ts
+++ b/modules/abstract-utxo/src/descriptor/assertDescriptorWalletAddress.ts
@@ -1,11 +1,9 @@
 import assert from 'assert';
 
-import * as utxolib from '@bitgo/utxo-lib';
-import { Descriptor } from '@bitgo/wasm-utxo';
-import { DescriptorMap } from '@bitgo/utxo-core/descriptor';
+import { Descriptor, address, descriptorWallet } from '@bitgo/wasm-utxo';
 
 import { UtxoCoinSpecific, VerifyAddressOptions } from '../abstractUtxoCoin';
-import { getNetworkFromCoinName, UtxoCoinName } from '../names';
+import { UtxoCoinName } from '../names';
 
 class DescriptorAddressMismatchError extends Error {
   constructor(descriptor: Descriptor, index: number, derivedAddress: string, expectedAddress: string) {
@@ -18,7 +16,7 @@ class DescriptorAddressMismatchError extends Error {
 export function assertDescriptorWalletAddress(
   coinName: UtxoCoinName,
   params: VerifyAddressOptions<UtxoCoinSpecific>,
-  descriptors: DescriptorMap
+  descriptors: descriptorWallet.DescriptorMap
 ): void {
   assert(params.coinSpecific);
   assert('descriptorName' in params.coinSpecific);
@@ -35,8 +33,7 @@ export function assertDescriptorWalletAddress(
     );
   }
   const derivedScript = Buffer.from(descriptor.atDerivationIndex(params.index).scriptPubkey());
-  const network = getNetworkFromCoinName(coinName);
-  const derivedAddress = utxolib.address.fromOutputScript(derivedScript, network);
+  const derivedAddress = address.fromOutputScriptWithCoin(derivedScript, coinName);
   if (params.address !== derivedAddress) {
     throw new DescriptorAddressMismatchError(descriptor, params.index, derivedAddress, params.address);
   }

--- a/modules/abstract-utxo/src/descriptor/descriptorWallet.ts
+++ b/modules/abstract-utxo/src/descriptor/descriptorWallet.ts
@@ -1,8 +1,8 @@
 import * as t from 'io-ts';
 import { IWallet, WalletCoinSpecific } from '@bitgo/sdk-core';
-import { DescriptorMap } from '@bitgo/utxo-core/descriptor';
 
 import { UtxoWallet, UtxoWalletData } from '../wallet';
+import type { DescriptorMap } from '../wasmUtil';
 
 import { NamedDescriptor } from './NamedDescriptor';
 import { DescriptorValidationPolicy, KeyTriple, toDescriptorMapValidate } from './validatePolicy';

--- a/modules/abstract-utxo/src/descriptor/index.ts
+++ b/modules/abstract-utxo/src/descriptor/index.ts
@@ -1,5 +1,5 @@
 export { Miniscript, Descriptor } from '@bitgo/wasm-utxo';
-export { DescriptorMap } from '@bitgo/utxo-core/descriptor';
+export type { DescriptorMap } from '../wasmUtil';
 export { assertDescriptorWalletAddress } from './assertDescriptorWalletAddress';
 export {
   NamedDescriptor,

--- a/modules/abstract-utxo/src/descriptor/validatePolicy.ts
+++ b/modules/abstract-utxo/src/descriptor/validatePolicy.ts
@@ -1,6 +1,8 @@
 import { EnvironmentName, Triple } from '@bitgo/sdk-core';
 import * as utxolib from '@bitgo/utxo-lib';
-import { DescriptorMap, toDescriptorMap } from '@bitgo/utxo-core/descriptor';
+import { descriptorWallet } from '@bitgo/wasm-utxo';
+
+import type { DescriptorMap } from '../wasmUtil';
 
 import { parseDescriptor } from './builder';
 import { hasValidSignature, NamedDescriptor, NamedDescriptorNative, toNamedDescriptorNative } from './NamedDescriptor';
@@ -91,7 +93,7 @@ export function toDescriptorMapValidate(
     toNamedDescriptorNative(v, 'derivable')
   );
   assertDescriptorPolicy(namedDescriptorsNative, policy, walletKeys);
-  return toDescriptorMap(namedDescriptorsNative);
+  return descriptorWallet.toDescriptorMap(namedDescriptorsNative);
 }
 
 export function getPolicyForEnv(env: EnvironmentName): DescriptorValidationPolicy {

--- a/modules/abstract-utxo/src/offlineVault/OfflineVaultHalfSigned.ts
+++ b/modules/abstract-utxo/src/offlineVault/OfflineVaultHalfSigned.ts
@@ -1,5 +1,5 @@
 import { BIP32Interface, bip32 } from '@bitgo/secp256k1';
-import * as utxolib from '@bitgo/utxo-lib';
+import { Psbt } from '@bitgo/wasm-utxo';
 import { BaseCoin } from '@bitgo/sdk-core';
 
 import { UtxoCoinName } from '../names';
@@ -11,8 +11,8 @@ export type OfflineVaultHalfSigned = {
   halfSigned: { txHex: string };
 };
 
-function createHalfSignedFromPsbt(psbt: utxolib.Psbt): OfflineVaultHalfSigned {
-  return { halfSigned: { txHex: psbt.toHex() } };
+function createHalfSignedFromPsbt(psbt: Psbt): OfflineVaultHalfSigned {
+  return { halfSigned: { txHex: Buffer.from(psbt.serialize()).toString('hex') } };
 }
 
 export function createHalfSigned(

--- a/modules/abstract-utxo/src/transaction/descriptor/index.ts
+++ b/modules/abstract-utxo/src/transaction/descriptor/index.ts
@@ -1,4 +1,4 @@
-export { DescriptorMap } from '@bitgo/utxo-core/descriptor';
+export type { DescriptorMap } from '../../wasmUtil';
 export { explainPsbt } from './explainPsbt';
 export { parse } from './parse';
 export { parseToAmountType } from './parseToAmountType';

--- a/modules/abstract-utxo/src/transaction/explainTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/explainTransaction.ts
@@ -7,6 +7,7 @@ import { toBip32Triple } from '../keychains';
 import { getPolicyForEnv } from '../descriptor/validatePolicy';
 import { UtxoCoinName } from '../names';
 import type { Unspent } from '../unspent';
+import { toWasmPsbt } from '../wasmUtil';
 
 import { getReplayProtectionPubkeys } from './fixedScript/replayProtection';
 import type {
@@ -42,7 +43,7 @@ export function explainTx<TNumber extends number | bigint>(
         walletKeys,
         getPolicyForEnv(params.wallet.bitgo.env)
       );
-      return descriptor.explainPsbt(tx, descriptors);
+      return descriptor.explainPsbt(toWasmPsbt(tx), descriptors, coinName);
     }
 
     throw new Error('legacy transactions are not supported for descriptor wallets');

--- a/modules/abstract-utxo/src/transaction/fixedScript/signPsbtWasm.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/signPsbtWasm.ts
@@ -1,7 +1,9 @@
 import assert from 'assert';
 
 import { BIP32Interface } from '@bitgo/utxo-lib';
-import { BIP32, ECPair, fixedScriptWallet } from '@bitgo/wasm-utxo';
+import { ECPair, fixedScriptWallet } from '@bitgo/wasm-utxo';
+
+import { toWasmBIP32 } from '../../wasmUtil';
 
 import { BulkSigningError, InputSigningError, TransactionSigningError } from './SigningError';
 import { Musig2Participant } from './musig2';
@@ -74,11 +76,6 @@ export function signAndVerifyPsbtWasm(
   }
 
   return tx;
-}
-
-function toWasmBIP32(key: BIP32Interface): BIP32 {
-  // Convert using base58 string to ensure private key is properly transferred
-  return BIP32.fromBase58(key.toBase58());
 }
 
 export async function signPsbtWithMusig2ParticipantWasm(

--- a/modules/abstract-utxo/src/wasmUtil.ts
+++ b/modules/abstract-utxo/src/wasmUtil.ts
@@ -1,0 +1,66 @@
+import { BIP32, ECPair, Psbt, descriptorWallet } from '@bitgo/wasm-utxo';
+import * as utxolib from '@bitgo/utxo-lib';
+
+export type BIP32Key = BIP32 | utxolib.BIP32Interface;
+export type ECPairKey = ECPair | utxolib.ECPairInterface | Uint8Array;
+export type UtxoLibPsbt = utxolib.Psbt | utxolib.bitgo.UtxoPsbt;
+
+/**
+ * Map of descriptor name to Descriptor instance.
+ * Re-exported from wasm-utxo for consistency.
+ */
+export type DescriptorMap = descriptorWallet.DescriptorMap;
+
+/**
+ * Key type accepted by descriptorWallet.signWithKey
+ */
+export type SignerKey = Parameters<typeof descriptorWallet.signWithKey>[1];
+
+/**
+ * Convert a utxo-lib BIP32Interface to a wasm-utxo BIP32 instance.
+ * Preserves private key by using base58 serialization.
+ */
+export function toWasmBIP32(key: BIP32Key): BIP32 {
+  if (key instanceof BIP32) {
+    return key;
+  }
+  // All utxo-lib BIP32Interface instances have toBase58
+  return BIP32.fromBase58(key.toBase58());
+}
+
+export function toWasmECPair(key: ECPairKey): ECPair {
+  if (key instanceof ECPair) {
+    return key;
+  }
+  if (key instanceof Uint8Array) {
+    return ECPair.from(key);
+  }
+  if (key.privateKey) {
+    return ECPair.fromPrivateKey(key.privateKey);
+  }
+  return ECPair.fromPublicKey(key.publicKey);
+}
+
+export function isUtxoLibPsbt(psbt: unknown): psbt is UtxoLibPsbt {
+  return psbt instanceof utxolib.Psbt || psbt instanceof utxolib.bitgo.UtxoPsbt;
+}
+
+export function toWasmPsbt(psbt: Psbt | UtxoLibPsbt | Uint8Array): Psbt {
+  if (psbt instanceof Psbt) {
+    return psbt;
+  }
+  if (psbt instanceof Uint8Array) {
+    return Psbt.deserialize(psbt);
+  }
+  if (isUtxoLibPsbt(psbt)) {
+    return Psbt.deserialize(psbt.toBuffer());
+  }
+  throw new Error('Unsupported PSBT type');
+}
+
+/**
+ * Sum the `value` property of an array of objects.
+ */
+export function sumValues(arr: { value: bigint }[]): bigint {
+  return arr.reduce((sum, e) => sum + e.value, BigInt(0));
+}

--- a/modules/abstract-utxo/test/unit/transaction/descriptor/explainPsbt.ts
+++ b/modules/abstract-utxo/test/unit/transaction/descriptor/explainPsbt.ts
@@ -2,9 +2,11 @@ import assert from 'assert';
 
 import { getKeyTriple } from '@bitgo/utxo-core/testutil';
 import { getDescriptorMap, mockPsbtDefaultWithDescriptorTemplate } from '@bitgo/utxo-core/testutil/descriptor';
+import { descriptorWallet } from '@bitgo/wasm-utxo';
 
 import type { TransactionExplanation } from '../../../../src/transaction/fixedScript/explainTransaction';
 import { explainPsbt } from '../../../../src/transaction/descriptor';
+import { toWasmPsbt } from '../../../../src/wasmUtil';
 
 import { getFixtureRoot } from './fixtures.utils';
 
@@ -19,13 +21,13 @@ function assertSignatureCount(expl: TransactionExplanation, signatures: number, 
 
 describe('explainPsbt', function () {
   it('has expected values', async function () {
-    const psbt = mockPsbtDefaultWithDescriptorTemplate('Wsh2Of3');
+    const psbt = toWasmPsbt(mockPsbtDefaultWithDescriptorTemplate('Wsh2Of3'));
     const keys = getKeyTriple('a');
     const descriptorMap = getDescriptorMap('Wsh2Of3', keys);
-    await assertEqualFixture('explainPsbt.a.json', explainPsbt(psbt, descriptorMap));
-    psbt.signAllInputsHD(keys[0]);
-    assertSignatureCount(explainPsbt(psbt, descriptorMap), 1, [1, 1]);
-    psbt.signAllInputsHD(keys[1]);
-    assertSignatureCount(explainPsbt(psbt, descriptorMap), 2, [2, 2]);
+    await assertEqualFixture('explainPsbt.a.json', explainPsbt(psbt, descriptorMap, 'btc'));
+    descriptorWallet.signWithKey(psbt, keys[0]);
+    assertSignatureCount(explainPsbt(psbt, descriptorMap, 'btc'), 1, [1, 1]);
+    descriptorWallet.signWithKey(psbt, keys[1]);
+    assertSignatureCount(explainPsbt(psbt, descriptorMap, 'btc'), 2, [2, 2]);
   });
 });

--- a/modules/abstract-utxo/test/unit/transaction/descriptor/parse.ts
+++ b/modules/abstract-utxo/test/unit/transaction/descriptor/parse.ts
@@ -1,7 +1,6 @@
 import assert from 'assert';
 
-import * as utxolib from '@bitgo/utxo-lib';
-import { Descriptor } from '@bitgo/wasm-utxo';
+import { Descriptor, descriptorWallet } from '@bitgo/wasm-utxo';
 import {
   getDefaultXPubs,
   getDescriptor,
@@ -9,12 +8,12 @@ import {
   mockPsbtDefault,
 } from '@bitgo/utxo-core/testutil/descriptor';
 import { toPlainObject } from '@bitgo/utxo-core/testutil';
-import { createAddressFromDescriptor } from '@bitgo/utxo-core/descriptor';
 
 import {
   ParsedOutputsBigInt,
   toBaseParsedTransactionOutputsFromPsbt,
 } from '../../../../src/transaction/descriptor/parse';
+import type { UtxoLibPsbt } from '../../../../src/wasmUtil';
 import {
   AggregateValidationError,
   assertExpectedOutputDifference,
@@ -62,7 +61,7 @@ describe('parse', function () {
   const psbt = mockPsbtDefault({ descriptorSelf, descriptorOther });
 
   function recipient(descriptor: Descriptor, index: number, value = 1000) {
-    return { value, address: createAddressFromDescriptor(descriptor, index, utxolib.networks.bitcoin) };
+    return { value, address: descriptorWallet.createAddressFromDescriptor(descriptor, index, 'btc') };
   }
 
   function internalRecipient(index: number, value?: number): OutputWithValue {
@@ -73,7 +72,7 @@ describe('parse', function () {
     return recipient(descriptorOther, index, value);
   }
 
-  function getBaseParsedTransaction(psbt: utxolib.bitgo.UtxoPsbt, recipients: OutputWithValue[]): ParsedOutputsBigInt {
+  function getBaseParsedTransaction(psbt: UtxoLibPsbt, recipients: OutputWithValue[]): ParsedOutputsBigInt {
     return toBaseParsedTransactionOutputsFromPsbt(
       psbt,
       getDescriptorMap('Wsh2Of3', getDefaultXPubs('a')),

--- a/modules/abstract-utxo/test/unit/transaction/descriptor/sign.ts
+++ b/modules/abstract-utxo/test/unit/transaction/descriptor/sign.ts
@@ -2,30 +2,43 @@ import assert from 'assert';
 
 import { getKeyTriple } from '@bitgo/utxo-core/testutil';
 import { getDescriptorMap, mockPsbtDefaultWithDescriptorTemplate } from '@bitgo/utxo-core/testutil/descriptor';
+import { Psbt } from '@bitgo/wasm-utxo';
 
 import { signPsbt } from '../../../../src/transaction/descriptor';
 import { ErrorUnknownInput } from '../../../../src/transaction/descriptor/signPsbt';
+import { toWasmPsbt } from '../../../../src/wasmUtil';
+
+function assertInputHasValidSignatures(psbt: Psbt, inputIndex: number) {
+  assert(psbt.hasPartialSignatures(inputIndex));
+  const partialSigs = psbt.getPartialSignatures(inputIndex);
+  assert(partialSigs.length > 0);
+  for (const sig of partialSigs) {
+    assert(psbt.validateSignatureAtInput(inputIndex, sig.pubkey));
+  }
+}
 
 describe('sign', function () {
-  const psbtUnsigned = mockPsbtDefaultWithDescriptorTemplate('Wsh2Of3');
+  const psbtUnsigned = toWasmPsbt(mockPsbtDefaultWithDescriptorTemplate('Wsh2Of3'));
   const keychain = getKeyTriple('a');
   const descriptorMap = getDescriptorMap('Wsh2Of3', keychain);
   const emptyDescriptorMap = new Map();
 
   it('should sign a transaction', async function () {
-    const psbt = psbtUnsigned.clone();
+    const psbt = Psbt.deserialize(psbtUnsigned.serialize());
     signPsbt(psbt, descriptorMap, keychain[0], { onUnknownInput: 'throw' });
-    assert(psbt.validateSignaturesOfAllInputs());
+    assertInputHasValidSignatures(psbt, 0);
+    assertInputHasValidSignatures(psbt, 1);
   });
 
   it('should be sensitive to onUnknownInput', async function () {
-    const psbt = psbtUnsigned.clone();
+    const psbt = Psbt.deserialize(psbtUnsigned.serialize());
     assert.throws(() => {
       signPsbt(psbt, emptyDescriptorMap, keychain[0], { onUnknownInput: 'throw' });
     }, new ErrorUnknownInput(0));
     signPsbt(psbt, emptyDescriptorMap, keychain[0], { onUnknownInput: 'skip' });
-    assert(psbt.data.inputs[0].partialSig === undefined);
+    assert(!psbt.hasPartialSignatures(0));
     signPsbt(psbt, emptyDescriptorMap, keychain[0], { onUnknownInput: 'sign' });
-    assert(psbt.validateSignaturesOfAllInputs());
+    assertInputHasValidSignatures(psbt, 0);
+    assertInputHasValidSignatures(psbt, 1);
   });
 });


### PR DESCRIPTION

Replace all usages of utxo-lib and utxo-core descriptor primitives with the
equivalent functionality from wasm-utxo. This includes:

- Using wasm-utxo Descriptor, Psbt, and descriptorWallet implementations
- Adding wasm utility functions for type conversion
- Converting existing PSBT handling to use the new API
- Updating address validation and derivation

Issue: BTC-2866