### PR TITLE
fix: token consolidation fix for TRX TSS wallets

### DIFF
--- a/modules/sdk-coin-trx/src/trxToken.ts
+++ b/modules/sdk-coin-trx/src/trxToken.ts
@@ -94,8 +94,18 @@ export class TrxToken extends Trx {
   }
 
   async verifyTransaction(params: VerifyTransactionOptions): Promise<boolean> {
-    const { txPrebuild: txPrebuild, txParams: txParams } = params;
+    const { txPrebuild: txPrebuild, txParams: txParams, walletType } = params;
     assert(txPrebuild.txHex, new Error('missing required tx prebuild property txHex'));
+
+    // For TSS wallets, TRC20 token transfers are TriggerSmartContract transactions.
+    // Trx.verifyTransaction already returns true for TriggerSmartContract in TSS mode
+    // (only TransferContract/native TRX gets validated against recipients there).
+    // We apply the same convention here: the TSS signing protocol itself provides
+    // cryptographic guarantees; recipients-based verification is not applicable.
+    if (walletType === 'tss') {
+      return true;
+    }
+
     const rawTx = txPrebuild.txHex;
 
     const txBuilder = getBuilder(this.getChain()).from(rawTx);


### PR DESCRIPTION
TICKET: CHALO-423

## Summary
                                                                                                                                                                                                                        
  - Add TSS wallet handling to TrxToken.verifyTransaction in sdk-coin-trx                                                                                                                                               
  - Fixes missing required property recipients error thrown during TRX MPC token consolidation signing                                                                                                                  
                                                                                                                                                                                                                        
  ## Problem            
                                                                                                                                                                                                                        
  When performing token consolidation on a TRX MPC (TSS/ECDSA) wallet, the SDK's consolidateAccount flow calls verifyTransaction on the TrxToken coin instance with walletType: 'tss'. The method immediately attempts  
  to resolve recipients from either txParams.recipients or txPrebuild.txInfo.recipients:
                                                                                                                                                                                                                        
  ```ts
  const recipients = txParams.recipients || (txPrebuild.txInfo as TronTxInfo).recipients;
  if (!recipients) {                                                                                                                                                                                                    
    throw new Error('missing required property recipients');
  }                                                                                                                                                                                                                     
  ```
                                                                                                                                                                                                                        
  For TSS consolidation:            
  - txParams.recipients is undefined — the consolidateAccount call params carry no recipients                                                                                                                           
  - txPrebuild.txInfo is a ParsedTransaction (with inputs/outputs) returned by the platform, not a TronTxInfo with a recipients array                                                                                   
                                    
  This causes the error to be thrown unconditionally for any TRX token consolidation on a TSS wallet.                                                                                                                   
                                       
  ## Fix                                                                                                                                                                                                                

  Add an early return for walletType === 'tss', consistent with how `Trx.verifyTransaction` already handles TRC20 token transfers in TSS mode.                                                                            
                                          
  `Trx.verifyTransaction` has an explicit TSS branch that decodes raw_data_hex and validates TransferContract (native TRX) against recipients. For TriggerSmartContract (all TRC20 transfers), it already returns true    
  without any recipients check:           
                                                                                                                                                                                                                        
  ```ts
  // trx.ts — existing behavior
  if (walletType === 'tss') {
    ...                                                                                                                                                                                                                 
    if (decodedTx.contractType === Enum.ContractType.Transfer) {
      return this.validateTransferContract(...); // native TRX: validates                                                                                                                                               
    }
    return true; // TriggerSmartContract / TRC20: no recipients check
  }                                                                                                                                                                                                                     
  ```                                     
                                                                                                                                                                                                                        
  TrxToken.verifyTransaction now follows the same convention. The TSS signing protocol itself (ECDSA MPC) provides the cryptographic guarantee that the user approved the specific transaction being signed.            
                                          
  ## Impact                                                                                                                                                                                                             
                                                                                                                                                                                                                      
  - TSS TRX token wallets: verifyTransaction returns true for TSS, unblocking consolidation. Consistent with existing Trx.verifyTransaction behavior for TRC20 in TSS mode.                                             
  - Non-TSS (on-chain multisig) TRX token wallets: completely unaffected — the full recipients validation path still runs when walletType is not 'tss'.