### PR TITLE
chore(sdk-core): bump @bitgo/public-types to 6.1.0

### DIFF
--- a/modules/sdk-core/package.json
+++ b/modules/sdk-core/package.json
@@ -40,7 +40,7 @@
     ]
   },
   "dependencies": {
-    "@bitgo/public-types": "5.96.2",
+    "@bitgo/public-types": "6.1.0",
     "@bitgo/sdk-lib-mpc": "^10.11.1",
     "@bitgo/secp256k1": "^1.11.0",
     "@bitgo/sjcl": "^1.1.0",


### PR DESCRIPTION
Bumps \`@bitgo/public-types\` from \`5.96.2\` to \`6.1.0\` in \`@bitgo/sdk-core\`.

6.1.0 adds \`WebAuthnOtpDevice\`, \`WebauthnDevice\`, and \`AuthenticatorInfo\` — required by WCN-187 (passkey types PR).

TICKET: WCN-374