### PR TITLE
feat(statics): onboard client requested tokens batch 2

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -3123,6 +3123,42 @@ export const allCoinsAndTokens = [
     Networks.test.basechain
   ),
   erc20Token(
+    '99f6ea7f-0f64-4b15-964e-c52c68a91460',
+    'tbaseeth:xusd',
+    'StraitsX USD',
+    6,
+    '0xe333e7754a2dc1e020a162ecab019254b9dab653',
+    UnderlyingAsset['tbaseeth:xusd'],
+    Networks.test.basechain
+  ),
+  erc20Token(
+    '04f00953-01ec-4e68-91b3-a11bed12203b',
+    'tbaseeth:xsgd',
+    'StraitsX SGD',
+    6,
+    '0xd8b130b01134c1d0f6ff1a9fa85142d7c1880933',
+    UnderlyingAsset['tbaseeth:xsgd'],
+    Networks.test.basechain
+  ),
+  erc20Token(
+    '4c05151a-957c-4e88-a280-d6023d831334',
+    'tbaseeth:usd1cx',
+    'USD1 Concrete Custodial Asset',
+    18,
+    '0xb988bcb8059fe2c5e3e3a09fb4873d0103775df3',
+    UnderlyingAsset['tbaseeth:usd1cx'],
+    Networks.test.basechain
+  ),
+  erc20Token(
+    '58d123bb-6ac9-4ad4-9742-c887447948b7',
+    'tbaseeth:ctusd1cx',
+    'Concrete USD1cx',
+    18,
+    '0x3d48f7edff9b64d0ae95bda88728d51bba29ddd2',
+    UnderlyingAsset['tbaseeth:ctusd1cx'],
+    Networks.test.basechain
+  ),
+  erc20Token(
     '439fb12d-fddf-4749-8a33-b7c79fefc1b4',
     'baseeth:wave',
     'Waveform',
@@ -5301,6 +5337,14 @@ export const allCoinsAndTokens = [
     18,
     '0x6985884c4392d348587b19cb9eaaf157f13271cd',
     UnderlyingAsset['arbeth:zro']
+  ),
+  arbethErc20(
+    'e342adb7-3623-41c0-b8ae-1cb7cd046f70',
+    'arbeth:tt',
+    'Test Token',
+    18,
+    '0x5f787c1615ab866ce4fd7d4880bc56b706f1942b',
+    UnderlyingAsset['arbeth:tt']
   ),
   tarbethErc20(
     'd6a8869d-3da4-4b95-a9af-f2a059ca651f',

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -1855,6 +1855,7 @@ export enum UnderlyingAsset {
   'hteth:stgcusd' = 'hteth:stgcusd',
   'hteth:stgfyusd' = 'hteth:stgfyusd',
   'hteth:tsteth' = 'hteth:tsteth',
+  'hteth:grtxp' = 'hteth:grtxp',
   THKD = 'thkd',
   THUNDER = 'thunder',
   TIO = 'tio',
@@ -2889,6 +2890,7 @@ export enum UnderlyingAsset {
   'bsc:zbt' = 'bsc:zbt',
   'bsc:iost' = 'bsc:iost',
   'bsc:sto' = 'bsc:sto',
+  'bsc:pt-cusdo-29oct2026' = 'bsc:pt-cusdo-29oct2026',
 
   // BSC NFTs
   // generic NFTs
@@ -2975,6 +2977,7 @@ export enum UnderlyingAsset {
   'arbeth:uxlink' = 'arbeth:uxlink',
   'arbeth:next' = 'arbeth:next',
   'arbeth:zro' = 'arbeth:zro',
+  'arbeth:tt' = 'arbeth:tt',
 
   // BaseETH mainnet tokens
   'baseeth:aero' = 'baseeth:aero',
@@ -3017,6 +3020,10 @@ export enum UnderlyingAsset {
 
   // BaseETH testnet tokens
   'tbaseeth:usdc' = 'tbaseeth:usdc',
+  'tbaseeth:xusd' = 'tbaseeth:xusd',
+  'tbaseeth:xsgd' = 'tbaseeth:xsgd',
+  'tbaseeth:usd1cx' = 'tbaseeth:usd1cx',
+  'tbaseeth:ctusd1cx' = 'tbaseeth:ctusd1cx',
 
   // Og mainnet tokens
   'og:wog' = 'og:wog',
@@ -3593,6 +3600,10 @@ export enum UnderlyingAsset {
   'eth:open' = 'eth:open',
   'eth:mbg' = 'eth:mbg',
   'eth:rekt' = 'eth:rekt',
+  'eth:shvon' = 'eth:shvon',
+  'eth:pt-cusdo-28may2026' = 'eth:pt-cusdo-28may2026',
+  'eth:usd1cx' = 'eth:usd1cx',
+  'eth:ctusd1cx' = 'eth:ctusd1cx',
 
   // ADA testnet tokens
   'tada:water' = 'tada:water',
@@ -3606,6 +3617,9 @@ export enum UnderlyingAsset {
   'ada:djed' = 'ada:djed',
   'ada:usda' = 'ada:usda',
   'ada:night' = 'ada:night',
+  'ada:lcc' = 'ada:lcc',
+  'ada:awlf' = 'ada:awlf',
+  'ada:asnek' = 'ada:asnek',
 
   // Canton testnet tokens
   'tcanton:testcoin1' = 'tcanton:testcoin1',

--- a/modules/statics/src/coins/adaTokens.ts
+++ b/modules/statics/src/coins/adaTokens.ts
@@ -102,4 +102,37 @@ export const adaTokens = [
     UnderlyingAsset['ada:night'],
     ADA_TOKEN_FEATURES
   ),
+  adaToken(
+    '81ba4af5-5a5d-45a3-9b8a-f9e48a5abbef',
+    'ada:lcc',
+    'Lazy Cat Coin',
+    0,
+    '03c2eb4f942703fa965df42ba8ac57e27c5e86802d058da63f4d888b4c4343',
+    'LCC',
+    'asset1pqp0lsp4q8rhx9vpfpw5khfj03v8puda266qrd',
+    UnderlyingAsset['ada:lcc'],
+    ADA_TOKEN_FEATURES
+  ),
+  adaToken(
+    'd06d31a3-f5c9-4e2f-96bb-9657e658f581',
+    'ada:awlf',
+    'AWLF',
+    6,
+    'a64ea329436e48925c5e41a95721304fda387bf1dd06efd66e47423141574c46',
+    'AWLF',
+    'asset18fnfgvwhwxasyamptac69t93cxvjfszsqvkamq',
+    UnderlyingAsset['ada:awlf'],
+    ADA_TOKEN_FEATURES
+  ),
+  adaToken(
+    '97360499-96fb-485d-a83a-cadd1509f311',
+    'ada:asnek',
+    'ASNEK',
+    6,
+    'fe38ef97888dfde0292b7d2ed103543ecf92a419a29634f513a1d71f41534e454b',
+    'ASNEK',
+    'asset19e9dq59euafqysqugza92jdvwfx882gt2hq5rm',
+    UnderlyingAsset['ada:asnek'],
+    ADA_TOKEN_FEATURES
+  ),
 ];

--- a/modules/statics/src/coins/bscTokens.ts
+++ b/modules/statics/src/coins/bscTokens.ts
@@ -1543,4 +1543,13 @@ export const bscTokens = [
     UnderlyingAsset['bsc:sto'],
     BSC_TOKEN_FEATURES
   ),
+  bscToken(
+    '8956e895-8607-4434-8f62-e731a8ffbe9b',
+    'bsc:pt-cusdo-29oct2026',
+    'PT-cUSDO-29OCT2026',
+    18,
+    '0xcd18d94fda553bb956d6130ad217b63ef65888d0',
+    UnderlyingAsset['bsc:pt-cusdo-29oct2026'],
+    BSC_TOKEN_FEATURES
+  ),
 ];

--- a/modules/statics/src/coins/erc20Coins.ts
+++ b/modules/statics/src/coins/erc20Coins.ts
@@ -14465,4 +14465,48 @@ export const erc20Coins = [
     '0x4bbe27b87c20f76349e47cbc3908477f7bbd71b0', // https://etherscan.io/token/0x4bbE27b87c20f76349E47cBc3908477f7bBD71B0
     UnderlyingAsset['eth:grtx']
   ),
+  erc20(
+    '7cf7c274-ecab-4c27-b918-0b044a5cd893',
+    'eth:shvon',
+    'SHVon',
+    18,
+    '0x2d8b65306a6c23da6342cb94d4251fb4302a624f',
+    UnderlyingAsset['eth:shvon']
+  ),
+  erc20(
+    '9fff6a5f-b144-4e5b-9837-cbf1f53acc70',
+    'eth:pt-cusdo-28may2026',
+    'PT-cUSDO-28MAY2026',
+    18,
+    '0x67aeeed39c1675e0df93ad8bab543b17992d433b',
+    UnderlyingAsset['eth:pt-cusdo-28may2026']
+  ),
+  erc20(
+    '9b5cbf21-579b-4ce8-81ab-406c30fd9c22',
+    'eth:usd1cx',
+    'USD1cx',
+    18,
+    '0x01c574403f72f42c73afdfa5fa24789477e702b8',
+    UnderlyingAsset['eth:usd1cx']
+  ),
+  erc20(
+    '5c2c3787-9b6f-4d92-a5a8-bfe3d50b165c',
+    'eth:ctusd1cx',
+    'ctUSD1cx',
+    18,
+    '0xcc4d271c881d73cd38d09ae9c5e7264aef2f6d47',
+    UnderlyingAsset['eth:ctusd1cx']
+  ),
+  terc20(
+    '0c333619-e5a6-4f9d-8bbc-5b0e5dc64d03',
+    'hteth:grtxp',
+    'GRTXP',
+    18,
+    '0x1bfec9fef31efed49ca6f45cae4c7911e20015c6',
+    UnderlyingAsset['hteth:grtxp'],
+    undefined,
+    undefined,
+    undefined,
+    Networks.test.hoodi
+  ),
 ];

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -2008,6 +2008,13 @@ export const ofcCoins = [
     18,
     UnderlyingAsset['arbeth:zro']
   ),
+  ofcArbethErc20(
+    '1680b663-da25-4e0e-8661-2770f51fc348',
+    'ofcarbeth:tt',
+    'Test Token',
+    18,
+    UnderlyingAsset['arbeth:tt']
+  ),
 
   ofcAvaxErc20('2bd6201d-c46c-481e-b82d-7cf3601679cb', 'ofcavaxc:aave-e', 'Aave', 18, UnderlyingAsset['avaxc:aave']),
   ofcAvaxErc20(

--- a/modules/statics/src/coins/ofcErc20Coins.ts
+++ b/modules/statics/src/coins/ofcErc20Coins.ts
@@ -3717,6 +3717,28 @@ export const ofcErc20Coins = [
     [CoinFeature.STABLECOIN]
   ),
   ofcerc20('dd95c7b9-2be8-4471-920d-40e1fd583bf3', 'ofceth:grtx', 'GreatX', 6, underlyingAssetForSymbol('eth:grtx')),
+  ofcerc20('4edef256-f213-4635-8157-61697c5b9e83', 'ofceth:shvon', 'SHVon', 18, underlyingAssetForSymbol('eth:shvon')),
+  ofcerc20(
+    'f3344177-236f-4dec-9c6a-1889dd3c7de5',
+    'ofceth:pt-cusdo-28may2026',
+    'PT-cUSDO-28MAY2026',
+    18,
+    underlyingAssetForSymbol('eth:pt-cusdo-28may2026')
+  ),
+  ofcerc20(
+    '23a5731a-e171-4079-80c4-4f165d0a59fc',
+    'ofceth:usd1cx',
+    'USD1cx',
+    18,
+    underlyingAssetForSymbol('eth:usd1cx')
+  ),
+  ofcerc20(
+    '0d2292d7-43fb-48fe-a917-e5cd89add370',
+    'ofceth:ctusd1cx',
+    'ctUSD1cx',
+    18,
+    underlyingAssetForSymbol('eth:ctusd1cx')
+  ),
   // New Base OFC tokens
   ofcerc20(
     'b096690d-92fd-4f02-83d6-e26a1ff393f3',

--- a/modules/statics/test/unit/tokenNamingConvention.ts
+++ b/modules/statics/test/unit/tokenNamingConvention.ts
@@ -64,6 +64,7 @@ describe('Token Naming Convention Tests', function () {
       'hteth:bgerchv2',
       'hteth:aut',
       'hteth:grtx',
+      'hteth:grtxp',
       'hterc6dp',
       'hterc2dp',
       'fixed',


### PR DESCRIPTION
Ticket: CSHLD-379


## Description
Onboards the following client-requested tokens as part of Batch 2:

**Mainnet:** ETH:SHVon, ETH:PT-cUSDO-28MAY2026, ETH:USD1cx, ETH:ctUSD1cx, BSC:PT-cUSDO-29OCT2026, ADA:LCC, ADA:AWLF, ADA:ASNEK, ARBETH:TT

**Testnet:** HTETH:GRTXP (Hoodi), TBASEETH:XUSD, TBASEETH:XSGD, TBASEETH:USD1cx, TBASEETH:ctUSD1cx

OFC entries added for all applicable mainnet tokens.

## Issue Number
CSHLD-379
