### PR TITLE
feat(statics): add abstracteth EVM chain

### DIFF
--- a/modules/sdk-core/src/bitgo/environments.ts
+++ b/modules/sdk-core/src/bitgo/environments.ts
@@ -218,6 +218,9 @@ const mainnetBase: EnvironmentTemplate = {
   wemixExplorerBaseUrl: 'https://api.etherscan.io/v2',
   sgbExplorerBaseUrl: 'https://songbird-explorer.flare.network',
   evm: {
+    abstracteth: {
+      baseUrl: 'https://api.abscan.org/api',
+    },
     apechain: {
       baseUrl: 'https://api.etherscan.io/v2',
     },
@@ -433,6 +436,9 @@ const testnetBase: EnvironmentTemplate = {
   somniaExplorerBaseUrl: 'https://shannon-explorer.somnia.network/',
   soneiumExplorerBaseUrl: 'https://soneium-minato.blockscout.com',
   evm: {
+    abstracteth: {
+      baseUrl: 'https://api.sepolia.abscan.org/api',
+    },
     apechain: {
       baseUrl: 'https://api.etherscan.io/v2',
     },

--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -1518,6 +1518,42 @@ export const allCoinsAndTokens = [
     COREDAO_FEATURES
   ),
   account(
+    'f3bc3fef-7370-453a-a651-01a0f4d54246',
+    'abstracteth',
+    'Abstract Ethereum',
+    Networks.main.abstracteth,
+    18,
+    UnderlyingAsset.ABSTRACTETH,
+    BaseUnit.ETH,
+    [
+      ...EVM_FEATURES,
+      CoinFeature.SHARED_EVM_SIGNING,
+      CoinFeature.SHARED_EVM_SDK,
+      CoinFeature.EVM_COMPATIBLE_IMS,
+      CoinFeature.EVM_COMPATIBLE_UI,
+      CoinFeature.EVM_COMPATIBLE_WP,
+      CoinFeature.SUPPORTS_ERC20,
+    ]
+  ),
+  account(
+    'dd6c9539-90e1-4fb1-a428-c2dee96107f8',
+    'tabstracteth',
+    'Testnet Abstract Ethereum',
+    Networks.test.abstracteth,
+    18,
+    UnderlyingAsset.ABSTRACTETH,
+    BaseUnit.ETH,
+    [
+      ...EVM_FEATURES,
+      CoinFeature.SHARED_EVM_SIGNING,
+      CoinFeature.SHARED_EVM_SDK,
+      CoinFeature.EVM_COMPATIBLE_IMS,
+      CoinFeature.EVM_COMPATIBLE_UI,
+      CoinFeature.EVM_COMPATIBLE_WP,
+      CoinFeature.SUPPORTS_ERC20,
+    ]
+  ),
+  account(
     'd308ba34-557a-43f2-84f3-5775f1f1a779',
     'apechain',
     'Ape Chain',

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -21,6 +21,7 @@ export enum CoinKind {
  */
 export enum CoinFamily {
   ADA = 'ada',
+  ABSTRACTETH = 'abstracteth', // Abstract L2 EVM
   APECHAIN = 'apechain',
   ALGO = 'algo',
   APT = 'apt',
@@ -557,6 +558,7 @@ export enum CoinFeature {
  */
 export enum UnderlyingAsset {
   INVALID_UNKNOWN = 'invalid_asset_type',
+  ABSTRACTETH = 'abstracteth', // Abstract L2 EVM
   ADA = 'ada',
   ALGO = 'algo',
   APE = 'ape',

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -266,6 +266,22 @@ export const ofcCoins = [
     CoinKind.CRYPTO
   ),
   ofc(
+    '8daf44a2-1615-4938-8ce7-66b0e47c38a3',
+    'ofcabstracteth',
+    'Abstract Ethereum',
+    18,
+    UnderlyingAsset.ABSTRACTETH,
+    CoinKind.CRYPTO
+  ),
+  tofc(
+    '0220e727-49b9-402c-96b7-4b5c0fc055c0',
+    'ofctabstracteth',
+    'Abstract Ethereum Testnet',
+    18,
+    UnderlyingAsset.ABSTRACTETH,
+    CoinKind.CRYPTO
+  ),
+  ofc(
     '7e4fc86c-7caf-4cd3-b801-a650b0bfcf64',
     'ofcapechain',
     'Ape Chain',

--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -1583,6 +1583,24 @@ class ApeChainTestnet extends Testnet implements EthereumNetwork {
   batcherContractAddress = '0x3e1e5d78e44f15593b3b61ed278f12c27f0ff33e';
 }
 
+class AbstractEth extends Mainnet implements EthereumNetwork {
+  name = 'Abstract Ethereum';
+  family = CoinFamily.ABSTRACTETH;
+  explorerUrl = 'https://abscan.org/tx/';
+  accountExplorerUrl = 'https://abscan.org/address/';
+  chainId = 2741;
+  nativeCoinOperationHashPrefix = '2741';
+}
+
+class AbstractEthTestnet extends Testnet implements EthereumNetwork {
+  name = 'Testnet Abstract Ethereum';
+  family = CoinFamily.ABSTRACTETH;
+  explorerUrl = 'https://sepolia.abscan.org/tx/';
+  accountExplorerUrl = 'https://sepolia.abscan.org/address/';
+  chainId = 11124;
+  nativeCoinOperationHashPrefix = '11124';
+}
+
 class Pharos extends Mainnet implements EthereumNetwork {
   name = 'Pharos';
   family = CoinFamily.PHRS;
@@ -2644,6 +2662,7 @@ export class DynamicNetwork extends BaseNetwork {
 
 export const Networks = {
   main: {
+    abstracteth: Object.freeze(new AbstractEth()),
     ada: Object.freeze(new Ada()),
     algorand: Object.freeze(new Algorand()),
     apechain: Object.freeze(new ApeChain()),
@@ -2765,6 +2784,7 @@ export const Networks = {
     unieth: Object.freeze(new Unieth()),
   },
   test: {
+    abstracteth: Object.freeze(new AbstractEthTestnet()),
     ada: Object.freeze(new AdaTestnet()),
     algorand: Object.freeze(new AlgorandTestnet()),
     apechain: Object.freeze(new ApeChainTestnet()),

--- a/modules/statics/test/unit/fixtures/expectedColdFeatures.ts
+++ b/modules/statics/test/unit/fixtures/expectedColdFeatures.ts
@@ -71,6 +71,7 @@ export const expectedColdFeatures = {
     'zketh',
   ],
   justTSS: [
+    'abstracteth',
     'ada',
     'apechain',
     'apt',
@@ -146,6 +147,7 @@ export const expectedColdFeatures = {
     'kavaevm',
     'xdc',
     'zeta',
+    'tabstracteth',
     'tada',
     'tasi',
     'tatom',


### PR DESCRIPTION
Add Abstract L2 (Abstract Ethereum) chain support to BitGoJS SDK.

## Changes

- `modules/statics/src/base.ts` - Added `ABSTRACTETH` to `CoinFamily` and `UnderlyingAsset` enums
- `modules/statics/src/networks.ts` - Added `AbstractEth` and `AbstractEthTestnet` network classes
- `modules/statics/src/allCoinsAndTokens.ts` - Added `abstracteth` and `tabstracteth` coin entries
- `modules/statics/src/coins/ofcCoins.ts` - Added `ofcabstracteth` and `ofctabstracteth` OFC entries
- `modules/sdk-core/src/bitgo/environments.ts` - Added explorer API URLs
- `modules/statics/test/unit/fixtures/expectedColdFeatures.ts` - Updated test fixtures

## Chain Details

- Mainnet Chain ID: 2741
- Testnet Chain ID: 11124
- Explorer: https://abscan.org
- Testnet Explorer: https://sepolia.abscan.org
- ERC20 support: enabled

Ticket: CECHO-665