### PR TITLE
feat(beta-tools)!: add UTXO coin packages to default patterns

### DIFF
--- a/modules/beta-tools/README.md
+++ b/modules/beta-tools/README.md
@@ -46,7 +46,7 @@ bump-bitgo-beta --tag beta
 | `--ignore <pkg...>` | `[]` | Packages to skip |
 | `--only-utxo` | `false` | Only bump UTXO-related packages |
 | `--ignore-utxo` | `true` (when `--only-utxo` not set) | Skip UTXO-related packages |
-| `--utxo-patterns <patterns...>` | `utxo, unspents, abstract-lightning, babylonlabs-io-btc-staking-ts` | Patterns for UTXO package detection |
+| `--utxo-patterns <patterns...>` | `utxo, unspents, abstract-lightning, babylonlabs-io-btc-staking-ts, sdk-coin-btc, sdk-coin-bch, sdk-coin-bsv, sdk-coin-btg, sdk-coin-dash, sdk-coin-doge, sdk-coin-ltc, sdk-coin-zec` | Patterns for UTXO package detection |
 | `--check-duplicates` | `true` | Check lockfile for duplicate versions after install (npm only) |
 | `--check-duplicate-packages <pkg...>` | `@bitgo-beta/utxo-lib, @bitgo/wasm-utxo` | Packages to check for duplicates |
 | `--dry-run` | `false` | Show what would be installed without installing |

--- a/modules/beta-tools/src/filterDependencies.ts
+++ b/modules/beta-tools/src/filterDependencies.ts
@@ -1,4 +1,17 @@
-export const DEFAULT_UTXO_PATTERNS = ['utxo', 'unspents', 'abstract-lightning', 'babylonlabs-io-btc-staking-ts'];
+export const DEFAULT_UTXO_PATTERNS = [
+  'utxo',
+  'unspents',
+  'abstract-lightning',
+  'babylonlabs-io-btc-staking-ts',
+  'sdk-coin-btc',
+  'sdk-coin-bch',
+  'sdk-coin-bsv',
+  'sdk-coin-btg',
+  'sdk-coin-dash',
+  'sdk-coin-doge',
+  'sdk-coin-ltc',
+  'sdk-coin-zec',
+];
 
 export interface FilterOptions {
   ignore: string[];


### PR DESCRIPTION
Add sdk-coin-* packages for BTC, BCH, BSV, BTG, DASH, DOGE, LTC, and
ZEC to default UTXO patterns. This ensures these coin packages are
properly included when using --only-utxo flag.

Issue: BTC-0

Co-authored-by: llm-git <llm-git@ttll.de>