### PR TITLE
feat(statics): exclude Singapore custody for COIN-7835 staked-yield t…

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -3762,7 +3762,8 @@ export const allCoinsAndTokens = [
     6,
     '0xb38809a63bc35fbb8b7ed9c66a24ff56412705a6',
     UnderlyingAsset['tbaseeth:tusdl'],
-    Networks.test.basechain
+    Networks.test.basechain,
+    [...AccountCoin.DEFAULT_FEATURES_EXCLUDE_SINGAPORE, CoinFeature.EIP1559]
   ),
   erc20Token(
     '439fb12d-fddf-4749-8a33-b7c79fefc1b4',
@@ -5492,7 +5493,7 @@ export const allCoinsAndTokens = [
     6,
     'TFDrx3FjBnxLegrfHN9F7SQdcyxWYHzEVa',
     UnderlyingAsset['ttrx:tusdlt'],
-    [...AccountCoin.DEFAULT_FEATURES, CoinFeature.STABLECOIN]
+    [...AccountCoin.DEFAULT_FEATURES_EXCLUDE_SINGAPORE, CoinFeature.STABLECOIN]
   ),
   talgoToken(
     '0e20b757-3e62-4400-887d-caff117481c8',

--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -4267,7 +4267,8 @@ export const allCoinsAndTokens = [
     18,
     '0xacfe6019ed1a7dc6f7b508c02d1b04ec88cc21bf',
     UnderlyingAsset['baseeth:vvv'],
-    Networks.main.basechain
+    Networks.main.basechain,
+    [...AccountCoin.DEFAULT_FEATURES_EXCLUDE_SINGAPORE, CoinFeature.EIP1559]
   ),
 
   // XDC mainnet tokens
@@ -4414,7 +4415,8 @@ export const allCoinsAndTokens = [
     18,
     '0xfd739d4e423301ce9385c1fb8850539d657c296d',
     UnderlyingAsset['hypeevm:khype'],
-    Networks.main.hypeevm
+    Networks.main.hypeevm,
+    [...AccountCoin.DEFAULT_FEATURES_EXCLUDE_SINGAPORE, CoinFeature.EIP1559]
   ),
   erc20Token(
     'fa292113-57f0-425a-841b-0e3111c8fd52',
@@ -4423,7 +4425,8 @@ export const allCoinsAndTokens = [
     18,
     '0x000000000000780555bd0bca3791f89f9542c2d6',
     UnderlyingAsset['hypeevm:kntq'],
-    Networks.main.hypeevm
+    Networks.main.hypeevm,
+    [...AccountCoin.DEFAULT_FEATURES_EXCLUDE_SINGAPORE, CoinFeature.EIP1559]
   ),
 
   // Story testnet tokens

--- a/modules/statics/src/coins/erc20Coins.ts
+++ b/modules/statics/src/coins/erc20Coins.ts
@@ -14772,7 +14772,7 @@ export const erc20Coins = [
     6,
     '0xda38de6dba36918e716ade6a3ac7944d6a5d5683',
     UnderlyingAsset['hteth:htusdl'],
-    [...ACCOUNT_COIN_DEFAULT_FEATURES, CoinFeature.STABLECOIN],
+    [...ACCOUNT_COIN_DEFAULT_FEATURES_EXCLUDE_SINGAPORE, CoinFeature.STABLECOIN],
     undefined,
     undefined,
     Networks.test.hoodi
@@ -14784,7 +14784,7 @@ export const erc20Coins = [
     6,
     '0xd73e58e2ebbb6015348361319766e5eef21e3e8c',
     UnderlyingAsset['hteth:htusdlt'],
-    [...ACCOUNT_COIN_DEFAULT_FEATURES, CoinFeature.STABLECOIN],
+    [...ACCOUNT_COIN_DEFAULT_FEATURES_EXCLUDE_SINGAPORE, CoinFeature.STABLECOIN],
     undefined,
     undefined,
     Networks.test.hoodi

--- a/modules/statics/src/coins/polygonTokens.ts
+++ b/modules/statics/src/coins/polygonTokens.ts
@@ -1,6 +1,10 @@
 import { AccountCoin, polygonErc20, tpolygonErc20 } from '../account';
 import { UnderlyingAsset, CoinFeature } from '../base';
-import { POLYGON_TOKEN_FEATURES, POLYGON_TOKEN_FEATURES_WITH_FRANKFURT } from '../coinFeatures';
+import {
+  POLYGON_TOKEN_FEATURES,
+  POLYGON_TOKEN_FEATURES_EXCLUDE_SINGAPORE,
+  POLYGON_TOKEN_FEATURES_WITH_FRANKFURT,
+} from '../coinFeatures';
 
 export const polygonTokens = [
   polygonErc20(
@@ -1312,7 +1316,7 @@ export const polygonTokens = [
     6,
     '0x934874830d4dd13b7ae00ae69a0b5b32e5b3cd3e',
     UnderlyingAsset['tpolygon:tusdl'],
-    [...POLYGON_TOKEN_FEATURES, CoinFeature.STABLECOIN]
+    [...POLYGON_TOKEN_FEATURES_EXCLUDE_SINGAPORE, CoinFeature.STABLECOIN]
   ),
   tpolygonErc20(
     'd2cb89da-a7d0-4200-b228-ddf5e68b633d',
@@ -1321,6 +1325,6 @@ export const polygonTokens = [
     6,
     '0x4d70b96e2fb36f8cd4edfcde011ae4e151fcf10d',
     UnderlyingAsset['tpolygon:tusdlt'],
-    [...POLYGON_TOKEN_FEATURES, CoinFeature.STABLECOIN]
+    [...POLYGON_TOKEN_FEATURES_EXCLUDE_SINGAPORE, CoinFeature.STABLECOIN]
   ),
 ];

--- a/modules/statics/src/coins/solTokens.ts
+++ b/modules/statics/src/coins/solTokens.ts
@@ -549,7 +549,7 @@ export const solTokens = [
     'mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So',
     'mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So',
     UnderlyingAsset.MSOL,
-    SOL_TOKEN_FEATURES
+    SOL_TOKEN_FEATURES_EXCLUDE_SINGAPORE
   ),
   solToken(
     'f33ad79e-31b4-4a6f-b85e-5c2a3669b5a5',


### PR DESCRIPTION
Jira: [COIN-7835](https://bitgoinc.atlassian.net/browse/COIN-7835)

Per compliance review (Louis Cheung, Gaurav Pal), the following tokens are capital-markets products that BitGo Singapore cannot custody. Each now uses the `EXCLUDE_SINGAPORE` feature preset.

**Mainnet**
| Token | Name |
|---|---|
| `hypeevm:khype` | Kinetiq Staked HYPE |
| `hypeevm:kntq` | Kinetiq |
| `baseeth:vvv` | Venice Token |
| `sol:msol` | Marinade Staked SOL |

**Testnet**
| Token | Name |
|---|---|
| `tbaseeth:tusdl` | USDL (BASE Sepolia) |
| `ttrx:tusdlt` | USDLT (Tron Shasta) |
| `hteth:htusdl` | USDL (Hoodi Sepolia) |
| `hteth:htusdlt` | USDLT (Hoodi Sepolia) |
| `tpolygon:tusdl` | USDL (Polygon Amoy) |
| `tpolygon:tusdlt` | USDLT (Polygon Amoy) |

All other batch tokens retain default custody features.

[COIN-7835]: https://bitgoinc.atlassian.net/browse/COIN-7835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ