### PR TITLE
feat(sdk): removing mention of mitm attack from hmac error

### DIFF
--- a/modules/bitgo/test/unit/bitgo.ts
+++ b/modules/bitgo/test/unit/bitgo.ts
@@ -559,7 +559,7 @@ describe('BitGo Prototype Methods', function () {
       const scope = nock(url).get('/').reply(200);
 
       // test suite bitgo object has hmac verification enabled, so it should throw when the nock responds
-      await bitgo.get(url).should.be.rejectedWith(/invalid response HMAC, possible man-in-the-middle-attack/);
+      await bitgo.get(url).should.be.rejectedWith(/invalid response HMAC/);
       scope.done();
     });
 

--- a/modules/bitgo/test/v2/unit/auth.ts
+++ b/modules/bitgo/test/v2/unit/auth.ts
@@ -48,11 +48,7 @@ describe('Auth', () => {
 
       const scope = nock(url).get('/').reply(200);
 
-      await bitgo
-        .get(url)
-        .should.be.rejectedWith(
-          'server response outside response validity time window, possible man-in-the-middle-attack'
-        );
+      await bitgo.get(url).should.be.rejectedWith('server response outside response validity time window');
       verifyResponseStub.restore();
       scope.done();
     });

--- a/modules/sdk-api/src/api.ts
+++ b/modules/sdk-api/src/api.ts
@@ -235,7 +235,7 @@ function assertVerificationResponse(
       bitgoToken: partialBitgoToken,
     };
     debug('Invalid response HMAC: %O', errorDetails);
-    throw new ApiResponseError('invalid response HMAC, possible man-in-the-middle-attack', 511, errorDetails);
+    throw new ApiResponseError('invalid response HMAC', 511, errorDetails);
   }
 
   if (bitgo.getAuthVersion() === 3 && !verificationResponse.isInResponseValidityWindow) {
@@ -244,11 +244,7 @@ function assertVerificationResponse(
       verificationTime: verificationResponse.verificationTime,
     };
     debug('Server response outside response validity time window: %O', errorDetails);
-    throw new ApiResponseError(
-      'server response outside response validity time window, possible man-in-the-middle-attack',
-      511,
-      errorDetails
-    );
+    throw new ApiResponseError('server response outside response validity time window', 511, errorDetails);
   }
 }
 


### PR DESCRIPTION
Ticket: ANT-00000

Removing mention of MITM attacks in the SDK. Typically these shouldn't surface to a client, but when they do they're a bit more fear mongering than we'd like. 