### PR TITLE
feat(statics): onboard tabstracteth:tmt ERC20 token (CECHO-850)

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -1558,6 +1558,18 @@ export const allCoinsAndTokens = [
       CoinFeature.SUPPORTS_ERC20,
     ]
   ),
+
+  // Abstract testnet tokens
+  erc20Token(
+    '3531e4da-5c4c-4b34-b936-aed409e21dde',
+    'tabstracteth:tmt',
+    'Test Mintable Token',
+    6,
+    '0x23d6e0dd3a066daf6cfdff6344e6e271945b7d8f',
+    UnderlyingAsset['tabstracteth:tmt'],
+    Networks.test.abstracteth
+  ),
+
   account(
     'd308ba34-557a-43f2-84f3-5775f1f1a779',
     'apechain',

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -3201,6 +3201,9 @@ export enum UnderlyingAsset {
   'megaeth:mega' = 'megaeth:mega',
   'megaeth:weth' = 'megaeth:weth',
 
+  // Abstract testnet tokens
+  'tabstracteth:tmt' = 'tabstracteth:tmt',
+
   // MegaEth testnet tokens
   'tmegaeth:tmt' = 'tmegaeth:tmt',
 


### PR DESCRIPTION
## Summary

Adds `tabstracteth:tmt` (Test Mintable Token) as an ERC20 on Abstract testnet (`tabstracteth`): `UnderlyingAsset` in `base.ts` and `erc20Token(...)` in `allCoinsAndTokens.ts`.

Supersedes closed bot-opened PR #8640 (same branch/commits; human-authored PR).

## Token

| Field | Value |
|-------|--------|
| Symbol | tabstracteth:tmt |
| Full name | Test Mintable Token |
| Contract | `0x23d6e0DD3a066daF6cFDfF6344e6E271945b7d8f` |
| Decimals | 6 |

Ticket: CECHO-850


Made with [Cursor](https://cursor.com)