### PR TITLE
feat(abstract-utxo): fix BIP322 sighash type handling with wasm-utxo 1.34.0

### DIFF
--- a/modules/abstract-utxo/package.json
+++ b/modules/abstract-utxo/package.json
@@ -67,7 +67,7 @@
     "@bitgo/utxo-core": "^1.32.0",
     "@bitgo/utxo-lib": "^11.20.0",
     "@bitgo/utxo-ord": "^1.25.0",
-    "@bitgo/wasm-utxo": "^1.32.0",
+    "@bitgo/wasm-utxo": "^1.34.0",
     "@types/lodash": "^4.14.121",
     "@types/superagent": "4.1.15",
     "bignumber.js": "^9.0.2",

--- a/modules/utxo-bin/package.json
+++ b/modules/utxo-bin/package.json
@@ -31,7 +31,7 @@
     "@bitgo/unspents": "^0.51.0",
     "@bitgo/utxo-core": "^1.32.0",
     "@bitgo/utxo-lib": "^11.20.0",
-    "@bitgo/wasm-utxo": "^1.32.0",
+    "@bitgo/wasm-utxo": "^1.34.0",
     "@noble/curves": "1.8.1",
     "archy": "^1.0.0",
     "bech32": "^2.0.0",

--- a/modules/utxo-core/package.json
+++ b/modules/utxo-core/package.json
@@ -81,7 +81,7 @@
     "@bitgo/secp256k1": "^1.10.0",
     "@bitgo/unspents": "^0.51.0",
     "@bitgo/utxo-lib": "^11.20.0",
-    "@bitgo/wasm-utxo": "^1.32.0",
+    "@bitgo/wasm-utxo": "^1.34.0",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
     "fast-sha256": "^1.3.0"
   },

--- a/modules/utxo-ord/package.json
+++ b/modules/utxo-ord/package.json
@@ -45,7 +45,7 @@
     "directory": "modules/utxo-ord"
   },
   "dependencies": {
-    "@bitgo/wasm-utxo": "^1.32.0"
+    "@bitgo/wasm-utxo": "^1.34.0"
   },
   "devDependencies": {
     "@bitgo/utxo-lib": "^11.20.0"

--- a/modules/utxo-staking/package.json
+++ b/modules/utxo-staking/package.json
@@ -63,7 +63,7 @@
     "@bitgo/babylonlabs-io-btc-staking-ts": "^3.4.0",
     "@bitgo/utxo-core": "^1.32.0",
     "@bitgo/utxo-lib": "^11.20.0",
-    "@bitgo/wasm-utxo": "^1.32.0",
+    "@bitgo/wasm-utxo": "^1.34.0",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
     "bip322-js": "^2.0.0",
     "bitcoinjs-lib": "^6.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -996,10 +996,10 @@
     monocle-ts "^2.3.13"
     newtype-ts "^0.3.5"
 
-"@bitgo/wasm-utxo@^1.32.0":
-  version "1.32.0"
-  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-1.32.0.tgz#fc7e7803eb584ba8ad16aeb0a2805d6905d287d3"
-  integrity sha512-fqUGh8XOrzbPcTxK3lhS9UjqKxx3UaN6L+eS3vocBeWHbQvl6jm9xPPQ+TDkeiUuZdxaj0+7ca4Algt9vyiXHg==
+"@bitgo/wasm-utxo@^1.34.0":
+  version "1.34.0"
+  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-1.34.0.tgz#318bcc0a20acc3f35b9547548ea36506beaab237"
+  integrity sha512-aJuLQ8fNAWmI213sIwMt9WJfWvsyVAmmyUWnojUdmK2iHwf6tIo4B9gWHoPuWwNYoqc/UJVbK3dDKxnMIUk/bg==
 
 "@brandonblack/musig@^0.0.1-alpha.0":
   version "0.0.1-alpha.1"
@@ -3080,10 +3080,10 @@
   resolved "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz"
   integrity sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==
 
-"@isaacs/brace-expansion@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz"
-  integrity sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==
+"@isaacs/brace-expansion@5.0.1", "@isaacs/brace-expansion@^5.0.0":
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz#0ef5a92d91f2fff2a37646ce54da9e5f599f6eff"
+  integrity sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==
   dependencies:
     "@isaacs/balanced-match" "^4.0.1"
 


### PR DESCRIPTION

This PR updates the wasm-utxo dependency to version 1.34.0, which fixes an
issue with sighash type handling in BIP322 messages for p2trMusig2
signatures.

The changes include:
- Adding a test case that verifies wasm-utxo correctly respects the
  sighashType when creating musig2 partial signatures
- Updating the abstract-utxo module to use the fixed wasm-utxo version

Issue: BTC-2866