### PR TITLE
fix(statics): remove staking feature from tflr:wflr

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -5854,7 +5854,7 @@ export const allCoinsAndTokens = [
     18,
     '0xab6fad89389b73dbc887d31206a26fd88d719d1f',
     UnderlyingAsset['tflr:wflr'],
-    WFLR_FEATURES
+    WFLR_FEATURES.filter((f) => f !== CoinFeature.STAKING)
   ),
   tflrErc20(
     'a1c8fdc6-e5b5-4170-b490-f585db8ab922',


### PR DESCRIPTION
## Summary
- Remove the `STAKING` coin feature from the `tflr:wflr` (Wrapped Flare Testnet) token
- Other tokens using `WFLR_FEATURES` (`flr:wflr`, `tflr:twc2flr`) are unaffected

## Test plan
- [ ] Verify `tflr:wflr` no longer has the `STAKING` feature
- [ ] Verify `flr:wflr` and `tflr:twc2flr` still have `STAKING`
- [ ] Run unit tests for statics module