### PR TITLE
feat(abstract-utxo): modernize test infrastructure

### DIFF
--- a/modules/abstract-utxo/package.json
+++ b/modules/abstract-utxo/package.json
@@ -26,7 +26,7 @@
     "build": "npm run build:cjs && npm run build:esm",
     "build:cjs": "yarn tsc --build --incremental --verbose .",
     "build:esm": "yarn tsc --project tsconfig.esm.json",
-    "fmt": "prettier --write .",
+    "fmt": "prettier --write '{src,test}/**/*.{ts,js,json}'",
     "check-fmt": "prettier --check '{src,test}/**/*.{ts,js,json}'",
     "clean": "rm -rf ./dist",
     "lint": "eslint --quiet .",

--- a/modules/abstract-utxo/test/integration/impl/bch/bch.ts
+++ b/modules/abstract-utxo/test/integration/impl/bch/bch.ts
@@ -1,5 +1,5 @@
-import * as should from 'should';
-import 'should-http';
+import assert from 'node:assert/strict';
+
 import { BitGoAPI } from '@bitgo/sdk-api';
 import { TestBitGo, TestBitGoAPI } from '@bitgo/sdk-test';
 import * as nock from 'nock';
@@ -34,13 +34,13 @@ describe('BCH:', function () {
         otp: bitgo.testUserOTP(),
       });
 
-      should.exist(transaction);
-      transaction.should.have.property('transfer');
-      transaction.should.have.property('txid');
-      transaction.should.have.property('tx');
-      transaction.status.should.containEql('signed');
-      transaction.transfer.type.should.containEql('send');
-      transaction.transfer.wallet.should.containEql(wallet._wallet.id);
+      assert.ok(transaction != null);
+      assert.ok('transfer' in transaction);
+      assert.ok('txid' in transaction);
+      assert.ok('tx' in transaction);
+      assert.ok(transaction.status.includes('signed'));
+      assert.ok(transaction.transfer.type.includes('send'));
+      assert.ok(transaction.transfer.wallet.includes(wallet._wallet.id));
     });
   });
 });

--- a/modules/abstract-utxo/test/unit/customSigner.ts
+++ b/modules/abstract-utxo/test/unit/customSigner.ts
@@ -1,11 +1,9 @@
 import * as utxoLib from '@bitgo/utxo-lib';
-import 'should';
-import 'should-sinon';
 import nock = require('nock');
 import * as sinon from 'sinon';
 import { CustomSigningFunction, common } from '@bitgo/sdk-core';
 
-import { defaultBitGo, getDefaultWalletKeys, getUtxoCoin, getUtxoWallet } from './util';
+import { defaultBitGo, getDefaultWalletKeys, getUtxoCoin, getUtxoWallet, assertHasProperty } from './util';
 
 nock.disableNetConnect();
 
@@ -65,8 +63,8 @@ describe('UTXO Custom Signer Function', function () {
     const scope = nocks({ txHex: psbt.toHex() });
     const result = await wallet.sendMany({ recipients, customSigningFunction });
 
-    result.should.have.property('ok', true);
-    customSigningFunction.should.have.been.calledTwice();
+    assertHasProperty(result, 'ok', true);
+    sinon.assert.calledTwice(customSigningFunction as sinon.SinonStub);
     scope.done();
   });
 
@@ -81,8 +79,8 @@ describe('UTXO Custom Signer Function', function () {
     const scope = nocks({ txHex: psbt.toHex() });
     const result = await wallet.sendMany({ recipients, customSigningFunction });
 
-    result.should.have.property('ok', true);
-    customSigningFunction.should.have.been.calledOnce();
+    assertHasProperty(result, 'ok', true);
+    sinon.assert.calledOnce(customSigningFunction as sinon.SinonStub);
     scope.done();
   });
 
@@ -97,8 +95,8 @@ describe('UTXO Custom Signer Function', function () {
     const scope = nocks({ txHex: tx.buildIncomplete().toHex() });
     const result = await wallet.sendMany({ recipients, customSigningFunction });
 
-    result.should.have.property('ok', true);
-    customSigningFunction.should.have.been.calledOnce();
+    assertHasProperty(result, 'ok', true);
+    sinon.assert.calledOnce(customSigningFunction as sinon.SinonStub);
     scope.done();
   });
 });

--- a/modules/abstract-utxo/test/unit/impl/bch/unit/bch.ts
+++ b/modules/abstract-utxo/test/unit/impl/bch/unit/bch.ts
@@ -1,7 +1,13 @@
+import assert from 'node:assert/strict';
+
 import { BitGoAPI } from '@bitgo/sdk-api';
 import { TestBitGo, TestBitGoAPI } from '@bitgo/sdk-test';
 
 import { Bch, Tbch } from '../../../../../src/impl/bch';
+
+function eq(actual: string, expected: string) {
+  assert.strictEqual(actual, expected);
+}
 
 describe('Custom BCH Tests', function () {
   const bitgo: TestBitGoAPI = TestBitGo.decorate(BitGoAPI, { env: 'test' });
@@ -15,145 +21,117 @@ describe('Custom BCH Tests', function () {
   // we use mainnet bch so we can reuse the mainnet address examples
   it('should correctly convert addresses', function () {
     // P2PKH cashaddr -> cashaddr
-    bch
-      .canonicalAddress('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a', 'cashaddr')
-      .should.equal('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a');
-    bch
-      .canonicalAddress('qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a', 'cashaddr')
-      .should.equal('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a');
-
+    eq(
+      bch.canonicalAddress('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a', 'cashaddr'),
+      'bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a'
+    );
+    eq(
+      bch.canonicalAddress('qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a', 'cashaddr'),
+      'bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a'
+    );
     // P2PKH base58 -> cashaddr
-    bch
-      .canonicalAddress('1BpEi6DfDAUFd7GtittLSdBeYJvcoaVggu', 'cashaddr')
-      .should.equal('bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a');
-
+    eq(
+      bch.canonicalAddress('1BpEi6DfDAUFd7GtittLSdBeYJvcoaVggu', 'cashaddr'),
+      'bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a'
+    );
     // P2SH cashaddr -> cashaddr
-    bch
-      .canonicalAddress('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq', 'cashaddr')
-      .should.equal('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq');
-    bch
-      .canonicalAddress('ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq', 'cashaddr')
-      .should.equal('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq');
-
+    eq(
+      bch.canonicalAddress('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq', 'cashaddr'),
+      'bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq'
+    );
+    eq(
+      bch.canonicalAddress('ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq', 'cashaddr'),
+      'bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq'
+    );
     // P2SH base58 -> cashaddr
-    bch
-      .canonicalAddress('3CWFddi6m4ndiGyKqzYvsFYagqDLPVMTzC', 'cashaddr')
-      .should.equal('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq');
-
+    eq(
+      bch.canonicalAddress('3CWFddi6m4ndiGyKqzYvsFYagqDLPVMTzC', 'cashaddr'),
+      'bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq'
+    );
     // no 'bitcoincash:' prefix
-    bch
-      .canonicalAddress('ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq', 'cashaddr')
-      .should.equal('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq');
-
+    eq(
+      bch.canonicalAddress('ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq', 'cashaddr'),
+      'bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq'
+    );
     // P2PKH cashaddr -> base58
-    bch
-      .canonicalAddress('bitcoincash:qqq3728yw0y47sqn6l2na30mcw6zm78dzqre909m2r', 'base58')
-      .should.equal('16w1D5WRVKJuZUsSRzdLp9w3YGcgoxDXb');
-    bch
-      .canonicalAddress('qqq3728yw0y47sqn6l2na30mcw6zm78dzqre909m2r', 'base58')
-      .should.equal('16w1D5WRVKJuZUsSRzdLp9w3YGcgoxDXb');
-
+    eq(
+      bch.canonicalAddress('bitcoincash:qqq3728yw0y47sqn6l2na30mcw6zm78dzqre909m2r', 'base58'),
+      '16w1D5WRVKJuZUsSRzdLp9w3YGcgoxDXb'
+    );
+    eq(
+      bch.canonicalAddress('qqq3728yw0y47sqn6l2na30mcw6zm78dzqre909m2r', 'base58'),
+      '16w1D5WRVKJuZUsSRzdLp9w3YGcgoxDXb'
+    );
     // P2PKH base58 -> base58
-    bch
-      .canonicalAddress('16w1D5WRVKJuZUsSRzdLp9w3YGcgoxDXb', 'base58')
-      .should.equal('16w1D5WRVKJuZUsSRzdLp9w3YGcgoxDXb');
-
+    eq(bch.canonicalAddress('16w1D5WRVKJuZUsSRzdLp9w3YGcgoxDXb', 'base58'), '16w1D5WRVKJuZUsSRzdLp9w3YGcgoxDXb');
     // P2SH cashaddr -> base58
-    bch
-      .canonicalAddress('bitcoincash:pr95sy3j9xwd2ap32xkykttr4cvcu7as4yc93ky28e', 'base58')
-      .should.equal('3LDsS579y7sruadqu11beEJoTjdFiFCdX4');
-    bch
-      .canonicalAddress('pr95sy3j9xwd2ap32xkykttr4cvcu7as4yc93ky28e', 'base58')
-      .should.equal('3LDsS579y7sruadqu11beEJoTjdFiFCdX4');
-
+    eq(
+      bch.canonicalAddress('bitcoincash:pr95sy3j9xwd2ap32xkykttr4cvcu7as4yc93ky28e', 'base58'),
+      '3LDsS579y7sruadqu11beEJoTjdFiFCdX4'
+    );
+    eq(
+      bch.canonicalAddress('pr95sy3j9xwd2ap32xkykttr4cvcu7as4yc93ky28e', 'base58'),
+      '3LDsS579y7sruadqu11beEJoTjdFiFCdX4'
+    );
     // P2SH base58 -> base58
-    bch
-      .canonicalAddress('3LDsS579y7sruadqu11beEJoTjdFiFCdX4', 'base58')
-      .should.equal('3LDsS579y7sruadqu11beEJoTjdFiFCdX4');
-
+    eq(bch.canonicalAddress('3LDsS579y7sruadqu11beEJoTjdFiFCdX4', 'base58'), '3LDsS579y7sruadqu11beEJoTjdFiFCdX4');
     // undefined version defaults to base58
-    bch
-      .canonicalAddress('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq')
-      .should.equal('3CWFddi6m4ndiGyKqzYvsFYagqDLPVMTzC');
-    bch
-      .canonicalAddress('ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq')
-      .should.equal('3CWFddi6m4ndiGyKqzYvsFYagqDLPVMTzC');
-
+    eq(
+      bch.canonicalAddress('bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq'),
+      '3CWFddi6m4ndiGyKqzYvsFYagqDLPVMTzC'
+    );
+    eq(bch.canonicalAddress('ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq'), '3CWFddi6m4ndiGyKqzYvsFYagqDLPVMTzC');
     // all capitalized
-    bch
-      .canonicalAddress('BITCOINCASH:QQQ3728YW0Y47SQN6L2NA30MCW6ZM78DZQRE909M2R', 'base58')
-      .should.equal('16w1D5WRVKJuZUsSRzdLp9w3YGcgoxDXb');
-    bch
-      .canonicalAddress('QQQ3728YW0Y47SQN6L2NA30MCW6ZM78DZQRE909M2R', 'base58')
-      .should.equal('16w1D5WRVKJuZUsSRzdLp9w3YGcgoxDXb');
-
+    eq(
+      bch.canonicalAddress('BITCOINCASH:QQQ3728YW0Y47SQN6L2NA30MCW6ZM78DZQRE909M2R', 'base58'),
+      '16w1D5WRVKJuZUsSRzdLp9w3YGcgoxDXb'
+    );
+    eq(
+      bch.canonicalAddress('QQQ3728YW0Y47SQN6L2NA30MCW6ZM78DZQRE909M2R', 'base58'),
+      '16w1D5WRVKJuZUsSRzdLp9w3YGcgoxDXb'
+    );
     // testnet addresses
-    tbch
-      .canonicalAddress('2NCEDmmKNNnqKvnWw7pE3RLzuFe5aHHVy1X', 'cashaddr')
-      .should.equal('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f');
-    tbch
-      .canonicalAddress('n3jYBjCzgGNydQwf83Hz6GBzGBhMkKfgL1', 'cashaddr')
-      .should.equal('bchtest:qremgr9dr9x5swv82k69qdjzrvdxgkaaesftdp5xla');
-    tbch
-      .canonicalAddress('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'cashaddr')
-      .should.equal('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f');
-    tbch
-      .canonicalAddress('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'cashaddr')
-      .should.equal('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f');
-    tbch
-      .canonicalAddress('prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'base58')
-      .should.equal('2NCEDmmKNNnqKvnWw7pE3RLzuFe5aHHVy1X');
-    tbch
-      .canonicalAddress('prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'base58')
-      .should.equal('2NCEDmmKNNnqKvnWw7pE3RLzuFe5aHHVy1X');
-    tbch
-      .canonicalAddress('prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'cashaddr')
-      .should.equal('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f');
+    eq(
+      tbch.canonicalAddress('2NCEDmmKNNnqKvnWw7pE3RLzuFe5aHHVy1X', 'cashaddr'),
+      'bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f'
+    );
+    eq(
+      tbch.canonicalAddress('n3jYBjCzgGNydQwf83Hz6GBzGBhMkKfgL1', 'cashaddr'),
+      'bchtest:qremgr9dr9x5swv82k69qdjzrvdxgkaaesftdp5xla'
+    );
+    eq(
+      tbch.canonicalAddress('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'cashaddr'),
+      'bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f'
+    );
+    eq(
+      tbch.canonicalAddress('bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'cashaddr'),
+      'bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f'
+    );
+    eq(
+      tbch.canonicalAddress('prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'base58'),
+      '2NCEDmmKNNnqKvnWw7pE3RLzuFe5aHHVy1X'
+    );
+    eq(
+      tbch.canonicalAddress('prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'base58'),
+      '2NCEDmmKNNnqKvnWw7pE3RLzuFe5aHHVy1X'
+    );
+    eq(
+      tbch.canonicalAddress('prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f', 'cashaddr'),
+      'bchtest:prgrnjengs555k3cff2s3gqxg3xyyr9uzyh9js5m8f'
+    );
   });
 
   it('should reject invalid addresses', function () {
-    // improperly short data segment
-    (() => {
-      bch.canonicalAddress('bitcoincash:sy3j9xwd2ap32xkykttr4cvcu7as4yc93ky28e', 'base58');
-    }).should.throw();
-
-    // mismatched data segment (cashaddr)
-    (() => {
-      bch.canonicalAddress('bitcoincash:yr95sy3j9xwd2ap32xkykttr4cvcu7as4yc93ky28e', 'base58');
-    }).should.throw();
-
-    // double prefix
-    (() => {
-      bch.canonicalAddress('bitcoincash:bitcoincash:pr95sy3j9xwd2ap32xkykttr4cvcu7as4yc93ky28e', 'base58');
-    }).should.throw();
-
-    // mismatched data segment (base58)
-    (() => {
-      bch.canonicalAddress('3DDsS579y7sruadqu11beEJoTjdFiFCdX4', 'base58');
-    }).should.throw();
-
-    // improper prefix
-    (() => {
-      bch.canonicalAddress(':qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a', 'base58');
-    }).should.throw();
-
-    (() => {
-      bch.canonicalAddress('bitcoin:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a', 'base58');
-    }).should.throw();
-
-    // mismatched capitalization
-    (() => {
-      bch.canonicalAddress('bitcoincash:QPM2Qsznhks23z7629mms6s4cwef74vcwvy22gdx6a', 'cashaddr');
-    }).should.throw();
-
-    // improper version
-    (() => {
-      bch.canonicalAddress('bitcoincash:qqq3728yw0y47sqn6l2na30mcw6zm78dzqre909m2r', 'blah');
-    }).should.throw();
-
-    // undefined address
-    (() => {
-      bch.canonicalAddress(undefined as any, 'blah');
-    }).should.throw();
+    assert.throws(() => bch.canonicalAddress('bitcoincash:sy3j9xwd2ap32xkykttr4cvcu7as4yc93ky28e', 'base58'));
+    assert.throws(() => bch.canonicalAddress('bitcoincash:yr95sy3j9xwd2ap32xkykttr4cvcu7as4yc93ky28e', 'base58'));
+    assert.throws(() =>
+      bch.canonicalAddress('bitcoincash:bitcoincash:pr95sy3j9xwd2ap32xkykttr4cvcu7as4yc93ky28e', 'base58')
+    );
+    assert.throws(() => bch.canonicalAddress('3DDsS579y7sruadqu11beEJoTjdFiFCdX4', 'base58'));
+    assert.throws(() => bch.canonicalAddress(':qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a', 'base58'));
+    assert.throws(() => bch.canonicalAddress('bitcoin:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a', 'base58'));
+    assert.throws(() => bch.canonicalAddress('bitcoincash:QPM2Qsznhks23z7629mms6s4cwef74vcwvy22gdx6a', 'cashaddr'));
+    assert.throws(() => bch.canonicalAddress('bitcoincash:qqq3728yw0y47sqn6l2na30mcw6zm78dzqre909m2r', 'blah'));
+    assert.throws(() => bch.canonicalAddress(undefined as any, 'blah'));
   });
 });

--- a/modules/abstract-utxo/test/unit/impl/bcha/unit/index.ts
+++ b/modules/abstract-utxo/test/unit/impl/bcha/unit/index.ts
@@ -1,3 +1,5 @@
+import assert from 'node:assert/strict';
+
 import { BitGoAPI } from '@bitgo/sdk-api';
 import { TestBitGo, TestBitGoAPI } from '@bitgo/sdk-test';
 
@@ -19,35 +21,36 @@ describe('Bcha', function () {
   });
 
   it('should instantiate the coin', function () {
-    let localBasecoin = bitgo.coin('tbcha');
-    localBasecoin.should.be.an.instanceof(Tbcha);
-
-    localBasecoin = bitgo.coin('bcha');
-    localBasecoin.should.be.an.instanceof(Bcha);
+    assert.ok(bitgo.coin('tbcha') instanceof Tbcha);
+    assert.ok(bitgo.coin('bcha') instanceof Bcha);
   });
 
   it('should return tbcha', function () {
-    basecoin.getChain().should.equal('tbcha');
+    assert.strictEqual(basecoin.getChain(), 'tbcha');
   });
 
   it('should return full name', function () {
-    basecoin.getFullName().should.equal('Testnet Bitcoin ABC');
+    assert.strictEqual(basecoin.getFullName(), 'Testnet Bitcoin ABC');
   });
 
   it('should convert addresses', function () {
     const mainnetBasecoin = bitgo.coin('bcha');
 
-    mainnetBasecoin
-      .canonicalAddress('38oymyUayu35QoLLKmc8CozbcHynH6Btkn', 'cashaddr')
-      .should.equal('ecash:pp8pnl7k6y8g073cggczfh22xrprxut5hymhjkq3er');
-    mainnetBasecoin
-      .canonicalAddress('ecash:pp8pnl7k6y8g073cggczfh22xrprxut5hymhjkq3er')
-      .should.equal('38oymyUayu35QoLLKmc8CozbcHynH6Btkn');
-    basecoin
-      .canonicalAddress('mzopZJiBCjeAHXkShhgxfRsALgrYt3kxNP', 'cashaddr')
-      .should.equal('ectest:qrfekq9s0c8tcuh75wpcxqnyl5e7dhqk4gq6pjct44');
-    basecoin
-      .canonicalAddress('ectest:qrfekq9s0c8tcuh75wpcxqnyl5e7dhqk4gq6pjct44')
-      .should.equal('mzopZJiBCjeAHXkShhgxfRsALgrYt3kxNP');
+    assert.strictEqual(
+      mainnetBasecoin.canonicalAddress('38oymyUayu35QoLLKmc8CozbcHynH6Btkn', 'cashaddr'),
+      'ecash:pp8pnl7k6y8g073cggczfh22xrprxut5hymhjkq3er'
+    );
+    assert.strictEqual(
+      mainnetBasecoin.canonicalAddress('ecash:pp8pnl7k6y8g073cggczfh22xrprxut5hymhjkq3er'),
+      '38oymyUayu35QoLLKmc8CozbcHynH6Btkn'
+    );
+    assert.strictEqual(
+      basecoin.canonicalAddress('mzopZJiBCjeAHXkShhgxfRsALgrYt3kxNP', 'cashaddr'),
+      'ectest:qrfekq9s0c8tcuh75wpcxqnyl5e7dhqk4gq6pjct44'
+    );
+    assert.strictEqual(
+      basecoin.canonicalAddress('ectest:qrfekq9s0c8tcuh75wpcxqnyl5e7dhqk4gq6pjct44'),
+      'mzopZJiBCjeAHXkShhgxfRsALgrYt3kxNP'
+    );
   });
 });

--- a/modules/abstract-utxo/test/unit/impl/bsv/unit/index.ts
+++ b/modules/abstract-utxo/test/unit/impl/bsv/unit/index.ts
@@ -1,3 +1,5 @@
+import assert from 'node:assert/strict';
+
 import { BitGoAPI } from '@bitgo/sdk-api';
 import { TestBitGo, TestBitGoAPI } from '@bitgo/sdk-test';
 
@@ -19,18 +21,15 @@ describe('Bsv', function () {
   });
 
   it('should instantiate the coin', function () {
-    let localBasecoin = bitgo.coin('tbsv');
-    localBasecoin.should.be.an.instanceof(Tbsv);
-
-    localBasecoin = bitgo.coin('bsv');
-    localBasecoin.should.be.an.instanceof(Bsv);
+    assert.ok(bitgo.coin('tbsv') instanceof Tbsv);
+    assert.ok(bitgo.coin('bsv') instanceof Bsv);
   });
 
   it('should return tbsv', function () {
-    basecoin.getChain().should.equal('tbsv');
+    assert.strictEqual(basecoin.getChain(), 'tbsv');
   });
 
   it('should return full name', function () {
-    basecoin.getFullName().should.equal('Testnet Bitcoin SV');
+    assert.strictEqual(basecoin.getFullName(), 'Testnet Bitcoin SV');
   });
 });

--- a/modules/abstract-utxo/test/unit/impl/btg/unit/index.ts
+++ b/modules/abstract-utxo/test/unit/impl/btg/unit/index.ts
@@ -1,3 +1,5 @@
+import assert from 'node:assert/strict';
+
 import { BitGoAPI } from '@bitgo/sdk-api';
 import { TestBitGo, TestBitGoAPI } from '@bitgo/sdk-test';
 
@@ -19,14 +21,14 @@ describe('Btg', function () {
 
   it('should instantiate the coin', function () {
     basecoin = bitgo.coin('btg');
-    basecoin.should.be.an.instanceof(Btg);
+    assert.ok(basecoin instanceof Btg);
   });
 
   it('should return btg', function () {
-    basecoin.getChain().should.equal('btg');
+    assert.strictEqual(basecoin.getChain(), 'btg');
   });
 
   it('should return full name', function () {
-    basecoin.getFullName().should.equal('Bitcoin Gold');
+    assert.strictEqual(basecoin.getFullName(), 'Bitcoin Gold');
   });
 });

--- a/modules/abstract-utxo/test/unit/impl/dash/unit/index.ts
+++ b/modules/abstract-utxo/test/unit/impl/dash/unit/index.ts
@@ -1,3 +1,5 @@
+import assert from 'node:assert/strict';
+
 import { BitGoAPI } from '@bitgo/sdk-api';
 import { TestBitGo, TestBitGoAPI } from '@bitgo/sdk-test';
 
@@ -19,18 +21,15 @@ describe('Dash', function () {
   });
 
   it('should instantiate the coin', function () {
-    let localBasecoin = bitgo.coin('tdash');
-    localBasecoin.should.be.an.instanceof(Tdash);
-
-    localBasecoin = bitgo.coin('dash');
-    localBasecoin.should.be.an.instanceof(Dash);
+    assert.ok(bitgo.coin('tdash') instanceof Tdash);
+    assert.ok(bitgo.coin('dash') instanceof Dash);
   });
 
   it('should return tdash', function () {
-    basecoin.getChain().should.equal('tdash');
+    assert.strictEqual(basecoin.getChain(), 'tdash');
   });
 
   it('should return full name', function () {
-    basecoin.getFullName().should.equal('Testnet Dash');
+    assert.strictEqual(basecoin.getFullName(), 'Testnet Dash');
   });
 });

--- a/modules/abstract-utxo/test/unit/impl/doge/unit/index.ts
+++ b/modules/abstract-utxo/test/unit/impl/doge/unit/index.ts
@@ -1,3 +1,5 @@
+import assert from 'node:assert/strict';
+
 import { BitGoAPI } from '@bitgo/sdk-api';
 import { TestBitGo, TestBitGoAPI } from '@bitgo/sdk-test';
 
@@ -19,18 +21,15 @@ describe('Doge', function () {
   });
 
   it('should instantiate the coin', function () {
-    let localBasecoin = bitgo.coin('tdoge');
-    localBasecoin.should.be.an.instanceof(Tdoge);
-
-    localBasecoin = bitgo.coin('doge');
-    localBasecoin.should.be.an.instanceof(Doge);
+    assert.ok(bitgo.coin('tdoge') instanceof Tdoge);
+    assert.ok(bitgo.coin('doge') instanceof Doge);
   });
 
   it('should return tdoge', function () {
-    basecoin.getChain().should.equal('tdoge');
+    assert.strictEqual(basecoin.getChain(), 'tdoge');
   });
 
   it('should return full name', function () {
-    basecoin.getFullName().should.equal('Testnet Dogecoin');
+    assert.strictEqual(basecoin.getFullName(), 'Testnet Dogecoin');
   });
 });

--- a/modules/abstract-utxo/test/unit/impl/zec/unit/index.ts
+++ b/modules/abstract-utxo/test/unit/impl/zec/unit/index.ts
@@ -1,4 +1,5 @@
-import 'should';
+import assert from 'node:assert/strict';
+
 import { BitGoAPI } from '@bitgo/sdk-api';
 
 import { Zec, Tzec } from '../../../../../src/impl/zec';
@@ -16,18 +17,15 @@ describe('Zec', function () {
   });
 
   it('should instantiate the coin', function () {
-    let localBasecoin = bitgo.coin('tzec');
-    localBasecoin.should.be.an.instanceof(Tzec);
-
-    localBasecoin = bitgo.coin('zec');
-    localBasecoin.should.be.an.instanceof(Zec);
+    assert.ok(bitgo.coin('tzec') instanceof Tzec);
+    assert.ok(bitgo.coin('zec') instanceof Zec);
   });
 
   it('should return tzec', function () {
-    basecoin.getChain().should.equal('tzec');
+    assert.strictEqual(basecoin.getChain(), 'tzec');
   });
 
   it('should return full name', function () {
-    basecoin.getFullName().should.equal('Testnet ZCash');
+    assert.strictEqual(basecoin.getFullName(), 'Testnet ZCash');
   });
 });

--- a/modules/abstract-utxo/test/unit/keychains.ts
+++ b/modules/abstract-utxo/test/unit/keychains.ts
@@ -1,6 +1,5 @@
 import * as assert from 'assert';
 
-import 'should';
 import { type TestBitGoAPI, TestBitGo } from '@bitgo/sdk-test';
 import { BitGoAPI } from '@bitgo/sdk-api';
 
@@ -14,7 +13,7 @@ function run(coin: AbstractUtxoCoin) {
     it('validates pub', function () {
       const { pub } = coin.keychains().create();
       assert.ok(pub);
-      coin.isValidPub(pub).should.equal(true);
+      assert.strictEqual(coin.isValidPub(pub), true);
     });
   });
 }

--- a/modules/abstract-utxo/test/unit/postProcessPrebuild.ts
+++ b/modules/abstract-utxo/test/unit/postProcessPrebuild.ts
@@ -1,4 +1,4 @@
-import 'should';
+import assert from 'node:assert/strict';
 
 import { fixedScriptWallet } from '@bitgo/wasm-utxo';
 import * as testutils from '@bitgo/wasm-utxo/testutils';
@@ -31,12 +31,12 @@ describe('Post Build Validation', function () {
     // Parse result as PSBT
     const resultPsbt = BitGoPsbt.fromBytes(Buffer.from(postProcessBuilt.txHex as string, 'hex'), 'tbtc');
 
-    resultPsbt.lockTime().should.equal(0);
+    assert.strictEqual(resultPsbt.lockTime(), 0);
 
     // Check sequences via parseTransactionWithWalletKeys
     const parsed = resultPsbt.parseTransactionWithWalletKeys(walletKeys, { replayProtection: { publicKeys: [] } });
     for (const input of parsed.inputs) {
-      input.sequence.should.equal(0xffffffff);
+      assert.strictEqual(input.sequence, 0xffffffff);
     }
   });
 });

--- a/modules/abstract-utxo/test/unit/prebuildAndSign.ts
+++ b/modules/abstract-utxo/test/unit/prebuildAndSign.ts
@@ -256,12 +256,13 @@ function run(coin: AbstractUtxoCoin, inputScripts: ScriptType[], txFormat: TxFor
           nockOutputAddresses: txFormat !== 'psbt',
         });
 
-        await wallet
-          .prebuildAndSignTransaction({
+        await assert.rejects(
+          wallet.prebuildAndSignTransaction({
             recipients: [recipient],
             walletPassphrase: Math.random().toString(),
-          })
-          .should.be.rejectedWith('unable to decrypt keychain with the given wallet passphrase');
+          }),
+          { message: 'unable to decrypt keychain with the given wallet passphrase' }
+        );
       });
     });
 

--- a/modules/abstract-utxo/test/unit/recovery/backupKeyRecovery.ts
+++ b/modules/abstract-utxo/test/unit/recovery/backupKeyRecovery.ts
@@ -1,6 +1,5 @@
 import assert from 'assert';
 
-import 'should';
 import nock = require('nock');
 import { Triple } from '@bitgo/sdk-core';
 import { BIP32, ECPair, fixedScriptWallet } from '@bitgo/wasm-utxo';
@@ -112,13 +111,13 @@ function run(
     });
 
     it('has expected input count', function () {
-      parsed.inputs.length.should.eql(recoverUnspents.length);
+      assert.strictEqual(parsed.inputs.length, recoverUnspents.length);
     });
 
     it('has recovery destination output', function () {
-      parsed.outputs.length.should.be.greaterThanOrEqual(1);
+      assert.ok(parsed.outputs.length >= 1);
       const outputAddresses = parsed.outputs.map((o) => o.address);
-      outputAddresses.includes(recoveryDestination).should.eql(true);
+      assert.ok(outputAddresses.includes(recoveryDestination));
     });
 
     it('has expected fee rate', function () {
@@ -136,7 +135,7 @@ function run(
       const signerKey = xprivs[signerIndex];
       for (let inputIndex = 0; inputIndex < recoverUnspents.length; inputIndex++) {
         const hasSig = psbt.verifySignature(inputIndex, signerKey);
-        hasSig.should.eql(expectSigned, `input ${inputIndex} signer ${signerIndex}`);
+        assert.strictEqual(hasSig, expectSigned, `input ${inputIndex} signer ${signerIndex}`);
       }
     }
 

--- a/modules/abstract-utxo/test/unit/recovery/crossChainRecovery.ts
+++ b/modules/abstract-utxo/test/unit/recovery/crossChainRecovery.ts
@@ -1,6 +1,5 @@
 import * as assert from 'assert';
 
-import should = require('should');
 import nock = require('nock');
 import { Triple } from '@bitgo/sdk-core';
 import { getSeed } from '@bitgo/sdk-test';
@@ -22,7 +21,7 @@ import {
   getFixture,
   keychainsBase58,
   KeychainBase58,
-  shouldEqualJSON,
+  assertEqualJSON,
   utxoCoins,
   getDefaultWasmWalletKeys,
   defaultBitGo,
@@ -154,7 +153,7 @@ function run<TNumber extends number | bigint = number>(sourceCoin: AbstractUtxoC
           })
         );
       }
-      shouldEqualJSON(
+      assertEqualJSON(
         recoveryObj,
         await getFixture(sourceCoin, `recovery/crossChainRecovery-${recoveryCoin.getChain()}-${name}`, recoveryObj)
       );
@@ -165,11 +164,11 @@ function run<TNumber extends number | bigint = number>(sourceCoin: AbstractUtxoC
       const wasmPsbt = fixedScriptWallet.BitGoPsbt.fromBytes(Buffer.from(psbtHex, 'hex'), sourceCoin.name);
       const parsed = wasmPsbt.parseTransactionWithWalletKeys(wasmWalletKeys, { replayProtection: { publicKeys: [] } });
       const unspents = getRecoveryUnspents();
-      should.equal(parsed.inputs.length, unspents.length);
+      assert.strictEqual(parsed.inputs.length, unspents.length);
       // Verify user key has signed each input (same pattern as backupKeyRecovery test)
       parsed.inputs.forEach((_, i) => {
         const userSigned = wasmPsbt.verifySignature(i, xprivs[0]);
-        userSigned.should.eql(true, `Input ${i} should be signed by user key`);
+        assert.strictEqual(userSigned, true, `Input ${i} should be signed by user key`);
       });
     }
 
@@ -192,7 +191,7 @@ function run<TNumber extends number | bigint = number>(sourceCoin: AbstractUtxoC
         ...params,
         xprv: keychainsBase58[0].prv,
       })) as CrossChainRecoverySigned<TNumber>;
-      should.equal(getRecoveryProviderStub.callCount, 1);
+      assert.strictEqual(getRecoveryProviderStub.callCount, 1);
 
       // Verify fixture match
       await matchFixture('signed', signedRecovery);
@@ -220,7 +219,7 @@ function run<TNumber extends number | bigint = number>(sourceCoin: AbstractUtxoC
         ...params,
         signed: false,
       })) as CrossChainRecoveryUnsigned<TNumber>;
-      should.equal(getRecoveryProviderStub.callCount, 1);
+      assert.strictEqual(getRecoveryProviderStub.callCount, 1);
 
       // Verify fixture match
       await matchFixture('unsigned', unsignedRecovery);

--- a/modules/abstract-utxo/test/unit/recovery/formatBackupKeyRecoveryResult.ts
+++ b/modules/abstract-utxo/test/unit/recovery/formatBackupKeyRecoveryResult.ts
@@ -1,4 +1,5 @@
-import 'should';
+import assert from 'node:assert/strict';
+
 import { Triple } from '@bitgo/sdk-core';
 import { BIP32, fixedScriptWallet, hasPsbtMagic } from '@bitgo/wasm-utxo';
 
@@ -10,11 +11,12 @@ import {
 } from '../../../src';
 import type { WalletUnspent } from '../../../src/unspent';
 import {
+  assertEqualJSON,
+  assertHasProperty,
   createWasmWalletKeys,
   getDefaultWasmWalletKeys,
   getFixture,
   getWalletAddress,
-  shouldEqualJSON,
   toUnspent,
   utxoCoins,
 } from '../util';
@@ -79,14 +81,14 @@ describe('formatBackupKeyRecoveryResult', function () {
         unspents,
       }) as FormattedOfflineVaultTxInfo;
 
-      result.should.have.property('txHex');
-      result.should.have.property('txInfo');
-      result.should.have.property('feeInfo');
-      result.should.have.property('coin');
-      result.coin!.should.equal(coin.getChain());
+      assertHasProperty(result, 'txHex');
+      assertHasProperty(result, 'txInfo');
+      assertHasProperty(result, 'feeInfo');
+      assertHasProperty(result, 'coin');
+      assert.strictEqual(result.coin!, coin.getChain());
 
       const txBuf = Buffer.from(result.txHex, 'hex');
-      hasPsbtMagic(txBuf).should.equal(true);
+      assert.strictEqual(hasPsbtMagic(txBuf), true);
     });
 
     it('matches fixture', async function () {
@@ -97,7 +99,7 @@ describe('formatBackupKeyRecoveryResult', function () {
         unspents,
       });
       const fixture = await getFixture(coin, 'recovery/formatBackupKeyRecovery-unsigned', result);
-      shouldEqualJSON(result, fixture);
+      assertEqualJSON(result, fixture);
     });
   });
 
@@ -126,15 +128,15 @@ describe('formatBackupKeyRecoveryResult', function () {
         unspents,
       }) as BackupKeyRecoveryTransansaction;
 
-      result.should.have.property('transactionHex');
-      result.should.have.property('coin');
-      result.should.have.property('backupKey');
-      result.should.have.property('recoveryAmount');
-      result.should.have.property('inputs');
-      result.backupKey!.should.equal('test-backup-key');
+      assertHasProperty(result, 'transactionHex');
+      assertHasProperty(result, 'coin');
+      assertHasProperty(result, 'backupKey');
+      assertHasProperty(result, 'recoveryAmount');
+      assertHasProperty(result, 'inputs');
+      assert.strictEqual(result.backupKey!, 'test-backup-key');
 
       const txBuf = Buffer.from(result.transactionHex!, 'hex');
-      hasPsbtMagic(txBuf).should.equal(false);
+      assert.strictEqual(hasPsbtMagic(txBuf), false);
     });
 
     it('matches fixture', async function () {
@@ -147,7 +149,7 @@ describe('formatBackupKeyRecoveryResult', function () {
         unspents,
       });
       const fixture = await getFixture(coin, 'recovery/formatBackupKeyRecovery-krs-keyternal', result);
-      shouldEqualJSON(result, fixture);
+      assertEqualJSON(result, fixture);
     });
   });
 
@@ -176,15 +178,15 @@ describe('formatBackupKeyRecoveryResult', function () {
         unspents,
       }) as BackupKeyRecoveryTransansaction;
 
-      result.should.have.property('transactionHex');
-      result.should.have.property('coin');
-      result.should.have.property('backupKey');
-      result.should.have.property('recoveryAmount');
-      result.backupKey!.should.equal('test-backup-key');
+      assertHasProperty(result, 'transactionHex');
+      assertHasProperty(result, 'coin');
+      assertHasProperty(result, 'backupKey');
+      assertHasProperty(result, 'recoveryAmount');
+      assert.strictEqual(result.backupKey!, 'test-backup-key');
 
       const txBuf = Buffer.from(result.transactionHex!, 'hex');
-      hasPsbtMagic(txBuf).should.equal(true);
-      (result.inputs === undefined).should.equal(true);
+      assert.strictEqual(hasPsbtMagic(txBuf), true);
+      assert.strictEqual(result.inputs, undefined);
     });
 
     it('matches fixture', async function () {
@@ -197,7 +199,7 @@ describe('formatBackupKeyRecoveryResult', function () {
         unspents,
       });
       const fixture = await getFixture(coin, 'recovery/formatBackupKeyRecovery-krs-dai', result);
-      shouldEqualJSON(result, fixture);
+      assertEqualJSON(result, fixture);
     });
   });
 
@@ -224,11 +226,11 @@ describe('formatBackupKeyRecoveryResult', function () {
         unspents,
       }) as BackupKeyRecoveryTransansaction;
 
-      result.should.have.property('transactionHex');
-      result.should.have.property('inputs');
+      assertHasProperty(result, 'transactionHex');
+      assertHasProperty(result, 'inputs');
 
       const txBuf = Buffer.from(result.transactionHex!, 'hex');
-      hasPsbtMagic(txBuf).should.equal(false);
+      assert.strictEqual(hasPsbtMagic(txBuf), false);
     });
 
     it('matches fixture', async function () {
@@ -239,7 +241,7 @@ describe('formatBackupKeyRecoveryResult', function () {
         unspents,
       });
       const fixture = await getFixture(coin, 'recovery/formatBackupKeyRecovery-fullySigned', result);
-      shouldEqualJSON(result, fixture);
+      assertEqualJSON(result, fixture);
     });
   });
 });

--- a/modules/abstract-utxo/test/unit/transaction.ts
+++ b/modules/abstract-utxo/test/unit/transaction.ts
@@ -19,7 +19,7 @@ import { SdkBackend } from '../../src/transaction/types';
 import type { Unspent, WalletUnspent } from '../../src/unspent';
 
 import {
-  shouldEqualJSON,
+  assertEqualJSON,
   getFixture,
   getUtxoWallet,
   mockUnspent,
@@ -231,7 +231,7 @@ function run<TNumber extends number | bigint = number>(
         ) as TransactionObjStages;
       }
 
-      shouldEqualJSON(
+      assertEqualJSON(
         toTransactionStagesObj(transactionStages),
         await getFixture(
           coin,
@@ -253,7 +253,10 @@ function run<TNumber extends number | bigint = number>(
         const walletUnspent = unspent as WalletUnspent<bigint>;
         const pubkeys = walletKeys.deriveForChainAndIndex(walletUnspent.chain, walletUnspent.index).publicKeys;
         pubkeys.forEach((pk, pkIndex) => {
-          psbt.validateSignaturesOfInputCommon(index, pk).should.eql(signedBy.includes(walletKeys.triple[pkIndex]));
+          assert.strictEqual(
+            psbt.validateSignaturesOfInputCommon(index, pk),
+            signedBy.includes(walletKeys.triple[pkIndex])
+          );
         });
       });
     }
@@ -293,8 +296,8 @@ function run<TNumber extends number | bigint = number>(
         const pubkeys = walletKeys.deriveForChainAndIndex(unspent.chain, unspent.index).publicKeys;
 
         pubkeys.forEach((pk, pkIndex) => {
-          utxolib.bitgo
-            .verifySignature<TNumber>(
+          assert.strictEqual(
+            utxolib.bitgo.verifySignature<TNumber>(
               transaction,
               index,
               prevOutputs[index].value,
@@ -302,8 +305,9 @@ function run<TNumber extends number | bigint = number>(
                 publicKey: pk,
               },
               prevOutputs
-            )
-            .should.eql(signedBy.includes(walletKeys.triple[pkIndex]));
+            ),
+            signedBy.includes(walletKeys.triple[pkIndex])
+          );
         });
       });
     }
@@ -329,7 +333,9 @@ function run<TNumber extends number | bigint = number>(
         expectedProperties.push('displayOrder', 'inputSignatures', 'signatures');
       }
 
-      explanation.should.have.properties(...expectedProperties);
+      for (const prop of expectedProperties) {
+        assert.ok(prop in explanation, `expected explanation to have property '${prop}'`);
+      }
 
       const expectedSignatureCount =
         stageName === 'prebuild' || pubs === undefined
@@ -341,14 +347,15 @@ function run<TNumber extends number | bigint = number>(
           : undefined;
 
       if ('inputSignatures' in explanation) {
-        explanation.inputSignatures.should.eql(
+        assert.deepStrictEqual(
+          explanation.inputSignatures,
           // FIXME(BG-35154): implement signature verification for replay protection inputs
           inputScripts.map((type) => (type === 'p2shP2pk' ? 0 : expectedSignatureCount))
         );
       }
       if ('signatures' in explanation) {
-        explanation.signatures.should.eql(expectedSignatureCount);
-        explanation.changeAmount.should.eql('0'); // no change addresses given
+        assert.deepStrictEqual(explanation.signatures, expectedSignatureCount);
+        assert.deepStrictEqual(explanation.changeAmount, '0'); // no change addresses given
       }
       let expectedOutputAmount =
         BigInt((txFormat === 'psbt' ? getUnspentsForPsbt() : getUnspents()).length) * BigInt(value);
@@ -360,7 +367,7 @@ function run<TNumber extends number | bigint = number>(
         }
       });
       expectedOutputAmount -= BigInt(1000); // fee of 1000
-      explanation.outputAmount.should.eql(expectedOutputAmount.toString());
+      assert.deepStrictEqual(explanation.outputAmount, expectedOutputAmount.toString());
     }
 
     it('have valid signature for half-signed transaction', function () {

--- a/modules/abstract-utxo/test/unit/util/assert.ts
+++ b/modules/abstract-utxo/test/unit/util/assert.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function assertHasProperty<T extends object>(obj: T, key: string, value?: unknown): void {
+  assert.ok(key in obj, `expected object to have property '${key}'`);
+  if (arguments.length >= 3) {
+    assert.strictEqual((obj as Record<string, unknown>)[key], value);
+  }
+}
+
+export function assertContains<T>(haystack: readonly T[] | string, needle: T | string): void {
+  if (typeof haystack === 'string') {
+    assert.ok(haystack.includes(needle as string), `expected '${haystack}' to contain '${needle}'`);
+  } else {
+    assert.ok(haystack.includes(needle as T), `expected array to contain ${JSON.stringify(needle)}`);
+  }
+}

--- a/modules/abstract-utxo/test/unit/util/fixtures.ts
+++ b/modules/abstract-utxo/test/unit/util/fixtures.ts
@@ -1,4 +1,4 @@
-import 'should';
+import assert from 'node:assert/strict';
 import * as mpath from 'path';
 import * as fs from 'fs/promises';
 
@@ -65,6 +65,6 @@ export async function getFixture<T>(coin: AbstractUtxoCoin, name: string, defaul
  * @param fixtureJSON
  * @throws Error if obj and fixtureJSON are different after normalizing obj under JSON:w
  */
-export function shouldEqualJSON<T>(obj: T, fixtureJSON: T): void {
-  JSON.parse(JSON.stringify(obj, serializeBigInt)).should.eql(fixtureJSON);
+export function assertEqualJSON<T>(obj: T, fixtureJSON: T): void {
+  assert.deepStrictEqual(JSON.parse(JSON.stringify(obj, serializeBigInt)), fixtureJSON);
 }

--- a/modules/abstract-utxo/test/unit/util/index.ts
+++ b/modules/abstract-utxo/test/unit/util/index.ts
@@ -1,3 +1,4 @@
+export * from './assert';
 export * from './utxoCoins';
 export * from './fixtures';
 export * from './keychains';

--- a/modules/abstract-utxo/test/unit/wallet.ts
+++ b/modules/abstract-utxo/test/unit/wallet.ts
@@ -1,5 +1,6 @@
+import assert from 'node:assert/strict';
+
 import * as utxoLib from '@bitgo/utxo-lib';
-import 'should';
 import nock = require('nock');
 import * as _ from 'lodash';
 import { Wallet, ManageUnspentsOptions, common } from '@bitgo/sdk-core';
@@ -65,7 +66,7 @@ describe('manage unspents', function () {
     await wallet.consolidateUnspents({ bulk: true, walletPassphrase });
 
     nocks.forEach((n) => {
-      n.isDone().should.be.true();
+      assert.strictEqual(n.isDone(), true);
     });
   });
 
@@ -99,7 +100,7 @@ describe('manage unspents', function () {
     await wallet.consolidateUnspents({ walletPassphrase });
 
     nocks.forEach((n) => {
-      n.isDone().should.be.true();
+      assert.strictEqual(n.isDone(), true);
     });
   });
 });
@@ -142,7 +143,7 @@ describe('max recipient', function () {
       // we only care about /tx/build and whether maxFeeRate is an allowed parameter
     }
 
-    response.isDone().should.be.true();
+    assert.strictEqual(response.isDone(), true);
   });
 });
 
@@ -181,7 +182,7 @@ describe('maxFeeRate verification', function () {
       // we only care about /tx/build and whether maxFeeRate is an allowed parameter
     }
 
-    response.isDone().should.be.true();
+    assert.strictEqual(response.isDone(), true);
   });
 
   it('should pass maxFeeRate parameter when consolidating unspents', async function () {
@@ -199,7 +200,7 @@ describe('maxFeeRate verification', function () {
       // we only care about /consolidateUnspents and whether maxFeeRate is an allowed parameter
     }
 
-    response.isDone().should.be.true();
+    assert.strictEqual(response.isDone(), true);
   });
 
   it('should only build tx (not sign/send) while consolidating unspents', async function () {
@@ -212,8 +213,8 @@ describe('maxFeeRate verification', function () {
 
     await wallet.consolidateUnspents({ recipients }, ManageUnspentsOptions.BUILD_ONLY);
 
-    toBeUsedNock.isDone().should.be.true();
-    unusedNocks.pendingMocks().length.should.eql(2);
+    assert.strictEqual(toBeUsedNock.isDone(), true);
+    assert.strictEqual(unusedNocks.pendingMocks().length, 2);
     nock.cleanAll();
   });
 
@@ -230,7 +231,7 @@ describe('maxFeeRate verification', function () {
       // we only care about /sweepWallet and whether maxFeeRate is an allowed parameter
     }
 
-    response.isDone().should.be.true();
+    assert.strictEqual(response.isDone(), true);
   });
 
   it('should pass maxFeeRate parameter when calling fanout unspents', async function () {
@@ -246,7 +247,7 @@ describe('maxFeeRate verification', function () {
       // we only care about /fanoutUnspents and whether maxFeeRate is an allowed parameter
     }
 
-    response.isDone().should.be.true();
+    assert.strictEqual(response.isDone(), true);
   });
 });
 
@@ -279,6 +280,6 @@ describe('allowPartialSweep verification', function () {
       // we only care about /sweepWallet and whether allowPartialSweep is an allowed parameter
     }
 
-    response.isDone().should.be.true();
+    assert.strictEqual(response.isDone(), true);
   });
 });


### PR DESCRIPTION
Replace shouldjs assertions with Node.js native assert/strict
throughout the abstract-utxo module test suite. This modernizes
testing infrastructure and eliminates a deprecated dependency.

Main changes:
- Switch to node:assert/strict for all assertions
- Add helper functions: `assertHasProperty`, `assertContains`,
  `assertEqualJSON`
- Update Sinon assertion syntax to use `sinon.assert.*` methods
- Simplify assertion patterns across unit and integration tests
- Align fmt script with check-fmt for consistency in formatting
  operations

Issue: BTC-2768