### PR TITLE
fix(sdk-core): rename bandwidthWeight/energyWeight to bandwidthSun/energySun

### DIFF
--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -564,8 +564,8 @@ export interface AccountResourceInfo {
     energySunRequired?: string;
   };
   maxResourcesDelegatable?: {
-    bandwidthWeight: string;
-    energyWeight: string;
+    bandwidthSun: string;
+    energySun: string;
   };
 }
 


### PR DESCRIPTION
## Summary
- Renames `bandwidthWeight` and `energyWeight` fields in the `maxResourcesDelegatable` property of `AccountResourceInfo` to `bandwidthSun` and `energySun` respectively, to better reflect the unit of measurement.

## Test plan
- [ ] Verify TypeScript compiles cleanly in `modules/sdk-core`
- [ ] Verify any consumers of `maxResourcesDelegatable` are updated accordingly

TICKET: CHALO-194