### PR TITLE
fix(sdk-core): use explicit undefined check for mpcv2PartyId

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -67,6 +67,8 @@ module.exports = {
         'VL-',
         'WIN-',
         'WP-',
+        'WAL-',
+        'WCN-',
         'WCI-',
         'COIN-',
         'FIAT-',

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
@@ -776,7 +776,7 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
     const hashBuffer = hash.update(bufferContent).digest();
     const otherSigner = new DklsDsg.Dsg(
       userKeyShare,
-      params.mpcv2PartyId ? params.mpcv2PartyId : 0,
+      params.mpcv2PartyId !== undefined ? params.mpcv2PartyId : 0,
       derivationPath,
       hashBuffer
     );


### PR DESCRIPTION
## Summary
- Falsy check `params.mpcv2PartyId ? ... : 0` treats party ID `0` as falsy. Replace with an explicit `undefined` check so the intent is correct and doesn't rely on the fallback coincidentally matching the desired default.

## Why no unit test
- `signRequestBase` is a private method with heavy dependencies (`DklsDsg.Dsg`, `openpgp`, `DklsComms`, BitGo API, wallet/coin interfaces) and zero existing test infrastructure — the mocking effort far outweighs the value for a one-line fix.
- The bug is coincidentally harmless: the falsy fallback (`0`) matches the actual desired default, so the old code produced correct results in all cases. The fix makes the *intent* correct rather than relying on that coincidence.

## Test plan
- [ ] Existing unit tests pass (`yarn unit-test-changed`)
- [ ] Code review confirms the `!== undefined` check is correct

Ticket: WAL-387