### PR TITLE
fix(sdk-lib-mpc): authenticate signatureR in DKLS DSG round 4 messages

### DIFF
--- a/modules/abstract-lightning/package.json
+++ b/modules/abstract-lightning/package.json
@@ -39,7 +39,7 @@
     ]
   },
   "dependencies": {
-    "@bitgo/public-types": "5.76.1",
+    "@bitgo/public-types": "5.92.0",
     "@bitgo/sdk-core": "^36.40.0",
     "@bitgo/statics": "^58.35.0",
     "@bitgo/utxo-lib": "^11.22.0",

--- a/modules/bitgo/package.json
+++ b/modules/bitgo/package.json
@@ -138,7 +138,7 @@
     "superagent": "^9.0.1"
   },
   "devDependencies": {
-    "@bitgo/public-types": "5.76.1",
+    "@bitgo/public-types": "5.92.0",
     "@bitgo/sdk-opensslbytes": "^2.1.0",
     "@bitgo/sdk-test": "^9.1.38",
     "@openpgp/web-stream-tools": "0.0.14",

--- a/modules/express/package.json
+++ b/modules/express/package.json
@@ -60,7 +60,7 @@
     "superagent": "^9.0.1"
   },
   "devDependencies": {
-    "@bitgo/public-types": "5.76.1",
+    "@bitgo/public-types": "5.92.0",
     "@bitgo/sdk-lib-mpc": "^10.10.2",
     "@bitgo/sdk-test": "^9.1.38",
     "@types/argparse": "^1.0.36",

--- a/modules/express/src/typedRoutes/api/index.ts
+++ b/modules/express/src/typedRoutes/api/index.ts
@@ -59,7 +59,8 @@ import { GetResourceDelegations } from './v2/resourceDelegations';
 //
 // > error TS7056: The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed.
 //
-// As a workaround, only construct expressApi with a single key and add it to the type union at the end
+// Workarounds: (1) export heavy httpRoute handlers as `HttpRoute<'post'>` (etc.) in their modules so apiSpec
+// inference stays small; (2) only construct expressApi with a single key and add it to the type union at the end.
 
 export const ExpressPingApiSpec = apiSpec({
   'express.ping': {

--- a/modules/express/src/typedRoutes/api/v2/sendCoins.ts
+++ b/modules/express/src/typedRoutes/api/v2/sendCoins.ts
@@ -1,5 +1,5 @@
 import * as t from 'io-ts';
-import { httpRoute, httpRequest, optional } from '@api-ts/io-ts-http';
+import { httpRoute, httpRequest, optional, type HttpRoute } from '@api-ts/io-ts-http';
 import { BitgoExpressError } from '../../schemas/error';
 import { SendManyResponse, EIP1559Params, MemoParams, TokenEnablement } from './sendmany';
 
@@ -412,7 +412,7 @@ export const SendCoinsRequestBody = {
  * @operationId express.wallet.sendcoins
  * @tag express
  */
-export const PostSendCoins = httpRoute({
+export const PostSendCoins: HttpRoute<'post'> = httpRoute({
   path: '/api/v2/{coin}/wallet/{id}/sendcoins',
   method: 'POST',
   request: httpRequest({

--- a/modules/express/src/typedRoutes/api/v2/sendmany.ts
+++ b/modules/express/src/typedRoutes/api/v2/sendmany.ts
@@ -1,6 +1,6 @@
 import * as t from 'io-ts';
 import { DateFromISOString } from 'io-ts-types';
-import { httpRoute, httpRequest, optional } from '@api-ts/io-ts-http';
+import { httpRoute, httpRequest, optional, type HttpRoute } from '@api-ts/io-ts-http';
 import { TransactionRequest as TxRequestResponse } from '@bitgo/public-types';
 import { BitgoExpressError } from '../../schemas/error';
 
@@ -790,7 +790,7 @@ export const SendManyResponse = t.intersection([
  * @operationId express.wallet.sendmany
  * @tag Express
  */
-export const PostSendMany = httpRoute({
+export const PostSendMany: HttpRoute<'post'> = httpRoute({
   path: '/api/v2/{coin}/wallet/{id}/sendmany',
   method: 'POST',
   request: httpRequest({

--- a/modules/express/src/typedRoutes/api/v2/walletSignTx.ts
+++ b/modules/express/src/typedRoutes/api/v2/walletSignTx.ts
@@ -1,5 +1,5 @@
 import * as t from 'io-ts';
-import { httpRoute, httpRequest, optional } from '@api-ts/io-ts-http';
+import { httpRoute, httpRequest, optional, type HttpRoute } from '@api-ts/io-ts-http';
 import { TransactionRequest as TxRequestResponse, TransactionRequestApiVersion } from '@bitgo/public-types';
 import { BitgoExpressError } from '../../schemas/error';
 import { Recipient } from './coinSignTx';
@@ -147,7 +147,7 @@ export const WalletSignTxResponse = {
  * @operationId express.v2.wallet.signtx
  * @tag Express
  */
-export const PostWalletSignTx = httpRoute({
+export const PostWalletSignTx: HttpRoute<'post'> = httpRoute({
   path: '/api/v2/{coin}/wallet/{id}/signtx',
   method: 'POST',
   request: httpRequest({

--- a/modules/express/src/typedRoutes/api/v2/walletTxSignTSS.ts
+++ b/modules/express/src/typedRoutes/api/v2/walletTxSignTSS.ts
@@ -1,5 +1,5 @@
 import * as t from 'io-ts';
-import { httpRoute, httpRequest, optional } from '@api-ts/io-ts-http';
+import { httpRoute, httpRequest, optional, type HttpRoute } from '@api-ts/io-ts-http';
 import { TransactionRequest as TxRequestResponse, TransactionRequestApiVersion } from '@bitgo/public-types';
 import { BitgoExpressError } from '../../schemas/error';
 import { Recipient } from './coinSignTx';
@@ -161,7 +161,7 @@ export const WalletTxSignTSSResponse = {
  * @tag express
  * @operationId express.v2.wallet.signtxtss
  */
-export const PostWalletTxSignTSS = httpRoute({
+export const PostWalletTxSignTSS: HttpRoute<'post'> = httpRoute({
   path: '/api/v2/{coin}/wallet/{id}/signtxtss',
   method: 'POST',
   request: httpRequest({

--- a/modules/express/test/unit/clientRoutes/externalSign.ts
+++ b/modules/express/test/unit/clientRoutes/externalSign.ts
@@ -1046,16 +1046,22 @@ async function signBitgoMPCv2Round3(
   userGPGPubKey: string
 ): Promise<{ userMsg4: MPCv2SignatureShareRound3Input }> {
   const parsedSignatureShare = JSON.parse(userShare.share) as MPCv2SignatureShareRound3Input;
+  const msg4 = parsedSignatureShare.data.msg4;
+  const signatureRAuthMessage =
+    msg4.signatureR && msg4.signatureRSignature
+      ? { message: msg4.signatureR, signature: msg4.signatureRSignature }
+      : undefined;
   const serializedMessages = await DklsComms.decryptAndVerifyIncomingMessages(
     {
       p2pMessages: [],
       broadcastMessages: [
         {
-          from: parsedSignatureShare.data.msg4.from,
+          from: msg4.from,
           payload: {
-            message: parsedSignatureShare.data.msg4.message,
-            signature: parsedSignatureShare.data.msg4.signature,
+            message: msg4.message,
+            signature: msg4.signature,
           },
+          signatureR: signatureRAuthMessage,
         },
       ],
     },

--- a/modules/sdk-coin-flrp/package.json
+++ b/modules/sdk-coin-flrp/package.json
@@ -47,7 +47,7 @@
     "@bitgo/sdk-test": "^9.1.38"
   },
   "dependencies": {
-    "@bitgo/public-types": "5.76.1",
+    "@bitgo/public-types": "5.92.0",
     "@bitgo/sdk-core": "^36.40.0",
     "@bitgo/secp256k1": "^1.11.0",
     "@bitgo/statics": "^58.35.0",

--- a/modules/sdk-coin-sol/package.json
+++ b/modules/sdk-coin-sol/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@bitgo/logger": "^1.4.0",
-    "@bitgo/public-types": "5.76.1",
+    "@bitgo/public-types": "5.92.0",
     "@bitgo/sdk-core": "^36.40.0",
     "@bitgo/sdk-lib-mpc": "^10.10.2",
     "@bitgo/statics": "^58.35.0",

--- a/modules/sdk-core/package.json
+++ b/modules/sdk-core/package.json
@@ -40,7 +40,7 @@
     ]
   },
   "dependencies": {
-    "@bitgo/public-types": "5.76.1",
+    "@bitgo/public-types": "5.92.0",
     "@bitgo/sdk-lib-mpc": "^10.10.2",
     "@bitgo/secp256k1": "^1.11.0",
     "@bitgo/sjcl": "^1.1.0",

--- a/modules/sdk-core/src/bitgo/tss/ecdsa/ecdsaMPCv2.ts
+++ b/modules/sdk-core/src/bitgo/tss/ecdsa/ecdsaMPCv2.ts
@@ -126,8 +126,12 @@ export async function getSignatureShareRoundThree(
     [getUserPartyGpgKey(userGpgKey, partyId)]
   );
   assert(MPCv2PartyFromStringOrNumber.is(userToBitGoEncryptedMsg4.broadcastMessages[0].from));
-  if (!userToBitGoEncryptedMsg4.broadcastMessages[0].signatureR?.message) {
+  const signatureR = userToBitGoEncryptedMsg4.broadcastMessages[0].signatureR;
+  if (!signatureR?.message) {
     throw Error('signatureR should be defined');
+  }
+  if (!signatureR.signature) {
+    throw Error('signatureR signature should be defined');
   }
   const share: MPCv2SignatureShareRound3Input = {
     type: 'round3Input',
@@ -136,7 +140,8 @@ export async function getSignatureShareRoundThree(
         from: userToBitGoEncryptedMsg4.broadcastMessages[0].from,
         message: userToBitGoEncryptedMsg4.broadcastMessages[0].payload.message,
         signature: userToBitGoEncryptedMsg4.broadcastMessages[0].payload.signature,
-        signatureR: userToBitGoEncryptedMsg4.broadcastMessages[0].signatureR.message,
+        signatureR: signatureR.message,
+        signatureRSignature: signatureR.signature,
       },
     },
   };

--- a/modules/sdk-lib-mpc/src/tss/ecdsa-dkls/commsLayer.ts
+++ b/modules/sdk-lib-mpc/src/tss/ecdsa-dkls/commsLayer.ts
@@ -188,9 +188,15 @@ export async function decryptAndVerifyIncomingMessages(
         if (!(await verifySignedData(m.payload, pubGpgKey.gpgKey))) {
           throw Error(`Failed to authenticate broadcast message from party: ${m.from}`);
         }
+        if (m.signatureR !== undefined) {
+          if (!(await verifySignedData(m.signatureR, pubGpgKey.gpgKey))) {
+            throw Error(`Failed to authenticate signatureR in broadcast message from party: ${m.from}`);
+          }
+        }
         return {
           from: m.from,
           payload: m.payload.message,
+          signatureR: m.signatureR?.message,
         };
       })
     ),
@@ -233,15 +239,16 @@ export async function encryptAndAuthOutgoingMessages(
         if (!prvGpgKey) {
           throw Error(`No private key provided for sender with ID: ${m.from}`);
         }
+        const [signedPayload, signedSignatureR] = await Promise.all([
+          detachSignData(Buffer.from(m.payload, 'base64'), prvGpgKey.gpgKey),
+          m.signatureR
+            ? detachSignData(Buffer.from(m.signatureR, 'base64'), prvGpgKey.gpgKey)
+            : Promise.resolve(undefined),
+        ]);
         return {
           from: m.from,
-          payload: await detachSignData(Buffer.from(m.payload, 'base64'), prvGpgKey.gpgKey),
-          signatureR: m.signatureR
-            ? {
-                message: m.signatureR,
-                signature: '',
-              }
-            : undefined,
+          payload: signedPayload,
+          signatureR: signedSignatureR,
         };
       })
     ),

--- a/modules/sdk-lib-mpc/test/unit/tss/ecdsa/dklsComms.ts
+++ b/modules/sdk-lib-mpc/test/unit/tss/ecdsa/dklsComms.ts
@@ -1,6 +1,8 @@
 import {
   decryptAndVerifySignedData,
   encryptAndDetachSignData,
+  decryptAndVerifyIncomingMessages,
+  encryptAndAuthOutgoingMessages,
   verifySignedData,
   SIGNATURE_DATE_TOLERANCE_MS,
 } from '../../../../src/tss/ecdsa-dkls/commsLayer';
@@ -163,5 +165,186 @@ describe('DKLS Communication Layer', function () {
       );
       result.should.equal(false);
     });
+  });
+});
+
+describe('DKLS encryptAndAuthOutgoingMessages / decryptAndVerifyIncomingMessages', function () {
+  let partyAKey: { publicKey: string; privateKey: string };
+  let partyBKey: { publicKey: string; privateKey: string };
+  let tampererKey: { publicKey: string; privateKey: string };
+
+  before(async function () {
+    openpgp.config.rejectCurves = new Set();
+    partyAKey = await openpgp.generateKey({
+      userIDs: [{ name: 'partyA', email: 'a@test.com' }],
+      curve: 'secp256k1',
+    });
+    partyBKey = await openpgp.generateKey({
+      userIDs: [{ name: 'partyB', email: 'b@test.com' }],
+      curve: 'secp256k1',
+    });
+    tampererKey = await openpgp.generateKey({
+      userIDs: [{ name: 'tamperer', email: 'evil@test.com' }],
+      curve: 'secp256k1',
+    });
+  });
+
+  const partyAId = 0;
+  const partyBId = 2;
+
+  it('should sign signatureR and verify it on receive', async function () {
+    const payload = Buffer.from('deadbeef', 'hex').toString('base64');
+    const signatureRBytes = Buffer.from('cafebabe', 'hex').toString('base64');
+
+    const encrypted = await encryptAndAuthOutgoingMessages(
+      {
+        p2pMessages: [],
+        broadcastMessages: [{ from: partyAId, payload, signatureR: signatureRBytes }],
+      },
+      [{ partyId: partyBId, gpgKey: partyBKey.publicKey }],
+      [{ partyId: partyAId, gpgKey: partyAKey.privateKey }]
+    );
+
+    const broadcastMsg = encrypted.broadcastMessages[0];
+    broadcastMsg.signatureR!.message.should.equal(signatureRBytes);
+    broadcastMsg.signatureR!.signature.should.not.equal('');
+
+    const decrypted = await decryptAndVerifyIncomingMessages(
+      {
+        p2pMessages: [],
+        broadcastMessages: [broadcastMsg],
+      },
+      [{ partyId: partyAId, gpgKey: partyAKey.publicKey }],
+      [{ partyId: partyBId, gpgKey: partyBKey.privateKey }]
+    );
+
+    decrypted.broadcastMessages[0].signatureR!.should.equal(signatureRBytes);
+  });
+
+  it('should reject a tampered signatureR on receive', async function () {
+    const payload = Buffer.from('deadbeef', 'hex').toString('base64');
+    const signatureRBytes = Buffer.from('cafebabe', 'hex').toString('base64');
+
+    const encrypted = await encryptAndAuthOutgoingMessages(
+      {
+        p2pMessages: [],
+        broadcastMessages: [{ from: partyAId, payload, signatureR: signatureRBytes }],
+      },
+      [{ partyId: partyBId, gpgKey: partyBKey.publicKey }],
+      [{ partyId: partyAId, gpgKey: partyAKey.privateKey }]
+    );
+
+    const tampered = {
+      ...encrypted.broadcastMessages[0],
+      signatureR: {
+        message: Buffer.from('00000000', 'hex').toString('base64'),
+        signature: encrypted.broadcastMessages[0].signatureR!.signature,
+      },
+    };
+
+    await decryptAndVerifyIncomingMessages(
+      { p2pMessages: [], broadcastMessages: [tampered] },
+      [{ partyId: partyAId, gpgKey: partyAKey.publicKey }],
+      [{ partyId: partyBId, gpgKey: partyBKey.privateKey }]
+    ).should.be.rejectedWith(`Failed to authenticate signatureR in broadcast message from party: ${partyAId}`);
+  });
+
+  it('should reject a signatureR signed by a different key', async function () {
+    const payload = Buffer.from('deadbeef', 'hex').toString('base64');
+    const signatureRBytes = Buffer.from('cafebabe', 'hex').toString('base64');
+
+    const encrypted = await encryptAndAuthOutgoingMessages(
+      {
+        p2pMessages: [],
+        broadcastMessages: [{ from: partyAId, payload, signatureR: signatureRBytes }],
+      },
+      [{ partyId: partyBId, gpgKey: partyBKey.publicKey }],
+      [{ partyId: partyAId, gpgKey: tampererKey.privateKey }]
+    );
+
+    await decryptAndVerifyIncomingMessages(
+      { p2pMessages: [], broadcastMessages: [encrypted.broadcastMessages[0]] },
+      [{ partyId: partyAId, gpgKey: partyAKey.publicKey }],
+      [{ partyId: partyBId, gpgKey: partyBKey.privateKey }]
+    ).should.be.rejectedWith(`Failed to authenticate broadcast message from party: ${partyAId}`);
+  });
+
+  it('should handle broadcast messages without signatureR unchanged', async function () {
+    const payload = Buffer.from('deadbeef', 'hex').toString('base64');
+
+    const encrypted = await encryptAndAuthOutgoingMessages(
+      {
+        p2pMessages: [],
+        broadcastMessages: [{ from: partyAId, payload }],
+      },
+      [{ partyId: partyBId, gpgKey: partyBKey.publicKey }],
+      [{ partyId: partyAId, gpgKey: partyAKey.privateKey }]
+    );
+
+    (encrypted.broadcastMessages[0].signatureR === undefined).should.equal(true);
+
+    const decrypted = await decryptAndVerifyIncomingMessages(
+      { p2pMessages: [], broadcastMessages: [encrypted.broadcastMessages[0]] },
+      [{ partyId: partyAId, gpgKey: partyAKey.publicKey }],
+      [{ partyId: partyBId, gpgKey: partyBKey.privateKey }]
+    );
+
+    (decrypted.broadcastMessages[0].signatureR === undefined).should.equal(true);
+  });
+
+  it('should skip signatureR verification when signatureR field is omitted (soft downgrade)', async function () {
+    const payload = Buffer.from('deadbeef', 'hex').toString('base64');
+    const signatureRBytes = Buffer.from('cafebabe', 'hex').toString('base64');
+
+    const encrypted = await encryptAndAuthOutgoingMessages(
+      {
+        p2pMessages: [],
+        broadcastMessages: [{ from: partyAId, payload, signatureR: signatureRBytes }],
+      },
+      [{ partyId: partyBId, gpgKey: partyBKey.publicKey }],
+      [{ partyId: partyAId, gpgKey: partyAKey.privateKey }]
+    );
+
+    const broadcastWithoutAuthR = {
+      from: encrypted.broadcastMessages[0].from,
+      payload: encrypted.broadcastMessages[0].payload,
+    };
+
+    const decrypted = await decryptAndVerifyIncomingMessages(
+      { p2pMessages: [], broadcastMessages: [broadcastWithoutAuthR] },
+      [{ partyId: partyAId, gpgKey: partyAKey.publicKey }],
+      [{ partyId: partyBId, gpgKey: partyBKey.privateKey }]
+    );
+
+    (decrypted.broadcastMessages[0].signatureR === undefined).should.equal(true);
+  });
+
+  it('should reject when signatureR message is present but signature is empty string', async function () {
+    const payload = Buffer.from('deadbeef', 'hex').toString('base64');
+    const signatureRBytes = Buffer.from('cafebabe', 'hex').toString('base64');
+
+    const encrypted = await encryptAndAuthOutgoingMessages(
+      {
+        p2pMessages: [],
+        broadcastMessages: [{ from: partyAId, payload, signatureR: signatureRBytes }],
+      },
+      [{ partyId: partyBId, gpgKey: partyBKey.publicKey }],
+      [{ partyId: partyAId, gpgKey: partyAKey.privateKey }]
+    );
+
+    const strippedSig = {
+      ...encrypted.broadcastMessages[0],
+      signatureR: {
+        message: encrypted.broadcastMessages[0].signatureR!.message,
+        signature: '',
+      },
+    };
+
+    // Empty armor: OpenPGP fails parsing before verifySignedData returns false.
+    await decryptAndVerifyIncomingMessages(
+      { p2pMessages: [], broadcastMessages: [strippedSig] },
+      [{ partyId: partyAId, gpgKey: partyAKey.publicKey }],
+      [{ partyId: partyBId, gpgKey: partyBKey.privateKey }]
+    ).should.be.rejected();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,7 +45,7 @@
 
 "@api-ts/openapi-generator@5.14.0":
   version "5.14.0"
-  resolved "https://registry.npmjs.org/@api-ts/openapi-generator/-/openapi-generator-5.14.0.tgz#13d8370ad04fa5b12d49e7f07651af216e4f7331"
+  resolved "https://registry.npmjs.org/@api-ts/openapi-generator/-/openapi-generator-5.14.0.tgz"
   integrity sha512-adpM9cRCkprZPawF7rcWL230S5pcGUnumsQaYonkmsIOEcYn7l6/qvtJI7ZXLFt3lqyH9ifPg3eBUk6nsyR2wA==
   dependencies:
     "@swc/core" "1.5.7"
@@ -999,10 +999,10 @@
     "@scure/base" "1.1.5"
     micro-eth-signer "0.7.2"
 
-"@bitgo/public-types@5.76.1":
-  version "5.76.1"
-  resolved "https://registry.npmjs.org/@bitgo/public-types/-/public-types-5.76.1.tgz#c36b245fccc4a90068fced8a4e2985d57f561bc1"
-  integrity sha512-S3dKa1to6xQj/cmtKrip6ytG1/4qBkRhZ117cOERlRcHHJFY8/h+1zCKazlRU+FRc8JUWcLlAoFnAcqifHw3Eg==
+"@bitgo/public-types@5.92.0":
+  version "5.92.0"
+  resolved "https://registry.npmjs.org/@bitgo/public-types/-/public-types-5.92.0.tgz"
+  integrity sha512-w4eVzf2Aggc/0MzjDnyY5AlCgikElwzhTriJVhpqUrS1jeqIxQ0dhuiKrruN/VnhUUNGPW9M20WOHg9eeQ+I9w==
   dependencies:
     fp-ts "^2.0.0"
     io-ts "npm:@bitgo-forks/io-ts@2.1.4"
@@ -1012,22 +1012,22 @@
 
 "@bitgo/wasm-dot@^1.7.0":
   version "1.7.0"
-  resolved "https://registry.npmjs.org/@bitgo/wasm-dot/-/wasm-dot-1.7.0.tgz#d22aafea9d38ebcb4b75d38538202237eadac685"
+  resolved "https://registry.npmjs.org/@bitgo/wasm-dot/-/wasm-dot-1.7.0.tgz"
   integrity sha512-KoXavJvyDHlEN+sWcigbgxYJtdFaU7gS0EkYQbNH4npVjNlzo6rL6gwjyWbyOy7oEs65DhpJ9vY5kRbE/bKiTQ==
 
 "@bitgo/wasm-solana@^2.6.0":
   version "2.6.0"
-  resolved "https://registry.npmjs.org/@bitgo/wasm-solana/-/wasm-solana-2.6.0.tgz#c8b57ab010f22f1a1c90681cd180814c4ec2867b"
+  resolved "https://registry.npmjs.org/@bitgo/wasm-solana/-/wasm-solana-2.6.0.tgz"
   integrity sha512-F9H4pXDMhfsZW5gNEcoaBzVoEMOQRP8wbQKmjsxbm5PXBq+0Aj54rOY3bswdrFZK377/aeB+tLjXu3h9i8gInQ==
 
 "@bitgo/wasm-ton@^1.1.1":
   version "1.1.1"
-  resolved "https://registry.npmjs.org/@bitgo/wasm-ton/-/wasm-ton-1.1.1.tgz#3361cbbe06e1fe40d13dbf384ef806b46a5e43df"
+  resolved "https://registry.npmjs.org/@bitgo/wasm-ton/-/wasm-ton-1.1.1.tgz"
   integrity sha512-Y4x2V2ZcYWlmx42v7dlrKDtT2DuUt8smk8E98mh7RhpiifJhLk2v5RmXDwBl0A3v9TzUOU6qMOnSS/iZ8Pq52w==
 
 "@bitgo/wasm-utxo@^4.1.0":
   version "4.1.0"
-  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-4.1.0.tgz#039ab84eb73bd0354bdf3e6f2a14fc043e139cdd"
+  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-4.1.0.tgz"
   integrity sha512-J6tKdfhJggt8LHKSh+KScz6/Q6VcX59D/1ycbUw/w+zWVOSKt+Z2+FFbYTJIVatxc4gA2bGqvHftC9dSbZBAwA==
 
 "@brandonblack/musig@^0.0.1-alpha.0":
@@ -1072,7 +1072,7 @@
 
 "@clack/core@^0.3.3":
   version "0.3.5"
-  resolved "https://registry.npmjs.org/@clack/core/-/core-0.3.5.tgz#3e1454c83a329353cc3a6ff8491e4284d49565bb"
+  resolved "https://registry.npmjs.org/@clack/core/-/core-0.3.5.tgz"
   integrity sha512-5cfhQNH+1VQ2xLQlmzXMqUoiaH0lRBq9/CLW9lTyMbuKLC3+xEK01tHVvyut++mLOn5urSHmkm6I0Lg9MaJSTQ==
   dependencies:
     picocolors "^1.0.0"
@@ -1080,7 +1080,7 @@
 
 "@clack/prompts@^0.7.0":
   version "0.7.0"
-  resolved "https://registry.npmjs.org/@clack/prompts/-/prompts-0.7.0.tgz#6aaef48ea803d91cce12bc80811cfcb8de2e75ea"
+  resolved "https://registry.npmjs.org/@clack/prompts/-/prompts-0.7.0.tgz"
   integrity sha512-0MhX9/B4iL6Re04jPrttDm+BsP8y6mS7byuv0BvXgdXhbV5PdlsHt55dvNsuBCPZ7xq1oTAOOuotR9NFbQyMSA==
   dependencies:
     "@clack/core" "^0.3.3"
@@ -2777,7 +2777,7 @@
 
 "@flarenetwork/flarejs@4.1.1":
   version "4.1.1"
-  resolved "https://registry.npmjs.org/@flarenetwork/flarejs/-/flarejs-4.1.1.tgz#5aac35a43431e9e08263094da48838e6159a69e7"
+  resolved "https://registry.npmjs.org/@flarenetwork/flarejs/-/flarejs-4.1.1.tgz"
   integrity sha512-XuzMROKI/4LfOWt2NY3suagmq0PjRbhyVaDznfVzTI0kRl/64xDc74kElusidewh55Y/5Ajrl1wBPrRhXG4fNQ==
   dependencies:
     "@noble/curves" "1.3.0"
@@ -2785,6 +2785,11 @@
     "@noble/secp256k1" "2.0.0"
     "@scure/base" "1.1.5"
     micro-eth-signer "0.7.2"
+
+"@gar/promise-retry@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz#65e726428e794bc4453948e0a41e6de4215ce8b0"
+  integrity sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==
 
 "@gar/promisify@^1.1.3":
   version "1.1.3"
@@ -3814,18 +3819,18 @@
     which "^5.0.0"
 
 "@npmcli/git@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/@npmcli/git/-/git-7.0.0.tgz"
-  integrity sha512-vnz7BVGtOctJAIHouCJdvWBhsTVSICMeUgZo2c7XAi5d5Rrl80S1H7oPym7K03cRuinK5Q6s2dw36+PgXQTcMA==
+  version "7.0.2"
+  resolved "https://registry.npmjs.org/@npmcli/git/-/git-7.0.2.tgz#680c3271fe51401c07ee41076be678851e600ff0"
+  integrity sha512-oeolHDjExNAJAnlYP2qzNjMX/Xi9bmu78C9dIGr4xjobrSKbuMYCph8lTzn4vnW3NjIqVmw/f8BCfouqyJXlRg==
   dependencies:
-    "@npmcli/promise-spawn" "^8.0.0"
-    ini "^5.0.0"
+    "@gar/promise-retry" "^1.0.0"
+    "@npmcli/promise-spawn" "^9.0.0"
+    ini "^6.0.0"
     lru-cache "^11.2.1"
     npm-pick-manifest "^11.0.1"
-    proc-log "^5.0.0"
-    promise-retry "^2.0.1"
+    proc-log "^6.0.0"
     semver "^7.3.5"
-    which "^5.0.0"
+    which "^6.0.0"
 
 "@npmcli/installed-package-contents@^2.0.1":
   version "2.1.0"
@@ -3940,6 +3945,13 @@
   dependencies:
     which "^5.0.0"
 
+"@npmcli/promise-spawn@^9.0.0":
+  version "9.0.1"
+  resolved "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-9.0.1.tgz#20e80cbdd2f24ad263a15de3ebbb1673cb82005b"
+  integrity sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q==
+  dependencies:
+    which "^6.0.0"
+
 "@npmcli/query@^4.0.0":
   version "4.0.1"
   resolved "https://registry.npmjs.org/@npmcli/query/-/query-4.0.1.tgz"
@@ -4006,49 +4018,49 @@
   integrity sha512-Iwf7gxWMeDdrNqXYkVOib6PlDYwLw51+nMiFm1UW5nKxbQyVYHp7lhQNHsZrQ7Oqo84m9swWgzE7bhs21HkbYQ==
 
 "@nx/nx-darwin-x64@*":
-  version "22.0.4"
-  resolved "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-22.0.4.tgz#7b501c1556cbfd7f88c8655d5a2c5fa4b237b8e1"
-  integrity sha512-p+pmlq/mdNhQb12RwHP9V6yAUX9CLy8GUT4ijPzFTbxqa9dZbJk69NpSRwpAhAvvQ30gp1Zyh0t0/k/yaZqMIg==
+  version "22.6.5"
+  resolved "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-22.6.5.tgz#55b5e7c9137dbfea2acfd7043a58bdaca4f4e9df"
+  integrity sha512-9jICxb7vfJ56y/7Yuh3b/n1QJqWxO9xnXKYEs6SO8xPoW/KomVckILGc1C6RQSs6/3ixVJC7k1Dh1wm5tKPFrg==
 
 "@nx/nx-freebsd-x64@*":
-  version "22.0.4"
-  resolved "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-22.0.4.tgz#6d9ba7748d406b0914985945eeb31adf9d382956"
-  integrity sha512-XW2SXtfO245DRnAXVGYJUB7aBJsJ2rPD5pizxJET+l3VmtHGp2crdVuftw6iqjgrf2eAS+yCe61Jnqh687vWFg==
+  version "22.6.5"
+  resolved "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-22.6.5.tgz#499e1fb013cf6fab217257d89405b9e19bf624a9"
+  integrity sha512-6B1wEKpqz5dI3AGMqttAVnA6M3DB/besAtuGyQiymK9ROlta1iuWgCcIYwcCQyhLn2Rx7vqj447KKcgCa8HlVw==
 
 "@nx/nx-linux-arm-gnueabihf@*":
-  version "22.0.4"
-  resolved "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-22.0.4.tgz#363c8adf6b4d836709a4d54f6263f113f1039af7"
-  integrity sha512-LCLuhbW3SIFz2FGiLdspCrNP889morCzTV/pEtxA8EgusWqCR8WjeSj3QvN8HN/GoXDsJxoUXvClZbHE+N6Hyg==
+  version "22.6.5"
+  resolved "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-22.6.5.tgz#e492bd050aee479976c290fb5b23f290c284d665"
+  integrity sha512-xV50B8mnDPboct7JkAHftajI02s+8FszA8WTzhore+YGR+lEKHTLpucwGEaQuMlSdLplH7pQix4B4uK5pcMhZw==
 
 "@nx/nx-linux-arm64-gnu@*":
-  version "22.0.4"
-  resolved "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.0.4.tgz#81d9470130742f7042d870e584bb7728ed3cbc44"
-  integrity sha512-2jvS8MYYOI8eUBRTmE8HKm5mRVLqS5Cvlj06tEAjxrmH5d7Bv8BG5Ps9yZzT0qswfVKChpzIliwPZomUjLTxmA==
+  version "22.6.5"
+  resolved "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.6.5.tgz#4bdab184c1405e87680bbc49bb1ee79a3d8b0200"
+  integrity sha512-2JkWuMGj+HpW6oPAvU5VdAx1afTnEbiM10Y3YOrl3fipWV4BiP5VDx762QTrfCraP4hl6yqTgvTe7F9xaby+jQ==
 
 "@nx/nx-linux-arm64-musl@*":
-  version "22.0.4"
-  resolved "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.0.4.tgz#7f8176cf76ef7fc81af4ef434ac3d3959dcbf272"
-  integrity sha512-IK9gf8/AOtTW6rZajmGAFCN7EBzjmkIevt9MtOehQGlNXlMXydvUYKE5VU7d4oglvYs8aJJyayihfiZbFnTS8g==
+  version "22.6.5"
+  resolved "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.6.5.tgz#c1eb8ea0bb92cfbe50f3ccebdf931ce79d2052f6"
+  integrity sha512-Z/zMqFClnEyqDXouJKEPoWVhMQIif5F0YuECWBYjd3ZLwQsXGTItoh+6Wm3XF/nGMA2uLOHyTq/X7iFXQY3RzA==
 
 "@nx/nx-linux-x64-gnu@*":
-  version "22.0.4"
-  resolved "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.0.4.tgz#faeb8d6f54d81dd73abc21a2928cf4c18b810cc6"
-  integrity sha512-CdALjMqqNgiffQQIlyxx6mrxJCOqDzmN6BW3w9msCPHVSPOPp4AenlT0kpC7ALvmNEUm0lC4r093QbN2t6a/wA==
+  version "22.6.5"
+  resolved "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.6.5.tgz#4f905688d30649c51035d71dca26a55666819cc2"
+  integrity sha512-FlotSyqNnaXSn0K+yWw+hRdYBwusABrPgKLyixfJIYRzsy+xPKN6pON6vZfqGwzuWF/9mEGReRz+iM8PiW0XSg==
 
 "@nx/nx-linux-x64-musl@*":
-  version "22.0.4"
-  resolved "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.0.4.tgz#2cc0e5be5415ac85f164943ea42ca4ca0889bcf9"
-  integrity sha512-2GPy+mAQo4JnfjTtsgGrHhZbTmmGy4RqaGowe0qMYCMuBME33ChG9iiRmArYmVtCAhYZVn26rK76/Vn3tK7fgg==
+  version "22.6.5"
+  resolved "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.6.5.tgz#94fed5da71aad67290ec10e35e30b9d065ed1c2e"
+  integrity sha512-RVOe2qcwhoIx6mxQURPjUfAW5SEOmT2gdhewvdcvX9ICq1hj5B2VarmkhTg0qroO7xiyqOqwq26mCzoV2I3NgQ==
 
 "@nx/nx-win32-arm64-msvc@*":
-  version "22.0.4"
-  resolved "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.0.4.tgz#796e81bef402f216fa170eddd912578acb7bd939"
-  integrity sha512-jnZCCnTXoqOIrH0L31+qHVHmJuDYPoN6sl37/S1epP9n4fhcy9tjSx4xvx/WQSd417lU9saC+g7Glx2uFdgcTw==
+  version "22.6.5"
+  resolved "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.6.5.tgz#60e3ad6379fbd6e9ae1d189d9803f156bcc29774"
+  integrity sha512-ZqurqI8VuYnsr2Kn4K4t+Gx6j/BZdf6qz/6Tv4A7XQQ6oNYVQgTqoNEFj+CCkVaIe6aIdCWpousFLqs+ZgBqYQ==
 
 "@nx/nx-win32-x64-msvc@*":
-  version "22.0.4"
-  resolved "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-22.0.4.tgz#958951dd96ee14d908674f2846a9dc0f85318618"
-  integrity sha512-CDBqgb9RV5aHMDLcsS9kDDULc38u/eieZBhHBL01Ca5Tq075QuHn4uly6sYyHwVOxrhY4eaWNSfV2xG3Bg6Gtw==
+  version "22.6.5"
+  resolved "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-22.6.5.tgz#d07d4d9d48c99f7b4c8c8a0dc2b14bf9239a3076"
+  integrity sha512-i2QFBJIuaYg9BHxrrnBV4O7W9rVL2k0pSIdk/rRp3EYJEU93iUng+qbZiY9wh1xvmXuUCE2G7TRd+8/SG/RFKg==
 
 "@octokit/auth-token@^2.4.4":
   version "2.5.0"
@@ -4509,7 +4521,7 @@
 
 "@polkadot/keyring@13.5.6", "@polkadot/keyring@^13.1.1", "@polkadot/keyring@^13.2.1":
   version "13.5.6"
-  resolved "https://registry.npmjs.org/@polkadot/keyring/-/keyring-13.5.6.tgz#b26d0cba323bb0520826211317701aa540428406"
+  resolved "https://registry.npmjs.org/@polkadot/keyring/-/keyring-13.5.6.tgz"
   integrity sha512-Ybe6Mflrh96FKR5tfEaf/93RxJD7x9UigseNOJW6Yd8LF+GesdxrqmZD7zh+53Hb7smGQWf/0FCfwhoWZVgPUQ==
   dependencies:
     "@polkadot/util" "13.5.6"
@@ -4829,7 +4841,7 @@
 
 "@puppeteer/browsers@2.6.1":
   version "2.6.1"
-  resolved "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.6.1.tgz#d75aec5010cae377c5e4742bf5e4f62a79c21315"
+  resolved "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.6.1.tgz"
   integrity sha512-aBSREisdsGH890S2rQqK82qmQYU3uFpSH8wcZWHgHzl3LfzsxAKbLNiAG9mO8v1Y0UICBeClICxPJvyr0rcuxg==
   dependencies:
     debug "^4.4.0"
@@ -5588,7 +5600,7 @@
 
 "@swc/core-darwin-arm64@1.5.7":
   version "1.5.7"
-  resolved "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.5.7.tgz#2b5cdbd34e4162e50de6147dd1a5cb12d23b08e8"
+  resolved "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.5.7.tgz"
   integrity sha512-bZLVHPTpH3h6yhwVl395k0Mtx8v6CGhq5r4KQdAoPbADU974Mauz1b6ViHAJ74O0IVE5vyy7tD3OpkQxL/vMDQ==
 
 "@swc/core-darwin-x64@1.5.7":
@@ -5638,7 +5650,7 @@
 
 "@swc/core@1.5.7":
   version "1.5.7"
-  resolved "https://registry.npmjs.org/@swc/core/-/core-1.5.7.tgz#e1db7b9887d5f34eb4a3256a738d0c5f1b018c33"
+  resolved "https://registry.npmjs.org/@swc/core/-/core-1.5.7.tgz"
   integrity sha512-U4qJRBefIJNJDRCCiVtkfa/hpiZ7w0R6kASea+/KLp+vkus3zcLSB8Ub8SvKgTIxjWpwsKcZlPf5nrv4ls46SQ==
   dependencies:
     "@swc/counter" "^0.1.2"
@@ -5657,7 +5669,7 @@
 
 "@swc/counter@^0.1.2", "@swc/counter@^0.1.3":
   version "0.1.3"
-  resolved "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz#cc7463bd02949611c6329596fccd2b0ec782b0e9"
+  resolved "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz"
   integrity sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==
 
 "@swc/helpers@^0.5.11":
@@ -5669,7 +5681,7 @@
 
 "@swc/types@0.1.7":
   version "0.1.7"
-  resolved "https://registry.npmjs.org/@swc/types/-/types-0.1.7.tgz#ea5d658cf460abff51507ca8d26e2d391bafb15e"
+  resolved "https://registry.npmjs.org/@swc/types/-/types-0.1.7.tgz"
   integrity sha512-scHWahbHF0eyj3JsxG9CFJgFdFNaVQCNAimBlT6PzS3n/HptxqREjsm4OH6AN3lYcffZYSPxXW8ua2BEHp0lJQ==
   dependencies:
     "@swc/counter" "^0.1.3"
@@ -6230,12 +6242,12 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*":
-  version "22.18.0"
-  resolved "https://registry.npmjs.org/@types/node/-/node-22.18.0.tgz"
-  integrity sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==
+"@types/node@*", "@types/node@^24.10.9":
+  version "24.10.9"
+  resolved "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz"
+  integrity sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==
   dependencies:
-    undici-types "~6.21.0"
+    undici-types "~7.16.0"
 
 "@types/node@11.11.6":
   version "11.11.6"
@@ -6279,13 +6291,6 @@
   integrity sha512-K7DIaHnh0mzVxreCR9qwgNxp3MH9dltPNIEddW9MYUlcKAzm+3grKNSTe2vCJHI1FaLpvpL5JGJrz1UZDKYvDg==
   dependencies:
     undici-types "~5.26.4"
-
-"@types/node@^24.10.9":
-  version "24.10.9"
-  resolved "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz#1aeb5142e4a92957489cac12b07f9c7fe26057d0"
-  integrity sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==
-  dependencies:
-    undici-types "~7.16.0"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.4"
@@ -6589,7 +6594,7 @@
 
 "@types/yargs@^17.0.0":
   version "17.0.35"
-  resolved "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz#07013e46aa4d7d7d50a49e15604c1c5340d4eb24"
+  resolved "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz"
   integrity sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==
   dependencies:
     "@types/yargs-parser" "*"
@@ -7579,7 +7584,7 @@ aws4@^1.8.0:
 
 axios@0.25.0, axios@0.27.2, axios@1.15.0, axios@1.7.4, axios@^0.21.2, axios@^0.26.1, axios@^1.13.0, axios@^1.6.0, axios@^1.8.3:
   version "1.15.0"
-  resolved "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz#0fcee91ef03d386514474904b27863b2c683bf4f"
+  resolved "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz"
   integrity sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==
   dependencies:
     follow-redirects "^1.15.11"
@@ -7588,7 +7593,7 @@ axios@0.25.0, axios@0.27.2, axios@1.15.0, axios@1.7.4, axios@^0.21.2, axios@^0.2
 
 b4a@^1.6.4:
   version "1.7.3"
-  resolved "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz#24cf7ccda28f5465b66aec2bac69e32809bf112f"
+  resolved "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz"
   integrity sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==
 
 b64-lite@^1.3.1, b64-lite@^1.4.0:
@@ -7655,12 +7660,12 @@ balanced-match@^1.0.0:
 
 bare-events@^2.5.4, bare-events@^2.7.0:
   version "2.8.2"
-  resolved "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz#7b3e10bd8e1fc80daf38bb516921678f566ab89f"
+  resolved "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz"
   integrity sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==
 
 bare-fs@^4.0.1:
   version "4.5.1"
-  resolved "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.1.tgz#498a20a332d4a7f0b310eb89b8d2319041aa1eef"
+  resolved "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.1.tgz"
   integrity sha512-zGUCsm3yv/ePt2PHNbVxjjn0nNB1MkIaR4wOCxJ2ig5pCf5cCVAYJXVhQg/3OhhJV6DB1ts7Hv0oUaElc2TPQg==
   dependencies:
     bare-events "^2.5.4"
@@ -7671,26 +7676,26 @@ bare-fs@^4.0.1:
 
 bare-os@^3.0.1:
   version "3.6.2"
-  resolved "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz#b3c4f5ad5e322c0fd0f3c29fc97d19009e2796e5"
+  resolved "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz"
   integrity sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==
 
 bare-path@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz#b59d18130ba52a6af9276db3e96a2e3d3ea52178"
+  resolved "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz"
   integrity sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==
   dependencies:
     bare-os "^3.0.1"
 
 bare-stream@^2.6.4:
   version "2.7.0"
-  resolved "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz#5b9e7dd0a354d06e82d6460c426728536c35d789"
+  resolved "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz"
   integrity sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==
   dependencies:
     streamx "^2.21.0"
 
 bare-url@^2.2.2:
   version "2.3.2"
-  resolved "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz#4aef382efa662b2180a6fe4ca07a71b39bdf7ca3"
+  resolved "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz"
   integrity sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==
   dependencies:
     bare-path "^3.0.0"
@@ -8780,7 +8785,7 @@ chrome-trace-event@^1.0.2:
 
 chromium-bidi@0.11.0:
   version "0.11.0"
-  resolved "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.11.0.tgz#9c3c42ee7b42d8448e9fce8d649dc8bfbcc31153"
+  resolved "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.11.0.tgz"
   integrity sha512-6CJWHkNRoyZyjV9Rwv2lYONZf1Xm0IuDyNq97nwSsxxP3wf5Bwy15K5rOvVKMtJ127jJBmxFUanSAOjgFRxgrA==
   dependencies:
     mitt "3.0.1"
@@ -8946,7 +8951,7 @@ cmd-shim@^7.0.0:
 
 cmd-ts@0.13.0:
   version "0.13.0"
-  resolved "https://registry.npmjs.org/cmd-ts/-/cmd-ts-0.13.0.tgz#57bdbc5dc95eb5a3503ab3ac9591c91427a79fa1"
+  resolved "https://registry.npmjs.org/cmd-ts/-/cmd-ts-0.13.0.tgz"
   integrity sha512-nsnxf6wNIM/JAS7T/x/1JmbEsjH0a8tezXqqpaL0O6+eV0/aDEnRxwjxpu0VzDdRcaC1ixGSbRlUuf/IU59I4g==
   dependencies:
     chalk "^4.0.0"
@@ -9822,7 +9827,7 @@ debug@^3.1.0, debug@^3.2.7:
 
 debug@^4.4.0, debug@~4.4.1:
   version "4.4.3"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
   dependencies:
     ms "^2.1.3"
@@ -10117,7 +10122,7 @@ detective@^4.0.0:
 
 devtools-protocol@0.0.1367902:
   version "0.0.1367902"
-  resolved "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz#7333bfc4466c5a54a4c6de48a9dfbcb4b811660c"
+  resolved "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz"
   integrity sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==
 
 dezalgo@^1.0.4:
@@ -10135,7 +10140,7 @@ di@^0.0.1:
 
 didyoumean@^1.2.2:
   version "1.2.2"
-  resolved "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz#989346ffe9e839b4555ecf5666edea0d3e8ad037"
+  resolved "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz"
   integrity sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==
 
 diff@^3.5.0:
@@ -10266,7 +10271,7 @@ domhandler@^5.0.2, domhandler@^5.0.3:
 
 dompurify@^3.3.1:
   version "3.3.1"
-  resolved "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz#c7e1ddebfe3301eacd6c0c12a4af284936dbbb86"
+  resolved "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz"
   integrity sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
@@ -11284,7 +11289,7 @@ eventemitter3@^4.0.0, eventemitter3@^4.0.4:
 
 events-universal@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz#b56a84fd611b6610e0a2d0f09f80fdf931e2dfe6"
+  resolved "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz"
   integrity sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==
   dependencies:
     bare-events "^2.7.0"
@@ -11518,7 +11523,7 @@ fast-diff@^1.1.2:
 
 fast-fifo@^1.2.0, fast-fifo@^1.3.2:
   version "1.3.2"
-  resolved "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz#286e31de96eb96d38a97899815740ba2a4f3640c"
+  resolved "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz"
   integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
 
 fast-glob@^3.2.5, fast-glob@^3.2.9:
@@ -11901,7 +11906,7 @@ fp-ts@2.16.2:
 
 fp-ts@2.16.9:
   version "2.16.9"
-  resolved "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.9.tgz#99628fc5e0bb3b432c4a16d8f4455247380bae8a"
+  resolved "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.9.tgz"
   integrity sha512-+I2+FnVB+tVaxcYyQkHUq7ZdKScaBlX53A41mxQtpIccsfyv8PzdzP7fzp2AY832T4aoK6UZ5WRX/ebGd8uZuQ==
 
 fp-ts@^2.0.0, fp-ts@^2.12.2, fp-ts@^2.16.2:
@@ -12961,7 +12966,7 @@ ignore@^5.0.4, ignore@^5.1.8, ignore@^5.2.0, ignore@^5.2.4:
 
 immutable@^5.0.2:
   version "5.1.5"
-  resolved "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz#93ee4db5c2a9ab42a4a783069f3c5d8847d40165"
+  resolved "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz"
   integrity sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==
 
 import-fresh@^3.0.0, import-fresh@^3.2.1, import-fresh@^3.3.0:
@@ -13055,6 +13060,11 @@ ini@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/ini/-/ini-5.0.0.tgz"
   integrity sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==
+
+ini@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz#efc7642b276f6a37d22fdf56ef50889d7146bf30"
+  integrity sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==
 
 init-package-json@8.2.2:
   version "8.2.2"
@@ -13153,7 +13163,7 @@ iobuffer@^5.3.2:
 
 ip-address@^9.0.5:
   version "9.0.5"
-  resolved "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz#117a960819b08780c3bd1f14ef3c1cc1d3f3ea5a"
+  resolved "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz"
   integrity sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==
   dependencies:
     jsbn "1.1.0"
@@ -13638,6 +13648,11 @@ isexe@^3.1.1:
   resolved "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz"
   integrity sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==
 
+isexe@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz#48f6576af8e87a18feb796b7ed5e2e5903b43dca"
+  integrity sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==
+
 iso-url@~0.4.7:
   version "0.4.7"
   resolved "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz"
@@ -13888,7 +13903,7 @@ js-yaml@^3.10.0, js-yaml@^3.13.1, js-yaml@^3.14.1:
 
 jsbn@1.1.0:
   version "1.1.0"
-  resolved "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
+  resolved "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz"
   integrity sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==
 
 jsbn@~0.1.0:
@@ -15293,7 +15308,7 @@ minizlib@^3.0.1, minizlib@^3.1.0:
 
 mitt@3.0.1:
   version "3.0.1"
-  resolved "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz#ea36cf0cc30403601ae074c8f77b7092cdab36d1"
+  resolved "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz"
   integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
 
 mkdirp@^0.5.5:
@@ -16229,7 +16244,7 @@ open@^8.4.0:
 
 openapi-types@12.1.3:
   version "12.1.3"
-  resolved "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz#471995eb26c4b97b7bd356aacf7b91b73e777dd3"
+  resolved "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz"
   integrity sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==
 
 opener@^1.5.2:
@@ -17316,6 +17331,11 @@ proc-log@^5.0.0:
   resolved "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz"
   integrity sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==
 
+proc-log@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz#18519482a37d5198e231133a70144a50f21f0215"
+  integrity sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==
+
 process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
@@ -17479,7 +17499,7 @@ proxy-agent@6.4.0:
 
 proxy-agent@^6.5.0:
   version "6.5.0"
-  resolved "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz#9e49acba8e4ee234aacb539f89ed9c23d02f232d"
+  resolved "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz"
   integrity sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==
   dependencies:
     agent-base "^7.1.2"
@@ -17503,7 +17523,7 @@ proxy-from-env@^1.1.0:
 
 proxy-from-env@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
+  resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz"
   integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 proxyquire@^2.1.3:
@@ -17552,7 +17572,7 @@ punycode@^2.1.0, punycode@^2.1.1:
 
 puppeteer-core@23.11.1:
   version "23.11.1"
-  resolved "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.11.1.tgz#3e064de11b3cb3a2df1a8060ff2d05b41be583db"
+  resolved "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.11.1.tgz"
   integrity sha512-3HZ2/7hdDKZvZQ7dhhITOUg4/wOrDRjyK2ZBllRB0ZCOi9u0cwq1ACHDjBB+nX+7+kltHjQvBRdeY7+W0T+7Gg==
   dependencies:
     "@puppeteer/browsers" "2.6.1"
@@ -17564,7 +17584,7 @@ puppeteer-core@23.11.1:
 
 puppeteer@^23.10.0:
   version "23.11.1"
-  resolved "https://registry.npmjs.org/puppeteer/-/puppeteer-23.11.1.tgz#98fd9040786b1219b1a4f639c270377586e8899c"
+  resolved "https://registry.npmjs.org/puppeteer/-/puppeteer-23.11.1.tgz"
   integrity sha512-53uIX3KR5en8l7Vd8n5DUv90Ae9QDQsyIthaUFVzwV6yU750RjqRznEtNMBT20VthqAdemnJN+hxVdmMHKt7Zw==
   dependencies:
     "@puppeteer/browsers" "2.6.1"
@@ -18529,7 +18549,7 @@ semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
 
 semver@^7.6.3:
   version "7.7.3"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz#4b5f4143d007633a8dc671cd0a6ef9147b8bb946"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz"
   integrity sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==
 
 send@0.19.0:
@@ -18907,7 +18927,7 @@ sirv@^2.0.3:
 
 sisteransi@^1.0.5:
   version "1.0.5"
-  resolved "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
+  resolved "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
 
 sjcl@^1.0.6, "sjcl@npm:@bitgo/sjcl@1.0.1":
@@ -19177,7 +19197,7 @@ split@^1.0.1:
 
 sprintf-js@^1.1.3:
   version "1.1.3"
-  resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz#4914b903a2f8b685d17fdf78a70e917e872e444a"
+  resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz"
   integrity sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==
 
 sprintf-js@~1.0.2:
@@ -19367,7 +19387,7 @@ streamroller@^3.1.5:
 
 streamx@^2.15.0, streamx@^2.21.0:
   version "2.23.0"
-  resolved "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz#7d0f3d00d4a6c5de5728aecd6422b4008d66fd0b"
+  resolved "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz"
   integrity sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==
   dependencies:
     events-universal "^1.0.0"
@@ -19758,7 +19778,7 @@ tape@^4.6.3:
 
 tar-fs@^3.0.6:
   version "3.1.1"
-  resolved "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz#4f164e59fb60f103d472360731e8c6bb4a7fe9ef"
+  resolved "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz"
   integrity sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==
   dependencies:
     pump "^3.0.0"
@@ -19769,7 +19789,7 @@ tar-fs@^3.0.6:
 
 tar-stream@^3.1.5:
   version "3.1.7"
-  resolved "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz#24b3fb5eabada19fe7338ed6d26e5f7c482e792b"
+  resolved "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz"
   integrity sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==
   dependencies:
     b4a "^1.6.4"
@@ -19789,7 +19809,7 @@ tar-stream@~2.2.0:
 
 tar@6.2.1, tar@^6.1.11, tar@^6.1.2:
   version "6.2.1"
-  resolved "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz#717549c541bc3c2af15751bea94b1dd068d4b03a"
+  resolved "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz"
   integrity sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==
   dependencies:
     chownr "^2.0.0"
@@ -19852,7 +19872,7 @@ test-exclude@^6.0.0:
 
 text-decoder@^1.1.0:
   version "1.2.3"
-  resolved "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz#b19da364d981b2326d5f43099c310cc80d770c65"
+  resolved "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz"
   integrity sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==
   dependencies:
     b4a "^1.6.4"
@@ -20330,7 +20350,7 @@ typed-array-length@^1.0.7:
 
 typed-query-selector@^2.12.0:
   version "2.12.0"
-  resolved "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz#92b65dbc0a42655fccf4aeb1a08b1dddce8af5f2"
+  resolved "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz"
   integrity sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==
 
 typedarray-to-buffer@^3.1.5:
@@ -20428,7 +20448,7 @@ unbox-primitive@^1.1.0:
 
 unbzip2-stream@^1.4.3:
   version "1.4.3"
-  resolved "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz#b0da04c4371311df771cdc215e87f2130991ace7"
+  resolved "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz"
   integrity sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==
   dependencies:
     buffer "^5.2.1"
@@ -20455,11 +20475,6 @@ undici-types@~6.19.2:
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
-undici-types@~6.21.0:
-  version "6.21.0"
-  resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz"
-  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
-
 undici-types@~7.10.0:
   version "7.10.0"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz"
@@ -20467,7 +20482,7 @@ undici-types@~7.10.0:
 
 undici-types@~7.16.0:
   version "7.16.0"
-  resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
+  resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz"
   integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
@@ -21173,6 +21188,13 @@ which@^5.0.0:
   dependencies:
     isexe "^3.1.1"
 
+which@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/which/-/which-6.0.1.tgz#021642443a198fb93b784a5606721cb18cfcbfce"
+  integrity sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==
+  dependencies:
+    isexe "^4.0.0"
+
 wide-align@1.1.5, wide-align@^1.1.5:
   version "1.1.5"
   resolved "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz"
@@ -21323,7 +21345,7 @@ ws@7.5.10, ws@8.17.1, ws@8.18.0, ws@^7, ws@^7.0.0, ws@^7.3.1, ws@^7.5.10:
 
 ws@~8.17.1:
   version "8.17.1"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz"
   integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
 
 wsl-utils@^0.1.0:
@@ -21534,7 +21556,7 @@ yoctocolors-cjs@^2.1.2:
 
 zod@3.23.8:
   version "3.23.8"
-  resolved "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz#e37b957b5d52079769fb8097099b592f0ef4067d"
+  resolved "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz"
   integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==
 
 zod@^3.21.4:


### PR DESCRIPTION
## Summary

### DKLS DSG round 4 — authenticate `signatureR`
- Sign `signatureR` bytes with the party GPG key in `encryptAndAuthOutgoingMessages()` — previously a hardcoded empty signature left the ECDSA nonce commitment R unauthenticated (F-04, severity: HIGH).
- Verify `signatureR` in `decryptAndVerifyIncomingMessages()` before returning it to callers.
- Transmit `signatureR` and `signatureRSignature` on round-3 / round-4 plumbing so the server can authenticate R before `combinePartialSignatures()` (aligned with `@bitgo/public-types`).

### Types & SDK wiring
- Bump **`@bitgo/public-types`** (e.g. **5.92.0**) so `msg4` includes `signatureRSignature` and the flow is typed end-to-end (reduces need for ad-hoc casts in tests). [PR](https://github.com/BitGo/public-types/pull/339)
- **`sdk-core`**: require `signatureR.message` / `signatureR.signature` where applicable; set `signatureR` + `signatureRSignature` on `msg4` for **`MPCv2SignatureShareRound3Input`**.
- **`express` tests** (`externalSign`): pass `signatureR` auth when both `signatureR` and `signatureRSignature` are present; soft downgrade when not.

### Express build (TS7056)
- Annotate heavy **`httpRoute`** exports as **`HttpRoute<'post'>`** (`PostSendMany`, `PostSendCoins`, `PostWalletSignTx`, `PostWalletTxSignTSS`) so `.d.ts` declaration emit stays under TypeScript’s serialization limit; update **`typedRoutes/api/index.ts`** notes accordingly.

## Test plan

- [x] `sdk-lib-mpc` unit tests (sign/verify round-trip, tampered R, wrong key, no-`signatureR` / soft-downgrade cases as applicable)
- [x] Relevant `sdk-core` / `bitgo` tests for MPCv2 / external-sign paths
- [x] `@bitgo/express` builds (`tsc`; TS7056 resolved for the routes above)

**Ticket:** [WAL-376](https://linear.app/bitgo/issue/WAL-376/security-dkls-dsg-signaturer-passed-unauthenticated-in-round-4)

