### PR TITLE
feat(sdk-coin-canton): added canton in coinFactory tokenConstuctor

### DIFF
--- a/modules/bitgo/src/v2/coinFactory.ts
+++ b/modules/bitgo/src/v2/coinFactory.ts
@@ -3,6 +3,7 @@
  */
 import { AdaToken } from '@bitgo/sdk-coin-ada';
 import { AlgoToken } from '@bitgo/sdk-coin-algo';
+import { CantonToken } from '@bitgo/sdk-coin-canton';
 import { Bcha, Tbcha } from '@bitgo/sdk-coin-bcha';
 import { HbarToken } from '@bitgo/sdk-coin-hbar';
 import { Near, TNear, Nep141Token } from '@bitgo/sdk-coin-near';
@@ -40,6 +41,7 @@ import {
   Tip20TokenConfig,
   PolyxTokenConfig,
   JettonTokenConfig,
+  CantonTokenConfig,
 } from '@bitgo/statics';
 import {
   Ada,
@@ -1085,6 +1087,9 @@ export function getTokenConstructor(tokenConfig: TokenConfig): CoinConstructor |
     case 'xdc':
     case 'txdc':
       return XdcToken.createTokenConstructor(tokenConfig as EthLikeTokenConfig);
+    case 'canton':
+    case 'tcanton':
+      return CantonToken.createTokenConstructor(tokenConfig as CantonTokenConfig);
     default:
       return undefined;
   }


### PR DESCRIPTION
Ticket: [CHALO-399](https://linear.app/bitgo/issue/CHALO-399/unsupportedcoinerror-for-cantontoken-in-bga)

[CHALO-399]: https://bitgoinc.atlassian.net/browse/CHALO-399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ