### PR TITLE
feat(sdk-coin-trx): increase default transaction expiration to 3 hours

### DIFF
--- a/modules/sdk-coin-trx/src/lib/utils.ts
+++ b/modules/sdk-coin-trx/src/lib/utils.ts
@@ -28,7 +28,7 @@ import { AbiCoder, hexConcat } from 'ethers/lib/utils';
 import { DELEGATION_TYPE_URL } from './constants';
 
 export const TRANSACTION_MAX_EXPIRATION = 86400000; // one day
-export const TRANSACTION_DEFAULT_EXPIRATION = 3600000; // one hour
+export const TRANSACTION_DEFAULT_EXPIRATION = 10800000; // three hours
 const ADDRESS_PREFIX_REGEX = /^(41)/;
 const ADDRESS_PREFIX = '41';
 

--- a/modules/sdk-coin-trx/test/unit/transactionBuilder/tokenTransferBuilder.ts
+++ b/modules/sdk-coin-trx/test/unit/transactionBuilder/tokenTransferBuilder.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import { describe, it } from 'node:test';
 import { getBuilder } from '../../../src/lib/builder';
 import { WrappedBuilder } from '../../../src';
+import { TRANSACTION_DEFAULT_EXPIRATION } from '../../../src/lib/utils';
 import {
   PARTICIPANTS,
   BLOCK_HASH,
@@ -34,6 +35,23 @@ describe('TRX Token Transfer Builder', () => {
         const txJson = tx.toJson();
         const rawData = txJson.raw_data;
         assert.deepStrictEqual(rawData.contract, TOKEN_TX_CONTRACT);
+      });
+
+      it('a token transfer transaction should have a default expiration of 3 hours', async () => {
+        const before = Date.now();
+        const txBuilder = initTxBuilder();
+        txBuilder.tokenTransferData(TOKEN_TRANSFER_RECIPIENT, '1000000000').sign({ key: PARTICIPANTS.custodian.pk });
+        const tx = await txBuilder.build();
+        const after = Date.now();
+        const txJson = tx.toJson();
+        const expiration = txJson.raw_data.expiration;
+
+        assert.equal(TRANSACTION_DEFAULT_EXPIRATION, 10800000, 'TRANSACTION_DEFAULT_EXPIRATION should be 3 hours');
+        // The default expiration should be ~3 hours (10800000ms) from when the tx was built
+        assert.ok(
+          expiration >= before + TRANSACTION_DEFAULT_EXPIRATION && expiration <= after + TRANSACTION_DEFAULT_EXPIRATION,
+          `Expiration ${expiration} should be approximately 3 hours from now`
+        );
       });
 
       it('from a signed token contract call transaction', async () => {


### PR DESCRIPTION
## Summary
- Change `TRANSACTION_DEFAULT_EXPIRATION` from 1 hour (3600000ms) to 3 hours (10800000ms) for all TRX transaction types (native transfers, token transfers, freeze, unfreeze, vote, delegate, undelegate, withdraw)
- Add test in `tokenTransferBuilder.ts` to verify token transfers use the 3-hour default expiration

## Test plan
- [ ] Verify token transfer builder test asserts `TRANSACTION_DEFAULT_EXPIRATION` equals 10800000 (3 hours)
- [ ] Verify token transfer transactions built without explicit expiration default to ~3 hours from now
- [ ] Run `sdk-coin-trx` unit tests

TICKET: COIN-7612

🤖 Generated with [Claude Code](https://claude.com/claude-code)