### PR TITLE
ci: add PR check for new npm packages not yet on registry

### DIFF
--- a/.github/actions/check-new-npm-packages/action.yml
+++ b/.github/actions/check-new-npm-packages/action.yml
@@ -1,0 +1,14 @@
+name: Check new npm packages are registered
+description: >
+  Detects newly added non-private packages in modules/ and verifies
+  each one is already registered on the npm registry. Fails with an
+  actionable message if any are missing.
+
+runs:
+  using: composite
+  steps:
+    - name: Check new packages are registered on npm
+      shell: bash
+      run: node ${{ github.action_path }}/index.js
+      env:
+        BASE_REF: ${{ github.event.pull_request.base.sha }}

--- a/.github/actions/check-new-npm-packages/index.js
+++ b/.github/actions/check-new-npm-packages/index.js
@@ -1,0 +1,101 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const { execSync } = require("node:child_process");
+
+const REGISTRY_URL = "https://registry.npmjs.org";
+const DO_TICKET_URL = "https://bitgoinc.atlassian.net/browse/DO-17865";
+
+function getAddedPackageJsonFiles() {
+  const baseRef = process.env.BASE_REF;
+  if (!baseRef) {
+    throw new Error("BASE_REF environment variable is not set");
+  }
+
+  const output = execSync(
+    `git diff ${baseRef} --name-only --diff-filter=A`,
+    { encoding: "utf-8" }
+  );
+
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => /^modules\/[^/]+\/package\.json$/.test(line));
+}
+
+function readPublicPackages(addedFiles) {
+  const repoRoot = path.resolve(__dirname, "..", "..", "..");
+  const packages = [];
+
+  for (const filePath of addedFiles) {
+    const absPath = path.join(repoRoot, filePath);
+    if (!fs.existsSync(absPath)) continue;
+
+    const pkg = JSON.parse(fs.readFileSync(absPath, "utf-8"));
+    if (pkg.private) continue;
+
+    const moduleDir = filePath.split("/")[1];
+    packages.push({ name: pkg.name, dir: moduleDir });
+  }
+
+  return packages;
+}
+
+async function packageExistsOnNpm(packageName) {
+  const url = `${REGISTRY_URL}/${packageName}`;
+  const response = await fetch(url, { method: "HEAD" });
+  return response.status === 200;
+}
+
+async function main() {
+  const addedFiles = getAddedPackageJsonFiles();
+
+  if (addedFiles.length === 0) {
+    console.log("No new modules/*/package.json files detected. Nothing to check.");
+    return;
+  }
+
+  const packages = readPublicPackages(addedFiles);
+
+  if (packages.length === 0) {
+    console.log("No new public packages detected. Nothing to check.");
+    return;
+  }
+
+  console.log(`Checking ${packages.length} new public package(s) against npm registry...\n`);
+
+  const results = await Promise.all(
+    packages.map(async (pkg) => {
+      const exists = await packageExistsOnNpm(pkg.name);
+      return { ...pkg, exists };
+    })
+  );
+
+  const missing = results.filter((r) => !r.exists);
+
+  if (missing.length === 0) {
+    console.log("All new packages are already registered on npm:");
+    for (const pkg of results) {
+      console.log(`  ✓ ${pkg.name}`);
+    }
+    return;
+  }
+
+  console.error("The following new package(s) are not yet registered on npm:\n");
+  for (const pkg of missing) {
+    console.error(`  - ${pkg.name} (modules/${pkg.dir})`);
+  }
+  console.error(`
+New packages must be configured for trusted publishing before merging.
+Please file a DevOps request using DO-17865 as a template:
+${DO_TICKET_URL}
+
+The DO ticket must be resolved and the package registered on npm
+before this PR can be merged.`);
+
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error("Unexpected error:", err);
+  process.exit(1);
+});

--- a/.github/workflows/check-new-npm-packages.yml
+++ b/.github/workflows/check-new-npm-packages.yml
@@ -1,0 +1,20 @@
+name: Check new npm packages
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'modules/**/package.json'
+
+jobs:
+  check-new-npm-packages:
+    name: Verify new packages exist on npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check new packages are registered on npm
+        uses: ./.github/actions/check-new-npm-packages


### PR DESCRIPTION
Adds a GitHub Actions workflow and composite action that runs on every PR targeting `master` (path-filtered to `modules/**/package.json`).

The check diffs the PR against its base SHA to find newly added `modules/*/package.json` files, skips private packages, then HEAD-checks each public package name against `registry.npmjs.org`. If any are missing it exits non-zero with an actionable error that includes the DO-17865 template link.

## Files added

- `.github/workflows/check-new-npm-packages.yml` — workflow triggered on PRs to master touching `modules/**/package.json`
- `.github/actions/check-new-npm-packages/action.yml` — composite action definition
- `.github/actions/check-new-npm-packages/index.js` — Node.js script using only built-ins

## Behaviour

- Detects newly **added** `modules/*/package.json` files via `git diff --diff-filter=A`
- Skips packages with `"private": true`
- HEAD-checks each remaining package against `registry.npmjs.org`
- Fails with actionable message + DO-17865 link if any are unregistered
- No external dependencies — pure Node.js built-ins

Closes VL-5461