### PR TITLE
feat(trx): use camelCase fields in getAccountResources response

### DIFF
--- a/modules/express/src/typedRoutes/api/v2/accountResources.ts
+++ b/modules/express/src/typedRoutes/api/v2/accountResources.ts
@@ -28,12 +28,12 @@ export const AccountResourcesBody = {
 export const AccountResourceInfo = t.intersection([
   t.type({
     address: t.string,
-    free_bandwidth_available: t.number,
-    free_bandwidth_used: t.number,
-    staked_bandwidth_available: t.number,
-    staked_bandwidth_used: t.number,
-    energy_available: t.number,
-    energy_used: t.number,
+    freeBandwidthAvailable: t.number,
+    freeBandwidthUsed: t.number,
+    stakedBandwidthAvailable: t.number,
+    stakedBandwidthUsed: t.number,
+    energyAvailable: t.number,
+    energyUsed: t.number,
   }),
   t.partial({
     resourceDeficitForAssetTransfer: t.intersection([

--- a/modules/express/test/unit/clientRoutes/trxResourceDelegation.ts
+++ b/modules/express/test/unit/clientRoutes/trxResourceDelegation.ts
@@ -25,12 +25,12 @@ describe('TRX Resource Delegation handlers', () => {
       resources: [
         {
           address: 'TAddr123',
-          free_bandwidth_available: 1500,
-          free_bandwidth_used: 0,
-          staked_bandwidth_available: 0,
-          staked_bandwidth_used: 0,
-          energy_available: 0,
-          energy_used: 0,
+          freeBandwidthAvailable: 1500,
+          freeBandwidthUsed: 0,
+          stakedBandwidthAvailable: 0,
+          stakedBandwidthUsed: 0,
+          energyAvailable: 0,
+          energyUsed: 0,
         },
       ],
       failedAddresses: [],

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -546,12 +546,12 @@ export interface GetAccountResourcesOptions {
 
 export interface AccountResourceInfo {
   address: string;
-  free_bandwidth_available: number;
-  free_bandwidth_used: number;
-  staked_bandwidth_available: number;
-  staked_bandwidth_used: number;
-  energy_available: number;
-  energy_used: number;
+  freeBandwidthAvailable: number;
+  freeBandwidthUsed: number;
+  stakedBandwidthAvailable: number;
+  stakedBandwidthUsed: number;
+  energyAvailable: number;
+  energyUsed: number;
   resourceDeficitForAssetTransfer?: {
     bandwidthDeficit: number;
     bandwidthSunRequired: string;


### PR DESCRIPTION
## Summary

- Renames six snake_case fields in `AccountResourceInfo` interface and the express typed route schema to camelCase:
  - `free_bandwidth_available` → `freeBandwidthAvailable`
  - `free_bandwidth_used` → `freeBandwidthUsed`
  - `staked_bandwidth_available` → `stakedBandwidthAvailable`
  - `staked_bandwidth_used` → `stakedBandwidthUsed`
  - `energy_available` → `energyAvailable`
  - `energy_used` → `energyUsed`
- Companion to bitgo-microservices change for CHALO-62

## Test plan

- [ ] TypeScript compiles with no errors
- [ ] Existing tests pass

Ticket: CHALO-62