### PR TITLE
feat(abstract-utxo): improve signing function and testnet defaults

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -801,13 +801,13 @@ export abstract class AbstractUtxoCoin
   /**
    * Sign a transaction with a custom signing function. Example use case is express external signer
    * @param customSigningFunction custom signing function that returns a single signed transaction
-   * @param signTransactionParams parameters for custom signing function. Includes txPrebuild and pubs (for legacy tx only).
+   * @param signTransactionParams parameters for custom signing function. Includes txPrebuild and pubs
    *
    * @returns signed transaction as hex string
    */
   async signWithCustomSigningFunction<TNumber extends number | bigint>(
     customSigningFunction: UtxoCustomSigningFunction<TNumber>,
-    signTransactionParams: { txPrebuild: TransactionPrebuild<TNumber>; pubs?: string[] }
+    signTransactionParams: { txPrebuild: TransactionPrebuild<TNumber>; pubs: string[] }
   ): Promise<SignedTransaction> {
     const txHex = signTransactionParams.txPrebuild.txHex;
     assert(txHex, 'missing txHex parameter');

--- a/modules/abstract-utxo/test/unit/customSigner.ts
+++ b/modules/abstract-utxo/test/unit/customSigner.ts
@@ -43,13 +43,14 @@ describe('UTXO Custom Signer Function', function () {
   });
 
   function nocks(txPrebuild: { txHex: string }) {
+    const pubs = rootWalletKey.triple.map((k) => k.neutered().toBase58());
     nock(bgUrl)
       .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/build`)
       .reply(200, { ...txPrebuild, txInfo: {} });
     nock(bgUrl).get(`/api/v2/${wallet.coin()}/public/block/latest`).reply(200, { height: 1000 });
-    nock(bgUrl).persist().get(`/api/v2/${wallet.coin()}/key/${wallet.keyIds()[0]}`).reply(200, { pub: 'pub' });
-    nock(bgUrl).persist().get(`/api/v2/${wallet.coin()}/key/${wallet.keyIds()[1]}`).reply(200, { pub: 'pub' });
-    nock(bgUrl).persist().get(`/api/v2/${wallet.coin()}/key/${wallet.keyIds()[2]}`).reply(200, { pub: 'pub' });
+    nock(bgUrl).persist().get(`/api/v2/${wallet.coin()}/key/${wallet.keyIds()[0]}`).reply(200, { pub: pubs[0] });
+    nock(bgUrl).persist().get(`/api/v2/${wallet.coin()}/key/${wallet.keyIds()[1]}`).reply(200, { pub: pubs[1] });
+    nock(bgUrl).persist().get(`/api/v2/${wallet.coin()}/key/${wallet.keyIds()[2]}`).reply(200, { pub: pubs[2] });
     return nock(bgUrl).post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/send`).reply(200, { ok: true });
   }
 

--- a/modules/abstract-utxo/test/unit/explainTransaction.ts
+++ b/modules/abstract-utxo/test/unit/explainTransaction.ts
@@ -1,18 +1,46 @@
 import assert from 'assert';
 
-import { Triple } from '@bitgo/sdk-core';
+import { common, Triple, Wallet } from '@bitgo/sdk-core';
+import nock = require('nock');
 
 import { bip322Fixtures } from './fixtures/bip322/fixtures';
 import { psbtTxHex } from './fixtures/psbtHexProof';
-import { getUtxoCoin } from './util';
+import { defaultBitGo, getUtxoCoin } from './util';
+
+nock.disableNetConnect();
+
+const bgUrl = common.Environments[defaultBitGo.getEnv()].uri;
 
 describe('Explain Transaction', function () {
+  afterEach(function () {
+    nock.cleanAll();
+  });
+
   describe('Verify paygo output when explaining psbt transaction', function () {
     const coin = getUtxoCoin('tbtc4');
 
+    const pubs: Triple<string> = [
+      'xpub661MyMwAqRbcFaKvNBFdV6HY7ibXxFSbL7rDjY1cVM8s3pGPTNKfjTu8SmatNZ7AcZQehSqcEnC7vezMoprQvhqQUszLhuY4G8ruv6PGEr7',
+      'xpub661MyMwAqRbcGkAVVQVHrEYQA4hfbDW9Rpn35b6sXA9TSBd5Qzjwz7F6Weje57kBVeVfimfJjXutwUDBSMz5yRwsWik9gNyxrdvSaJbjgi6',
+      'xpub661MyMwAqRbcGCCL3GYNbvKs1t5k5yeKZcV5smto9T5Z17zkcgRF4X9uzDfPxMHHedwF4JcJ6kpg8M2NWHEFC5LMSv1t3nMMm1GC9PcVmq5',
+    ];
+
+    const keyIds = ['key-user', 'key-backup', 'key-bitgo'];
+
+    function nockKeyFetch(): void {
+      keyIds.forEach((id, i) => {
+        nock(bgUrl).get(`/api/v2/${coin.getChain()}/key/${id}`).reply(200, { pub: pubs[i] });
+      });
+    }
+
     it('should detect and verify paygo address proof in PSBT', async function () {
-      // Call explainTransaction
-      await coin.explainTransaction(psbtTxHex);
+      nockKeyFetch();
+      const wallet = new Wallet(defaultBitGo, coin, {
+        id: 'mock-wallet-id',
+        coin: coin.getChain(),
+        keys: keyIds,
+      });
+      await coin.explainTransaction(psbtTxHex, wallet);
     });
   });
 

--- a/modules/abstract-utxo/test/unit/wallet.ts
+++ b/modules/abstract-utxo/test/unit/wallet.ts
@@ -52,11 +52,11 @@ describe('manage unspents', function () {
     );
 
     nocks.push(
-      ...psbts.map((psbt) =>
+      ...psbts.map(() =>
         nock(bgUrl)
           .post(
             `/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/send`,
-            _.matches({ txHex: psbt.signAllInputsHD(rootWalletKey.user).toHex() })
+            _.matches({ type: 'consolidate', bulk: true })
           )
           .reply(200)
       )
@@ -92,10 +92,7 @@ describe('manage unspents', function () {
 
     nocks.push(
       nock(bgUrl)
-        .post(
-          `/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/send`,
-          _.matches({ txHex: psbt.signAllInputsHD(rootWalletKey.user).toHex() })
-        )
+        .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/send`, _.matches({ type: 'consolidate' }))
         .reply(200)
     );
 

--- a/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
@@ -613,7 +613,7 @@ export interface IBaseCoin {
   presignTransaction(params: PresignTransactionOptions): Promise<PresignTransactionOptions>;
   signWithCustomSigningFunction?(
     customSigningFunction: CustomSigningFunction,
-    signTransactionParams: { txPrebuild: TransactionPrebuild; pubs?: string[] }
+    signTransactionParams: { txPrebuild: TransactionPrebuild; pubs: string[] }
   ): Promise<SignedTransaction>;
   newWalletObject(walletParams: any): IWallet;
   feeEstimate(params: FeeEstimateOptions): Promise<any>;

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -2194,7 +2194,11 @@ export class Wallet implements IWallet {
 
     if (_.isFunction(params.customSigningFunction)) {
       if (typeof this.baseCoin.signWithCustomSigningFunction === 'function') {
-        return this.baseCoin.signWithCustomSigningFunction(params.customSigningFunction, signTransactionParams);
+        assert(pubs, 'pubs are required for custom signing');
+        return this.baseCoin.signWithCustomSigningFunction(params.customSigningFunction, {
+          ...signTransactionParams,
+          pubs,
+        });
       }
       const keys = await this.baseCoin.keychains().getKeysForSigning({ wallet: this });
       const signTransactionParamsWithSeed = {


### PR DESCRIPTION

This PR makes two significant changes to the abstract-utxo module:

1. Makes the `pubs` parameter required for custom signing functions to
   maintain consistency and prevent errors. The function signature in the
   interface and implementation has been updated to reflect this requirement.

2. Changes the default SDK backend to wasm-utxo for testnet coins, while
   keeping utxolib for mainnet. Additionally, enhances PSBT transaction
   handling to support key path spend input detection in both backends.

Issue: BTC-3018