### PR TITLE
feat: add Stable EVM chain support

### DIFF
--- a/modules/sdk-core/src/bitgo/environments.ts
+++ b/modules/sdk-core/src/bitgo/environments.ts
@@ -242,6 +242,9 @@ const mainnetBase: EnvironmentTemplate = {
     sonic: {
       baseUrl: 'https://api.etherscan.io/v2',
     },
+    stable: {
+      baseUrl: 'https://stablescan.xyz/api',
+    },
     seievm: {
       baseUrl: 'https://api.etherscan.io/v2',
     },
@@ -429,6 +432,9 @@ const testnetBase: EnvironmentTemplate = {
     },
     sonic: {
       baseUrl: 'https://api.etherscan.io/v2',
+    },
+    stable: {
+      baseUrl: 'https://testnet.stablescan.xyz/api',
     },
     seievm: {
       baseUrl: 'https://api.etherscan.io/v2',

--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -1771,6 +1771,42 @@ export const allCoinsAndTokens = [
     ]
   ),
   account(
+    '599ab8d6-ebda-460e-8527-677157f86021',
+    'stable',
+    'Stable',
+    Networks.main.stable,
+    18,
+    UnderlyingAsset.STABLE,
+    BaseUnit.ETH,
+    [
+      ...EVM_FEATURES,
+      CoinFeature.SHARED_EVM_SIGNING,
+      CoinFeature.SHARED_EVM_SDK,
+      CoinFeature.EVM_COMPATIBLE_IMS,
+      CoinFeature.EVM_COMPATIBLE_UI,
+      CoinFeature.EVM_COMPATIBLE_WP,
+      CoinFeature.SUPPORTS_ERC20,
+    ]
+  ),
+  account(
+    'fd6b7af0-aff3-45fb-9a71-2d7100a1cd89',
+    'tstable',
+    'Testnet Stable',
+    Networks.test.stable,
+    18,
+    UnderlyingAsset.STABLE,
+    BaseUnit.ETH,
+    [
+      ...EVM_FEATURES,
+      CoinFeature.SHARED_EVM_SIGNING,
+      CoinFeature.SHARED_EVM_SDK,
+      CoinFeature.EVM_COMPATIBLE_IMS,
+      CoinFeature.EVM_COMPATIBLE_UI,
+      CoinFeature.EVM_COMPATIBLE_WP,
+      CoinFeature.SUPPORTS_ERC20,
+    ]
+  ),
+  account(
     'df01a650-3c8b-4182-a7cb-8ee7ad115c21',
     'xpl',
     'Plasma',

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -103,6 +103,7 @@ export enum CoinFamily {
   SOL = 'sol',
   SONIC = 'sonic',
   SONEIUM = 'soneium',
+  STABLE = 'stable',
   STT = 'stt',
   SUI = 'sui',
   STX = 'stx',
@@ -633,6 +634,7 @@ export enum UnderlyingAsset {
   SGB = 'sgb',
   SOL = 'sol',
   SONIC = 'sonic',
+  STABLE = 'stable',
   SUI = 'sui',
   STX = 'stx',
   TIA = 'tia', // Celestia

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -185,6 +185,15 @@ export const ofcCoins = [
     UnderlyingAsset.SONIC,
     CoinKind.CRYPTO
   ),
+  ofc('13151b0b-3734-452d-8ad9-21af03a08bfe', 'ofcstable', 'Stable', 18, UnderlyingAsset.STABLE, CoinKind.CRYPTO),
+  tofc(
+    '39a4dd77-b824-47b9-baff-b45398012511',
+    'ofctstable',
+    'Stable Testnet',
+    18,
+    UnderlyingAsset.STABLE,
+    CoinKind.CRYPTO
+  ),
   ofc(
     'ec31b18d-f034-4e84-837e-2c7d2908bbae',
     'ofchypeevm',

--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -1809,6 +1809,24 @@ class SonicTestnet extends Testnet implements EthereumNetwork {
   walletImplementationAddress = '0x944fef03af368414f29dc31a72061b8d64f568d2';
 }
 
+class Stable extends Mainnet implements EthereumNetwork {
+  name = 'Stable';
+  family = CoinFamily.STABLE;
+  explorerUrl = 'https://stablescan.xyz/tx/';
+  accountExplorerUrl = 'https://stablescan.xyz/address/';
+  chainId = 988;
+  nativeCoinOperationHashPrefix = '988';
+}
+
+class StableTestnet extends Testnet implements EthereumNetwork {
+  name = 'Testnet Stable';
+  family = CoinFamily.STABLE;
+  explorerUrl = 'https://testnet.stablescan.xyz/tx/';
+  accountExplorerUrl = 'https://testnet.stablescan.xyz/address/';
+  chainId = 2201;
+  nativeCoinOperationHashPrefix = '2201';
+}
+
 class Kaia extends Mainnet implements EthereumNetwork {
   name = 'Kaia';
   family = CoinFamily.KAIA;
@@ -2483,6 +2501,7 @@ export const Networks = {
     sgb: Object.freeze(new Songbird()),
     sol: Object.freeze(new Sol()),
     sonic: Object.freeze(new Sonic()),
+    stable: Object.freeze(new Stable()),
     sui: Object.freeze(new Sui()),
     near: Object.freeze(new Near()),
     stx: Object.freeze(new Stx()),
@@ -2603,6 +2622,7 @@ export const Networks = {
     stt: Object.freeze(new SomniaTestnet()),
     soneium: Object.freeze(new SoneiumTestnet()),
     sonic: Object.freeze(new SonicTestnet()),
+    stable: Object.freeze(new StableTestnet()),
     kaia: Object.freeze(new KaiaTestnet()),
     susd: Object.freeze(new SUSDTestnet()),
     coreum: Object.freeze(new CoreumTestnet()),

--- a/modules/statics/test/unit/fixtures/expectedColdFeatures.ts
+++ b/modules/statics/test/unit/fixtures/expectedColdFeatures.ts
@@ -124,6 +124,7 @@ export const expectedColdFeatures = {
     'sol',
     'sonic',
     'somi',
+    'stable',
     'sui',
     'tao',
     'tempo',
@@ -211,6 +212,7 @@ export const expectedColdFeatures = {
     'tseievm',
     'tton',
     'tsonic',
+    'tstable',
   ],
   neither: [
     'ethw',


### PR DESCRIPTION
## Summary
- Add Stable L2 EVM chain support (mainnet chainId: 988, testnet: 2201)
- Add STABLE to CoinFamily and UnderlyingAsset enums
- Add network configs with correct explorer URLs (stablescan.xyz)
- Add stable/tstable coin entries with EVM features
- Add OFC entries (ofcstable/ofctstable) for off-chain trading
- Update environment URLs and test fixtures

## Test plan
- [ ] Verify coin entries are correctly registered
- [ ] Run unit tests: `yarn workspace @bitgo/statics test`
- [ ] Verify network configs have correct chain IDs

Ticket: WIN-8747
CECHO-114