### PR TITLE
fix(statics): migrate xtzevm testnet from deprecated shadownet to ghostnet

### DIFF
--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -743,8 +743,8 @@ class XtzEvmTestnet extends Testnet implements EthereumNetwork {
   family = CoinFamily.XTZEVM;
   explorerUrl = 'https://shadownet.explorer.etherlink.com/tx/';
   accountExplorerUrl = 'https://shadownet.explorer.etherlink.com/address/';
-  chainId = 128123;
-  nativeCoinOperationHashPrefix = '128123';
+  chainId = 127823;
+  nativeCoinOperationHashPrefix = '127823';
 }
 
 class Pyrmont extends Testnet implements AccountNetwork {


### PR DESCRIPTION


Linear: [CECHO-864](https://linear.app/bitgo/issue/CECHO-864/xtzevm-testnet-migration-to-new-network)

https://docs.etherlink.com/network/migrating-testnet/

🤖 Generated with [Claude Code](https://claude.com/claude-code)