### PR TITLE
refactor(express): add union operationId types to handleDecrypt and h…

### DIFF
--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -96,13 +96,13 @@ function handleLogin(req: ExpressApiRouteRequest<'express.login', 'post'>) {
   return req.bitgo.authenticate(body);
 }
 
-function handleDecrypt(req: ExpressApiRouteRequest<'express.decrypt', 'post'>) {
+function handleDecrypt(req: ExpressApiRouteRequest<'express.v1.decrypt' | 'express.decrypt', 'post'>) {
   return {
     decrypted: req.bitgo.decrypt(req.body),
   };
 }
 
-function handleEncrypt(req: ExpressApiRouteRequest<'express.encrypt', 'post'>) {
+function handleEncrypt(req: ExpressApiRouteRequest<'express.v1.encrypt' | 'express.encrypt', 'post'>) {
   return {
     encrypted: req.bitgo.encrypt(req.body),
   };


### PR DESCRIPTION
TICKET-234

Context - https://bitgo.slack.com/archives/C057BHBRG4B/p1764020095794829?thread_ts=1764018507.602879&cid=C057BHBRG4B

**Summary**

1. handleDecrypt and handleEncrypt in clientRoutes.ts are each registered for both v1 and v2 routes (express.v1.decrypt/express.decrypt and express.v1.encrypt/express.encrypt), but their parameter types previously only referenced the v2 operationId.
2. Updated both handlers to use the union type ('express.v1.decrypt' | 'express.decrypt' and 'express.v1.encrypt' | 'express.encrypt') so the TypeScript type accurately reflects both route registrations.

**Why this matters**
Without the union type, TypeScript only validates the handler against the v2 schema. If v1 and v2 schemas **ever diverge** (e.g. different request body fields), the v1 registration would silently accept a handler that is only type-safe for v2, leading to potential runtime bugs with no compile-time warning.

Both the end points are splitted in these pr's:https://github.com/BitGo/BitGoJS/pull/8560
https://github.com/BitGo/BitGoJS/pull/8553