### PR TITLE
fix(statics): set xtzevm decimals to 18

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -403,7 +403,7 @@ export const allCoinsAndTokens = [
     'xtzevm',
     'XTZ EVM',
     Networks.main.xtzevm,
-    6,
+    18,
     UnderlyingAsset.XTZEVM,
     BaseUnit.ETH,
     [
@@ -421,7 +421,7 @@ export const allCoinsAndTokens = [
     'txtzevm',
     'Testnet XTZ EVM',
     Networks.test.xtzevm,
-    6,
+    18,
     UnderlyingAsset.XTZEVM,
     BaseUnit.ETH,
     [

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -251,12 +251,12 @@ export const ofcCoins = [
     UnderlyingAsset.HYPEEVM,
     CoinKind.CRYPTO
   ),
-  ofc('dc825481-0a15-44ab-84e6-6f182b13eb87', 'ofcxtzevm', 'XTZ EVM', 6, UnderlyingAsset.XTZEVM, CoinKind.CRYPTO),
+  ofc('dc825481-0a15-44ab-84e6-6f182b13eb87', 'ofcxtzevm', 'XTZ EVM', 18, UnderlyingAsset.XTZEVM, CoinKind.CRYPTO),
   tofc(
     '0e42884b-c01e-461b-b108-1ed0d0fbbd7b',
     'ofctxtzevm',
     'XTZ EVM Testnet',
-    6,
+    18,
     UnderlyingAsset.XTZEVM,
     CoinKind.CRYPTO
   ),


### PR DESCRIPTION
## Summary
- Fix decimal places for Etherlink (XTZ EVM) from 6 to 18 across mainnet, testnet, and OFC coins
- Etherlink uses standard EVM 18 decimals; the incorrect value of 6 caused balances to display inflated by 10^12 (e.g. 100 XTZ showing as 100B TXTZEVM)

## Ticket
[CECHO-973](https://linear.app/bitgo/issue/CECHO-973/fix-decimal-issue-in-test-xtzevm-wallet)

## Test plan
- [ ] Verify testnet wallet balance displays correctly after deployment
- [ ] Verify deposit/withdrawal amounts render with correct decimals

🤖 Generated with [Claude Code](https://claude.com/claude-code)