### PR TITLE
fix(sdk-coin-polyx): fix address creation flow for Polyx

### DIFF
--- a/modules/sdk-coin-polyx/src/lib/transactionBuilderFactory.ts
+++ b/modules/sdk-coin-polyx/src/lib/transactionBuilderFactory.ts
@@ -1,4 +1,4 @@
-import { BaseTransactionBuilderFactory, NotImplementedError } from '@bitgo/sdk-core';
+import { BaseTransactionBuilderFactory } from '@bitgo/sdk-core';
 import { BaseCoin as CoinConfig } from '@bitgo/statics';
 import { decode } from '@substrate/txwrapper-polkadot';
 import { TransferBuilder } from './transferBuilder';
@@ -67,8 +67,8 @@ export class TransactionBuilderFactory extends BaseTransactionBuilderFactory {
     return new WithdrawUnbondedBuilder(this._coinConfig).material(this._material);
   }
 
-  getWalletInitializationBuilder(): void {
-    throw new NotImplementedError(`walletInitialization for ${this._coinConfig.name} not implemented`);
+  getWalletInitializationBuilder(): RegisterDidWithCDDBuilder {
+    return this.getRegisterDidWithCDDBuilder();
   }
 
   from(rawTxn: string): TransactionBuilder<TxMethod, SupportedTransaction> {

--- a/modules/sdk-coin-polyx/src/polyx.ts
+++ b/modules/sdk-coin-polyx/src/polyx.ts
@@ -346,6 +346,14 @@ export class Polyx extends SubstrateCoin {
   }
 
   /**
+   * Polyx requires a wallet initialization transaction (RegisterDidWithCDD)
+   * to create an on-chain identity before the address can receive funds.
+   */
+  requiresWalletInitializationTransaction(): boolean {
+    return true;
+  }
+
+  /**
    * Gets config for how token enablements work for this coin
    * @returns
    *    requiresTokenEnablement: True if tokens need to be enabled for this coin

--- a/modules/sdk-coin-polyx/test/unit/polyx.ts
+++ b/modules/sdk-coin-polyx/test/unit/polyx.ts
@@ -180,6 +180,20 @@ describe('Polyx:', function () {
     });
   });
 
+  describe('Address Creation Flow:', function () {
+    it('should require wallet initialization transaction', function () {
+      const mainCoin = bitgo.coin('polyx') as Polyx;
+      mainCoin.requiresWalletInitializationTransaction().should.equal(true);
+      baseCoin.requiresWalletInitializationTransaction().should.equal(true);
+    });
+
+    it('should return a RegisterDidWithCDDBuilder from getWalletInitializationBuilder', function () {
+      const { RegisterDidWithCDDBuilder } = require('../../src/lib');
+      const builder = baseCoin.getBuilder().getWalletInitializationBuilder();
+      builder.should.be.instanceOf(RegisterDidWithCDDBuilder);
+    });
+  });
+
   describe('Token Enablement:', function () {
     it('should have correct token enablement config', function () {
       const config = baseCoin.getTokenEnablementConfig();


### PR DESCRIPTION
## Summary
- Fix `getWalletInitializationBuilder()` in `TransactionBuilderFactory` to return a `RegisterDidWithCDDBuilder` instead of throwing `NotImplementedError`
- Override `requiresWalletInitializationTransaction()` in `Polyx` to return `true`, since Polymesh requires an on-chain DID registration (`cddRegisterDidWithCdd`) before an address can receive funds
- Add unit tests covering both new behaviors

## Test plan
- [ ] Run `BITGOJS_TEST_PASSWORD=test yarn run unit-test --scope @bitgo/sdk-coin-polyx` — 104 tests pass
- [ ] Verify `getWalletInitializationBuilder()` returns a `RegisterDidWithCDDBuilder` instance
- [ ] Verify `requiresWalletInitializationTransaction()` returns `true` for both polyx and tpolyx

Ticket: CECHO-58

🤖 Generated with [Claude Code](https://claude.com/claude-code)