### PR TITLE
feat(sdk-core): add bridgeFunds intent support for HyperEVM TSS wallets

### DIFF
--- a/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
@@ -155,6 +155,7 @@ export abstract class MpcUtils {
         'transferAccept',
         'transferReject',
         'transferOfferWithdrawn',
+        'bridgeFunds',
       ].includes(params.intentType)
     ) {
       assert(params.recipients, `'recipients' is a required parameter for ${params.intentType} intent`);
@@ -222,6 +223,12 @@ export abstract class MpcUtils {
           return {
             ...baseIntent,
             tokenName: params.tokenName,
+            feeOptions: params.feeOptions,
+          };
+        case 'bridgeFunds':
+          return {
+            ...baseIntent,
+            amount: params.amount,
             feeOptions: params.feeOptions,
           };
         default:

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -271,6 +271,10 @@ export interface PrebuildTransactionWithIntentOptions extends IntentOptionsBase 
   txRequestId?: string;
   isTestTransaction?: boolean;
   contractId?: string;
+  /**
+   * Amount for intents that use a top-level amount instead of recipients (e.g. bridgeFunds).
+   */
+  amount?: { value: string; symbol: string };
 }
 export interface IntentRecipient {
   address: {
@@ -342,6 +346,10 @@ export interface PopulatedIntent extends PopulatedIntentBase {
   txRequestId?: string;
   isTestTransaction?: boolean;
   contractId?: string;
+  /**
+   * Amount for intents that use a top-level amount instead of recipients (e.g. bridgeFunds).
+   */
+  amount?: { value: string; symbol: string };
 }
 
 export type TxRequestState =

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -219,6 +219,11 @@ export interface PrebuildTransactionOptions {
   txRequestId?: string;
   isTestTransaction?: boolean;
   contractId?: string;
+  /**
+   * Amount for intents that use a top-level amount instead of recipients (e.g. bridgeFunds).
+   * Named intentAmount to avoid collision with SendOptions.amount which is string | number.
+   */
+  intentAmount?: { value: string; symbol: string };
 }
 
 export interface PrebuildAndSignTransactionOptions extends PrebuildTransactionOptions, WalletSignTransactionOptions {

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -3746,6 +3746,21 @@ export class Wallet implements IWallet {
           params.preview
         );
         break;
+      case 'bridgeFunds':
+        txRequest = await this.tssUtils!.prebuildTxWithIntent(
+          {
+            reqId,
+            intentType: 'bridgeFunds',
+            sequenceId: params.sequenceId,
+            comment: params.comment,
+            amount: params.intentAmount,
+            nonce: params.nonce,
+            feeOptions,
+          },
+          apiVersion,
+          params.preview
+        );
+        break;
       default:
         throw new Error(`transaction type not supported: ${params.type}`);
     }


### PR DESCRIPTION
Add support for the bridgeFunds intent type in the TSS prebuildTransaction flow, enabling bridging assets from HyperCore to HyperEVM.

Unlike payment intents that use recipients, bridgeFunds uses a top-level amount field (value + symbol) since the bridge destination is implicit.

TICKET: [CECHO-103](https://bitgoinc.atlassian.net/browse/CECHO-103)
<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->


[CECHO-103]: https://bitgoinc.atlassian.net/browse/CECHO-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ