### PR TITLE
feat(abstract-utxo): bump wasm-utxo to 4.8.0

### DIFF
--- a/modules/abstract-utxo/package.json
+++ b/modules/abstract-utxo/package.json
@@ -66,7 +66,7 @@
     "@bitgo/utxo-core": "^1.36.0",
     "@bitgo/utxo-lib": "^11.22.0",
     "@bitgo/utxo-ord": "^1.29.0",
-    "@bitgo/wasm-utxo": "^4.7.0",
+    "@bitgo/wasm-utxo": "^4.8.0",
     "@types/lodash": "^4.14.121",
     "@types/superagent": "4.1.15",
     "bignumber.js": "^9.0.2",

--- a/modules/utxo-bin/package.json
+++ b/modules/utxo-bin/package.json
@@ -31,7 +31,7 @@
     "@bitgo/unspents": "^0.51.3",
     "@bitgo/utxo-core": "^1.36.0",
     "@bitgo/utxo-lib": "^11.22.0",
-    "@bitgo/wasm-utxo": "^4.7.0",
+    "@bitgo/wasm-utxo": "^4.8.0",
     "@noble/curves": "1.8.1",
     "archy": "^1.0.0",
     "bech32": "^2.0.0",

--- a/modules/utxo-core/package.json
+++ b/modules/utxo-core/package.json
@@ -81,7 +81,7 @@
     "@bitgo/secp256k1": "^1.11.0",
     "@bitgo/unspents": "^0.51.3",
     "@bitgo/utxo-lib": "^11.22.0",
-    "@bitgo/wasm-utxo": "^4.7.0",
+    "@bitgo/wasm-utxo": "^4.8.0",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
     "fast-sha256": "^1.3.0"
   },

--- a/modules/utxo-ord/package.json
+++ b/modules/utxo-ord/package.json
@@ -45,7 +45,7 @@
     "directory": "modules/utxo-ord"
   },
   "dependencies": {
-    "@bitgo/wasm-utxo": "^4.7.0"
+    "@bitgo/wasm-utxo": "^4.8.0"
   },
   "devDependencies": {
     "@bitgo/utxo-lib": "^11.22.0"

--- a/modules/utxo-staking/package.json
+++ b/modules/utxo-staking/package.json
@@ -63,7 +63,7 @@
     "@bitgo/babylonlabs-io-btc-staking-ts": "^3.5.0",
     "@bitgo/utxo-core": "^1.36.0",
     "@bitgo/utxo-lib": "^11.22.0",
-    "@bitgo/wasm-utxo": "^4.7.0",
+    "@bitgo/wasm-utxo": "^4.8.0",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
     "bip322-js": "^2.0.0",
     "bitcoinjs-lib": "^6.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1030,10 +1030,10 @@
   resolved "https://registry.npmjs.org/@bitgo/wasm-ton/-/wasm-ton-1.1.1.tgz"
   integrity sha512-Y4x2V2ZcYWlmx42v7dlrKDtT2DuUt8smk8E98mh7RhpiifJhLk2v5RmXDwBl0A3v9TzUOU6qMOnSS/iZ8Pq52w==
 
-"@bitgo/wasm-utxo@^4.7.0":
-  version "4.7.0"
-  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-4.7.0.tgz#2ec1103c840b3be1a2ed29fae4ebc03fd57160a6"
-  integrity sha512-7T1vZNxM1dGPi2EqbWAFzHN0A8uWlR05c9Q7UAmZv1dQt6SBTsGc5rPyoEmwvkyPJSdbvcPS3NCoTyWIcbqUUA==
+"@bitgo/wasm-utxo@^4.8.0":
+  version "4.8.0"
+  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-4.8.0.tgz#744b20d239e5430402d61bd4ba7b1fbd77cc9ff3"
+  integrity sha512-FV4ll1nAiR8RKtkJAsjauz+bmcllDuo8Cx0aFTbnS+0yKQAGQCjc9AJXW9CvZC65fi1dTj9+hmcLugWrQ0h92A==
 
 "@brandonblack/musig@^0.0.1-alpha.0":
   version "0.0.1-alpha.1"


### PR DESCRIPTION
Update wasm-utxo dependency across multiple modules to version 4.8.0.

Contains fixes for abstract-utxo bip322.

Co-authored-by: llm-git <llm-git@ttll.de>