### PR TITLE
feat: add verification flow for v4

### DIFF
--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -1323,7 +1323,7 @@ function parseBody(req: express.Request, res: express.Response, next: express.Ne
  * @param config
  */
 function prepareBitGo(config: Config) {
-  const { env, customRootUri, customBitcoinNetwork } = config;
+  const { env, customRootUri, customBitcoinNetwork, authVersion } = config;
 
   return function prepBitGo(req: express.Request, res: express.Response, next: express.NextFunction) {
     // Get access token
@@ -1334,6 +1334,31 @@ function prepareBitGo(config: Config) {
         accessToken = authSplit[1];
       }
     }
+
+    // Get token ID from custom header (required for v4 auth)
+    // For v2/v3, this header is ignored if present.
+    // For v4, if both accessToken and authVersion=4 are present, tokenId must be provided
+    // or the request will be rejected with a clear error message.
+    //
+    // Header name: `Access-Key-Id`
+    // Expected value: the MongoDB ObjectId (`_id`) of the access token document.
+    // When making v4-authenticated requests through BitGoExpress, clients MUST set this
+    // header to the token's `_id` so that BitGo can correctly identify the access token.
+    const tokenIdHeader = req.headers['access-key-id'];
+    const tokenId = tokenIdHeader ? (Array.isArray(tokenIdHeader) ? tokenIdHeader[0] : tokenIdHeader) : undefined;
+
+    // Enforce v4 auth requirements at the BitGoExpress middleware level to provide
+    // an immediate, clear error when the Access-Key-Id header (tokenId) is missing.
+    if (authVersion === 4 && accessToken && !tokenId) {
+      res.status(400).send({
+        error:
+          'BitGoExpress is configured with authVersion=4 and a bearer access token, ' +
+          'but the Access-Key-Id header is missing. ' +
+          'For v4 auth, requests must include the Access-Key-Id header identifying the access token.',
+      });
+      return;
+    }
+
     const userAgent = req.headers['user-agent']
       ? BITGOEXPRESS_USER_AGENT + ' ' + req.headers['user-agent']
       : BITGOEXPRESS_USER_AGENT;
@@ -1343,7 +1368,9 @@ function prepareBitGo(config: Config) {
       env,
       customRootURI: customRootUri,
       customBitcoinNetwork,
+      authVersion,
       accessToken,
+      ...(tokenId ? { tokenId } : {}),
       userAgent,
       ...(useProxyUrl
         ? {

--- a/modules/express/test/unit/config.ts
+++ b/modules/express/test/unit/config.ts
@@ -280,4 +280,87 @@ describe('Config:', () => {
     should.not.exist(parsed.disableproxy);
     argvStub.restore();
   });
+
+  describe('authVersion parsing', () => {
+    it('should correctly handle authVersion 2', () => {
+      const envStub = sinon.stub(process, 'env').value({ BITGO_AUTH_VERSION: '2' });
+      const { config: proxyConfig } = proxyquire('../../src/config', {
+        './args': {
+          args: () => {
+            return {};
+          },
+        },
+      });
+      proxyConfig().authVersion.should.equal(2);
+      envStub.restore();
+    });
+
+    it('should correctly handle authVersion 3', () => {
+      const envStub = sinon.stub(process, 'env').value({ BITGO_AUTH_VERSION: '3' });
+      const { config: proxyConfig } = proxyquire('../../src/config', {
+        './args': {
+          args: () => {
+            return {};
+          },
+        },
+      });
+      proxyConfig().authVersion.should.equal(3);
+      envStub.restore();
+    });
+
+    it('should correctly handle authVersion 4', () => {
+      const envStub = sinon.stub(process, 'env').value({ BITGO_AUTH_VERSION: '4' });
+      const { config: proxyConfig } = proxyquire('../../src/config', {
+        './args': {
+          args: () => {
+            return {};
+          },
+        },
+      });
+      proxyConfig().authVersion.should.equal(4);
+      envStub.restore();
+    });
+
+    it('should clamp invalid authVersion values to 2', () => {
+      const consoleStub = sinon.stub(console, 'warn').returns(undefined);
+      const envStub = sinon.stub(process, 'env').value({ BITGO_AUTH_VERSION: '5' });
+      const { config: proxyConfig } = proxyquire('../../src/config', {
+        './args': {
+          args: () => {
+            return {};
+          },
+        },
+      });
+      proxyConfig().authVersion.should.equal(2);
+      consoleStub.calledOnce.should.be.true();
+      consoleStub.restore();
+      envStub.restore();
+    });
+
+    it('should handle authVersion precedence: args override env', () => {
+      const envStub = sinon.stub(process, 'env').value({ BITGO_AUTH_VERSION: '3' });
+      const { config: proxyConfig } = proxyquire('../../src/config', {
+        './args': {
+          args: () => {
+            return { authversion: 4 };
+          },
+        },
+      });
+      proxyConfig().authVersion.should.equal(4);
+      envStub.restore();
+    });
+
+    it('should default to authVersion 2 when not provided', () => {
+      const envStub = sinon.stub(process, 'env').value({});
+      const { config: proxyConfig } = proxyquire('../../src/config', {
+        './args': {
+          args: () => {
+            return {};
+          },
+        },
+      });
+      proxyConfig().authVersion.should.equal(2);
+      envStub.restore();
+    });
+  });
 });

--- a/modules/sdk-api/src/api.ts
+++ b/modules/sdk-api/src/api.ts
@@ -10,6 +10,7 @@ import urlLib from 'url';
 import querystring from 'querystring';
 
 import { ApiResponseError, BitGoRequest } from '@bitgo/sdk-core';
+import { extractPathWithQuery } from '@bitgo/sdk-hmac';
 
 import { AuthVersion, VerifyResponseOptions } from './types';
 import { BitGoAPI } from './bitgoAPI';
@@ -213,6 +214,135 @@ export function setRequestQueryString(req: superagent.SuperAgentRequest): void {
   }
 }
 
+/** Result from version-specific response verification. */
+interface ResponseVerificationResult {
+  verificationResult: {
+    isValid: boolean;
+    expectedHmac: string;
+    isInResponseValidityWindow: boolean;
+    verificationTime: number;
+  };
+  hmacErrorDetails: Record<string, unknown>;
+  responseTimestamp: string | number;
+}
+
+/**
+ * Verify a v4 server response HMAC.
+ *
+ * Returns undefined if the server didn't sign the response (e.g. error before
+ * auth middleware ran), signalling the caller to pass the response through
+ * without verification.
+ *
+ * @param authToken - The raw access token (HMAC key). Guaranteed non-undefined by the caller.
+ */
+function verifyV4ResponseHeaders(
+  bitgo: BitGoAPI,
+  method: VerifyResponseOptions['method'],
+  req: superagent.SuperAgentRequest,
+  response: superagent.Response,
+  authToken: string
+): ResponseVerificationResult | undefined {
+  const hmac = response.header['x-signature'];
+  const timestamp = response.header['x-request-timestamp'];
+  const authRequestId = response.header['x-auth-request-id'];
+
+  if (!hmac || !timestamp) {
+    // request fails before reaching the auth middleware (e.g. 4xx/5xx). For
+    // successful (2xx) responses, we require v4 signature headers and treat
+    // their absence as a protocol/authentication error.
+    debug(
+      'v4 response verification %s: server response (status %d) missing HMAC headers (x-signature: %s, x-request-timestamp: %s)',
+      response.status >= 200 && response.status < 300 ? 'failed' : 'skipped',
+      response.status,
+      hmac ? 'present' : 'missing',
+      timestamp ? 'present' : 'missing'
+    );
+
+    // For 2xx responses, missing v4 signature headers are not allowed; this
+    // would permit an attacker or intermediary to strip HMAC headers and
+    // bypass response verification.
+    if (response.status >= 200 && response.status < 300) {
+      throw new ApiResponseError(
+        'Missing required v4 response signature headers (x-signature and/or x-request-timestamp) on successful response',
+        511,
+        { status: response.status, body: response.body }
+      );
+    }
+
+    return undefined;
+  }
+
+  // Hash the raw response body bytes.
+  // Convert response.text to a Buffer (UTF-8) so we're hashing the actual bytes,
+  // not relying on Node's implicit string encoding in crypto.update().
+  const rawResponseBuffer = Buffer.from(response.text || '');
+  const bodyHashHex = bitgo.calculateBodyHash(rawResponseBuffer);
+
+  // req.v4PathWithQuery is always set by requestPatch; fallback parses req.url as a safety net.
+  let pathWithQuery = req.v4PathWithQuery;
+  if (!pathWithQuery) {
+    // Use sdk-hmac's extractPathWithQuery helper which handles both absolute URLs
+    pathWithQuery = extractPathWithQuery(req.url);
+  }
+
+  const result = bitgo.verifyResponse({
+    hmac,
+    timestampSec: Number(timestamp),
+    method: req.v4Method || method,
+    pathWithQuery,
+    bodyHashHex,
+    authRequestId: authRequestId || req.v4AuthRequestId || '',
+    statusCode: response.status,
+    rawToken: authToken,
+  });
+
+  return {
+    verificationResult: result,
+    responseTimestamp: timestamp,
+    hmacErrorDetails: { expectedHmac: result.expectedHmac, receivedHmac: hmac, preimage: result.preimage },
+  };
+}
+
+/**
+ * Verify a v2/v3 server response HMAC.
+ *
+ * @param authToken - The raw access token (HMAC key). Guaranteed non-undefined by the caller.
+ */
+function verifyV2V3ResponseHeaders(
+  bitgo: BitGoAPI,
+  token: string | undefined,
+  method: VerifyResponseOptions['method'],
+  req: superagent.SuperAgentRequest,
+  response: superagent.Response,
+  authVersion: AuthVersion,
+  authToken: string
+): ResponseVerificationResult {
+  const result = bitgo.verifyResponse({
+    url: req.url,
+    hmac: response.header.hmac,
+    statusCode: response.status,
+    text: response.text,
+    timestamp: response.header.timestamp,
+    token: authToken,
+    method,
+    authVersion,
+  });
+
+  const partialBitgoToken = token ? token.substring(0, 10) : '';
+  const partialRequestToken = authToken ? authToken.substring(0, 10) : '';
+  return {
+    verificationResult: result,
+    responseTimestamp: response.header.timestamp,
+    hmacErrorDetails: {
+      expectedHmac: result.expectedHmac,
+      receivedHmac: response.header.hmac,
+      hmacInput: result.signatureSubject,
+      requestToken: partialRequestToken,
+      bitgoToken: partialBitgoToken,
+    },
+  };
+}
+
 /**
  * Verify that the response received from the server is signed correctly.
  * Right now, it is very permissive with the timestamp variance.
@@ -230,40 +360,33 @@ export function verifyResponse(
     return response;
   }
 
-  const verificationResponse = bitgo.verifyResponse({
-    url: req.url,
-    hmac: response.header.hmac,
-    statusCode: response.status,
-    text: response.text,
-    timestamp: response.header.timestamp,
-    token: req.authenticationToken,
-    method,
-    authVersion,
-  });
+  // --- Build version-specific params, call bitgo.verifyResponse(), collect error context ---
+  // req.authenticationToken is guaranteed non-undefined here (checked above).
+  const authToken = req.authenticationToken as string;
+  let result: ResponseVerificationResult;
 
-  if (!verificationResponse.isValid) {
-    // calculate the HMAC
-    const receivedHmac = response.header.hmac;
-    const expectedHmac = verificationResponse.expectedHmac;
-    const signatureSubject = verificationResponse.signatureSubject;
-    // Log only the first 10 characters of the token to ensure the full token isn't logged.
-    const partialBitgoToken = token ? token.substring(0, 10) : '';
-    const errorDetails = {
-      expectedHmac,
-      receivedHmac,
-      hmacInput: signatureSubject,
-      requestToken: req.authenticationToken,
-      bitgoToken: partialBitgoToken,
-    };
-    debug('Invalid response HMAC: %O', errorDetails);
-    throw new ApiResponseError('invalid response HMAC, possible man-in-the-middle-attack', 511, errorDetails);
+  if (authVersion === 4) {
+    const v4Result = verifyV4ResponseHeaders(bitgo, method, req, response, authToken);
+    if (!v4Result) {
+      // Server didn't sign the response — pass through without verification
+      return response;
+    }
+    result = v4Result;
+  } else {
+    result = verifyV2V3ResponseHeaders(bitgo, token, method, req, response, authVersion, authToken);
   }
 
-  if (bitgo.getAuthVersion() === 3 && !verificationResponse.isInResponseValidityWindow) {
-    const errorDetails = {
-      timestamp: response.header.timestamp,
-      verificationTime: verificationResponse.verificationTime,
-    };
+  // --- Common validation for all auth versions ---
+  const { verificationResult, hmacErrorDetails, responseTimestamp } = result;
+
+  if (!verificationResult.isValid) {
+    debug('Invalid response HMAC: %O', hmacErrorDetails);
+    throw new ApiResponseError('invalid response HMAC, possible man-in-the-middle-attack', 511, hmacErrorDetails);
+  }
+
+  // v3 and v4 enforce the response validity window; v2 does not
+  if (authVersion >= 3 && !verificationResult.isInResponseValidityWindow) {
+    const errorDetails = { timestamp: responseTimestamp, verificationTime: verificationResult.verificationTime };
     debug('Server response outside response validity time window: %O', errorDetails);
     throw new ApiResponseError(
       'server response outside response validity time window, possible man-in-the-middle-attack',
@@ -271,5 +394,6 @@ export function verifyResponse(
       errorDetails
     );
   }
+
   return response;
 }

--- a/modules/sdk-api/src/bitgoAPI.ts
+++ b/modules/sdk-api/src/bitgoAPI.ts
@@ -26,6 +26,7 @@ import * as sdkHmac from '@bitgo/sdk-hmac';
 import * as utxolib from '@bitgo/utxo-lib';
 import { bip32, ECPairInterface } from '@bitgo/utxo-lib';
 import * as bitcoinMessage from 'bitcoinjs-message';
+import * as crypto from 'crypto';
 import { type Agent } from 'http';
 import debugLib from 'debug';
 import * as _ from 'lodash';
@@ -54,6 +55,9 @@ import {
   CalculateHmacSubjectOptions,
   CalculateRequestHeadersOptions,
   CalculateRequestHmacOptions,
+  CalculateV4PreimageOptions,
+  CalculateV4RequestHmacOptions,
+  CalculateV4RequestHeadersOptions,
   ChangePasswordOptions,
   Constants,
   DeprecatedVerifyAddressOptions,
@@ -69,6 +73,7 @@ import {
   ReconstituteSecretOptions,
   RegisterPushTokenOptions,
   RemoveAccessTokenOptions,
+  HashableData,
   RequestHeaders,
   RequestMethods,
   SplitSecret,
@@ -81,6 +86,9 @@ import {
   VerifyPushTokenOptions,
   VerifyResponseInfo,
   VerifyResponseOptions,
+  V4RequestHeaders,
+  VerifyV4ResponseInfo,
+  VerifyV4ResponseOptions,
   VerifyShardsOptions,
   WebhookOptions,
 } from './types';
@@ -123,6 +131,7 @@ export class BitGoAPI implements BitGoBase {
   protected _extensionKey?: ECPairInterface;
   protected _reqId?: IRequestTracer;
   protected _token?: string;
+  protected _tokenId?: string; // MongoDB _id of the access token (v4 bearer value)
   protected _version = pjson.version;
   protected _userAgent?: string;
   protected _ecdhXprv?: string;
@@ -278,6 +287,9 @@ export class BitGoAPI implements BitGoBase {
     this._baseApiUrlV2 = this._baseUrl + '/api/v2';
     this._baseApiUrlV3 = this._baseUrl + '/api/v3';
     this._token = params.accessToken;
+    if (this._authVersion === 4 && params.tokenId) {
+      this._tokenId = params.tokenId;
+    }
 
     const clientConstants = params.clientConstants;
     this._initializeClientConstants(clientConstants);
@@ -427,36 +439,99 @@ export class BitGoAPI implements BitGoBase {
       req.isV2Authenticated = true;
       req.authenticationToken = this._token;
       // some of the older tokens appear to be only 40 characters long
-      if ((this._token && this._token.length !== 67 && this._token.indexOf('v2x') !== 0) || req.forceV1Auth) {
+      // Skip the v1 fallback check entirely for v4, since v4 raw tokens may not match v2 format
+      if (
+        this._authVersion !== 4 &&
+        ((this._token && this._token.length !== 67 && this._token.indexOf('v2x') !== 0) || req.forceV1Auth)
+      ) {
         // use the old method
         req.isV2Authenticated = false;
 
         req.set('Authorization', 'Bearer ' + this._token);
-        debug('sending v1 %s request to %s with token %s', method, url, this._token?.substr(0, 8));
+        debug('sending v1 %s request to %s with token %s', method, url, this._token?.slice(0, 8));
         return originalThen(onfulfilled).catch(onrejected);
       }
 
-      req.set('BitGo-Auth-Version', this._authVersion === 3 ? '3.0' : '2.0');
-
       const data = serializeRequestData(req);
-      if (this._token) {
-        setRequestQueryString(req);
 
-        const requestProperties = this.calculateRequestHeaders({
-          url: req.url,
-          token: this._token,
-          method,
-          text: data || '',
-          authVersion: this._authVersion,
-        });
-        req.set('Auth-Timestamp', requestProperties.timestamp.toString());
+      if (this._authVersion === 4) {
+        req.set('BitGo-Auth-Version', '4.0');
 
-        // we're not sending the actual token, but only its hash
-        req.set('Authorization', 'Bearer ' + requestProperties.tokenHash);
-        debug('sending v2 %s request to %s with token %s', method, url, this._token?.substr(0, 8));
+        if (this._token && !this._tokenId) {
+          // Create the error and route it through the provided then handlers to preserve
+          // the expected Promise/then contract for superagent requests.
+          const err = new Error(
+            'v4 auth requires both accessToken and tokenId. ' +
+              'Set tokenId in the constructor or call authenticateWithAccessToken({ accessToken, tokenId }).'
+          );
 
-        // set the HMAC
-        req.set('HMAC', requestProperties.hmac);
+          // Route the rejection through the provided then handlers to preserve the
+          // expected Promise/then contract for superagent requests.
+          if (onrejected) {
+            return Promise.reject(err).then(onfulfilled, onrejected);
+          }
+
+          return Promise.reject(err);
+        }
+
+        if (this._token && this._tokenId) {
+          setRequestQueryString(req);
+
+          // Convert serialized body to Buffer for exact byte hashing
+          const rawBodyBuffer = Buffer.from(data || '');
+          const authRequestId = crypto.randomUUID();
+
+          // Extract path with query from the fully resolved URL
+          const urlObj = new URL(req.url);
+          const pathWithQuery = urlObj.pathname + urlObj.search;
+
+          const v4Headers = this.calculateV4RequestHeaders({
+            method,
+            pathWithQuery,
+            rawBody: rawBodyBuffer,
+            rawToken: this._token,
+            authRequestId,
+          });
+
+          req.set('Authorization', 'Bearer ' + this._tokenId);
+          req.set('X-Request-Timestamp', v4Headers.timestampSec.toString());
+          req.set('X-Auth-Request-Id', v4Headers.authRequestId);
+          req.set('X-Content-SHA256', v4Headers.bodyHashHex);
+          req.set('X-Signature', v4Headers.hmac);
+
+          const safeTokenPrefix = (this._token ?? '').slice(0, 8).replace(/[\r\n]/g, '');
+          debug('sending v4 %s request to %s with token %s', method, url, safeTokenPrefix);
+
+          // Store request metadata for response HMAC verification.
+          // authenticationToken is the raw token (HMAC key), NOT the _tokenId.
+          req.authenticationToken = this._token;
+          req.v4AuthRequestId = authRequestId;
+          req.v4Method = method;
+          req.v4PathWithQuery = pathWithQuery;
+        }
+      } else {
+        req.set('BitGo-Auth-Version', this._authVersion === 3 ? '3.0' : '2.0');
+
+        if (this._token) {
+          setRequestQueryString(req);
+
+          const requestProperties = this.calculateRequestHeaders({
+            url: req.url,
+            token: this._token,
+            method,
+            text: data || '',
+            authVersion: this._authVersion,
+          });
+          req.set('Auth-Timestamp', requestProperties.timestamp.toString());
+
+          // we're not sending the actual token, but only its hash
+          req.set('Authorization', 'Bearer ' + requestProperties.tokenHash);
+          const tokenPrefixForLog = this._token ? this._token.slice(0, 8).replace(/[\r\n]/g, '') : undefined;
+          debug('sending v2 %s request to %s with token %s', method, url, tokenPrefixForLog);
+
+          // set the HMAC
+          req.set('HMAC', requestProperties.hmac);
+        }
       }
 
       if (this.getAdditionalHeadersCb) {
@@ -545,10 +620,56 @@ export class BitGoAPI implements BitGoBase {
   }
 
   /**
-   * Verify the HMAC for an HTTP response
+   * Verify the HMAC for an HTTP response.
+   * Delegates to sdkHmac.verifyV4Response for v4, sdkHmac.verifyResponse for v2/v3.
    */
-  verifyResponse(params: VerifyResponseOptions): VerifyResponseInfo {
-    return sdkHmac.verifyResponse({ ...params, authVersion: this._authVersion });
+  verifyResponse(params: VerifyV4ResponseOptions): VerifyV4ResponseInfo;
+  verifyResponse(params: VerifyResponseOptions): VerifyResponseInfo;
+  verifyResponse(params: VerifyResponseOptions | VerifyV4ResponseOptions): VerifyResponseInfo | VerifyV4ResponseInfo {
+    if (this._authVersion === 4) {
+      return sdkHmac.verifyV4Response(params as VerifyV4ResponseOptions);
+    }
+    return sdkHmac.verifyResponse({ ...(params as VerifyResponseOptions), authVersion: this._authVersion });
+  }
+
+  /**
+   * Calculate the SHA256 hash of a request or response body.
+   * Returns the hash as a lowercase hex string.
+   * @param body - Raw body bytes (string, Buffer, Uint8Array, or ArrayBuffer)
+   */
+  calculateBodyHash(body: HashableData): string {
+    return sdkHmac.calculateBodyHash(body);
+  }
+
+  /**
+   * Build the canonical v4 preimage string for a request.
+   * Useful for debugging and testing HMAC calculations.
+   */
+  calculateV4Preimage(params: CalculateV4PreimageOptions): string {
+    return sdkHmac.calculateV4Preimage(params);
+  }
+
+  /**
+   * Calculate the HMAC-SHA256 signature for a v4 HTTP request.
+   */
+  calculateV4RequestHmac(params: CalculateV4RequestHmacOptions): string {
+    return sdkHmac.calculateV4RequestHmac(params);
+  }
+
+  /**
+   * Generate all header values required for a v4 authenticated request.
+   * Returns timestampSec, hmac, bodyHashHex, and authRequestId.
+   */
+  calculateV4RequestHeaders(params: CalculateV4RequestHeadersOptions): V4RequestHeaders {
+    return sdkHmac.calculateV4RequestHeaders(params);
+  }
+
+  /**
+   * Build the canonical v4 preimage string for a response.
+   * Includes the statusCode field. Useful for debugging and testing.
+   */
+  calculateV4ResponsePreimage(params: Omit<VerifyV4ResponseOptions, 'hmac' | 'rawToken'>): string {
+    return sdkHmac.calculateV4ResponsePreimage(params);
   }
 
   /**
@@ -735,6 +856,7 @@ export class BitGoAPI implements BitGoBase {
     return {
       user: this._user,
       token: this._token,
+      tokenId: this._tokenId,
       extensionKey: this._extensionKey ? this._extensionKey.toWIF() : undefined,
       ecdhXprv: this._ecdhXprv,
     };
@@ -748,6 +870,13 @@ export class BitGoAPI implements BitGoBase {
   }
 
   /**
+   * Get the token ID (MongoDB _id) used as the v4 bearer token value.
+   */
+  get tokenId(): string | undefined {
+    return this._tokenId;
+  }
+
+  /**
    * Deserialize a JSON serialized BitGo object.
    *
    * Overwrites the properties on the current BitGo object with
@@ -758,6 +887,7 @@ export class BitGoAPI implements BitGoBase {
   fromJSON(json: BitGoJson): void {
     this._user = json.user;
     this._token = json.token;
+    this._tokenId = json.tokenId;
     this._ecdhXprv = json.ecdhXprv;
     if (json.extensionKey) {
       const network = common.Environments[this.getEnv()].network;
@@ -858,9 +988,12 @@ export class BitGoAPI implements BitGoBase {
   /**
    * Synchronous method for activating an access token.
    */
-  authenticateWithAccessToken({ accessToken }: AccessTokenOptions): void {
+  authenticateWithAccessToken({ accessToken, tokenId }: AccessTokenOptions): void {
     debug('now authenticating with access token %s', accessToken.substring(0, 8));
     this._token = accessToken;
+    if (this._authVersion === 4 && tokenId) {
+      this._tokenId = tokenId;
+    }
   }
 
   /**
@@ -967,6 +1100,10 @@ export class BitGoAPI implements BitGoBase {
 
       if (body.access_token) {
         this._token = body.access_token;
+        // For v4, store the token ID for use as the bearer value
+        if (this._authVersion === 4 && (body.id || body.token_id)) {
+          this._tokenId = body.id || body.token_id;
+        }
         // if the downgrade was forced, adding a warning message might be prudent
       } else {
         // check the presence of an encrypted ECDH xprv
@@ -979,6 +1116,11 @@ export class BitGoAPI implements BitGoBase {
         const responseDetails = this.handleTokenIssuance(response.body, password);
         this._token = responseDetails.token;
         this._ecdhXprv = responseDetails.ecdhXprv;
+
+        // For v4, store the token ID for use as the bearer value
+        if (this._authVersion === 4 && (body.id || body.token_id)) {
+          this._tokenId = body.id || body.token_id;
+        }
 
         // verify the response's authenticity
         verifyResponse(this, responseDetails.token, 'post', request, response, this._authVersion);
@@ -1029,6 +1171,10 @@ export class BitGoAPI implements BitGoBase {
 
       if (body.access_token) {
         this._token = body.access_token;
+        // For v4, store the token ID for use as the bearer value
+        if (this._authVersion === 4 && (body.id || body.token_id)) {
+          this._tokenId = body.id || body.token_id;
+        }
         response.body.access_token = body.access_token;
       } else {
         throw new Error('Failed to login. Please contact support@bitgo.com');
@@ -1131,6 +1277,7 @@ export class BitGoAPI implements BitGoBase {
     // TODO: are there any other fields which should be cleared?
     this._user = undefined;
     this._token = undefined;
+    this._tokenId = undefined;
     this._refreshToken = undefined;
     this._ecdhXprv = undefined;
   }
@@ -1162,6 +1309,10 @@ export class BitGoAPI implements BitGoBase {
       .result();
     this._token = body.access_token;
     this._refreshToken = body.refresh_token;
+    // For v4, update the token ID (a new token may have a new ID)
+    if (this._authVersion === 4 && (body.id || body.token_id)) {
+      this._tokenId = body.id || body.token_id;
+    }
     return body;
   }
 
@@ -1259,7 +1410,7 @@ export class BitGoAPI implements BitGoBase {
       if (!this._ecdhXprv) {
         // without a private key, the user cannot decrypt the new access token the server will send
         request.forceV1Auth = true;
-        debug('forcing v1 auth for adding access token using token %s', this._token?.substr(0, 8));
+        debug('forcing v1 auth for adding access token using token %s', this._token?.slice(0, 8));
       }
 
       const response = await request.send(params);
@@ -1273,6 +1424,11 @@ export class BitGoAPI implements BitGoBase {
 
       const responseDetails = this.handleTokenIssuance(response.body);
       response.body.token = responseDetails.token;
+
+      // For v4, store the token ID (MongoDB _id) from the response
+      if (this._authVersion === 4 && (response.body.id || response.body.token_id)) {
+        this._tokenId = response.body.id || response.body.token_id;
+      }
 
       return handleResponseResult<AddAccessTokenResponse>()(response);
     } catch (e) {
@@ -1886,6 +2042,10 @@ export class BitGoAPI implements BitGoBase {
 
     this._token = body.access_token;
     this._refreshToken = body.refresh_token;
+    // For v4, store the token ID for use as the bearer value
+    if (this._authVersion === 4 && (body.id || body.token_id)) {
+      this._tokenId = body.id || body.token_id;
+    }
     this._user = await this.me();
     return body;
   }

--- a/modules/sdk-api/src/types.ts
+++ b/modules/sdk-api/src/types.ts
@@ -17,14 +17,23 @@ export {
   CalculateHmacSubjectOptions,
   CalculateRequestHeadersOptions,
   CalculateRequestHmacOptions,
+  CalculateV4PreimageOptions,
+  CalculateV4RequestHmacOptions,
+  CalculateV4RequestHeadersOptions,
+  HashableData,
   RequestHeaders,
   supportedRequestMethods,
+  V4RequestHeaders,
   VerifyResponseInfo,
   VerifyResponseOptions,
+  VerifyV4ResponseInfo,
+  VerifyV4ResponseOptions,
 } from '@bitgo/sdk-hmac';
 export interface BitGoAPIOptions {
   accessToken?: string;
-  authVersion?: 2 | 3;
+  /** MongoDB _id of the access token. Required for v4 authentication (used as the Bearer value). */
+  tokenId?: string;
+  authVersion?: 2 | 3 | 4;
   clientConstants?:
     | Record<string, any>
     | {
@@ -75,6 +84,8 @@ export interface BitGoAPIOptions {
 
 export interface AccessTokenOptions {
   accessToken: string;
+  /** MongoDB _id of the access token. Required for v4 authentication (used as the Bearer value). */
+  tokenId?: string;
 }
 
 export interface PingOptions {
@@ -137,6 +148,8 @@ export interface User {
 export interface BitGoJson {
   user?: User;
   token?: string;
+  /** MongoDB _id of the access token. Required for v4 authentication (used as the Bearer value). */
+  tokenId?: string;
   extensionKey?: string;
   ecdhXprv?: string;
 }

--- a/modules/sdk-api/test/unit/v4auth.ts
+++ b/modules/sdk-api/test/unit/v4auth.ts
@@ -1,0 +1,1166 @@
+import * as assert from 'assert';
+import * as crypto from 'crypto';
+import * as sinon from 'sinon';
+import nock from 'nock';
+
+import { BitGoAPI } from '../../src/bitgoAPI';
+import { verifyResponse } from '../../src/api';
+
+/**
+ * Comprehensive test suite for v4 Authentication Support.
+ *
+ * Covers:
+ * - Constructor / authenticateWithAccessToken / clear: _tokenId lifecycle
+ * - requestPatch: v4 headers set correctly, v2/v3 headers NOT set, request metadata stored
+ * - verifyResponse (BitGoAPI method): v4 delegation, v2/v3 backward compat
+ * - verifyResponse (api.ts function): valid v4, invalid HMAC, expired timestamp, missing sig, v2/v3 compat
+ * - v4 helper methods on BitGoAPI: calculateBodyHash, calculateV4Preimage, etc.
+ * - v1 auth guard skipped for v4
+ */
+
+const TEST_TOKEN = 'v2x5b735fed2486593f8fea19113e5c717308f90a5fb00e740e46c7bfdcc078cfd0';
+const TEST_TOKEN_ID = '507f1f77bcf86cd799439011'; // MongoDB ObjectId-like
+const EMPTY_BODY_HASH = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+const TEST_BASE_URL = 'https://app.example.local';
+
+/** Helper: nock returns header values as strings (lowercase keys). */
+function h(headers: Record<string, string | string[]>, name: string): string {
+  const v = headers[name];
+  return Array.isArray(v) ? v[0] : (v as string);
+}
+
+function createV4Bitgo(opts: Record<string, unknown> = {}): BitGoAPI {
+  return new BitGoAPI({
+    env: 'custom',
+    customRootURI: TEST_BASE_URL,
+    authVersion: 4,
+    accessToken: TEST_TOKEN,
+    tokenId: TEST_TOKEN_ID,
+    ...opts,
+  });
+}
+
+function computeHmac(key: string, message: string): string {
+  return crypto.createHmac('sha256', key).update(message).digest('hex');
+}
+
+function computeSha256(data: string | Buffer): string {
+  return crypto.createHash('sha256').update(data).digest('hex');
+}
+
+function nowSec(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+/**
+ * Helper to create valid v4 response headers for mocked responses.
+ * This is needed because the security fix requires 2xx responses to have v4 signature headers.
+ */
+function createV4ResponseHeaders(
+  method: string,
+  pathWithQuery: string,
+  statusCode: number,
+  bodyText: string,
+  authRequestId: string,
+  rawToken: string
+): Record<string, string> {
+  const timestampSec = nowSec();
+  const bodyHashHex = computeSha256(bodyText);
+  const preimage = `${timestampSec}\n${method}\n${pathWithQuery}\n${statusCode}\n${bodyHashHex}\n${authRequestId}\n`;
+  const hmac = computeHmac(rawToken, preimage);
+
+  return {
+    'x-signature': hmac,
+    'x-request-timestamp': timestampSec.toString(),
+    'x-auth-request-id': authRequestId,
+    'x-content-sha256': bodyHashHex,
+  };
+}
+
+describe('v4 Authentication', function () {
+  afterEach(function () {
+    nock.cleanAll();
+    sinon.restore();
+  });
+
+  // ─────────────────────────────────────────────────────────
+  // 1. Token ID lifecycle
+  // ─────────────────────────────────────────────────────────
+  describe('tokenId lifecycle', function () {
+    it('should store tokenId from constructor when authVersion is 4', function () {
+      const bitgo = createV4Bitgo();
+      assert.strictEqual(bitgo.tokenId, TEST_TOKEN_ID);
+    });
+
+    it('should NOT store tokenId from constructor when authVersion is 2', function () {
+      const bitgo = new BitGoAPI({
+        env: 'custom',
+        customRootURI: TEST_BASE_URL,
+        authVersion: 2,
+        accessToken: TEST_TOKEN,
+        tokenId: TEST_TOKEN_ID,
+      } as any);
+      assert.strictEqual(bitgo.tokenId, undefined);
+    });
+
+    it('should store tokenId via authenticateWithAccessToken when authVersion is 4', function () {
+      const bitgo = new BitGoAPI({
+        env: 'custom',
+        customRootURI: TEST_BASE_URL,
+        authVersion: 4,
+      });
+      assert.strictEqual(bitgo.tokenId, undefined);
+      bitgo.authenticateWithAccessToken({ accessToken: TEST_TOKEN, tokenId: TEST_TOKEN_ID });
+      assert.strictEqual(bitgo.tokenId, TEST_TOKEN_ID);
+    });
+
+    it('should NOT store tokenId via authenticateWithAccessToken when authVersion is 2', function () {
+      const bitgo = new BitGoAPI({
+        env: 'custom',
+        customRootURI: TEST_BASE_URL,
+        authVersion: 2,
+      });
+      bitgo.authenticateWithAccessToken({ accessToken: TEST_TOKEN, tokenId: TEST_TOKEN_ID });
+      assert.strictEqual(bitgo.tokenId, undefined);
+    });
+
+    it('should clear _tokenId when clear() is called', function () {
+      const bitgo = createV4Bitgo();
+      assert.strictEqual(bitgo.tokenId, TEST_TOKEN_ID);
+      bitgo.clear();
+      assert.strictEqual(bitgo.tokenId, undefined);
+    });
+
+    it('should persist tokenId through toJSON/fromJSON round-trip', function () {
+      const bitgo = createV4Bitgo();
+      const json = bitgo.toJSON();
+      assert.strictEqual(json.tokenId, TEST_TOKEN_ID);
+
+      const bitgo2 = new BitGoAPI({
+        env: 'custom',
+        customRootURI: TEST_BASE_URL,
+        authVersion: 4,
+      });
+      bitgo2.fromJSON(json);
+      assert.strictEqual(bitgo2.tokenId, TEST_TOKEN_ID);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────
+  // 2. requestPatch — v4 request headers
+  // ─────────────────────────────────────────────────────────
+  describe('requestPatch v4 headers', function () {
+    it('should set all 6 v4 headers on a GET request', async function () {
+      const bitgo = createV4Bitgo();
+
+      const scope = nock(TEST_BASE_URL)
+        .get('/api/v2/wallet/abc123')
+        .reply(function () {
+          const hdr = this.req.headers;
+
+          // v4-specific headers
+          assert.strictEqual(h(hdr, 'bitgo-auth-version'), '4.0');
+          assert.ok(
+            h(hdr, 'authorization').startsWith('Bearer ' + TEST_TOKEN_ID),
+            'Authorization should be Bearer <tokenId>'
+          );
+          assert.ok(h(hdr, 'x-request-timestamp'), 'X-Request-Timestamp must be set');
+          assert.ok(h(hdr, 'x-auth-request-id'), 'X-Auth-Request-Id must be set');
+          assert.ok(h(hdr, 'x-content-sha256'), 'X-Content-SHA256 must be set');
+          assert.ok(h(hdr, 'x-signature'), 'X-Signature must be set');
+
+          // GET requests should have empty body hash
+          assert.strictEqual(
+            h(hdr, 'x-content-sha256'),
+            EMPTY_BODY_HASH,
+            'GET body hash should be SHA256 of empty buffer'
+          );
+
+          // v2/v3 headers must NOT be present
+          assert.strictEqual(hdr['auth-timestamp'], undefined, 'Auth-Timestamp must NOT be set for v4');
+          assert.strictEqual(hdr['hmac'], undefined, 'HMAC must NOT be set for v4');
+
+          // Generate valid v4 response headers for the security fix
+          const authRequestId = h(hdr, 'x-auth-request-id');
+          const bodyText = JSON.stringify({ id: 'wallet123' });
+          const responseHeaders = createV4ResponseHeaders(
+            'GET',
+            '/api/v2/wallet/abc123',
+            200,
+            bodyText,
+            authRequestId,
+            TEST_TOKEN
+          );
+
+          return [200, { id: 'wallet123' }, responseHeaders];
+        });
+
+      await bitgo.get(bitgo.url('/wallet/abc123', 2)).result();
+      assert.ok(scope.isDone());
+    });
+
+    it('should set correct body hash for POST request with JSON body', async function () {
+      const bitgo = createV4Bitgo();
+      const body = { address: 'tb1qtest', amount: 100000 };
+
+      const scope = nock(TEST_BASE_URL)
+        .post('/api/v2/wallet/abc123/sendcoins')
+        .reply(function (_uri, requestBody) {
+          const bodyString = typeof requestBody === 'string' ? requestBody : JSON.stringify(requestBody);
+          const expectedHash = computeSha256(bodyString);
+          assert.strictEqual(
+            h(this.req.headers, 'x-content-sha256'),
+            expectedHash,
+            'Body hash should match SHA256 of serialized body'
+          );
+          // Generate valid v4 response headers for the security fix
+          const authRequestId = h(this.req.headers, 'x-auth-request-id');
+          const responseBodyText = JSON.stringify({ txid: 'tx123' });
+          const responseHeaders = createV4ResponseHeaders(
+            'POST',
+            '/api/v2/wallet/abc123/sendcoins',
+            200,
+            responseBodyText,
+            authRequestId,
+            TEST_TOKEN
+          );
+          return [200, { txid: 'tx123' }, responseHeaders];
+        });
+
+      await bitgo.post(bitgo.url('/wallet/abc123/sendcoins', 2)).send(body).result();
+      assert.ok(scope.isDone());
+    });
+
+    it('should set X-Auth-Request-Id as a valid UUID', async function () {
+      const bitgo = createV4Bitgo();
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+      const scope = nock(TEST_BASE_URL)
+        .get('/api/v2/wallet/abc123')
+        .reply(function () {
+          const authRequestId = h(this.req.headers, 'x-auth-request-id');
+          assert.ok(
+            uuidRegex.test(authRequestId),
+            `X-Auth-Request-Id should be a valid UUID v4, got: ${authRequestId}`
+          );
+          // Generate valid v4 response headers for the security fix
+          const bodyText = JSON.stringify({ id: 'wallet123' });
+          const responseHeaders = createV4ResponseHeaders(
+            'GET',
+            '/api/v2/wallet/abc123',
+            200,
+            bodyText,
+            authRequestId,
+            TEST_TOKEN
+          );
+          return [200, { id: 'wallet123' }, responseHeaders];
+        });
+
+      await bitgo.get(bitgo.url('/wallet/abc123', 2)).result();
+      assert.ok(scope.isDone());
+    });
+
+    it('should generate unique X-Auth-Request-Id per request', async function () {
+      const bitgo = createV4Bitgo();
+      const requestIds: string[] = [];
+
+      nock(TEST_BASE_URL)
+        .get('/api/v2/wallet/abc123')
+        .times(3)
+        .reply(function () {
+          const authRequestId = h(this.req.headers, 'x-auth-request-id');
+          requestIds.push(authRequestId);
+          // Generate valid v4 response headers for the security fix
+          const bodyText = JSON.stringify({ id: 'wallet123' });
+          const responseHeaders = createV4ResponseHeaders(
+            'GET',
+            '/api/v2/wallet/abc123',
+            200,
+            bodyText,
+            authRequestId,
+            TEST_TOKEN
+          );
+          return [200, { id: 'wallet123' }, responseHeaders];
+        });
+
+      await bitgo.get(bitgo.url('/wallet/abc123', 2)).result();
+      await bitgo.get(bitgo.url('/wallet/abc123', 2)).result();
+      await bitgo.get(bitgo.url('/wallet/abc123', 2)).result();
+
+      // All 3 should be unique
+      const unique = new Set(requestIds);
+      assert.strictEqual(unique.size, 3, 'Each request should have a unique X-Auth-Request-Id');
+    });
+
+    it('should use timestamp in seconds (not milliseconds)', async function () {
+      const bitgo = createV4Bitgo();
+
+      const scope = nock(TEST_BASE_URL)
+        .get('/api/v2/wallet/abc123')
+        .reply(function () {
+          const ts = Number(h(this.req.headers, 'x-request-timestamp'));
+          const now = nowSec();
+          // Timestamp should be within 5 seconds of now (in seconds, not ms)
+          assert.ok(ts <= now + 5 && ts >= now - 5, `Timestamp ${ts} should be close to ${now} (seconds)`);
+          // It definitely shouldn't be in milliseconds (13 digits)
+          assert.ok(ts < 1e11, 'Timestamp should be in seconds, not milliseconds');
+          // Generate valid v4 response headers for the security fix
+          const authRequestId = h(this.req.headers, 'x-auth-request-id');
+          const bodyText = JSON.stringify({ id: 'wallet123' });
+          const responseHeaders = createV4ResponseHeaders(
+            'GET',
+            '/api/v2/wallet/abc123',
+            200,
+            bodyText,
+            authRequestId,
+            TEST_TOKEN
+          );
+          return [200, { id: 'wallet123' }, responseHeaders];
+        });
+
+      await bitgo.get(bitgo.url('/wallet/abc123', 2)).result();
+      assert.ok(scope.isDone());
+    });
+
+    it('should NOT set v4 auth headers when token or tokenId is missing', async function () {
+      const bitgo = new BitGoAPI({
+        env: 'custom',
+        customRootURI: TEST_BASE_URL,
+        authVersion: 4,
+        // No accessToken or tokenId
+      });
+
+      const scope = nock(TEST_BASE_URL)
+        .get('/api/v2/wallet/abc123')
+        .reply(function () {
+          // Should still set BitGo-Auth-Version
+          assert.strictEqual(h(this.req.headers, 'bitgo-auth-version'), '4.0');
+          // But should NOT set auth headers since no token
+          assert.strictEqual(this.req.headers['x-signature'], undefined, 'X-Signature must NOT be set without token');
+          return [200, { id: 'wallet123' }];
+        });
+
+      await bitgo.get(bitgo.url('/wallet/abc123', 2)).result();
+      assert.ok(scope.isDone());
+    });
+
+    it('should NOT trigger v1 auth fallback for v4 tokens that do not match v2x format', async function () {
+      // Use a token that doesn't match v2 format (not 67 chars, doesn't start with v2x)
+      const shortToken = 'abcdef1234567890abcdef1234567890';
+      const bitgo = new BitGoAPI({
+        env: 'custom',
+        customRootURI: TEST_BASE_URL,
+        authVersion: 4,
+        accessToken: shortToken,
+        tokenId: TEST_TOKEN_ID,
+      });
+
+      const scope = nock(TEST_BASE_URL)
+        .get('/api/v2/wallet/abc123')
+        .reply(function () {
+          const authHeader = h(this.req.headers, 'authorization');
+          // For v4, Authorization should be Bearer <tokenId>, NOT Bearer <rawToken>
+          assert.strictEqual(authHeader, 'Bearer ' + TEST_TOKEN_ID);
+          // v4 headers should be present (not v1 fallback)
+          assert.ok(this.req.headers['x-signature'], 'v4 headers should be set, not v1 fallback');
+          // Generate valid v4 response headers for the security fix
+          const authRequestId = h(this.req.headers, 'x-auth-request-id');
+          const bodyText = JSON.stringify({ id: 'wallet123' });
+          const responseHeaders = createV4ResponseHeaders(
+            'GET',
+            '/api/v2/wallet/abc123',
+            200,
+            bodyText,
+            authRequestId,
+            shortToken
+          );
+          return [200, { id: 'wallet123' }, responseHeaders];
+        });
+
+      await bitgo.get(bitgo.url('/wallet/abc123', 2)).result();
+      assert.ok(scope.isDone());
+    });
+
+    it('should set isV2Authenticated = true for v4', async function () {
+      // Verify that v4 requests work correctly and that isV2Authenticated is set.
+      // Note: We can't directly assert on req.isV2Authenticated here since the request
+      // object is internal, but the successful request completion confirms the flow works.
+      const bitgo = createV4Bitgo();
+
+      const scope = nock(TEST_BASE_URL)
+        .get('/api/v2/wallet/abc123')
+        .reply(function () {
+          // Generate valid v4 response headers for the security fix
+          const authRequestId = h(this.req.headers, 'x-auth-request-id') || 'test-uuid-1234';
+          const bodyText = JSON.stringify({ id: 'wallet123' });
+          const responseHeaders = createV4ResponseHeaders(
+            'GET',
+            '/api/v2/wallet/abc123',
+            200,
+            bodyText,
+            authRequestId,
+            TEST_TOKEN
+          );
+          return [200, { id: 'wallet123' }, responseHeaders];
+        });
+
+      // For v4 requests, isV2Authenticated should be true (set in requestPatch).
+      // If it were false, verifyResponse would skip verification, but the request would
+      // still succeed. This test verifies the v4 request flow completes successfully.
+      await bitgo.get(bitgo.url('/wallet/abc123', 2)).result();
+      assert.ok(scope.isDone());
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────
+  // 3. v2/v3 backward compatibility
+  // ─────────────────────────────────────────────────────────
+  describe('v2/v3 backward compatibility', function () {
+    // Use 'mock' env (hmacVerificationEnforced: false) so nock responses without
+    // proper HMAC headers don't cause verification failures. We're testing request
+    // headers here, not response verification.
+    const MOCK_URL = 'https://bitgo.fakeurl';
+
+    it('should still set v2 headers (Auth-Timestamp, HMAC) when authVersion is 2', async function () {
+      const bitgo = new BitGoAPI({
+        env: 'mock',
+        authVersion: 2,
+        accessToken: TEST_TOKEN,
+        hmacVerification: false,
+      });
+
+      const scope = nock(MOCK_URL)
+        .get('/api/v2/wallet/abc123')
+        .reply(function () {
+          const hdr = this.req.headers;
+          assert.strictEqual(h(hdr, 'bitgo-auth-version'), '2.0');
+          assert.ok(hdr['auth-timestamp'], 'Auth-Timestamp should be set for v2');
+          assert.ok(hdr['hmac'], 'HMAC should be set for v2');
+          // v4 headers must NOT be present
+          assert.strictEqual(hdr['x-signature'], undefined, 'X-Signature must NOT be set for v2');
+          assert.strictEqual(hdr['x-request-timestamp'], undefined, 'X-Request-Timestamp must NOT be set for v2');
+          assert.strictEqual(hdr['x-auth-request-id'], undefined, 'X-Auth-Request-Id must NOT be set for v2');
+          assert.strictEqual(hdr['x-content-sha256'], undefined, 'X-Content-SHA256 must NOT be set for v2');
+          return [200, { id: 'wallet123' }];
+        });
+
+      await bitgo.get(bitgo.url('/wallet/abc123', 2)).result();
+      assert.ok(scope.isDone());
+    });
+
+    it('should still set v3 headers when authVersion is 3', async function () {
+      const bitgo = new BitGoAPI({
+        env: 'mock',
+        authVersion: 3,
+        accessToken: TEST_TOKEN,
+        hmacVerification: false,
+      });
+
+      const scope = nock(MOCK_URL)
+        .get('/api/v2/wallet/abc123')
+        .reply(function () {
+          const hdr = this.req.headers;
+          assert.strictEqual(h(hdr, 'bitgo-auth-version'), '3.0');
+          assert.ok(hdr['auth-timestamp'], 'Auth-Timestamp should be set for v3');
+          assert.ok(hdr['hmac'], 'HMAC should be set for v3');
+          return [200, { id: 'wallet123' }];
+        });
+
+      await bitgo.get(bitgo.url('/wallet/abc123', 2)).result();
+      assert.ok(scope.isDone());
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────
+  // 4. BitGoAPI.verifyResponse (method overload)
+  // ─────────────────────────────────────────────────────────
+  describe('BitGoAPI.verifyResponse method', function () {
+    it('should delegate to verifyV4Response for authVersion 4', function () {
+      const bitgo = createV4Bitgo();
+      const responseBody = '{"id":"wallet123","coin":"tbtc"}';
+      const bodyHash = computeSha256(responseBody);
+      const ts = nowSec();
+      const preimage = `${ts}\nGET\n/api/v2/wallet/abc123\n200\n${bodyHash}\ntest-uuid-1234\n`;
+      const hmac = computeHmac(TEST_TOKEN, preimage);
+
+      const result = bitgo.verifyResponse({
+        hmac,
+        timestampSec: ts,
+        method: 'GET',
+        pathWithQuery: '/api/v2/wallet/abc123',
+        bodyHashHex: bodyHash,
+        authRequestId: 'test-uuid-1234',
+        statusCode: 200,
+        rawToken: TEST_TOKEN,
+      });
+
+      assert.strictEqual(result.isValid, true);
+      assert.strictEqual(result.expectedHmac, hmac);
+      assert.strictEqual(result.isInResponseValidityWindow, true);
+      assert.strictEqual(result.preimage, preimage);
+    });
+
+    it('should return isValid=false for wrong HMAC', function () {
+      const bitgo = createV4Bitgo();
+      const bodyHash = EMPTY_BODY_HASH;
+      const ts = nowSec();
+
+      const result = bitgo.verifyResponse({
+        hmac: 'deadbeef'.repeat(8),
+        timestampSec: ts,
+        method: 'GET',
+        pathWithQuery: '/api/v2/wallet/abc123',
+        bodyHashHex: bodyHash,
+        authRequestId: 'test-uuid-1234',
+        statusCode: 200,
+        rawToken: TEST_TOKEN,
+      });
+
+      assert.strictEqual(result.isValid, false);
+    });
+
+    it('should return isInResponseValidityWindow=false for expired timestamp', function () {
+      const bitgo = createV4Bitgo();
+      const bodyHash = EMPTY_BODY_HASH;
+      const oldTs = nowSec() - 600; // 10 minutes ago (outside 5-min window)
+      const preimage = `${oldTs}\nGET\n/api/v2/wallet/abc123\n200\n${bodyHash}\ntest-uuid-1234\n`;
+      const hmac = computeHmac(TEST_TOKEN, preimage);
+
+      const result = bitgo.verifyResponse({
+        hmac,
+        timestampSec: oldTs,
+        method: 'GET',
+        pathWithQuery: '/api/v2/wallet/abc123',
+        bodyHashHex: bodyHash,
+        authRequestId: 'test-uuid-1234',
+        statusCode: 200,
+        rawToken: TEST_TOKEN,
+      });
+
+      assert.strictEqual(result.isValid, true);
+      assert.strictEqual(result.isInResponseValidityWindow, false);
+    });
+
+    it('should delegate to v2/v3 verifyResponse for authVersion 2', function () {
+      const bitgo = new BitGoAPI({
+        env: 'custom',
+        customRootURI: TEST_BASE_URL,
+        authVersion: 2,
+        accessToken: TEST_TOKEN,
+      });
+
+      const result = bitgo.verifyResponse({
+        url: 'https://google.com/api',
+        hmac: 'somehash',
+        timestamp: 1521590532925,
+        token: TEST_TOKEN,
+        statusCode: 200,
+        text: 'fakedata',
+        method: 'get',
+        authVersion: 2,
+      });
+
+      // Should return a v2/v3 VerifyResponseInfo with signatureSubject
+      assert.ok('signatureSubject' in result, 'v2 result should have signatureSubject');
+      assert.ok('expectedHmac' in result, 'v2 result should have expectedHmac');
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────
+  // 5. api.ts verifyResponse function
+  // ─────────────────────────────────────────────────────────
+  describe('api.ts verifyResponse function', function () {
+    function mockReq(overrides: Record<string, unknown> = {}): any {
+      return {
+        isV2Authenticated: true,
+        authenticationToken: TEST_TOKEN,
+        url: TEST_BASE_URL + '/api/v2/wallet/abc123',
+        v4AuthRequestId: 'test-uuid-1234',
+        v4Method: 'get',
+        v4PathWithQuery: '/api/v2/wallet/abc123',
+        ...overrides,
+      };
+    }
+
+    it('should pass through valid v4 response', function () {
+      const bitgo = createV4Bitgo();
+      const body = '{"id":"wallet123"}';
+      const bodyHash = computeSha256(body);
+      const ts = nowSec();
+      const preimage = `${ts}\nGET\n/api/v2/wallet/abc123\n200\n${bodyHash}\ntest-uuid-1234\n`;
+      const hmac = computeHmac(TEST_TOKEN, preimage);
+
+      const req = mockReq();
+      const response = {
+        status: 200,
+        text: body,
+        header: {
+          'x-signature': hmac,
+          'x-request-timestamp': ts.toString(),
+          'x-auth-request-id': 'test-uuid-1234',
+          'x-content-sha256': bodyHash,
+        },
+      };
+
+      const result = verifyResponse(bitgo, TEST_TOKEN, 'get', req, response as any, 4);
+      assert.strictEqual(result, response);
+    });
+
+    it('should throw ApiResponseError for invalid v4 HMAC', function () {
+      const bitgo = createV4Bitgo();
+      const body = '{"id":"wallet123"}';
+      const ts = nowSec();
+
+      const req = mockReq();
+      const response = {
+        status: 200,
+        text: body,
+        header: {
+          'x-signature': 'deadbeef'.repeat(8), // wrong HMAC
+          'x-request-timestamp': ts.toString(),
+          'x-auth-request-id': 'test-uuid-1234',
+        },
+      };
+
+      assert.throws(
+        () => verifyResponse(bitgo, TEST_TOKEN, 'get', req, response as any, 4),
+        (err: any) => {
+          assert.strictEqual(err.status, 511);
+          assert.ok(err.message.includes('invalid response HMAC'));
+          return true;
+        }
+      );
+    });
+
+    it('should throw ApiResponseError for expired v4 timestamp', function () {
+      const bitgo = createV4Bitgo();
+      const body = '{"id":"wallet123"}';
+      const bodyHash = computeSha256(body);
+      const oldTs = nowSec() - 600; // 10 minutes ago
+      const preimage = `${oldTs}\nGET\n/api/v2/wallet/abc123\n200\n${bodyHash}\ntest-uuid-1234\n`;
+      const hmac = computeHmac(TEST_TOKEN, preimage);
+
+      const req = mockReq();
+      const response = {
+        status: 200,
+        text: body,
+        header: {
+          'x-signature': hmac,
+          'x-request-timestamp': oldTs.toString(),
+          'x-auth-request-id': 'test-uuid-1234',
+        },
+      };
+
+      assert.throws(
+        () => verifyResponse(bitgo, TEST_TOKEN, 'get', req, response as any, 4),
+        (err: any) => {
+          assert.strictEqual(err.status, 511);
+          assert.ok(err.message.includes('response validity time window'));
+          return true;
+        }
+      );
+    });
+
+    it('should pass through when server did not sign the v4 response (missing x-signature) for non-2xx', function () {
+      const bitgo = createV4Bitgo();
+      const req = mockReq();
+      const response = {
+        status: 401,
+        text: '{"error":"Unauthorized"}',
+        header: {
+          // No x-signature or x-request-timestamp
+        },
+      };
+
+      const result = verifyResponse(bitgo, TEST_TOKEN, 'get', req, response as any, 4);
+      assert.strictEqual(result, response, 'Should return response as-is when server signature is missing for non-2xx');
+    });
+
+    it('should throw ApiResponseError when 2xx response is missing v4 signature headers', function () {
+      const bitgo = createV4Bitgo();
+      const req = mockReq();
+      const response = {
+        status: 200,
+        text: '{"id":"wallet123"}',
+        body: { id: 'wallet123' },
+        header: {
+          // No x-signature or x-request-timestamp
+        },
+      };
+
+      assert.throws(
+        () => verifyResponse(bitgo, TEST_TOKEN, 'get', req, response as any, 4),
+        (err: any) => {
+          assert.strictEqual(err.status, 511);
+          assert.ok(err.message.includes('Missing required v4 response signature headers'));
+          return true;
+        },
+        'Should throw ApiResponseError for 2xx response with missing v4 signature headers'
+      );
+    });
+
+    it('should pass through when request is not v2 authenticated', function () {
+      const bitgo = createV4Bitgo();
+      const req = mockReq({ isV2Authenticated: false });
+      const response = {
+        status: 200,
+        text: '{"id":"wallet123"}',
+        header: {},
+      };
+
+      const result = verifyResponse(bitgo, TEST_TOKEN, 'get', req, response as any, 4);
+      assert.strictEqual(result, response, 'Should return response as-is when not v2 authenticated');
+    });
+
+    it('should pass through when authenticationToken is missing', function () {
+      const bitgo = createV4Bitgo();
+      const req = mockReq({ authenticationToken: undefined });
+      const response = {
+        status: 200,
+        text: '{"id":"wallet123"}',
+        header: {},
+      };
+
+      const result = verifyResponse(bitgo, TEST_TOKEN, 'get', req, response as any, 4);
+      assert.strictEqual(result, response, 'Should return response as-is when auth token is missing');
+    });
+
+    it('should verify v4 response with POST method and body', function () {
+      const bitgo = createV4Bitgo();
+      const body = '{"txid":"tx123","status":"signed"}';
+      const bodyHash = computeSha256(body);
+      const ts = nowSec();
+      const preimage = `${ts}\nPOST\n/api/v2/wallet/abc123/sendcoins\n200\n${bodyHash}\npost-uuid-5678\n`;
+      const hmac = computeHmac(TEST_TOKEN, preimage);
+
+      const req = mockReq({
+        v4Method: 'post',
+        v4PathWithQuery: '/api/v2/wallet/abc123/sendcoins',
+        v4AuthRequestId: 'post-uuid-5678',
+      });
+      const response = {
+        status: 200,
+        text: body,
+        header: {
+          'x-signature': hmac,
+          'x-request-timestamp': ts.toString(),
+          'x-auth-request-id': 'post-uuid-5678',
+        },
+      };
+
+      const result = verifyResponse(bitgo, TEST_TOKEN, 'post', req, response as any, 4);
+      assert.strictEqual(result, response);
+    });
+
+    it('should verify v4 response with query string in path', function () {
+      const bitgo = createV4Bitgo();
+      const body = '{"wallets":[]}';
+      const bodyHash = computeSha256(body);
+      const ts = nowSec();
+      const pathWithQuery = '/api/v2/wallets?limit=25&coin=tbtc';
+      const preimage = `${ts}\nGET\n${pathWithQuery}\n200\n${bodyHash}\nquery-uuid-9999\n`;
+      const hmac = computeHmac(TEST_TOKEN, preimage);
+
+      const req = mockReq({
+        v4Method: 'get',
+        v4PathWithQuery: pathWithQuery,
+        v4AuthRequestId: 'query-uuid-9999',
+      });
+      const response = {
+        status: 200,
+        text: body,
+        header: {
+          'x-signature': hmac,
+          'x-request-timestamp': ts.toString(),
+          'x-auth-request-id': 'query-uuid-9999',
+        },
+      };
+
+      const result = verifyResponse(bitgo, TEST_TOKEN, 'get', req, response as any, 4);
+      assert.strictEqual(result, response);
+    });
+
+    it('should verify v4 response for DELETE with empty body', function () {
+      const bitgo = createV4Bitgo();
+      const body = '';
+      const bodyHash = computeSha256(Buffer.from(''));
+      const ts = nowSec();
+      const preimage = `${ts}\nDELETE\n/api/v2/wallet/abc123\n204\n${bodyHash}\ndel-uuid-0000\n`;
+      const hmac = computeHmac(TEST_TOKEN, preimage);
+
+      const req = mockReq({
+        v4Method: 'del',
+        v4PathWithQuery: '/api/v2/wallet/abc123',
+        v4AuthRequestId: 'del-uuid-0000',
+      });
+      const response = {
+        status: 204,
+        text: body,
+        header: {
+          'x-signature': hmac,
+          'x-request-timestamp': ts.toString(),
+          'x-auth-request-id': 'del-uuid-0000',
+        },
+      };
+
+      const result = verifyResponse(bitgo, TEST_TOKEN, 'del', req, response as any, 4);
+      assert.strictEqual(result, response);
+    });
+
+    it('should detect tampered v4 response body', function () {
+      const bitgo = createV4Bitgo();
+      const originalBody = '{"id":"wallet123"}';
+      const bodyHash = computeSha256(originalBody);
+      const ts = nowSec();
+      const preimage = `${ts}\nGET\n/api/v2/wallet/abc123\n200\n${bodyHash}\ntest-uuid-1234\n`;
+      const hmac = computeHmac(TEST_TOKEN, preimage);
+
+      const req = mockReq();
+      const response = {
+        status: 200,
+        text: '{"id":"wallet999_TAMPERED"}', // tampered body
+        header: {
+          'x-signature': hmac,
+          'x-request-timestamp': ts.toString(),
+          'x-auth-request-id': 'test-uuid-1234',
+        },
+      };
+
+      assert.throws(
+        () => verifyResponse(bitgo, TEST_TOKEN, 'get', req, response as any, 4),
+        (err: any) => {
+          assert.strictEqual(err.status, 511);
+          assert.ok(err.message.includes('invalid response HMAC'));
+          return true;
+        }
+      );
+    });
+
+    it('should detect tampered v4 status code', function () {
+      const bitgo = createV4Bitgo();
+      const body = '{"id":"wallet123"}';
+      const bodyHash = computeSha256(body);
+      const ts = nowSec();
+      // HMAC was computed with statusCode 200
+      const preimage = `${ts}\nGET\n/api/v2/wallet/abc123\n200\n${bodyHash}\ntest-uuid-1234\n`;
+      const hmac = computeHmac(TEST_TOKEN, preimage);
+
+      const req = mockReq();
+      const response = {
+        status: 403, // but response arrives with 403
+        text: body,
+        header: {
+          'x-signature': hmac,
+          'x-request-timestamp': ts.toString(),
+          'x-auth-request-id': 'test-uuid-1234',
+        },
+      };
+
+      assert.throws(
+        () => verifyResponse(bitgo, TEST_TOKEN, 'get', req, response as any, 4),
+        (err: any) => {
+          assert.strictEqual(err.status, 511);
+          return true;
+        }
+      );
+    });
+
+    it('should still verify v2 responses correctly (backward compat)', function () {
+      const bitgo = new BitGoAPI({
+        env: 'custom',
+        customRootURI: TEST_BASE_URL,
+        authVersion: 2,
+        accessToken: TEST_TOKEN,
+      });
+
+      const ts = Date.now();
+      const url = TEST_BASE_URL + '/api/v2/wallet/abc123';
+      const body = '{"id":"wallet123"}';
+      // v2 preimage: timestamp|path|statusCode|body
+      const subject = `${ts}|/api/v2/wallet/abc123|200|${body}`;
+      const hmac = computeHmac(TEST_TOKEN, subject);
+
+      const req: any = {
+        isV2Authenticated: true,
+        authenticationToken: TEST_TOKEN,
+        url,
+      };
+      const response: any = {
+        status: 200,
+        text: body,
+        header: {
+          hmac,
+          timestamp: ts.toString(),
+        },
+      };
+
+      const result = verifyResponse(bitgo, TEST_TOKEN, 'get', req, response, 2);
+      assert.strictEqual(result, response);
+    });
+
+    it('should enforce validity window for v3 (authVersion >= 3)', function () {
+      const bitgo = new BitGoAPI({
+        env: 'custom',
+        customRootURI: TEST_BASE_URL,
+        authVersion: 3,
+        accessToken: TEST_TOKEN,
+      });
+
+      const oldTs = Date.now() - 10 * 60 * 1000; // 10 minutes ago in ms
+      const url = TEST_BASE_URL + '/api/v2/wallet/abc123';
+      const body = '{"id":"wallet123"}';
+      // v3 preimage with statusCode: METHOD|timestamp|path|statusCode|body
+      const subject = `GET|${oldTs}|/api/v2/wallet/abc123|200|${body}`;
+      const hmac = computeHmac(TEST_TOKEN, subject);
+
+      const req: any = {
+        isV2Authenticated: true,
+        authenticationToken: TEST_TOKEN,
+        url,
+      };
+      const response: any = {
+        status: 200,
+        text: body,
+        header: {
+          hmac,
+          timestamp: oldTs.toString(),
+        },
+      };
+
+      assert.throws(
+        () => verifyResponse(bitgo, TEST_TOKEN, 'get', req, response, 3),
+        (err: any) => {
+          assert.strictEqual(err.status, 511);
+          assert.ok(err.message.includes('response validity time window'));
+          return true;
+        }
+      );
+    });
+
+    it('should NOT enforce validity window for v2', function () {
+      const bitgo = new BitGoAPI({
+        env: 'custom',
+        customRootURI: TEST_BASE_URL,
+        authVersion: 2,
+        accessToken: TEST_TOKEN,
+      });
+
+      const oldTs = Date.now() - 10 * 60 * 1000; // 10 minutes ago in ms
+      const url = TEST_BASE_URL + '/api/v2/wallet/abc123';
+      const body = '{"id":"wallet123"}';
+      // v2 preimage: timestamp|path|statusCode|body
+      const subject = `${oldTs}|/api/v2/wallet/abc123|200|${body}`;
+      const hmac = computeHmac(TEST_TOKEN, subject);
+
+      const req: any = {
+        isV2Authenticated: true,
+        authenticationToken: TEST_TOKEN,
+        url,
+      };
+      const response: any = {
+        status: 200,
+        text: body,
+        header: {
+          hmac,
+          timestamp: oldTs.toString(),
+        },
+      };
+
+      // Should NOT throw for v2, even with old timestamp
+      const result = verifyResponse(bitgo, TEST_TOKEN, 'get', req, response, 2);
+      assert.strictEqual(result, response);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────
+  // 6. v4 helper methods on BitGoAPI
+  // ─────────────────────────────────────────────────────────
+  describe('v4 helper methods', function () {
+    it('calculateBodyHash should return SHA256 of Buffer input', function () {
+      const bitgo = createV4Bitgo();
+      const body = Buffer.from('{"address":"tb1qtest","amount":100000}');
+      const expected = computeSha256(body);
+      assert.strictEqual(bitgo.calculateBodyHash(body), expected);
+    });
+
+    it('calculateBodyHash should return empty buffer hash for empty input', function () {
+      const bitgo = createV4Bitgo();
+      assert.strictEqual(bitgo.calculateBodyHash(Buffer.from('')), EMPTY_BODY_HASH);
+    });
+
+    it('calculateBodyHash should accept string input', function () {
+      const bitgo = createV4Bitgo();
+      const body = '{"test":"value"}';
+      const expected = computeSha256(body);
+      assert.strictEqual(bitgo.calculateBodyHash(body), expected);
+    });
+
+    it('calculateV4Preimage should build newline-separated preimage with trailing newline', function () {
+      const bitgo = createV4Bitgo();
+      const result = bitgo.calculateV4Preimage({
+        timestampSec: 1700000000,
+        method: 'post',
+        pathWithQuery: '/api/v2/wallet/abc123',
+        bodyHashHex: 'abcdef123456',
+        authRequestId: 'test-uuid',
+      });
+      assert.strictEqual(result, '1700000000\nPOST\n/api/v2/wallet/abc123\nabcdef123456\ntest-uuid\n');
+    });
+
+    it('calculateV4Preimage should normalize del to DELETE', function () {
+      const bitgo = createV4Bitgo();
+      const result = bitgo.calculateV4Preimage({
+        timestampSec: 1700000000,
+        method: 'del',
+        pathWithQuery: '/api/v2/wallet/abc123',
+        bodyHashHex: EMPTY_BODY_HASH,
+        authRequestId: 'test-uuid',
+      });
+      assert.ok(result.includes('\nDELETE\n'), 'del should be normalized to DELETE');
+    });
+
+    it('calculateV4RequestHmac should return valid HMAC', function () {
+      const bitgo = createV4Bitgo();
+      const params = {
+        timestampSec: 1700000000,
+        method: 'GET',
+        pathWithQuery: '/api/v2/wallet/abc123',
+        bodyHashHex: EMPTY_BODY_HASH,
+        authRequestId: 'test-uuid-1234',
+        rawToken: TEST_TOKEN,
+      };
+      const result = bitgo.calculateV4RequestHmac(params);
+      const preimage = `1700000000\nGET\n/api/v2/wallet/abc123\n${EMPTY_BODY_HASH}\ntest-uuid-1234\n`;
+      const expected = computeHmac(TEST_TOKEN, preimage);
+      assert.strictEqual(result, expected);
+    });
+
+    it('calculateV4RequestHeaders should return all 4 header values', function () {
+      const bitgo = createV4Bitgo();
+      const result = bitgo.calculateV4RequestHeaders({
+        method: 'POST',
+        pathWithQuery: '/api/v2/wallet/abc123/sendcoins',
+        rawBody: Buffer.from('{"amount":100000}'),
+        rawToken: TEST_TOKEN,
+        authRequestId: 'header-uuid',
+      });
+
+      assert.ok(result.hmac, 'should have hmac');
+      assert.ok(typeof result.timestampSec === 'number', 'should have timestampSec');
+      assert.ok(result.bodyHashHex, 'should have bodyHashHex');
+      assert.strictEqual(result.authRequestId, 'header-uuid');
+      assert.strictEqual(result.bodyHashHex, computeSha256(Buffer.from('{"amount":100000}')));
+    });
+
+    it('calculateV4ResponsePreimage should include statusCode', function () {
+      const bitgo = createV4Bitgo();
+      const result = bitgo.calculateV4ResponsePreimage({
+        timestampSec: 1700000000,
+        method: 'GET',
+        pathWithQuery: '/api/v2/wallet/abc123',
+        statusCode: 200,
+        bodyHashHex: EMPTY_BODY_HASH,
+        authRequestId: 'test-uuid',
+      });
+      assert.strictEqual(result, `1700000000\nGET\n/api/v2/wallet/abc123\n200\n${EMPTY_BODY_HASH}\ntest-uuid\n`);
+    });
+
+    it('calculateV4ResponsePreimage should differ from request preimage (has statusCode)', function () {
+      const bitgo = createV4Bitgo();
+      const commonParams = {
+        timestampSec: 1700000000,
+        method: 'GET',
+        pathWithQuery: '/api/v2/wallet/abc123',
+        bodyHashHex: EMPTY_BODY_HASH,
+        authRequestId: 'test-uuid',
+      };
+      const requestPreimage = bitgo.calculateV4Preimage(commonParams);
+      const responsePreimage = bitgo.calculateV4ResponsePreimage({ ...commonParams, statusCode: 200 });
+      assert.notStrictEqual(requestPreimage, responsePreimage, 'Request and response preimage should differ');
+      assert.ok(responsePreimage.includes('\n200\n'), 'Response preimage should contain status code');
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────
+  // 7. HMAC signature correctness (end-to-end)
+  // ─────────────────────────────────────────────────────────
+  describe('HMAC signature correctness', function () {
+    it('request HMAC should be verifiable with the same preimage construction', function () {
+      const bitgo = createV4Bitgo();
+      const body = '{"address":"tb1qtest","amount":100000}';
+      const rawBody = Buffer.from(body);
+      const authRequestId = 'e2e-uuid-1234';
+      const pathWithQuery = '/api/v2/wallet/abc123/sendcoins';
+
+      const headers = bitgo.calculateV4RequestHeaders({
+        method: 'POST',
+        pathWithQuery,
+        rawBody,
+        rawToken: TEST_TOKEN,
+        authRequestId,
+      });
+
+      // Manually reconstruct and verify
+      const bodyHash = computeSha256(rawBody);
+      assert.strictEqual(headers.bodyHashHex, bodyHash);
+
+      const preimage = `${headers.timestampSec}\nPOST\n${pathWithQuery}\n${bodyHash}\n${authRequestId}\n`;
+      const expectedHmac = computeHmac(TEST_TOKEN, preimage);
+      assert.strictEqual(headers.hmac, expectedHmac);
+    });
+
+    it('response verification should match manual preimage + HMAC calculation', function () {
+      const bitgo = createV4Bitgo();
+      const responseBody = '{"txid":"tx123","status":"signed"}';
+      const bodyHash = computeSha256(responseBody);
+      const ts = nowSec();
+      const pathWithQuery = '/api/v2/wallet/abc123/sendcoins';
+
+      // Manually build response preimage
+      const preimage = `${ts}\nPOST\n${pathWithQuery}\n200\n${bodyHash}\nresponse-uuid\n`;
+      const hmac = computeHmac(TEST_TOKEN, preimage);
+
+      const result = bitgo.verifyResponse({
+        hmac,
+        timestampSec: ts,
+        method: 'POST',
+        pathWithQuery,
+        bodyHashHex: bodyHash,
+        authRequestId: 'response-uuid',
+        statusCode: 200,
+        rawToken: TEST_TOKEN,
+      });
+
+      assert.strictEqual(result.isValid, true);
+      assert.strictEqual(result.expectedHmac, hmac);
+      assert.strictEqual(result.preimage, preimage);
+    });
+
+    it('different token should produce different HMAC', function () {
+      const bitgo = createV4Bitgo();
+      const body = '{"test":"data"}';
+      const rawBody = Buffer.from(body);
+      const otherToken = 'v2xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+
+      const headers1 = bitgo.calculateV4RequestHeaders({
+        method: 'POST',
+        pathWithQuery: '/api/v2/test',
+        rawBody,
+        rawToken: TEST_TOKEN,
+        authRequestId: 'uuid-1',
+      });
+
+      const headers2 = bitgo.calculateV4RequestHeaders({
+        method: 'POST',
+        pathWithQuery: '/api/v2/test',
+        rawBody,
+        rawToken: otherToken,
+        authRequestId: 'uuid-1',
+      });
+
+      assert.notStrictEqual(headers1.hmac, headers2.hmac, 'Different tokens should produce different HMACs');
+      // Body hash should be the same (doesn't depend on token)
+      assert.strictEqual(headers1.bodyHashHex, headers2.bodyHashHex);
+    });
+  });
+});

--- a/modules/sdk-hmac/src/types.ts
+++ b/modules/sdk-hmac/src/types.ts
@@ -1,6 +1,6 @@
 export const supportedRequestMethods = ['get', 'post', 'put', 'del', 'patch', 'options', 'delete'] as const;
 
-export type AuthVersion = 2 | 3;
+export type AuthVersion = 2 | 3 | 4;
 
 export interface CalculateHmacSubjectOptions<T> {
   urlPath: string;

--- a/types/superagent/index.d.ts
+++ b/types/superagent/index.d.ts
@@ -6,5 +6,11 @@ declare module 'superagent' {
     forceV1Auth: boolean;
     authenticationToken?: string;
     isV2Authenticated?: boolean;
+    /** v4 auth: the auth request ID (UUID) used in the request preimage */
+    v4AuthRequestId?: string;
+    /** v4 auth: the HTTP method used in the request preimage */
+    v4Method?: string;
+    /** v4 auth: the path with query string used in the request preimage */
+    v4PathWithQuery?: string;
   }
 }


### PR DESCRIPTION
TICKET: CAAS-819

This pull request introduces significant improvements to authentication version handling and response verification in the BitGo Express and SDK-API modules. The main focus is on normalizing and enforcing the `authVersion` configuration, adding stricter validation and error handling for v4 authentication, and refactoring response HMAC verification logic to be more robust and version-aware. Comprehensive tests have also been added to ensure correct behavior.

**Authentication version handling and enforcement:**

- Added a `parseAuthVersion` function to normalize `authVersion` values to 2, 3, or 4, defaulting or clamping invalid values to 2, and updated config parsing to use this function. The `Config` interface now strictly types `authVersion` as `2 | 3 | 4`. [[1]](diffhunk://#diff-2bea36add34a5a41d4c914c98c264764f1a728c4d4e7fa27d6e8423a0ddb7098R7-R24) [[2]](diffhunk://#diff-2bea36add34a5a41d4c914c98c264764f1a728c4d4e7fa27d6e8423a0ddb7098L39-R57) [[3]](diffhunk://#diff-2bea36add34a5a41d4c914c98c264764f1a728c4d4e7fa27d6e8423a0ddb7098L65-R83) [[4]](diffhunk://#diff-2bea36add34a5a41d4c914c98c264764f1a728c4d4e7fa27d6e8423a0ddb7098L91-R109)
- Updated the BitGo Express middleware (`prepareBitGo`) to enforce v4 authentication requirements: if `authVersion=4` and an access token is present, the `Access-Key-Id` header must be provided, otherwise the request is rejected with a clear error message. The middleware now passes `authVersion` and `tokenId` to the SDK. [[1]](diffhunk://#diff-851997953dfe5ce12d4c10bbabf8afa6bc49777505aae9197b0bcc6534da6677L1326-R1326) [[2]](diffhunk://#diff-851997953dfe5ce12d4c10bbabf8afa6bc49777505aae9197b0bcc6534da6677R1337-R1361) [[3]](diffhunk://#diff-851997953dfe5ce12d4c10bbabf8afa6bc49777505aae9197b0bcc6534da6677R1371-R1373)
- The SDK-API's `BitGoAPI` class now stores the `tokenId` (MongoDB ObjectId) for v4 tokens, enabling correct v4 authentication. [[1]](diffhunk://#diff-df16a39a5dd8ff3e08c35c03e392be8cc23c2f37954fd970edeb418502e77432R134) [[2]](diffhunk://#diff-df16a39a5dd8ff3e08c35c03e392be8cc23c2f37954fd970edeb418502e77432R290-R292)

**Response HMAC verification improvements:**

- Refactored the `verifyResponse` function in the SDK-API to cleanly separate v2/v3 and v4 logic, using new helpers `verifyV4ResponseHeaders` and `verifyV2V3ResponseHeaders`. The v4 logic now strictly requires signature headers on successful responses and provides detailed error context.
- Added and updated imports and types to support the new verification logic, including new interfaces for v4 verification and HMAC error details. [[1]](diffhunk://#diff-133d95aa79232eb5c5c32d343badab29969f92d1fff9419c7f93700ff6981248R13) [[2]](diffhunk://#diff-df16a39a5dd8ff3e08c35c03e392be8cc23c2f37954fd970edeb418502e77432R58-R60) [[3]](diffhunk://#diff-df16a39a5dd8ff3e08c35c03e392be8cc23c2f37954fd970edeb418502e77432R76) [[4]](diffhunk://#diff-df16a39a5dd8ff3e08c35c03e392be8cc23c2f37954fd970edeb418502e77432R89-R91) [[5]](diffhunk://#diff-df16a39a5dd8ff3e08c35c03e392be8cc23c2f37954fd970edeb418502e77432R290-R292)

**Testing and validation:**

- Added comprehensive unit tests for `authVersion` parsing, covering correct values, clamping of invalid values, precedence of command-line arguments over environment variables, and defaulting behavior.

These changes improve security, reliability, and clarity around authentication and response verification for all supported authentication versions.

---

**Authentication version normalization and enforcement**
- Added `parseAuthVersion` to strictly normalize and clamp `authVersion` to 2, 3, or 4, and updated config parsing and typing to enforce this. [[1]](diffhunk://#diff-2bea36add34a5a41d4c914c98c264764f1a728c4d4e7fa27d6e8423a0ddb7098R7-R24) [[2]](diffhunk://#diff-2bea36add34a5a41d4c914c98c264764f1a728c4d4e7fa27d6e8423a0ddb7098L39-R57) [[3]](diffhunk://#diff-2bea36add34a5a41d4c914c98c264764f1a728c4d4e7fa27d6e8423a0ddb7098L65-R83) [[4]](diffhunk://#diff-2bea36add34a5a41d4c914c98c264764f1a728c4d4e7fa27d6e8423a0ddb7098L91-R109)
- BitGo Express middleware now enforces that v4 requests must include the `Access-Key-Id` header when an access token is present, rejecting non-compliant requests with a clear error. [[1]](diffhunk://#diff-851997953dfe5ce12d4c10bbabf8afa6bc49777505aae9197b0bcc6534da6677L1326-R1326) [[2]](diffhunk://#diff-851997953dfe5ce12d4c10bbabf8afa6bc49777505aae9197b0bcc6534da6677R1337-R1361) [[3]](diffhunk://#diff-851997953dfe5ce12d4c10bbabf8afa6bc49777505aae9197b0bcc6534da6677R1371-R1373)
- SDK-API's `BitGoAPI` class now stores the `tokenId` for v4 tokens, enabling correct v4 authentication. [[1]](diffhunk://#diff-df16a39a5dd8ff3e08c35c03e392be8cc23c2f37954fd970edeb418502e77432R134) [[2]](diffhunk://#diff-df16a39a5dd8ff3e08c35c03e392be8cc23c2f37954fd970edeb418502e77432R290-R292)

**Response verification refactor**
- Refactored `verifyResponse` in SDK-API to use version-specific helpers for v2/v3 and v4, with stricter enforcement and detailed error context for v4 HMAC verification.
- Updated and added relevant imports and types to support the new verification logic. [[1]](diffhunk://#diff-133d95aa79232eb5c5c32d343badab29969f92d1fff9419c7f93700ff6981248R13) [[2]](diffhunk://#diff-df16a39a5dd8ff3e08c35c03e392be8cc23c2f37954fd970edeb418502e77432R58-R60) [[3]](diffhunk://#diff-df16a39a5dd8ff3e08c35c03e392be8cc23c2f37954fd970edeb418502e77432R76) [[4]](diffhunk://#diff-df16a39a5dd8ff3e08c35c03e392be8cc23c2f37954fd970edeb418502e77432R89-R91) [[5]](diffhunk://#diff-df16a39a5dd8ff3e08c35c03e392be8cc23c2f37954fd970edeb418502e77432R290-R292)

**Testing**
- Added comprehensive unit tests to verify correct parsing and precedence of `authVersion` configuration.