### PR TITLE
fix(sdk-lib-mpc): throw in Dsg.endSession() when signature exists

### DIFF
--- a/modules/sdk-lib-mpc/src/tss/ecdsa-dkls/dsg.ts
+++ b/modules/sdk-lib-mpc/src/tss/ecdsa-dkls/dsg.ts
@@ -164,7 +164,7 @@ export class Dsg {
    */
   endSession(): void {
     if (this._signature) {
-      new Error('Session already ended because combined signature was produced.');
+      throw new Error('Session already ended because combined signature was produced.');
     }
     if (this.dsgSession) {
       this.dsgSession.free();

--- a/modules/sdk-lib-mpc/test/unit/tss/ecdsa/dklsDsg.ts
+++ b/modules/sdk-lib-mpc/test/unit/tss/ecdsa/dklsDsg.ts
@@ -217,6 +217,29 @@ describe('DKLS Dsg 2x3', function () {
     await party.init().should.be.rejectedWith(/Invalid messageHash length/);
   });
 
+  it('should throw in endSession() when signature has already been produced', async function () {
+    const vector = vectors[0];
+    const party1 = new DklsDsg.Dsg(
+      fs.readFileSync(shareFiles[vector.party1]),
+      vector.party1,
+      vector.derivationPath,
+      crypto.createHash('sha256').update(Buffer.from(vector.msgToSign, 'hex')).digest()
+    );
+    const party2 = new DklsDsg.Dsg(
+      fs.readFileSync(shareFiles[vector.party2]),
+      vector.party2,
+      vector.derivationPath,
+      crypto.createHash('sha256').update(Buffer.from(vector.msgToSign, 'hex')).digest()
+    );
+    const round4Messages = await executeTillRound(4, party1, party2);
+    party1.handleIncomingMessages({
+      p2pMessages: [],
+      broadcastMessages: round4Messages[1].broadcastMessages,
+    });
+    should.exist(party1.signature);
+    (() => party1.endSession()).should.throw('Session already ended because combined signature was produced.');
+  });
+
   it(`should fail when signing two different messages`, async function () {
     const party1 = new DklsDsg.Dsg(
       fs.readFileSync(`${__dirname}/fixtures/userShare`),


### PR DESCRIPTION
## Summary
- `Dsg.endSession()` at `dsg.ts:167` was constructing `new Error(...)` without `throw`, silently resetting `dsgState` to `Uninitialized` after signing
- A subsequent `init()` call would succeed, enabling inadvertent session reuse on the same key share
- Fix adds `throw` to the existing `new Error(...)` call

## Test plan
- [ ] New unit test verifying `endSession()` throws when signature is already produced
- [ ] Full DKLS Dsg 2x3 test suite (11 tests) continues to pass

Ticket: WAL-383

🤖 Generated with [Claude Code](https://claude.com/claude-code)