### PR TITLE
feat(root):add minimum length for xprv key and v2x token WP-8145

### DIFF
--- a/modules/logger/src/sanitizeLog.ts
+++ b/modules/logger/src/sanitizeLog.ts
@@ -17,6 +17,8 @@ const SENSITIVE_KEYS = new Set([
 
 const SENSITIVE_PREFIXES = ['v2x', 'xprv'];
 
+const MIN_SENSITIVE_STRING_LENGTH = 10;
+
 /**
  * Checks if a key is sensitive (case-insensitive)
  */
@@ -29,9 +31,10 @@ function isSensitiveKey(key: string): boolean {
  * Unlike isSensitiveKey (which checks property names), this identifies
  * sensitive data by recognizable content patterns — useful when there
  * is no key context (e.g. top-level strings, array elements).
+ * Requires a minimum length to avoid false positives on short strings.
  */
 function isSensitiveStringValue(s: string): boolean {
-  return SENSITIVE_PREFIXES.some((prefix) => s.startsWith(prefix));
+  return s.length >= MIN_SENSITIVE_STRING_LENGTH && SENSITIVE_PREFIXES.some((prefix) => s.startsWith(prefix));
 }
 
 export function getErrorData(error: unknown): unknown {

--- a/modules/logger/test/unit/sanitizeLog.ts
+++ b/modules/logger/test/unit/sanitizeLog.ts
@@ -33,8 +33,12 @@ describe('sanitize', function () {
       assert.strictEqual(sanitize(V2_TOKEN), '<REMOVED>');
     });
 
-    it('should redact a short string starting with v2x', function () {
-      assert.strictEqual(sanitize('v2xaabb'), '<REMOVED>');
+    it('should not redact a short string starting with v2x', function () {
+      assert.strictEqual(sanitize('v2xaabb'), 'v2xaabb');
+    });
+
+    it('should not redact a short string starting with xprv', function () {
+      assert.strictEqual(sanitize('xprv9abc'), 'xprv9abc');
     });
 
     it('should redact a string starting with xprv', function () {
@@ -106,8 +110,8 @@ describe('sanitize', function () {
       assert.deepStrictEqual(sanitize({ key: XPRV_KEY }), { key: '<REMOVED>' });
     });
 
-    it('should redact a short v2x object value', function () {
-      assert.deepStrictEqual(sanitize({ key: 'v2xaabb' }), { key: '<REMOVED>' });
+    it('should not redact a short v2x object value', function () {
+      assert.deepStrictEqual(sanitize({ key: 'v2xaabb' }), { key: 'v2xaabb' });
     });
 
     it('should not redact when sensitive prefix is not at the start of value', function () {


### PR DESCRIPTION
TICKET: WP-8145

Added **MIN_SENSITIVE_STRING_LENGTH = 10** inorder not to sanitize the small strings like "v2x2bc" and "xprv12sc".
Not a must needed change but good to have.