### PR TITLE
feat(statics): rename sol:usdc.a to sol:usdca (WIN-8883)

### DIFF
--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -1926,7 +1926,7 @@ export enum UnderlyingAsset {
   'sol:usdt' = 'sol:usdt',
   'sol:usdc' = 'sol:usdc',
   'sol:agri' = 'sol:agri',
-  'sol:usdc.a' = 'sol:usdc.a',
+  'sol:usdca' = 'sol:usdca',
   USCC = 'uscc',
   USDC = 'usdc',
   'USDC-POS-WORMHOLE' = 'usdc-pos-wormhole',

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -750,10 +750,10 @@ export const ofcCoins = [
   ]),
   ofcsolToken(
     '2ad7fab3-71f1-4201-8c6d-16ef57f012b7',
-    'ofcsol:usdc.a',
+    'ofcsol:usdca',
     'USDC.a Bridged ART20',
     6,
-    UnderlyingAsset['sol:usdc.a'],
+    UnderlyingAsset['sol:usdca'],
     [...SOL_TOKEN_FEATURES, CoinFeature.STABLECOIN]
   ),
   ofcsolToken(

--- a/modules/statics/src/coins/solTokens.ts
+++ b/modules/statics/src/coins/solTokens.ts
@@ -3636,12 +3636,12 @@ export const solTokens = [
   ),
   solToken(
     'e13fd5e0-0828-4f06-884b-de1bc5cf42c5',
-    'sol:usdc.a',
+    'sol:usdca',
     'USDC.a Bridged ART20',
     6,
     'AByhZPfGEU9a68KCAvT76Yev85oeur4SoL2VLZuB3HQj', // https://solscan.io/token/AByhZPfGEU9a68KCAvT76Yev85oeur4SoL2VLZuB3HQj
     'AByhZPfGEU9a68KCAvT76Yev85oeur4SoL2VLZuB3HQj',
-    UnderlyingAsset['sol:usdc.a'],
+    UnderlyingAsset['sol:usdca'],
     [...SOL_TOKEN_FEATURES, CoinFeature.STABLECOIN]
   ),
 ];


### PR DESCRIPTION
## Summary
Rename `sol:usdc.a` to `sol:usdca` to comply with token naming conventions (no dots allowed in token identifiers).

## Background
During WIN-8782 token onboarding, `sol:usdc.a` was added but later identified as violating the naming convention policy against using dots (.) in token names.

## Changes
- `base.ts`: Renamed `UnderlyingAsset['sol:usdc.a']` → `UnderlyingAsset['sol:usdca']`
- `solTokens.ts`: Renamed `sol:usdc.a` → `sol:usdca`
- `ofcCoins.ts`: Renamed `ofcsol:usdc.a` → `ofcsol:usdca`

## Contract Details (unchanged)
- Chain: Solana (SPL Token)
- Mint Address: `AByhZPfGEU9a68KCAvT76Yev85oeur4SoL2VLZuB3HQj`
- Name: USDC.a Bridged ART20
- Decimals: 6
- Token ID: `e13fd5e0-0828-4f06-884b-de1bc5cf42c5`
- OFC ID: `2ad7fab3-71f1-4201-8c6d-16ef57f012b7`

## Issue
WIN-8883

## Test Plan
- [ ] Verify token identifier has no dots
- [ ] Verify token is recognized with new name