### PR TITLE
feat(abstract-cosmos): add contract call decoding

### DIFF
--- a/modules/abstract-cosmos/src/lib/ContractCallBuilder.ts
+++ b/modules/abstract-cosmos/src/lib/ContractCallBuilder.ts
@@ -1,6 +1,5 @@
 import { TransactionType } from '@bitgo/sdk-core';
 import { BaseCoin as CoinConfig } from '@bitgo/statics';
-import { fromBase64 } from '@cosmjs/encoding';
 
 import * as constants from './constants';
 import { CosmosTransactionMessage, ExecuteContractMessage, MessageData } from './iface';
@@ -20,32 +19,24 @@ export class ContractCallBuilder<CustomMessage = never> extends CosmosTransactio
   }
 
   /** @inheritdoc */
-  messages(messages: (CosmosTransactionMessage<CustomMessage> | MessageData<CustomMessage>)[]): this {
+  messages(messages: (CosmosTransactionMessage<CustomMessage> | Partial<MessageData<CustomMessage>>)[]): this {
     this._messages = messages.map((message) => {
-      const msg = message as MessageData<CustomMessage>;
-      const { typeUrl, value } = msg;
-
-      // Handle pre-encoded messages (base64 string input)
-      if (typeUrl && typeof value === 'string') {
-        try {
-          return { typeUrl, value: fromBase64(value) } as MessageData<CustomMessage>;
-        } catch (err: unknown) {
-          throw new Error(`Invalid base64 string in message value: ${String(err)}`);
-        }
-      }
-
-      // Handle already-encoded messages (Uint8Array from deserialization)
-      if (typeUrl && value instanceof Uint8Array) {
-        return { typeUrl, value } as MessageData<CustomMessage>;
-      }
-
-      // Handle typed ExecuteContractMessage
       const executeContractMessage = message as ExecuteContractMessage;
+
+      if (!executeContractMessage.msg) {
+        // Pre-encoded message from deserialization round-trip
+        return message as MessageData<CustomMessage>;
+      }
+
+      if (CosmosUtils.isGroupProposal(executeContractMessage)) {
+        return {
+          typeUrl: constants.groupProposalMsgTypeUrl,
+          value: executeContractMessage.msg,
+        } as MessageData<CustomMessage>;
+      }
+
       this._utils.validateExecuteContractMessage(executeContractMessage, this.transactionType);
-      return {
-        typeUrl: constants.executeContractMsgTypeUrl,
-        value: executeContractMessage,
-      };
+      return { typeUrl: constants.executeContractMsgTypeUrl, value: executeContractMessage };
     });
     return this;
   }

--- a/modules/sdk-coin-hash/test/unit/transactionBuilder/contractCallBuilder.ts
+++ b/modules/sdk-coin-hash/test/unit/transactionBuilder/contractCallBuilder.ts
@@ -4,7 +4,7 @@ import { TestBitGo, TestBitGoAPI } from '@bitgo/sdk-test';
 import { fromBase64, toHex } from '@cosmjs/encoding';
 import should from 'should';
 import { Hash, Thash } from '../../../src';
-import { TEST_CONTRACT_CALL } from '../../resources/hash';
+import { TEST_CONTRACT_CALL, testnetAddress } from '../../resources/hash';
 
 describe('Hash ContractCall Builder', () => {
   let bitgo: TestBitGoAPI;
@@ -24,17 +24,12 @@ describe('Hash ContractCall Builder', () => {
     txBuilder.feeGranter(TEST_CONTRACT_CALL.feeGranter);
     txBuilder.publicKey(toHex(fromBase64(TEST_CONTRACT_CALL.pubKey)));
 
-    // Wrap the inner message in a group proposal
-    // const wrappedMessage = wrapInGroupProposal(
-    //   TEST_CONTRACT_CALL.preEncodedMessageValue,
-    //   TEST_CONTRACT_CALL.proposer,
-    //   testnetAddress.groupPolicyAddress
-    // );
-
     txBuilder.messages([
       {
-        typeUrl: '/cosmos.group.v1.MsgSubmitProposal',
-        value: TEST_CONTRACT_CALL.encodedProposal,
+        sender: TEST_CONTRACT_CALL.proposer,
+        contract: testnetAddress.groupPolicyAddress,
+        msg: fromBase64(TEST_CONTRACT_CALL.encodedProposal),
+        funds: [],
       },
     ]);
     return txBuilder;


### PR DESCRIPTION
- Auto-detect Cosmos group proposals (MsgSubmitProposal) by decoding ExecuteContractMessage.msg via protobuf in ContractCallBuilder
- Add CosmosUtils.isGroupProposal() and CosmosUtils.decodeMsg() for message type detection

Ticket: WIN-8842

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
