### PR TITLE
refactor(express): update operationId walletSigntxV2

### DIFF
--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -730,7 +730,7 @@ async function handleV2AcceptWalletShare(req: express.Request) {
 /**
  * handle wallet sign transaction
  */
-async function handleV2SignTxWallet(req: ExpressApiRouteRequest<'express.v2.wallet.signtx', 'post'>) {
+async function handleV2SignTxWallet(req: ExpressApiRouteRequest<'express.wallet.signtx', 'post'>) {
   const bitgo = req.bitgo;
   const coin = bitgo.coin(req.decoded.coin);
   const wallet = await coin.wallets().get({ id: req.decoded.id });
@@ -1785,7 +1785,7 @@ export function setupAPIRoutes(app: express.Application, config: Config): void {
 
   // sign transaction
   router.post('express.signtx', [prepareBitGo(config), typedPromiseWrapper(handleV2SignTx)]);
-  router.post('express.v2.wallet.signtx', [prepareBitGo(config), typedPromiseWrapper(handleV2SignTxWallet)]);
+  router.post('express.wallet.signtx', [prepareBitGo(config), typedPromiseWrapper(handleV2SignTxWallet)]);
   router.post('express.wallet.signtxtss', [prepareBitGo(config), typedPromiseWrapper(handleV2SignTSSWalletTx)]);
   router.post('express.wallet.recovertoken', [prepareBitGo(config), typedPromiseWrapper(handleV2RecoverToken)]);
 

--- a/modules/express/src/typedRoutes/api/index.ts
+++ b/modules/express/src/typedRoutes/api/index.ts
@@ -288,7 +288,7 @@ export const ExpressExternalSigningApiSpec = apiSpec({
 });
 
 export const ExpressWalletSigningApiSpec = apiSpec({
-  'express.v2.wallet.signtx': {
+  'express.wallet.signtx': {
     post: PostWalletSignTx,
   },
   'express.wallet.signtxtss': {

--- a/modules/express/src/typedRoutes/api/v2/walletSignTx.ts
+++ b/modules/express/src/typedRoutes/api/v2/walletSignTx.ts
@@ -144,7 +144,7 @@ export const WalletSignTxResponse = {
 /**
  * Sign transactions for multisignature wallets using external-signing mode. You must maintain your keys, in the clear, on a separate Express server. BitGo doesn't decrypt your private keys.
  *
- * @operationId express.v2.wallet.signtx
+ * @operationId express.wallet.signtx
  * @tag Express
  */
 export const PostWalletSignTx: HttpRoute<'post'> = httpRoute({


### PR DESCRIPTION
Ticket: WCI-50

Context - https://bitgo.slack.com/archives/C057BHBRG4B/p1764020095794829?thread_ts=1764018507.602879&cid=C057BHBRG4B

The API behavior is not changing. We are splitting the combined v[12] route into two separate V1 and V2 routes, so both will continue to work and clients will not be affected.