### PR TITLE
feat(statics): add ofchteth:grtxp OFC token

### DIFF
--- a/modules/statics/src/coins/ofcErc20Coins.ts
+++ b/modules/statics/src/coins/ofcErc20Coins.ts
@@ -3942,6 +3942,20 @@ export const tOfcErc20Coins = [
     'hteth'
   ),
   tofcerc20(
+    'ae475c8a-9fa0-49fe-9a77-66cfbc023c71',
+    'ofchteth:grtxp',
+    'GreatX Property Token',
+    18,
+    UnderlyingAsset['hteth:grtxp'],
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    'hteth'
+  ),
+  tofcerc20(
     '4dc4534c-72b8-4a68-a914-210dae1e5d4d',
     'ofchteth:usd1',
     'Test USD1 Token',


### PR DESCRIPTION
Ticket: CSHLD-379

## Description:
- Adds `ofchteth:grtxp` (GreatX Property Token) OFC token to `ofcErc20Coins.ts`
- `hteth:grtxp` was already registered as a testnet ERC-20 on Hoodi network
- The OFC equivalent `ofchteth:grtxp` was missed in the original batch 2 onboarding (CSHLD-379)
- Without this, prime-microservices staging config fails to resolve the OFC backing for `hteth:grtxp`