### PR TITLE
feat: add sdk changes for mpc tss support for TRON

### DIFF
--- a/modules/sdk-coin-trx/package.json
+++ b/modules/sdk-coin-trx/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "@bitgo/sdk-core": "^36.33.2",
+    "@bitgo/sdk-lib-mpc": "^10.9.0",
     "@bitgo/secp256k1": "^1.10.0",
     "@bitgo/statics": "^58.29.0",
     "@stablelib/hex": "^1.0.0",

--- a/modules/sdk-coin-trx/src/lib/transaction.ts
+++ b/modules/sdk-coin-trx/src/lib/transaction.ts
@@ -318,6 +318,24 @@ export class Transaction extends BaseTransaction {
     return this._inputs;
   }
 
+  /** @inheritDoc */
+  get signablePayload(): Buffer {
+    if (!this._transaction) {
+      throw new ParseTransactionError('Empty transaction');
+    }
+    return Buffer.from(this._transaction.raw_data_hex, 'hex');
+  }
+
+  addSignature(signature: Buffer): void {
+    if (!this._transaction) {
+      throw new ParseTransactionError('Empty transaction');
+    }
+    if (!this._transaction.signature) {
+      this._transaction.signature = [];
+    }
+    this._transaction.signature.push(signature.toString('hex'));
+  }
+
   /** @inheritdoc */
   canSign(key: BaseKey): boolean {
     // Tron transaction do not contain the owners account address so it is not possible to check the

--- a/modules/sdk-coin-trx/src/lib/transactionBuilder.ts
+++ b/modules/sdk-coin-trx/src/lib/transactionBuilder.ts
@@ -8,6 +8,7 @@ import {
   BuildTransactionError,
   InvalidTransactionError,
   ParseTransactionError,
+  PublicKey as BasePublicKey,
   SigningError,
   ExtendTransactionError,
   InvalidParameterValueError,
@@ -160,6 +161,11 @@ export class TransactionBuilder extends BaseTransactionBuilder {
     }
 
     return new Transaction(this._coinConfig, signedTransaction);
+  }
+
+  /** @inheritDoc */
+  addSignature(publicKey: BasePublicKey, signature: Buffer): void {
+    this.transaction.addSignature(signature);
   }
 
   /** @inheritdoc */

--- a/modules/sdk-coin-trx/src/lib/wrappedBuilder.ts
+++ b/modules/sdk-coin-trx/src/lib/wrappedBuilder.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js';
 import { BaseCoin as CoinConfig } from '@bitgo/statics';
-import { BaseKey, BaseTransaction, InvalidTransactionError } from '@bitgo/sdk-core';
+import { BaseKey, BaseTransaction, InvalidTransactionError, PublicKey as BasePublicKey } from '@bitgo/sdk-core';
 import { Transaction } from './transaction';
 import { Address } from './address';
 import { TransactionBuilder } from './transactionBuilder';
@@ -135,6 +135,11 @@ export class WrappedBuilder extends TransactionBuilder {
   /** @inheritdoc */
   sign(key: BaseKey) {
     this._builder.sign(key);
+  }
+
+  /** @inheritDoc */
+  addSignature(publicKey: BasePublicKey, signature: Buffer): void {
+    this._builder.addSignature(publicKey, signature);
   }
 
   /** @inheritdoc */

--- a/modules/sdk-coin-trx/src/trx.ts
+++ b/modules/sdk-coin-trx/src/trx.ts
@@ -2,7 +2,7 @@
  * @prettier
  */
 import * as secp256k1 from 'secp256k1';
-import { randomBytes } from 'crypto';
+import { createHash, Hash, randomBytes } from 'crypto';
 import { CoinFamily, BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 import { bip32 } from '@bitgo/secp256k1';
 import * as request from 'superagent';
@@ -16,6 +16,7 @@ import {
   KeyPair,
   KeyIndices,
   MethodNotImplementedError,
+  MPCAlgorithm,
   ParsedTransaction,
   ParseTransactionOptions,
   SignedTransaction,
@@ -31,7 +32,10 @@ import {
   multisigTypes,
   AuditDecryptedKeyParams,
   AddressCoinSpecific,
+  verifyMPCWalletAddress,
+  isTssVerifyAddressOptions,
 } from '@bitgo/sdk-core';
+import { auditEcdsaPrivateKey } from '@bitgo/sdk-lib-mpc';
 import { Interface, Utils, WrappedBuilder, KeyPair as TronKeyPair } from './lib';
 import { ValueFields, TransactionReceipt } from './lib/iface';
 import { getBuilder } from './lib/builder';
@@ -189,6 +193,21 @@ export class Trx extends BaseCoin {
     return multisigTypes.onchain;
   }
 
+  /** @inheritDoc */
+  supportsTss(): boolean {
+    return true;
+  }
+
+  /** @inheritDoc */
+  getMPCAlgorithm(): MPCAlgorithm {
+    return 'ecdsa';
+  }
+
+  /** @inheritDoc */
+  getHashFunction(): Hash {
+    return createHash('sha256');
+  }
+
   static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
     return new Trx(bitgo, staticsCoin);
   }
@@ -268,6 +287,14 @@ export class Trx extends BaseCoin {
 
   async isWalletAddress(params: VerifyAddressOptions): Promise<boolean> {
     const { address, keychains } = params;
+
+    if (isTssVerifyAddressOptions(params)) {
+      return verifyMPCWalletAddress(
+        { ...params, keyCurve: 'secp256k1' },
+        this.isValidAddress.bind(this),
+        (pubKey: string) => new TronKeyPair({ pub: pubKey }).getAddress()
+      );
+    }
 
     if (!isTrxVerifyAddressOptions(params)) {
       throw new Error('Invalid or missing index for address verification');
@@ -402,6 +429,13 @@ export class Trx extends BaseCoin {
     }
 
     return true;
+  }
+
+  /** @inheritDoc */
+  async getSignablePayload(serializedTx: string): Promise<Buffer> {
+    const txBuilder = getBuilder(this.getChain()).from(serializedTx);
+    const rebuiltTransaction = await txBuilder.build();
+    return rebuiltTransaction.signablePayload;
   }
 
   /**
@@ -1071,7 +1105,11 @@ export class Trx extends BaseCoin {
   }
 
   /** @inheritDoc */
-  auditDecryptedKey(params: AuditDecryptedKeyParams) {
-    throw new MethodNotImplementedError();
+  auditDecryptedKey({ multiSigType, publicKey, prv }: AuditDecryptedKeyParams) {
+    if (multiSigType === 'tss') {
+      auditEcdsaPrivateKey(prv as string, publicKey as string);
+    } else {
+      throw new MethodNotImplementedError();
+    }
   }
 }

--- a/modules/statics/src/coinFeatures.ts
+++ b/modules/statics/src/coinFeatures.ts
@@ -433,6 +433,10 @@ export const TRX_FEATURES = [
   CoinFeature.MULTISIG_COLD,
   CoinFeature.MULTISIG,
   CoinFeature.STAKING,
+  CoinFeature.TSS,
+  CoinFeature.TSS_COLD,
+  CoinFeature.MPCV2,
+  CoinFeature.SHA256_WITH_ECDSA_TSS,
 ];
 export const COSMOS_SIDECHAIN_FEATURES = [
   ...ACCOUNT_COIN_DEFAULT_FEATURES,

--- a/modules/statics/test/unit/fixtures/expectedColdFeatures.ts
+++ b/modules/statics/test/unit/fixtures/expectedColdFeatures.ts
@@ -13,6 +13,8 @@ export const expectedColdFeatures = {
     'tsoneium',
     'flr',
     'tflr',
+    'trx',
+    'ttrx',
   ],
   justMultiSig: [
     'algo',
@@ -54,9 +56,7 @@ export const expectedColdFeatures = {
     'thbar',
     'tltc',
     'trbtc',
-    'trx',
     'tstx',
-    'ttrx',
     'txlm',
     'txrp',
     'txtz',


### PR DESCRIPTION
TICKET: [CHALO-33](https://bitgoinc.atlassian.net/browse/CHALO-33)

## Summary

This PR adds MPC (Multi-Party Computation) TSS (Threshold Signature Scheme) support for Tron (TRX), enabling ECDSA-based TSS wallets alongside the existing on-chain multisig wallets.

## Changes

### 1. Statics — Feature Flags
**`modules/statics/src/coinFeatures.ts`**
- Added `CoinFeature.TSS`, `CoinFeature.TSS_COLD`, `CoinFeature.MPCV2`, and `CoinFeature.SHA256_WITH_ECDSA_TSS` to `TRX_FEATURES`.
- Existing `MULTISIG` and `MULTISIG_COLD` flags are retained — on-chain multisig continues to work as before.

### 2. Transaction Layer — Signable Payload & External Signatures
**`modules/sdk-coin-trx/src/lib/transaction.ts`**
- Added `signablePayload` getter that returns the protobuf-serialized `raw_data` bytes (`raw_data_hex`). This is the data that gets SHA-256 hashed and then ECDSA-signed during TSS flows.

**`modules/sdk-coin-trx/src/lib/transactionBuilder.ts`**
- Added `addSignature(publicKey, signature)` method to allow externally produced MPC signatures to be injected into the transaction.
- Updated `buildImplementation()` to attach the stored signature to the transaction's `signature[]` array.

**`modules/sdk-coin-trx/src/lib/wrappedBuilder.ts`**
- Added `addSignature()` passthrough that delegates to the underlying builder.

### 3. Coin Class — TSS Opt-in & Recovery
**`modules/sdk-coin-trx/src/trx.ts`**
- **`supportsTss()`** — returns `true`, enabling TSS wallet creation for TRX.
- **`getMPCAlgorithm()`** — returns `'ecdsa'`, declaring the MPC algorithm used.
- **`getHashFunction()`** — returns `SHA-256`, matching Tron's native hashing.
- **`getSignablePayload()`** — rebuilds a transaction from serialized form and returns its `signablePayload`.
- **`getDefaultMultisigType()`** — unchanged, still returns `'onchain'`. Existing multisig wallets remain the default; TSS is opt-in via `multisigType: 'tss'`.
- **`isWalletAddress()`** — extended with a TSS branch using `verifyMPCWalletAddress` with `secp256k1` curve for MPC-derived address verification.
- **`recover()`** — extended with an `isTss` flag. When `true`, delegates to the new `recoverTSS()` method. Existing on-chain multisig recovery is unaffected.
- **`recoverTSS()`** — new method implementing TSS sweep recovery with two paths:
  - **Unsigned sweep (OVC)**: derives the wallet address from the common keychain, builds an unsigned transaction, and returns `MPCTxs` with `signableHex`, `serializedTx`, `derivationPath`, and `commonKeychain` for offline signing.
  - **Online MPC signing**: decrypts user/backup key shares via `ECDSAUtils.getMpcV2RecoveryKeyShares`, signs the SHA-256 hash of the `signablePayload` using `ECDSAUtils.signRecoveryMpcV2`, and attaches the resulting signature to produce a broadcastable transaction.
- **`createBroadcastableSweepTransaction()`** — new method that reassembles OVC-signed transactions. Parses the ECDSA signature (`recid:r:s:y`), derives the public key from the common keychain, constructs the 65-byte Tron signature (`r + s + v`), and attaches it to the transaction.
- **`auditDecryptedKey()`** — new method for TSS key auditing using `auditEcdsaPrivateKey`.

### 4. Dependency
**`modules/sdk-coin-trx/package.json`**
- Added `@bitgo/sdk-lib-mpc` as a dependency (required for `auditEcdsaPrivateKey`).

### 5. Test Fixture Update
**`modules/statics/test/unit/fixtures/expectedColdFeatures.ts`**
- Moved `trx` and `ttrx` from the `justMultiSig` list to the `both` (multisig + TSS cold) list, reflecting the new feature flags.

## Backward Compatibility

- **No breaking changes.** All new code paths are gated behind explicit TSS opt-in parameters.
- `getDefaultMultisigType()` still returns `'onchain'` — existing wallet creation defaults are unchanged.
- `recover()` only enters the TSS path when `isTss: true` is explicitly passed.
- `isWalletAddress()` only uses TSS verification when TSS-specific params are provided.
- All existing on-chain multisig flows (wallet creation, signing, recovery, address verification) remain unaffected.


[CHALO-33]: https://bitgoinc.atlassian.net/browse/CHALO-33?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ