### PR TITLE
ci(workflows): upgrade aws-actions/configure-aws-credentials to v6

### DIFF
--- a/.github/workflows/claude-pr.yml
+++ b/.github/workflows/claude-pr.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Configure AWS Credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::199765120567:role/${{ github.event.repository.name }}-iam-protected
           aws-region: us-west-2


### PR DESCRIPTION
Node.js 20 actions are deprecated; forced migration to Node.js 24 on June 2, 2026.

Changes `aws-actions/configure-aws-credentials@v5` to `@v6` in `.github/workflows/claude-pr.yml`.

Ticket: DX-496