### PR TITLE
refactor: derive getBaseFactor from statics in AbstractLightningCoin

### DIFF
--- a/modules/abstract-lightning/src/abstractLightningCoin.ts
+++ b/modules/abstract-lightning/src/abstractLightningCoin.ts
@@ -10,19 +10,25 @@ import {
   VerifyAddressOptions,
   VerifyTransactionOptions,
 } from '@bitgo/sdk-core';
+import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 import * as utxolib from '@bitgo/utxo-lib';
 import { randomBytes } from 'crypto';
 import { bip32 } from '@bitgo/utxo-lib';
 
 export abstract class AbstractLightningCoin extends BaseCoin {
+  protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
   private readonly _network: utxolib.Network;
-  protected constructor(bitgo: BitGoBase, network: utxolib.Network) {
+  protected constructor(bitgo: BitGoBase, network: utxolib.Network, staticsCoin?: Readonly<StaticsBaseCoin>) {
     super(bitgo);
+    if (!staticsCoin) {
+      throw new Error('missing required constructor parameter staticsCoin');
+    }
+    this._staticsCoin = staticsCoin;
     this._network = network;
   }
 
   getBaseFactor(): number {
-    return 1e11;
+    return Math.pow(10, this._staticsCoin.decimalPlaces);
   }
 
   verifyTransaction(params: VerifyTransactionOptions): Promise<boolean> {

--- a/modules/sdk-coin-lnbtc/package.json
+++ b/modules/sdk-coin-lnbtc/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@bitgo/abstract-lightning": "^7.8.3",
     "@bitgo/sdk-core": "^36.34.0",
+    "@bitgo/statics": "^58.30.0",
     "@bitgo/utxo-lib": "^11.21.0"
   },
   "devDependencies": {

--- a/modules/sdk-coin-lnbtc/src/lnbtc.ts
+++ b/modules/sdk-coin-lnbtc/src/lnbtc.ts
@@ -1,14 +1,15 @@
 import { AbstractLightningCoin } from '@bitgo/abstract-lightning';
 import { BitGoBase, BaseCoin } from '@bitgo/sdk-core';
+import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 import * as utxolib from '@bitgo/utxo-lib';
 
 export class Lnbtc extends AbstractLightningCoin {
-  constructor(bitgo: BitGoBase, network?: utxolib.Network) {
-    super(bitgo, network || utxolib.networks.bitcoin);
+  constructor(bitgo: BitGoBase, network?: utxolib.Network, staticsCoin?: Readonly<StaticsBaseCoin>) {
+    super(bitgo, network || utxolib.networks.bitcoin, staticsCoin);
   }
 
-  static createInstance(bitgo: BitGoBase): BaseCoin {
-    return new Lnbtc(bitgo);
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+    return new Lnbtc(bitgo, undefined, staticsCoin);
   }
 
   getChain(): string {

--- a/modules/sdk-coin-lnbtc/src/tlnbtc.ts
+++ b/modules/sdk-coin-lnbtc/src/tlnbtc.ts
@@ -2,16 +2,17 @@
  * @prettier
  */
 import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
+import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 import { Lnbtc } from './lnbtc';
 import * as utxolib from '@bitgo/utxo-lib';
 
 export class Tlnbtc extends Lnbtc {
-  constructor(bitgo: BitGoBase) {
-    super(bitgo, utxolib.networks.testnet);
+  constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
+    super(bitgo, utxolib.networks.testnet, staticsCoin);
   }
 
-  static createInstance(bitgo: BitGoBase): BaseCoin {
-    return new Tlnbtc(bitgo);
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+    return new Tlnbtc(bitgo, staticsCoin);
   }
 
   getChain(): string {


### PR DESCRIPTION
Replace the hardcoded 1e11 return value in getBaseFactor() with Math.pow(10, this._staticsCoin.decimalPlaces), following the same pattern used by Dot, Bld, Osmo, and other coins. The statics LightningCoin already has decimalPlaces: 11 so behavior is unchanged.

BTC-3158

TICKET: BTC-3158

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
