### PR TITLE
fix: coinName fix in token config

### DIFF
--- a/modules/statics/src/tokenConfig.ts
+++ b/modules/statics/src/tokenConfig.ts
@@ -42,7 +42,7 @@ import {
 } from './account';
 import { CoinFamily, CoinKind, BaseCoin, CoinFeature } from './base';
 import { coins } from './coins';
-import { Networks, NetworkType } from './networks';
+import { EthereumNetwork, Networks, NetworkType } from './networks';
 import { OfcCoin } from './ofc';
 
 export interface BaseTokenConfig {
@@ -1148,9 +1148,11 @@ export enum TokenTypeEnum {
 }
 
 function getEthLikeTokenConfig(coin: EthLikeERC20Token): EthLikeTokenConfig {
+  const network = coin.network as EthereumNetwork;
+  const baseCoin = coins.coinNameFromChainId(network.chainId) ?? coin.name.split(':')[0].toLowerCase();
   return {
     type: coin.name,
-    coin: coin.name.split(':')[0].toLowerCase(),
+    coin: baseCoin,
     network: coin.network.type === NetworkType.MAINNET ? 'Mainnet' : 'Testnet',
     name: coin.fullName,
     tokenContractAddress: coin.contractAddress.toString().toLowerCase(),
@@ -1159,9 +1161,11 @@ function getEthLikeTokenConfig(coin: EthLikeERC20Token): EthLikeTokenConfig {
 }
 
 function getEthLikeERC721TokenConfig(coin: EthLikeERC721Token): EthLikeERC721TokenConfig {
+  const network = coin.network as EthereumNetwork;
+  const baseCoin = coins.coinNameFromChainId(network.chainId) ?? coin.name.split(':')[0].toLowerCase();
   return {
     type: coin.name,
-    coin: coin.name.split(':')[0].toLowerCase(),
+    coin: baseCoin,
     network: coin.network.type === NetworkType.MAINNET ? 'Mainnet' : 'Testnet',
     name: coin.fullName,
     tokenContractAddress: coin.contractAddress.toString().toLowerCase(),


### PR DESCRIPTION
ticket: cecho-125

Replace hardcoded coin.name.split(':')[0] base coin derivation in getEthLikeTokenConfig and getEthLikeERC721TokenConfig with coins.coinNameFromChainId(network.chainId), falling back to the split logic for backward compatibility
Fixes token registration for coins like hbarevm:tmt where the token name prefix doesn't match the expected testnet base coin name (e.g., hbarevm:tmt is a testnet token but name.split(':')[0] returns hbarevm instead of thbarevm)

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
