### PR TITLE
[SC-6159] Add kycHash to StakeOptions for XDC masternode staking

### DIFF
--- a/modules/sdk-core/src/bitgo/staking/iStakingWallet.ts
+++ b/modules/sdk-core/src/bitgo/staking/iStakingWallet.ts
@@ -164,6 +164,14 @@ export interface StakeOptions {
   region?: string;
 }
 
+export interface XdcStakeOptions extends StakeOptions {
+  /**
+   * XDC masternode KYC document hash — IPFS CIDv0 (Qm...) returned by the
+   * staking-service KYC upload endpoint, injected before calling stake().
+   */
+  kycHash?: string;
+}
+
 export interface TronStakeOptions extends StakeOptions {
   /**
    * Tron staking resource type (Energy or Bandwidth)
@@ -311,7 +319,7 @@ export interface IStakingWallet {
   readonly walletId: string;
   readonly coin: string;
   stake(
-    options: StakeOptions | TronStakeOptions | TaoStakeOptions | VetStakeOptions | StoryStakeOptions
+    options: StakeOptions | TronStakeOptions | TaoStakeOptions | VetStakeOptions | StoryStakeOptions | XdcStakeOptions
   ): Promise<StakingRequest>;
   unstake(options: UnstakeOptions | EthUnstakeOptions): Promise<StakingRequest>;
   switchValidator(options: SwitchValidatorOptions | TaoSwitchValidatorOptions): Promise<StakingRequest>;

--- a/modules/sdk-core/src/bitgo/staking/stakingWallet.ts
+++ b/modules/sdk-core/src/bitgo/staking/stakingWallet.ts
@@ -25,6 +25,7 @@ import {
   TaoSwitchValidatorOptions,
   VetStakeOptions,
   StoryStakeOptions,
+  XdcStakeOptions,
 } from './iStakingWallet';
 import { BitGoBase } from '../bitgoBase';
 import { IWallet, PrebuildTransactionResult } from '../wallet';
@@ -63,7 +64,7 @@ export class StakingWallet implements IStakingWallet {
    * @return StakingRequest
    */
   async stake(
-    options: StakeOptions | TronStakeOptions | TaoStakeOptions | VetStakeOptions | StoryStakeOptions
+    options: StakeOptions | TronStakeOptions | TaoStakeOptions | VetStakeOptions | StoryStakeOptions | XdcStakeOptions
   ): Promise<StakingRequest> {
     return await this.createStakingRequest(options, 'STAKE');
   }
@@ -325,7 +326,8 @@ export class StakingWallet implements IStakingWallet {
       | TaoStakeOptions
       | TaoSwitchValidatorOptions
       | VetStakeOptions
-      | StoryStakeOptions,
+      | StoryStakeOptions
+      | XdcStakeOptions,
     type: string
   ): Promise<StakingRequest> {
     return await this.bitgo


### PR DESCRIPTION
## Summary

Add `kycHash?: string` to `StakeOptions` in `iStakingWallet.ts` to support XDC masternode staking.

**File changed**: `modules/sdk-core/src/bitgo/staking/iStakingWallet.ts`

```typescript
/** XDC masternode KYC document hash — IPFS CIDv0 (Qm...) or CIDv1 (bafy...) */
kycHash?: string;
```

## Context

XDC masternode staking requires a 2-step flow:
1. Upload KYC PDF → `POST /kyc/upload` → `{ hash: "QmTzQ1..." }`
2. Submit stake request with `{ validator, kycHash }` → creates AUTHORIZE + DELEGATE txs

The `kycHash` is obtained from the staking-service KYC upload endpoint (PR: BitGo/staking-service#6582) and must be forwarded in the stake request body. Since `stakingWallet.stake()` spreads all `StakeOptions` fields into the POST body, only this interface change is needed.

`validator?: string` already exists in `StakeOptions` — no further changes required.

## Related
- staking-service PR: https://github.com/BitGo/staking-service/pull/6637
- Parent story: SC-6158
- Epic: SC-5651 (XDC Staking Go-Live)

Ticket: [SC-6159](https://bitgoinc.atlassian.net/browse/SC-6159)

[SC-6159]: https://bitgoinc.atlassian.net/browse/SC-6159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ