### PR TITLE
feat(staking): add subType param in ClaimRewardsOptions

### DIFF
--- a/modules/sdk-core/src/bitgo/staking/iStakingWallet.ts
+++ b/modules/sdk-core/src/bitgo/staking/iStakingWallet.ts
@@ -228,9 +228,22 @@ export interface TaoSwitchValidatorOptions extends SwitchValidatorOptions {
 }
 
 export interface ClaimRewardsOptions {
+  /**
+   * amount of rewards to claim
+   */
   amount: string;
+  /**
+   * clientId
+   */
   clientId?: string;
+  /**
+   * delegationId
+   */
   delegationId?: string;
+  /**
+   * coin specific staking subtype
+   */
+  subType?: string;
 }
 
 export interface DelegationOptions {


### PR DESCRIPTION
linear: SC-5888

## Description

Adding support for passing in a subtype for Claim Rewards requests. This change is being made so users can claim SSV rewards for the P2P staking ETH subtype.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update