### PR TITLE
fix(sdk-coin-xdc): add tokenApproval to verifyTssTransaction

### DIFF
--- a/modules/sdk-coin-xdc/src/xdc.ts
+++ b/modules/sdk-coin-xdc/src/xdc.ts
@@ -62,7 +62,8 @@ export class Xdc extends AbstractEthLikeNewCoins {
       !txParams?.recipients &&
       !(
         txParams.prebuildTx?.consolidateId ||
-        (txParams.type && ['acceleration', 'fillNonce', 'transferToken'].includes(txParams.type))
+        (txParams.type &&
+          ['acceleration', 'fillNonce', 'transferToken', 'tokenApproval', 'consolidate'].includes(txParams.type))
       )
     ) {
       throw new Error(`missing txParams`);

--- a/modules/sdk-coin-xdc/src/xdcToken.ts
+++ b/modules/sdk-coin-xdc/src/xdcToken.ts
@@ -73,7 +73,8 @@ export class XdcToken extends EthLikeToken {
       !txParams?.recipients &&
       !(
         txParams.prebuildTx?.consolidateId ||
-        (txParams.type && ['acceleration', 'fillNonce', 'transferToken'].includes(txParams.type))
+        (txParams.type &&
+          ['acceleration', 'fillNonce', 'transferToken', 'tokenApproval', 'consolidate'].includes(txParams.type))
       )
     ) {
       throw new Error(`missing txParams`);

--- a/modules/sdk-coin-xdc/test/unit/xdcToken.ts
+++ b/modules/sdk-coin-xdc/test/unit/xdcToken.ts
@@ -160,6 +160,40 @@ describe('XDC Token:', function () {
       result.should.equal(true);
     });
 
+    it('should return true for tokenApproval type without recipients', async function () {
+      const token = bitgo.coin('txdc:tmt') as XdcToken;
+      const mockWallet = {} as unknown as IWallet;
+
+      const result = await token.verifyTssTransaction({
+        txParams: {
+          type: 'tokenApproval',
+        },
+        txPrebuild: mockTokenTransferData.txPrebuild as unknown as Parameters<
+          typeof token.verifyTssTransaction
+        >[0]['txPrebuild'],
+        wallet: mockWallet,
+      });
+
+      result.should.equal(true);
+    });
+
+    it('should return true for consolidate type without recipients', async function () {
+      const token = bitgo.coin('txdc:tmt') as XdcToken;
+      const mockWallet = {} as unknown as IWallet;
+
+      const result = await token.verifyTssTransaction({
+        txParams: {
+          type: 'consolidate',
+        },
+        txPrebuild: mockTokenTransferData.txPrebuild as unknown as Parameters<
+          typeof token.verifyTssTransaction
+        >[0]['txPrebuild'],
+        wallet: mockWallet,
+      });
+
+      result.should.equal(true);
+    });
+
     it('should throw error when txParams.recipients is missing and no valid type', async function () {
       const token = bitgo.coin('txdc:tmt') as XdcToken;
       const mockWallet = {} as unknown as IWallet;


### PR DESCRIPTION
the bypass list in xdcToken.ts and xdc.ts was copied from a stale bscToken.ts and was missing tokenApproval and consolidate transaction types. This caused enableToken (TXCD:TMT) to fail with "missing txParams" because tokenApproval transactions have no recipients and were not in the bypass list.

Fixes CECHO-915.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

TICKET: CECHO-915

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
