### PR TITLE
fix(deps): upgrade axios to 1.15.2 to patch security vulnerabilities

### DIFF
--- a/modules/sdk-coin-atom/package.json
+++ b/modules/sdk-coin-atom/package.json
@@ -53,7 +53,7 @@
     "@bitgo/sdk-api": "^1.79.0",
     "@bitgo/sdk-test": "^9.1.40",
     "@types/lodash": "^4.14.183",
-    "axios": "^1.13.0"
+    "axios": "1.15.2"
   },
   "gitHead": "18e460ddf02de2dbf13c2aa243478188fb539f0c",
   "files": [

--- a/modules/sdk-coin-sui/package.json
+++ b/modules/sdk-coin-sui/package.json
@@ -56,7 +56,7 @@
     "@bitgo/sdk-api": "^1.79.0",
     "@bitgo/sdk-test": "^9.1.40",
     "@types/lodash": "^4.14.183",
-    "axios": "^1.13.0",
+    "axios": "1.15.2",
     "debug": "^4.3.4"
   },
   "gitHead": "18e460ddf02de2dbf13c2aa243478188fb539f0c",

--- a/modules/utxo-lib/package.json
+++ b/modules/utxo-lib/package.json
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@types/fs-extra": "^9.0.12",
     "@types/node": "^24.10.9",
-    "axios": "^1.13.0",
+    "axios": "1.15.2",
     "debug": "^3.1.0",
     "fs-extra": "^9.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@polkadot/keyring": "13.5.6",
     "elliptic": "^6.6.1",
     "cookie": "^0.7.1",
-    "axios": "1.15.0",
+    "axios": "1.15.2",
     "canvg": "4.0.3",
     "**/stellar-sdk/**/bignumber.js": "4.1.0",
     "**/stellar-base/**/bignumber.js": "4.1.0",
@@ -165,7 +165,7 @@
     "test:prepare-release": "mocha --require tsx ./scripts/tests/prepareRelease/prepare-release-main.test.ts"
   },
   "dependencies": {
-    "axios": "1.15.0",
+    "axios": "1.15.2",
     "terser": "^5.14.2",
     "tmp": "^0.2.3",
     "bigint-buffer": "npm:@trufflesuite/bigint-buffer@1.1.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7605,10 +7605,10 @@ aws4@^1.8.0:
   resolved "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz"
   integrity sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==
 
-axios@0.25.0, axios@0.27.2, axios@1.15.0, axios@1.7.4, axios@^0.21.2, axios@^0.26.1, axios@^1.13.0, axios@^1.6.0, axios@^1.8.3:
-  version "1.15.0"
-  resolved "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz"
-  integrity sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==
+axios@0.25.0, axios@0.27.2, axios@1.15.2, axios@1.7.4, axios@^0.21.2, axios@^0.26.1, axios@^1.15.2, axios@^1.6.0, axios@^1.8.3:
+  version "1.15.2"
+  resolved "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz#eb8fb6d30349abace6ade5b4cb4d9e8a0dc23e5b"
+  integrity sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==
   dependencies:
     follow-redirects "^1.15.11"
     form-data "^4.0.5"


### PR DESCRIPTION
Ticket: CGD-1025
to unblock beta release: https://github.com/BitGo/BitGoJS/actions/runs/25366781118/job/74379575161

GHA CVEs
https://github.com/advisories/GHSA-pmwg-cvhr-8vh7
https://github.com/advisories/GHSA-q8qp-cvcw-x6jj
https://github.com/advisories/GHSA-pf86-5x62-jrwf
https://github.com/advisories/GHSA-6chq-wfr3-2hj9