### PR TITLE
refactor(abstract-utxo): replace utxo-lib utility imports with standalone equivalents

### DIFF
--- a/modules/abstract-utxo/package.json
+++ b/modules/abstract-utxo/package.json
@@ -63,7 +63,6 @@
     "@bitgo/blockapis": "^1.13.0",
     "@bitgo/sdk-api": "^1.74.1",
     "@bitgo/sdk-core": "^36.31.1",
-    "@bitgo/secp256k1": "^1.10.0",
     "@bitgo/utxo-core": "^1.33.0",
     "@bitgo/utxo-lib": "^11.21.0",
     "@bitgo/utxo-ord": "^1.26.0",

--- a/modules/abstract-utxo/package.json
+++ b/modules/abstract-utxo/package.json
@@ -70,7 +70,6 @@
     "@types/lodash": "^4.14.121",
     "@types/superagent": "4.1.15",
     "bignumber.js": "^9.0.2",
-    "bitcoinjs-message": "npm:@bitgo-forks/bitcoinjs-message@1.0.0-master.3",
     "debug": "^3.1.0",
     "io-ts": "npm:@bitgo-forks/io-ts@2.1.4",
     "lodash": "^4.17.14",

--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -3,7 +3,7 @@ import { randomBytes } from 'crypto';
 
 import _ from 'lodash';
 import * as utxolib from '@bitgo/utxo-lib';
-import { bip32 } from '@bitgo/secp256k1';
+import { BIP32, fixedScriptWallet } from '@bitgo/wasm-utxo';
 import { bitgo, getMainnet } from '@bitgo/utxo-lib';
 import {
   AddressCoinSpecific,
@@ -42,7 +42,6 @@ import {
   isValidPrv,
   isValidXprv,
 } from '@bitgo/sdk-core';
-import { fixedScriptWallet } from '@bitgo/wasm-utxo';
 
 import {
   backupKeyRecovery,
@@ -496,7 +495,7 @@ export abstract class AbstractUtxoCoin
    */
   isValidPub(pub: string): boolean {
     try {
-      return bip32.fromBase58(pub).isNeutered();
+      return BIP32.fromBase58(pub).isNeutered();
     } catch (e) {
       return false;
     }
@@ -978,7 +977,7 @@ export abstract class AbstractUtxoCoin
       // maximum entropy and gives us maximum security against cracking.
       seed = randomBytes(512 / 8);
     }
-    const extendedKey = bip32.fromSeed(seed);
+    const extendedKey = BIP32.fromSeed(seed);
     return {
       pub: extendedKey.neutered().toBase58(),
       prv: extendedKey.toBase58(),
@@ -1084,7 +1083,7 @@ export abstract class AbstractUtxoCoin
       throw new Error('invalid private key');
     }
     if (publicKey) {
-      const genPubKey = bip32.fromBase58(prv).neutered().toBase58();
+      const genPubKey = BIP32.fromBase58(prv).neutered().toBase58();
       if (genPubKey !== publicKey) {
         throw new Error('public key does not match private key');
       }

--- a/modules/abstract-utxo/src/descriptor/createWallet/createDescriptorWallet.ts
+++ b/modules/abstract-utxo/src/descriptor/createWallet/createDescriptorWallet.ts
@@ -1,5 +1,5 @@
 import { BitGoAPI } from '@bitgo/sdk-api';
-import { bip32 } from '@bitgo/secp256k1';
+import { BIP32 } from '@bitgo/wasm-utxo';
 import { Wallet } from '@bitgo/sdk-core';
 
 import { AbstractUtxoCoin } from '../../abstractUtxoCoin';
@@ -56,12 +56,12 @@ export async function createDescriptorWalletWithWalletPassphrase(
   if (!userKeychain.prv) {
     throw new Error('Missing private key');
   }
-  const userKey = bip32.fromBase58(userKeychain.prv);
+  const userKey = BIP32.fromBase58(userKeychain.prv);
   const cosigners = [backupKeychain, bitgoKeychain].map((keychain) => {
     if (!keychain.pub) {
       throw new Error('Missing public key');
     }
-    return bip32.fromBase58(keychain.pub);
+    return BIP32.fromBase58(keychain.pub);
   });
   return createDescriptorWallet(bitgo, coin, {
     ...params,

--- a/modules/abstract-utxo/src/impl/btc/inscriptionBuilder.ts
+++ b/modules/abstract-utxo/src/impl/btc/inscriptionBuilder.ts
@@ -12,7 +12,6 @@ import {
   Triple,
   xprvToRawPrv,
 } from '@bitgo/sdk-core';
-import { bip32 } from '@bitgo/secp256k1';
 import {
   createPsbtForSingleInscriptionPassingTransaction,
   DefaultInscriptionConstraints,
@@ -27,10 +26,11 @@ import {
   WalletUnspent,
   type TapLeafScript,
 } from '@bitgo/utxo-ord';
-import { fixedScriptWallet } from '@bitgo/wasm-utxo';
+import { BIP32, fixedScriptWallet } from '@bitgo/wasm-utxo';
 
 import { AbstractUtxoCoin } from '../../abstractUtxoCoin';
 import { fetchKeychains } from '../../keychains';
+import { toUtxolibBIP32 } from '../../wasmUtil';
 
 /** Key identifier for signing */
 type SignerKey = 'user' | 'backup' | 'bitgo';
@@ -58,7 +58,7 @@ export class InscriptionBuilder implements IInscriptionBuilder {
     const user = await this.wallet.baseCoin.keychains().get({ id: this.wallet.keyIds()[KeyIndices.USER] });
     assert(user.pub);
 
-    const userKey = bip32.fromBase58(user.pub);
+    const userKey = toUtxolibBIP32(BIP32.fromBase58(user.pub));
     const { key: derivedKey } = BaseCoin.deriveKeyWithSeedBip32(userKey, inscriptionData.toString());
 
     const result = inscriptions.createInscriptionRevealData(

--- a/modules/abstract-utxo/src/offlineVault/OfflineVaultSignable.ts
+++ b/modules/abstract-utxo/src/offlineVault/OfflineVaultSignable.ts
@@ -1,4 +1,4 @@
-import { BIP32Interface, bip32 } from '@bitgo/secp256k1';
+import { BIP32 } from '@bitgo/wasm-utxo';
 import { Triple } from '@bitgo/sdk-core';
 import * as t from 'io-ts';
 
@@ -28,8 +28,6 @@ export type OfflineVaultUnsigned = t.TypeOf<typeof OfflineVaultSignable>;
 
 type WithXpub = { xpub: string };
 type NamedKeys = { user: WithXpub; backup: WithXpub; bitgo: WithXpub };
-export function toKeyTriple(xpubs: NamedKeys): Triple<BIP32Interface> {
-  return [xpubs.user.xpub, xpubs.backup.xpub, xpubs.bitgo.xpub].map((xpub) =>
-    bip32.fromBase58(xpub)
-  ) as Triple<BIP32Interface>;
+export function toKeyTriple(xpubs: NamedKeys): Triple<BIP32> {
+  return [BIP32.fromBase58(xpubs.user.xpub), BIP32.fromBase58(xpubs.backup.xpub), BIP32.fromBase58(xpubs.bitgo.xpub)];
 }

--- a/modules/abstract-utxo/src/offlineVault/descriptor/transaction.ts
+++ b/modules/abstract-utxo/src/offlineVault/descriptor/transaction.ts
@@ -1,6 +1,5 @@
 import * as t from 'io-ts';
-import { Psbt } from '@bitgo/wasm-utxo';
-import type { BIP32Interface } from '@bitgo/utxo-lib';
+import { bip32, Psbt } from '@bitgo/wasm-utxo';
 
 import { DescriptorMap, NamedDescriptor } from '../../descriptor';
 import { OfflineVaultSignable, toKeyTriple } from '../OfflineVaultSignable';
@@ -34,7 +33,7 @@ export function getDescriptorsFromDescriptorTransaction(tx: DescriptorTransactio
   return toDescriptorMapValidate(descriptors, pubkeys, policy);
 }
 
-export function getHalfSignedPsbt(tx: DescriptorTransaction, prv: BIP32Interface, coinName: UtxoCoinName): Psbt {
+export function getHalfSignedPsbt(tx: DescriptorTransaction, prv: bip32.BIP32Interface, coinName: UtxoCoinName): Psbt {
   const psbt = toWasmPsbt(Buffer.from(tx.coinSpecific.txHex, 'hex'));
   const descriptorMap = getDescriptorsFromDescriptorTransaction(tx);
   signPsbt(psbt, descriptorMap, prv, { onUnknownInput: 'throw' });

--- a/modules/abstract-utxo/src/recovery/crossChainRecovery.ts
+++ b/modules/abstract-utxo/src/recovery/crossChainRecovery.ts
@@ -1,5 +1,4 @@
-import { BIP32Interface, bip32 } from '@bitgo/secp256k1';
-import { CoinName, fixedScriptWallet, address as wasmAddress } from '@bitgo/wasm-utxo';
+import { BIP32, CoinName, fixedScriptWallet, address as wasmAddress } from '@bitgo/wasm-utxo';
 import { BitGoBase, IWallet, Keychain, Triple, Wallet } from '@bitgo/sdk-core';
 import { decrypt } from '@bitgo/sdk-api';
 
@@ -294,9 +293,9 @@ async function getFeeRateSatVB(coin: AbstractUtxoCoin): Promise<number> {
  * @param wallet
  * @return signing key
  */
-async function getPrv(xprv?: string, passphrase?: string, wallet?: IWallet | WalletV1): Promise<BIP32Interface> {
+async function getPrv(xprv?: string, passphrase?: string, wallet?: IWallet | WalletV1): Promise<BIP32> {
   if (xprv) {
-    const key = bip32.fromBase58(xprv);
+    const key = BIP32.fromBase58(xprv);
     if (key.isNeutered()) {
       throw new Error(`not a private key`);
     }

--- a/modules/abstract-utxo/src/transaction/bip322.ts
+++ b/modules/abstract-utxo/src/transaction/bip322.ts
@@ -1,6 +1,5 @@
 import { decodeOrElse } from '@bitgo/sdk-core';
-import { bitgo } from '@bitgo/utxo-lib';
-import { bip322, fixedScriptWallet, Transaction, type CoinName, type Triple } from '@bitgo/wasm-utxo';
+import { bip322, fixedScriptWallet, hasPsbtMagic, Transaction, type CoinName, type Triple } from '@bitgo/wasm-utxo';
 import * as t from 'io-ts';
 
 const BIP322MessageInfo = t.type({
@@ -52,7 +51,7 @@ export function verifyTransactionFromBroadcastableMessage(
   }
   const network = coinName as CoinName;
 
-  if (bitgo.isPsbt(message.txHex)) {
+  if (hasPsbtMagic(Buffer.from(message.txHex, 'hex'))) {
     const psbt = fixedScriptWallet.BitGoPsbt.fromBytes(Buffer.from(message.txHex, 'hex'), network);
     try {
       message.messageInfo.forEach((info, inputIndex) => {

--- a/modules/abstract-utxo/src/transaction/fixedScript/SigningError.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/SigningError.ts
@@ -1,11 +1,20 @@
 import type { Unspent } from '../../unspent';
 
-import type { PsbtParsedScriptType } from './signPsbtUtxolib';
+export type PsbtParsedScriptType =
+  | 'p2sh'
+  | 'p2wsh'
+  | 'p2shP2wsh'
+  | 'p2shP2pk'
+  | 'taprootKeyPathSpend'
+  | 'taprootScriptPathSpend'
+  | 'p2trLegacy'
+  | 'p2trMusig2ScriptPath'
+  | 'p2trMusig2KeyPath';
 
 export class InputSigningError<TNumber extends number | bigint = number> extends Error {
   static expectedWalletUnspent<TNumber extends number | bigint>(
     inputIndex: number,
-    inputType: PsbtParsedScriptType | null, // null for legacy transaction format
+    inputType: PsbtParsedScriptType | null,
     unspent: Unspent<TNumber> | { id: string }
   ): InputSigningError<TNumber> {
     return new InputSigningError(
@@ -18,7 +27,7 @@ export class InputSigningError<TNumber extends number | bigint = number> extends
 
   constructor(
     public inputIndex: number,
-    public inputType: PsbtParsedScriptType | null, // null for legacy transaction format
+    public inputType: PsbtParsedScriptType | null,
     public unspent: Unspent<TNumber> | { id: string },
     public reason: Error | string
   ) {

--- a/modules/abstract-utxo/src/transaction/fixedScript/parseTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/parseTransaction.ts
@@ -2,7 +2,6 @@ import assert from 'assert';
 
 import _ from 'lodash';
 import { ITransactionRecipient, Triple, VerificationOptions, Wallet } from '@bitgo/sdk-core';
-import * as utxolib from '@bitgo/utxo-lib';
 
 import type { AbstractUtxoCoin, ParseTransactionOptions } from '../../abstractUtxoCoin';
 import type { FixedScriptWalletOutput, Output, ParsedTransaction } from '../types';
@@ -15,6 +14,7 @@ import {
   toOutputScript,
 } from '../recipient';
 import { ComparableOutput, ExpectedOutput, outputDifference } from '../outputDifference';
+import { toTNumber } from '../../tnumber';
 
 import type { TransactionExplanation } from './explainTransaction';
 import { CustomChangeOptions, parseOutput } from './parseOutput';
@@ -231,10 +231,10 @@ export async function parseTransaction<TNumber extends bigint | number>(
   // these are all the non-wallet outputs that had been originally explicitly specified in recipients
   const explicitExternalOutputs = explicitOutputs.filter((output) => output.external);
   // this is the sum of all the originally explicitly specified non-wallet output values
-  const explicitExternalSpendAmount = utxolib.bitgo.toTNumber<TNumber>(
-    explicitExternalOutputs.reduce((sum: bigint, o) => sum + BigInt(o.value), BigInt(0)) as bigint,
+  const explicitExternalSpendAmount = toTNumber(
+    explicitExternalOutputs.reduce((sum: bigint, o) => sum + BigInt(o.value), BigInt(0)),
     coin.amountType
-  );
+  ) as TNumber;
 
   /**
    * The calculation of the implicit external spend amount pertains to verifying the pay-as-you-go-fee BitGo
@@ -250,10 +250,10 @@ export async function parseTransaction<TNumber extends bigint | number>(
   // make sure that all the extra addresses are change addresses
   // get all the additional external outputs the server added and calculate their values
   const implicitExternalOutputs = implicitOutputs.filter((output) => output.external);
-  const implicitExternalSpendAmount = utxolib.bitgo.toTNumber<TNumber>(
-    implicitExternalOutputs.reduce((sum: bigint, o) => sum + BigInt(o.value), BigInt(0)) as bigint,
+  const implicitExternalSpendAmount = toTNumber(
+    implicitExternalOutputs.reduce((sum: bigint, o) => sum + BigInt(o.value), BigInt(0)),
     coin.amountType
-  );
+  ) as TNumber;
 
   function toOutputs(outputs: ExpectedOutput[] | ComparableOutputWithExternal<bigint | 'max'>[]): Output[] {
     return outputs.map((output) => ({

--- a/modules/abstract-utxo/src/transaction/fixedScript/replayProtection.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/replayProtection.ts
@@ -1,6 +1,6 @@
-import { utxolibCompat } from '@bitgo/wasm-utxo';
+import { address, type AddressFormat } from '@bitgo/wasm-utxo';
 
-import { getNetworkFromCoinName, UtxoCoinName } from '../../names';
+import { UtxoCoinName } from '../../names';
 
 export const pubkeyProd = Buffer.from('0255b9f71ac2c78fffd83e3e37b9e17ae70d5437b7f56d0ed2e93b7de08015aa59', 'hex');
 
@@ -27,18 +27,14 @@ const replayProtectionScriptsProd = [Buffer.from('a914174315cfde84f4c45395ac6f15
 // bchtest:pqtjmnzwqffkrk2349g3cecfwwjwxusvnq87n07cal
 const replayProtectionScriptsTestnet = [Buffer.from('a914172dcc4e025361d951a9511c670973a4e3720c9887', 'hex')];
 
-export function getReplayProtectionAddresses(
-  coinName: UtxoCoinName,
-  format: 'default' | 'cashaddr' = 'default'
-): string[] {
-  const network = getNetworkFromCoinName(coinName);
+export function getReplayProtectionAddresses(coinName: UtxoCoinName, format: AddressFormat = 'default'): string[] {
   switch (coinName) {
     case 'bch':
     case 'bsv':
-      return replayProtectionScriptsProd.map((script) => utxolibCompat.fromOutputScript(script, network, format));
+      return replayProtectionScriptsProd.map((script) => address.fromOutputScriptWithCoin(script, coinName, format));
     case 'tbsv':
     case 'tbch':
-      return replayProtectionScriptsTestnet.map((script) => utxolibCompat.fromOutputScript(script, network, format));
+      return replayProtectionScriptsTestnet.map((script) => address.fromOutputScriptWithCoin(script, coinName, format));
     default:
       return [];
   }

--- a/modules/abstract-utxo/src/transaction/fixedScript/signPsbtUtxolib.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/signPsbtUtxolib.ts
@@ -1,7 +1,6 @@
 import assert from 'assert';
 
 import * as utxolib from '@bitgo/utxo-lib';
-import { BIP32Interface } from '@bitgo/secp256k1';
 import { bitgo } from '@bitgo/utxo-lib';
 import debugLib from 'debug';
 
@@ -35,7 +34,7 @@ export type PsbtParsedScriptType =
  */
 export function signAndVerifyPsbt(
   psbt: utxolib.bitgo.UtxoPsbt,
-  signerKeychain: BIP32Interface
+  signerKeychain: utxolib.BIP32Interface
 ): utxolib.bitgo.UtxoPsbt {
   const txInputs = psbt.txInputs;
   const outputIds: string[] = [];
@@ -107,7 +106,7 @@ const PSBT_CACHE = new Map<string, utxolib.bitgo.UtxoPsbt>();
 export async function signPsbtWithMusig2ParticipantUtxolib(
   coin: Musig2Participant<utxolib.bitgo.UtxoPsbt>,
   tx: utxolib.bitgo.UtxoPsbt,
-  signerKeychain: BIP32Interface | undefined,
+  signerKeychain: utxolib.BIP32Interface | undefined,
   params: {
     signingStep: 'signerNonce' | 'cosignerNonce' | 'signerSignature' | undefined;
     walletId: string | undefined;

--- a/modules/abstract-utxo/src/transaction/fixedScript/signPsbtWasm.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/signPsbtWasm.ts
@@ -1,7 +1,6 @@
 import assert from 'assert';
 
-import { BIP32Interface } from '@bitgo/utxo-lib';
-import { BIP32, ECPair, fixedScriptWallet } from '@bitgo/wasm-utxo';
+import { BIP32, bip32, ECPair, fixedScriptWallet } from '@bitgo/wasm-utxo';
 
 import { toWasmBIP32 } from '../../wasmUtil';
 
@@ -36,7 +35,7 @@ function hasKeyPathSpendInput(
  */
 export function signAndVerifyPsbtWasm(
   tx: fixedScriptWallet.BitGoPsbt,
-  signerKeychain: BIP32Interface | BIP32,
+  signerKeychain: bip32.BIP32Interface | BIP32,
   rootWalletKeys: fixedScriptWallet.RootWalletKeys,
   replayProtection: ReplayProtectionKeys
 ): fixedScriptWallet.BitGoPsbt {
@@ -81,7 +80,7 @@ export function signAndVerifyPsbtWasm(
 export async function signPsbtWithMusig2ParticipantWasm(
   coin: Musig2Participant<fixedScriptWallet.BitGoPsbt>,
   tx: fixedScriptWallet.BitGoPsbt,
-  signerKeychain: BIP32Interface | undefined,
+  signerKeychain: bip32.BIP32Interface | undefined,
   rootWalletKeys: fixedScriptWallet.RootWalletKeys,
   params: {
     replayProtection: ReplayProtectionKeys;

--- a/modules/abstract-utxo/src/transaction/fixedScript/signTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/signTransaction.ts
@@ -2,13 +2,13 @@ import assert from 'assert';
 
 import { isTriple } from '@bitgo/sdk-core';
 import _ from 'lodash';
-import { BIP32Interface } from '@bitgo/secp256k1';
 import { bitgo } from '@bitgo/utxo-lib';
 import * as utxolib from '@bitgo/utxo-lib';
-import { BIP32, fixedScriptWallet } from '@bitgo/wasm-utxo';
+import { BIP32, bip32, fixedScriptWallet } from '@bitgo/wasm-utxo';
 
 import { UtxoCoinName } from '../../names';
 import type { Unspent } from '../../unspent';
+import { toUtxolibBIP32 } from '../../wasmUtil';
 
 import { Musig2Participant } from './musig2';
 import { signLegacyTransaction } from './signLegacyTransaction';
@@ -21,33 +21,30 @@ import { getReplayProtectionPubkeys } from './replayProtection';
  */
 export function signAndVerifyPsbt(
   psbt: utxolib.bitgo.UtxoPsbt,
-  signerKeychain: BIP32Interface | BIP32,
+  signerKeychain: bip32.BIP32Interface | BIP32,
   rootWalletKeys: fixedScriptWallet.RootWalletKeys | undefined,
   replayProtection: ReplayProtectionKeys | undefined
 ): utxolib.bitgo.UtxoPsbt;
 export function signAndVerifyPsbt(
   psbt: fixedScriptWallet.BitGoPsbt,
-  signerKeychain: BIP32Interface | BIP32,
+  signerKeychain: bip32.BIP32Interface | BIP32,
   rootWalletKeys: fixedScriptWallet.RootWalletKeys,
   replayProtection: ReplayProtectionKeys
 ): fixedScriptWallet.BitGoPsbt;
 export function signAndVerifyPsbt(
   psbt: utxolib.bitgo.UtxoPsbt | fixedScriptWallet.BitGoPsbt,
-  signerKeychain: BIP32Interface | BIP32,
+  signerKeychain: bip32.BIP32Interface | BIP32,
   rootWalletKeys: fixedScriptWallet.RootWalletKeys,
   replayProtection: ReplayProtectionKeys
 ): utxolib.bitgo.UtxoPsbt | fixedScriptWallet.BitGoPsbt;
 export function signAndVerifyPsbt(
   psbt: utxolib.bitgo.UtxoPsbt | fixedScriptWallet.BitGoPsbt,
-  signerKeychain: BIP32Interface | BIP32,
+  signerKeychain: bip32.BIP32Interface | BIP32,
   rootWalletKeys: fixedScriptWallet.RootWalletKeys | undefined,
   replayProtection: ReplayProtectionKeys | undefined
 ): utxolib.bitgo.UtxoPsbt | fixedScriptWallet.BitGoPsbt {
   if (psbt instanceof bitgo.UtxoPsbt) {
-    if (signerKeychain instanceof BIP32) {
-      signerKeychain = utxolib.bip32.fromBase58(signerKeychain.toBase58());
-    }
-    return signAndVerifyPsbtUtxolib(psbt, signerKeychain);
+    return signAndVerifyPsbtUtxolib(psbt, toUtxolibBIP32(signerKeychain));
   }
   assert(rootWalletKeys, 'rootWalletKeys required for wasm-utxo signing');
   assert(replayProtection, 'replayProtection required for wasm-utxo signing');
@@ -59,7 +56,7 @@ export async function signTransaction<
 >(
   coin: Musig2Participant<utxolib.bitgo.UtxoPsbt> | Musig2Participant<fixedScriptWallet.BitGoPsbt>,
   tx: T,
-  signerKeychain: BIP32Interface | undefined,
+  signerKeychain: bip32.BIP32Interface | undefined,
   coinName: UtxoCoinName,
   params: {
     walletId: string | undefined;
@@ -84,7 +81,7 @@ export async function signTransaction<
     const signedPsbt = await signPsbtWithMusig2ParticipantUtxolib(
       coin as Musig2Participant<utxolib.bitgo.UtxoPsbt>,
       tx,
-      signerKeychain,
+      signerKeychain ? toUtxolibBIP32(signerKeychain) : undefined,
       {
         signingStep: params.signingStep,
         walletId: params.walletId,

--- a/modules/abstract-utxo/src/transaction/signTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/signTransaction.ts
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import { BitGoBase } from '@bitgo/sdk-core';
-import * as utxolib from '@bitgo/utxo-lib';
-import { bip32 } from '@bitgo/secp256k1';
+import { BIP32 } from '@bitgo/wasm-utxo';
 import buildDebug from 'debug';
 
 import { AbstractUtxoCoin, SignTransactionOptions } from '../abstractUtxoCoin';
@@ -15,14 +14,14 @@ import { encodeTransaction } from './decode';
 
 const debug = buildDebug('bitgo:abstract-utxo:transaction:signTransaction');
 
-function getSignerKeychain(userPrv: unknown): utxolib.BIP32Interface | undefined {
+function getSignerKeychain(userPrv: unknown): BIP32 | undefined {
   if (userPrv === undefined) {
     return undefined;
   }
   if (typeof userPrv !== 'string') {
     throw new Error('expected user private key to be a string');
   }
-  const signerKeychain = bip32.fromBase58(userPrv, utxolib.networks.bitcoin);
+  const signerKeychain = BIP32.fromBase58(userPrv);
   if (signerKeychain.isNeutered()) {
     throw new Error('expected user private key but received public key');
   }

--- a/modules/abstract-utxo/src/unspent.ts
+++ b/modules/abstract-utxo/src/unspent.ts
@@ -1,4 +1,4 @@
-import * as utxolib from '@bitgo/utxo-lib';
+import { fixedScriptWallet } from '@bitgo/wasm-utxo';
 
 /**
  * Unspent transaction output (UTXO) type definition
@@ -35,7 +35,7 @@ export interface Unspent<TNumber extends number | bigint = number> {
  * - index: number (index for wallet derivation)
  */
 export interface WalletUnspent<TNumber extends number | bigint = number> extends Unspent<TNumber> {
-  chain: utxolib.bitgo.ChainCode;
+  chain: fixedScriptWallet.ChainCode;
   index: number;
 }
 

--- a/modules/abstract-utxo/src/wasmUtil.ts
+++ b/modules/abstract-utxo/src/wasmUtil.ts
@@ -1,7 +1,7 @@
-import { BIP32, ECPair, Psbt, descriptorWallet } from '@bitgo/wasm-utxo';
+import { BIP32, bip32, ECPair, Psbt, descriptorWallet } from '@bitgo/wasm-utxo';
 import * as utxolib from '@bitgo/utxo-lib';
 
-export type BIP32Key = BIP32 | utxolib.BIP32Interface;
+export type BIP32Key = BIP32 | bip32.BIP32Interface | utxolib.BIP32Interface;
 export type ECPairKey = ECPair | utxolib.ECPairInterface | Uint8Array;
 export type UtxoLibPsbt = utxolib.Psbt | utxolib.bitgo.UtxoPsbt;
 
@@ -26,6 +26,14 @@ export function toWasmBIP32(key: BIP32Key): BIP32 {
   }
   // All utxo-lib BIP32Interface instances have toBase58
   return BIP32.fromBase58(key.toBase58());
+}
+
+/**
+ * Convert a wasm-utxo BIP32 to a utxo-lib BIP32Interface.
+ * Used at boundaries where utxo-lib APIs require their own BIP32Interface type.
+ */
+export function toUtxolibBIP32(key: BIP32Key): utxolib.BIP32Interface {
+  return utxolib.bip32.fromBase58(key.toBase58());
 }
 
 export function toWasmECPair(key: ECPairKey): ECPair {

--- a/modules/abstract-utxo/test/unit/coins.ts
+++ b/modules/abstract-utxo/test/unit/coins.ts
@@ -2,9 +2,9 @@ import * as assert from 'assert';
 
 import * as utxolib from '@bitgo/utxo-lib';
 
-import { getMainnetCoinName, getNetworkFromCoinName, utxoCoinsMainnet, utxoCoinsTestnet } from '../../src/names';
+import { getMainnetCoinName, utxoCoinsMainnet, utxoCoinsTestnet } from '../../src/names';
 
-import { getUtxoCoinForNetwork, utxoCoins } from './util';
+import { getNetworkForCoinName, getUtxoCoinForNetwork, utxoCoins } from './util';
 
 describe('utxoCoins', function () {
   it('has expected chain/network values for items', function () {
@@ -13,7 +13,7 @@ describe('utxoCoins', function () {
         c.getChain(),
         c.getFamily(),
         c.getFullName(),
-        utxolib.getNetworkName(getNetworkFromCoinName(c.name)),
+        utxolib.getNetworkName(getNetworkForCoinName(c.name)),
       ]),
       [
         ['btc', 'btc', 'Bitcoin', 'bitcoin'],

--- a/modules/abstract-utxo/test/unit/util/transaction.ts
+++ b/modules/abstract-utxo/test/unit/util/transaction.ts
@@ -3,8 +3,10 @@ import assert from 'assert';
 import * as utxolib from '@bitgo/utxo-lib';
 import { ECPair, fixedScriptWallet, hasPsbtMagic, address as wasmAddress } from '@bitgo/wasm-utxo';
 
-import { getCoinName, UtxoCoinName } from '../../../src/names';
+import type { UtxoCoinName } from '../../../src/names';
 import type { Unspent, WalletUnspent } from '../../../src/unspent';
+
+import { getCoinNameForNetwork } from './utxoCoins';
 const { isWalletUnspent, signInputWithUnspent } = utxolib.bitgo;
 type UtxolibRootWalletKeys = utxolib.bitgo.RootWalletKeys;
 type WasmRootWalletKeys = fixedScriptWallet.RootWalletKeys;
@@ -28,7 +30,7 @@ function toTxOutput<TNumber extends number | bigint = number>(
   network: utxolib.Network
 ): utxolib.TxOutput<TNumber> {
   return {
-    script: Buffer.from(wasmAddress.toOutputScriptWithCoin(u.address, getCoinName(network))),
+    script: Buffer.from(wasmAddress.toOutputScriptWithCoin(u.address, getCoinNameForNetwork(network))),
     value: u.value,
   };
 }

--- a/modules/abstract-utxo/test/unit/util/unspents.ts
+++ b/modules/abstract-utxo/test/unit/util/unspents.ts
@@ -3,9 +3,10 @@ import { getSeed } from '@bitgo/sdk-test';
 import * as wasmUtxo from '@bitgo/wasm-utxo';
 
 import { getReplayProtectionAddresses } from '../../../src';
-import { getCoinName, isUtxoCoinName, type UtxoCoinName } from '../../../src/names';
+import { isUtxoCoinName, type UtxoCoinName } from '../../../src/names';
 import type { Unspent, UnspentWithPrevTx, WalletUnspent } from '../../../src/unspent';
 
+import { getCoinNameForNetwork } from './utxoCoins';
 import { getWalletAddress } from './address';
 
 const { chainCodesP2sh, getExternalChainCode, getInternalChainCode } = utxolib.bitgo;
@@ -25,7 +26,7 @@ function toCoinName(network: NetworkArg): UtxoCoinName {
     }
     return network;
   }
-  return getCoinName(network);
+  return getCoinNameForNetwork(network);
 }
 
 export type InputScriptType = utxolib.bitgo.outputScripts.ScriptType2Of3 | 'replayProtection';


### PR DESCRIPTION

Replace utxo-lib utility functions (crypto, address, bip32, opcodes) with
standalone equivalents from @bitgo/wasm-utxo, @bitgo/secp256k1, and local
implementations. This does not affect transaction decoding or signing paths.

This PR includes:

- Replacing bitcoinjs-message with @bitgo/wasm-utxo for message verification
- Removing unused helper functions now handled by the wasm module
- Replacing various utxolib utilities with wasm-utxo equivalents:
  - crypto.hash160/address.toBase58Check with local implementations
  - utxolib.address.* with wasm-utxo address module
  - bitgo.isPsbt() with hasPsbtMagic()
  - utxolib address with wasm-utxo address in replayProtection
  - utxolib.bitgo.toTNumber() with local helper
  - Inlining PsbtParsedScriptType type locally
  - Changing ChainCode type import to wasm-utxo
  - Importing BIP32Interface from secp256k1
  - Adding coinNameToNetwork map and getNetworkForCoinName helper

This change simplifies the code and reduces dependencies while maintaining
the same functionality.

BTC-2768