### PR TITLE
CSHLD-756: Support Ondo test tokens on mainnet (Gated)

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -3876,6 +3876,15 @@ export const allCoinsAndTokens = [
     [...AccountCoin.DEFAULT_FEATURES_EXCLUDE_SINGAPORE, CoinFeature.EIP1559]
   ),
   erc20Token(
+    '941e3bbc-aaa4-4e06-837d-3511c9c09e5c',
+    'tbaseeth:ttbills',
+    'Test TBILLS',
+    6,
+    '0x52ae479d8b7ef0f3c27a3eb0072fb3995bdb77ca',
+    UnderlyingAsset['tbaseeth:ttbills'],
+    Networks.test.basechain
+  ),
+  erc20Token(
     '439fb12d-fddf-4749-8a33-b7c79fefc1b4',
     'baseeth:wave',
     'Waveform',
@@ -6473,6 +6482,14 @@ export const allCoinsAndTokens = [
     18,
     '0x58b9cb810a68a7f3e1e4f8cb45d1b9b3c79705e8',
     UnderlyingAsset['arbeth:next']
+  ),
+  arbethErc20(
+    '15d3b597-f001-41f7-8fa3-2b6754d7878a',
+    'arbeth:week',
+    'WEEK_DEFI',
+    18,
+    '0x5ae39d492e06bedf5a261687af18c653e920a8a3',
+    UnderlyingAsset['arbeth:week']
   ),
 
   opethErc20(

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -2514,6 +2514,12 @@ export enum UnderlyingAsset {
   'eth:prompt' = 'eth:prompt',
   'eth:yb' = 'eth:yb',
   'eth:btr' = 'eth:btr',
+  // Ondo Test Tokens (Mainnet Gated)
+  'eth:t-bincon' = 'eth:t-bincon',
+  'eth:t-iauon' = 'eth:t-iauon',
+  'eth:t-iemgon' = 'eth:t-iemgon',
+  'eth:t-ibiton' = 'eth:t-ibiton',
+  'eth:t-ivvon' = 'eth:t-ivvon',
   'morph:usdc' = 'morph:usdc',
   'morpheth:usdc' = 'morpheth:usdc',
   'morph:usdt' = 'morph:usdt',
@@ -2618,6 +2624,7 @@ export enum UnderlyingAsset {
   'tavaxc:bitgo' = 'tavaxc:bitgo',
   'tavaxc:stavax' = 'tavaxc:stavax',
   'tavaxc:rtest' = 'tavaxc:rtest',
+  'tavaxc:tkula' = 'tavaxc:tkula',
   'avaxc:usdc-e' = 'avaxc:usdc-e',
   'avaxc:usdt-e' = 'avaxc:usdt-e',
   // Begin FTX missing AVAXC tokens
@@ -3020,6 +3027,12 @@ export enum UnderlyingAsset {
   'bsc:esports' = 'bsc:esports',
   'bsc:xter' = 'bsc:xter',
   'bsc:usdau' = 'bsc:usdau',
+  // Ondo Test Tokens (Mainnet Gated)
+  'bsc:t-bincon' = 'bsc:t-bincon',
+  'bsc:t-iauon' = 'bsc:t-iauon',
+  'bsc:t-iemgon' = 'bsc:t-iemgon',
+  'bsc:t-ibiton' = 'bsc:t-ibiton',
+  'bsc:t-ivvon' = 'bsc:t-ivvon',
 
   // BSC NFTs
   // generic NFTs
@@ -3114,6 +3127,7 @@ export enum UnderlyingAsset {
   'arbeth:testamzn' = 'arbeth:testamzn',
   'arbeth:testpltr' = 'arbeth:testpltr',
   'arbeth:testnflx' = 'arbeth:testnflx',
+  'arbeth:week' = 'arbeth:week',
 
   // BaseETH mainnet tokens
   'baseeth:aero' = 'baseeth:aero',
@@ -3169,6 +3183,7 @@ export enum UnderlyingAsset {
   'tbaseeth:usd1cx' = 'tbaseeth:usd1cx',
   'tbaseeth:ctusd1cx' = 'tbaseeth:ctusd1cx',
   'tbaseeth:tusdl' = 'tbaseeth:tusdl',
+  'tbaseeth:ttbills' = 'tbaseeth:ttbills',
 
   // Og mainnet tokens
   'og:wog' = 'og:wog',

--- a/modules/statics/src/coins/avaxTokens.ts
+++ b/modules/statics/src/coins/avaxTokens.ts
@@ -800,4 +800,12 @@ export const avaxTokens = [
     '0xaeb95ae5888b9ba0636373da39d5ad85eef318e0',
     UnderlyingAsset['tavaxc:rtest']
   ),
+  tavaxErc20(
+    'adac9ba2-37a8-466a-9069-e2b2d0b05684',
+    'tavaxc:tkula',
+    'Test KULA',
+    18,
+    '0xf9d118f8835b3a4261c3d3b2de89034022153e53',
+    UnderlyingAsset['tavaxc:tkula']
+  ),
 ];

--- a/modules/statics/src/coins/bscTokens.ts
+++ b/modules/statics/src/coins/bscTokens.ts
@@ -1633,4 +1633,50 @@ export const bscTokens = [
     UnderlyingAsset['bsc:usdau'],
     BSC_TOKEN_FEATURES_EXCLUDE_SINGAPORE
   ),
+  // Ondo Test Tokens (Mainnet Gated)
+  bscToken(
+    '70f45912-f817-454c-ae1d-05f60f10ccee',
+    'bsc:t-bincon',
+    't-BINCon',
+    18,
+    '0x904d33dc5e5afef460efcfdde273b7bb9077261f',
+    UnderlyingAsset['bsc:t-bincon'],
+    BSC_TOKEN_FEATURES
+  ),
+  bscToken(
+    '1284e04c-8922-4f79-9fc6-b4828ec865ee',
+    'bsc:t-iauon',
+    't-IAUon',
+    18,
+    '0xf51c954bf744da45530b1ad68d1b8ad8e1733a3f',
+    UnderlyingAsset['bsc:t-iauon'],
+    BSC_TOKEN_FEATURES
+  ),
+  bscToken(
+    '00819077-3203-4adf-a88d-6396c3f1c573',
+    'bsc:t-iemgon',
+    't-IEMGon',
+    18,
+    '0xae6b1f80343bcab207e441d002f9f466dc116270',
+    UnderlyingAsset['bsc:t-iemgon'],
+    BSC_TOKEN_FEATURES
+  ),
+  bscToken(
+    '5e818d05-3504-4320-b94e-a6d5d42c8884',
+    'bsc:t-ibiton',
+    't-IBITon',
+    18,
+    '0x5bd0885b43acd57d3a023cc6eb8c24bc54785aac',
+    UnderlyingAsset['bsc:t-ibiton'],
+    BSC_TOKEN_FEATURES
+  ),
+  bscToken(
+    'c9fcf59a-be49-4f88-a960-b9d088684b13',
+    'bsc:t-ivvon',
+    't-IVVon',
+    18,
+    '0xee0297fb06ac2bb60b5f49e541050361bfe91e1b',
+    UnderlyingAsset['bsc:t-ivvon'],
+    BSC_TOKEN_FEATURES
+  ),
 ];

--- a/modules/statics/src/coins/erc20Coins.ts
+++ b/modules/statics/src/coins/erc20Coins.ts
@@ -14286,6 +14286,47 @@ export const erc20Coins = [
     '0x2816169a49953c548bfeb3948dcf05c4a0e4657d',
     UnderlyingAsset['eth:melion']
   ),
+  // Ondo Test Tokens (Mainnet Gated)
+  erc20(
+    '98b175fc-55fc-4f5a-ab5d-f264917bf19c',
+    'eth:t-bincon',
+    't-BINCon',
+    18,
+    '0xd9ad9e6eb77f2b3739348f077128a1c24c60fbf4',
+    UnderlyingAsset['eth:t-bincon']
+  ),
+  erc20(
+    '93a70b9c-2566-4e2c-9cf2-c5286d611700',
+    'eth:t-iauon',
+    't-IAUon',
+    18,
+    '0x7c9da75d1432af7b9a1efb60eabeb157730776aa',
+    UnderlyingAsset['eth:t-iauon']
+  ),
+  erc20(
+    '7b06c2d3-e914-4591-bac5-e5a592e3ff41',
+    'eth:t-iemgon',
+    't-IEMGon',
+    18,
+    '0x6b9947b9f56041e27d787b578b91cc0e96d9ed53',
+    UnderlyingAsset['eth:t-iemgon']
+  ),
+  erc20(
+    '2eb866a7-540f-4b57-ba52-e55dab073a7a',
+    'eth:t-ibiton',
+    't-IBITon',
+    18,
+    '0x98874a1e7d9d9f5d5cec117124c44671495ab950',
+    UnderlyingAsset['eth:t-ibiton']
+  ),
+  erc20(
+    'bd2a287f-4bb9-48c7-b269-04d4da0f7a34',
+    'eth:t-ivvon',
+    't-IVVon',
+    18,
+    '0xdc5c90371aa7f044e79be6623d0b32cd1a0e105b',
+    UnderlyingAsset['eth:t-ivvon']
+  ),
   erc20(
     '6e7f1a86-e938-42ed-afe8-b58364a7f498',
     'eth:six',

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -2413,6 +2413,13 @@ export const ofcCoins = [
     18,
     UnderlyingAsset['avaxc:link']
   ),
+  tofcAvaxErc20(
+    '75c2f266-e1a1-4ba0-b7b5-ca6d701d8b70',
+    'ofctavaxc:tkula',
+    'Test KULA',
+    18,
+    UnderlyingAsset['tavaxc:tkula']
+  ),
   ofcAvaxErc20(
     '49608052-e4ea-4623-9732-595368ff053b',
     'ofcavaxc:shrap',
@@ -4575,6 +4582,30 @@ export const ofcCoins = [
   ),
   ofcBscToken('d08948fa-0378-4736-a5ab-0b4ec9182b8a', 'ofcbsc:xter', 'Xterio', 18, UnderlyingAsset['bsc:xter']),
   ofcBscToken('b73d634a-a60d-4e2d-835b-3d8a527979b1', 'ofcbsc:usdau', 'USD GOLD', 18, UnderlyingAsset['bsc:usdau']),
+  // Ondo Test Tokens OFC (BSC)
+  ofcBscToken(
+    '389e7bc3-fb66-4660-a2e9-ae2082ed42df',
+    'ofcbsc:t-bincon',
+    't-BINCon',
+    18,
+    UnderlyingAsset['bsc:t-bincon']
+  ),
+  ofcBscToken('02f28844-b269-41c7-a9b6-af4a50287f2a', 'ofcbsc:t-iauon', 't-IAUon', 18, UnderlyingAsset['bsc:t-iauon']),
+  ofcBscToken(
+    'dc4e019d-d836-47b9-ab1a-3d189da9dfca',
+    'ofcbsc:t-iemgon',
+    't-IEMGon',
+    18,
+    UnderlyingAsset['bsc:t-iemgon']
+  ),
+  ofcBscToken(
+    'ee2e49ce-8655-46bd-857d-e2dc4922f368',
+    'ofcbsc:t-ibiton',
+    't-IBITon',
+    18,
+    UnderlyingAsset['bsc:t-ibiton']
+  ),
+  ofcBscToken('414e67d8-5449-477d-b3d4-df50ca543bf3', 'ofcbsc:t-ivvon', 't-IVVon', 18, UnderlyingAsset['bsc:t-ivvon']),
   // New Arbitrum OFC token
   ofcArbethErc20(
     'd58490c0-07d2-4642-8af7-efa2453392e9',
@@ -4582,6 +4613,13 @@ export const ofcCoins = [
     'Everclear',
     18,
     UnderlyingAsset['arbeth:next']
+  ),
+  ofcArbethErc20(
+    'db174d8d-b074-4682-ad77-bb42d0a1f768',
+    'ofcarbeth:week',
+    'WEEK_DEFI',
+    18,
+    UnderlyingAsset['arbeth:week']
   ),
   // New SOL OFC tokens
   ofcsolToken(

--- a/modules/statics/src/coins/ofcErc20Coins.ts
+++ b/modules/statics/src/coins/ofcErc20Coins.ts
@@ -4229,6 +4229,42 @@ export const ofcErc20Coins = [
     true,
     'chiliz'
   ),
+  // Ondo Test Tokens OFC
+  ofcerc20(
+    'f0ab07ba-319e-453b-9fb1-b1a4d1a4612b',
+    'ofceth:t-bincon',
+    't-BINCon',
+    18,
+    underlyingAssetForSymbol('eth:t-bincon')
+  ),
+  ofcerc20(
+    'b6824fb1-c363-4c7f-81aa-0822824338d0',
+    'ofceth:t-iauon',
+    't-IAUon',
+    18,
+    underlyingAssetForSymbol('eth:t-iauon')
+  ),
+  ofcerc20(
+    'bed582a6-e707-482c-b4bc-6111342b4e04',
+    'ofceth:t-iemgon',
+    't-IEMGon',
+    18,
+    underlyingAssetForSymbol('eth:t-iemgon')
+  ),
+  ofcerc20(
+    'd50e00a6-5f4f-42b2-9445-2cf2b1681abd',
+    'ofceth:t-ibiton',
+    't-IBITon',
+    18,
+    underlyingAssetForSymbol('eth:t-ibiton')
+  ),
+  ofcerc20(
+    '4beeecb7-a658-4463-be7c-d4797b499d9c',
+    'ofceth:t-ivvon',
+    't-IVVon',
+    18,
+    underlyingAssetForSymbol('eth:t-ivvon')
+  ),
 ];
 
 export const tOfcErc20Coins = [
@@ -6562,6 +6598,20 @@ export const tOfcErc20Coins = [
     UnderlyingAsset['tbaseeth:tusdl'],
     undefined,
     [CoinFeature.STABLECOIN],
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    'tbaseeth'
+  ),
+  tofcerc20(
+    'db419053-4226-4dd3-8fce-f0f2c28fafaa',
+    'ofctbaseeth:ttbills',
+    'Test TBILLS',
+    6,
+    UnderlyingAsset['tbaseeth:ttbills'],
+    undefined,
+    undefined,
     undefined,
     undefined,
     undefined,


### PR DESCRIPTION
## Summary

Add Ondo test tokens on mainnet (gated), testnet tokens, and WEEK token on Arbitrum as part of token onboarding for CSHLD-756.

**Linear**: [CSHLD-756](https://linear.app/bitgo/issue/CSHLD-756)

## Changes

- Add 5 Ondo test tokens (`t-BINCon`, `t-IAUon`, `t-IEMGon`, `t-IBITon`, `t-IVVon`) on ETH mainnet with OFC equivalents
- Add same 5 Ondo test tokens on BSC mainnet with OFC equivalents
- Add `tbaseeth:ttbills` (Base Sepolia, 6 decimals) with OFC equivalent
- Add `tavaxc:tkula` (Avalanche Fuji, 18 decimals) with OFC equivalent
- Add `arbeth:week` (Arbitrum mainnet, 18 decimals) with OFC equivalent
- 13 on-chain tokens + 13 OFC equivalents = 26 total entries

**Note:** `teth:tusdc` on Sepolia is not included — requires adding Ethereum Sepolia network support (separate ticket).

## Test Plan

- `npx lerna run build --scope @bitgo/statics` — passes
- `npx lerna run unit-test --scope @bitgo/statics` — passes
- All contract addresses verified lowercase
- All UUIDs are unique (generated via uuid v4)

Closes CSHLD-756