### PR TITLE
fix(sdk-coin-tempo): fix nonce 0 RLP encoding and verifyTransaction

### DIFF
--- a/modules/sdk-coin-tempo/src/lib/transaction.ts
+++ b/modules/sdk-coin-tempo/src/lib/transaction.ts
@@ -128,7 +128,7 @@ export class Tip20Transaction extends BaseTransaction {
       callsTuples,
       accessTuples,
       '0x', // nonceKey (reserved for 2D nonce system)
-      ethers.utils.hexlify(this.txRequest.nonce),
+      this.txRequest.nonce ? this.bigintToHex(BigInt(this.txRequest.nonce)) : '0x',
       '0x', // validBefore (reserved for time bounds)
       '0x', // validAfter (reserved for time bounds)
       this.txRequest.feeToken || '0x',

--- a/modules/sdk-coin-tempo/src/tempo.ts
+++ b/modules/sdk-coin-tempo/src/tempo.ts
@@ -25,7 +25,7 @@ import {
 } from '@bitgo/sdk-core';
 import { BaseCoin as StaticsBaseCoin, coins } from '@bitgo/statics';
 import { Tip20Transaction, Tip20TransactionBuilder } from './lib';
-import { amountToTip20Units, isValidMemoId as isValidMemoIdUtil } from './lib/utils';
+import { amountToTip20Units, isTip20Transaction, isValidMemoId as isValidMemoIdUtil } from './lib/utils';
 import * as url from 'url';
 import * as querystring from 'querystring';
 
@@ -213,6 +213,9 @@ export class Tempo extends AbstractEthLikeNewCoins {
     if (!txHex) {
       return {};
     }
+    if (!isTip20Transaction(txHex)) {
+      return {};
+    }
     const txBuilder = this.getTransactionBuilder();
     txBuilder.from(txHex);
     const tx = (await txBuilder.build()) as Tip20Transaction;
@@ -241,8 +244,14 @@ export class Tempo extends AbstractEthLikeNewCoins {
       return true;
     }
 
+    // signableHex may arrive without the 0x prefix (e.g. from the TSS signing flow).
+    const txHex = txPrebuild.txHex.startsWith('0x') ? txPrebuild.txHex : '0x' + txPrebuild.txHex;
+    if (!isTip20Transaction(txHex)) {
+      throw new Error(`Invalid Tempo transaction hex: expected a 0x76 TIP-20 transaction`);
+    }
+
     const txBuilder = this.getTransactionBuilder();
-    txBuilder.from(txPrebuild.txHex);
+    txBuilder.from(txHex);
     const tx = (await txBuilder.build()) as Tip20Transaction;
     const operations = tx.getOperations();
 


### PR DESCRIPTION
Ticket: CECHO-325

- ethers.utils.hexlify(0) emits "0x00" but Tempo's RLP decoder requires empty bytes ("0x") for zero, breaking first withdrawals (nonce 0). Use bigintToHex which handles this correctly.
- Add 0x-prefix normalization in verifyTransaction for TSS signableHex compatibility. Guard parseTransaction against non-TIP-20 hex.

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
