### PR TITLE
feat: onboard Tesla, Amazon, Palantir, Netflix tokens to Arbitrum mai…

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -5820,32 +5820,32 @@ export const allCoinsAndTokens = [
     '0x0726773451af83203583b5d38b3a11f752b1a96b',
     UnderlyingAsset['arbeth:bull']
   ),
-  tarbethErc20(
-    '9e3f8d7c-6b5a-4e2d-9f9c-8a7b6d5e4f3c',
+  arbethErc20(
+    '0f847466-f4e3-4f33-aee3-8b99f6637547',
     'arbeth:testtsla',
     'Tesla (Test)',
     18,
     '0xb94263fa0a2a29ea32c1f90ccaeeaffd0bb73908',
     UnderlyingAsset['arbeth:testtsla']
   ),
-  tarbethErc20(
-    '0f4a9e8d-7c6b-5a4e-9a0d-9b8c7e6f5a4b',
+  arbethErc20(
+    '1a137f85-4f8f-4191-8760-2b161e240bf2',
     'arbeth:testamzn',
     'Amazon (Test)',
     18,
     '0x76fca8a5bc14fce9eb613d96674868d687498804',
     UnderlyingAsset['arbeth:testamzn']
   ),
-  tarbethErc20(
-    '1a5b0f9e-8d7c-4b5a-9b1e-0c9d8f7a6b5c',
+  arbethErc20(
+    'd33cf58a-5e21-418b-bcb0-103f15fe1965',
     'arbeth:testpltr',
     'Palantir Technologies Inc (Test)',
     18,
     '0x99cd69ef9221c7fe0ad5618a7527244ef79636c6',
     UnderlyingAsset['arbeth:testpltr']
   ),
-  tarbethErc20(
-    '2b6c1a0f-9e8d-4c6b-9c2f-1d0e9a8b7c6d',
+  arbethErc20(
+    'a52a4906-7a39-4d4d-9b63-d4845685ecfa',
     'arbeth:testnflx',
     'Netflix Inc (Test)',
     18,

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -2041,6 +2041,34 @@ export const ofcCoins = [
     18,
     UnderlyingAsset['arbeth:tt']
   ),
+  ofcArbethErc20(
+    '51d64734-29a7-4d95-ab81-4073d3071945',
+    'ofcarbeth:testtsla',
+    'Tesla (Test)',
+    18,
+    UnderlyingAsset['arbeth:testtsla']
+  ),
+  ofcArbethErc20(
+    '98d1b16b-be68-4ea4-bc41-b19ad8f0eceb',
+    'ofcarbeth:testamzn',
+    'Amazon (Test)',
+    18,
+    UnderlyingAsset['arbeth:testamzn']
+  ),
+  ofcArbethErc20(
+    '4eceb506-7e84-4108-9190-76cc4cfeb0e7',
+    'ofcarbeth:testpltr',
+    'Palantir (Test)',
+    18,
+    UnderlyingAsset['arbeth:testpltr']
+  ),
+  ofcArbethErc20(
+    'bdd471d7-6561-4d92-93aa-51254dea517e',
+    'ofcarbeth:testnflx',
+    'Netflix (Test)',
+    18,
+    UnderlyingAsset['arbeth:testnflx']
+  ),
 
   ofcAvaxErc20('2bd6201d-c46c-481e-b82d-7cf3601679cb', 'ofcavaxc:aave-e', 'Aave', 18, UnderlyingAsset['avaxc:aave']),
   ofcAvaxErc20(

--- a/modules/statics/src/coins/ofcErc20Coins.ts
+++ b/modules/statics/src/coins/ofcErc20Coins.ts
@@ -4112,34 +4112,6 @@ export const tOfcErc20Coins = [
   tofcerc20('055ebe86-72cc-4f0e-b46f-c517d8e3687a', 'ofcterc', 'Test ERC Token', 18, UnderlyingAsset.TERC),
   tofcerc20('ac822eb1-4aa0-40d2-836d-7a24db24d47a', 'ofctest', 'Test Mintable ERC20 Token', 18, UnderlyingAsset.TEST),
   tofcerc20(
-    'e0f5b3c8-2d9a-4e7b-9a1c-8d3f6b0e9a2d',
-    'ofctarbeth:testtsla',
-    'Tesla (Test)',
-    18,
-    UnderlyingAsset['arbeth:testtsla']
-  ),
-  tofcerc20(
-    'f1a6c4d9-3e0b-4f8c-9b2d-9e4a7c1f0b3e',
-    'ofctarbeth:testamzn',
-    'Amazon (Test)',
-    18,
-    UnderlyingAsset['arbeth:testamzn']
-  ),
-  tofcerc20(
-    'a2b7d5e0-4f1c-4a9d-9c3e-0f5b8d2a1c4f',
-    'ofctarbeth:testpltr',
-    'Palantir (Test)',
-    18,
-    UnderlyingAsset['arbeth:testpltr']
-  ),
-  tofcerc20(
-    'b3c8e6f1-5a2d-4b0e-8d4f-1a6c9e3b2d5a',
-    'ofctarbeth:testnflx',
-    'Netflix (Test)',
-    18,
-    UnderlyingAsset['arbeth:testnflx']
-  ),
-  tofcerc20(
     '67b3f68b-a0bd-4bd7-b67e-36e8220bf67e',
     'ofcterc18dp13',
     'Test ERC Token 18 decimals',


### PR DESCRIPTION
## Description

Onboards Tesla, Amazon, Palantir, and Netflix tokens to Arbitrum mainnet.

## Changes

- Migrated 4 tokens from `tarbethErc20()` (testnet) to `arbethErc20()` (mainnet)
- Migrated 4 OFC tokens from `tofcerc20()` to `ofcArbethErc20()` (mainnet)
- Assigned new UUIDs for mainnet instances
- Contract addresses remain on Arbitrum One mainnet

### Tokens
- `arbeth:testtsla` - Tesla (Test)
- `arbeth:testamzn` - Amazon (Test)  
- `arbeth:testpltr` - Palantir Technologies Inc (Test)
- `arbeth:testnflx` - Netflix Inc (Test)

## Ticket
CGARD-591
