### PR TITLE
feat(abstract-utxo): upgrade @bitgo/wasm-utxo to v2.1.0

### DIFF
--- a/modules/abstract-utxo/package.json
+++ b/modules/abstract-utxo/package.json
@@ -66,7 +66,7 @@
     "@bitgo/utxo-core": "^1.34.0",
     "@bitgo/utxo-lib": "^11.21.0",
     "@bitgo/utxo-ord": "^1.27.0",
-    "@bitgo/wasm-utxo": "^1.42.0",
+    "@bitgo/wasm-utxo": "^2.1.0",
     "@types/lodash": "^4.14.121",
     "@types/superagent": "4.1.15",
     "bignumber.js": "^9.0.2",

--- a/modules/abstract-utxo/src/transaction/fixedScript/explainPsbtWasm.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/explainPsbtWasm.ts
@@ -78,7 +78,7 @@ export function explainPsbtWasm(
   const customChangeAmount = customChangeOutputs.reduce((sum, output) => sum + BigInt(output.amount), BigInt(0));
 
   return {
-    id: psbt.unsignedTxid(),
+    id: psbt.unsignedTxId(),
     outputAmount: outputAmount.toString(),
     changeAmount: changeAmount.toString(),
     customChangeAmount: customChangeAmount.toString(),

--- a/modules/abstract-utxo/src/transaction/fixedScript/signPsbtWasm.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/signPsbtWasm.ts
@@ -95,13 +95,13 @@ export async function signPsbtWithMusig2ParticipantWasm(
       case 'signerNonce':
         assert(wasmSigner);
         tx.generateMusig2Nonces(wasmSigner);
-        PSBT_CACHE_WASM.set(tx.unsignedTxid(), tx);
+        PSBT_CACHE_WASM.set(tx.unsignedTxId(), tx);
         return tx;
       case 'cosignerNonce':
         assert(params.walletId, 'walletId is required for MuSig2 bitgo nonce');
         return await coin.getMusig2Nonces(tx, params.walletId);
       case 'signerSignature': {
-        const txId = tx.unsignedTxid();
+        const txId = tx.unsignedTxId();
         const cachedPsbt = PSBT_CACHE_WASM.get(txId);
         assert(
           cachedPsbt,

--- a/modules/abstract-utxo/test/unit/postProcessPrebuild.ts
+++ b/modules/abstract-utxo/test/unit/postProcessPrebuild.ts
@@ -31,7 +31,7 @@ describe('Post Build Validation', function () {
     // Parse result as PSBT
     const resultPsbt = BitGoPsbt.fromBytes(Buffer.from(postProcessBuilt.txHex as string, 'hex'), 'tbtc');
 
-    resultPsbt.lockTime.should.equal(0);
+    resultPsbt.lockTime().should.equal(0);
 
     // Check sequences via parseTransactionWithWalletKeys
     const parsed = resultPsbt.parseTransactionWithWalletKeys(walletKeys, { replayProtection: { publicKeys: [] } });

--- a/modules/utxo-bin/package.json
+++ b/modules/utxo-bin/package.json
@@ -31,7 +31,7 @@
     "@bitgo/unspents": "^0.51.1",
     "@bitgo/utxo-core": "^1.34.0",
     "@bitgo/utxo-lib": "^11.21.0",
-    "@bitgo/wasm-utxo": "^1.42.0",
+    "@bitgo/wasm-utxo": "^2.1.0",
     "@noble/curves": "1.8.1",
     "archy": "^1.0.0",
     "bech32": "^2.0.0",

--- a/modules/utxo-core/package.json
+++ b/modules/utxo-core/package.json
@@ -81,7 +81,7 @@
     "@bitgo/secp256k1": "^1.10.0",
     "@bitgo/unspents": "^0.51.1",
     "@bitgo/utxo-lib": "^11.21.0",
-    "@bitgo/wasm-utxo": "^1.42.0",
+    "@bitgo/wasm-utxo": "^2.1.0",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
     "fast-sha256": "^1.3.0"
   },

--- a/modules/utxo-ord/package.json
+++ b/modules/utxo-ord/package.json
@@ -45,7 +45,7 @@
     "directory": "modules/utxo-ord"
   },
   "dependencies": {
-    "@bitgo/wasm-utxo": "^1.42.0"
+    "@bitgo/wasm-utxo": "^2.1.0"
   },
   "devDependencies": {
     "@bitgo/utxo-lib": "^11.21.0"

--- a/modules/utxo-staking/package.json
+++ b/modules/utxo-staking/package.json
@@ -63,7 +63,7 @@
     "@bitgo/babylonlabs-io-btc-staking-ts": "^3.4.1",
     "@bitgo/utxo-core": "^1.34.0",
     "@bitgo/utxo-lib": "^11.21.0",
-    "@bitgo/wasm-utxo": "^1.42.0",
+    "@bitgo/wasm-utxo": "^2.1.0",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
     "bip322-js": "^2.0.0",
     "bitcoinjs-lib": "^6.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -990,10 +990,10 @@
   resolved "https://registry.npmjs.org/@bitgo/wasm-solana/-/wasm-solana-2.6.0.tgz#c8b57ab010f22f1a1c90681cd180814c4ec2867b"
   integrity sha512-F9H4pXDMhfsZW5gNEcoaBzVoEMOQRP8wbQKmjsxbm5PXBq+0Aj54rOY3bswdrFZK377/aeB+tLjXu3h9i8gInQ==
 
-"@bitgo/wasm-utxo@^1.42.0":
-  version "1.42.0"
-  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-1.42.0.tgz#29754e9b947fd9d5c303cb5f5043a031cd04754b"
-  integrity sha512-VKhlaSVjD7dTjYw5yNbRVTQh84zuyiEcLSldhzbnkrWgZL+3+xYaOAWicVJaE5Bk37AYWRL+7aiwbCtosF7zug==
+"@bitgo/wasm-utxo@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-2.1.0.tgz#a2087b795a3eb7bfca2cc25a88b3491a74d4da06"
+  integrity sha512-JukZ+g0lH1IzcwAVGp41a4XgWVZvL1hA+ym3KsU7NIqhOG57brc1nSVoqAhIe93gsfWQ7hyz3jsFueBXbwBQmQ==
 
 "@brandonblack/musig@^0.0.1-alpha.0":
   version "0.0.1-alpha.1"


### PR DESCRIPTION
Update wasm-utxo dependency across multiple modules and adapt to
breaking API change where `unsignedTxid()` was renamed to
`unsignedTxId()`.

Issue: BTC-2768

Co-authored-by: llm-git <llm-git@ttll.de>