### PR TITLE
feat(statics): exclude Singapore custody for USDGold and ARCHITECT Global Value

### DIFF
--- a/modules/statics/src/coins/bscTokens.ts
+++ b/modules/statics/src/coins/bscTokens.ts
@@ -1631,6 +1631,6 @@ export const bscTokens = [
     18,
     '0x166a75bd1eba55d4723c84c62127123e7a73f95b',
     UnderlyingAsset['bsc:usdau'],
-    BSC_TOKEN_FEATURES
+    BSC_TOKEN_FEATURES_EXCLUDE_SINGAPORE
   ),
 ];

--- a/modules/statics/src/coins/erc20Coins.ts
+++ b/modules/statics/src/coins/erc20Coins.ts
@@ -14752,7 +14752,8 @@ export const erc20Coins = [
     'ARCHITECT Global Value',
     18,
     '0x6624c638780816228a25a15a4f30287d30c459c2',
-    UnderlyingAsset['eth:architectgvi']
+    UnderlyingAsset['eth:architectgvi'],
+    ACCOUNT_COIN_DEFAULT_FEATURES_EXCLUDE_SINGAPORE
   ),
   erc20(
     '1bec62df-bf62-4e45-9613-ce56112a4fd0',


### PR DESCRIPTION
## Summary

Per Compliance assessment ([Jacelyn's note on COIN-7835](https://bitgoinc.atlassian.net/browse/COIN-7835)): USDGold and ARCHITECT Global Value have been flagged as high-risk for BitGo Singapore custody.

| Token | Symbol | Change |
|---|---|---|
| USDGold | `bsc:usdau` | `BSC_TOKEN_FEATURES` → `BSC_TOKEN_FEATURES_EXCLUDE_SINGAPORE` |
| ARCHITECT Global Value | `eth:architectgvi` | default features → `ACCOUNT_COIN_DEFAULT_FEATURES_EXCLUDE_SINGAPORE` |

## Test plan

- [x] `@bitgo/statics` builds clean
- [x] `@bitgo/statics` tests pass
- [ ] Verify `bsc:usdau` and `eth:architectgvi` no longer carry the SG-eligible feature in CI artifacts

Ref: COIN-7835

🤖 Generated with [Claude Code](https://claude.com/claude-code)