### PR TITLE
fix(CECHO-164): correct Sahara AI (eth:sahara) token contract address

### DIFF
--- a/modules/statics/src/coins/erc20Coins.ts
+++ b/modules/statics/src/coins/erc20Coins.ts
@@ -14571,7 +14571,7 @@ export const erc20Coins = [
     'eth:sahara',
     'Sahara AI',
     18,
-    '0xfdfbb411c4a70aa7c95d5c981a6fb4da867e1111',
+    '0xfdffb411c4a70aa7c95d5c981a6fb4da867e1111',
     UnderlyingAsset['eth:sahara']
   ),
   erc20(


### PR DESCRIPTION
Fix typo in address: 0xfdfb -> 0xfdff (second byte).
Verified contract on Etherscan: 0xFDFfB411C4A70AA7C95D5C981a6Fb4Da867e1111
CECHO-164