### PR TITLE
feat(abstract-utxo): add customChangeXpubs to explainTransaction

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -243,6 +243,7 @@ export interface ExplainTransactionOptions<TNumber extends number | bigint = num
   txInfo?: TransactionInfo<TNumber>;
   feeInfo?: string;
   pubs?: Triple<string>;
+  customChangeXpubs?: Triple<string>;
   decodeWith?: SdkBackend;
 }
 

--- a/modules/abstract-utxo/src/transaction/explainTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/explainTransaction.ts
@@ -27,6 +27,7 @@ export function explainTx<TNumber extends number | bigint>(
   params: {
     wallet?: IWallet;
     pubs?: string[];
+    customChangeXpubs?: Triple<string>;
     txInfo?: { unspents?: Unspent<TNumber>[] };
     changeInfo?: fixedScript.ChangeAddressInfo[];
   },
@@ -49,7 +50,7 @@ export function explainTx<TNumber extends number | bigint>(
     throw new Error('legacy transactions are not supported for descriptor wallets');
   }
   if (tx instanceof utxolib.bitgo.UtxoPsbt) {
-    return fixedScript.explainPsbt(tx, params, coinName);
+    return fixedScript.explainPsbt(tx, { ...params, customChangePubs: params.customChangeXpubs }, coinName);
   } else if (tx instanceof fixedScriptWallet.BitGoPsbt) {
     const pubs = params.pubs;
     if (!pubs) {
@@ -68,6 +69,7 @@ export function explainTx<TNumber extends number | bigint>(
       replayProtection: {
         publicKeys: getReplayProtectionPubkeys(coinName),
       },
+      customChangeWalletXpubs: params.customChangeXpubs,
     });
   } else {
     return fixedScript.explainLegacyTx(tx, params, coinName);

--- a/modules/abstract-utxo/test/unit/customChangeWalletFixtures.ts
+++ b/modules/abstract-utxo/test/unit/customChangeWalletFixtures.ts
@@ -1,0 +1,68 @@
+import assert from 'assert';
+
+import { BIP32, message } from '@bitgo/wasm-utxo';
+
+import { verifyKeySignature } from '../../src/verifyKey';
+
+const KEY_ROLES = ['user', 'backup', 'bitgo'] as const;
+type KeyRole = (typeof KEY_ROLES)[number];
+
+function signKeySignature(signerPrivateKey: BIP32, pubToSign: string): string {
+  assert(signerPrivateKey.privateKey, 'signer must have a private key');
+  return Buffer.from(message.signMessage(pubToSign, signerPrivateKey.privateKey)).toString('hex');
+}
+
+function createMockCustomChangeKeySignatures(
+  signerPrivateKey: BIP32,
+  changeKeychains: { pub: string }[]
+): Record<KeyRole, string> {
+  return {
+    user: signKeySignature(signerPrivateKey, changeKeychains[0].pub),
+    backup: signKeySignature(signerPrivateKey, changeKeychains[1].pub),
+    bitgo: signKeySignature(signerPrivateKey, changeKeychains[2].pub),
+  };
+}
+
+describe('Custom Change Wallet Key Signatures', function () {
+  const mainUserKey = BIP32.fromSeedSha256('main-user');
+  const changeKeys = [
+    BIP32.fromSeedSha256('change-user'),
+    BIP32.fromSeedSha256('change-backup'),
+    BIP32.fromSeedSha256('change-bitgo'),
+  ];
+  const changeKeychains = changeKeys.map((k) => ({ pub: k.neutered().toBase58() }));
+
+  it('should accept signatures from the correct key', function () {
+    const signatures = createMockCustomChangeKeySignatures(mainUserKey, changeKeychains);
+
+    for (const role of KEY_ROLES) {
+      const index = KEY_ROLES.indexOf(role);
+      assert.ok(
+        verifyKeySignature({
+          userKeychain: { pub: mainUserKey.neutered().toBase58() },
+          keychainToVerify: changeKeychains[index],
+          keySignature: signatures[role],
+        }),
+        `failed to verify mock custom change ${role} key signature`
+      );
+    }
+  });
+
+  it('should reject signatures from a different key', function () {
+    const wrongKey = BIP32.fromSeedSha256('wrong-key');
+    const badSignatures = createMockCustomChangeKeySignatures(wrongKey, changeKeychains);
+
+    for (const role of KEY_ROLES) {
+      const index = KEY_ROLES.indexOf(role);
+      assert.strictEqual(
+        verifyKeySignature({
+          userKeychain: { pub: mainUserKey.neutered().toBase58() },
+          keychainToVerify: changeKeychains[index],
+          keySignature: badSignatures[role],
+        }),
+        false,
+        `should have rejected custom change ${role} key signature from wrong key`
+      );
+    }
+  });
+});


### PR DESCRIPTION

Add support for custom change wallet functionality in explainTransaction
and parseTransaction methods. This allows Bitcoin wallets to send change to
a different wallet by providing customChangeXpubs.

Includes validation for custom change key signatures in the parsing flow
to ensure the change wallet keys were properly authorized by the sender.

Added tests for signature verification and rejection of invalid signatures.

Issue: BTC-2768