### PR TITLE
feat(workflows): remove dependency audit from PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        check: ['lint', 'format', 'commit-lint', 'dependencies', 'audit']
+        check: ['lint', 'format', 'commit-lint', 'dependencies']
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -130,9 +130,8 @@ jobs:
         if: matrix.check == 'dependencies'
         run: yarn run check-deps
 
-      - name: Audit Dependencies
-        if: matrix.check == 'audit'
-        run: yarn run improved-yarn-audit --min-severity high
+      # We conciously do not audit dependencies as a PR step since errors are typically
+      # unrelated to the PR changes. This check is performed in `publish.yml`.
 
   license-analysis:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install BitGoJS
         run: yarn install --with-frozen-lockfile
 
+      - name: Audit Dependencies
+        run: yarn run improved-yarn-audit --min-severity high
+
       - name: Set Environment Variable for Alpha
         if: github.ref != 'refs/heads/master' # only publish changes if on feature branches
         run: |


### PR DESCRIPTION

Move dependency audit from ci.yml to publish.yml workflow to reduce
unrelated PR failures. Audit check will still run during publishing.

Issue: BTC-3003