### PR TITLE
refactor(express): split ping endpoint into v1 and v2

### DIFF
--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -76,7 +76,7 @@ const BITGOEXPRESS_USER_AGENT = `BitGoExpress/${pjson.version} BitGoJS/${version
 const FORWARDED_HEADERS = ['x-bitgo-otp'];
 
 function handlePing(
-  req: ExpressApiRouteRequest<'express.ping', 'get'>,
+  req: ExpressApiRouteRequest<'express.v1.ping' | 'express.ping', 'get'>,
   res: express.Response,
   next: express.NextFunction
 ) {
@@ -1692,6 +1692,7 @@ export function setupAPIRoutes(app: express.Application, config: Config): void {
   const router = createExpressRouter();
   app.use(router);
 
+  router.get('express.v1.ping', [prepareBitGo(config), typedPromiseWrapper(handlePing)]);
   router.get('express.ping', [prepareBitGo(config), typedPromiseWrapper(handlePing)]);
   router.get('express.pingExpress', [typedPromiseWrapper(handlePingExpress)]);
 

--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -76,7 +76,7 @@ const BITGOEXPRESS_USER_AGENT = `BitGoExpress/${pjson.version} BitGoJS/${version
 const FORWARDED_HEADERS = ['x-bitgo-otp'];
 
 function handlePing(
-  req: ExpressApiRouteRequest<'express.ping', 'get'>,
+  req: ExpressApiRouteRequest<'express.v2.ping', 'get'>,
   res: express.Response,
   next: express.NextFunction
 ) {
@@ -1694,7 +1694,8 @@ export function setupAPIRoutes(app: express.Application, config: Config): void {
   const router = createExpressRouter();
   app.use(router);
 
-  router.get('express.ping', [prepareBitGo(config), typedPromiseWrapper(handlePing)]);
+  router.get('express.v1.ping', [prepareBitGo(config), typedPromiseWrapper(handlePing)]);
+  router.get('express.v2.ping', [prepareBitGo(config), typedPromiseWrapper(handlePing)]);
   router.get('express.pingExpress', [typedPromiseWrapper(handlePingExpress)]);
 
   // auth

--- a/modules/express/src/typedRoutes/api/index.ts
+++ b/modules/express/src/typedRoutes/api/index.ts
@@ -2,7 +2,8 @@ import * as t from 'io-ts';
 import { apiSpec } from '@api-ts/io-ts-http';
 import * as express from 'express';
 
-import { GetPing } from './common/ping';
+import { GetV1Ping } from './v1/ping';
+import { GetV2Ping } from './v2/ping';
 import { GetPingExpress } from './common/pingExpress';
 import { PostLogin } from './common/login';
 import { PostV1Decrypt } from './v1/decrypt';
@@ -65,8 +66,11 @@ import { GetResourceDelegations } from './v2/resourceDelegations';
 // inference stays small; (2) only construct expressApi with a single key and add it to the type union at the end.
 
 export const ExpressPingApiSpec = apiSpec({
+  'express.v1.ping': {
+    get: GetV1Ping,
+  },
   'express.ping': {
-    get: GetPing,
+    get: GetV2Ping,
   },
 });
 

--- a/modules/express/src/typedRoutes/api/index.ts
+++ b/modules/express/src/typedRoutes/api/index.ts
@@ -2,7 +2,8 @@ import * as t from 'io-ts';
 import { apiSpec } from '@api-ts/io-ts-http';
 import * as express from 'express';
 
-import { GetPing } from './common/ping';
+import { GetV1Ping } from './v1/ping';
+import { GetV2Ping } from './v2/ping';
 import { GetPingExpress } from './common/pingExpress';
 import { PostLogin } from './common/login';
 import { PostDecrypt } from './common/decrypt';
@@ -63,8 +64,11 @@ import { GetResourceDelegations } from './v2/resourceDelegations';
 // inference stays small; (2) only construct expressApi with a single key and add it to the type union at the end.
 
 export const ExpressPingApiSpec = apiSpec({
-  'express.ping': {
-    get: GetPing,
+  'express.v1.ping': {
+    get: GetV1Ping,
+  },
+  'express.v2.ping': {
+    get: GetV2Ping,
   },
 });
 

--- a/modules/express/src/typedRoutes/api/v1/ping.ts
+++ b/modules/express/src/typedRoutes/api/v1/ping.ts
@@ -1,0 +1,22 @@
+import * as t from 'io-ts';
+import { httpRoute, httpRequest } from '@api-ts/io-ts-http';
+import { BitgoExpressError } from '../../schemas/error';
+
+/**
+ * Ping (v1)
+ *
+ * Health check endpoint that returns 200 when the Express server is running.
+ *
+ * @operationId express.v1.ping
+ * @tag Express
+ * @private
+ */
+export const GetV1Ping = httpRoute({
+  path: '/api/v1/ping',
+  method: 'GET',
+  request: httpRequest({}),
+  response: {
+    200: t.type({}),
+    404: BitgoExpressError,
+  },
+});

--- a/modules/express/src/typedRoutes/api/v1/ping.ts
+++ b/modules/express/src/typedRoutes/api/v1/ping.ts
@@ -3,13 +3,15 @@ import { httpRoute, httpRequest } from '@api-ts/io-ts-http';
 import { BitgoExpressError } from '../../schemas/error';
 
 /**
- * Ping
+ * Ping (v1)
  *
- * @operationId express.ping
- * @tag express
+ * Health check endpoint that returns 200 when the Express server is running.
+ *
+ * @operationId express.v1.ping
+ * @tag Express
  */
-export const GetPing = httpRoute({
-  path: '/api/v[12]/ping',
+export const GetV1Ping = httpRoute({
+  path: '/api/v1/ping',
   method: 'GET',
   request: httpRequest({}),
   response: {

--- a/modules/express/src/typedRoutes/api/v2/ping.ts
+++ b/modules/express/src/typedRoutes/api/v2/ping.ts
@@ -5,11 +5,14 @@ import { BitgoExpressError } from '../../schemas/error';
 /**
  * Ping
  *
+ * Health check endpoint that returns 200 when the Express server is running.
+ *
  * @operationId express.ping
- * @tag express
+ * @tag Express
+ * @public
  */
-export const GetPing = httpRoute({
-  path: '/api/v[12]/ping',
+export const GetV2Ping = httpRoute({
+  path: '/api/v2/ping',
   method: 'GET',
   request: httpRequest({}),
   response: {

--- a/modules/express/src/typedRoutes/api/v2/ping.ts
+++ b/modules/express/src/typedRoutes/api/v2/ping.ts
@@ -1,0 +1,21 @@
+import * as t from 'io-ts';
+import { httpRoute, httpRequest } from '@api-ts/io-ts-http';
+import { BitgoExpressError } from '../../schemas/error';
+
+/**
+ * Ping
+ *
+ * Health check endpoint that returns 200 when the Express server is running.
+ *
+ * @operationId express.v2.ping
+ * @tag Express
+ */
+export const GetV2Ping = httpRoute({
+  path: '/api/v2/ping',
+  method: 'GET',
+  request: httpRequest({}),
+  response: {
+    200: t.type({}),
+    404: BitgoExpressError,
+  },
+});


### PR DESCRIPTION
Ticket: WCI-187

Context - https://bitgo.slack.com/archives/C057BHBRG4B/p1764020095794829?thread_ts=1764018507.602879&cid=C057BHBRG4B

The API behavior is not changing. We are splitting the combined v[12] route into two separate V1 and V2 routes, so both will continue to work and clients will not be affected.

