### PR TITLE
feat(abstract-utxo)!: enable legacy tx format for mainnet

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -421,9 +421,9 @@ export abstract class AbstractUtxoCoin
 
   public readonly amountType: 'number' | 'bigint';
 
-  protected readonly supportedTxFormats: { readonly psbt: boolean; readonly legacy: boolean } = {
+  protected supportedTxFormats: { psbt: boolean; legacy: boolean } = {
     psbt: true,
-    legacy: false,
+    legacy: this.isMainnet(),
   };
 
   protected constructor(bitgo: BitGoBase, amountType: 'number' | 'bigint' = 'number') {

--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -79,6 +79,7 @@ import {
   getFullNameFromCoinName,
   getMainnetCoinName,
   getNetworkFromCoinName,
+  isMainnetCoin,
   isUtxoCoinNameMainnet,
   UtxoCoinName,
   UtxoCoinNameMainnet,
@@ -408,6 +409,15 @@ export abstract class AbstractUtxoCoin
   implements Musig2Participant<utxolib.bitgo.UtxoPsbt>, Musig2Participant<fixedScriptWallet.BitGoPsbt>
 {
   abstract name: UtxoCoinName;
+
+  /**
+   * Returns whether this coin is a mainnet coin.
+   * Default implementation uses the name property.
+   * Can be overridden by subclasses.
+   */
+  protected isMainnet(): boolean {
+    return isMainnetCoin(this.name);
+  }
 
   public readonly amountType: 'number' | 'bigint';
 


### PR DESCRIPTION
Changes the supportedTxFormats property from readonly to mutable
and sets legacy format support based on network type. Legacy
format is now enabled for mainnet networks while remaining
disabled for testnet.

Adds a protected `isMainnet()` method to AbstractUtxoCoin class
that delegates to `isMainnetCoin()` helper and can be overridden
by subclasses if needed.

Issue: BTC-0