### PR TITLE
feat: forward X-BitGo-OTP header from client requests to BitGo API

### DIFF
--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -69,6 +69,12 @@ const debug = debugLib('bitgo:express');
 
 const BITGOEXPRESS_USER_AGENT = `BitGoExpress/${pjson.version} BitGoJS/${version}`;
 
+/**
+ * Headers from the incoming request that should be forwarded to the BitGo API.
+ * Header names must be lowercase (Express normalizes incoming headers to lowercase).
+ */
+const FORWARDED_HEADERS = ['x-bitgo-otp'];
+
 function handlePing(
   req: ExpressApiRouteRequest<'express.ping', 'get'>,
   res: express.Response,
@@ -1338,6 +1344,13 @@ export function redirectRequest(
   if (request) {
     if (req.params.enterpriseId) {
       request.set('enterprise-id', req.params.enterpriseId);
+    }
+
+    for (const header of FORWARDED_HEADERS) {
+      const value = req.headers[header];
+      if (value) {
+        request.set(header, Array.isArray(value) ? value[0] : value);
+      }
     }
 
     return request.result().then((result) => {

--- a/modules/express/test/unit/clientRoutes/index.ts
+++ b/modules/express/test/unit/clientRoutes/index.ts
@@ -16,6 +16,7 @@ describe('common methods', () => {
       req = {
         body: {},
         params: {},
+        headers: {},
         bitgo,
       } as express.Request;
       next = () => undefined;
@@ -50,6 +51,36 @@ describe('common methods', () => {
       const result = await redirectRequest(bitgo, 'POST', url, req, next);
       result.status.should.equal(201);
       result.body.should.deepEqual({ success: true });
+    });
+
+    it('should forward X-BitGo-OTP header when present', async () => {
+      const url = 'https://example.com/api';
+      const setStub = sandbox.stub();
+      const response = { res: { statusCode: 200 }, result: async () => ({ success: true }), set: setStub };
+      sandbox
+        .stub(bitgo, 'get')
+        .withArgs(url)
+        .returns(response as any);
+
+      req.headers = { 'x-bitgo-otp': '123456' } as any;
+      const result = await redirectRequest(bitgo, 'GET', url, req, next);
+      result.status.should.equal(200);
+      setStub.calledWith('x-bitgo-otp', '123456').should.be.true();
+    });
+
+    it('should not forward X-BitGo-OTP header when not present', async () => {
+      const url = 'https://example.com/api';
+      const setStub = sandbox.stub();
+      const response = { res: { statusCode: 200 }, result: async () => ({ success: true }), set: setStub };
+      sandbox
+        .stub(bitgo, 'get')
+        .withArgs(url)
+        .returns(response as any);
+
+      req.headers = {} as any;
+      const result = await redirectRequest(bitgo, 'GET', url, req, next);
+      result.status.should.equal(200);
+      setStub.calledWith('x-bitgo-otp').should.be.false();
     });
 
     it('should handle error response and return status and body', async () => {


### PR DESCRIPTION
## Description

This change adds support for forwarding the `X-BitGo-OTP` header from incoming client requests to the BitGo API. This enables clients to pass OTP (One-Time Password) credentials through the Express proxy to the backend BitGo service.

The implementation introduces a configurable `FORWARDED_HEADERS` list that specifies which headers should be forwarded from incoming requests to the BitGo API. Currently, only `x-bitgo-otp` is included, but the design allows for easy addition of other headers in the future.

### Changes Made:
- Added `FORWARDED_HEADERS` constant to define which headers should be forwarded
- Updated `redirectRequest()` function to iterate through forwarded headers and set them on outgoing requests
- Added proper handling for both string and array header values (Express can normalize headers to arrays)
- Added unit tests to verify the header is forwarded when present and not forwarded when absent

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Added two new unit tests in `modules/express/test/unit/clientRoutes/index.ts`:
1. `should forward X-BitGo-OTP header when present` - Verifies the header is correctly forwarded to the BitGo API when included in the incoming request
2. `should not forward X-BitGo-OTP header when not present` - Verifies the code handles the absence of the header gracefully

Both tests verify the behavior through stubbed responses and assertion on the `set()` method calls.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

TICKET: CUS-80