### PR TITLE
chore(root): exclude minimatch ReDoS from yarn audit

### DIFF
--- a/.iyarc
+++ b/.iyarc
@@ -30,3 +30,16 @@ GHSA-3ppc-4f35-3m26
 # - This CVE affects tar's extraction process with specially crafted archives
 # - Our usage is limited to archive PACKING operations only, not extraction
 GHSA-83g3-92jg-28cx
+
+# Excluded because:
+# - Transitive dependency through lerna, depcheck, nyc, eslint, yeoman-generator, glob, shelljs
+# - minimatch ReDoS via crafted glob patterns (same class as GHSA-3ppc-4f35-3m26)
+# - Only affects dev-time tooling, not production code
+GHSA-7r86-cg39-jmmj
+
+# Excluded because:
+# - Transitive dependency through lerna, depcheck, nyc, eslint, yeoman-generator, glob, shelljs
+# - minimatch ReDoS via crafted glob patterns (same class as GHSA-3ppc-4f35-3m26)
+# - Only affects dev-time tooling, not production code
+# - Mitigated by controlled inputs (our own build scripts, not user-provided patterns)
+GHSA-23c5-xmqv-rm74


### PR DESCRIPTION
TICKET: WP-8085

SDK release failed because of the two failing advisories (GHSA-7r86-cg39-jmmj and GHSA-23c5-xmqv-rm74) are both minimatch ReDoS vulnerabilities, the same class of issue as the already-excluded `GHSA-3ppc-4f35-3m26`. 

https://github.com/BitGo/build-system/actions/runs/22464347697/job/65066725322#step:11:248 