### PR TITLE
feat: Onboard tokens SBET, ZRO, yPRISM, nvYLDS, nvHELOC, DONT, NIL, S…

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -71,6 +71,7 @@ module.exports = {
         'FIAT-',
         'ME-',
         'ANT-',
+        'CGARD-',
         '#', // Prefix used by GitHub issues
       ],
     },

--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -4515,6 +4515,18 @@ export const allCoinsAndTokens = [
     'VAULTA',
     'A'
   ),
+  eosToken(
+    'bced2aec-ed0d-4686-803d-c9368367dce0',
+    'eos:SBET',
+    'SportBet SBET',
+    4,
+    'sportbetsbet',
+    'sportbetsbet',
+    UnderlyingAsset.EOS_SBET,
+    AccountCoin.DEFAULT_FEATURES,
+    '',
+    'SBET'
+  ),
   teosToken(
     '1c627bb5-4bee-4ab0-8bb6-3d535e17a769',
     'teos:CHEX',
@@ -4977,6 +4989,14 @@ export const allCoinsAndTokens = [
     '0xf84d28a8d28292842dd73d1c5f99476a80b6666a',
     UnderlyingAsset['arbeth:tbill'],
     AccountCoin.DEFAULT_FEATURES_EXCLUDE_SINGAPORE
+  ),
+  arbethErc20(
+    '7911d5d4-4138-4a9a-b046-553aa406e02e',
+    'arbeth:zro',
+    'LayerZero',
+    18,
+    '0x6985884c4392d348587b19cb9eaaf157f13271cd',
+    UnderlyingAsset['arbeth:zro']
   ),
   tarbethErc20(
     'd6a8869d-3da4-4b95-a9af-f2a059ca651f',
@@ -5780,6 +5800,18 @@ export const allCoinsAndTokens = [
     '0x5145494a5f5100e645e4b0aa950fa6b68f614e8c59e17bc5ded3495123a79178::ns::NS',
     UnderlyingAsset['sui:suins'],
     SUI_TOKEN_FEATURES
+  ),
+  suiToken(
+    '634d40ff-009a-4619-8651-9fa8e03e92e6',
+    'sui:suiusde',
+    'eSui Dollar',
+    6,
+    '0x41d587e5336f1c86cad50d38a7136db99333bb9bda91cea4ba69115defeb1402',
+    'sui_usde',
+    'SUI_USDE',
+    '0x41d587e5336f1c86cad50d38a7136db99333bb9bda91cea4ba69115defeb1402::sui_usde::SUI_USDE',
+    UnderlyingAsset['sui:suiusde'],
+    [...SUI_TOKEN_FEATURES, CoinFeature.STABLECOIN]
   ),
   suiToken(
     '6ba90645-42ba-47d8-ba09-8b00228bfe33',

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -1056,7 +1056,12 @@ export enum UnderlyingAsset {
   'eth:bito' = 'eth:bito',
   'ETH:ECASH' = 'eth:ecash',
   'ETH:OORT' = 'eth:oort',
+  'eth:prism' = 'eth:prism',
   'eth:ultra' = 'eth:ultra',
+  'eth:yprism' = 'eth:yprism',
+  'eth:nvylds' = 'eth:nvylds',
+  'eth:nvheloc' = 'eth:nvheloc',
+  'eth:nil' = 'eth:nil',
   'eth:dragonx' = 'eth:dragonx',
   ETHHEDGE = 'ethhedge',
   ETHMOON = 'ethmoon',
@@ -2118,6 +2123,7 @@ export enum UnderlyingAsset {
   'eth:sky' = 'eth:sky',
   'eth:uco' = 'eth:uco',
   'eth:fuel' = 'eth:fuel',
+  'eth:xprism' = 'eth:xprism',
   'eth:xreth' = 'eth:xreth',
   'eth:xy' = 'eth:xy',
   'eth:yu' = 'eth:yu',
@@ -2146,6 +2152,7 @@ export enum UnderlyingAsset {
   'eth:lngvx' = 'eth:lngvx',
   'eth:eqtyx' = 'eth:eqtyx',
   'eth:deuro' = 'eth:deuro',
+  'eth:usat' = 'eth:usat',
   'eth:usdf' = 'eth:usdf',
   'eth:ausd' = 'eth:ausd',
   'eth:ags' = 'eth:ags',
@@ -2469,6 +2476,7 @@ export enum UnderlyingAsset {
   CHEX = 'chex',
   IQ = 'iq',
   EOS_BOX = 'eos:box',
+  EOS_SBET = 'eos:sbet',
   VAULTA = 'vaulta',
 
   // Avax Token ERC-20
@@ -2698,6 +2706,7 @@ export enum UnderlyingAsset {
   // BSC Token BEP-20
   'bsc:sol' = 'bsc:sol',
   'bsc:solv' = 'bsc:solv',
+  'bsc:stable' = 'bsc:stable',
   'bsc:brise' = 'bsc:brise',
   'bsc:bsw' = 'bsc:bsw',
   'bsc:burger' = 'bsc:burger',
@@ -2943,6 +2952,7 @@ export enum UnderlyingAsset {
   'arbeth:gmx' = 'arbeth:gmx',
   'arbeth:uxlink' = 'arbeth:uxlink',
   'arbeth:next' = 'arbeth:next',
+  'arbeth:zro' = 'arbeth:zro',
 
   // BaseETH mainnet tokens
   'baseeth:aero' = 'baseeth:aero',
@@ -3289,6 +3299,7 @@ export enum UnderlyingAsset {
   'sol:superbonds' = 'sol:superbonds',
   'sol:would' = 'sol:would',
   'sol:dog' = 'sol:dog',
+  'sol:dont' = 'sol:dont',
   'sol:saros' = 'sol:saros',
   'sol:babydoge' = 'sol:babydoge',
   'sol:useless' = 'sol:useless',
@@ -3384,6 +3395,7 @@ export enum UnderlyingAsset {
   // Sui tokens
   'sui:deep' = 'sui:deep',
   'sui:suins' = 'sui:suins',
+  'sui:suiusde' = 'sui:suiusde',
   'sui:fdusd' = 'sui:fdusd',
   'sui:usdc' = 'sui:usdc',
   'sui:wusdc' = 'sui:wusdc',

--- a/modules/statics/src/coins/bscTokens.ts
+++ b/modules/statics/src/coins/bscTokens.ts
@@ -17,6 +17,15 @@ export const bscTokens = [
     BSC_TOKEN_FEATURES
   ),
   bscToken(
+    '344b4235-9aec-4478-9637-0df3ddc9dff0',
+    'bsc:stable',
+    'Stable',
+    18,
+    '0x011ebe7d75e2c9d1e0bd0be0bef5c36f0a90075f',
+    UnderlyingAsset['bsc:stable'],
+    BSC_TOKEN_FEATURES
+  ),
+  bscToken(
     'b7540916-53ed-49e9-b8a4-8a853fd7d607',
     'bsc:brise',
     'Bitrise Token',

--- a/modules/statics/src/coins/erc20Coins.ts
+++ b/modules/statics/src/coins/erc20Coins.ts
@@ -98,6 +98,15 @@ export const erc20Coins = [
     UnderlyingAsset['eth:hegic']
   ),
   erc20(
+    '23661500-e738-4d87-8805-6e08e4cdbd0b',
+    'eth:xprism',
+    'Staked Portfolio of Risk-adjusted Investment Strategy',
+    18,
+    '0x12e04c932d682a2999b4582f7c9b86171b73220d',
+    UnderlyingAsset['eth:xprism'],
+    AccountCoin.getFeaturesByTypeExcluding([CoinFeature.CUSTODY_BITGO_SINGAPORE], ETH_FEATURES)
+  ),
+  erc20(
     'e5195aca-b807-4fb9-b8c3-b4440cb24f67',
     'eth:xreth',
     'Constellation Staked ETH',
@@ -11132,6 +11141,15 @@ export const erc20Coins = [
     )
   ),
   erc20(
+    '86ed6c06-9a02-49e0-bb33-066775135704',
+    'eth:usat',
+    'Tether America USD',
+    6,
+    '0x07041776f5007aca2a54844f50503a18a72a8b68',
+    UnderlyingAsset['eth:usat'],
+    [...AccountCoin.DEFAULT_FEATURES, CoinFeature.STABLECOIN]
+  ),
+  erc20(
     'ad73ed49-cbce-4809-a2e1-9d66c7f7a8d8',
     'eth:usdf',
     'Falcon USD',
@@ -11698,6 +11716,15 @@ export const erc20Coins = [
     UnderlyingAsset['eth:pokt']
   ),
   erc20(
+    '6b87364b-1616-48f1-8e8c-21b83e599486',
+    'eth:prism',
+    'Portfolio of Risk-adjusted Investment Strategy Mix',
+    18,
+    '0x06bb4ab600b7d22eb2c312f9babc22be6a619046',
+    UnderlyingAsset['eth:prism'],
+    AccountCoin.getFeaturesByTypeExcluding([CoinFeature.CUSTODY_BITGO_SINGAPORE], ETH_FEATURES)
+  ),
+  erc20(
     '648bf099-cefc-4ed3-9af8-14feecc89503',
     'eth:lon',
     'Tokenlon Network',
@@ -12209,6 +12236,41 @@ export const erc20Coins = [
     18,
     '0xe868084cf08f3c3db11f4b73a95473762d9463f7',
     UnderlyingAsset['eth:yu']
+  ),
+  erc20(
+    '16b94299-9ab8-4dfb-a0e0-fb906006d890',
+    'eth:yprism',
+    'yPRISM',
+    18,
+    '0xdd5eff0756db08bad0ff16b66f88f506e7318894',
+    UnderlyingAsset['eth:yprism'],
+    AccountCoin.getFeaturesByTypeExcluding([CoinFeature.CUSTODY_BITGO_SINGAPORE], ETH_FEATURES)
+  ),
+  erc20(
+    'dcd5baad-31a9-433c-804b-2ce8604c3d18',
+    'eth:nvylds',
+    'NUVA YLDS',
+    12,
+    '0x82c9e80f0e099bf61e061ee96e23df605388d902',
+    UnderlyingAsset['eth:nvylds'],
+    AccountCoin.getFeaturesByTypeExcluding([CoinFeature.CUSTODY_BITGO_SINGAPORE], ETH_FEATURES)
+  ),
+  erc20(
+    '08d068f6-95a0-4550-9d57-60a706ebb610',
+    'eth:nvheloc',
+    'NUVA HELOC',
+    12,
+    '0x4acb074ff8152de067be3da282dda6469992b42d',
+    UnderlyingAsset['eth:nvheloc'],
+    AccountCoin.getFeaturesByTypeExcluding([CoinFeature.CUSTODY_BITGO_SINGAPORE], ETH_FEATURES)
+  ),
+  erc20(
+    '529b268a-55bf-40d1-89f5-d9ed0d8d4070',
+    'eth:nil',
+    'Nillion',
+    6,
+    '0x7cf9a80db3b29ee8efe3710aadb7b95270572d47',
+    UnderlyingAsset['eth:nil']
   ),
   terc20(
     '0205f0d6-0647-47c9-ad8b-c48d048e54f3',

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -87,6 +87,7 @@ export const ofcCoins = [
   ofc('afa494f3-a56d-4b81-991d-066b4aae181c', 'ofcbsv', 'Bitcoin SV', 8, UnderlyingAsset.BSV, CoinKind.CRYPTO),
   ofc('5b206383-7b8c-4199-8456-71e7a84527d5', 'ofcdot', 'Polkadot', 10, UnderlyingAsset.DOT, CoinKind.CRYPTO),
   ofc('f1ed2667-fed1-4db8-87f5-061282d6147b', 'ofceos', 'Eos', 4, UnderlyingAsset.EOS, CoinKind.CRYPTO),
+  ofc('6933eef0-7d11-498e-b810-5884b6efae2a', 'ofcsbet', 'SportBet SBET', 4, UnderlyingAsset.EOS_SBET, CoinKind.CRYPTO),
   ofc('6c0714f3-fb74-4bb7-b17d-e34e48821890', 'ofcetc', 'Ethereum Classic', 18, UnderlyingAsset.ETC, CoinKind.CRYPTO),
   ofc('49bc92d3-3085-4124-bdb3-df86385dd9b5', 'ofcstx', 'Stacks', 6, UnderlyingAsset.STX, CoinKind.CRYPTO),
   ofc('181974a6-b042-460e-acec-46733f8af941', 'ofchbar', 'Hedera', 8, UnderlyingAsset.HBAR, CoinKind.CRYPTO),
@@ -1148,6 +1149,14 @@ export const ofcCoins = [
     SOL_TOKEN_FEATURES
   ),
   ofcsolToken(
+    '68cf253c-fea8-4255-922e-65ff53bd0c9d',
+    'ofcsol:dont',
+    'DisclaimerCoin',
+    6,
+    UnderlyingAsset['sol:dont'],
+    SOL_TOKEN_FEATURES
+  ),
+  ofcsolToken(
     '3d4bfe68-49cb-4d30-aef0-d143a9e9d9a7',
     'ofcsol:saros',
     'Saros',
@@ -1923,6 +1932,13 @@ export const ofcCoins = [
     18,
     UnderlyingAsset['arbeth:uxlink']
   ),
+  ofcArbethErc20(
+    'b1fd241b-97a9-4074-a3ee-cbfd5b4ed431',
+    'ofcarbeth:zro',
+    'LayerZero',
+    18,
+    UnderlyingAsset['arbeth:zro']
+  ),
 
   ofcAvaxErc20('2bd6201d-c46c-481e-b82d-7cf3601679cb', 'ofcavaxc:aave-e', 'Aave', 18, UnderlyingAsset['avaxc:aave']),
   ofcAvaxErc20(
@@ -2193,6 +2209,7 @@ export const ofcCoins = [
     [CoinFeature.STABLECOIN]
   ),
   ofcBscToken('6a1e8b8c-4d7e-4f9a-9d8f-f6e72f8c7e65', 'ofcbsc:solv', 'SOLV Protocol', 9, UnderlyingAsset['bsc:solv']),
+  ofcBscToken('6d96470a-3c8e-44de-a18e-9dd224d4bcc0', 'ofcbsc:stable', 'Stable', 18, UnderlyingAsset['bsc:stable']),
   ofcBscToken('f8c3d7b5-2d9e-4b3f-8a1e-7c6d9e3a2f4b', 'ofcbsc:brise', 'Bitrise Token', 9, UnderlyingAsset['bsc:brise']),
   ofcBscToken('2e9f4c6b-8a7d-4b2e-9d3f-7c6a5e8b1f2a', 'ofcbsc:bsw', 'Biswap', 18, UnderlyingAsset['bsc:bsw']),
   ofcBscToken(
@@ -3913,6 +3930,13 @@ export const ofcCoins = [
     UnderlyingAsset['tton:ukwny-us']
   ),
   ofcSuiToken('6313a162-0c48-4c0c-ae73-27cc3df9e000', 'ofcsui:deep', 'Deepbook', 6, UnderlyingAsset['sui:deep']),
+  ofcSuiToken(
+    '51efbb9d-0cf9-48aa-a96f-7a7317807a3e',
+    'ofcsui:suiusde',
+    'eSui Dollar',
+    6,
+    UnderlyingAsset['sui:suiusde']
+  ),
   tofcSuiToken(
     'b6e53ed9-5a86-4994-8b69-ca59c243cac6',
     'ofctsui:deep',

--- a/modules/statics/src/coins/ofcErc20Coins.ts
+++ b/modules/statics/src/coins/ofcErc20Coins.ts
@@ -330,6 +330,13 @@ export const ofcErc20Coins = [
   ofcerc20('6f9c8419-182f-4fe4-a82c-bd99939eb3b6', 'ofceth:hard', 'Kava Lend', 6, underlyingAssetForSymbol('eth:hard')),
   ofcerc20('8ee9f243-5192-43e0-a1ea-3b6b329b1bbc', 'ofceth:hegic', 'Hegic', 18, underlyingAssetForSymbol('eth:hegic')),
   ofcerc20(
+    'f3a87df7-c341-4e36-a53d-cc71e32fb552',
+    'ofceth:xprism',
+    'Staked Portfolio of Risk-adjusted Investment Strategy',
+    18,
+    UnderlyingAsset['eth:xprism']
+  ),
+  ofcerc20(
     '9321cc5f-623e-428c-a831-43cd381bdcda',
     'ofceth:xreth',
     'Constellation Staked ETH',
@@ -3368,6 +3375,7 @@ export const ofcErc20Coins = [
     18,
     underlyingAssetForSymbol('eth:deuro')
   ),
+  ofcerc20('a2159d62-1b1c-4e8b-ba43-332959015dbc', 'ofceth:usat', 'Tether America USD', 6, UnderlyingAsset['eth:usat']),
   ofcerc20(
     'e7b1c5d2-9e6e-4c9b-9f3e-2d2a4e5b6c8d',
     'ofceth:usdf',
@@ -3975,6 +3983,14 @@ export const tOfcErc20Coins = [
     'Wrapped Pocket Network',
     6,
     underlyingAssetForSymbol('eth:pokt')
+  ),
+
+  ofcerc20(
+    '9284c8a3-e1bd-4b34-ad08-1366af0ba57b',
+    'ofceth:prism',
+    'Portfolio of Risk-adjusted Investment Strategy Mix',
+    18,
+    UnderlyingAsset['eth:prism']
   ),
 
   ofcerc20(
@@ -4982,6 +4998,10 @@ export const tOfcErc20Coins = [
     UnderlyingAsset['eth:fidd']
   ),
   ofcerc20('c71454e2-c51c-40df-8605-e57f2d97ed53', 'ofceth:yu', 'Yala Stablecoin', 18, UnderlyingAsset['eth:yu']),
+  ofcerc20('f689a6e4-d76f-4591-afda-57e3c52fad22', 'ofceth:yprism', 'yPRISM', 18, UnderlyingAsset['eth:yprism']),
+  ofcerc20('253e2858-a27b-4d39-b1fc-b8f719584d1f', 'ofceth:nvylds', 'NUVA YLDS', 12, UnderlyingAsset['eth:nvylds']),
+  ofcerc20('e68260cc-3f0c-4429-9681-5a2cd46a6c87', 'ofceth:nvheloc', 'NUVA HELOC', 12, UnderlyingAsset['eth:nvheloc']),
+  ofcerc20('02a7867a-754e-4132-8802-1b4aa979a441', 'ofceth:nil', 'Nillion', 6, UnderlyingAsset['eth:nil']),
   ofcerc20('14912a5e-254c-4c6f-9f9c-f9ce11b7b293', 'ofceth:bard', 'Lombard', 18, UnderlyingAsset['eth:bard']),
   ofcerc20('a31a6330-cbd6-49b0-b8b1-a7f9a48e770c', 'ofceth:sfp', 'SafePal Token', 18, UnderlyingAsset['eth:sfp']),
   ofcerc20('60f825f0-ed18-46b2-a03f-fd93b5e94f43', 'ofceth:aztec', 'Aztec', 18, UnderlyingAsset['eth:aztec']),

--- a/modules/statics/src/coins/solTokens.ts
+++ b/modules/statics/src/coins/solTokens.ts
@@ -2816,6 +2816,16 @@ export const solTokens = [
     SOL_TOKEN_FEATURES
   ),
   solToken(
+    '11001926-a01a-4006-8f13-70e375c8d0bf',
+    'sol:dont',
+    'DisclaimerCoin',
+    6,
+    'FbmmdcCYHL7WETG89xtWmNFMzQAaQ8Zs9NXVbimibonk',
+    'FbmmdcCYHL7WETG89xtWmNFMzQAaQ8Zs9NXVbimibonk',
+    UnderlyingAsset['sol:dont'],
+    SOL_TOKEN_FEATURES
+  ),
+  solToken(
     'a73223a4-e35f-4324-b0dd-21eb31d641db',
     'sol:saros',
     'Saros',


### PR DESCRIPTION
### **Token Onboarding Update**

**Ticket:** [CGARD-71](https://bitgoinc.atlassian.net/browse/CGARD-71)

---

### **Onboarded tokens**

| ID | Token Name | Network / Standard |
| :--- | :--- | :--- |
| **eos:sbet** | SportBet | EOS (EOS) |
| **arbeth:zro** | LayerZero | ARB (ARBeth) |
| **eth:yprism** | yPRISM | ETH (ERC-20) |
| **eth:nvylds** | NUVA YLDS | ETH (ERC-20) |
| **eth:nvheloc** | NUVA HELOC | ETH (ERC-20) |
| **sol:dont** | DisclaimerCoin | SOL (SPL) |
| **eth:nil** | Nillion | ETH (ERC-20) |
| **bsc:stable** | Stable | BSC (BEP-20) |
| **sui:suiusde** | eSui Dollar | SUI (SUI Token) |
| **eth:prism** | Portfolio of Risk-adjusted Investment Strategy Mix | ETH (ERC-20) |
| **eth:xprism** | Staked Portfolio of Risk-adjusted Investment Strategy | ETH (ERC-20) |
| **eth:usat** | Tether America USD | ETH (ERC-20) |

---

### **Regulatory Gating**
> The following assets are gated for **BitGo Singapore** custody due to **CMP classification**:
> `eth:yprism`, `eth:nvylds`, `eth:nvheloc`, `eth:prism`, `eth:xprism`

---

### **Notes**
* **SEI:** Skipped; currently waiting for confirmation regarding the token symbol.
* **Wrapped Bitcoin (Sollet):** The token `SOL:SOBTC` is already onboarded under the symbol `sol:btc-sollet`, but it remains gated in AMS.




[CGARD-71]: https://bitgoinc.atlassian.net/browse/CGARD-71?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ