### PR TITLE
fix(tss): verify recipients before signing

### DIFF
--- a/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
+++ b/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
@@ -3109,9 +3109,16 @@ export abstract class AbstractEthLikeNewCoins extends AbstractEthLikeCoin {
         txParams.prebuildTx?.consolidateId ||
         txPrebuild?.consolidateId ||
         (txParams.type &&
-          ['acceleration', 'fillNonce', 'transferToken', 'tokenApproval', 'consolidate', 'bridgeFunds'].includes(
-            txParams.type
-          ))
+          [
+            'acceleration',
+            'fillNonce',
+            'transferToken',
+            'tokenApproval',
+            'consolidate',
+            'bridgeFunds',
+            'enableToken',
+            'customTx',
+          ].includes(txParams.type))
       )
     ) {
       throw new Error('missing txParams');

--- a/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsa.ts
+++ b/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsa.ts
@@ -749,6 +749,7 @@ describe('TSS Ecdsa Utils:', async function () {
           backupNShare: backupKeyShare.nShares[1],
         }),
         reqId,
+        txParams: { recipients: [{ address: '0xrecipient', amount: '1000' }] },
       });
       signedTxRequest.unsignedTxs.should.deepEqual(txRequest.unsignedTxs);
       const userGpgActual = sendShareSpy.getCalls()[0].args[10] as string;
@@ -766,10 +767,123 @@ describe('TSS Ecdsa Utils:', async function () {
           backupNShare: backupKeyShare.nShares[1],
         }),
         reqId,
+        txParams: { recipients: [{ address: '0xrecipient', amount: '1000' }] },
       });
       signedTxRequest.unsignedTxs.should.deepEqual(txRequest.unsignedTxs);
       const userGpgActual = sendShareSpy.getCalls()[0].args[10] as string;
       userGpgActual.should.startWith('-----BEGIN PGP PUBLIC KEY BLOCK-----');
+    });
+
+    it('signTxRequest should fail when txParams is missing', async function () {
+      await tssUtils
+        .signTxRequest({
+          txRequest,
+          prv: JSON.stringify({
+            pShare: userKeyShare.pShare,
+            bitgoNShare: bitgoKeyShare.nShares[1],
+            backupNShare: backupKeyShare.nShares[1],
+          }),
+          reqId,
+        })
+        .should.be.rejectedWith(
+          'Recipient details are required to verify this transaction before signing. Pass txParams with at least one recipient.'
+        );
+    });
+
+    it('signTxRequest should fail when txParams has empty recipients', async function () {
+      await tssUtils
+        .signTxRequest({
+          txRequest,
+          prv: JSON.stringify({
+            pShare: userKeyShare.pShare,
+            bitgoNShare: bitgoKeyShare.nShares[1],
+            backupNShare: backupKeyShare.nShares[1],
+          }),
+          reqId,
+          txParams: { recipients: [] },
+        })
+        .should.be.rejectedWith(
+          'Recipient details are required to verify this transaction before signing. Pass txParams with at least one recipient.'
+        );
+    });
+
+    it('signTxRequest should succeed when recipients are only in intent (smart contract interaction)', async function () {
+      await setupSignTxRequestNocks(false, userSignShare, aShare, dShare, enterpriseData);
+      const txRequestWithIntentRecipients = {
+        ...txRequest,
+        intent: {
+          intentType: 'contractCall',
+          recipients: [
+            {
+              address: { address: '0xrecipient' },
+              amount: { value: '1000', symbol: 'hteth' },
+            },
+          ],
+        },
+      };
+      const signedTxRequest = await tssUtils.signTxRequest({
+        txRequest: txRequestWithIntentRecipients,
+        prv: JSON.stringify({
+          pShare: userKeyShare.pShare,
+          bitgoNShare: bitgoKeyShare.nShares[1],
+          backupNShare: backupKeyShare.nShares[1],
+        }),
+        reqId,
+        // no txParams.recipients — should fall back to intent.recipients
+      });
+      signedTxRequest.unsignedTxs.should.deepEqual(txRequest.unsignedTxs);
+    });
+
+    it('signTxRequest should succeed for no-recipient tx types (tokenApproval)', async function () {
+      await setupSignTxRequestNocks(false, userSignShare, aShare, dShare, enterpriseData);
+      const signedTxRequest = await tssUtils.signTxRequest({
+        txRequest,
+        prv: JSON.stringify({
+          pShare: userKeyShare.pShare,
+          bitgoNShare: bitgoKeyShare.nShares[1],
+          backupNShare: backupKeyShare.nShares[1],
+        }),
+        reqId,
+        txParams: { type: 'tokenApproval' },
+      });
+      signedTxRequest.unsignedTxs.should.deepEqual(txRequest.unsignedTxs);
+    });
+
+    it('signTxRequest should succeed for no-recipient tx types (acceleration)', async function () {
+      await setupSignTxRequestNocks(false, userSignShare, aShare, dShare, enterpriseData);
+      const signedTxRequest = await tssUtils.signTxRequest({
+        txRequest,
+        prv: JSON.stringify({
+          pShare: userKeyShare.pShare,
+          bitgoNShare: bitgoKeyShare.nShares[1],
+          backupNShare: backupKeyShare.nShares[1],
+        }),
+        reqId,
+        txParams: { type: 'acceleration' },
+      });
+      signedTxRequest.unsignedTxs.should.deepEqual(txRequest.unsignedTxs);
+    });
+
+    it('signTxRequest should prefer txParams.recipients over intent.recipients when both are present', async function () {
+      await setupSignTxRequestNocks(false, userSignShare, aShare, dShare, enterpriseData);
+      const txRequestWithBothRecipients = {
+        ...txRequest,
+        intent: {
+          intentType: 'contractCall',
+          recipients: [{ address: { address: '0xintentRecipient' }, amount: { value: '9999', symbol: 'hteth' } }],
+        },
+      };
+      const signedTxRequest = await tssUtils.signTxRequest({
+        txRequest: txRequestWithBothRecipients,
+        prv: JSON.stringify({
+          pShare: userKeyShare.pShare,
+          bitgoNShare: bitgoKeyShare.nShares[1],
+          backupNShare: backupKeyShare.nShares[1],
+        }),
+        reqId,
+        txParams: { recipients: [{ address: '0xrecipient', amount: '1000' }] },
+      });
+      signedTxRequest.unsignedTxs.should.deepEqual(txRequest.unsignedTxs);
     });
 
     it('signTxRequest should fail with wrong recipient', async function () {

--- a/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsa.ts
+++ b/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsa.ts
@@ -747,6 +747,7 @@ describe('TSS Ecdsa Utils:', async function () {
           backupNShare: backupKeyShare.nShares[1],
         }),
         reqId,
+        txParams: { recipients: [{ address: '0xrecipient', amount: '1000' }] },
       });
       signedTxRequest.unsignedTxs.should.deepEqual(txRequest.unsignedTxs);
       const userGpgActual = sendShareSpy.getCalls()[0].args[10] as string;
@@ -764,10 +765,123 @@ describe('TSS Ecdsa Utils:', async function () {
           backupNShare: backupKeyShare.nShares[1],
         }),
         reqId,
+        txParams: { recipients: [{ address: '0xrecipient', amount: '1000' }] },
       });
       signedTxRequest.unsignedTxs.should.deepEqual(txRequest.unsignedTxs);
       const userGpgActual = sendShareSpy.getCalls()[0].args[10] as string;
       userGpgActual.should.startWith('-----BEGIN PGP PUBLIC KEY BLOCK-----');
+    });
+
+    it('signTxRequest should fail when txParams is missing', async function () {
+      await tssUtils
+        .signTxRequest({
+          txRequest,
+          prv: JSON.stringify({
+            pShare: userKeyShare.pShare,
+            bitgoNShare: bitgoKeyShare.nShares[1],
+            backupNShare: backupKeyShare.nShares[1],
+          }),
+          reqId,
+        })
+        .should.be.rejectedWith(
+          'Recipient details are required to verify this transaction before signing. Pass txParams with at least one recipient.'
+        );
+    });
+
+    it('signTxRequest should fail when txParams has empty recipients', async function () {
+      await tssUtils
+        .signTxRequest({
+          txRequest,
+          prv: JSON.stringify({
+            pShare: userKeyShare.pShare,
+            bitgoNShare: bitgoKeyShare.nShares[1],
+            backupNShare: backupKeyShare.nShares[1],
+          }),
+          reqId,
+          txParams: { recipients: [] },
+        })
+        .should.be.rejectedWith(
+          'Recipient details are required to verify this transaction before signing. Pass txParams with at least one recipient.'
+        );
+    });
+
+    it('signTxRequest should succeed when recipients are only in intent (smart contract interaction)', async function () {
+      await setupSignTxRequestNocks(false, userSignShare, aShare, dShare, enterpriseData);
+      const txRequestWithIntentRecipients = {
+        ...txRequest,
+        intent: {
+          intentType: 'contractCall',
+          recipients: [
+            {
+              address: { address: '0xrecipient' },
+              amount: { value: '1000', symbol: 'hteth' },
+            },
+          ],
+        },
+      };
+      const signedTxRequest = await tssUtils.signTxRequest({
+        txRequest: txRequestWithIntentRecipients,
+        prv: JSON.stringify({
+          pShare: userKeyShare.pShare,
+          bitgoNShare: bitgoKeyShare.nShares[1],
+          backupNShare: backupKeyShare.nShares[1],
+        }),
+        reqId,
+        // no txParams.recipients — should fall back to intent.recipients
+      });
+      signedTxRequest.unsignedTxs.should.deepEqual(txRequest.unsignedTxs);
+    });
+
+    it('signTxRequest should succeed for no-recipient tx types (tokenApproval)', async function () {
+      await setupSignTxRequestNocks(false, userSignShare, aShare, dShare, enterpriseData);
+      const signedTxRequest = await tssUtils.signTxRequest({
+        txRequest,
+        prv: JSON.stringify({
+          pShare: userKeyShare.pShare,
+          bitgoNShare: bitgoKeyShare.nShares[1],
+          backupNShare: backupKeyShare.nShares[1],
+        }),
+        reqId,
+        txParams: { type: 'tokenApproval' },
+      });
+      signedTxRequest.unsignedTxs.should.deepEqual(txRequest.unsignedTxs);
+    });
+
+    it('signTxRequest should succeed for no-recipient tx types (acceleration)', async function () {
+      await setupSignTxRequestNocks(false, userSignShare, aShare, dShare, enterpriseData);
+      const signedTxRequest = await tssUtils.signTxRequest({
+        txRequest,
+        prv: JSON.stringify({
+          pShare: userKeyShare.pShare,
+          bitgoNShare: bitgoKeyShare.nShares[1],
+          backupNShare: backupKeyShare.nShares[1],
+        }),
+        reqId,
+        txParams: { type: 'acceleration' },
+      });
+      signedTxRequest.unsignedTxs.should.deepEqual(txRequest.unsignedTxs);
+    });
+
+    it('signTxRequest should prefer txParams.recipients over intent.recipients when both are present', async function () {
+      await setupSignTxRequestNocks(false, userSignShare, aShare, dShare, enterpriseData);
+      const txRequestWithBothRecipients = {
+        ...txRequest,
+        intent: {
+          intentType: 'contractCall',
+          recipients: [{ address: { address: '0xintentRecipient' }, amount: { value: '9999', symbol: 'hteth' } }],
+        },
+      };
+      const signedTxRequest = await tssUtils.signTxRequest({
+        txRequest: txRequestWithBothRecipients,
+        prv: JSON.stringify({
+          pShare: userKeyShare.pShare,
+          bitgoNShare: bitgoKeyShare.nShares[1],
+          backupNShare: backupKeyShare.nShares[1],
+        }),
+        reqId,
+        txParams: { recipients: [{ address: '0xrecipient', amount: '1000' }] },
+      });
+      signedTxRequest.unsignedTxs.should.deepEqual(txRequest.unsignedTxs);
     });
 
     it('signTxRequest should fail with wrong recipient', async function () {

--- a/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsaMPCv2/signTxRequest.ts
+++ b/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsaMPCv2/signTxRequest.ts
@@ -193,6 +193,7 @@ describe('signTxRequest:', function () {
       txRequest,
       prv: userPrvBase64,
       reqId,
+      txParams: { recipients: [{ address: '0xrecipient', amount: '1000' }] },
     });
     nockPromises[0].isDone().should.be.true();
     nockPromises[1].isDone().should.be.true();
@@ -215,6 +216,7 @@ describe('signTxRequest:', function () {
       prv: backupPrvBase64,
       mpcv2PartyId: 1,
       reqId,
+      txParams: { recipients: [{ address: '0xrecipient', amount: '1000' }] },
     });
     nockPromises[0].isDone().should.be.true();
     nockPromises[1].isDone().should.be.true();
@@ -236,6 +238,7 @@ describe('signTxRequest:', function () {
       txRequest,
       prv: userPrvBase64,
       reqId,
+      txParams: { recipients: [{ address: '0xrecipient', amount: '1000' }] },
     });
     nockPromises[0].isDone().should.be.true();
     nockPromises[1].isDone().should.be.true();
@@ -257,6 +260,7 @@ describe('signTxRequest:', function () {
       txRequest,
       prv: userPrvBase64,
       reqId,
+      txParams: { recipients: [{ address: '0xrecipient', amount: '1000' }] },
     });
     nockPromises[0].isDone().should.be.true();
     nockPromises[1].isDone().should.be.true();
@@ -277,10 +281,121 @@ describe('signTxRequest:', function () {
         txRequest,
         prv: userPrvBase64,
         reqId,
+        txParams: { recipients: [{ address: '0xrecipient', amount: '1000' }] },
       })
       .should.be.rejectedWith('Too many requests, slow down!');
     nockPromises[0].isDone().should.be.true();
     nockPromises[1].isDone().should.be.false();
+  });
+
+  it('rejects signTxRequest when txParams is missing', async function () {
+    const userShare = fs.readFileSync(shareFiles[vector.party1]);
+    const userPrvBase64 = Buffer.from(userShare).toString('base64');
+    await tssUtils
+      .signTxRequest({
+        txRequest,
+        prv: userPrvBase64,
+        reqId,
+      })
+      .should.be.rejectedWith(
+        'Recipient details are required to verify this transaction before signing. Pass txParams with at least one recipient.'
+      );
+  });
+
+  it('rejects signTxRequest when txParams has empty recipients', async function () {
+    const userShare = fs.readFileSync(shareFiles[vector.party1]);
+    const userPrvBase64 = Buffer.from(userShare).toString('base64');
+    await tssUtils
+      .signTxRequest({
+        txRequest,
+        prv: userPrvBase64,
+        reqId,
+        txParams: { recipients: [] },
+      })
+      .should.be.rejectedWith(
+        'Recipient details are required to verify this transaction before signing. Pass txParams with at least one recipient.'
+      );
+  });
+
+  it('accepts signTxRequest when recipients are only in intent (smart contract interaction)', async function () {
+    const userShare = fs.readFileSync(shareFiles[vector.party1]);
+    const userPrvBase64 = Buffer.from(userShare).toString('base64');
+    const txRequestWithIntentRecipients = {
+      ...txRequest,
+      intent: {
+        intentType: 'contractCall',
+        recipients: [
+          {
+            address: { address: '0xrecipient' },
+            amount: { value: '1000', symbol: 'hteth' },
+          },
+        ],
+      },
+    };
+    // Should not throw the recipients guard error — falls back to intent.recipients
+    await tssUtils
+      .signTxRequest({
+        txRequest: txRequestWithIntentRecipients,
+        prv: userPrvBase64,
+        reqId,
+        // no txParams.recipients
+      })
+      .should.not.be.rejectedWith(
+        'Recipient details are required to verify this transaction before signing. Pass txParams with at least one recipient.'
+      );
+  });
+
+  it('accepts signTxRequest for no-recipient tx types (tokenApproval)', async function () {
+    const userShare = fs.readFileSync(shareFiles[vector.party1]);
+    const userPrvBase64 = Buffer.from(userShare).toString('base64');
+    // Should not throw the recipients guard error — type exemption applies
+    await tssUtils
+      .signTxRequest({
+        txRequest,
+        prv: userPrvBase64,
+        reqId,
+        txParams: { type: 'tokenApproval' },
+      })
+      .should.not.be.rejectedWith(
+        'Recipient details are required to verify this transaction before signing. Pass txParams with at least one recipient.'
+      );
+  });
+
+  it('accepts signTxRequest for no-recipient tx types (acceleration)', async function () {
+    const userShare = fs.readFileSync(shareFiles[vector.party1]);
+    const userPrvBase64 = Buffer.from(userShare).toString('base64');
+    await tssUtils
+      .signTxRequest({
+        txRequest,
+        prv: userPrvBase64,
+        reqId,
+        txParams: { type: 'acceleration' },
+      })
+      .should.not.be.rejectedWith(
+        'Recipient details are required to verify this transaction before signing. Pass txParams with at least one recipient.'
+      );
+  });
+
+  it('accepts signTxRequest when txParams.recipients takes priority over intent.recipients', async function () {
+    const userShare = fs.readFileSync(shareFiles[vector.party1]);
+    const userPrvBase64 = Buffer.from(userShare).toString('base64');
+    const txRequestWithBothRecipients = {
+      ...txRequest,
+      intent: {
+        intentType: 'contractCall',
+        recipients: [{ address: { address: '0xintentRecipient' }, amount: { value: '9999', symbol: 'hteth' } }],
+      },
+    };
+    await tssUtils
+      .signTxRequest({
+        txRequest: txRequestWithBothRecipients,
+        prv: userPrvBase64,
+        reqId,
+        txParams: { recipients: [{ address: '0xrecipient', amount: '1000' }] },
+      })
+      .should.not.be.rejectedWith(
+        'Recipient details are required to verify this transaction before signing. Pass txParams with at least one recipient.'
+      );
   });
 });
 

--- a/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsaMPCv2/signTxRequest.ts
+++ b/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsaMPCv2/signTxRequest.ts
@@ -318,8 +318,6 @@ describe('signTxRequest:', function () {
   });
 
   it('accepts signTxRequest when recipients are only in intent (smart contract interaction)', async function () {
-    const userShare = fs.readFileSync(shareFiles[vector.party1]);
-    const userPrvBase64 = Buffer.from(userShare).toString('base64');
     const txRequestWithIntentRecipients = {
       ...txRequest,
       intent: {
@@ -332,53 +330,120 @@ describe('signTxRequest:', function () {
         ],
       },
     };
-    // Should not throw the recipients guard error — falls back to intent.recipients
-    await tssUtils
-      .signTxRequest({
-        txRequest: txRequestWithIntentRecipients,
-        prv: userPrvBase64,
-        reqId,
-        // no txParams.recipients
-      })
-      .should.not.be.rejectedWith(
-        'Recipient details are required to verify this transaction before signing. Pass txParams with at least one recipient.'
-      );
+    const nockPromises = [
+      await nockTxRequestResponseSignatureShareRoundOne(bitgoParty, txRequestWithIntentRecipients, bitgoGpgKey),
+      await nockTxRequestResponseSignatureShareRoundTwo(bitgoParty, txRequestWithIntentRecipients, bitgoGpgKey),
+      await nockTxRequestResponseSignatureShareRoundThree(txRequestWithIntentRecipients),
+      await nockSendTxRequest(txRequestWithIntentRecipients),
+    ];
+    await Promise.all(nockPromises);
+
+    const userShare = fs.readFileSync(shareFiles[vector.party1]);
+    const userPrvBase64 = Buffer.from(userShare).toString('base64');
+    // Falls back to intent.recipients — guard should pass and signing should complete
+    await tssUtils.signTxRequest({
+      txRequest: txRequestWithIntentRecipients,
+      prv: userPrvBase64,
+      reqId,
+      // no txParams.recipients
+    });
+    nockPromises[0].isDone().should.be.true();
+    nockPromises[1].isDone().should.be.true();
+    nockPromises[2].isDone().should.be.true();
   });
 
   it('accepts signTxRequest for no-recipient tx types (tokenApproval)', async function () {
+    const nockPromises = [
+      await nockTxRequestResponseSignatureShareRoundOne(bitgoParty, txRequest, bitgoGpgKey),
+      await nockTxRequestResponseSignatureShareRoundTwo(bitgoParty, txRequest, bitgoGpgKey),
+      await nockTxRequestResponseSignatureShareRoundThree(txRequest),
+      await nockSendTxRequest(txRequest),
+    ];
+    await Promise.all(nockPromises);
+
     const userShare = fs.readFileSync(shareFiles[vector.party1]);
     const userPrvBase64 = Buffer.from(userShare).toString('base64');
-    // Should not throw the recipients guard error — type exemption applies
-    await tssUtils
-      .signTxRequest({
-        txRequest,
-        prv: userPrvBase64,
-        reqId,
-        txParams: { type: 'tokenApproval' },
-      })
-      .should.not.be.rejectedWith(
-        'Recipient details are required to verify this transaction before signing. Pass txParams with at least one recipient.'
-      );
+    // Type exemption applies — guard passes without recipients
+    await tssUtils.signTxRequest({
+      txRequest,
+      prv: userPrvBase64,
+      reqId,
+      txParams: { type: 'tokenApproval' },
+    });
+    nockPromises[0].isDone().should.be.true();
+    nockPromises[1].isDone().should.be.true();
+    nockPromises[2].isDone().should.be.true();
   });
 
   it('accepts signTxRequest for no-recipient tx types (acceleration)', async function () {
+    const nockPromises = [
+      await nockTxRequestResponseSignatureShareRoundOne(bitgoParty, txRequest, bitgoGpgKey),
+      await nockTxRequestResponseSignatureShareRoundTwo(bitgoParty, txRequest, bitgoGpgKey),
+      await nockTxRequestResponseSignatureShareRoundThree(txRequest),
+      await nockSendTxRequest(txRequest),
+    ];
+    await Promise.all(nockPromises);
+
     const userShare = fs.readFileSync(shareFiles[vector.party1]);
     const userPrvBase64 = Buffer.from(userShare).toString('base64');
-    await tssUtils
-      .signTxRequest({
-        txRequest,
-        prv: userPrvBase64,
-        reqId,
-        txParams: { type: 'acceleration' },
-      })
-      .should.not.be.rejectedWith(
-        'Recipient details are required to verify this transaction before signing. Pass txParams with at least one recipient.'
-      );
+    await tssUtils.signTxRequest({
+      txRequest,
+      prv: userPrvBase64,
+      reqId,
+      txParams: { type: 'acceleration' },
+    });
+    nockPromises[0].isDone().should.be.true();
+    nockPromises[1].isDone().should.be.true();
+    nockPromises[2].isDone().should.be.true();
+  });
+
+  it('accepts signTxRequest for no-recipient tx types (customTx)', async function () {
+    const nockPromises = [
+      await nockTxRequestResponseSignatureShareRoundOne(bitgoParty, txRequest, bitgoGpgKey),
+      await nockTxRequestResponseSignatureShareRoundTwo(bitgoParty, txRequest, bitgoGpgKey),
+      await nockTxRequestResponseSignatureShareRoundThree(txRequest),
+      await nockSendTxRequest(txRequest),
+    ];
+    await Promise.all(nockPromises);
+
+    const userShare = fs.readFileSync(shareFiles[vector.party1]);
+    const userPrvBase64 = Buffer.from(userShare).toString('base64');
+    // DeFi/WalletConnect smart contract interactions have no traditional recipients
+    await tssUtils.signTxRequest({
+      txRequest,
+      prv: userPrvBase64,
+      reqId,
+      txParams: { type: 'customTx' },
+    });
+    nockPromises[0].isDone().should.be.true();
+    nockPromises[1].isDone().should.be.true();
+    nockPromises[2].isDone().should.be.true();
+  });
+
+  it('accepts signTxRequest for no-recipient tx types (enableToken)', async function () {
+    const nockPromises = [
+      await nockTxRequestResponseSignatureShareRoundOne(bitgoParty, txRequest, bitgoGpgKey),
+      await nockTxRequestResponseSignatureShareRoundTwo(bitgoParty, txRequest, bitgoGpgKey),
+      await nockTxRequestResponseSignatureShareRoundThree(txRequest),
+      await nockSendTxRequest(txRequest),
+    ];
+    await Promise.all(nockPromises);
+
+    const userShare = fs.readFileSync(shareFiles[vector.party1]);
+    const userPrvBase64 = Buffer.from(userShare).toString('base64');
+    // TSS wallets do not populate recipients for token enablement — exemption must apply
+    await tssUtils.signTxRequest({
+      txRequest,
+      prv: userPrvBase64,
+      reqId,
+      txParams: { type: 'enableToken' },
+    });
+    nockPromises[0].isDone().should.be.true();
+    nockPromises[1].isDone().should.be.true();
+    nockPromises[2].isDone().should.be.true();
   });
 
   it('accepts signTxRequest when txParams.recipients takes priority over intent.recipients', async function () {
-    const userShare = fs.readFileSync(shareFiles[vector.party1]);
-    const userPrvBase64 = Buffer.from(userShare).toString('base64');
     const txRequestWithBothRecipients = {
       ...txRequest,
       intent: {
@@ -386,16 +451,26 @@ describe('signTxRequest:', function () {
         recipients: [{ address: { address: '0xintentRecipient' }, amount: { value: '9999', symbol: 'hteth' } }],
       },
     };
-    await tssUtils
-      .signTxRequest({
-        txRequest: txRequestWithBothRecipients,
-        prv: userPrvBase64,
-        reqId,
-        txParams: { recipients: [{ address: '0xrecipient', amount: '1000' }] },
-      })
-      .should.not.be.rejectedWith(
-        'Recipient details are required to verify this transaction before signing. Pass txParams with at least one recipient.'
-      );
+    const nockPromises = [
+      await nockTxRequestResponseSignatureShareRoundOne(bitgoParty, txRequestWithBothRecipients, bitgoGpgKey),
+      await nockTxRequestResponseSignatureShareRoundTwo(bitgoParty, txRequestWithBothRecipients, bitgoGpgKey),
+      await nockTxRequestResponseSignatureShareRoundThree(txRequestWithBothRecipients),
+      await nockSendTxRequest(txRequestWithBothRecipients),
+    ];
+    await Promise.all(nockPromises);
+
+    const userShare = fs.readFileSync(shareFiles[vector.party1]);
+    const userPrvBase64 = Buffer.from(userShare).toString('base64');
+    // txParams.recipients takes priority — guard passes and signing completes
+    await tssUtils.signTxRequest({
+      txRequest: txRequestWithBothRecipients,
+      prv: userPrvBase64,
+      reqId,
+      txParams: { recipients: [{ address: '0xrecipient', amount: '1000' }] },
+    });
+    nockPromises[0].isDone().should.be.true();
+    nockPromises[1].isDone().should.be.true();
+    nockPromises[2].isDone().should.be.true();
   });
 });
 

--- a/modules/sdk-core/src/bitgo/pendingApproval/pendingApproval.ts
+++ b/modules/sdk-core/src/bitgo/pendingApproval/pendingApproval.ts
@@ -250,7 +250,9 @@ export class PendingApproval implements IPendingApproval {
     }
 
     const decryptedPrv = await this.wallet.getPrv({ walletPassphrase });
-    const txRequest = await this.tssUtils!.recreateTxRequest(txRequestId, decryptedPrv, reqId);
+    const pendingApprovalRecipients = this._pendingApproval.info?.transactionRequest?.recipients;
+    const txParams = pendingApprovalRecipients?.length ? { recipients: pendingApprovalRecipients } : undefined;
+    const txRequest = await this.tssUtils!.recreateTxRequest(txRequestId, decryptedPrv, reqId, txParams);
     if (txRequest.apiVersion === 'lite') {
       if (!txRequest.unsignedTxs || txRequest.unsignedTxs.length === 0) {
         throw new Error('Unexpected error, no transactions found in txRequest.');

--- a/modules/sdk-core/src/bitgo/pendingApproval/pendingApproval.ts
+++ b/modules/sdk-core/src/bitgo/pendingApproval/pendingApproval.ts
@@ -246,7 +246,9 @@ export class PendingApproval implements IPendingApproval {
     }
 
     const decryptedPrv = await this.wallet.getPrv({ walletPassphrase });
-    const txRequest = await this.tssUtils!.recreateTxRequest(txRequestId, decryptedPrv, reqId);
+    const pendingApprovalRecipients = this._pendingApproval.info?.transactionRequest?.recipients;
+    const txParams = pendingApprovalRecipients?.length ? { recipients: pendingApprovalRecipients } : undefined;
+    const txRequest = await this.tssUtils!.recreateTxRequest(txRequestId, decryptedPrv, reqId, txParams);
     if (txRequest.apiVersion === 'lite') {
       if (!txRequest.unsignedTxs || txRequest.unsignedTxs.length === 0) {
         throw new Error('Unexpected error, no transactions found in txRequest.');

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
@@ -39,6 +39,7 @@ import {
   TxRequest,
   TxRequestVersion,
 } from './baseTypes';
+import { TransactionParams } from '../../baseCoin/iBaseCoin';
 import { GShare, SignShare } from '../../../account-lib/mpc/tss';
 import { RequestTracer } from '../util';
 import { envRequiresBitgoPubGpgKeyConfig, getBitgoMpcGpgPubKey } from '../../tss/bitgoPubKeys';
@@ -538,11 +539,16 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
    * @param {RequestTracer} reqId id tracer.
    * @returns {Promise<any>}
    */
-  async recreateTxRequest(txRequestId: string, decryptedPrv: string, reqId: IRequestTracer): Promise<TxRequest> {
+  async recreateTxRequest(
+    txRequestId: string,
+    decryptedPrv: string,
+    reqId: IRequestTracer,
+    txParams?: TransactionParams
+  ): Promise<TxRequest> {
     await this.deleteSignatureShares(txRequestId, reqId);
     // after delete signatures shares get the tx without them
     const txRequest = await getTxRequest(this.bitgo, this.wallet.id(), txRequestId, reqId);
-    return await this.signTxRequest({ txRequest, prv: decryptedPrv, reqId });
+    return await this.signTxRequest({ txRequest, prv: decryptedPrv, reqId, txParams });
   }
 
   /**

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
@@ -39,6 +39,7 @@ import {
   TxRequest,
   TxRequestVersion,
 } from './baseTypes';
+import { TransactionParams } from '../../baseCoin/iBaseCoin';
 import { GShare, SignShare } from '../../../account-lib/mpc/tss';
 import { RequestTracer } from '../util';
 import { envRequiresBitgoPubGpgKeyConfig, getBitgoMpcGpgPubKey } from '../../tss/bitgoPubKeys';
@@ -533,11 +534,16 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
    * @param {RequestTracer} reqId id tracer.
    * @returns {Promise<any>}
    */
-  async recreateTxRequest(txRequestId: string, decryptedPrv: string, reqId: IRequestTracer): Promise<TxRequest> {
+  async recreateTxRequest(
+    txRequestId: string,
+    decryptedPrv: string,
+    reqId: IRequestTracer,
+    txParams?: TransactionParams
+  ): Promise<TxRequest> {
     await this.deleteSignatureShares(txRequestId, reqId);
     // after delete signatures shares get the tx without them
     const txRequest = await getTxRequest(this.bitgo, this.wallet.id(), txRequestId, reqId);
-    return await this.signTxRequest({ txRequest, prv: decryptedPrv, reqId });
+    return await this.signTxRequest({ txRequest, prv: decryptedPrv, reqId, txParams });
   }
 
   /**

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -760,7 +760,12 @@ export interface ITssUtils<KeyShare = EDDSA.KeyShare> {
   deleteSignatureShares(txRequestId: string): Promise<SignatureShareRecord[]>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   sendTxRequest(txRequestId: string): Promise<any>;
-  recreateTxRequest(txRequestId: string, decryptedPrv: string, reqId: IRequestTracer): Promise<TxRequest>;
+  recreateTxRequest(
+    txRequestId: string,
+    decryptedPrv: string,
+    reqId: IRequestTracer,
+    txParams?: TransactionParams
+  ): Promise<TxRequest>;
   getTxRequest(txRequestId: string): Promise<TxRequest>;
   supportedTxRequestVersions(): TxRequestVersion[];
 }

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -759,7 +759,12 @@ export interface ITssUtils<KeyShare = EDDSA.KeyShare> {
   deleteSignatureShares(txRequestId: string): Promise<SignatureShareRecord[]>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   sendTxRequest(txRequestId: string): Promise<any>;
-  recreateTxRequest(txRequestId: string, decryptedPrv: string, reqId: IRequestTracer): Promise<TxRequest>;
+  recreateTxRequest(
+    txRequestId: string,
+    decryptedPrv: string,
+    reqId: IRequestTracer,
+    txParams?: TransactionParams
+  ): Promise<TxRequest>;
   getTxRequest(txRequestId: string): Promise<TxRequest>;
   supportedTxRequestVersions(): TxRequestVersion[];
 }

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/base.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/base.ts
@@ -1,61 +1,12 @@
 import { secp256k1 } from '@noble/curves/secp256k1';
 
-import { IBaseCoin, TransactionParams } from '../../../baseCoin';
+import { IBaseCoin } from '../../../baseCoin';
 import baseTSSUtils from '../baseTSSUtils';
 import { KeyShare } from './types';
-import { BackupGpgKey, PopulatedIntent, TxRequest } from '../baseTypes';
+import { BackupGpgKey } from '../baseTypes';
 import { generateGPGKeyPair } from '../../opengpgUtils';
 import { BitGoBase } from '../../../bitgoBase';
 import { IWallet } from '../../../wallet';
-import { InvalidTransactionError } from '../../../errors';
-
-/**
- * Transaction types that legitimately carry no explicit recipients.
- * verifyTransaction handles no-recipient validation for these internally.
- * Mirrors the bypass list in abstractEthLikeNewCoins.ts verifyTssTransaction.
- */
-export const NO_RECIPIENT_TX_TYPES = new Set([
-  'acceleration',
-  'fillNonce',
-  'transferToken',
-  'tokenApproval',
-  'consolidate',
-  'bridgeFunds',
-]);
-
-/**
- * Resolves the effective txParams for TSS signing recipient verification.
- *
- * For smart contract interactions, recipients live in txRequest.intent.recipients
- * (native amount = 0, so buildParams is empty). Falls back to intent recipients
- * mapped to ITransactionRecipient shape when txParams.recipients is absent.
- *
- * Throws InvalidTransactionError if no recipients can be resolved and the
- * transaction type is not a known no-recipient type.
- */
-export function resolveEffectiveTxParams(
-  txRequest: TxRequest,
-  txParams: TransactionParams | undefined
-): TransactionParams {
-  const intentRecipients = (txRequest.intent as PopulatedIntent)?.recipients?.map((intentRecipient) => ({
-    address: intentRecipient.address.address,
-    amount: intentRecipient.amount.value,
-    data: intentRecipient.data,
-  }));
-
-  const effectiveTxParams: TransactionParams = {
-    ...txParams,
-    recipients: txParams?.recipients?.length ? txParams.recipients : intentRecipients,
-  };
-
-  if (!effectiveTxParams.recipients?.length && !NO_RECIPIENT_TX_TYPES.has(effectiveTxParams.type ?? '')) {
-    throw new InvalidTransactionError(
-      'Recipient details are required to verify this transaction before signing. Pass txParams with at least one recipient.'
-    );
-  }
-
-  return effectiveTxParams;
-}
 
 /** @inheritdoc */
 export class BaseEcdsaUtils extends baseTSSUtils<KeyShare> {

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/base.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/base.ts
@@ -1,12 +1,61 @@
 import { secp256k1 } from '@noble/curves/secp256k1';
 
-import { IBaseCoin } from '../../../baseCoin';
+import { IBaseCoin, TransactionParams } from '../../../baseCoin';
 import baseTSSUtils from '../baseTSSUtils';
 import { KeyShare } from './types';
-import { BackupGpgKey } from '../baseTypes';
+import { BackupGpgKey, PopulatedIntent, TxRequest } from '../baseTypes';
 import { generateGPGKeyPair } from '../../opengpgUtils';
 import { BitGoBase } from '../../../bitgoBase';
 import { IWallet } from '../../../wallet';
+import { InvalidTransactionError } from '../../../errors';
+
+/**
+ * Transaction types that legitimately carry no explicit recipients.
+ * verifyTransaction handles no-recipient validation for these internally.
+ * Mirrors the bypass list in abstractEthLikeNewCoins.ts verifyTssTransaction.
+ */
+export const NO_RECIPIENT_TX_TYPES = new Set([
+  'acceleration',
+  'fillNonce',
+  'transferToken',
+  'tokenApproval',
+  'consolidate',
+  'bridgeFunds',
+]);
+
+/**
+ * Resolves the effective txParams for TSS signing recipient verification.
+ *
+ * For smart contract interactions, recipients live in txRequest.intent.recipients
+ * (native amount = 0, so buildParams is empty). Falls back to intent recipients
+ * mapped to ITransactionRecipient shape when txParams.recipients is absent.
+ *
+ * Throws InvalidTransactionError if no recipients can be resolved and the
+ * transaction type is not a known no-recipient type.
+ */
+export function resolveEffectiveTxParams(
+  txRequest: TxRequest,
+  txParams: TransactionParams | undefined
+): TransactionParams {
+  const intentRecipients = (txRequest.intent as PopulatedIntent)?.recipients?.map((intentRecipient) => ({
+    address: intentRecipient.address.address,
+    amount: intentRecipient.amount.value,
+    data: intentRecipient.data,
+  }));
+
+  const effectiveTxParams: TransactionParams = {
+    ...txParams,
+    recipients: txParams?.recipients?.length ? txParams.recipients : intentRecipients,
+  };
+
+  if (!effectiveTxParams.recipients?.length && !NO_RECIPIENT_TX_TYPES.has(effectiveTxParams.type ?? '')) {
+    throw new InvalidTransactionError(
+      'Recipient details are required to verify this transaction before signing. Pass txParams with at least one recipient.'
+    );
+  }
+
+  return effectiveTxParams;
+}
 
 /** @inheritdoc */
 export class BaseEcdsaUtils extends baseTSSUtils<KeyShare> {

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
@@ -45,7 +45,8 @@ import {
   TssEcdsaStep2ReturnMessage,
   TxRequestChallengeResponse,
 } from '../../../tss/types';
-import { BaseEcdsaUtils, resolveEffectiveTxParams } from './base';
+import { BaseEcdsaUtils } from './base';
+import { resolveEffectiveTxParams } from '../recipientUtils';
 import { IRequestTracer } from '../../../../api';
 
 const encryptNShare = ECDSAMethods.encryptNShare;

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
@@ -45,7 +45,7 @@ import {
   TssEcdsaStep2ReturnMessage,
   TxRequestChallengeResponse,
 } from '../../../tss/types';
-import { BaseEcdsaUtils } from './base';
+import { BaseEcdsaUtils, resolveEffectiveTxParams } from './base';
 import { IRequestTracer } from '../../../../api';
 
 const encryptNShare = ECDSAMethods.encryptNShare;
@@ -745,6 +745,8 @@ export class EcdsaUtils extends BaseEcdsaUtils {
       const unsignedTx =
         txRequest.apiVersion === 'full' ? txRequest.transactions![0].unsignedTx : txRequest.unsignedTxs[0];
 
+      const effectiveTxParams = resolveEffectiveTxParams(txRequest, params.txParams);
+
       // For ICP transactions, the HSM signs the serializedTxHex, while the user signs the signableHex separately.
       // Verification cannot be performed directly on the signableHex alone. However, we can parse the serializedTxHex
       // to regenerate the signableHex and compare it against the provided value for verification.
@@ -752,14 +754,14 @@ export class EcdsaUtils extends BaseEcdsaUtils {
       if (this.baseCoin.getConfig().family === 'icp') {
         await this.baseCoin.verifyTransaction({
           txPrebuild: { txHex: unsignedTx.serializedTxHex, txInfo: unsignedTx.signableHex },
-          txParams: params.txParams || { recipients: [] },
+          txParams: effectiveTxParams,
           wallet: this.wallet,
           walletType: this.wallet.multisigType(),
         });
       } else {
         await this.baseCoin.verifyTransaction({
           txPrebuild: { txHex: unsignedTx.signableHex },
-          txParams: params.txParams || { recipients: [] },
+          txParams: effectiveTxParams,
           wallet: this.wallet,
           walletType: this.wallet.multisigType(),
         });

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
@@ -46,7 +46,7 @@ import {
   TSSParamsWithPrv,
   TxRequest,
 } from '../baseTypes';
-import { BaseEcdsaUtils } from './base';
+import { BaseEcdsaUtils, resolveEffectiveTxParams } from './base';
 import { EcdsaMPCv2KeyGenSendFn, KeyGenSenderForEnterprise } from './ecdsaMPCv2KeyGenSender';
 import { envRequiresBitgoPubGpgKeyConfig, isBitgoMpcPubKey } from '../../../tss/bitgoPubKeys';
 
@@ -737,6 +737,8 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
       const unsignedTx =
         txRequest.apiVersion === 'full' ? txRequest.transactions![0].unsignedTx : txRequest.unsignedTxs[0];
 
+      const effectiveTxParams = resolveEffectiveTxParams(txRequest, params.txParams);
+
       // For ICP transactions, the HSM signs the serializedTxHex, while the user signs the signableHex separately.
       // Verification cannot be performed directly on the signableHex alone. However, we can parse the serializedTxHex
       // to regenerate the signableHex and compare it against the provided value for verification.
@@ -744,14 +746,14 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
       if (this.baseCoin.getConfig().family === 'icp') {
         await this.baseCoin.verifyTransaction({
           txPrebuild: { txHex: unsignedTx.serializedTxHex, txInfo: unsignedTx.signableHex },
-          txParams: params.txParams || { recipients: [] },
+          txParams: effectiveTxParams,
           wallet: this.wallet,
           walletType: this.wallet.multisigType(),
         });
       } else {
         await this.baseCoin.verifyTransaction({
           txPrebuild: { txHex: unsignedTx.signableHex },
-          txParams: params.txParams || { recipients: [] },
+          txParams: effectiveTxParams,
           wallet: this.wallet,
           walletType: this.wallet.multisigType(),
         });

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
@@ -46,7 +46,8 @@ import {
   TSSParamsWithPrv,
   TxRequest,
 } from '../baseTypes';
-import { BaseEcdsaUtils, resolveEffectiveTxParams } from './base';
+import { BaseEcdsaUtils } from './base';
+import { resolveEffectiveTxParams } from '../recipientUtils';
 import { EcdsaMPCv2KeyGenSendFn, KeyGenSenderForEnterprise } from './ecdsaMPCv2KeyGenSender';
 import { envRequiresBitgoPubGpgKeyConfig, isBitgoMpcPubKey } from '../../../tss/bitgoPubKeys';
 

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
@@ -46,7 +46,7 @@ import {
   TSSParamsWithPrv,
   TxRequest,
 } from '../baseTypes';
-import { BaseEcdsaUtils } from './base';
+import { BaseEcdsaUtils, resolveEffectiveTxParams } from './base';
 import { EcdsaMPCv2KeyGenSendFn, KeyGenSenderForEnterprise } from './ecdsaMPCv2KeyGenSender';
 import { envRequiresBitgoPubGpgKeyConfig, isBitgoMpcPubKey } from '../../../tss/bitgoPubKeys';
 
@@ -736,6 +736,8 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
       const unsignedTx =
         txRequest.apiVersion === 'full' ? txRequest.transactions![0].unsignedTx : txRequest.unsignedTxs[0];
 
+      const effectiveTxParams = resolveEffectiveTxParams(txRequest, params.txParams);
+
       // For ICP transactions, the HSM signs the serializedTxHex, while the user signs the signableHex separately.
       // Verification cannot be performed directly on the signableHex alone. However, we can parse the serializedTxHex
       // to regenerate the signableHex and compare it against the provided value for verification.
@@ -743,14 +745,14 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
       if (this.baseCoin.getConfig().family === 'icp') {
         await this.baseCoin.verifyTransaction({
           txPrebuild: { txHex: unsignedTx.serializedTxHex, txInfo: unsignedTx.signableHex },
-          txParams: params.txParams || { recipients: [] },
+          txParams: effectiveTxParams,
           wallet: this.wallet,
           walletType: this.wallet.multisigType(),
         });
       } else {
         await this.baseCoin.verifyTransaction({
           txPrebuild: { txHex: unsignedTx.signableHex },
-          txParams: params.txParams || { recipients: [] },
+          txParams: effectiveTxParams,
           wallet: this.wallet,
           walletType: this.wallet.multisigType(),
         });

--- a/modules/sdk-core/src/bitgo/utils/tss/recipientUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/recipientUtils.ts
@@ -1,0 +1,53 @@
+import { TransactionParams } from '../../baseCoin';
+import { InvalidTransactionError } from '../../errors';
+import { PopulatedIntent, TxRequest } from './baseTypes';
+
+/**
+ * Transaction types that legitimately carry no explicit recipients.
+ * verifyTransaction handles no-recipient validation for these internally.
+ * Mirrors the bypass list in abstractEthLikeNewCoins.ts verifyTssTransaction.
+ */
+export const NO_RECIPIENT_TX_TYPES = new Set([
+  'acceleration',
+  'fillNonce',
+  'transferToken',
+  'tokenApproval',
+  'consolidate',
+  'bridgeFunds',
+  'enableToken',
+  'customTx', // DeFi/WalletConnect smart contract interactions have no traditional recipients
+]);
+
+/**
+ * Resolves the effective txParams for TSS signing recipient verification.
+ *
+ * For smart contract interactions, recipients live in txRequest.intent.recipients
+ * (native amount = 0, so buildParams is empty). Falls back to intent recipients
+ * mapped to ITransactionRecipient shape when txParams.recipients is absent.
+ *
+ * Throws InvalidTransactionError if no recipients can be resolved and the
+ * transaction type is not a known no-recipient type.
+ */
+export function resolveEffectiveTxParams(
+  txRequest: TxRequest,
+  txParams: TransactionParams | undefined
+): TransactionParams {
+  const intentRecipients = (txRequest.intent as PopulatedIntent)?.recipients?.map((intentRecipient) => ({
+    address: intentRecipient.address.address,
+    amount: intentRecipient.amount.value,
+    data: intentRecipient.data,
+  }));
+
+  const effectiveTxParams: TransactionParams = {
+    ...txParams,
+    recipients: txParams?.recipients?.length ? txParams.recipients : intentRecipients,
+  };
+
+  if (!effectiveTxParams.recipients?.length && !NO_RECIPIENT_TX_TYPES.has(effectiveTxParams.type ?? '')) {
+    throw new InvalidTransactionError(
+      'Recipient details are required to verify this transaction before signing. Pass txParams with at least one recipient.'
+    );
+  }
+
+  return effectiveTxParams;
+}

--- a/modules/sdk-core/test/unit/bitgo/utils/tss/recipientUtils.ts
+++ b/modules/sdk-core/test/unit/bitgo/utils/tss/recipientUtils.ts
@@ -1,0 +1,121 @@
+import 'should';
+import * as assert from 'assert';
+
+// Import directly from source so no top-level export change is needed
+const getModule = () => require('../../../../../src/bitgo/utils/tss/recipientUtils');
+
+function makeTxRequest(
+  intentRecipients?: { address: { address: string }; amount: { value: string }; data?: string }[]
+): any {
+  return {
+    txRequestId: 'test-req-id',
+    intent: intentRecipients ? { intentType: 'contractCall', recipients: intentRecipients } : { intentType: 'payment' },
+    transactions: [],
+    unsignedTxs: [],
+    state: 'pendingUserSignature',
+    walletType: 'hot',
+    walletId: 'walletId',
+    policiesChecked: true,
+    version: 1,
+    userId: 'userId',
+  };
+}
+
+describe('recipientUtils', function () {
+  describe('NO_RECIPIENT_TX_TYPES', function () {
+    it('contains exactly the 8 expected exempted types', function () {
+      const { NO_RECIPIENT_TX_TYPES } = getModule();
+      const expected = [
+        'acceleration',
+        'fillNonce',
+        'transferToken',
+        'tokenApproval',
+        'consolidate',
+        'bridgeFunds',
+        'enableToken',
+        'customTx',
+      ];
+      expected.forEach((t) => assert.ok(NO_RECIPIENT_TX_TYPES.has(t), `${t} should be in NO_RECIPIENT_TX_TYPES`));
+      assert.strictEqual(NO_RECIPIENT_TX_TYPES.size, expected.length);
+    });
+  });
+
+  describe('resolveEffectiveTxParams', function () {
+    it('uses txParams.recipients when provided', function () {
+      const { resolveEffectiveTxParams } = getModule();
+      const txRequest = makeTxRequest();
+      const result = resolveEffectiveTxParams(txRequest, { recipients: [{ address: '0xabc', amount: '100' }] });
+      result.recipients[0].address.should.equal('0xabc');
+      result.recipients[0].amount.should.equal('100');
+    });
+
+    it('falls back to intent.recipients when txParams has no recipients', function () {
+      const { resolveEffectiveTxParams } = getModule();
+      const txRequest = makeTxRequest([{ address: { address: '0xintent' }, amount: { value: '500' } }]);
+      const result = resolveEffectiveTxParams(txRequest, {});
+      result.recipients[0].address.should.equal('0xintent');
+      result.recipients[0].amount.should.equal('500');
+    });
+
+    it('falls back to intent.recipients when txParams is undefined', function () {
+      const { resolveEffectiveTxParams } = getModule();
+      const txRequest = makeTxRequest([{ address: { address: '0xintent' }, amount: { value: '999' } }]);
+      const result = resolveEffectiveTxParams(txRequest, undefined);
+      result.recipients[0].address.should.equal('0xintent');
+    });
+
+    it('prefers txParams.recipients over intent.recipients when both present', function () {
+      const { resolveEffectiveTxParams } = getModule();
+      const txRequest = makeTxRequest([{ address: { address: '0xintent' }, amount: { value: '9999' } }]);
+      const result = resolveEffectiveTxParams(txRequest, { recipients: [{ address: '0xexplicit', amount: '1' }] });
+      result.recipients[0].address.should.equal('0xexplicit');
+    });
+
+    it('maps intent.data field through to the recipient', function () {
+      const { resolveEffectiveTxParams } = getModule();
+      const txRequest = makeTxRequest([
+        { address: { address: '0xcontract' }, amount: { value: '0' }, data: '0xabcdef' },
+      ]);
+      const result = resolveEffectiveTxParams(txRequest, undefined);
+      result.recipients[0].data.should.equal('0xabcdef');
+    });
+
+    it('throws InvalidTransactionError when no recipients and type is not exempted', function () {
+      const { resolveEffectiveTxParams } = getModule();
+      const txRequest = makeTxRequest();
+      assert.throws(
+        () => resolveEffectiveTxParams(txRequest, {}),
+        /Recipient details are required to verify this transaction before signing/
+      );
+    });
+
+    it('throws when txParams is undefined and intent has no recipients', function () {
+      const { resolveEffectiveTxParams } = getModule();
+      const txRequest = makeTxRequest();
+      assert.throws(
+        () => resolveEffectiveTxParams(txRequest, undefined),
+        /Recipient details are required to verify this transaction before signing/
+      );
+    });
+
+    const NO_RECIPIENT_TYPES = [
+      'acceleration',
+      'fillNonce',
+      'transferToken',
+      'tokenApproval',
+      'consolidate',
+      'bridgeFunds',
+      'enableToken', // TSS wallets do not populate recipients for token enablement
+      'customTx', // DeFi/WalletConnect smart contract interactions have no traditional recipients
+    ];
+
+    NO_RECIPIENT_TYPES.forEach((type) => {
+      it(`allows empty recipients for no-recipient tx type: ${type}`, function () {
+        const { resolveEffectiveTxParams } = getModule();
+        const txRequest = makeTxRequest();
+        const result = resolveEffectiveTxParams(txRequest, { type });
+        result.type.should.equal(type);
+      });
+    });
+  });
+});


### PR DESCRIPTION
TICKET: WAL-375

## Description

Ensures `verifyTransaction` always receives recipient details before any signing material is sent to BitGo, preventing a compromised API from silently substituting `signableHex` with attacker-controlled bytes.

A `resolveEffectiveTxParams()` guard is added to both ECDSA and MPCv2 `signRequestBase()` paths. It resolves recipients from three sources in priority order:

1. **`txParams.recipients`** — normal case.
2. **`txRequest.intent.recipients`** — fallback for smart-contract interactions (e.g. Tempo `supplyController`) where native ETH amount = 0 so `buildParams` is empty but intent carries the recipients.
  3. **`NO_RECIPIENT_TX_TYPES`** exemption — types that legitimately carry no recipients; `verifyTransaction` handles validation internally for these. Throws `InvalidTransactionError` if none of the above apply.

A database query against `marts.wallet_platform.bitgo2__transaction_request` identified all intent types where `INTENT:recipients IS NULL OR ARRAY_SIZE(INTENT:recipients) = 0`. Two ECDSA-path types with significant
  record counts were missing from the exemption list:

  - enableToken (17,765 records) — TSS wallets call buildTokenEnablements() which does not populate buildParams.recipients
  - customTx (7,082 records) — DeFi/WalletConnect smart contract interactions; already exempted at populateIntent() server-side but inconsistently enforced at signing

Both have been added to NO_RECIPIENT_TX_TYPES and the abstractEthLikeNewCoins.ts bypass list.

 ## NO_RECIPIENT_TX_TYPES (8 types)

  | Type | Reason |
  |---|---|
  | `acceleration`, `fillNonce`, `transferToken`, `tokenApproval`, `consolidate`, `bridgeFunds` | Pre-existing exemptions |
  | `enableToken` | TSS wallets do not populate recipients for token enablement — confirmed via prod DB  |
  | `customTx` | DeFi/WalletConnect smart contract interactions — already exempted at `populateIntent()` server-side; must be consistent at signing  |

  Both `recipientUtils.ts` and the inline bypass list in `abstractEthLikeNewCoins.ts verifyTssTransaction` are kept in sync.

A previous PR (#8462) hard-threw on any empty recipients, breaking cases 2 and 3. It was reverted in #8538. This PR supersedes it.

 ## Testing

  **New unit tests — `tss/recipientUtils.ts` (16 tests):**
  - All 8 exempt types pass without recipients
  - `txParams.recipients` takes priority over intent
  - Intent fallback when `txParams` is empty or undefined
  - Throws for non-exempt types with no recipients

  **Updated integration tests — `ecdsaMPCv2/signTxRequest.ts` (13 tests):**
  - Replaced 4 false-confidence `.should.not.be.rejectedWith()` assertions with nock-backed `isDone()` assertions that prove signing completes end-to-end
  - Added acceptance tests for `enableToken` and `customTx` exemptions
  - Existing reject tests unchanged
