### PR TITLE
fix(abstract-utxo): guard undefined address in preprocessBuildParams

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -558,6 +558,9 @@ export abstract class AbstractUtxoCoin
         params.recipients instanceof Array
           ? params?.recipients?.map((recipient) => {
               const { address, ...rest } = recipient;
+              if (address === undefined) {
+                return recipient; // Already { script, amount } — pass through unchanged
+              }
               return { ...rest, ...fromExtendedAddressFormat(address) };
             })
           : params.recipients;

--- a/modules/abstract-utxo/test/unit/transaction/recipient.ts
+++ b/modules/abstract-utxo/test/unit/transaction/recipient.ts
@@ -2,6 +2,22 @@ import assert from 'assert';
 
 import { getUtxoCoin } from '../util/utxoCoins';
 
+describe('AbstractUtxoCoin.preprocessBuildParams', function () {
+  const coin = getUtxoCoin('btc');
+
+  it('does not crash when recipients includes an OP_RETURN output with no address field', function () {
+    const params = {
+      recipients: [
+        { address: '3L3jdUJ9YCpGFjYB2Tuu7iBJes6ZHJFmnS', amount: '999612' },
+        { amount: '0', script: '6a0c3230323651312d6175646974' }, // OP_RETURN, no address
+      ],
+    };
+    assert.doesNotThrow(() => coin.preprocessBuildParams(params));
+    // The OP_RETURN recipient should be passed through unchanged
+    assert.deepStrictEqual(params.recipients[1], { amount: '0', script: '6a0c3230323651312d6175646974' });
+  });
+});
+
 describe('AbstractUtxoCoin.checkRecipient', function () {
   const coin = getUtxoCoin('btc');
 


### PR DESCRIPTION
## Summary
- Guard against `undefined` address in `preprocessBuildParams` before calling `fromExtendedAddressFormat`, passing OP_RETURN recipients (`{ script, amount }`) through unchanged
- Add unit test for `preprocessBuildParams` with a mixed normal + OP_RETURN recipients array

## Root Cause
When a recipient has no `address` field (e.g. an OP_RETURN output using `{ script, amount }`), destructuring in `preprocessBuildParams` gives `address = undefined`. Calling `fromExtendedAddressFormat(undefined)` → `isScriptRecipient(undefined)` → `undefined.toLowerCase()` → **TypeError crash**.

The `checkRecipient` path already had an `address &&` guard (PR #8649), but `preprocessBuildParams` was missed.

## Test Plan
- [ ] `yarn unit-test --scope @bitgo/abstract-utxo` passes including the new `preprocessBuildParams` test
- [ ] Repro script (`wcn323Repro.ts`) runs to completion without `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` — confirmed against test env, pending approval created successfully

## Ticket
WAL-375