### PR TITLE
fix: trading account sign payload should call the ofc url instead of ofctoken

### DIFF
--- a/modules/sdk-core/src/bitgo/trading/tradingAccount.ts
+++ b/modules/sdk-core/src/bitgo/trading/tradingAccount.ts
@@ -61,7 +61,7 @@ export class TradingAccount implements ITradingAccount {
     }
 
     // we do not parse the payload here, we instead sends the payload as a stringified JSON to be signed, just like how we process it locally
-    const url = this.wallet.url('/tx/sign');
+    const url = this.bitgo.coin('ofc').url('/wallet/' + this.wallet.id() + '/tx/sign');
     const payload = typeof params.payload !== 'string' ? JSON.stringify(params.payload) : params.payload;
     const { signature } = await this.wallet.bitgo.post(url).send({ payload }).result();
 

--- a/modules/sdk-core/test/unit/bitgo/trading/tradingAccount.ts
+++ b/modules/sdk-core/test/unit/bitgo/trading/tradingAccount.ts
@@ -26,6 +26,9 @@ describe('TradingAccount', function () {
 
     mockBitGo = {
       post: sinon.stub().returns({ send: sendStub }),
+      coin: sinon.stub().callsFake((coin: string) => ({
+        url: sinon.stub().callsFake((url: string) => `https://app.bitgo-staging.com/api/v2/${coin}${url}`),
+      })),
       decrypt: sinon
         .stub()
         .callsFake(({ input, password }) =>
@@ -48,7 +51,6 @@ describe('TradingAccount', function () {
     mockWallet = {
       id: sinon.stub().returns('test-wallet-id'),
       keyIds: sinon.stub().returns(['user-key-id', 'bitgo-key-id']),
-      url: sinon.stub().returns('https://example.com/wallet/test-wallet-id/tx/sign'),
       toJSON: sinon.stub().returns({
         id: 'test-wallet-id',
         keys: ['user-key-id', 'backup-key-id', 'bitgo-key-id'],
@@ -73,12 +75,17 @@ describe('TradingAccount', function () {
   });
 
   describe('signPayload', function () {
+    it('should call the right url', async function () {
+      const expectedUrl = `https://app.bitgo-staging.com/api/v2/ofc/wallet/test-wallet-id/tx/sign`;
+      await tradingAccount.signPayload({ payload });
+      mockBitGo.post.calledWith(expectedUrl).should.be.true();
+    });
+
     describe('without walletPassphrase or prv (BitGo remote signing)', function () {
       it('should sign using the BitGo key remotely when no passphrase is provided', async function () {
         const result = await tradingAccount.signPayload({ payload });
 
         mockWallet.toJSON.calledOnce.should.be.true();
-        mockWallet.url.calledWith('/tx/sign').should.be.true();
         mockBitGo.post.calledOnce.should.be.true();
         sendStub.calledWith({ payload: JSON.stringify(payload) }).should.be.true();
         result.should.equal(signature);


### PR DESCRIPTION


TICKET: WCN-564

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
