### PR TITLE
feat: rebrand Coreum to TX

### DIFF
--- a/modules/sdk-coin-coreum/test/unit/coreum.ts
+++ b/modules/sdk-coin-coreum/test/unit/coreum.ts
@@ -46,7 +46,7 @@ describe('Coreum', function () {
 
     tcoreum.getChain().should.equal('tcoreum');
     tcoreum.getFamily().should.equal('coreum');
-    tcoreum.getFullName().should.equal('Testnet Coreum');
+    tcoreum.getFullName().should.equal('Testnet TX');
     tcoreum.getBaseFactor().should.equal(1e6);
   });
 

--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -1114,7 +1114,7 @@ export const allCoinsAndTokens = [
   account(
     'df2f040b-89f3-4bb3-8da7-2445c7fdefca',
     'tcoreum',
-    'Testnet Coreum',
+    'Testnet TX',
     Networks.test.coreum,
     6,
     UnderlyingAsset.COREUM,

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -745,7 +745,7 @@ export const ofcCoins = [
     UnderlyingAsset.ARBETH,
     CoinKind.CRYPTO
   ),
-  tofc('3091d79a-7737-4493-b3e6-6765998b9486', 'ofctcoreum', 'Test Coreum', 6, UnderlyingAsset.COREUM, CoinKind.CRYPTO),
+  tofc('3091d79a-7737-4493-b3e6-6765998b9486', 'ofctcoreum', 'Testnet TX', 6, UnderlyingAsset.COREUM, CoinKind.CRYPTO),
   tofc(
     '90ac199d-4061-4c5f-9d48-4439c7ec2033',
     'ofctcelo',

--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -1102,7 +1102,7 @@ class Coreum extends Mainnet implements AccountNetwork {
 }
 
 class CoreumTestnet extends Testnet implements AccountNetwork {
-  name = 'CoreumTestnet';
+  name = 'Testnet TX';
   family = CoinFamily.COREUM;
   explorerUrl = 'https://explorer.testnet-1.coreum.dev/coreum/transactions/';
 }


### PR DESCRIPTION
## Summary
Rebrand Coreum to TX - display names only.

## Changes
- Testnet: `Testnet Coreum` → `Testnet TX`

## Technical Note
Coin symbols ( `tcoreum`) and internal identifiers remain unchanged. Only user-facing display names updated - no impact to existing wallets, APIs, or integrations.

**Ticket:** CGARD-318