### PR TITLE
feat: onboard new tokens - Bitlayer, HASTRA PRIME, Kamino, and test t…

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -5793,6 +5793,38 @@ export const allCoinsAndTokens = [
     '0x0726773451af83203583b5d38b3a11f752b1a96b',
     UnderlyingAsset['arbeth:bull']
   ),
+  tarbethErc20(
+    '9e3f8d7c-6b5a-4e2d-9f9c-8a7b6d5e4f3c',
+    'arbeth:testtsla',
+    'Tesla (Test)',
+    18,
+    '0xb94263fa0a2a29ea32c1f90ccaeeaffd0bb73908',
+    UnderlyingAsset['arbeth:testtsla']
+  ),
+  tarbethErc20(
+    '0f4a9e8d-7c6b-5a4e-9a0d-9b8c7e6f5a4b',
+    'arbeth:testamzn',
+    'Amazon (Test)',
+    18,
+    '0x76fca8a5bc14fce9eb613d96674868d687498804',
+    UnderlyingAsset['arbeth:testamzn']
+  ),
+  tarbethErc20(
+    '1a5b0f9e-8d7c-4b5a-9b1e-0c9d8f7a6b5c',
+    'arbeth:testpltr',
+    'Palantir Technologies Inc (Test)',
+    18,
+    '0x99cd69ef9221c7fe0ad5618a7527244ef79636c6',
+    UnderlyingAsset['arbeth:testpltr']
+  ),
+  tarbethErc20(
+    '2b6c1a0f-9e8d-4c6b-9c2f-1d0e9a8b7c6d',
+    'arbeth:testnflx',
+    'Netflix Inc (Test)',
+    18,
+    '0xf10e5372335a33da22a78a6581fd7383b422875a',
+    UnderlyingAsset['arbeth:testnflx']
+  ),
   arbethErc20(
     '6a69ea1d-ce7d-4603-89df-cf2f6490d1f9',
     'arbeth:xai',

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -2432,6 +2432,7 @@ export enum UnderlyingAsset {
   'eth:spec' = 'eth:spec',
   'eth:prompt' = 'eth:prompt',
   'eth:yb' = 'eth:yb',
+  'eth:btr' = 'eth:btr',
   'morph:usdc' = 'morph:usdc',
   'morpheth:usdc' = 'morpheth:usdc',
   'morph:usdt' = 'morph:usdt',
@@ -2535,6 +2536,7 @@ export enum UnderlyingAsset {
   'tavaxc:xsgd' = 'tavaxc:xsgd',
   'tavaxc:bitgo' = 'tavaxc:bitgo',
   'tavaxc:stavax' = 'tavaxc:stavax',
+  'tavaxc:rtest' = 'tavaxc:rtest',
   'avaxc:usdc-e' = 'avaxc:usdc-e',
   'avaxc:usdt-e' = 'avaxc:usdt-e',
   // Begin FTX missing AVAXC tokens
@@ -2899,6 +2901,7 @@ export enum UnderlyingAsset {
   'bsc:bard' = 'bsc:bard',
   'bsc:home' = 'bsc:home',
   'bsc:zbt' = 'bsc:zbt',
+  'bsc:btr' = 'bsc:btr',
   'bsc:iost' = 'bsc:iost',
   'bsc:sto' = 'bsc:sto',
   'bsc:pt-cusdo-29oct2026' = 'bsc:pt-cusdo-29oct2026',
@@ -2989,6 +2992,10 @@ export enum UnderlyingAsset {
   'arbeth:next' = 'arbeth:next',
   'arbeth:zro' = 'arbeth:zro',
   'arbeth:tt' = 'arbeth:tt',
+  'arbeth:testtsla' = 'arbeth:testtsla',
+  'arbeth:testamzn' = 'arbeth:testamzn',
+  'arbeth:testpltr' = 'arbeth:testpltr',
+  'arbeth:testnflx' = 'arbeth:testnflx',
 
   // BaseETH mainnet tokens
   'baseeth:aero' = 'baseeth:aero',
@@ -3438,6 +3445,10 @@ export enum UnderlyingAsset {
   'sol:skr' = 'sol:skr',
   'sol:bmt' = 'sol:bmt',
   'sol:huma' = 'sol:huma',
+  'sol:prime' = 'sol:prime',
+  'sol:kwyld-usdc' = 'sol:kwyld-usdc',
+  'sol:kprme-cash' = 'sol:kprme-cash',
+  'sol:kwyld-cash' = 'sol:kwyld-cash',
 
   'tsol:txsgd' = 'sol:txsgd',
   'tsol:txusd' = 'sol:txusd',

--- a/modules/statics/src/coins/avaxTokens.ts
+++ b/modules/statics/src/coins/avaxTokens.ts
@@ -792,4 +792,12 @@ export const avaxTokens = [
     '0x3f964a0630b429ffb1797f2ce9fd8e5a45c5ad18',
     UnderlyingAsset['tavaxc:stavax']
   ),
+  tavaxErc20(
+    '3d7e2b1a-0f9e-4d7c-9d3a-2e1f0b9c8d7e',
+    'tavaxc:rtest',
+    'REtokens Test Security',
+    9,
+    '0xaeb95ae5888b9ba0636373da39d5ad85eef318e0',
+    UnderlyingAsset['tavaxc:rtest']
+  ),
 ];

--- a/modules/statics/src/coins/bscTokens.ts
+++ b/modules/statics/src/coins/bscTokens.ts
@@ -1535,6 +1535,15 @@ export const bscTokens = [
     BSC_TOKEN_FEATURES
   ),
   bscToken(
+    '4d7f8e9a-6c2b-4a3f-9d1e-5b8c7a6f4e2d',
+    'bsc:btr',
+    'Bitlayer',
+    18,
+    '0xfed13d0c40790220fbde712987079eda1ed75c51',
+    UnderlyingAsset['bsc:btr'],
+    BSC_TOKEN_FEATURES
+  ),
+  bscToken(
     '5803d1f3-5950-4410-b0de-db7aa3f0f67c',
     'bsc:iost',
     'IOSToken',

--- a/modules/statics/src/coins/erc20Coins.ts
+++ b/modules/statics/src/coins/erc20Coins.ts
@@ -14582,6 +14582,14 @@ export const erc20Coins = [
     '0x94314a14df63779c99c0764a30e0cd22fa78fc0e',
     UnderlyingAsset['eth:epic']
   ),
+  erc20(
+    '7c8e6f41-9d3a-4b2e-8f5c-1a7b9c6d4e3f',
+    'eth:btr',
+    'Bitlayer',
+    18,
+    '0x6c76de483f1752ac8473e2b4983a873991e70da7',
+    UnderlyingAsset['eth:btr']
+  ),
   terc20(
     '0c333619-e5a6-4f9d-8bbc-5b0e5dc64d03',
     'hteth:grtxp',

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -817,6 +817,28 @@ export const ofcCoins = [
     UnderlyingAsset['sol:usdca'],
     [...SOL_TOKEN_FEATURES, CoinFeature.STABLECOIN]
   ),
+  ofcsolToken('a6b1c9d4-8e5f-4a0c-9b3d-7f9e0a4c6b8d', 'ofcsol:prime', 'HASTRA PRIME', 6, UnderlyingAsset['sol:prime']),
+  ofcsolToken(
+    'b7c2d0e5-9f6a-4b1d-9c4e-8a0f1b5d7c9e',
+    'ofcsol:kwyld-usdc',
+    'Kamino kWYLD-USDC',
+    6,
+    UnderlyingAsset['sol:kwyld-usdc']
+  ),
+  ofcsolToken(
+    'c8d3e1f6-0a7b-4c2e-9d5f-9b1a2c6e8d0f',
+    'ofcsol:kprme-cash',
+    'Kamino kPRME-CASH',
+    6,
+    UnderlyingAsset['sol:kprme-cash']
+  ),
+  ofcsolToken(
+    'd9e4f2a7-1b8c-4d3f-9e6a-0c2b3d7f9e1a',
+    'ofcsol:kwyld-cash',
+    'Kamino kWYLD-CASH',
+    6,
+    UnderlyingAsset['sol:kwyld-cash']
+  ),
   ofcsolToken(
     'c382f3cc-c071-4ef5-89ac-bcb85d8d415f',
     'ofcsol:wec',
@@ -2277,6 +2299,7 @@ export const ofcCoins = [
     UnderlyingAsset['bsc:twt']
   ),
   ofcBscToken('822d85d7-f42d-40de-a14c-220a375eda3f', 'ofcbsc:sfp', 'SafePal Token', 18, UnderlyingAsset['bsc:sfp']),
+  ofcBscToken('f5a0b8c3-7d4e-4f9b-9a2c-6e8d9f3b5c7a', 'ofcbsc:btr', 'Bitlayer', 18, UnderlyingAsset['bsc:btr']),
   ofcBscToken('10226e82-2fac-49f4-8ee0-e0f7affeaeec', 'ofcbsc:mask', 'Mask Network', 18, UnderlyingAsset['bsc:mask']),
   ofcBscToken(
     'a1380903-6d91-4555-b8ef-74b1bcd993d0',

--- a/modules/statics/src/coins/ofcErc20Coins.ts
+++ b/modules/statics/src/coins/ofcErc20Coins.ts
@@ -4112,6 +4112,34 @@ export const tOfcErc20Coins = [
   tofcerc20('055ebe86-72cc-4f0e-b46f-c517d8e3687a', 'ofcterc', 'Test ERC Token', 18, UnderlyingAsset.TERC),
   tofcerc20('ac822eb1-4aa0-40d2-836d-7a24db24d47a', 'ofctest', 'Test Mintable ERC20 Token', 18, UnderlyingAsset.TEST),
   tofcerc20(
+    'e0f5b3c8-2d9a-4e7b-9a1c-8d3f6b0e9a2d',
+    'ofctarbeth:testtsla',
+    'Tesla (Test)',
+    18,
+    UnderlyingAsset['arbeth:testtsla']
+  ),
+  tofcerc20(
+    'f1a6c4d9-3e0b-4f8c-9b2d-9e4a7c1f0b3e',
+    'ofctarbeth:testamzn',
+    'Amazon (Test)',
+    18,
+    UnderlyingAsset['arbeth:testamzn']
+  ),
+  tofcerc20(
+    'a2b7d5e0-4f1c-4a9d-9c3e-0f5b8d2a1c4f',
+    'ofctarbeth:testpltr',
+    'Palantir (Test)',
+    18,
+    UnderlyingAsset['arbeth:testpltr']
+  ),
+  tofcerc20(
+    'b3c8e6f1-5a2d-4b0e-8d4f-1a6c9e3b2d5a',
+    'ofctarbeth:testnflx',
+    'Netflix (Test)',
+    18,
+    UnderlyingAsset['arbeth:testnflx']
+  ),
+  tofcerc20(
     '67b3f68b-a0bd-4bd7-b67e-36e8220bf67e',
     'ofcterc18dp13',
     'Test ERC Token 18 decimals',
@@ -6142,6 +6170,7 @@ export const tOfcErc20Coins = [
     true,
     'opeth'
   ),
+  ofcerc20('e4f9a7b2-6c3d-4e8a-9f1b-5d7c8e2a4b6f', 'ofceth:btr', 'Bitlayer', 18, UnderlyingAsset['eth:btr']),
 ];
 
 function underlyingAssetForSymbol(underlyingAssetValue: string): UnderlyingAsset {

--- a/modules/statics/src/coins/solTokens.ts
+++ b/modules/statics/src/coins/solTokens.ts
@@ -3694,4 +3694,44 @@ export const solTokens = [
     UnderlyingAsset['sol:huma'],
     SOL_TOKEN_FEATURES
   ),
+  solToken(
+    'a5e3f7d8-9b2c-4f1e-8a6d-7c9b4e3f2a1d',
+    'sol:prime',
+    'HASTRA PRIME',
+    6,
+    '3b8X44fLF9ooXaUm3hhSgjpmVs6rZZ3pPoGnGahc3Uu7',
+    '3b8X44fLF9ooXaUm3hhSgjpmVs6rZZ3pPoGnGahc3Uu7',
+    UnderlyingAsset['sol:prime'],
+    SOL_TOKEN_FEATURES
+  ),
+  solToken(
+    'b6f4e8c9-0d3a-4e2f-9b7c-8d0e5a6f4b2e',
+    'sol:kwyld-usdc',
+    'Kamino wYLD-USDC (Raydium)',
+    6,
+    '68Hn1fCCZAfZd63cCMvUzJ3dKx31cP6sKVm2RE2xF333',
+    '68Hn1fCCZAfZd63cCMvUzJ3dKx31cP6sKVm2RE2xF333',
+    UnderlyingAsset['sol:kwyld-usdc'],
+    SOL_TOKEN_FEATURES
+  ),
+  solToken(
+    'c7f5e9d0-1e4b-4f3c-8c8d-9e1f6a7c5c3f',
+    'sol:kprme-cash',
+    'Kamino PRME-CASH (Raydium)',
+    6,
+    'CrLxQrrinWEZ7vypFqKMbL7bUKoxYhBhmzAdvGKtfso1',
+    'CrLxQrrinWEZ7vypFqKMbL7bUKoxYhBhmzAdvGKtfso1',
+    UnderlyingAsset['sol:kprme-cash'],
+    SOL_TOKEN_FEATURES
+  ),
+  solToken(
+    'd8a6f0e1-2f5c-4a4b-9d9e-0f2a7b8b6d4a',
+    'sol:kwyld-cash',
+    'Kamino wYLD-CASH (Raydium)',
+    6,
+    '3YwBxuntXkdB1jjnYKfGx9WzA8oPzzLUjnN2DkondHQL',
+    '3YwBxuntXkdB1jjnYKfGx9WzA8oPzzLUjnN2DkondHQL',
+    UnderlyingAsset['sol:kwyld-cash'],
+    SOL_TOKEN_FEATURES
+  ),
 ];


### PR DESCRIPTION
## Description
Onboard 11 new tokens (6 mainnet + 5 testnet) and their OFC versions to BitGoJS statics.

## Changes
### On - chain Tokens (11 tokens)
**Mainnet Tokens (6):**
- ETH:BTR (Bitlayer)
- BSC:BTR (Bitlayer)
- SOL:PRIME (HASTRA PRIME)
- SOL:kWYLD-USDC (Kamino kWYLD-USDC)
- SOL:kPRME-CASH (Kamino kPRME-CASH)
- SOL:kWYLD-CASH (Kamino kWYLD-CASH)

**Testnet Tokens (5):**
- ARBETH:TESTTSLA (Tesla (Test))
- ARBETH:TESTAMZN (Amazon (Test))
- ARBETH:TESTPLTR (Palantir (Test))
- ARBETH:TESTNFLX (Netflix (Test))
- TAVAXC:RTEST (REtokens Test Security)

### OFC Tokens (10 tokens)
Added corresponding OFC versions for all tokens except TAVAXC:RTEST.

## Ticket
CGARD-591