### PR TITLE
ci(scripts): decouple Docker Hub check from npm publish

### DIFF
--- a/.github/workflows/npmjs-release.yml
+++ b/.github/workflows/npmjs-release.yml
@@ -34,6 +34,7 @@ jobs:
       express-version: ${{ steps.compute-express-git-tag.outputs.version }}
       express-git-tag: ${{ steps.compute-express-git-tag.outputs.git-tag }}
       express-git-sha: ${{ steps.compute-express-git-sha.outputs.git-sha }}
+      express-docker-exists: ${{ steps.check-docker-image.outputs.express-docker-exists }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -165,15 +166,25 @@ jobs:
 
       - name: Check if Docker image already exists in Docker Hub
         if: inputs.dry-run == false
+        id: check-docker-image
         run: |
           VERSION="${{ steps.compute-express-git-tag.outputs.version }}"
-
           if curl -s -f "https://hub.docker.com/v2/repositories/bitgo/express/tags/$VERSION" > /dev/null; then
-            echo "::error::Docker image bitgo/express:$VERSION already exists in Docker Hub"
-            exit 1
+            echo "⚠️ Docker image bitgo/express:$VERSION already exists in Docker Hub — Docker publish will be skipped"
+            echo "express-docker-exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "✅ Docker image bitgo/express:$VERSION does not exist in Docker Hub"
+            echo "express-docker-exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-          echo "✅ Docker image bitgo/express:$VERSION does not exist in Docker Hub"
+      - name: Summarise Docker image status
+        if: inputs.dry-run == false
+        run: |
+          if [ "${{ steps.check-docker-image.outputs.express-docker-exists }}" == "true" ]; then
+            echo "### ⚠️ Docker publish skipped" >> "$GITHUB_STEP_SUMMARY"
+            echo "Image \`bitgo/express:${{ steps.compute-express-git-tag.outputs.version }}\` already exists in Docker Hub." >> "$GITHUB_STEP_SUMMARY"
+            echo "The npm release will proceed normally." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Update Express GitHub summary
         if: inputs.dry-run == false
@@ -286,7 +297,7 @@ jobs:
 
   publish-express-to-docker-hub:
     name: Publish Express To Docker Hub
-    if: inputs.dry-run == false
+    if: inputs.dry-run == false && needs.get-release-context.outputs.express-docker-exists != 'true'
     needs:
       - get-release-context
       - release-bitgojs


### PR DESCRIPTION
Replace the hard exit-1 Docker Hub duplicate check in `get-release-context` with a soft check that emits an output flag (`express-docker-exists`). Gate only `publish-express-to-docker-hub` on this flag so that `release-bitgojs` (npm publish) can always run, even when the Docker image was already pushed in a prior partial run.

Adds a step summary entry so the skip is visible in the workflow UI.

Closes VL-5459