### PR TITLE
fix: exclude GHSA-rpmf-866q-6p89 (basic-ftp DoS) from yarn audit to unblock publish

### DIFF
--- a/.iyarc
+++ b/.iyarc
@@ -87,3 +87,15 @@ GHSA-xq3m-2v4x-88gg
 #   project are controlled internal endpoints, not user-supplied FTP URLs
 # - Pinned at 5.2.2 in root resolutions; upstream get-uri has not yet updated to require 5.3.0
 GHSA-rp42-5vxx-qpwr
+
+# Excluded because:
+# - DoS via unbounded multiline control response buffering in basic-ftp (severity: high, CVSS 7.5)
+# - A malicious FTP server can send an unterminated multiline response during the banner phase
+#   (before auth), causing the client to buffer unbounded data into FtpContext._partialResponse
+# - Same transitive chain as GHSA-rp42-5vxx-qpwr: pac-proxy-agent > get-uri > basic-ftp
+# - Used only for PAC-based proxy URL resolution, not for any direct FTP operations
+# - Exploitation requires connecting to a malicious FTP server; all proxy targets in this
+#   project are controlled internal endpoints, not user-supplied FTP URLs
+# - No compatible patched version available in the current get-uri dependency chain
+# - Ticket: SI-512
+GHSA-rpmf-866q-6p89


### PR DESCRIPTION
ticket: SI-512

## Summary

- Adds `GHSA-rpmf-866q-6p89` to `.iyarc` to exclude it from the yarn audit check
- This unblocks the `chore(root): publish modules` CI job which was failing with 5 HIGH severity findings — all the same advisory (`GHSA-rpmf-866q-6p89`) reported across 5 different dependency paths through `basic-ftp`

## Why the exclusion is safe

The vulnerability is a client-side DoS in `basic-ftp` via unbounded multiline FTP control response buffering. The affected package reaches us through:

```
@bitgo/sdk-api > proxy-agent > pac-proxy-agent > get-uri > basic-ftp
```

- `basic-ftp` is used only for **PAC-based proxy URL resolution**, not for direct FTP operations
- Exploitation requires connecting to a **malicious FTP server** — all proxy targets are controlled internal endpoints
- A sibling advisory on the same package (`GHSA-rp42-5vxx-qpwr`, DoS via `Client.list()`) is already excluded under the same rationale
- No compatible patched version is available in the current `get-uri` dependency chain

## Impact

Unblocks the publish of `@bitgo/sdk-coin-hbar` containing the `explainTransaction` fix for HBAR staking (PR #8700, merged), which is needed to unblock end-to-end HBAR stake signing on staging.

## Related

- SI-511: BitGoJS `explainTransaction` fix for HBAR (PR #8700)
- SI-508: bitgo-microservices `stakedNodeId` fix
- SI-506: staking-service HBAR implementation
- Failing CI run: https://github.com/BitGo/BitGoJS/actions/runs/25464115442/job/74714441980