### PR TITLE
add(express): add private and public to calculateMinerFeeInfo

### DIFF
--- a/modules/express/src/typedRoutes/api/v1/calculateMinerFeeInfo.ts
+++ b/modules/express/src/typedRoutes/api/v1/calculateMinerFeeInfo.ts
@@ -31,6 +31,7 @@ export const CalculateMinerFeeInfoResponse = t.type({
  *
  * @operationId express.v1.calculateminerfeeinfo
  * @tag Express
+ * @private
  */
 export const PostV1CalculateMinerFeeInfo = httpRoute({
   path: '/api/v1/calculateminerfeeinfo',

--- a/modules/express/src/typedRoutes/api/v2/calculateMinerFeeInfo.ts
+++ b/modules/express/src/typedRoutes/api/v2/calculateMinerFeeInfo.ts
@@ -7,6 +7,7 @@ import { CalculateMinerFeeInfoRequestBody, CalculateMinerFeeInfoResponse } from 
  *
  * @operationId express.calculateminerfeeinfo
  * @tag Express
+ * @public
  */
 export const PostV2CalculateMinerFeeInfo = httpRoute({
   path: '/api/v2/calculateminerfeeinfo',


### PR DESCRIPTION
Ticket: WCI-228

Context - https://bitgo.slack.com/archives/C057BHBRG4B/p1764020095794829?thread_ts=1764018507.602879&cid=C057BHBRG4B

The API behavior is not changing. We are splitting the combined v[12] route into two separate V1 and V2 routes, so both will continue to work and clients will not be affected.

