### PR TITLE
fix: align statics UUIDs for KRWQ and HYBOND with prod AMS DB

### DIFF
--- a/modules/statics/src/coins/botOfcTokens.ts
+++ b/modules/statics/src/coins/botOfcTokens.ts
@@ -794,7 +794,7 @@ export const botOfcTokens = [
     undefined
   ),
   AccountCtors.ofcerc20(
-    'c673dd10-076e-47b7-a53f-3a622c7cf38c',
+    '02af63f1-21b9-41a6-836a-a273f0faa276',
     'ofceth:krwq',
     'KRWQ',
     18,
@@ -806,7 +806,7 @@ export const botOfcTokens = [
     undefined
   ),
   AccountCtors.ofcerc20(
-    'cb98a20f-f22a-494a-b8e6-53212aa96f5a',
+    'adf94a02-974e-4fec-8132-d066ac52e49d',
     'ofceth:hybond',
     'HYBOND',
     18,

--- a/modules/statics/src/coins/botTokens.ts
+++ b/modules/statics/src/coins/botTokens.ts
@@ -797,7 +797,7 @@ export const botTokens = [
     undefined
   ),
   AccountCtors.erc20(
-    'ffb0d91e-c6d9-4cef-b5ea-f3781a757197',
+    '4bbcfef1-dde0-4931-a5d2-e7da10c8a1c6',
     'eth:krwq',
     'KRWQ',
     18,
@@ -809,7 +809,7 @@ export const botTokens = [
     undefined
   ),
   AccountCtors.erc20(
-    'f940b8f1-4911-4632-94ce-f4c0d950defb',
+    '910c83a4-7a4e-4892-8be6-89a0c3e99394',
     'eth:hybond',
     'HYBOND',
     18,


### PR DESCRIPTION
## Summary
- Updates `static_id` UUIDs for KRWQ and HYBOND (base + OFC) in `botTokens.ts` and `botOfcTokens.ts` to match the values already in the prod AMS database.
- These tokens were onboarded via the AMS API before being added to statics, causing a UUID mismatch that makes the AMS statics migration fail with `E11000 duplicate key error`.

Resolves [CSHLD-701](https://linear.app/bitgo/issue/CSHLD-701)

## Test plan
- [ ] Verify `eth:krwq`, `eth:hybond`, `ofceth:krwq`, `ofceth:hybond` resolve correctly in statics with the updated UUIDs
- [ ] Re-run the AMS statics migration on prod after this merges and the statics package is published — should no longer hit duplicate key errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)