### PR TITLE
fix: add per-token error isolation in bulk token registration

### DIFF
--- a/modules/bitgo/src/bitgo.ts
+++ b/modules/bitgo/src/bitgo.ts
@@ -85,7 +85,11 @@ export class BitGo extends BitGoAPI {
     const assetEnvironment = ['prod', 'adminProd'].includes(this.getEnv()) ? 'mainnet' : 'testnet';
     const url = this.url(`/assets/list/${assetEnvironment}`);
     const tokenConfigMap = (await this.executeAssetRequest(url)) as Record<string, TrimmedAmsTokenConfig[]>;
-    this.initCoinFactory(tokenConfigMap);
+    try {
+      this.initCoinFactory(tokenConfigMap);
+    } catch (e) {
+      throw new Error(`Failed to initialize coin factory from AMS token metadata: ${(e as Error).message}`);
+    }
   }
 
   /**

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -470,12 +470,21 @@ export function createTokenMapUsingConfigDetails(tokenConfigMap: Record<string, 
 
   // add the tokens not present in the static coin map
   for (const tokenConfigs of Object.values(tokenConfigMap)) {
+    if (!tokenConfigs.length) continue;
     const tokenConfig = tokenConfigs[0];
 
     if (!isCoinPresentInCoinMap({ ...tokenConfig }) && !nftAndOtherTokens.has(tokenConfig.name)) {
-      const token = createToken(tokenConfig);
-      if (token) {
-        BaseCoins.set(token.name, token);
+      try {
+        const token = createToken(tokenConfig);
+        if (token) {
+          BaseCoins.set(token.name, token);
+        }
+      } catch (e) {
+        console.warn(
+          `Skipping malformed token: name="${tokenConfig.name}" id="${tokenConfig.id}" family="${
+            tokenConfig.family
+          }" error=${(e as Error).message}`
+        );
       }
     }
   }
@@ -519,6 +528,7 @@ export function createTokenMapUsingTrimmedConfigDetails(
   const networkNameMap = getNetworksMap();
 
   for (const tokenConfigs of Object.values(reducedTokenConfigMap)) {
+    if (!tokenConfigs.length) continue;
     const tokenConfig = tokenConfigs[0];
     const network = networkNameMap.get(tokenConfig.network.name);
 


### PR DESCRIPTION
TICKET: CGD-722

Wrap createToken() in a try/catch in createTokenMapUsingConfigDetails() so a single malformed AMS entry is skipped with a structured warning instead of aborting the entire loop. Add empty-array guards before tokenConfigs[0] accesses in both createTokenMapUsingConfigDetails() and createTokenMapUsingTrimmedConfigDetails(). Wrap initCoinFactory() in registerAllTokens() for defence-in-depth error surfacing.

