### PR TITLE
ci(release): add bitgo-express docker publish job to npmjs-release

### DIFF
--- a/.github/workflows/npmjs-release.yml
+++ b/.github/workflows/npmjs-release.yml
@@ -19,6 +19,7 @@ permissions:
 env:
   NX_NO_CLOUD: true
   NX_SKIP_NX_CACHE: true
+  DOCKER_HUB_USERNAME: "bgdeploybot"
 
 jobs:
   get-release-context:
@@ -30,6 +31,9 @@ jobs:
       last-release-sha: ${{ steps.get-release-info.outputs.last-release-sha }}
       current-master-sha: ${{ steps.get-release-info.outputs.current-master-sha }}
       commits-since-release: ${{ steps.get-release-info.outputs.commits-since-release }}
+      express-version: ${{ steps.compute-express-git-tag.outputs.version }}
+      express-git-tag: ${{ steps.compute-express-git-tag.outputs.git-tag }}
+      express-git-sha: ${{ steps.compute-express-git-sha.outputs.git-sha }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -107,6 +111,85 @@ jobs:
           done
 
           echo "" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Checkout rel/latest branch
+        if: inputs.dry-run == false
+        uses: actions/checkout@v6
+        with:
+          ref: rel/latest
+
+      - name: Compute express target version and tag
+        if: inputs.dry-run == false
+        id: compute-express-git-tag
+        run: |
+          VERSION=$(jq -r '.version' ./modules/express/package.json)
+          TAG="@bitgo/express@$VERSION"
+          echo "Current latest express version: $VERSION"
+          echo "Expected latest express git tag: $TAG"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "git-tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout express target git tag
+        if: inputs.dry-run == false
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.compute-express-git-tag.outputs.git-tag }}
+          fetch-depth: 2
+
+      - name: Parse express release information
+        if: inputs.dry-run == false
+        id: compute-express-git-sha
+        run: |
+          GIT_SHA=$(git rev-parse HEAD)
+          echo "Git SHA: $GIT_SHA"
+          echo "git-sha=$GIT_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Sanity Check Express Git Tag
+        if: inputs.dry-run == false
+        run: |
+          # Since git tags can be moved, we need to ensure the tag we're releasing
+          # actually corresponds to a version bump in package.json
+          CURRENT_VERSION="${{ steps.compute-express-git-tag.outputs.version }}"
+          PREVIOUS_VERSION=$(git show HEAD~1:./modules/express/package.json | jq -r '.version')
+
+          echo "Current version: $CURRENT_VERSION"
+          echo "Previous version: $PREVIOUS_VERSION"
+
+          if [ "$CURRENT_VERSION" == "$PREVIOUS_VERSION" ]; then
+            echo "::error::Express version bump does not line up with git tag location."
+            echo "::error::This suggests the git tag may have been moved."
+            exit 1
+          fi
+
+          echo "✅ Express version bump lines up with git tag"
+
+      - name: Check if Docker image already exists in Docker Hub
+        if: inputs.dry-run == false
+        run: |
+          VERSION="${{ steps.compute-express-git-tag.outputs.version }}"
+
+          if curl -s -f "https://hub.docker.com/v2/repositories/bitgo/express/tags/$VERSION" > /dev/null; then
+            echo "::error::Docker image bitgo/express:$VERSION already exists in Docker Hub"
+            exit 1
+          fi
+
+          echo "✅ Docker image bitgo/express:$VERSION does not exist in Docker Hub"
+
+      - name: Update Express GitHub summary
+        if: inputs.dry-run == false
+        run: |
+          {
+            echo "## BitGo Express Release Information"
+            echo ""
+            echo "Express Version: ${{ steps.compute-express-git-tag.outputs.version }}"
+            echo "Git Tag: ${{ steps.compute-express-git-tag.outputs.git-tag }}"
+            echo "Commit SHA: ${{ steps.compute-express-git-sha.outputs.git-sha }}"
+            echo ""
+            echo "### Docker Images to be deployed:"
+            echo "- \`bitgo/express:latest\`"
+            echo "- \`bitgo/express:${{ steps.compute-express-git-tag.outputs.version }}\`"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
 
   release-bitgojs:
     name: Release BitGoJS
@@ -200,3 +283,48 @@ jobs:
             --latest \
             --title "v${{ steps.extract-version.outputs.new-version }}" \
             --notes-file "${{ steps.version-bump-summary.outputs.text-file }}"
+
+  publish-express-to-docker-hub:
+    name: Publish Express To Docker Hub
+    if: inputs.dry-run == false
+    needs:
+      - get-release-context
+      - release-bitgojs
+    runs-on: ${{ vars.BASE_RUNNER_TYPE || 'ubuntu-latest' }}
+    timeout-minutes: 40
+    environment: bitgo-express
+    steps:
+      - name: Checkout BitGoJS repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.get-release-context.outputs.express-git-sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ env.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_API_KEY }}
+
+      - name: Generate build date
+        id: build-date
+        run: |
+          BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          echo "build-date=$BUILD_DATE" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push Express Docker image
+        id: docker-build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            bitgo/express:latest
+            bitgo/express:${{ needs.get-release-context.outputs.express-version }}
+          build-args: |
+            VERSION=${{ needs.get-release-context.outputs.express-version }}
+            BUILD_DATE=${{ steps.build-date.outputs.build-date }}
+            GIT_HASH=${{ needs.get-release-context.outputs.express-git-sha }}


### PR DESCRIPTION
## Summary
- Adds express-version/git-tag/git-sha outputs to the existing `get-release-context` job; express steps (checkout `rel/latest`, resolve tag, sanity-check version bump, Docker Hub existence check) are appended at the end and gated on `inputs.dry-run == false`
- Adds `publish-express-to-docker-hub` job that depends on both `get-release-context` and `release-bitgojs`, uses `DOCKER_HUB_API_KEY` from the `bitgo-express` GitHub environment (provisioned via INF-486)
- Workflow chain: `get-release-context` → `release-bitgojs` → `publish-express-to-docker-hub`
- Vault and Slack notification steps intentionally omitted

## Test plan
- [ ] Verify workflow YAML has no syntax errors
- [ ] Trigger `npmjs-release` with `dry-run: true` — express steps and publish job should be skipped
- [ ] Trigger `npmjs-release` with `dry-run: false` — publish job runs after `release-bitgojs` and image appears in Docker Hub

Ticket: VL-4192

Generated with Claude Code