### PR TITLE
fix(statics): update goUSD mainnet contract address

### DIFF
--- a/modules/statics/src/coins/erc20Coins.ts
+++ b/modules/statics/src/coins/erc20Coins.ts
@@ -2950,7 +2950,7 @@ export const erc20Coins = [
     'eth:gousd',
     'goUSD',
     6,
-    '0xf1f6b8cc3a0d544a40f1d29909396378370e6938',
+    '0x04f4f7b8bb7b8aca7beb8a027603dfc6eb66af5d',
     UnderlyingAsset['eth:gousd'],
     [...ACCOUNT_COIN_DEFAULT_FEATURES, CoinFeature.STABLECOIN]
   ),


### PR DESCRIPTION
Ticket: SCAAS-2676

Now that gousd has been burned manually from the old contract, we can change the address back to the new smart contract for gousd.