### PR TITLE
feat(statics): add CoinFeature.STAKING to txdc coin features

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -1538,7 +1538,7 @@ export const allCoinsAndTokens = [
     18,
     UnderlyingAsset.XDC,
     BaseUnit.ETH,
-    XDC_FEATURES
+    [...XDC_FEATURES, CoinFeature.STAKING]
   ),
   account(
     '297edf01-b166-45fb-be6f-da6680635f72',


### PR DESCRIPTION
## Summary

- Add `CoinFeature.STAKING` to `txdc` (testnet XDC) via inline spread in `allCoinsAndTokens.ts`

The mainnet `xdc` coin is intentionally left unchanged — testnet-only change until full XDC staking go-live.

- [ ] CI passes all checks

Ticket: SC-5664