### PR TITLE
refactor(express): split verifyAddress into V1 and V2

### DIFF
--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -112,7 +112,9 @@ function handleEncrypt(req: ExpressApiRouteRequest<'express.encrypt', 'post'>) {
  * @deprecated
  * @param req
  */
-function handleVerifyAddress(req: ExpressApiRouteRequest<'express.verifyaddress', 'post'>) {
+function handleVerifyAddress(
+  req: ExpressApiRouteRequest<'express.v1.verifyaddress' | 'express.verifyaddress', 'post'>
+) {
   return {
     verified: req.bitgo.verifyAddress(req.body),
   };
@@ -1702,6 +1704,7 @@ export function setupAPIRoutes(app: express.Application, config: Config): void {
   router.post('express.decrypt', [prepareBitGo(config), typedPromiseWrapper(handleDecrypt)]);
   router.post('express.v1.encrypt', [prepareBitGo(config), typedPromiseWrapper(handleEncrypt)]);
   router.post('express.encrypt', [prepareBitGo(config), typedPromiseWrapper(handleEncrypt)]);
+  router.post('express.v1.verifyaddress', [prepareBitGo(config), typedPromiseWrapper(handleVerifyAddress)]);
   router.post('express.verifyaddress', [prepareBitGo(config), typedPromiseWrapper(handleVerifyAddress)]);
   router.post('express.v1.calculateminerfeeinfo', [
     prepareBitGo(config),

--- a/modules/express/src/typedRoutes/api/index.ts
+++ b/modules/express/src/typedRoutes/api/index.ts
@@ -9,7 +9,8 @@ import { PostV1Decrypt } from './v1/decrypt';
 import { PostV2Decrypt } from './v2/decrypt';
 import { PostV1Encrypt } from './v1/encrypt';
 import { PostV2Encrypt } from './v2/encrypt';
-import { PostVerifyAddress } from './common/verifyAddress';
+import { PostV1VerifyAddress } from './v1/verifyAddress';
+import { PostV2VerifyAddress } from './v2/verifyAddress';
 import { PostV1CalculateMinerFeeInfo } from './v1/calculateMinerFeeInfo';
 import { PostV2CalculateMinerFeeInfo } from './v2/calculateMinerFeeInfo';
 import { PostAcceptShare } from './v1/acceptShare';
@@ -101,8 +102,11 @@ export const ExpressEncryptApiSpec = apiSpec({
 });
 
 export const ExpressVerifyAddressApiSpec = apiSpec({
+  'express.v1.verifyaddress': {
+    post: PostV1VerifyAddress,
+  },
   'express.verifyaddress': {
-    post: PostVerifyAddress,
+    post: PostV2VerifyAddress,
   },
 });
 

--- a/modules/express/src/typedRoutes/api/v1/verifyAddress.ts
+++ b/modules/express/src/typedRoutes/api/v1/verifyAddress.ts
@@ -3,17 +3,21 @@ import { httpRoute, httpRequest } from '@api-ts/io-ts-http';
 import { BitgoExpressError } from '../../schemas/error';
 
 export const VerifyAddressBody = {
+  /** Address which should be verified for correct format */
   address: t.string,
 };
 
 /**
- * Verify Address
+ * Verify Address (v1)
  *
- * @operationId express.verifyaddress
- * @tag express
+ * Verify that a given address string is valid for any supported coin.
+ *
+ * @operationId express.v1.verifyaddress
+ * @tag Express
+ * @private
  */
-export const PostVerifyAddress = httpRoute({
-  path: '/api/v[12]/verifyaddress',
+export const PostV1VerifyAddress = httpRoute({
+  path: '/api/v1/verifyaddress',
   method: 'POST',
   request: httpRequest({
     body: VerifyAddressBody,

--- a/modules/express/src/typedRoutes/api/v2/verifyAddress.ts
+++ b/modules/express/src/typedRoutes/api/v2/verifyAddress.ts
@@ -1,0 +1,27 @@
+import * as t from 'io-ts';
+import { httpRoute, httpRequest } from '@api-ts/io-ts-http';
+import { BitgoExpressError } from '../../schemas/error';
+import { VerifyAddressBody } from '../v1/verifyAddress';
+
+/**
+ * Verify Address
+ *
+ * Verify that a given address string is valid for any supported coin.
+ *
+ * @operationId express.verifyaddress
+ * @tag Express
+ * @public
+ */
+export const PostV2VerifyAddress = httpRoute({
+  path: '/api/v2/verifyaddress',
+  method: 'POST',
+  request: httpRequest({
+    body: VerifyAddressBody,
+  }),
+  response: {
+    200: t.type({
+      verified: t.boolean,
+    }),
+    404: BitgoExpressError,
+  },
+});

--- a/modules/express/test/unit/typedRoutes/decode.ts
+++ b/modules/express/test/unit/typedRoutes/decode.ts
@@ -3,7 +3,7 @@ import * as t from 'io-ts';
 import { DecryptRequestBody } from '../../../src/typedRoutes/api/v1/decrypt';
 import { EncryptRequestBody } from '../../../src/typedRoutes/api/v1/encrypt';
 import { LoginRequest } from '../../../src/typedRoutes/api/common/login';
-import { VerifyAddressBody } from '../../../src/typedRoutes/api/common/verifyAddress';
+import { VerifyAddressBody } from '../../../src/typedRoutes/api/v1/verifyAddress';
 import { VerifyAddressV2Body, VerifyAddressV2Params } from '../../../src/typedRoutes/api/v2/verifyCoinAddress';
 import { SimpleCreateRequestBody } from '../../../src/typedRoutes/api/v1/simpleCreate';
 import { KeychainLocalRequestParams } from '../../../src/typedRoutes/api/v2/keychainLocal';

--- a/modules/express/test/unit/typedRoutes/verifyAddress.ts
+++ b/modules/express/test/unit/typedRoutes/verifyAddress.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 import * as t from 'io-ts';
-import { VerifyAddressBody, PostVerifyAddress } from '../../../src/typedRoutes/api/common/verifyAddress';
+import { VerifyAddressBody, PostV1VerifyAddress } from '../../../src/typedRoutes/api/v1/verifyAddress';
+import { PostV2VerifyAddress } from '../../../src/typedRoutes/api/v2/verifyAddress';
 import { assertDecode } from './common';
 import 'should';
 import 'should-http';
@@ -40,7 +41,7 @@ describe('VerifyAddress codec tests', function () {
   });
 
   describe('VerifyAddressResponse', function () {
-    const VerifyAddressResponse = PostVerifyAddress.response[200];
+    const VerifyAddressResponse = PostV1VerifyAddress.response[200];
 
     it('should validate response with verified=true', function () {
       const validResponse = {
@@ -79,18 +80,33 @@ describe('VerifyAddress codec tests', function () {
     });
   });
 
-  describe('PostVerifyAddress route definition', function () {
+  describe('PostV1VerifyAddress route definition', function () {
     it('should have the correct path', function () {
-      assert.strictEqual(PostVerifyAddress.path, '/api/v[12]/verifyaddress');
+      assert.strictEqual(PostV1VerifyAddress.path, '/api/v1/verifyaddress');
     });
 
     it('should have the correct HTTP method', function () {
-      assert.strictEqual(PostVerifyAddress.method, 'POST');
+      assert.strictEqual(PostV1VerifyAddress.method, 'POST');
     });
 
     it('should have the correct response types', function () {
-      assert.ok(PostVerifyAddress.response[200]);
-      assert.ok(PostVerifyAddress.response[404]);
+      assert.ok(PostV1VerifyAddress.response[200]);
+      assert.ok(PostV1VerifyAddress.response[404]);
+    });
+  });
+
+  describe('PostV2VerifyAddress route definition', function () {
+    it('should have the correct path', function () {
+      assert.strictEqual(PostV2VerifyAddress.path, '/api/v2/verifyaddress');
+    });
+
+    it('should have the correct HTTP method', function () {
+      assert.strictEqual(PostV2VerifyAddress.method, 'POST');
+    });
+
+    it('should have the correct response types', function () {
+      assert.ok(PostV2VerifyAddress.response[200]);
+      assert.ok(PostV2VerifyAddress.response[404]);
     });
   });
 
@@ -122,7 +138,7 @@ describe('VerifyAddress codec tests', function () {
       result.body.should.have.property('verified');
       assert.strictEqual(result.body.verified, true);
 
-      const decodedResponse = assertDecode(PostVerifyAddress.response[200], result.body);
+      const decodedResponse = assertDecode(PostV1VerifyAddress.response[200], result.body);
       assert.strictEqual(decodedResponse.verified, true);
     });
 
@@ -142,7 +158,7 @@ describe('VerifyAddress codec tests', function () {
       assert.strictEqual(result.status, 200);
       assert.strictEqual(result.body.verified, true);
 
-      const decodedResponse = assertDecode(PostVerifyAddress.response[200], result.body);
+      const decodedResponse = assertDecode(PostV2VerifyAddress.response[200], result.body);
       assert.strictEqual(decodedResponse.verified, true);
     });
 
@@ -163,7 +179,7 @@ describe('VerifyAddress codec tests', function () {
       result.body.should.have.property('verified');
       assert.strictEqual(result.body.verified, false);
 
-      const decodedResponse = assertDecode(PostVerifyAddress.response[200], result.body);
+      const decodedResponse = assertDecode(PostV1VerifyAddress.response[200], result.body);
       assert.strictEqual(decodedResponse.verified, false);
     });
 


### PR DESCRIPTION
Ticket: WCI-222

Context - https://bitgo.slack.com/archives/C057BHBRG4B/p1764020095794829?thread_ts=1764018507.602879&cid=C057BHBRG4B

The API behavior is not changing. We are splitting the combined v[12] route into two separate V1 and V2 routes, so both will continue to work and clients will not be affected.