### PR TITLE
feat(abstract-utxo): update wasm-utxo dependency and API usage

### DIFF
--- a/modules/abstract-utxo/package.json
+++ b/modules/abstract-utxo/package.json
@@ -66,7 +66,7 @@
     "@bitgo/utxo-core": "^1.33.0",
     "@bitgo/utxo-lib": "^11.21.0",
     "@bitgo/utxo-ord": "^1.26.0",
-    "@bitgo/wasm-utxo": "^1.36.0",
+    "@bitgo/wasm-utxo": "^1.42.0",
     "@types/lodash": "^4.14.121",
     "@types/superagent": "4.1.15",
     "bignumber.js": "^9.0.2",

--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -159,7 +159,7 @@ function hasKeyPathSpendInput<TNumber extends number | bigint>(
     assert(pubs && isTriple(pubs), 'pub triple is required to check for key path spend inputs in wasm-utxo PSBT');
     const rootWalletKeys = fixedScriptWallet.RootWalletKeys.fromXpubs(pubs);
     const replayProtection = { publicKeys: getReplayProtectionPubkeys(coinName) };
-    const parsed = tx.parseTransactionWithWalletKeys(rootWalletKeys, replayProtection);
+    const parsed = tx.parseTransactionWithWalletKeys(rootWalletKeys, { replayProtection });
     return parsed.inputs.some((input) => input.scriptType === 'p2trMusig2KeyPath');
   }
   return false;

--- a/modules/abstract-utxo/src/transaction/fixedScript/explainPsbtWasm.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/explainPsbtWasm.ts
@@ -49,7 +49,7 @@ export function explainPsbtWasm(
     customChangeWalletXpubs?: Triple<string>;
   }
 ): TransactionExplanationWasm {
-  const parsed = psbt.parseTransactionWithWalletKeys(walletXpubs, params.replayProtection);
+  const parsed = psbt.parseTransactionWithWalletKeys(walletXpubs, { replayProtection: params.replayProtection });
 
   const changeOutputs: FixedScriptWalletOutput[] = [];
   const outputs: Output[] = [];

--- a/modules/abstract-utxo/src/transaction/fixedScript/signPsbtWasm.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/signPsbtWasm.ts
@@ -24,7 +24,7 @@ function hasKeyPathSpendInput(
   rootWalletKeys: fixedScriptWallet.RootWalletKeys,
   replayProtection: ReplayProtectionKeys
 ): boolean {
-  const parsed = tx.parseTransactionWithWalletKeys(rootWalletKeys, replayProtection);
+  const parsed = tx.parseTransactionWithWalletKeys(rootWalletKeys, { replayProtection });
   return parsed.inputs.some((input) => input.scriptType === 'p2trMusig2KeyPath');
 }
 
@@ -49,7 +49,7 @@ export function signAndVerifyPsbtWasm(
   }
 
   // Verify signatures for all signed inputs (still per-input for granular error reporting)
-  const parsed = tx.parseTransactionWithWalletKeys(rootWalletKeys, replayProtection);
+  const parsed = tx.parseTransactionWithWalletKeys(rootWalletKeys, { replayProtection });
   const verifyErrors: InputSigningError<bigint>[] = [];
 
   parsed.inputs.forEach((input, inputIndex) => {

--- a/modules/abstract-utxo/test/unit/postProcessPrebuild.ts
+++ b/modules/abstract-utxo/test/unit/postProcessPrebuild.ts
@@ -34,7 +34,7 @@ describe('Post Build Validation', function () {
     resultPsbt.lockTime.should.equal(0);
 
     // Check sequences via parseTransactionWithWalletKeys
-    const parsed = resultPsbt.parseTransactionWithWalletKeys(walletKeys, { publicKeys: [] });
+    const parsed = resultPsbt.parseTransactionWithWalletKeys(walletKeys, { replayProtection: { publicKeys: [] } });
     for (const input of parsed.inputs) {
       input.sequence.should.equal(0xffffffff);
     }

--- a/modules/abstract-utxo/test/unit/recovery/backupKeyRecovery.ts
+++ b/modules/abstract-utxo/test/unit/recovery/backupKeyRecovery.ts
@@ -93,7 +93,9 @@ function run(
       );
 
       // Parse generated PSBT
-      parsed = psbt.parseTransactionWithWalletKeys(wasmWalletKeys, { publicKeys: replayProtection });
+      parsed = psbt.parseTransactionWithWalletKeys(wasmWalletKeys, {
+        replayProtection: { publicKeys: replayProtection },
+      });
 
       // Load and parse fixture PSBT
       const psbtHex = Buffer.from(psbt.serialize()).toString('hex');
@@ -104,7 +106,9 @@ function run(
         Buffer.from(storedFixture.psbtHex, 'hex'),
         fixtureCoin.name
       );
-      fixtureParsed = fixturePsbt.parseTransactionWithWalletKeys(wasmWalletKeys, { publicKeys: replayProtection });
+      fixtureParsed = fixturePsbt.parseTransactionWithWalletKeys(wasmWalletKeys, {
+        replayProtection: { publicKeys: replayProtection },
+      });
     });
 
     it('has expected input count', function () {

--- a/modules/abstract-utxo/test/unit/recovery/crossChainRecovery.ts
+++ b/modules/abstract-utxo/test/unit/recovery/crossChainRecovery.ts
@@ -163,7 +163,7 @@ function run<TNumber extends number | bigint = number>(sourceCoin: AbstractUtxoC
     function checkRecoveryPsbtSignature(psbtHex: string) {
       // Parse using wasm-utxo for signature verification
       const wasmPsbt = fixedScriptWallet.BitGoPsbt.fromBytes(Buffer.from(psbtHex, 'hex'), sourceCoin.name);
-      const parsed = wasmPsbt.parseTransactionWithWalletKeys(wasmWalletKeys, { publicKeys: [] });
+      const parsed = wasmPsbt.parseTransactionWithWalletKeys(wasmWalletKeys, { replayProtection: { publicKeys: [] } });
       const unspents = getRecoveryUnspents();
       should.equal(parsed.inputs.length, unspents.length);
       // Verify user key has signed each input (same pattern as backupKeyRecovery test)

--- a/modules/abstract-utxo/test/unit/transaction/fixedScript/signPsbt.ts
+++ b/modules/abstract-utxo/test/unit/transaction/fixedScript/signPsbt.ts
@@ -66,7 +66,7 @@ function assertSignedWasm(
   replayProtection: ReplayProtectionKeys
 ): void {
   const wasmUserKey = BIP32.from(userKey);
-  const parsed = psbt.parseTransactionWithWalletKeys(rootWalletKeys, replayProtection);
+  const parsed = psbt.parseTransactionWithWalletKeys(rootWalletKeys, { replayProtection });
 
   // Verify that all wallet inputs have been signed by user key
   parsed.inputs.forEach((input, inputIndex) => {

--- a/modules/abstract-utxo/test/unit/util/transaction.ts
+++ b/modules/abstract-utxo/test/unit/util/transaction.ts
@@ -50,8 +50,12 @@ export function assertEqualParsedPsbt(
   }
   const aPsbt = fixedScriptWallet.BitGoPsbt.fromBytes(a, coinName);
   const bPsbt = fixedScriptWallet.BitGoPsbt.fromBytes(b, coinName);
-  const aParsed = aPsbt.parseTransactionWithWalletKeys(walletKeys, { publicKeys: replayProtection });
-  const bParsed = bPsbt.parseTransactionWithWalletKeys(walletKeys, { publicKeys: replayProtection });
+  const aParsed = aPsbt.parseTransactionWithWalletKeys(walletKeys, {
+    replayProtection: { publicKeys: replayProtection },
+  });
+  const bParsed = bPsbt.parseTransactionWithWalletKeys(walletKeys, {
+    replayProtection: { publicKeys: replayProtection },
+  });
   assert.deepStrictEqual(aParsed, bParsed);
 }
 

--- a/modules/utxo-bin/package.json
+++ b/modules/utxo-bin/package.json
@@ -31,7 +31,7 @@
     "@bitgo/unspents": "^0.51.1",
     "@bitgo/utxo-core": "^1.33.0",
     "@bitgo/utxo-lib": "^11.21.0",
-    "@bitgo/wasm-utxo": "^1.36.0",
+    "@bitgo/wasm-utxo": "^1.42.0",
     "@noble/curves": "1.8.1",
     "archy": "^1.0.0",
     "bech32": "^2.0.0",

--- a/modules/utxo-core/package.json
+++ b/modules/utxo-core/package.json
@@ -81,7 +81,7 @@
     "@bitgo/secp256k1": "^1.10.0",
     "@bitgo/unspents": "^0.51.1",
     "@bitgo/utxo-lib": "^11.21.0",
-    "@bitgo/wasm-utxo": "^1.36.0",
+    "@bitgo/wasm-utxo": "^1.42.0",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
     "fast-sha256": "^1.3.0"
   },

--- a/modules/utxo-ord/package.json
+++ b/modules/utxo-ord/package.json
@@ -45,7 +45,7 @@
     "directory": "modules/utxo-ord"
   },
   "dependencies": {
-    "@bitgo/wasm-utxo": "^1.36.0"
+    "@bitgo/wasm-utxo": "^1.42.0"
   },
   "devDependencies": {
     "@bitgo/utxo-lib": "^11.21.0"

--- a/modules/utxo-ord/test/psbt.ts
+++ b/modules/utxo-ord/test/psbt.ts
@@ -22,7 +22,7 @@ function assertValidPsbt(
   expectedFee: bigint
 ) {
   const replayProtection = { publicKeys: [] as Uint8Array[] };
-  const parsed = psbt.parseTransactionWithWalletKeys(rootWalletKeys, replayProtection);
+  const parsed = psbt.parseTransactionWithWalletKeys(rootWalletKeys, { replayProtection });
 
   // Sign all inputs with both signers
   const signer1 = BIP32.fromBase58(signerKeys[0]);
@@ -114,7 +114,7 @@ describe('OutputLayout to PSBT conversion', function () {
       }
       const psbt1 = f();
       const replayProtection = { publicKeys: [] as Uint8Array[] };
-      const parsed1 = psbt1.parseTransactionWithWalletKeys(rootWalletKeys, replayProtection);
+      const parsed1 = psbt1.parseTransactionWithWalletKeys(rootWalletKeys, { replayProtection });
       assert.deepStrictEqual(
         parsed1.inputs.map((i) => `${i.previousOutput.txid}:${i.previousOutput.vout}`),
         expectedUnspentSelection.map((u) => u.id)

--- a/modules/utxo-staking/package.json
+++ b/modules/utxo-staking/package.json
@@ -63,7 +63,7 @@
     "@bitgo/babylonlabs-io-btc-staking-ts": "^3.4.0",
     "@bitgo/utxo-core": "^1.33.0",
     "@bitgo/utxo-lib": "^11.21.0",
-    "@bitgo/wasm-utxo": "^1.36.0",
+    "@bitgo/wasm-utxo": "^1.42.0",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
     "bip322-js": "^2.0.0",
     "bitcoinjs-lib": "^6.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -996,10 +996,10 @@
     monocle-ts "^2.3.13"
     newtype-ts "^0.3.5"
 
-"@bitgo/wasm-utxo@^1.36.0":
-  version "1.36.0"
-  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-1.36.0.tgz#4a0e9998e159ed9b6ecae7b9dad6f27971dd8690"
-  integrity sha512-3ArjiSE/Mm4B9DM5hZQIxnKXMYYB7m4SniZsN/X1fRv6dvhkKWp/wCX7yV6SJAQ81OH2tDbYSACrEpGLHszBUg==
+"@bitgo/wasm-utxo@^1.42.0":
+  version "1.42.0"
+  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-1.42.0.tgz#29754e9b947fd9d5c303cb5f5043a031cd04754b"
+  integrity sha512-VKhlaSVjD7dTjYw5yNbRVTQh84zuyiEcLSldhzbnkrWgZL+3+xYaOAWicVJaE5Bk37AYWRL+7aiwbCtosF7zug==
 
 "@brandonblack/musig@^0.0.1-alpha.0":
   version "0.0.1-alpha.1"


### PR DESCRIPTION

This PR updates the WASM-UTXO dependency from version 1.36.0 to 1.42.0
across multiple modules. It also updates all calls to
parseTransactionWithWalletKeys to match the new signature which requires
replay protection options to be passed within an options object.

Issue: BTC-0