### PR TITLE
chore(utxo-core): remove nonWitnessUtxo from Bip322 input

### DIFF
--- a/modules/utxo-core/src/bip322/toSign.ts
+++ b/modules/utxo-core/src/bip322/toSign.ts
@@ -59,7 +59,6 @@ export function addBip322Input(psbt: Psbt, message: string, addressDetails: Addr
     hash: toSpendTx.getId(), // vin[0].prevout.hash = to_spend.txid
     index: 0, // vin[0].prevout.n = 0
     sequence: 0, // vin[0].nSequence = 0
-    nonWitnessUtxo: toSpendTx.toBuffer(), // previous transaction for us to rebuild later to verify
     sighashType: Transaction.SIGHASH_ALL,
   });
   const inputIndex = psbt.data.inputs.length - 1;


### PR DESCRIPTION
Remove unnecessary nonWitnessUtxo field from Bip322 input creation.

TICKET: BTC-2998

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
