### PR TITLE
fix(sdk-coin-sol): use null check for decimalPlaces in token transfer builders

### DIFF
--- a/modules/sdk-coin-sol/src/lib/tokenTransferBuilder.ts
+++ b/modules/sdk-coin-sol/src/lib/tokenTransferBuilder.ts
@@ -124,7 +124,7 @@ export class TokenTransferBuilder extends TransactionBuilder {
         let tokenName: string;
         let programId: string | undefined;
         let decimals: number | undefined;
-        if (sendParams.tokenAddress && sendParams.programId && sendParams.decimalPlaces) {
+        if (sendParams.tokenAddress && sendParams.programId && sendParams.decimalPlaces != null) {
           tokenAddress = sendParams.tokenAddress;
           tokenName = sendParams.tokenName;
           programId = sendParams.programId;

--- a/modules/sdk-coin-sol/src/lib/transferBuilderV2.ts
+++ b/modules/sdk-coin-sol/src/lib/transferBuilderV2.ts
@@ -138,7 +138,7 @@ export class TransferBuilderV2 extends TransactionBuilder {
           let tokenName: string;
           let programId: string | undefined;
           let decimals: number | undefined;
-          if (sendParams.tokenAddress && sendParams.programId && sendParams.decimalPlaces) {
+          if (sendParams.tokenAddress && sendParams.programId && sendParams.decimalPlaces != null) {
             tokenName = sendParams.tokenName;
             tokenAddress = sendParams.tokenAddress;
             decimals = sendParams.decimalPlaces;


### PR DESCRIPTION
## Summary
- Fix JS falsy check bug where `decimalPlaces: 0` (e.g. NFTs) causes `buildImplementation` to skip the `sendParams` branch and throw "Could not determine token information" during PA approval
- Changed `&& sendParams.decimalPlaces` to `&& sendParams.decimalPlaces != null` in both `tokenTransferBuilder.ts` and `transferBuilderV2.ts`

## Impact
- Blocks all SPL token transfers where `decimalPlaces` is `0` (NFTs, certain tokens)
- Affects `uniqueDoubleSpendPreventionIds` → `build()` path during pending approval

## Test plan
- [x] TypeScript compilation passes
- [x] Unit tests pass 
- [ ] Verify NFT transfer via `customTx` completes PA approval after deploy

TICKET: CECHO-606

🤖 Generated with [Claude Code](https://claude.com/claude-code)