### PR TITLE
fix(sdk-lib-mpc): add keyShare to EdDSA MPCv2 getReducedKeyShare

### DIFF
--- a/modules/sdk-lib-mpc/src/tss/eddsa-mps/dkg.ts
+++ b/modules/sdk-lib-mpc/src/tss/eddsa-mps/dkg.ts
@@ -234,14 +234,18 @@ export class DKG {
   }
 
   /**
-   * Returns a CBOR-encoded reduced representation containing the public key.
+   * Returns a CBOR-encoded ReducedKeyShare buffer containing the party's opaque
+   * signing key share in the `keyShare` field. This buffer is private key material.
+   * The caller encrypts it and stores it as `reducedEncryptedPrv` on the key card QR code.
    */
   getReducedKeyShare(): Buffer {
-    if (!this.sharePk) {
+    if (!this.keyShare || !this.sharePk || !this.shareChaincode) {
       throw Error('DKG session not initialized');
     }
     const reducedKeyShare: EddsaReducedKeyShare = {
+      keyShare: Array.from(this.keyShare),
       pub: Array.from(this.sharePk),
+      rootChainCode: Array.from(this.shareChaincode),
     };
     return Buffer.from(encode(reducedKeyShare));
   }

--- a/modules/sdk-lib-mpc/src/tss/eddsa-mps/types.ts
+++ b/modules/sdk-lib-mpc/src/tss/eddsa-mps/types.ts
@@ -3,7 +3,9 @@ import { isLeft } from 'fp-ts/Either';
 import * as t from 'io-ts';
 
 export const ReducedKeyShareType = t.type({
+  keyShare: t.array(t.number),
   pub: t.array(t.number),
+  rootChainCode: t.array(t.number),
 });
 
 export type EddsaReducedKeyShare = t.TypeOf<typeof ReducedKeyShareType>;

--- a/modules/sdk-lib-mpc/test/unit/tss/eddsa/dkg.ts
+++ b/modules/sdk-lib-mpc/test/unit/tss/eddsa/dkg.ts
@@ -205,12 +205,38 @@ describe('EdDSA MPS DKG', function () {
       );
       assert(Buffer.isBuffer(bitgoReduced) && bitgoReduced.length > 0, 'BitGo reduced key share should be non-empty');
 
-      const userPub = Buffer.from(MPSTypes.getDecodedReducedKeyShare(userReduced).pub).toString('hex');
-      const backupPub = Buffer.from(MPSTypes.getDecodedReducedKeyShare(backupReduced).pub).toString('hex');
-      const bitgoPub = Buffer.from(MPSTypes.getDecodedReducedKeyShare(bitgoReduced).pub).toString('hex');
+      const userDecoded = MPSTypes.getDecodedReducedKeyShare(userReduced);
+      const backupDecoded = MPSTypes.getDecodedReducedKeyShare(backupReduced);
+      const bitgoDecoded = MPSTypes.getDecodedReducedKeyShare(bitgoReduced);
+
+      const userPub = Buffer.from(userDecoded.pub).toString('hex');
+      const backupPub = Buffer.from(backupDecoded.pub).toString('hex');
+      const bitgoPub = Buffer.from(bitgoDecoded.pub).toString('hex');
 
       assert.strictEqual(userPub, backupPub, 'User and backup should have same public key in reduced share');
       assert.strictEqual(backupPub, bitgoPub, 'Backup and BitGo should have same public key in reduced share');
+
+      // keyShare must be present and non-empty (opaque WASM bincode needed for DSG)
+      assert(userDecoded.keyShare.length > 0, 'User reduced share must include keyShare');
+      assert(backupDecoded.keyShare.length > 0, 'Backup reduced share must include keyShare');
+      assert(bitgoDecoded.keyShare.length > 0, 'BitGo reduced share must include keyShare');
+
+      // rootChainCode must be 32 bytes
+      assert.strictEqual(userDecoded.rootChainCode.length, 32, 'User rootChainCode must be 32 bytes');
+      assert.strictEqual(backupDecoded.rootChainCode.length, 32, 'Backup rootChainCode must be 32 bytes');
+      assert.strictEqual(bitgoDecoded.rootChainCode.length, 32, 'BitGo rootChainCode must be 32 bytes');
+
+      // All parties derive the same chaincode
+      assert.strictEqual(
+        Buffer.from(userDecoded.rootChainCode).toString('hex'),
+        Buffer.from(backupDecoded.rootChainCode).toString('hex'),
+        'User and backup should have same rootChainCode'
+      );
+      assert.strictEqual(
+        Buffer.from(backupDecoded.rootChainCode).toString('hex'),
+        Buffer.from(bitgoDecoded.rootChainCode).toString('hex'),
+        'Backup and BitGo should have same rootChainCode'
+      );
     });
   });
 


### PR DESCRIPTION
getReducedKeyShare() was only serialising sharePk (the 32-byte public key) into the CBOR keycard payload, silently discarding the opaque WASM signing key share and chain code. Recovery signing via DSG requires the full keyShare buffer as input to ed25519_dsg_round0_process, making the old format unusable for SDK-local hot-wallet recovery.

ReducedKeyShareType now includes keyShare, pub, and rootChainCode, matching the pattern of ECDSA MPCv2's ReducedKeyShare. Tests updated to assert all three fields are present and correct.

Ticket: WCI-385

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
