### PR TITLE
fix(statics): correct IPTestnet tx explorer URL to aeneid storyscan

### DIFF
--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -1568,7 +1568,7 @@ class IP extends Mainnet implements EthereumNetwork {
 class IPTestnet extends Testnet implements EthereumNetwork {
   name = 'StoryTestnet';
   family = CoinFamily.IP;
-  explorerUrl = 'https://aeneid.explorer.story.foundation/tx/';
+  explorerUrl = 'https://aeneid.storyscan.io/tx/';
   accountExplorerUrl = 'https://aeneid.storyscan.io/address/';
   chainId = 1315;
   nativeCoinOperationHashPrefix = '1315';


### PR DESCRIPTION
The explorerUrl for IPTestnet was pointing to aeneid.explorer.story.foundation which returns a page-not-found error. Updated to aeneid.storyscan.io/tx/ to match the account explorer domain already in use for that network.

Ticket: CECHO-770