### PR TITLE
fix(statics): add account explorer url for near

### DIFF
--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -1350,6 +1350,7 @@ class Near extends Mainnet implements AccountNetwork {
   name = 'Near';
   family = CoinFamily.NEAR;
   explorerUrl = 'https://nearblocks.io/txns/';
+  accountExplorerUrl = 'https://nearblocks.io/address/';
   feeReserve = '50000000000000000000000';
   storageReserve = '2000000000000000000000'; // feeReserve + storageReserve is minimum account balance for a NEAR wallet https://docs.near.org/integrator/faq#is-there-a-minimum-account-balance
 }
@@ -1358,6 +1359,7 @@ class NearTestnet extends Testnet implements AccountNetwork {
   name = 'NearTestnet';
   family = CoinFamily.NEAR;
   explorerUrl = 'https://testnet.nearblocks.io/txns/';
+  accountExplorerUrl = 'https://testnet.nearblocks.io/address/';
   feeReserve = '50000000000000000000000';
   storageReserve = '2000000000000000000000'; // feeReserve + storageReserve is minimum account balance for a NEAR wallet https://docs.near.org/integrator/faq#is-there-a-minimum-account-balance
 }

--- a/modules/statics/test/unit/networks.ts
+++ b/modules/statics/test/unit/networks.ts
@@ -61,6 +61,15 @@ Object.entries(Networks).forEach(([category, networks]) => {
         Networks.test.ada.accountExplorerUrl.should.equal('https://preprod.cardanoscan.io/address/');
       });
     });
+
+    describe('Near Network', function () {
+      it('should have correct explorer URLs', function () {
+        Networks.main.near.explorerUrl.should.equal('https://nearblocks.io/txns/');
+        Networks.main.near.accountExplorerUrl.should.equal('https://nearblocks.io/address/');
+        Networks.test.near.explorerUrl.should.equal('https://testnet.nearblocks.io/txns/');
+        Networks.test.near.accountExplorerUrl.should.equal('https://testnet.nearblocks.io/address/');
+      });
+    });
   });
 });
 


### PR DESCRIPTION
TICKET: CSHLD-684

## Description

NEAR mainnet and testnet networks were missing `accountExplorerUrl`, which is used to generate the explorer link on the network gas tanks page. Without it, clicking the explorer link next to NEAR didn't work.

Added:
- `accountExplorerUrl = 'https://nearblocks.io/address/'` for mainnet
- `accountExplorerUrl = 'https://testnet.nearblocks.io/address/'` for testnet

Follows the same pattern as PR #8075 which added `accountExplorerUrl` for Sui and Ada.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit tests added for Near network explorer URLs in `modules/statics/test/unit/networks.ts`, matching the pattern of existing Sui and Ada tests.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective