### PR TITLE
refactor(abstract-utxo): migrate to wasm-utxo and remove dead code

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -400,8 +400,6 @@ export abstract class AbstractUtxoCoin
 {
   abstract name: UtxoCoinName;
 
-  public altScriptHash?: number;
-  public supportAltScriptDestination?: boolean;
   public readonly amountType: 'number' | 'bigint';
 
   protected constructor(bitgo: BitGoBase, amountType: 'number' | 'bigint' = 'number') {

--- a/modules/abstract-utxo/src/impl/bch/bch.ts
+++ b/modules/abstract-utxo/src/impl/bch/bch.ts
@@ -1,5 +1,5 @@
 import { BitGoBase } from '@bitgo/sdk-core';
-import * as utxolib from '@bitgo/utxo-lib';
+import { address as wasmAddress } from '@bitgo/wasm-utxo';
 
 import { AbstractUtxoCoin } from '../../abstractUtxoCoin';
 import { UtxoCoinName } from '../../names';
@@ -34,12 +34,13 @@ export class Bch extends AbstractUtxoCoin {
     }
 
     if (version === 'base58') {
-      return utxolib.addressFormat.toCanonicalFormat(address, this.network);
+      const script = wasmAddress.toOutputScriptWithCoin(address, this.name);
+      return wasmAddress.fromOutputScriptWithCoin(script, this.name, 'default');
     }
 
     if (version === 'cashaddr') {
-      const script = utxolib.addressFormat.toOutputScriptTryFormats(address, this.network);
-      return utxolib.addressFormat.fromOutputScriptWithFormat(script, version, this.network);
+      const script = wasmAddress.toOutputScriptWithCoin(address, this.name);
+      return wasmAddress.fromOutputScriptWithCoin(script, this.name, 'cashaddr');
     }
 
     throw new Error(`invalid version ${version}`);

--- a/modules/abstract-utxo/src/impl/ltc/ltc.ts
+++ b/modules/abstract-utxo/src/impl/ltc/ltc.ts
@@ -1,19 +1,10 @@
 import { BitGoBase } from '@bitgo/sdk-core';
-import * as utxolib from '@bitgo/utxo-lib';
 
 import { AbstractUtxoCoin } from '../../abstractUtxoCoin';
 import { UtxoCoinName } from '../../names';
 
 export class Ltc extends AbstractUtxoCoin {
   readonly name: UtxoCoinName = 'ltc';
-
-  constructor(bitgo: BitGoBase) {
-    super(bitgo);
-    // use legacy script hash version, which is the current Bitcoin one
-    this.altScriptHash = utxolib.networks.bitcoin.scriptHash;
-    // do not support alt destinations in prod
-    this.supportAltScriptDestination = false;
-  }
 
   static createInstance(bitgo: BitGoBase): Ltc {
     return new Ltc(bitgo);

--- a/modules/abstract-utxo/src/impl/ltc/tltc.ts
+++ b/modules/abstract-utxo/src/impl/ltc/tltc.ts
@@ -1,5 +1,4 @@
 import { BitGoBase } from '@bitgo/sdk-core';
-import * as utxolib from '@bitgo/utxo-lib';
 
 import { UtxoCoinName } from '../../names';
 
@@ -8,12 +7,6 @@ import { Ltc } from './ltc';
 export class Tltc extends Ltc {
   readonly name: UtxoCoinName = 'tltc';
 
-  constructor(bitgo: BitGoBase) {
-    super(bitgo);
-    this.altScriptHash = utxolib.networks.testnet.scriptHash;
-    // support alt destinations on test
-    this.supportAltScriptDestination = false;
-  }
   static createInstance(bitgo: BitGoBase): Tltc {
     return new Tltc(bitgo);
   }


### PR DESCRIPTION

This PR includes two related refactoring changes to abstract-utxo:

1. Remove unused altScriptHash and supportAltScriptDestination properties
   - These properties were set but never actually used in the BitGo codebase
   - Removing them eliminates utxo-lib dependency from ltc.ts and tltc.ts

2. Migrate BCH canonicalAddress function to use wasm-utxo
   - Replace utxo-lib addressFormat functions with wasm-utxo address module
   - This change affects address format conversion (cashaddr/base58) for BCH

BTC-2650