### PR TITLE
refactor(express): splits calculateMinerFeeInfo into v1 and v2

### DIFF
--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -1656,6 +1656,10 @@ export function setupAPIRoutes(app: express.Application, config: Config): void {
   router.post('express.decrypt', [prepareBitGo(config), typedPromiseWrapper(handleDecrypt)]);
   router.post('express.encrypt', [prepareBitGo(config), typedPromiseWrapper(handleEncrypt)]);
   router.post('express.verifyaddress', [prepareBitGo(config), typedPromiseWrapper(handleVerifyAddress)]);
+  router.post('express.v1.calculateminerfeeinfo', [
+    prepareBitGo(config),
+    typedPromiseWrapper(handleCalculateMinerFeeInfo),
+  ]);
   router.post('express.calculateminerfeeinfo', [
     prepareBitGo(config),
     typedPromiseWrapper(handleCalculateMinerFeeInfo),

--- a/modules/express/src/typedRoutes/api/index.ts
+++ b/modules/express/src/typedRoutes/api/index.ts
@@ -8,7 +8,8 @@ import { PostLogin } from './common/login';
 import { PostDecrypt } from './common/decrypt';
 import { PostEncrypt } from './common/encrypt';
 import { PostVerifyAddress } from './common/verifyAddress';
-import { PostCalculateMinerFeeInfo } from './common/calculateMinerFeeInfo';
+import { PostV1CalculateMinerFeeInfo } from './v1/calculateMinerFeeInfo';
+import { PostV2CalculateMinerFeeInfo } from './v2/calculateMinerFeeInfo';
 import { PostAcceptShare } from './v1/acceptShare';
 import { PostSimpleCreate } from './v1/simpleCreate';
 import { PutPendingApproval } from './v1/pendingApproval';
@@ -101,8 +102,11 @@ export const ExpressVerifyCoinAddressApiSpec = apiSpec({
 });
 
 export const ExpressCalculateMinerFeeInfoApiSpec = apiSpec({
+  'express.v1.calculateminerfeeinfo': {
+    post: PostV1CalculateMinerFeeInfo,
+  },
   'express.calculateminerfeeinfo': {
-    post: PostCalculateMinerFeeInfo,
+    post: PostV2CalculateMinerFeeInfo,
   },
 });
 

--- a/modules/express/src/typedRoutes/api/v1/calculateMinerFeeInfo.ts
+++ b/modules/express/src/typedRoutes/api/v1/calculateMinerFeeInfo.ts
@@ -27,22 +27,16 @@ export const CalculateMinerFeeInfoResponse = t.type({
 });
 
 /**
- * Calculate miner fee info
+ * Calculate miner fee info (v1)
  *
  * Calculates the estimated size and fee for a transaction based on the number and types of inputs and outputs.
  * This is useful for estimating the fee before creating a transaction.
  *
- * The calculation takes into account:
- * 1. The number and types of inputs (P2SH, P2PKH, P2SH-P2WSH)
- * 2. The number of outputs
- * 3. Whether the transaction contains uncompressed public keys
- * 4. The fee rate (in satoshis per kilobyte)
- *
- * @operationId express.calculateminerfeeinfo
+ * @operationId express.v1.calculateminerfeeinfo
  * @tag express
  */
-export const PostCalculateMinerFeeInfo = httpRoute({
-  path: '/api/v[12]/calculateminerfeeinfo',
+export const PostV1CalculateMinerFeeInfo = httpRoute({
+  path: '/api/v1/calculateminerfeeinfo',
   method: 'POST',
   request: httpRequest({
     body: CalculateMinerFeeInfoRequestBody,

--- a/modules/express/src/typedRoutes/api/v2/calculateMinerFeeInfo.ts
+++ b/modules/express/src/typedRoutes/api/v2/calculateMinerFeeInfo.ts
@@ -1,0 +1,31 @@
+import { httpRoute, httpRequest } from '@api-ts/io-ts-http';
+import { BitgoExpressError } from '../../schemas/error';
+import { CalculateMinerFeeInfoRequestBody, CalculateMinerFeeInfoResponse } from '../v1/calculateMinerFeeInfo';
+
+/**
+ * Calculate miner fee info
+ *
+ * Calculates the estimated size and fee for a transaction based on the number and types of inputs and outputs.
+ * This is useful for estimating the fee before creating a transaction.
+ *
+ * The calculation takes into account:
+ * 1. The number and types of inputs (P2SH, P2PKH, P2SH-P2WSH)
+ * 2. The number of outputs
+ * 3. Whether the transaction contains uncompressed public keys
+ * 4. The fee rate (in satoshis per kilobyte)
+ *
+ * @operationId express.calculateminerfeeinfo
+ * @tag express
+ */
+export const PostV2CalculateMinerFeeInfo = httpRoute({
+  path: '/api/v2/calculateminerfeeinfo',
+  method: 'POST',
+  request: httpRequest({
+    body: CalculateMinerFeeInfoRequestBody,
+  }),
+  response: {
+    200: CalculateMinerFeeInfoResponse,
+    400: BitgoExpressError,
+    404: BitgoExpressError,
+  },
+});

--- a/modules/express/test/unit/typedRoutes/calculateMinerFeeInfo.ts
+++ b/modules/express/test/unit/typedRoutes/calculateMinerFeeInfo.ts
@@ -3,8 +3,9 @@ import * as t from 'io-ts';
 import {
   CalculateMinerFeeInfoRequestBody,
   CalculateMinerFeeInfoResponse,
-  PostCalculateMinerFeeInfo,
-} from '../../../src/typedRoutes/api/common/calculateMinerFeeInfo';
+  PostV1CalculateMinerFeeInfo,
+} from '../../../src/typedRoutes/api/v1/calculateMinerFeeInfo';
+import { PostV2CalculateMinerFeeInfo } from '../../../src/typedRoutes/api/v2/calculateMinerFeeInfo';
 import { assertDecode } from './common';
 import 'should';
 import 'should-http';
@@ -301,25 +302,43 @@ describe('CalculateMinerFeeInfo codec tests', function () {
     });
   });
 
-  describe('PostCalculateMinerFeeInfo route definition', function () {
-    it('should have the correct path', function () {
-      assert.strictEqual(PostCalculateMinerFeeInfo.path, '/api/v[12]/calculateminerfeeinfo');
+  describe('PostV1CalculateMinerFeeInfo route definition', function () {
+    it('should have the correct path for v1', function () {
+      assert.strictEqual(PostV1CalculateMinerFeeInfo.path, '/api/v1/calculateminerfeeinfo');
     });
 
     it('should have the correct HTTP method', function () {
-      assert.strictEqual(PostCalculateMinerFeeInfo.method, 'POST');
+      assert.strictEqual(PostV1CalculateMinerFeeInfo.method, 'POST');
     });
 
     it('should have the correct request configuration', function () {
-      // Verify the route is configured with a request property
-      assert.ok(PostCalculateMinerFeeInfo.request);
+      assert.ok(PostV1CalculateMinerFeeInfo.request);
     });
 
     it('should have the correct response types', function () {
-      // Check that the response object has the expected status codes
-      assert.ok(PostCalculateMinerFeeInfo.response[200]);
-      assert.ok(PostCalculateMinerFeeInfo.response[400]);
-      assert.ok(PostCalculateMinerFeeInfo.response[404]);
+      assert.ok(PostV1CalculateMinerFeeInfo.response[200]);
+      assert.ok(PostV1CalculateMinerFeeInfo.response[400]);
+      assert.ok(PostV1CalculateMinerFeeInfo.response[404]);
+    });
+  });
+
+  describe('PostV2CalculateMinerFeeInfo route definition', function () {
+    it('should have the correct path for v2', function () {
+      assert.strictEqual(PostV2CalculateMinerFeeInfo.path, '/api/v2/calculateminerfeeinfo');
+    });
+
+    it('should have the correct HTTP method', function () {
+      assert.strictEqual(PostV2CalculateMinerFeeInfo.method, 'POST');
+    });
+
+    it('should have the correct request configuration', function () {
+      assert.ok(PostV2CalculateMinerFeeInfo.request);
+    });
+
+    it('should have the correct response types', function () {
+      assert.ok(PostV2CalculateMinerFeeInfo.response[200]);
+      assert.ok(PostV2CalculateMinerFeeInfo.response[400]);
+      assert.ok(PostV2CalculateMinerFeeInfo.response[404]);
     });
   });
 


### PR DESCRIPTION
Ticket: WP-7409

Context - https://bitgo.slack.com/archives/C057BHBRG4B/p1764020095794829?thread_ts=1764018507.602879&cid=C057BHBRG4B

The API behavior is not changing. We are splitting the combined v[12] route into two separate V1 and V2 routes, so both will continue to work and clients will not be affected.

