### PR TITLE
feat: rebrand Coreum to TX (mainnet)

### DIFF
--- a/modules/sdk-coin-coreum/test/unit/coreum.ts
+++ b/modules/sdk-coin-coreum/test/unit/coreum.ts
@@ -41,7 +41,7 @@ describe('Coreum', function () {
   it('should return the right info', function () {
     coreum.getChain().should.equal('coreum');
     coreum.getFamily().should.equal('coreum');
-    coreum.getFullName().should.equal('Coreum');
+    coreum.getFullName().should.equal('TX');
     coreum.getBaseFactor().should.equal(1e6);
 
     tcoreum.getChain().should.equal('tcoreum');

--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -1097,7 +1097,7 @@ export const allCoinsAndTokens = [
   account(
     '7df858d5-9da3-4071-ab06-399962ea87b7',
     'coreum',
-    'Coreum',
+    'TX',
     Networks.main.coreum,
     6,
     UnderlyingAsset.COREUM,

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -134,7 +134,7 @@ export const ofcCoins = [
     UnderlyingAsset.ARBETH,
     CoinKind.CRYPTO
   ),
-  ofc('8b93e788-52fa-4fd6-b499-40f13fe194fc', 'ofccoreum', 'Coreum', 6, UnderlyingAsset.COREUM, CoinKind.CRYPTO),
+  ofc('8b93e788-52fa-4fd6-b499-40f13fe194fc', 'ofccoreum', 'TX', 6, UnderlyingAsset.COREUM, CoinKind.CRYPTO),
   ofc('a88adc55-c1c8-4a4e-8436-df3868a50daa', 'ofccelo', 'Celo Gold', 18, UnderlyingAsset.CELO, CoinKind.CRYPTO),
   ofc('17cf28b5-f958-46c3-be88-53cc42bf0c76', 'ofcchiliz', 'Chiliz', 18, UnderlyingAsset.CHILIZ, CoinKind.CRYPTO),
   tofc(

--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -1098,15 +1098,15 @@ class TonTestnet extends Testnet implements AccountNetwork {
 }
 
 class Coreum extends Mainnet implements AccountNetwork {
-  name = 'Coreum';
+  name = 'TX';
   family = CoinFamily.COREUM;
-  explorerUrl = 'https://www.mintscan.io/coreum/tx/';
+  explorerUrl = 'https://explorer.tx.org/tx/transactions/';
 }
 
 class CoreumTestnet extends Testnet implements AccountNetwork {
   name = 'Testnet TX';
   family = CoinFamily.COREUM;
-  explorerUrl = 'https://explorer.testnet-1.coreum.dev/coreum/transactions/';
+  explorerUrl = 'https://explorer.testnet-1.tx.org/tx/transactions/';
 }
 
 class Rune extends Mainnet implements AccountNetwork {


### PR DESCRIPTION
# Rebrand Coreum to TX (Mainnet)


## Changes Made

### 1. Coin Names Updated
- **Mainnet**: Changed from "Coreum" to "TX"

### 2. Explorer URLs Updated
- **Mainnet**: `https://explorer.tx.org/tx/transactions/`
- **Testnet**: `https://explorer.testnet-1.tx.org/tx/transactions/`

### 3. Updated tests

Testnet changes are done in this PR : https://github.com/BitGo/BitGoJS/pull/8167

Ticket: CGARD-318