### PR TITLE
fix: update serialize-javascript to 7.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "**/cacache/glob": "11.1.0",
     "**/pacote/glob": "11.1.0",
     "**/sha.js": ">=2.4.12",
+    "**/serialize-javascript": "7.0.3",
     "jspdf": ">=4.2.0",
     "@ethereumjs/util": "8.0.3",
     "@types/keyv": "3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18671,12 +18671,10 @@ send@0.19.0:
     range-parser "~1.2.1"
     statuses "2.0.1"
 
-serialize-javascript@^6.0.0, serialize-javascript@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz"
-  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
-  dependencies:
-    randombytes "^2.1.0"
+serialize-javascript@7.0.3, serialize-javascript@^6.0.0, serialize-javascript@^6.0.2:
+  version "7.0.3"
+  resolved "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz#c92008d8a21bc7b2307c2e885a4bd0f03b2aee6c"
+  integrity sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==
 
 serve-index@^1.9.1:
   version "1.9.1"


### PR DESCRIPTION
## Fix serialize-javascript RCE Vulnerability (GHSA-5c6j-r48x-rmvq)

### Summary
Updates `serialize-javascript` from `6.0.2` to `7.0.3` to resolve a Remote Code Execution (RCE) vulnerability.

### Vulnerability Details
- **CVE**: GHSA-5c6j-r48x-rmvq
- **Severity**: HIGH
- **Attack Vector**: RCE via malicious `RegExp.flags` and `Date.prototype.toISOString()` methods


### Changes
- Added Yarn resolution `**/serialize-javascript: 7.0.3` to force version across all transitive dependencies
- Updated `yarn.lock` to reflect the resolution

Failed Job: https://github.com/BitGo/BitGoJS/actions/runs/22571247763/job/65379334392

Ticket: CGARD-518
