### PR TITLE
fix(statics): update BABY explorer links to Mintscan

### DIFF
--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -1124,13 +1124,13 @@ class RuneTestNet extends Testnet implements AccountNetwork {
 class Baby extends Mainnet implements AccountNetwork {
   name = 'Babylon';
   family = CoinFamily.BABY;
-  explorerUrl = 'https://babylon.explorers.guru/transaction/';
+  explorerUrl = 'https://www.mintscan.io/babylon/tx/';
 }
 
 class BabyTestnet extends Testnet implements AccountNetwork {
   name = 'Testnet Babylon';
   family = CoinFamily.BABY;
-  explorerUrl = 'https://testnet.babylon.explorers.guru/transaction/';
+  explorerUrl = 'https://www.mintscan.io/babylon-testnet/tx/';
 }
 
 class Mantra extends Mainnet implements CosmosNetwork {


### PR DESCRIPTION
Replace deprecated Nodes.Guru explorer URLs for Babylon (BABY) with Mintscan URLs, as the Babylon team has deprecated Nodes.Guru.

Mainnet: https://www.mintscan.io/babylon/tx/
Testnet: https://www.mintscan.io/babylon-testnet/tx/

Closes CSHLD-561