### PR TITLE
fix(abstract-eth): validate maxPriorityFeePerGas <= maxFeePerGas (CGD-573)

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -75,6 +75,7 @@ module.exports = {
         'ME-',
         'ANT-',
         'CGARD-',
+        'CGD-',
         'CHALO-',
         'CECHO-',
         'CSHLD-',

--- a/modules/abstract-eth/src/lib/transactionBuilder.ts
+++ b/modules/abstract-eth/src/lib/transactionBuilder.ts
@@ -539,8 +539,13 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
       this.validateValue(new BigNumber(fee.gasLimit));
     }
     if (fee.eip1559) {
-      this.validateValue(new BigNumber(fee.eip1559.maxFeePerGas));
-      this.validateValue(new BigNumber(fee.eip1559.maxPriorityFeePerGas));
+      const maxFee = new BigNumber(fee.eip1559.maxFeePerGas);
+      const priorityFee = new BigNumber(fee.eip1559.maxPriorityFeePerGas);
+      this.validateValue(maxFee);
+      this.validateValue(priorityFee);
+      if (priorityFee.isGreaterThan(maxFee)) {
+        throw new BuildTransactionError('maxPriorityFeePerGas cannot exceed maxFeePerGas');
+      }
     }
     if (fee.gasPrice) {
       this.validateValue(new BigNumber(fee.gasPrice));

--- a/modules/abstract-eth/test/unit/transactionBuilder/walletInitialization.ts
+++ b/modules/abstract-eth/test/unit/transactionBuilder/walletInitialization.ts
@@ -129,3 +129,17 @@ export async function testRecoveryTransactionWithoutData(txBuilder: TransactionB
     await txBuilder.build().should.be.rejectedWith('Invalid transaction: missing contract call data field');
   });
 }
+
+export function testEip1559PriorityFeeExceedsMaxFee(txBuilder: TransactionBuilder) {
+  it('fail when maxPriorityFeePerGas exceeds maxFeePerGas', () => {
+    (() =>
+      txBuilder.fee({
+        eip1559: {
+          maxFeePerGas: '1000000000',
+          maxPriorityFeePerGas: '9000000000',
+        },
+        fee: '1000000000',
+        gasLimit: '21000',
+      })).should.throw('maxPriorityFeePerGas cannot exceed maxFeePerGas');
+  });
+}

--- a/modules/sdk-coin-eth/test/unit/transactionBuilder/walletInitialization.ts
+++ b/modules/sdk-coin-eth/test/unit/transactionBuilder/walletInitialization.ts
@@ -301,6 +301,26 @@ describe('Eth Transaction builder wallet initialization', function () {
       should.doesNotThrow(() => txBuilder.fee({ fee: '10' }));
     });
 
+    it('eip1559 maxPriorityFeePerGas must not exceed maxFeePerGas', () => {
+      const txBuilder: any = getBuilder('eth');
+      assert.throws(
+        () =>
+          txBuilder.fee({
+            fee: '1000000000',
+            gasLimit: '21000',
+            eip1559: { maxFeePerGas: '1000000000', maxPriorityFeePerGas: '9000000000' },
+          }),
+        /maxPriorityFeePerGas cannot exceed maxFeePerGas/
+      );
+      should.doesNotThrow(() =>
+        txBuilder.fee({
+          fee: '1000000000',
+          gasLimit: '21000',
+          eip1559: { maxFeePerGas: '1000000000', maxPriorityFeePerGas: '1000000000' },
+        })
+      );
+    });
+
     it('a private key', () => {
       const txBuilder: any = getBuilder('eth');
       assert.throws(() => txBuilder.validateKey({ key: 'abc' }), /Invalid key/);


### PR DESCRIPTION
## Summary

- Adds cross-field EIP-1559 validation in `transactionBuilder.ts` `fee()` setter: throws `BuildTransactionError` when `maxPriorityFeePerGas > maxFeePerGas`
- Adds `testEip1559PriorityFeeExceedsMaxFee` helper in `abstract-eth` test utilities
- Adds an inline test in `sdk-coin-eth` covering both the invalid case and the equal-value boundary

## Context

EIP-1559 transactions with `maxPriorityFeePerGas > maxFeePerGas` are rejected by Ethereum nodes. The SDK previously accepted such values silently — the transaction passed signing but failed at broadcast. A partial mitigation already exists in the microservices API layer (`validateEip1559Params()`), but SDK consumers using offline signing or direct builder access were unprotected.

## Test plan

- [x] `yarn run unit-test --scope @bitgo/abstract-eth` — 70 passing
- [x] `yarn run unit-test --scope @bitgo/sdk-coin-eth` — 142 passing (9 pre-existing failures due to missing `BITGOJS_TEST_PASSWORD`, unrelated to this change)
- [x] New test confirmed isolated: `mocha --grep maxPriorityFeePerGas` → 1 passing

Ticket: CGD-573

🤖 Generated with [Claude Code](https://claude.com/claude-code)