### PR TITLE
fix: surface error details in sendAccountConsolidations failure array

### DIFF
--- a/modules/bitgo/test/v2/unit/accountConsolidations.ts
+++ b/modules/bitgo/test/v2/unit/accountConsolidations.ts
@@ -266,9 +266,44 @@ describe('Account Consolidations:', function () {
 
           consolidations.success.length.should.equal(1);
           consolidations.failure.length.should.equal(1);
+          consolidations.failure[0].should.have.property('message');
+          consolidations.failure[0].should.have.property('name');
 
           scopeWithSuccess.isDone().should.be.True();
           scopeWithError.isDone().should.be.True();
+          scopeBuild.isDone().should.be.True();
+        });
+
+        it('should return serializable error objects in the failure array', async function () {
+          const scopeBuild = nock(bgUrl)
+            .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/consolidateAccount/build`)
+            .query({})
+            .reply(200, fixtures.buildAccountConsolidation);
+
+          sinon.stub(wallet, 'getKeychainsAndValidatePassphrase').resolves([]);
+
+          const firstError = new Error('unable to decrypt keychain with the given wallet passphrase');
+          firstError.name = 'KeyDecryptionError';
+          const secondError = new Error('insufficient funds');
+          secondError.name = 'InsufficientFundsError';
+
+          sinon.stub(wallet, 'sendAccountConsolidation').onCall(0).rejects(firstError).onCall(1).rejects(secondError);
+
+          const consolidations = await wallet.sendAccountConsolidations();
+
+          consolidations.failure.length.should.equal(2);
+
+          // failure entries must be plain serializable objects, not Error instances
+          (consolidations.failure[0] instanceof Error).should.be.False();
+          consolidations.failure[0].message.should.equal('unable to decrypt keychain with the given wallet passphrase');
+          consolidations.failure[0].name.should.equal('KeyDecryptionError');
+          JSON.stringify(consolidations.failure[0]).should.not.equal('{}');
+
+          (consolidations.failure[1] instanceof Error).should.be.False();
+          consolidations.failure[1].message.should.equal('insufficient funds');
+          consolidations.failure[1].name.should.equal('InsufficientFundsError');
+          JSON.stringify(consolidations.failure[1]).should.not.equal('{}');
+
           scopeBuild.isDone().should.be.True();
         });
       });

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -3389,7 +3389,7 @@ export class Wallet implements IWallet {
         }
       }
       const successfulTxs: any[] = [];
-      const failedTxs = new Array<Error>();
+      const failedTxs: { message: string; name: string }[] = [];
       for (const unsignedBuild of unsignedBuilds) {
         // fold any of the parameters we used to build this transaction into the unsignedBuild
         const unsignedBuildWithOptions: PrebuildAndSignTransactionOptions = Object.assign({}, params);
@@ -3399,7 +3399,7 @@ export class Wallet implements IWallet {
           const sendTx = await this.sendAccountConsolidation(unsignedBuildWithOptions);
           successfulTxs.push(sendTx);
         } catch (e) {
-          failedTxs.push(e);
+          failedTxs.push({ message: e.message, name: e.name });
         }
       }
 


### PR DESCRIPTION
Error objects pushed to failedTxs were serializing to empty {} in the API response due to non-enumerable properties on JS Error instances. Convert caught errors to plain objects with message and name before storing, so failures are visible to callers.

Ticket: COIN-7828

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
