### PR TITLE
fix(root): exclude tar vulnerability

### DIFF
--- a/.iyarc
+++ b/.iyarc
@@ -49,3 +49,10 @@ GHSA-23c5-xmqv-rm74
 # - serialize-javascript RCE via malicious RegExp.flags and Date.prototype.toISOString()
 # - Only affects dev-time tooling, not production code
 GHSA-5c6j-r48x-rmvq
+
+# Excluded because:
+# - Transitive dependency through lerna and yeoman-generator requiring tar < 7.5.7
+# - This CVE affects tar's extraction process (hardlink path traversal in crafted archives)
+# - Our usage is limited to archive PACKING operations only, not extraction
+# - Forcing tar v7.5.7+ breaks lerna's packDirectory API (same constraint as GHSA-8qq5-rm4j-mr97)
+GHSA-qffp-2rhf-9h96


### PR DESCRIPTION
Ticket: WP-8127

Slack ref - https://bitgo.slack.com/archives/C010AEXLLCR/p1772693119445179?thread_ts=1772573311.968949&cid=C010AEXLLCR

**Root Cause**

The fix for GHSA-qffp-2rhf-9h96 is in tar@7.5.7+. However, lerna requires tar v6 — forcing an upgrade to v7.x breaks lerna's packDirectory API. This is the same constraint that caused 4 prior tar advisories to be excluded in .iyarc:

- GHSA-8qq5-rm4j-mr97 (excluded)

- GHSA-r6q2-hw4h-h46w (excluded)

- GHSA-34x7-hfp2-rc4v (excluded)

- GHSA-83g3-92jg-28cx (excluded)


**Why It Is Safe to Exclude**

GHSA-qffp-2rhf-9h96 is the same vulnerability class (tar extraction: hardlink/symlink path traversal when extracting malicious archives) as all 4 previously excluded advisories.

BitGo's usage of lerna/yeoman's tar is PACKING only (e.g. lerna publish), never extraction of untrusted archives.

lerna and yeoman-generator are dev-time tools only — not used in production.

The exploitable attack surface (extracting a maliciously crafted archive) does not exist in this repo's use case.

**Fix**

Add GHSA-qffp-2rhf-9h96 to .iyarc with justification matching the existing tar exclusions:

```
# Excluded because:
# - Transitive dependency through lerna and yeoman-generator requiring tar < 7.5.7
# - This CVE affects tar's extraction process (hardlink path traversal in crafted archives)
# - Our usage is limited to archive PACKING operations only, not extraction
# - Forcing tar v7.5.7+ breaks lerna's packDirectory API (same constraint as GHSA-8qq5-rm4j-mr97)
GHSA-qffp-2rhf-9h96
```