### PR TITLE
feat(statics): rename Stable to USDT0

### DIFF
--- a/modules/sdk-core/src/bitgo/environments.ts
+++ b/modules/sdk-core/src/bitgo/environments.ts
@@ -245,7 +245,7 @@ const mainnetBase: EnvironmentTemplate = {
     sonic: {
       baseUrl: 'https://api.etherscan.io/v2',
     },
-    stable: {
+    usdt0: {
       baseUrl: 'https://stablescan.xyz/api',
     },
     seievm: {
@@ -439,7 +439,7 @@ const testnetBase: EnvironmentTemplate = {
     sonic: {
       baseUrl: 'https://api.etherscan.io/v2',
     },
-    stable: {
+    usdt0: {
       baseUrl: 'https://testnet.stablescan.xyz/api',
     },
     seievm: {

--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -1772,11 +1772,11 @@ export const allCoinsAndTokens = [
   ),
   account(
     '599ab8d6-ebda-460e-8527-677157f86021',
-    'stable',
-    'Stable',
-    Networks.main.stable,
+    'usdt0',
+    'USDT0',
+    Networks.main.usdt0,
     18,
-    UnderlyingAsset.STABLE,
+    UnderlyingAsset.USDT0,
     BaseUnit.ETH,
     [
       ...EVM_FEATURES,
@@ -1790,11 +1790,11 @@ export const allCoinsAndTokens = [
   ),
   account(
     'fd6b7af0-aff3-45fb-9a71-2d7100a1cd89',
-    'tstable',
-    'Testnet Stable',
-    Networks.test.stable,
+    'tusdt0',
+    'Testnet USDT0',
+    Networks.test.usdt0,
     18,
-    UnderlyingAsset.STABLE,
+    UnderlyingAsset.USDT0,
     BaseUnit.ETH,
     [
       ...EVM_FEATURES,

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -104,7 +104,6 @@ export enum CoinFamily {
   SOL = 'sol',
   SONIC = 'sonic',
   SONEIUM = 'soneium',
-  STABLE = 'stable',
   STT = 'stt',
   SUI = 'sui',
   STX = 'stx',
@@ -114,6 +113,7 @@ export enum CoinFamily {
   TIA = 'tia', // Celestia
   TON = 'ton',
   TRX = 'trx',
+  USDT0 = 'usdt0', // Stable EVM L1
   VET = 'vet',
   WORLD = 'world',
   WEMIX = 'wemix',
@@ -635,16 +635,16 @@ export enum UnderlyingAsset {
   SEIEVM = 'seievm',
   SGB = 'sgb',
   SOL = 'sol',
+  SOMI = 'somi', // Somnia Chain
+  SONEIUM = 'soneium',
   SONIC = 'sonic',
-  STABLE = 'stable',
-  SUI = 'sui',
+  STT = 'stt',
   STX = 'stx',
+  SUI = 'sui',
   TIA = 'tia', // Celestia
   TON = 'ton',
   TRX = 'trx',
-  SONEIUM = 'soneium',
-  STT = 'stt',
-  SOMI = 'somi', // Somnia Chain
+  USDT0 = 'usdt0', // Stable EVM L1
   VET = 'vet',
   WEMIX = 'wemix',
   WORLD = 'world',

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -194,13 +194,13 @@ export const ofcCoins = [
     UnderlyingAsset.SONIC,
     CoinKind.CRYPTO
   ),
-  ofc('13151b0b-3734-452d-8ad9-21af03a08bfe', 'ofcstable', 'Stable', 18, UnderlyingAsset.STABLE, CoinKind.CRYPTO),
+  ofc('13151b0b-3734-452d-8ad9-21af03a08bfe', 'ofcusdt0', 'USDT0', 18, UnderlyingAsset.USDT0, CoinKind.CRYPTO),
   tofc(
     '39a4dd77-b824-47b9-baff-b45398012511',
-    'ofctstable',
-    'Stable Testnet',
+    'ofctusdt0',
+    'USDT0 Testnet',
     18,
-    UnderlyingAsset.STABLE,
+    UnderlyingAsset.USDT0,
     CoinKind.CRYPTO
   ),
   ofc(

--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -1827,18 +1827,18 @@ class SonicTestnet extends Testnet implements EthereumNetwork {
   walletImplementationAddress = '0x944fef03af368414f29dc31a72061b8d64f568d2';
 }
 
-class Stable extends Mainnet implements EthereumNetwork {
-  name = 'Stable';
-  family = CoinFamily.STABLE;
+class Usdt0 extends Mainnet implements EthereumNetwork {
+  name = 'USDT0';
+  family = CoinFamily.USDT0;
   explorerUrl = 'https://stablescan.xyz/tx/';
   accountExplorerUrl = 'https://stablescan.xyz/address/';
   chainId = 988;
   nativeCoinOperationHashPrefix = '988';
 }
 
-class StableTestnet extends Testnet implements EthereumNetwork {
-  name = 'Testnet Stable';
-  family = CoinFamily.STABLE;
+class Usdt0Testnet extends Testnet implements EthereumNetwork {
+  name = 'Testnet USDT0';
+  family = CoinFamily.USDT0;
   explorerUrl = 'https://testnet.stablescan.xyz/tx/';
   accountExplorerUrl = 'https://testnet.stablescan.xyz/address/';
   chainId = 2201;
@@ -2520,7 +2520,6 @@ export const Networks = {
     sgb: Object.freeze(new Songbird()),
     sol: Object.freeze(new Sol()),
     sonic: Object.freeze(new Sonic()),
-    stable: Object.freeze(new Stable()),
     sui: Object.freeze(new Sui()),
     near: Object.freeze(new Near()),
     stx: Object.freeze(new Stx()),
@@ -2532,6 +2531,7 @@ export const Networks = {
     tia: Object.freeze(new Tia()),
     ton: Object.freeze(new Ton()),
     trx: Object.freeze(new Trx()),
+    usdt0: Object.freeze(new Usdt0()),
     vet: Object.freeze(new Vet()),
     wemix: Object.freeze(new Wemix()),
     world: Object.freeze(new World()),
@@ -2642,7 +2642,6 @@ export const Networks = {
     stt: Object.freeze(new SomniaTestnet()),
     soneium: Object.freeze(new SoneiumTestnet()),
     sonic: Object.freeze(new SonicTestnet()),
-    stable: Object.freeze(new StableTestnet()),
     kaia: Object.freeze(new KaiaTestnet()),
     susd: Object.freeze(new SUSDTestnet()),
     coreum: Object.freeze(new CoreumTestnet()),
@@ -2651,6 +2650,7 @@ export const Networks = {
     tia: Object.freeze(new TiaTestnet()),
     ton: Object.freeze(new TonTestnet()),
     trx: Object.freeze(new TrxTestnet()),
+    usdt0: Object.freeze(new Usdt0Testnet()),
     vet: Object.freeze(new VetTestnet()),
     wemix: Object.freeze(new WemixTestnet()),
     world: Object.freeze(new WorldTestnet()),

--- a/modules/statics/test/unit/fixtures/expectedColdFeatures.ts
+++ b/modules/statics/test/unit/fixtures/expectedColdFeatures.ts
@@ -125,8 +125,8 @@ export const expectedColdFeatures = {
     'sol',
     'sonic',
     'somi',
-    'stable',
     'sui',
+    'usdt0',
     'tao',
     'tempo',
     'vet',
@@ -214,7 +214,7 @@ export const expectedColdFeatures = {
     'tseievm',
     'tton',
     'tsonic',
-    'tstable',
+    'tusdt0',
   ],
   neither: [
     'ethw',


### PR DESCRIPTION
## Summary
- Renamed `stable`/`tstable` to `usdt0`/`tusdt0` to match the BitGo ticker
- Updated CoinFamily and UnderlyingAsset from `STABLE` to `USDT0`
- Updated OFC entries from `ofcstable`/`ofctstable` to `ofcusdt0`/`ofctusdt0`
- Updated environment keys
- Entries arranged alphabetically

## Ticket
WIN-8747

## Test plan
- [ ] Verify unit tests pass
- [ ] Verify coin registration with new ticker