### PR TITLE
feat(bitgo): add support for Export txn type in prebuildTransaction

### DIFF
--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -3536,6 +3536,76 @@ describe('V2 Wallet:', function () {
         args[1]!.should.equal('full');
       });
 
+      it('should call prebuildTxWithIntent with the correct params for Export', async function () {
+        const recipients = [
+          {
+            address: 'P-costwo1xxt27rgnrjyaw2wmuswxumlmme2tapj62s7uy0',
+            amount: '50000000000000000',
+          },
+        ];
+        const feeOptions = {
+          maxFeePerGas: 3000000000,
+          maxPriorityFeePerGas: 2000000000,
+        };
+
+        const prebuildTxWithIntent = sandbox.stub(ECDSAUtils.EcdsaUtils.prototype, 'prebuildTxWithIntent');
+        prebuildTxWithIntent.resolves(txRequestFull);
+
+        await tssEthWallet.prebuildTransaction({
+          reqId,
+          type: 'Export',
+          recipients,
+          nonce: '5',
+          feeOptions,
+        });
+
+        sinon.assert.calledOnce(prebuildTxWithIntent);
+        const args = prebuildTxWithIntent.args[0];
+        args[0]!.intentType.should.equal('export');
+        args[0]!.recipients!.should.deepEqual(recipients);
+        args[0]!.nonce!.should.equal('5');
+        args[0]!.feeOptions!.should.deepEqual(feeOptions);
+        args[1]!.should.equal('full');
+      });
+
+      it('should call prebuildTxWithIntent with the correct params for Import', async function () {
+        const prebuildTxWithIntent = sandbox.stub(ECDSAUtils.EcdsaUtils.prototype, 'prebuildTxWithIntent');
+        prebuildTxWithIntent.resolves(txRequestFull);
+
+        await tssEthWallet.prebuildTransaction({
+          reqId,
+          type: 'Import',
+          recipients: [],
+        });
+
+        sinon.assert.calledOnce(prebuildTxWithIntent);
+        const args = prebuildTxWithIntent.args[0];
+        args[0]!.intentType.should.equal('import');
+        args[0]!.recipients!.should.deepEqual([]);
+        args[0]!.should.not.have.property('nonce');
+        args[0]!.should.not.have.property('feeOptions');
+        args[1]!.should.equal('full');
+      });
+
+      it('should call prebuildTxWithIntent with the correct params for ImportToC', async function () {
+        const prebuildTxWithIntent = sandbox.stub(ECDSAUtils.EcdsaUtils.prototype, 'prebuildTxWithIntent');
+        prebuildTxWithIntent.resolves(txRequestFull);
+
+        await tssEthWallet.prebuildTransaction({
+          reqId,
+          type: 'ImportToC',
+          recipients: [],
+        });
+
+        sinon.assert.calledOnce(prebuildTxWithIntent);
+        const args = prebuildTxWithIntent.args[0];
+        args[0]!.intentType.should.equal('importtoc');
+        args[0]!.recipients!.should.deepEqual([]);
+        args[0]!.should.not.have.property('nonce');
+        args[0]!.should.not.have.property('feeOptions');
+        args[1]!.should.equal('full');
+      });
+
       it('should call prebuildTxWithIntent with the correct feeOptions when passing using the legacy format', async function () {
         const recipients = [
           {
@@ -3843,6 +3913,34 @@ describe('V2 Wallet:', function () {
         intent.amount!.should.deepEqual(amount);
         intent.feeOptions!.should.deepEqual(feeOptions);
         intent.should.have.property('recipients', undefined);
+      });
+
+      it('populate intent should return valid export intent for EVM cross-chain', async function () {
+        const mpcUtils = new ECDSAUtils.EcdsaUtils(bitgo, bitgo.coin('hteth'));
+        const feeOptions = {
+          maxFeePerGas: 3000000000,
+          maxPriorityFeePerGas: 2000000000,
+        };
+        const recipients = [
+          {
+            address: 'P-costwo1xxt27rgnrjyaw2wmuswxumlmme2tapj62s7uy0',
+            amount: '50000000000000000',
+          },
+        ];
+
+        const intent = mpcUtils.populateIntent(bitgo.coin('hteth'), {
+          reqId,
+          intentType: 'export',
+          recipients,
+          feeOptions,
+          nonce: '5',
+        });
+
+        intent.intentType.should.equal('export');
+        intent.feeOptions!.should.deepEqual(feeOptions);
+        intent.nonce!.should.equal('5');
+        intent.recipients!.should.be.an.Array().with.lengthOf(1);
+        intent.recipients![0].address.address.should.equal(recipients[0].address);
       });
 
       it('should build a single recipient transfer transaction providing apiVersion parameter as "full" ', async function () {

--- a/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
@@ -236,6 +236,13 @@ export abstract class MpcUtils {
             feeOptions: params.feeOptions,
             feeToken: params.feeToken,
           };
+        case 'export':
+          return {
+            ...baseIntent,
+            feeOptions: params.feeOptions,
+            feeToken: params.feeToken,
+            nonce: params.nonce,
+          };
         default:
           throw new Error(`Unsupported intent type ${params.intentType}`);
       }

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -4141,6 +4141,48 @@ export class Wallet implements IWallet {
           params.preview
         );
         break;
+      case 'Export':
+        txRequest = await this.tssUtils!.prebuildTxWithIntent(
+          {
+            reqId,
+            intentType: 'export',
+            sequenceId: params.sequenceId,
+            comment: params.comment,
+            recipients: params.recipients || [],
+            nonce: params.nonce,
+            feeOptions,
+            feeToken: params.feeToken,
+          },
+          apiVersion,
+          params.preview
+        );
+        break;
+      case 'Import':
+        txRequest = await this.tssUtils!.prebuildTxWithIntent(
+          {
+            reqId,
+            intentType: 'import',
+            sequenceId: params.sequenceId,
+            comment: params.comment,
+            recipients: params.recipients || [],
+          },
+          apiVersion,
+          params.preview
+        );
+        break;
+      case 'ImportToC':
+        txRequest = await this.tssUtils!.prebuildTxWithIntent(
+          {
+            reqId,
+            intentType: 'importtoc',
+            sequenceId: params.sequenceId,
+            comment: params.comment,
+            recipients: params.recipients || [],
+          },
+          apiVersion,
+          params.preview
+        );
+        break;
       default:
         throw new Error(`transaction type not supported: ${params.type}`);
     }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                         
                                                                                                                                                                                                                     
  - Add `Export`, `Import`, and `ImportToC` cases to the TSS `prebuildTransactionTxRequests` switch for MPC cross-chain transfers                                                                                    
  - Add `export` case to the EVM `populateIntent` switch in `mpcUtils.ts`
  - Add unit tests for all new cases                                                                                                                                                                                 
                                                            
  ## Context

  MPC (TSS) wallets use `prebuildTransactionTxRequests` which routes transaction types to the `/txrequests` endpoint via `prebuildTxWithIntent`. The existing multisig flow bypasses this switch entirely — it POSTs
  directly to `/tx/build` where `params.type` is forwarded as-is. That's why multisig cross-chain works but MPC wallets hit `"transaction type not supported: Export"`.

  This PR adds the three Avalanche/Flare atomic transaction types to the TSS prebuild switch:

  | `params.type` (from caller) | `intentType` (sent to WP) | Direction |
  |---|---|---|
  | `Export` | `export` | C→P or P→C export |
  | `Import` | `import` | Import into P-chain |
  | `ImportToC` | `importtoc` | Import into C-chain |

  The `Export` case passes `recipients`, `nonce`, `feeOptions`, and `feeToken` since C-chain exports need gas pricing. `Import` and `ImportToC` only pass `recipients` since P-chain fees are computed server-side.

  The `populateIntent` EVM switch also needs the `export` case because FLR is EVM (`baseCoin.isEVM() === true`), so without it the intent would throw `"Unsupported intent type export"` at the EVM default case.
  `Import` and `ImportToC` don't need EVM cases because they originate from FLRP which is non-EVM and uses the generic fallback path.

  ## Changes

  | File | Change |
  |---|---|
  | `modules/sdk-core/src/bitgo/wallet/wallet.ts` | Add `case 'Export'`, `case 'Import'`, `case 'ImportToC'` to `prebuildTransactionTxRequests` switch |
  | `modules/sdk-core/src/bitgo/utils/mpcUtils.ts` | Add `case 'export'` to EVM `populateIntent` switch |
  | `modules/bitgo/test/v2/unit/wallet.ts` | Add 4 unit tests: 3 for prebuild cases + 1 for populateIntent |

  ## Test plan

  - [ ] `yarn unit-test --scope bitgo -- --grep "Export"` — 3 prebuild tests pass
  - [ ] `yarn unit-test --scope bitgo -- --grep "export intent"` — populateIntent test passes
  - [ ] Existing wallet tests still pass (no regression)