### PR TITLE
fix(sdk-coin-ada): add serializedtxhash alias for ovc readability

### DIFF
--- a/modules/sdk-coin-ada/src/ada.ts
+++ b/modules/sdk-coin-ada/src/ada.ts
@@ -534,6 +534,8 @@ export class Ada extends BaseCoin {
         feeInfo: feeInfo,
         coinSpecific: coinSpecific,
       };
+      // Add serializedTxHex alias so OVC can read it natively (OVC Transaction type uses serializedTxHex)
+      (transaction as MPCTx & { serializedTxHex: string }).serializedTxHex = serializedTx;
       const unsignedTx: MPCUnsignedTx = { unsignedTx: transaction, signatureShares: [] };
       const transactions: MPCUnsignedTx[] = [unsignedTx];
       const txRequest: RecoveryTxRequest = {


### PR DESCRIPTION
Ticket: CSHLD-523

**SUMMARY**
Adding serializedTxHex alias so the OVC can read it(previously was just reading as serializedTx, which caused the failure to read the file in ovc)