### PR TITLE
chore: address audit findings

### DIFF
--- a/.iyarc
+++ b/.iyarc
@@ -24,3 +24,9 @@ GHSA-34x7-hfp2-rc4v
 # - Our usage is dev-time tooling only (build, test, file search)
 # - Mitigated by controlled inputs (our own build scripts, not user-provided patterns)
 GHSA-3ppc-4f35-3m26
+
+# Excluded because:
+# - Transitive dependency through lerna and yeoman-generator requiring tar < 7.5.4
+# - This CVE affects tar's extraction process with specially crafted archives
+# - Our usage is limited to archive PACKING operations only, not extraction
+GHSA-83g3-92jg-28cx

--- a/modules/key-card/package.json
+++ b/modules/key-card/package.json
@@ -36,7 +36,7 @@
     "@bitgo/sdk-api": "^1.74.1",
     "@bitgo/sdk-core": "^36.31.1",
     "@bitgo/statics": "^58.25.0",
-    "jspdf": "^4.1.0",
+    "jspdf": ">=4.2.0",
     "qrcode": "^1.5.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "**/cacache/glob": "11.1.0",
     "**/pacote/glob": "11.1.0",
     "**/sha.js": ">=2.4.12",
-    "jspdf": ">=4.1.0",
+    "jspdf": ">=4.2.0",
     "@ethereumjs/util": "8.0.3",
     "@types/keyv": "3.1.4",
     "@types/react": "17.0.24",

--- a/yarn.lock
+++ b/yarn.lock
@@ -889,7 +889,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/runtime@7.6.0", "@babel/runtime@^7.0.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.6", "@babel/runtime@^7.20.13", "@babel/runtime@^7.25.0", "@babel/runtime@^7.28.2", "@babel/runtime@^7.28.4", "@babel/runtime@^7.7.6":
+"@babel/runtime@7.6.0", "@babel/runtime@^7.0.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.6", "@babel/runtime@^7.20.13", "@babel/runtime@^7.25.0", "@babel/runtime@^7.28.2", "@babel/runtime@^7.28.6", "@babel/runtime@^7.7.6":
   version "7.28.4"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz#a70226016fabe25c5783b2f22d3e1c9bc5ca3326"
   integrity sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==
@@ -14085,12 +14085,12 @@ jsonpointer@^5.0.0:
   resolved "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz"
   integrity sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==
 
-jspdf@>=4.1.0, jspdf@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/jspdf/-/jspdf-4.1.0.tgz#4fb476251c8751c996175cfaac02d30fdf8c7b7a"
-  integrity sha512-xd1d/XRkwqnsq6FP3zH1Q+Ejqn2ULIJeDZ+FTKpaabVpZREjsJKRJwuokTNgdqOU+fl55KgbvgZ1pRTSWCP2kQ==
+jspdf@>=4.2.0:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/jspdf/-/jspdf-4.2.0.tgz#f5b42a8e1592c3da1531d005adc87ccc19272965"
+  integrity sha512-hR/hnRevAXXlrjeqU5oahOE+Ln9ORJUB5brLHHqH67A+RBQZuFr5GkbI9XQI8OUFSEezKegsi45QRpc4bGj75Q==
   dependencies:
-    "@babel/runtime" "^7.28.4"
+    "@babel/runtime" "^7.28.6"
     fast-png "^6.2.0"
     fflate "^0.8.1"
   optionalDependencies:


### PR DESCRIPTION
This is the full audit finding:
```
Vulnerability Found:

  Severity: HIGH
  Modules: lerna>@npmcli/run-script>node-gyp>tar, lerna>@lerna/create>@npmcli/run-script>node-gyp>tar, lerna>@npmcli/run-script>node-gyp>make-fetch-happen>cacache>tar, lerna>@lerna/create>@npmcli/run-script>node-gyp>make-fetch-happen>cacache>tar, lerna>@lerna/create>pacote>@npmcli/run-script>node-gyp>make-fetch-happen>cacache>tar, lerna>@npmcli/arborist>@npmcli/metavuln-calculator>pacote>@npmcli/run-script>node-gyp>make-fetch-happen>cacache>tar, lerna>@lerna/create>@npmcli/arborist>@npmcli/metavuln-calculator>pacote>@npmcli/run-script>node-gyp>make-fetch-happen>cacache>tar, lerna>@npmcli/arborist>@npmcli/metavuln-calculator>pacote>tar, lerna>@lerna/create>@npmcli/arborist>@npmcli/metavuln-calculator>pacote>tar, lerna>@npmcli/arborist>cacache>tar, lerna>@lerna/create>@npmcli/arborist>cacache>tar, lerna>@npmcli/arborist>npm-registry-fetch>make-fetch-happen>cacache>tar, lerna>@lerna/create>@npmcli/arborist>npm-registry-fetch>make-fetch-happen>cacache>tar, lerna>libnpmpublish>npm-registry-fetch>make-fetch-happen>cacache>tar, lerna>@lerna/create>libnpmpublish>npm-registry-fetch>make-fetch-happen>cacache>tar, lerna>@lerna/create>libnpmpublish>sigstore>@sigstore/sign>make-fetch-happen>cacache>tar, lerna>@lerna/create>libnpmpublish>sigstore>@sigstore/tuf>tuf-js>make-fetch-happen>cacache>tar, lerna>pacote>tar, lerna>@lerna/create>pacote>tar, lerna>tar, lerna>@lerna/create>tar, yeoman-generator>pacote>cacache>tar, yeoman-generator>pacote>@npmcli/run-script>node-gyp>tar, yeoman-generator>pacote>npm-registry-fetch>make-fetch-happen>cacache>tar, yeoman-generator>pacote>@npmcli/run-script>node-gyp>make-fetch-happen>cacache>tar, yeoman-generator>pacote>sigstore>@sigstore/tuf>tuf-js>make-fetch-happen>cacache>tar, lerna>libnpmaccess>npm-registry-fetch>make-fetch-happen>cacache>tar
  URL: https://github.com/advisories/GHSA-83g3-92jg-28cx
```

As for the `jspdf` update, we are requesting an exception since it addresses another high severity finding:
```
Vulnerability Found:

  Severity: HIGH
  Modules: @bitgo/key-card>jspdf, @bitgo/web-demo>@bitgo/key-card>jspdf
  URL: https://github.com/advisories/GHSA-67pg-wm7f-q7fj
```

TICKET: WP-7983