### PR TITLE
fix(passkey-crypto): pin sdk-core to 36.44.0

### DIFF
--- a/modules/passkey-crypto/package.json
+++ b/modules/passkey-crypto/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@bitgo/public-types": "6.1.0",
-    "@bitgo/sdk-core": "^36.42.0",
+    "@bitgo/sdk-core": "36.44.0",
     "@bitgo/sjcl": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Pins `@bitgo/sdk-core` to `36.44.0` in `modules/passkey-crypto/package.json` to satisfy the `check-versions` CI check
- Follow-up to #8637 where `package.json` was not included in the merge commit

TICKET: WCN-188