### PR TITLE
feat(sdk-coin-dot): add dual ESM/CJS build for browser WASM support

### DIFF
--- a/modules/sdk-coin-dot/package.json
+++ b/modules/sdk-coin-dot/package.json
@@ -2,13 +2,29 @@
   "name": "@bitgo/sdk-coin-dot",
   "version": "4.11.7",
   "description": "BitGo SDK coin library for Polkadot",
-  "main": "./dist/src/index.js",
-  "types": "./dist/src/index.d.ts",
+  "main": "./dist/cjs/src/index.js",
+  "module": "./dist/esm/index.js",
+  "browser": "./dist/esm/index.js",
+  "types": "./dist/cjs/src/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/src/index.d.ts",
+        "default": "./dist/cjs/src/index.js"
+      }
+    }
+  },
   "scripts": {
-    "build": "yarn tsc --build --incremental --verbose .",
+    "build": "npm run build:cjs && npm run build:esm",
+    "build:cjs": "yarn tsc --build --incremental --verbose .",
+    "build:esm": "yarn tsc --project tsconfig.esm.json",
     "fmt": "prettier --write .",
     "check-fmt": "prettier --check '**/*.{ts,js,json}'",
-    "clean": "rm -r ./dist",
+    "clean": "rm -rf ./dist",
     "lint": "eslint --quiet .",
     "prepare": "npm run build",
     "test": "npm run coverage",
@@ -66,6 +82,7 @@
   },
   "gitHead": "18e460ddf02de2dbf13c2aa243478188fb539f0c",
   "files": [
-    "dist"
+    "dist/cjs",
+    "dist/esm"
   ]
 }

--- a/modules/sdk-coin-dot/tsconfig.esm.json
+++ b/modules/sdk-coin-dot/tsconfig.esm.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/esm",
+    "rootDir": "./src",
+    "module": "ES2020",
+    "target": "ES2020",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM"],
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "test", "dist"],
+  "references": []
+}

--- a/modules/sdk-coin-dot/tsconfig.json
+++ b/modules/sdk-coin-dot/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist",
+    "outDir": "./dist/cjs",
     "rootDir": "./",
     "strictPropertyInitialization": false,
     "esModuleInterop": true,


### PR DESCRIPTION
Add dual ESM/CJS build support to sdk-coin-dot to enable browser compatibility with @bitgo/wasm-dot. Same pattern as sdk-coin-sol (#8060).

Needed to properly handle async WASM initialization.

- Update package.json with module, browser, exports fields
- Add tsconfig.esm.json for ESM build
- Update tsconfig.json to output CJS to dist/cjs

Ticket: BTC-3148