### PR TITLE
fix(sdk-lib-mpc): use MPSUtil.executeTillRound in derive tests

### DIFF
--- a/modules/sdk-lib-mpc/test/unit/tss/eddsa/derive.ts
+++ b/modules/sdk-lib-mpc/test/unit/tss/eddsa/derive.ts
@@ -1,7 +1,8 @@
 import assert from 'assert';
 import { ed25519 } from '@noble/curves/ed25519';
+import { EddsaMPSDsg, MPSUtil } from '../../../../src/tss/eddsa-mps';
 import { deriveUnhardenedMps } from '../../../../src/tss/eddsa-mps/derive';
-import { generateEdDsaDKGKeyShares, runEdDsaDSG } from './util';
+import { generateEdDsaDKGKeyShares } from './util';
 
 const MESSAGE = Buffer.from('The Times 03/Jan/2009 Chancellor on brink of second bailout for banks');
 
@@ -63,28 +64,40 @@ describe('deriveUnhardenedMps', function () {
   });
 
   describe('DSG signature cross-check against the public key derived by deriveUnhardenedMps', function () {
+    let sigAtRoot: Buffer;
+    let sigAtM0: Buffer;
+    let sigAtM01: Buffer;
+
+    before(function () {
+      const dsgA1 = new EddsaMPSDsg.DSG(0);
+      MPSUtil.executeTillRound(3, dsgA1, new EddsaMPSDsg.DSG(2), userKeyShare, bitgoKeyShare, MESSAGE, 'm');
+      sigAtRoot = dsgA1.getSignature();
+
+      const dsgA2 = new EddsaMPSDsg.DSG(0);
+      MPSUtil.executeTillRound(3, dsgA2, new EddsaMPSDsg.DSG(2), userKeyShare, bitgoKeyShare, MESSAGE, 'm/0');
+      sigAtM0 = dsgA2.getSignature();
+
+      const dsgA3 = new EddsaMPSDsg.DSG(0);
+      MPSUtil.executeTillRound(3, dsgA3, new EddsaMPSDsg.DSG(2), userKeyShare, bitgoKeyShare, MESSAGE, 'm/0/1');
+      sigAtM01 = dsgA3.getSignature();
+    });
+
     it('signature from DSG at "m" verifies against the root public key', function () {
-      const { dsgA } = runEdDsaDSG(userKeyShare, bitgoKeyShare, 0, 2, MESSAGE, 'm');
-      const sig = dsgA.getSignature();
-      assert(ed25519.verify(sig, MESSAGE, rootPubKey), 'DSG at "m" should verify against the raw DKG public key');
+      assert(ed25519.verify(sigAtRoot, MESSAGE, rootPubKey), 'DSG at "m" should verify against the raw DKG public key');
     });
 
     it('signature from DSG at "m/0" verifies against deriveUnhardenedMps(commonKeychain, "m/0")', function () {
       const derivedPk = Buffer.from(deriveUnhardenedMps(commonKeychain, 'm/0').slice(0, 64), 'hex');
-      const { dsgA } = runEdDsaDSG(userKeyShare, bitgoKeyShare, 0, 2, MESSAGE, 'm/0');
-      const sig = dsgA.getSignature();
       assert(
-        ed25519.verify(sig, MESSAGE, derivedPk),
+        ed25519.verify(sigAtM0, MESSAGE, derivedPk),
         'DSG at "m/0" should verify against deriveUnhardenedMps result at "m/0"'
       );
     });
 
     it('signature from DSG at "m/0/1" verifies against deriveUnhardenedMps(commonKeychain, "m/0/1")', function () {
       const derivedPk = Buffer.from(deriveUnhardenedMps(commonKeychain, 'm/0/1').slice(0, 64), 'hex');
-      const { dsgA } = runEdDsaDSG(userKeyShare, bitgoKeyShare, 0, 2, MESSAGE, 'm/0/1');
-      const sig = dsgA.getSignature();
       assert(
-        ed25519.verify(sig, MESSAGE, derivedPk),
+        ed25519.verify(sigAtM01, MESSAGE, derivedPk),
         'DSG at "m/0/1" should verify against deriveUnhardenedMps result at "m/0/1"'
       );
     });


### PR DESCRIPTION
The CI on the [WCI-390 PR](https://github.com/BitGo/BitGoJS/pull/8766) failed with:

`  TypeError: (0 , import_util.runEdDsaDSG) is not a function`

###   Fix

  Replace the runEdDsaDSG calls with inline MPSUtil.executeTillRound — the same pattern already used throughout dsg.ts. No test logic changes; this is purely a fix.
  
  TICKET: WCI-390

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
