### PR TITLE
feat(ci): integrate nightshift feedback loop workflow

### DIFF
--- a/.github/workflows/nightshift-scheduler.yaml
+++ b/.github/workflows/nightshift-scheduler.yaml
@@ -1,0 +1,11 @@
+name: nightshift-scheduler
+run-name: "nightshift scheduler"
+
+on:
+  schedule:
+    - cron: "0 6 * * 1-5"
+  workflow_dispatch:
+
+jobs:
+  schedule:
+    uses: BitGo/nightshift-actions/.github/workflows/nightshift-scheduler.yaml@v1

--- a/.github/workflows/nightshift-task.yaml
+++ b/.github/workflows/nightshift-task.yaml
@@ -1,0 +1,21 @@
+name: nightshift-task
+run-name: "nightshift: ${{ inputs.task_type }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      task_type:
+        description: "Task type to run"
+        required: true
+        type: string
+
+jobs:
+  run:
+    uses: BitGo/nightshift-actions/.github/workflows/nightshift-task.yaml@v1
+    with:
+      task_type: ${{ inputs.task_type }}
+      provider: bedrock
+      aws_oidc_role: arn:aws:iam::199765120567:role/${{ github.event.repository.name }}-iam-protected
+      aws_inference_role: arn:aws:iam::168000258654:role/BedrockInferenceRole
+      aws_region: us-west-2
+      bedrock_model: arn:aws:bedrock:us-west-2:168000258654:inference-profile/us.anthropic.claude-opus-4-6-v1:0

--- a/.nightshift.yaml
+++ b/.nightshift.yaml
@@ -1,0 +1,164 @@
+max_tasks_per_run: 3
+
+tasks:
+  enabled:
+    - lint-fix
+    - test-gap
+    - dead-code
+    - dependency-risk
+    - security-footgun
+    - doc-drift
+    - adr-draft
+    - pr-feedback-loop
+
+  priorities:
+    security-footgun: 9
+    pr-feedback-loop: 8
+    lint-fix: 7
+    test-gap: 6
+    adr-draft: 5
+
+  cooldowns:
+    lint-fix: "24h"
+    test-gap: "72h"
+    dead-code: "7d"
+    doc-drift: "7d"
+    adr-draft: "14d"
+    pr-feedback-loop: "48h"
+
+  custom:
+    - type: "pr-feedback-loop"
+      name: "PR Feedback Loop — Doc Updater"
+      category: pr
+      cooldown: "48h"
+      priority: 8
+      prompt: |
+        You are running a nightshift maintenance task: PR Feedback Loop — Doc Updater.
+
+        You are an automated agent running inside a GitHub Actions workflow via
+        Claude Code. Your job is to review recent merged pull requests, extract
+        recurring patterns and learnings, and open a pull request that updates
+        the project's living documentation — including anti-patterns, ADRs, and
+        the CLAUDE.md harness — to reflect those learnings.
+
+        ## Objective
+
+        Analyze merged PRs from the last 14 days for recurring themes, new
+        coding patterns, anti-patterns, and architectural decisions. Produce a
+        pull request that updates `docs/anti-patterns/` and/or `docs/adr/` to
+        capture these learnings before they are lost.
+
+        ## Instructions
+
+        1. Check for an existing open PR with branch name matching
+           `nightshift/pr-feedback-loop-*`. If one is open, stop and report.
+
+        2. Gather context:
+           - Run `git log --oneline --since="14 days ago" --merges origin/master`
+             to list merged PRs from the last 14 days.
+           - For each merge commit, read the diff with
+             `git show --stat <sha>` to understand what changed.
+           - Run `gh pr list --state merged --limit 30 --json number,title,body,reviews`
+             to get PR metadata including titles, descriptions, and review comments.
+           - Run `gh pr view <number> --comments` for the top 10 PRs by change
+             volume to gather reviewer feedback and discussion context.
+
+        3. Identify learnings. Look for:
+           - Code patterns reviewers asked to change (>1 PR): candidate
+             anti-patterns.
+           - Architectural choices made consistently across PRs: candidate ADR.
+           - Patterns in CLAUDE.md instructions that were violated and caught
+             in review: reinforcement of existing rules.
+           - New patterns introduced that should be documented for agents and
+             developers.
+
+        4. Cross-reference existing docs:
+           - Read all files in `docs/anti-patterns/` (if the directory exists).
+           - Read all files in `docs/adr/` (if the directory exists).
+           - Read `CLAUDE.md` at the repo root.
+           - Skip learnings that are already documented.
+
+        5. Create a branch named `nightshift/pr-feedback-loop-YYYY-MM-DD`.
+
+        6. For each new anti-pattern identified (minimum 2 PRs showing the
+           pattern):
+           - Create or update a file in `docs/anti-patterns/` using the
+             filename format `AP-NNN-short-name.md` (increment from existing).
+           - Use this structure:
+             ```markdown
+             # AP-NNN: <Title>
+
+             **Status:** Draft — pending expert review
+             **Detected:** YYYY-MM-DD
+             **Source PRs:** #<n>, #<n>
+
+             ## Description
+
+             <What the anti-pattern is and why it is harmful.>
+
+             ## Example
+
+             ```<language>
+             // Bad
+             <bad code example from the PRs if available>
+
+             // Good
+             <preferred alternative>
+             ```
+
+             ## Detection
+
+             <How to spot this in code review or static analysis.>
+             ```
+
+        7. For each new architectural decision identified (clear, non-trivial,
+           affects the whole codebase):
+           - Create a file in `docs/adr/` using filename format
+             `ADR-NNN-short-name.md`.
+           - Use MADR template: Title, Status (Proposed), Context, Decision,
+             Consequences.
+
+        8. If CLAUDE.md should be updated to mention a new pattern or constraint
+           learned from PRs, add a minimal note under a `## Patterns` section.
+           Only add, never remove.
+
+        9. Commit changes using conventional commit format:
+           `docs(anti-patterns): add AP-NNN detected from recent PRs`
+
+        10. Open a draft pull request. Apply labels `nightshift` and
+            `feedback-loop`. Request review from `CODEOWNERS` if the file
+            exists.
+
+        ## Pull Request Format
+
+        Title: `nightshift: PR feedback loop YYYY-MM-DD`
+
+        Body:
+        - Summary of PRs analyzed (count and date range)
+        - Anti-patterns added or updated (list with source PR numbers)
+        - ADRs added (list)
+        - CLAUDE.md changes (if any)
+        - Note: "All changes are drafts — expert review required before merge"
+
+        ## Rules
+
+        - NEVER auto-merge. All output requires human expert review.
+        - Only create anti-pattern docs for patterns seen in 2+ PRs.
+        - Only create ADR docs for decisions that are non-trivial and
+          not already captured.
+        - Do not modify code, only documentation.
+        - Do not delete or overwrite existing ADRs or anti-patterns;
+          only add or append.
+        - Mark all new documents with `Status: Draft — pending expert review`.
+        - Use conventional commit format for all commits.
+
+labels:
+  - nightshift
+  - automated
+
+pull_requests:
+  draft: true
+  branch_prefix: "nightshift/"
+  labels:
+    - nightshift
+    - automated

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,37 @@
+# Architecture Decision Records
+
+This directory captures significant architectural decisions made in BitGoJS.
+
+Each file follows the naming convention `ADR-NNN-short-name.md` using the
+[MADR](https://adr.github.io/madr/) template.
+
+ADRs are created automatically by the nightshift `adr-draft` and
+`pr-feedback-loop` tasks and require expert review before merge.
+
+## Status values
+
+- **Proposed** — drafted, not yet reviewed
+- **Accepted** — reviewed and approved by the team
+- **Deprecated** — superseded by a later decision
+- **Rejected** — considered but not adopted
+
+## Template
+
+```markdown
+# ADR-NNN: <Title>
+
+**Status:** Proposed
+**Date:** YYYY-MM-DD
+
+## Context
+
+<Why this decision was needed.>
+
+## Decision
+
+<What was decided.>
+
+## Consequences
+
+<What becomes easier or harder as a result.>
+```

--- a/docs/anti-patterns/README.md
+++ b/docs/anti-patterns/README.md
@@ -1,0 +1,37 @@
+# Anti-Patterns
+
+This directory captures recurring coding mistakes and patterns identified from
+code review, incidents, and automated PR analysis.
+
+Each file follows the naming convention `AP-NNN-short-name.md`.
+
+Anti-pattern records are created automatically by the nightshift `pr-feedback-loop`
+task and require expert review before merge. See `CODEOWNERS` for reviewers.
+
+## Format
+
+```markdown
+# AP-NNN: <Title>
+
+**Status:** Draft — pending expert review | Accepted | Deprecated
+**Detected:** YYYY-MM-DD
+**Source PRs:** #<n>, #<n>
+
+## Description
+
+What the anti-pattern is and why it is harmful.
+
+## Example
+
+```language
+// Bad
+<bad code>
+
+// Good
+<preferred alternative>
+```
+
+## Detection
+
+How to spot this in code review or static analysis.
+```


### PR DESCRIPTION
_**Ticket:** WCN-171_

## Summary

- Adds `.github/workflows/nightshift-scheduler.yaml` and `nightshift-task.yaml` to run BitGo's nightshift-actions on a weekday cron via AWS Bedrock.
- Adds `.nightshift.yaml` enabling built-in tasks (lint-fix, test-gap, dead-code, security-footgun, adr-draft) plus a new custom `pr-feedback-loop` task.
- The `pr-feedback-loop` task reviews merged PRs from the last 14 days, extracts recurring patterns and review feedback, and opens draft PRs updating `docs/anti-patterns/` and `docs/adr/`.
- Scaffolds `docs/anti-patterns/` and `docs/adr/` with format READMEs so the feedback loop has a home for its output.

## Notes

- All nightshift-generated doc PRs are opened as drafts marked "pending expert review" and must NOT be auto-merged.
- Anti-patterns are only written when seen in 2+ PRs to avoid outsized influence from single comments.
- CODEOWNERS should be updated to require review of `docs/anti-patterns/` and `docs/adr/` changes.

## Test Plan

- [ ] Manually trigger the `nightshift-task` workflow from Actions tab with `task_type: pr-feedback-loop`
- [ ] Verify a draft PR is opened with `nightshift` and `feedback-loop` labels
- [ ] Confirm generated docs are in `docs/anti-patterns/` or `docs/adr/` and marked as drafts