### PR TITLE
Revert "Merge pull request #8462 from BitGo/WAL-375-mpcv2-sign-tx-req

### DIFF
--- a/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsa.ts
+++ b/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsa.ts
@@ -747,7 +747,6 @@ describe('TSS Ecdsa Utils:', async function () {
           backupNShare: backupKeyShare.nShares[1],
         }),
         reqId,
-        txParams: { recipients: [{ address: '0xrecipient', amount: '1000' }] },
       });
       signedTxRequest.unsignedTxs.should.deepEqual(txRequest.unsignedTxs);
       const userGpgActual = sendShareSpy.getCalls()[0].args[10] as string;
@@ -765,44 +764,10 @@ describe('TSS Ecdsa Utils:', async function () {
           backupNShare: backupKeyShare.nShares[1],
         }),
         reqId,
-        txParams: { recipients: [{ address: '0xrecipient', amount: '1000' }] },
       });
       signedTxRequest.unsignedTxs.should.deepEqual(txRequest.unsignedTxs);
       const userGpgActual = sendShareSpy.getCalls()[0].args[10] as string;
       userGpgActual.should.startWith('-----BEGIN PGP PUBLIC KEY BLOCK-----');
-    });
-
-    it('signTxRequest should fail when txParams is missing', async function () {
-      await tssUtils
-        .signTxRequest({
-          txRequest,
-          prv: JSON.stringify({
-            pShare: userKeyShare.pShare,
-            bitgoNShare: bitgoKeyShare.nShares[1],
-            backupNShare: backupKeyShare.nShares[1],
-          }),
-          reqId,
-        })
-        .should.be.rejectedWith(
-          'Recipient details are required to verify this transaction before signing. Pass txParams with at least one recipient.'
-        );
-    });
-
-    it('signTxRequest should fail when txParams has empty recipients', async function () {
-      await tssUtils
-        .signTxRequest({
-          txRequest,
-          prv: JSON.stringify({
-            pShare: userKeyShare.pShare,
-            bitgoNShare: bitgoKeyShare.nShares[1],
-            backupNShare: backupKeyShare.nShares[1],
-          }),
-          reqId,
-          txParams: { recipients: [] },
-        })
-        .should.be.rejectedWith(
-          'Recipient details are required to verify this transaction before signing. Pass txParams with at least one recipient.'
-        );
     });
 
     it('signTxRequest should fail with wrong recipient', async function () {

--- a/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsaMPCv2/signTxRequest.ts
+++ b/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsaMPCv2/signTxRequest.ts
@@ -193,7 +193,6 @@ describe('signTxRequest:', function () {
       txRequest,
       prv: userPrvBase64,
       reqId,
-      txParams: { recipients: [{ address: '0xrecipient', amount: '1000' }] },
     });
     nockPromises[0].isDone().should.be.true();
     nockPromises[1].isDone().should.be.true();
@@ -216,7 +215,6 @@ describe('signTxRequest:', function () {
       prv: backupPrvBase64,
       mpcv2PartyId: 1,
       reqId,
-      txParams: { recipients: [{ address: '0xrecipient', amount: '1000' }] },
     });
     nockPromises[0].isDone().should.be.true();
     nockPromises[1].isDone().should.be.true();
@@ -238,7 +236,6 @@ describe('signTxRequest:', function () {
       txRequest,
       prv: userPrvBase64,
       reqId,
-      txParams: { recipients: [{ address: '0xrecipient', amount: '1000' }] },
     });
     nockPromises[0].isDone().should.be.true();
     nockPromises[1].isDone().should.be.true();
@@ -260,7 +257,6 @@ describe('signTxRequest:', function () {
       txRequest,
       prv: userPrvBase64,
       reqId,
-      txParams: { recipients: [{ address: '0xrecipient', amount: '1000' }] },
     });
     nockPromises[0].isDone().should.be.true();
     nockPromises[1].isDone().should.be.true();
@@ -281,40 +277,10 @@ describe('signTxRequest:', function () {
         txRequest,
         prv: userPrvBase64,
         reqId,
-        txParams: { recipients: [{ address: '0xrecipient', amount: '1000' }] },
       })
       .should.be.rejectedWith('Too many requests, slow down!');
     nockPromises[0].isDone().should.be.true();
     nockPromises[1].isDone().should.be.false();
-  });
-
-  it('rejects signTxRequest when txParams is missing', async function () {
-    const userShare = fs.readFileSync(shareFiles[vector.party1]);
-    const userPrvBase64 = Buffer.from(userShare).toString('base64');
-    await tssUtils
-      .signTxRequest({
-        txRequest,
-        prv: userPrvBase64,
-        reqId,
-      })
-      .should.be.rejectedWith(
-        'Recipient details are required to verify this transaction before signing. Pass txParams with at least one recipient.'
-      );
-  });
-
-  it('rejects signTxRequest when txParams has empty recipients', async function () {
-    const userShare = fs.readFileSync(shareFiles[vector.party1]);
-    const userPrvBase64 = Buffer.from(userShare).toString('base64');
-    await tssUtils
-      .signTxRequest({
-        txRequest,
-        prv: userPrvBase64,
-        reqId,
-        txParams: { recipients: [] },
-      })
-      .should.be.rejectedWith(
-        'Recipient details are required to verify this transaction before signing. Pass txParams with at least one recipient.'
-      );
   });
 });
 

--- a/modules/sdk-core/src/bitgo/pendingApproval/pendingApproval.ts
+++ b/modules/sdk-core/src/bitgo/pendingApproval/pendingApproval.ts
@@ -246,9 +246,7 @@ export class PendingApproval implements IPendingApproval {
     }
 
     const decryptedPrv = await this.wallet.getPrv({ walletPassphrase });
-    const pendingApprovalRecipients = this._pendingApproval.info?.transactionRequest?.recipients;
-    const txParams = pendingApprovalRecipients?.length ? { recipients: pendingApprovalRecipients } : undefined;
-    const txRequest = await this.tssUtils!.recreateTxRequest(txRequestId, decryptedPrv, reqId, txParams);
+    const txRequest = await this.tssUtils!.recreateTxRequest(txRequestId, decryptedPrv, reqId);
     if (txRequest.apiVersion === 'lite') {
       if (!txRequest.unsignedTxs || txRequest.unsignedTxs.length === 0) {
         throw new Error('Unexpected error, no transactions found in txRequest.');

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
@@ -39,7 +39,6 @@ import {
   TxRequest,
   TxRequestVersion,
 } from './baseTypes';
-import { TransactionParams } from '../../baseCoin/iBaseCoin';
 import { GShare, SignShare } from '../../../account-lib/mpc/tss';
 import { RequestTracer } from '../util';
 import { envRequiresBitgoPubGpgKeyConfig, getBitgoMpcGpgPubKey } from '../../tss/bitgoPubKeys';
@@ -534,16 +533,11 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
    * @param {RequestTracer} reqId id tracer.
    * @returns {Promise<any>}
    */
-  async recreateTxRequest(
-    txRequestId: string,
-    decryptedPrv: string,
-    reqId: IRequestTracer,
-    txParams?: TransactionParams
-  ): Promise<TxRequest> {
+  async recreateTxRequest(txRequestId: string, decryptedPrv: string, reqId: IRequestTracer): Promise<TxRequest> {
     await this.deleteSignatureShares(txRequestId, reqId);
     // after delete signatures shares get the tx without them
     const txRequest = await getTxRequest(this.bitgo, this.wallet.id(), txRequestId, reqId);
-    return await this.signTxRequest({ txRequest, prv: decryptedPrv, reqId, txParams });
+    return await this.signTxRequest({ txRequest, prv: decryptedPrv, reqId });
   }
 
   /**

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -759,12 +759,7 @@ export interface ITssUtils<KeyShare = EDDSA.KeyShare> {
   deleteSignatureShares(txRequestId: string): Promise<SignatureShareRecord[]>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   sendTxRequest(txRequestId: string): Promise<any>;
-  recreateTxRequest(
-    txRequestId: string,
-    decryptedPrv: string,
-    reqId: IRequestTracer,
-    txParams?: TransactionParams
-  ): Promise<TxRequest>;
+  recreateTxRequest(txRequestId: string, decryptedPrv: string, reqId: IRequestTracer): Promise<TxRequest>;
   getTxRequest(txRequestId: string): Promise<TxRequest>;
   supportedTxRequestVersions(): TxRequestVersion[];
 }

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
@@ -47,7 +47,6 @@ import {
 } from '../../../tss/types';
 import { BaseEcdsaUtils } from './base';
 import { IRequestTracer } from '../../../../api';
-import { InvalidTransactionError } from '../../../errors';
 
 const encryptNShare = ECDSAMethods.encryptNShare;
 
@@ -746,12 +745,6 @@ export class EcdsaUtils extends BaseEcdsaUtils {
       const unsignedTx =
         txRequest.apiVersion === 'full' ? txRequest.transactions![0].unsignedTx : txRequest.unsignedTxs[0];
 
-      if (!params.txParams?.recipients?.length) {
-        throw new InvalidTransactionError(
-          'Recipient details are required to verify this transaction before signing. Pass txParams with at least one recipient.'
-        );
-      }
-
       // For ICP transactions, the HSM signs the serializedTxHex, while the user signs the signableHex separately.
       // Verification cannot be performed directly on the signableHex alone. However, we can parse the serializedTxHex
       // to regenerate the signableHex and compare it against the provided value for verification.
@@ -759,14 +752,14 @@ export class EcdsaUtils extends BaseEcdsaUtils {
       if (this.baseCoin.getConfig().family === 'icp') {
         await this.baseCoin.verifyTransaction({
           txPrebuild: { txHex: unsignedTx.serializedTxHex, txInfo: unsignedTx.signableHex },
-          txParams: params.txParams,
+          txParams: params.txParams || { recipients: [] },
           wallet: this.wallet,
           walletType: this.wallet.multisigType(),
         });
       } else {
         await this.baseCoin.verifyTransaction({
           txPrebuild: { txHex: unsignedTx.signableHex },
-          txParams: params.txParams,
+          txParams: params.txParams || { recipients: [] },
           wallet: this.wallet,
           walletType: this.wallet.multisigType(),
         });

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
@@ -32,7 +32,6 @@ import {
   verifyBitGoMessagesAndSignaturesRoundOne,
   verifyBitGoMessagesAndSignaturesRoundTwo,
 } from '../../../tss/ecdsa/ecdsaMPCv2';
-import { InvalidTransactionError } from '../../../errors';
 import { KeyCombined } from '../../../tss/ecdsa/types';
 import { generateGPGKeyPair } from '../../opengpgUtils';
 import {
@@ -737,12 +736,6 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
       const unsignedTx =
         txRequest.apiVersion === 'full' ? txRequest.transactions![0].unsignedTx : txRequest.unsignedTxs[0];
 
-      if (!params.txParams?.recipients?.length) {
-        throw new InvalidTransactionError(
-          'Recipient details are required to verify this transaction before signing. Pass txParams with at least one recipient.'
-        );
-      }
-
       // For ICP transactions, the HSM signs the serializedTxHex, while the user signs the signableHex separately.
       // Verification cannot be performed directly on the signableHex alone. However, we can parse the serializedTxHex
       // to regenerate the signableHex and compare it against the provided value for verification.
@@ -750,14 +743,14 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
       if (this.baseCoin.getConfig().family === 'icp') {
         await this.baseCoin.verifyTransaction({
           txPrebuild: { txHex: unsignedTx.serializedTxHex, txInfo: unsignedTx.signableHex },
-          txParams: params.txParams,
+          txParams: params.txParams || { recipients: [] },
           wallet: this.wallet,
           walletType: this.wallet.multisigType(),
         });
       } else {
         await this.baseCoin.verifyTransaction({
           txPrebuild: { txHex: unsignedTx.signableHex },
-          txParams: params.txParams,
+          txParams: params.txParams || { recipients: [] },
           wallet: this.wallet,
           walletType: this.wallet.multisigType(),
         });


### PR DESCRIPTION
Revert [WAL-375](https://bitgoinc.atlassian.net/browse/WAL-375)

PR #8462 added a guard in signRequestBase() (ECDSA + MPCv2) that throws before verifyTransaction if txParams.recipients is empty or missing. This breaks TSS transaction types:

  - Smart contract interactions (e.g. Tempo supplyController) — recipients live in txRequest.intent, not txParams.recipients

#### Follow-up

A targeted fix is tracked in [WAL-375](https://linear.app/bitgo/issue/WAL-375/security-mpcv2-signtxrequest-defaults-txparams-to-empty-recipients) that:
  1. Falls back to txRequest.intent.recipients (mapped to ITransactionRecipient) for smart contract interactions
  2. Exempts known no-recipient types by mirroring the bypass list in abstractEthLikeNewCoins.ts:3112
