### PR TITLE
fix(statics): Remove unnecessary ChilizERC20Token class and factory functions 

### DIFF
--- a/modules/statics/src/account.ts
+++ b/modules/statics/src/account.ts
@@ -518,16 +518,6 @@ export class CoredaoERC20Token extends ContractAddressDefinedToken {
 }
 
 /**
- * The Chiliz Chain network supports tokens
- * Chiliz Chain Tokens are ERC20 tokens
- */
-export class ChilizERC20Token extends ContractAddressDefinedToken {
-  constructor(options: Erc20ConstructorOptions) {
-    super(options);
-  }
-}
-
-/**
  * The World Chain network supports tokens
  * World Chain Tokens are ERC20 tokens
  */
@@ -2716,96 +2706,6 @@ export function tcoredaoErc20(
   primaryKeyCurve: KeyCurve = KeyCurve.Secp256k1
 ) {
   return coredaoErc20(
-    id,
-    name,
-    fullName,
-    decimalPlaces,
-    contractAddress,
-    asset,
-    features,
-    prefix,
-    suffix,
-    network,
-    primaryKeyCurve
-  );
-}
-
-/**
- * Factory function for ChilizErc20 token instances.
- *
- * @param id uuid v4
- * @param name unique identifier of the token
- * @param fullName Complete human-readable name of the token
- * @param decimalPlaces Number of decimal places this token supports (divisibility exponent)
- * @param contractAddress Contract address of this token
- * @param asset Asset which this coin represents. This is the same for both mainnet and testnet variants of a coin.
- * @param prefix? Optional token prefix. Defaults to empty string
- * @param suffix? Optional token suffix. Defaults to token name.
- * @param network? Optional token network. Defaults to Chiliz Chain mainnet network.
- * @param features? Features of this coin. Defaults to the DEFAULT_FEATURES defined in `AccountCoin`
- * @param primaryKeyCurve The elliptic curve for this chain/token
- */
-export function chilizErc20(
-  id: string,
-  name: string,
-  fullName: string,
-  decimalPlaces: number,
-  contractAddress: string,
-  asset: UnderlyingAsset,
-  features: CoinFeature[] = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.EIP1559],
-  prefix = '',
-  suffix: string = name.toUpperCase(),
-  network: AccountNetwork = Networks.main.chiliz,
-  primaryKeyCurve: KeyCurve = KeyCurve.Secp256k1
-) {
-  return Object.freeze(
-    new ChilizERC20Token({
-      id,
-      name,
-      fullName,
-      network,
-      contractAddress,
-      prefix,
-      suffix,
-      features,
-      decimalPlaces,
-      asset,
-      isToken: true,
-      primaryKeyCurve,
-      baseUnit: BaseUnit.ETH,
-    })
-  );
-}
-
-/**
- * Factory function for Chiliz testnet ChilizErc20 token instances.
- *
- * @param id uuid v4
- * @param name unique identifier of the token
- * @param fullName Complete human-readable name of the token
- * @param decimalPlaces Number of decimal places this token supports (divisibility exponent)
- * @param contractAddress Contract address of this token
- * @param asset Asset which this coin represents. This is the same for both mainnet and testnet variants of a coin.
- * @param prefix? Optional token prefix. Defaults to empty string
- * @param suffix? Optional token suffix. Defaults to token name.
- * @param network? Optional token network. Defaults to the Chiliz Chain test network.
- * @param features? Features of this coin. Defaults to the DEFAULT_FEATURES defined in `AccountCoin`
- * @param primaryKeyCurve The elliptic curve for this chain/token
- */
-export function tchilizErc20(
-  id: string,
-  name: string,
-  fullName: string,
-  decimalPlaces: number,
-  contractAddress: string,
-  asset: UnderlyingAsset,
-  features: CoinFeature[] = [...AccountCoin.DEFAULT_FEATURES, CoinFeature.EIP1559],
-  prefix = '',
-  suffix: string = name.toUpperCase(),
-  network: AccountNetwork = Networks.test.chiliz,
-  primaryKeyCurve: KeyCurve = KeyCurve.Secp256k1
-) {
-  return chilizErc20(
     id,
     name,
     fullName,

--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -7,8 +7,6 @@ import {
   arbethErc20,
   beraErc20,
   celoToken,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  chilizErc20,
   coredaoErc20,
   eosToken,
   erc1155,
@@ -34,8 +32,6 @@ import {
   tarbethErc20,
   tberaErc20,
   tceloToken,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  tchilizErc20,
   tcoredaoErc20,
   teosToken,
   terc1155,


### PR DESCRIPTION
## Summary
- Remove unnecessary `ChilizERC20Token` class and factory functions (ERC20 automation handles tokens automatically)

## Changes
- `account.ts`: Removed `ChilizERC20Token` class and `chilizErc20`/`tchilizErc20` factory functions

## Test plan
- [ ] CI passes
- [ ] Verify symbol changes are correct