### PR TITLE
fix(statics): set xtzevm decimals to 6 (CECHO-117)

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -398,7 +398,7 @@ export const allCoinsAndTokens = [
     'xtzevm',
     'XTZ EVM',
     Networks.main.xtzevm,
-    18,
+    6,
     UnderlyingAsset.XTZEVM,
     BaseUnit.ETH,
     [
@@ -416,7 +416,7 @@ export const allCoinsAndTokens = [
     'txtzevm',
     'Testnet XTZ EVM',
     Networks.test.xtzevm,
-    18,
+    6,
     UnderlyingAsset.XTZEVM,
     BaseUnit.ETH,
     [

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -218,12 +218,12 @@ export const ofcCoins = [
     UnderlyingAsset.HYPEEVM,
     CoinKind.CRYPTO
   ),
-  ofc('dc825481-0a15-44ab-84e6-6f182b13eb87', 'ofcxtzevm', 'XTZ EVM', 18, UnderlyingAsset.XTZEVM, CoinKind.CRYPTO),
+  ofc('dc825481-0a15-44ab-84e6-6f182b13eb87', 'ofcxtzevm', 'XTZ EVM', 6, UnderlyingAsset.XTZEVM, CoinKind.CRYPTO),
   tofc(
     '0e42884b-c01e-461b-b108-1ed0d0fbbd7b',
     'ofctxtzevm',
     'XTZ EVM Testnet',
-    18,
+    6,
     UnderlyingAsset.XTZEVM,
     CoinKind.CRYPTO
   ),


### PR DESCRIPTION
- xtzevm, txtzevm: 18 -> 6 in allCoinsAndTokens
- ofcxtzevm, ofctxtzevm: 18 -> 6 in ofcCoins 
Etherlink (XTZ EVM) native token uses 6 decimals.

TICKET: CECHO-117

