### PR TITLE
refactor(express): split encrypt into v1 and v2

### DIFF
--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -1701,6 +1701,7 @@ export function setupAPIRoutes(app: express.Application, config: Config): void {
   router.post('express.login', [prepareBitGo(config), typedPromiseWrapper(handleLogin)]);
 
   router.post('express.decrypt', [prepareBitGo(config), typedPromiseWrapper(handleDecrypt)]);
+  router.post('express.v1.encrypt', [prepareBitGo(config), typedPromiseWrapper(handleEncrypt)]);
   router.post('express.encrypt', [prepareBitGo(config), typedPromiseWrapper(handleEncrypt)]);
   router.post('express.verifyaddress', [prepareBitGo(config), typedPromiseWrapper(handleVerifyAddress)]);
   router.post('express.v1.calculateminerfeeinfo', [

--- a/modules/express/src/typedRoutes/api/index.ts
+++ b/modules/express/src/typedRoutes/api/index.ts
@@ -6,7 +6,8 @@ import { GetPing } from './common/ping';
 import { GetPingExpress } from './common/pingExpress';
 import { PostLogin } from './common/login';
 import { PostDecrypt } from './common/decrypt';
-import { PostEncrypt } from './common/encrypt';
+import { PostV1Encrypt } from './v1/encrypt';
+import { PostV2Encrypt } from './v2/encrypt';
 import { PostVerifyAddress } from './common/verifyAddress';
 import { PostV1CalculateMinerFeeInfo } from './v1/calculateMinerFeeInfo';
 import { PostV2CalculateMinerFeeInfo } from './v2/calculateMinerFeeInfo';
@@ -87,8 +88,11 @@ export const ExpressDecryptApiSpec = apiSpec({
 });
 
 export const ExpressEncryptApiSpec = apiSpec({
+  'express.v1.encrypt': {
+    post: PostV1Encrypt,
+  },
   'express.encrypt': {
-    post: PostEncrypt,
+    post: PostV2Encrypt,
   },
 });
 

--- a/modules/express/src/typedRoutes/api/v1/encrypt.ts
+++ b/modules/express/src/typedRoutes/api/v1/encrypt.ts
@@ -1,0 +1,34 @@
+import * as t from 'io-ts';
+import { httpRoute, httpRequest, optional } from '@api-ts/io-ts-http';
+import { BitgoExpressError } from '../../schemas/error';
+
+export const EncryptRequestBody = {
+  /** Plaintext message which should be encrypted */
+  input: t.string,
+  /** Password which should be used to encrypt message */
+  password: optional(t.string),
+  adata: optional(t.string),
+};
+
+/**
+ * Encrypt message (v1)
+ *
+ * Symmetrically encrypt an arbitrary message with provided password
+ *
+ * @operationId express.v1.encrypt
+ * @tag Express
+ * @private
+ */
+export const PostV1Encrypt = httpRoute({
+  path: '/api/v1/encrypt',
+  method: 'POST',
+  request: httpRequest({
+    body: EncryptRequestBody,
+  }),
+  response: {
+    200: t.type({
+      encrypted: t.string,
+    }),
+    404: BitgoExpressError,
+  },
+});

--- a/modules/express/src/typedRoutes/api/v2/encrypt.ts
+++ b/modules/express/src/typedRoutes/api/v2/encrypt.ts
@@ -1,21 +1,19 @@
 import * as t from 'io-ts';
-import { httpRoute, httpRequest, optional } from '@api-ts/io-ts-http';
+import { httpRoute, httpRequest } from '@api-ts/io-ts-http';
 import { BitgoExpressError } from '../../schemas/error';
-
-export const EncryptRequestBody = {
-  input: t.string,
-  password: optional(t.string),
-  adata: optional(t.string),
-};
+import { EncryptRequestBody } from '../v1/encrypt';
 
 /**
- * Encrypt
+ * Encrypt message
+ *
+ * Symmetrically encrypt an arbitrary message with provided password
  *
  * @operationId express.encrypt
- * @tag express
+ * @tag Express
+ * @public
  */
-export const PostEncrypt = httpRoute({
-  path: '/api/v[12]/encrypt',
+export const PostV2Encrypt = httpRoute({
+  path: '/api/v2/encrypt',
   method: 'POST',
   request: httpRequest({
     body: EncryptRequestBody,

--- a/modules/express/test/unit/typedRoutes/decode.ts
+++ b/modules/express/test/unit/typedRoutes/decode.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as t from 'io-ts';
 import { DecryptRequestBody } from '../../../src/typedRoutes/api/common/decrypt';
-import { EncryptRequestBody } from '../../../src/typedRoutes/api/common/encrypt';
+import { EncryptRequestBody } from '../../../src/typedRoutes/api/v1/encrypt';
 import { LoginRequest } from '../../../src/typedRoutes/api/common/login';
 import { VerifyAddressBody } from '../../../src/typedRoutes/api/common/verifyAddress';
 import { VerifyAddressV2Body, VerifyAddressV2Params } from '../../../src/typedRoutes/api/v2/verifyAddress';

--- a/modules/express/test/unit/typedRoutes/encrypt.ts
+++ b/modules/express/test/unit/typedRoutes/encrypt.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 import * as t from 'io-ts';
-import { EncryptRequestBody, PostEncrypt } from '../../../src/typedRoutes/api/common/encrypt';
+import { EncryptRequestBody, PostV1Encrypt } from '../../../src/typedRoutes/api/v1/encrypt';
+import { PostV2Encrypt } from '../../../src/typedRoutes/api/v2/encrypt';
 import { assertDecode } from './common';
 import 'should';
 import 'should-http';
@@ -92,7 +93,7 @@ describe('Encrypt codec tests', function () {
   });
 
   describe('EncryptResponse', function () {
-    const EncryptResponse = PostEncrypt.response[200];
+    const EncryptResponse = PostV1Encrypt.response[200];
 
     it('should validate response with required field', function () {
       const validResponse = {
@@ -139,24 +140,41 @@ describe('Encrypt codec tests', function () {
     });
   });
 
-  describe('PostEncrypt route definition', function () {
+  describe('PostV1Encrypt route definition', function () {
     it('should have the correct path', function () {
-      assert.strictEqual(PostEncrypt.path, '/api/v[12]/encrypt');
+      assert.strictEqual(PostV1Encrypt.path, '/api/v1/encrypt');
     });
 
     it('should have the correct HTTP method', function () {
-      assert.strictEqual(PostEncrypt.method, 'POST');
+      assert.strictEqual(PostV1Encrypt.method, 'POST');
     });
 
     it('should have the correct request configuration', function () {
-      // Verify the route is configured with a request property
-      assert.ok(PostEncrypt.request);
+      assert.ok(PostV1Encrypt.request);
     });
 
     it('should have the correct response types', function () {
-      // Check that the response object has the expected status codes
-      assert.ok(PostEncrypt.response[200]);
-      assert.ok(PostEncrypt.response[404]);
+      assert.ok(PostV1Encrypt.response[200]);
+      assert.ok(PostV1Encrypt.response[404]);
+    });
+  });
+
+  describe('PostV2Encrypt route definition', function () {
+    it('should have the correct path', function () {
+      assert.strictEqual(PostV2Encrypt.path, '/api/v2/encrypt');
+    });
+
+    it('should have the correct HTTP method', function () {
+      assert.strictEqual(PostV2Encrypt.method, 'POST');
+    });
+
+    it('should have the correct request configuration', function () {
+      assert.ok(PostV2Encrypt.request);
+    });
+
+    it('should have the correct response types', function () {
+      assert.ok(PostV2Encrypt.response[200]);
+      assert.ok(PostV2Encrypt.response[404]);
     });
   });
 
@@ -191,7 +209,7 @@ describe('Encrypt codec tests', function () {
       result.body.should.have.property('encrypted');
       assert.strictEqual(result.body.encrypted, mockEncryptResponse);
 
-      const decodedResponse = assertDecode(PostEncrypt.response[200], result.body);
+      const decodedResponse = assertDecode(PostV1Encrypt.response[200], result.body);
       assert.strictEqual(decodedResponse.encrypted, mockEncryptResponse);
     });
 
@@ -213,7 +231,7 @@ describe('Encrypt codec tests', function () {
       result.body.should.have.property('encrypted');
       assert.strictEqual(result.body.encrypted, mockEncryptResponse);
 
-      const decodedResponse = assertDecode(PostEncrypt.response[200], result.body);
+      const decodedResponse = assertDecode(PostV2Encrypt.response[200], result.body);
       assert.strictEqual(decodedResponse.encrypted, mockEncryptResponse);
     });
 
@@ -235,7 +253,7 @@ describe('Encrypt codec tests', function () {
       assert.strictEqual(result.status, 200);
       assert.strictEqual(result.body.encrypted, mockEncryptResponse);
 
-      const decodedResponse = assertDecode(PostEncrypt.response[200], result.body);
+      const decodedResponse = assertDecode(PostV1Encrypt.response[200], result.body);
       assert.strictEqual(decodedResponse.encrypted, mockEncryptResponse);
     });
 
@@ -257,7 +275,7 @@ describe('Encrypt codec tests', function () {
       assert.strictEqual(result.status, 200);
       assert.strictEqual(result.body.encrypted, mockEncryptResponse);
 
-      const decodedResponse = assertDecode(PostEncrypt.response[200], result.body);
+      const decodedResponse = assertDecode(PostV2Encrypt.response[200], result.body);
       assert.strictEqual(decodedResponse.encrypted, mockEncryptResponse);
     });
 
@@ -279,7 +297,7 @@ describe('Encrypt codec tests', function () {
       assert.strictEqual(result.status, 200);
       assert.strictEqual(result.body.encrypted, mockLongEncrypted);
 
-      const decodedResponse = assertDecode(PostEncrypt.response[200], result.body);
+      const decodedResponse = assertDecode(PostV1Encrypt.response[200], result.body);
       assert.strictEqual(decodedResponse.encrypted, mockLongEncrypted);
     });
 
@@ -300,7 +318,7 @@ describe('Encrypt codec tests', function () {
       assert.strictEqual(result.status, 200);
       assert.strictEqual(result.body.encrypted, mockEncryptResponse);
 
-      const decodedResponse = assertDecode(PostEncrypt.response[200], result.body);
+      const decodedResponse = assertDecode(PostV2Encrypt.response[200], result.body);
       assert.ok(decodedResponse);
     });
 
@@ -321,7 +339,7 @@ describe('Encrypt codec tests', function () {
       assert.strictEqual(result.status, 200);
       assert.strictEqual(result.body.encrypted, mockEncryptResponse);
 
-      const decodedResponse = assertDecode(PostEncrypt.response[200], result.body);
+      const decodedResponse = assertDecode(PostV1Encrypt.response[200], result.body);
       assert.ok(decodedResponse);
     });
   });


### PR DESCRIPTION
Ticket: WCI-185

Context - https://bitgo.slack.com/archives/C057BHBRG4B/p1764020095794829?thread_ts=1764018507.602879&cid=C057BHBRG4B

The API behavior is not changing. We are splitting the combined v[12] route into two separate V1 and V2 routes, so both will continue to work and clients will not be affected.

