### PR TITLE
feat(sdk-core): add removePasskeyFromWallet function

### DIFF
--- a/modules/sdk-core/src/bitgo/index.ts
+++ b/modules/sdk-core/src/bitgo/index.ts
@@ -15,6 +15,7 @@ export * from './errors';
 export * from './inscriptionBuilder';
 export * from './internal';
 export * from './keychain';
+export * from './passkey';
 export * as bitcoin from './legacyBitcoin';
 export * from './market';
 export * from './pendingApproval';

--- a/modules/sdk-core/src/bitgo/passkey/index.ts
+++ b/modules/sdk-core/src/bitgo/passkey/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './removePasskeyFromWallet';

--- a/modules/sdk-core/src/bitgo/passkey/removePasskeyFromWallet.ts
+++ b/modules/sdk-core/src/bitgo/passkey/removePasskeyFromWallet.ts
@@ -1,0 +1,35 @@
+import { BitGoBase } from '../bitgoBase';
+import { WebAuthnOtpDevice } from './types';
+
+export async function removePasskeyFromWallet(params: {
+  bitgo: BitGoBase;
+  walletId: string;
+  device: WebAuthnOtpDevice;
+  walletPassphrase: string;
+}): Promise<void> {
+  const { bitgo, walletId, device, walletPassphrase } = params;
+
+  // Fetch wallet to infer coin and keychainId
+  // We use a temporary coin to access the wallets API; the wallet's actual coin is read after fetch
+  const walletData = await bitgo.get(bitgo.url(`/wallet/${walletId}`, 2)).result();
+
+  const coin = walletData.coin as string;
+  const keychainId = (walletData.keys as string[])[0];
+
+  // Fetch user keychain
+  const keychain = await bitgo.get(bitgo.url(`/${coin}/key/${keychainId}`, 2)).result();
+
+  if (!keychain.encryptedPrv) {
+    throw new Error(`Keychain ${keychainId} has no encryptedPrv. Cannot verify passphrase before passkey removal.`);
+  }
+
+  // Verify passphrase before any mutation
+  try {
+    bitgo.decrypt({ password: walletPassphrase, input: keychain.encryptedPrv });
+  } catch {
+    throw new Error('Incorrect wallet passphrase. Passkey removal aborted to prevent lockout.');
+  }
+
+  // DELETE the webauthn device using device.id (MongoDB ObjectId), not credentialId
+  await bitgo.del(bitgo.url(`/key/${keychainId}/webauthndevice/${device.id}`, 2)).result();
+}

--- a/modules/sdk-core/src/bitgo/passkey/types.ts
+++ b/modules/sdk-core/src/bitgo/passkey/types.ts
@@ -1,0 +1,8 @@
+// TODO: replace with: export type { WebAuthnOtpDevice } from '@bitgo/public-types'
+export interface WebAuthnOtpDevice {
+  id: string; // serialized MongoDB _id — used for DELETE
+  credentialId: string; // from authenticatorInfo.credID
+  prfSalt?: string;
+  isPasskey?: boolean;
+  extensions?: Record<string, boolean>;
+}

--- a/modules/sdk-core/test/unit/bitgo/passkey/removePasskeyFromWallet.ts
+++ b/modules/sdk-core/test/unit/bitgo/passkey/removePasskeyFromWallet.ts
@@ -1,0 +1,121 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import 'should';
+import { removePasskeyFromWallet } from '../../../../src/bitgo/passkey/removePasskeyFromWallet';
+import { WebAuthnOtpDevice } from '../../../../src/bitgo/passkey/types';
+
+describe('removePasskeyFromWallet', function () {
+  const walletId = 'wallet-abc123';
+  const keychainId = 'key-user-id';
+  const encryptedPrv = 'encrypted-prv-string';
+  const walletPassphrase = 'correct-passphrase';
+  const decryptedPrv = 'xprv-decrypted';
+
+  const device: WebAuthnOtpDevice = {
+    id: 'mongo-object-id-123',
+    credentialId: 'cred-id-456',
+    prfSalt: 'some-salt',
+    isPasskey: true,
+  };
+
+  let mockBitGo: sinon.SinonStubbedInstance<{
+    url: (path: string, version?: number) => string;
+    get: (url: string) => { result: () => Promise<unknown> };
+    del: (url: string) => { result: () => Promise<unknown> };
+    decrypt: (params: { password: string; input: string }) => string;
+  }>;
+
+  beforeEach(function () {
+    mockBitGo = {
+      url: sinon.stub().callsFake((path: string, version?: number) => `/api/v${version ?? 1}${path}`),
+      get: sinon.stub(),
+      del: sinon.stub(),
+      decrypt: sinon.stub(),
+    };
+
+    // Default: wallet fetch returns coin + keys
+    (mockBitGo.get as sinon.SinonStub).withArgs(`/api/v2/wallet/${walletId}`).returns({
+      result: sinon.stub().resolves({ coin: 'tbtc', keys: [keychainId, 'backup-key-id', 'bitgo-key-id'] }),
+    });
+
+    // Default: keychain fetch returns encryptedPrv
+    (mockBitGo.get as sinon.SinonStub).withArgs(`/api/v2/tbtc/key/${keychainId}`).returns({
+      result: sinon.stub().resolves({ id: keychainId, encryptedPrv }),
+    });
+
+    // Default: decrypt succeeds
+    (mockBitGo.decrypt as sinon.SinonStub).returns(decryptedPrv);
+
+    // Default: DELETE succeeds
+    (mockBitGo.del as sinon.SinonStub).returns({
+      result: sinon.stub().resolves({}),
+    });
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it('should successfully remove a passkey device', async function () {
+    await removePasskeyFromWallet({
+      bitgo: mockBitGo as any,
+      walletId,
+      device,
+      walletPassphrase,
+    });
+
+    // Verify decrypt was called with the right args
+    sinon.assert.calledOnce(mockBitGo.decrypt);
+    sinon.assert.calledWithExactly(mockBitGo.decrypt, { password: walletPassphrase, input: encryptedPrv });
+
+    // Verify DELETE was called with device.id (not credentialId)
+    sinon.assert.calledOnce(mockBitGo.del);
+    sinon.assert.calledWithExactly(mockBitGo.del, `/api/v2/key/${keychainId}/webauthndevice/${device.id}`);
+  });
+
+  it('should throw and not call DELETE if passphrase is wrong', async function () {
+    (mockBitGo.decrypt as sinon.SinonStub).throws(new Error('decryption failed'));
+
+    await assert.rejects(
+      () =>
+        removePasskeyFromWallet({
+          bitgo: mockBitGo as any,
+          walletId,
+          device,
+          walletPassphrase: 'wrong-passphrase',
+        }),
+      (err: Error) => {
+        assert.ok(err.message.includes('Incorrect wallet passphrase'));
+        assert.ok(err.message.includes('Passkey removal aborted to prevent lockout'));
+        return true;
+      }
+    );
+
+    // DELETE must NOT have been called
+    sinon.assert.notCalled(mockBitGo.del);
+  });
+
+  it('should throw descriptively if keychain has no encryptedPrv', async function () {
+    (mockBitGo.get as sinon.SinonStub).withArgs(`/api/v2/tbtc/key/${keychainId}`).returns({
+      result: sinon.stub().resolves({ id: keychainId }),
+    });
+
+    await assert.rejects(
+      () =>
+        removePasskeyFromWallet({
+          bitgo: mockBitGo as any,
+          walletId,
+          device,
+          walletPassphrase,
+        }),
+      (err: Error) => {
+        assert.ok(err.message.includes('no encryptedPrv'));
+        return true;
+      }
+    );
+
+    // No decrypt or DELETE should be called
+    sinon.assert.notCalled(mockBitGo.decrypt);
+    sinon.assert.notCalled(mockBitGo.del);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `removePasskeyFromWallet()` to `modules/sdk-core/src/bitgo/passkey/`
- Infers coin and keychainId from fetched wallet (walletId-only interface)
- Verifies wallet passphrase via `decrypt()` **before** issuing any DELETE — wrong passphrase aborts cleanly with no side effects
- DELETEs `/api/v2/key/{keychainId}/webauthndevice/{device.id}` using MongoDB ObjectId (not credentialId)
- Exports `WebAuthnOtpDevice` type stub (to be replaced with `@bitgo/public-types` once that PR merges)

## Test plan

- [x] Unit: successful passkey removal — verifies decrypt called with correct args, DELETE called with `device.id`
- [x] Unit: wrong passphrase — verifies error thrown with lockout message, DELETE NOT called
- [x] Unit: missing `encryptedPrv` — verifies descriptive error thrown, no decrypt or DELETE called

TICKET: WCN-190