### PR TITLE
chore: update audit exclusions for sanitize-html XSS

### DIFF
--- a/.iyarc
+++ b/.iyarc
@@ -68,22 +68,10 @@ GHSA-9ppj-qmqm-q256
 GHSA-2w8x-224x-785m
 
 # Excluded because:
-# - Arbitrary code execution in protobufjs via malicious protobuf definition files (severity: critical)
-# - Affects protobufjs < 7.5.5; installed versions: 6.11.4 (@cosmjs/stargate), 7.2.5 (@hashgraph/sdk,
-#   sdk-coin-islm, sdk-coin-trx, sdk-coin-hbar), 7.5.4 (abstract-cosmos, sdk-coin-icp)
-# - Exploitation requires attacker-controlled .proto definition files; all protobuf definitions in this
-#   repo are static files bundled within trusted upstream dependencies — not user-supplied
-# - Versions 6.11.4 and 7.2.5 are pinned by upstream deps (@cosmjs ~6.11.x, @hashgraph/sdk 7.2.5)
-#   that do not yet support 7.5.5
-GHSA-xq3m-2v4x-88gg
-
-# Excluded because:
-# - DoS via memory exhaustion in basic-ftp <= 5.2.2 (severity: high, CVSS 7.5)
-# - Client.list() buffers entire directory listings without size limits; a malicious FTP server
-#   can send unbounded data to exhaust client memory
-# - Transitive dependency through pac-proxy-agent > get-uri > basic-ftp; used for PAC-based
-#   proxy resolution, not direct FTP operations
-# - Exploitation requires connecting to a malicious FTP server; all proxy targets in this
-#   project are controlled internal endpoints, not user-supplied FTP URLs
-# - Pinned at 5.2.2 in root resolutions; upstream get-uri has not yet updated to require 5.3.0
-GHSA-rp42-5vxx-qpwr
+# - XSS via xmp raw-text passthrough in sanitize-html (severity: critical, CVE-2026-44990)
+# - patched_versions: "<0.0.0" — no upstream fix exists yet
+# - Used in @bitgo/sdk-api to strip all HTML from API error response text (allowedTags: [])
+# - Output is appended to a JavaScript error string server-side, never rendered as HTML in a browser
+# - The xmp bypass produces live HTML markup in output, but since we discard all tags and use
+#   the result as plain text in Error messages, there is no DOM rendering path and no XSS risk
+GHSA-rpr9-rxv7-x643


### PR DESCRIPTION
Remove stale exclusions GHSA-xq3m-2v4x-88gg and GHSA-rp42-5vxx-qpwr which are no longer reported by yarn audit. Add GHSA-rpr9-rxv7-x643 (sanitize-html xmp XSS, CVE-2026-44990, no upstream fix yet); our usage strips all tags with allowedTags: [] and outputs plain text in error messages, so there is no DOM rendering path.

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
