### PR TITLE
CGD-576: Remove unreachable _counter undefined guard in abstract-eth

### DIFF
--- a/modules/abstract-eth/src/lib/transactionBuilder.ts
+++ b/modules/abstract-eth/src/lib/transactionBuilder.ts
@@ -386,9 +386,6 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
     if (this._common === undefined) {
       throw new BuildTransactionError('Invalid transaction: network common');
     }
-    if (this._counter === undefined) {
-      throw new BuildTransactionError('Invalid transaction: missing address counter');
-    }
   }
 
   /** @inheritdoc */

--- a/modules/sdk-coin-eth/test/unit/transactionBuilder/walletInitialization.ts
+++ b/modules/sdk-coin-eth/test/unit/transactionBuilder/walletInitialization.ts
@@ -340,20 +340,16 @@ describe('Eth Transaction builder wallet initialization', function () {
 
     it('a transaction to build', async () => {
       const txBuilder: any = getBuilder('eth');
-      txBuilder.counter(undefined);
       txBuilder.type(TransactionType.WalletInitialization);
       assert.throws(() => txBuilder.validateTransaction(), /Invalid transaction: missing fee/);
       txBuilder.fee({
         fee: '10',
         gasLimit: '1000',
       });
-      assert.throws(() => txBuilder.validateTransaction(), /Invalid transaction: missing address counter/);
-      assert.throws(() => txBuilder.validateTransaction(), /Invalid transaction: missing address counter/);
       const source = {
         prv: sourcePrv,
       };
       const sourceKeyPair = new KeyPair(source);
-      assert.throws(() => txBuilder.validateTransaction(), /Invalid transaction: missing address counter/);
       txBuilder.counter(1);
       assert.throws(() => txBuilder.validateTransaction(), /wrong number of owners -- required: 3, found: 0/);
       txBuilder.owner(sourceKeyPair.getAddress());


### PR DESCRIPTION
## Summary

Removes a dead code guard in `abstract-eth` `TransactionBuilder` that was flagged in the internal security audit. The `_counter === undefined` check in `validateBaseTransactionFields` can never be true since `_counter` is typed as `number` and always initialized to `0` in the constructor.

**Jira**: [WP-8439](https://bitgoinc.atlassian.net/browse/WP-8439)
**Linear**: [CGD-576](https://linear.app/bitgo/issue/CGD-576)

## Changes

- Remove unreachable `if (this._counter === undefined)` guard from `validateBaseTransactionFields` in `modules/abstract-eth/src/lib/transactionBuilder.ts`

## Test Plan

- Existing unit tests for `abstract-eth` cover transaction validation — no behavior change expected.

CLOSES TICKET: CGD-576

[WP-8439]: https://bitgoinc.atlassian.net/browse/WP-8439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ