### PR TITLE
fix: use serialize without signature validation in WASM explain path

### DIFF
--- a/modules/sdk-coin-sol/src/lib/transaction.ts
+++ b/modules/sdk-coin-sol/src/lib/transaction.ts
@@ -507,8 +507,15 @@ export class Transaction extends BaseTransaction {
     // This validates the WASM path against production traffic before
     // replacing the legacy implementation for all networks.
     if (this._coinConfig.name === 'tsol') {
+      // explainTransaction should work on unsigned/partially-signed transactions
+      // (e.g., during parseTransaction round-trips where null signatures become
+      // zero-filled buffers). Use serialize without signature validation since
+      // we only need to read the transaction, not broadcast it.
+      const txBase64 = Buffer.from(
+        this._solTransaction.serialize({ verifySignatures: false, requireAllSignatures: false })
+      ).toString('base64');
       return explainSolTransaction({
-        txBase64: this.toBroadcastFormat(),
+        txBase64,
         feeInfo: this._lamportsPerSignature ? { fee: this._lamportsPerSignature.toString() } : undefined,
         tokenAccountRentExemptAmount: this._tokenAccountRentExemptAmount,
         coinName: this._coinConfig.name,


### PR DESCRIPTION
explainTransaction() for tsol calls toBroadcastFormat() to get bytes for the WASM parser. toBroadcastFormat() calls @solana/web3.js serialize() which validates signatures by default. After a deserialize-rebuild round-trip (e.g. during parseTransaction), null signatures become zero-filled buffers that fail validation.

Use serialize({ verifySignatures: false, requireAllSignatures: false }) instead since explain only needs to read the transaction, not broadcast it.

BTC-3099

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
