### PR TITLE
ci: remove fossa license-analysis job from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,47 +144,6 @@ jobs:
       # We conciously do not audit dependencies as a PR step since errors are typically
       # unrelated to the PR changes. This check is performed in `publish.yml`.
 
-  license-analysis:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: socketdev/action@v1
-        with:
-          mode: firewall-free
-
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Setup node 22
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 22
-
-      - name: restore lerna dependencies
-        id: lerna-cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
-        with:
-          path: |
-            node_modules
-            modules/*/node_modules
-          key: ${{ runner.os }}-node22-${{ hashFiles('yarn.lock') }}-${{ hashFiles('tsconfig.packages.json') }}-${{ hashFiles('**/package.json') }}
-
-      - name: Install Packages
-        if: steps.lerna-cache.outputs.cache-hit != 'true'
-        run: sfw yarn install --with-frozen-lockfile --ignore-scripts
-
-      - name: build packages
-        env:
-          # Workaround for https://github.com/nodejs/node/issues/51555
-          DISABLE_V8_COMPILE_CACHE: '1'
-        run: yarn run postinstall
-
-      - name: Run Fossa Analysis
-        uses: fossas/fossa-action@3ebcea1862c6ffbd5cf1b4d0bd6b3fe7bd6f2cac # v1.7.0
-        with:
-          api-key: ${{ secrets.FOSSA_API_KEY }}
-          branch: ${{ github.head_ref || github.ref_name }}
-          project: BitGo/BitGoJS
-
   browser-test:
     runs-on: ubuntu-22.04
 


### PR DESCRIPTION
The fossa `license-analysis` job has been migrated to internal checks. Removing the old job to avoid failures on dependabot PRs.

Ticket: VL-4461