### PR TITLE
feat(sdk-core): added OFC BitGo signing on wallet and coins object

### DIFF
--- a/modules/sdk-core/src/bitgo/trading/iTradingAccount.ts
+++ b/modules/sdk-core/src/bitgo/trading/iTradingAccount.ts
@@ -18,6 +18,7 @@ export interface SignPayloadParameters {
 
 export interface ITradingAccount {
   readonly id: string;
+  readonly userKeySigningRequired: boolean;
   signPayload(params: SignPayloadParameters): Promise<string>;
   toNetwork(): ITradingNetwork;
 }

--- a/modules/sdk-core/src/bitgo/trading/tradingAccount.ts
+++ b/modules/sdk-core/src/bitgo/trading/tradingAccount.ts
@@ -11,11 +11,16 @@ export class TradingAccount implements ITradingAccount {
   private readonly enterpriseId: string;
 
   public wallet: IWallet;
+  public readonly userKeySigningRequired: boolean;
 
   constructor(enterpriseId: string, wallet: IWallet, bitgo: BitGoBase) {
     this.enterpriseId = enterpriseId;
     this.wallet = wallet;
     this.bitgo = bitgo;
+
+    const walletData = this.wallet.toJSON();
+    this.userKeySigningRequired =
+      walletData.coinSpecific?.userKeySigningRequired ?? walletData.userKeySigningRequired ?? true;
   }
 
   get id(): string {
@@ -48,10 +53,9 @@ export class TradingAccount implements ITradingAccount {
     params: Omit<SignPayloadParameters, 'walletPassphrase' | 'prv'>
   ): Promise<string> {
     const walletData = this.wallet.toJSON();
-    const userKeySigningRequired = walletData.coinSpecific?.userKeySigningRequired ?? walletData.userKeySigningRequired;
-    if (userKeySigningRequired) {
+    if (this.userKeySigningRequired) {
       throw new Error(
-        'Wallet must use user key to sign ofc transaction, please provide the wallet passphrase or visit your wallet settings page to configure one.'
+        'Wallet must use user key to sign ofc transaction, please provide the wallet passphrase, the private key, or visit your wallet settings page to configure one.'
       );
     }
     if (walletData.keys.length < 2) {

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -2137,7 +2137,7 @@ export class Wallet implements IWallet {
    * @param params
    * - txPrebuild
    * - [keychain / key] (object) or prv (string)
-   * - walletPassphrase
+   * - walletPassphrase (optional ONLY for OFC wallets with userKeySigningRequired = false)
    * - verifyTxParams (optional) - when provided, the transaction will be verified before signing
    *   - txParams: transaction parameters used for verification
    *   - verification: optional verification options
@@ -2264,6 +2264,17 @@ export class Wallet implements IWallet {
       };
       return params.customSigningFunction(signTransactionParamsWithSeed);
     }
+
+    if (this.baseCoin.getFamily() === 'ofc') {
+      const userKeySigningRequired = this.toTradingAccount().userKeySigningRequired;
+      const prv = userKeySigningRequired ? await this.getUserPrvAsync(presign as GetUserPrvOptions) : undefined;
+      return this.baseCoin.signTransaction({
+        ...signTransactionParams,
+        prv,
+        wallet: this,
+      });
+    }
+
     return this.baseCoin.signTransaction({
       ...signTransactionParams,
       prv: await this.getUserPrvAsync(presign as GetUserPrvOptions),

--- a/modules/sdk-core/src/coins/ofc.ts
+++ b/modules/sdk-core/src/coins/ofc.ts
@@ -15,6 +15,7 @@ import {
   SignTransactionOptions,
   VerifyAddressOptions,
   VerifyTransactionOptions,
+  Wallet,
 } from '../';
 
 export class Ofc extends BaseCoin {
@@ -102,6 +103,26 @@ export class Ofc extends BaseCoin {
 
   async signTransaction(params: SignTransactionOptions): Promise<SignedTransaction> {
     throw new MethodNotImplementedError();
+  }
+
+  /**
+   * Signs a message using a trading wallet's BitGo Key
+   * @param wallet - uses the BitGo key of this trading wallet to sign the message remotely in a KMS
+   * @param message
+   */
+  async signMessage(wallet: Wallet, message: string): Promise<Buffer>;
+  /**
+   * Signs a message using the private key
+   * @param key - uses the private key to sign the message
+   * @param message
+   */
+  async signMessage(key: { prv: string }, message: string): Promise<Buffer>;
+  async signMessage(keyOrWallet: { prv: string } | Wallet, message: string): Promise<Buffer> {
+    if (!(keyOrWallet instanceof Wallet)) {
+      return super.signMessage(keyOrWallet, message);
+    }
+    const signatureHexString = await keyOrWallet.toTradingAccount().signPayload({ payload: message });
+    return Buffer.from(signatureHexString, 'hex');
   }
 
   /** @inheritDoc */

--- a/modules/sdk-core/src/coins/ofcToken.ts
+++ b/modules/sdk-core/src/coins/ofcToken.ts
@@ -9,17 +9,25 @@ import {
   SignTransactionOptions as BaseSignTransactionOptions,
   SignedTransaction,
   ITransactionRecipient,
+  IWallet,
 } from '../';
 import { isBolt11Invoice } from '../lightning';
 
 import { Ofc } from './ofc';
 
-export interface SignTransactionOptions extends BaseSignTransactionOptions {
-  txPrebuild: {
-    payload: string;
-  };
+type OfcAllowRemoteSignOptions = BaseSignTransactionOptions & {
+  txPrebuild: { payload: string };
+  wallet: IWallet;
+  prv?: string; // optional: forwarded to signPayload if present
+};
+
+type OfcLocalSignOptions = BaseSignTransactionOptions & {
+  txPrebuild: { payload: string };
   prv: string;
-}
+  wallet?: never; // excludes wallet from this branch
+};
+
+export type SignTransactionOptions = OfcAllowRemoteSignOptions | OfcLocalSignOptions;
 
 export { OfcTokenConfig };
 
@@ -107,15 +115,30 @@ export class OfcToken extends Ofc {
   }
 
   /**
-   * Assemble keychain and half-sign prebuilt transaction
+   * Signs a half-signed OFC transaction.
+   * Signs the transaction remotely using the BitGo key if prv is not provided.
    * @param params
    * @returns {Promise<SignedTransaction>}
    */
   async signTransaction(params: SignTransactionOptions): Promise<SignedTransaction> {
     const txPrebuild = params.txPrebuild;
     const payload = txPrebuild.payload;
-    const signatureBuffer = (await this.signMessage(params, payload)) as any;
-    const signature: string = signatureBuffer.toString('hex');
+
+    let signature: string;
+    if (params.wallet) {
+      const tradingAccount = params.wallet.toTradingAccount();
+      if (!params.prv && tradingAccount.userKeySigningRequired) {
+        throw new Error(
+          'Wallet must use user key to sign ofc transaction, please provide the private key or visit your wallet settings page to configure one.'
+        );
+      }
+      signature = await tradingAccount.signPayload({ payload, prv: params.prv });
+    } else if (params.prv) {
+      signature = (await this.signMessage({ prv: params.prv }, payload)).toString('hex');
+    } else {
+      throw new Error('You must pass in either one of wallet or prv');
+    }
+
     return { halfSigned: { payload, signature } } as any;
   }
 

--- a/modules/sdk-core/test/unit/bitgo/trading/tradingAccount.ts
+++ b/modules/sdk-core/test/unit/bitgo/trading/tradingAccount.ts
@@ -7,8 +7,10 @@ import { TradingAccount } from '../../../../src/bitgo/trading/tradingAccount';
 
 describe('TradingAccount', function () {
   let tradingAccount: TradingAccount;
+  let userKeyRequiredTradingAccount: TradingAccount;
   let mockBitGo: any;
   let mockWallet: any;
+  let mockUserKeyRequiredWallet: any;
   let mockBaseCoin: any;
   let sendStub: sinon.SinonStub;
 
@@ -54,13 +56,27 @@ describe('TradingAccount', function () {
       toJSON: sinon.stub().returns({
         id: 'test-wallet-id',
         keys: ['user-key-id', 'backup-key-id', 'bitgo-key-id'],
-        coinSpecific: {},
+        coinSpecific: {
+          userKeySigningRequired: false,
+        },
       }),
       baseCoin: mockBaseCoin,
       bitgo: mockBitGo,
     };
 
+    mockUserKeyRequiredWallet = {
+      ...mockWallet,
+      toJSON: sinon.stub().returns({
+        id: 'test-wallet-id',
+        keys: ['user-key-id', 'backup-key-id', 'bitgo-key-id'],
+        coinSpecific: {
+          userKeySigningRequired: true,
+        },
+      }),
+    };
+
     tradingAccount = new TradingAccount(enterpriseId, mockWallet, mockBitGo);
+    userKeyRequiredTradingAccount = new TradingAccount(enterpriseId, mockUserKeyRequiredWallet, mockBitGo);
   });
 
   afterEach(function () {
@@ -85,7 +101,6 @@ describe('TradingAccount', function () {
       it('should sign using the BitGo key remotely when no passphrase is provided', async function () {
         const result = await tradingAccount.signPayload({ payload });
 
-        mockWallet.toJSON.calledOnce.should.be.true();
         mockBitGo.post.calledOnce.should.be.true();
         sendStub.calledWith({ payload: JSON.stringify(payload) }).should.be.true();
         result.should.equal(signature);
@@ -98,31 +113,18 @@ describe('TradingAccount', function () {
       });
 
       it('should throw if coinSpecific.userKeySigningRequired is true and no passphrase and prv are provided', async function () {
-        mockWallet.toJSON.onCall(mockWallet.toJSON.callCount).returns({
-          id: 'test-wallet-id',
-          keys: ['user-key-id', 'backup-key-id', 'bitgo-key-id'],
-          coinSpecific: { userKeySigningRequired: true },
-        });
-
-        await tradingAccount
+        await userKeyRequiredTradingAccount
           .signPayload({ payload })
           .should.be.rejectedWith(
-            'Wallet must use user key to sign ofc transaction, please provide the wallet passphrase or visit your wallet settings page to configure one.'
+            'Wallet must use user key to sign ofc transaction, please provide the wallet passphrase, the private key, or visit your wallet settings page to configure one.'
           );
       });
 
       it('should fall back to top-level userKeySigningRequired when coinSpecific does not carry it', async function () {
-        mockWallet.toJSON.onCall(mockWallet.toJSON.callCount).returns({
-          id: 'test-wallet-id',
-          keys: ['user-key-id', 'backup-key-id', 'bitgo-key-id'],
-          coinSpecific: {},
-          userKeySigningRequired: true,
-        });
-
-        await tradingAccount
+        await userKeyRequiredTradingAccount
           .signPayload({ payload })
           .should.be.rejectedWith(
-            'Wallet must use user key to sign ofc transaction, please provide the wallet passphrase or visit your wallet settings page to configure one.'
+            'Wallet must use user key to sign ofc transaction, please provide the wallet passphrase, the private key, or visit your wallet settings page to configure one.'
           );
       });
 

--- a/modules/sdk-core/test/unit/bitgo/wallet/ofcWalletSignTransaction.ts
+++ b/modules/sdk-core/test/unit/bitgo/wallet/ofcWalletSignTransaction.ts
@@ -3,66 +3,210 @@
  */
 import sinon from 'sinon';
 import 'should';
-import { Wallet } from '../../../../src';
+import { Wallet, BaseCoin } from '../../../../src';
+import { OfcToken } from '../../../../src/coins';
 
-describe('Wallet - OFC signTransaction', function () {
+const TEST_TOKEN_CONFIG = {
+  coin: 'ofcusdt',
+  decimalPlaces: 6,
+  name: 'OFCUSDT',
+  type: 'ofcusdt',
+  backingCoin: 'usdt',
+  isFiat: false,
+};
+
+describe('Wallet - OFC', function () {
   let wallet: Wallet;
   let mockBitGo: any;
-  let mockBaseCoin: any;
-  let mockWalletData: any;
+  let ofcToken: OfcToken;
+  let signMessageStub: sinon.SinonStub;
+  const signatureBytes = Buffer.from('aabbccdd', 'hex');
+  const payload = '{"amount":"100","from":"alice","to":"bob"}';
+  const prv = 'test-prv';
+  // bg-<32 hex chars> is valid for OfcToken without needing to resolve the backing coin
+  const recipients = [{ address: 'bg-aabbccddeeff00112233445566778899', amount: '100' }];
+  const userPub =
+    'xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC51xERxh8vDMjc3PiGpQ3VeQcHBiGxbsrRXbCKQZZxBtDMrmBRzxRMkBJGsC9bsYb5tggVF3jGfEE';
+
+  const walletData = {
+    id: 'test-wallet-id',
+    coin: 'ofcusdt',
+    keys: ['user-key', 'backup-key', 'bitgo-key'],
+    type: 'trading',
+    multisigType: 'onchain',
+    enterprise: 'ent-id',
+  };
+
+  /**
+   * Creates a fluent request mock that handles .query().send().result() and .send().result()
+   * chains, resolving with the provided value.
+   */
+  function makeRequestChain(resolved: unknown): any {
+    const chain: any = {};
+    chain.query = sinon.stub().returns(chain);
+    chain.send = sinon.stub().returns(chain);
+    chain.result = sinon.stub().resolves(resolved);
+    return chain;
+  }
 
   beforeEach(function () {
+    signMessageStub = sinon.stub(BaseCoin.prototype, 'signMessage');
+    signMessageStub.withArgs({ prv }, payload).resolves(signatureBytes);
+    sinon.stub(BaseCoin.prototype, 'keychains').returns({
+      getKeysForSigning: sinon.stub().resolves([{ id: walletData.keys[0], pub: userPub }]),
+    } as any);
     mockBitGo = {
-      url: sinon.stub().returns('https://test.bitgo.com'),
+      url: sinon.stub().returns('https://test.bitgo.com/'),
       post: sinon.stub(),
-      get: sinon.stub(),
       setRequestTracer: sinon.stub(),
     };
-
-    mockBaseCoin = {
-      getFamily: sinon.stub().returns('ofc'),
-      url: sinon.stub().returns('https://test.bitgo.com/wallet'),
-      keychains: sinon.stub(),
-      supportsTss: sinon.stub().returns(false),
-      getMPCAlgorithm: sinon.stub(),
-      presignTransaction: sinon.stub().resolvesArg(0),
-      keyIdsForSigning: sinon.stub().returns([0]),
-      signTransaction: sinon.stub().resolves({ halfSigned: { payload: 'test', signature: 'aabbcc' } }),
-    };
-
-    mockWalletData = {
-      id: 'test-wallet-id',
-      coin: 'ofcusdt',
-      keys: ['user-key', 'backup-key', 'bitgo-key'],
-      multisigType: 'onchain',
-      enterprise: 'ent-id',
-    };
-
-    wallet = new Wallet(mockBitGo, mockBaseCoin, mockWalletData);
+    ofcToken = new OfcToken(mockBitGo, TEST_TOKEN_CONFIG);
+    mockBitGo.coin = sinon.stub().returns(ofcToken);
+    wallet = new Wallet(mockBitGo, ofcToken, walletData);
   });
 
   afterEach(function () {
     sinon.restore();
   });
 
-  it('should pass prv and paylaod to baseCoin.signTransaction', async function () {
-    const txPrebuild = { txInfo: { payload: '{"amount":"100"}' } } as any;
-    const prv = 'test-prv';
+  describe('with userKeySigningRequired: true (local signing via user key)', function () {
+    const buildUrl = () => ofcToken.url('/wallet/' + walletData.id + '/tx/build');
+    const signUrl = () => ofcToken.url('/wallet/' + walletData.id + '/tx/sign');
+    const sendUrl = () => ofcToken.url('/wallet/' + walletData.id + '/tx/send');
 
-    await wallet.signTransaction({ txPrebuild, prv });
+    describe('signTransaction', function () {
+      it('should call baseCoin.signMessage with the prv and payload', async function () {
+        const result = await wallet.signTransaction({ txPrebuild: { payload } as any, prv });
 
-    mockBaseCoin.signTransaction.calledOnce.should.be.true();
-    mockBaseCoin.signTransaction.calledWith({ txPrebuild, prv });
-    const callArgs = mockBaseCoin.signTransaction.getCall(0).args[0];
-    callArgs.prv.should.equal(prv);
+        signMessageStub.calledOnceWith({ prv }, payload).should.be.true();
+        mockBitGo.post.called.should.be.false();
+        result.should.deepEqual({ halfSigned: { payload, signature: signatureBytes.toString('hex') } });
+      });
+
+      describe('with walletPassphrase and keychain', function () {
+        const walletPassphrase = 'test-passphrase';
+        const encryptedPrv = 'encrypted-prv-blob';
+
+        beforeEach(function () {
+          // compiled wallet.js: getUserPrv (sync) → decryptKeychainPrivateKey → bitgo.decrypt
+          // TypeScript source:  getUserPrvAsync        → decryptKeychainPrivateKeyAsync → bitgo.decryptAsync
+          mockBitGo.decrypt = sinon.stub().returns(prv);
+          mockBitGo.decryptAsync = sinon.stub().resolves(prv);
+        });
+
+        it('should decrypt the keychain with the passphrase and sign via baseCoin.signMessage', async function () {
+          const result = await wallet.signTransaction({
+            txPrebuild: { payload } as any,
+            walletPassphrase,
+            keychain: { pub: userPub, encryptedPrv } as any,
+          });
+
+          const decryptCalled =
+            mockBitGo.decrypt.calledWith({ input: encryptedPrv, password: walletPassphrase }) ||
+            mockBitGo.decryptAsync.calledWith({ input: encryptedPrv, password: walletPassphrase });
+          decryptCalled.should.be.true();
+          signMessageStub.calledOnceWith({ prv }, payload).should.be.true();
+          mockBitGo.post.called.should.be.false();
+          result.should.deepEqual({ halfSigned: { payload, signature: signatureBytes.toString('hex') } });
+        });
+      });
+    });
+
+    describe('prebuildAndSignTransaction', function () {
+      beforeEach(function () {
+        mockBitGo.post.withArgs(buildUrl()).returns(makeRequestChain({ payload }));
+      });
+
+      it('should call the prebuild API then sign locally with the prv', async function () {
+        const result = await wallet.prebuildAndSignTransaction({ prv });
+
+        mockBitGo.post.calledWith(buildUrl()).should.be.true();
+        mockBitGo.post.calledWith(signUrl()).should.be.false();
+        signMessageStub.calledOnceWith({ prv }, payload).should.be.true();
+        result.should.deepEqual({ halfSigned: { payload, signature: signatureBytes.toString('hex') } });
+      });
+    });
+
+    describe('sendMany', function () {
+      beforeEach(function () {
+        mockBitGo.post.withArgs(buildUrl()).returns(makeRequestChain({ payload }));
+        mockBitGo.post.withArgs(sendUrl()).returns(makeRequestChain({ txid: 'test-txid', status: 'signed' }));
+      });
+
+      it('should prebuild, sign locally, and submit to the send endpoint', async function () {
+        const result = await wallet.sendMany({ recipients, prv });
+
+        mockBitGo.post.calledWith(buildUrl()).should.be.true();
+        signMessageStub.calledOnceWith({ prv }, payload).should.be.true();
+        mockBitGo.post.calledWith(sendUrl()).should.be.true();
+        result.should.deepEqual({ txid: 'test-txid', status: 'signed' });
+      });
+    });
   });
 
-  it('should return the result from baseCoin.signTransaction', async function () {
-    const txPrebuild = { txInfo: { payload: '{"amount":"100"}' } } as any;
-    const prv = 'test-prv';
+  describe('with userKeySigningRequired: false (remote signing via BitGo key)', function () {
+    const signUrl = () => ofcToken.url('/wallet/' + walletData.id + '/tx/sign');
+    const buildUrl = () => ofcToken.url('/wallet/' + walletData.id + '/tx/build');
+    const sendUrl = () => ofcToken.url('/wallet/' + walletData.id + '/tx/send');
+    const hexSignature = 'deadbeef';
+    let remoteWallet: Wallet;
 
-    const result = await wallet.signTransaction({ txPrebuild, prv });
+    beforeEach(function () {
+      remoteWallet = new Wallet(mockBitGo, ofcToken, { ...walletData, userKeySigningRequired: false });
+      // compiled wallet.js calls getUserPrv (sync) for all coins; stub to return undefined
+      // so the remote signing path reaches baseCoin.signTransaction with prv: undefined
+      (remoteWallet as any).getUserPrv = sinon.stub().returns(undefined);
+      mockBitGo.post.withArgs(signUrl()).returns(makeRequestChain({ signature: hexSignature }));
+    });
 
-    result.should.deepEqual({ halfSigned: { payload: 'test', signature: 'aabbcc' } });
+    it('should sign locally when userKeySigningRequired is true and prv is provided', async function () {
+      const strictWallet = new Wallet(mockBitGo, ofcToken, { ...walletData, userKeySigningRequired: true });
+      const result = await strictWallet.signTransaction({ txPrebuild: { payload } as any, prv });
+
+      signMessageStub.calledOnceWith({ prv }, payload).should.be.true();
+      mockBitGo.post.calledWith(signUrl()).should.be.false();
+      result.should.deepEqual({ halfSigned: { payload, signature: signatureBytes.toString('hex') } });
+    });
+
+    describe('signTransaction', function () {
+      it('should POST to the sign endpoint and return the halfSigned result', async function () {
+        const result = await remoteWallet.signTransaction({ txPrebuild: { payload } as any });
+
+        mockBitGo.post.calledWith(signUrl()).should.be.true();
+        signMessageStub.called.should.be.false();
+        result.should.deepEqual({ halfSigned: { payload, signature: hexSignature } });
+      });
+    });
+
+    describe('prebuildAndSignTransaction', function () {
+      beforeEach(function () {
+        mockBitGo.post.withArgs(buildUrl()).returns(makeRequestChain({ payload }));
+      });
+
+      it('should prebuild and remotely sign the transaction', async function () {
+        const result = await remoteWallet.prebuildAndSignTransaction({});
+
+        mockBitGo.post.calledWith(buildUrl()).should.be.true();
+        mockBitGo.post.calledWith(signUrl()).should.be.true();
+        signMessageStub.called.should.be.false();
+        result.should.deepEqual({ halfSigned: { payload, signature: hexSignature } });
+      });
+    });
+
+    describe('sendMany', function () {
+      beforeEach(function () {
+        mockBitGo.post.withArgs(buildUrl()).returns(makeRequestChain({ payload }));
+        mockBitGo.post.withArgs(sendUrl()).returns(makeRequestChain({ txid: 'test-txid', status: 'signed' }));
+      });
+
+      it('should prebuild, remotely sign, and send the transaction', async function () {
+        const result = await remoteWallet.sendMany({ recipients });
+
+        mockBitGo.post.calledWith(buildUrl()).should.be.true();
+        mockBitGo.post.calledWith(signUrl()).should.be.true();
+        signMessageStub.called.should.be.false();
+        result.should.deepEqual({ txid: 'test-txid', status: 'signed' });
+      });
+    });
   });
 });

--- a/modules/sdk-core/test/unit/coins/ofc.ts
+++ b/modules/sdk-core/test/unit/coins/ofc.ts
@@ -1,0 +1,140 @@
+/**
+ * @prettier
+ */
+import sinon from 'sinon';
+import 'should';
+import { Ofc, OfcToken, SignTransactionOptions } from '../../../src/coins';
+import { BaseCoin, Wallet } from '../../../src';
+
+const TEST_TOKEN_CONFIG = {
+  coin: 'ofcusdt',
+  decimalPlaces: 6,
+  name: 'OFCUSDT',
+  type: 'ofcusdt',
+  backingCoin: 'usdt',
+  isFiat: false,
+};
+
+describe('Ofc / OfcToken', function () {
+  let mockBitGo: any;
+  let signMessageStub: sinon.SinonStub;
+  const hexSignature = 'deadbeef';
+  const signatureBytes = Buffer.from('aabbccdd', 'hex');
+  const walletData = {
+    id: 'wallet-id',
+    keys: ['userKey', 'bitgoKey'],
+    type: 'trading',
+    multisigType: 'onchain',
+    enterprise: 'ent-id',
+    userKeySigningRequired: false,
+  };
+
+  beforeEach(function () {
+    signMessageStub = sinon.stub(BaseCoin.prototype, 'signMessage').resolves(signatureBytes);
+    mockBitGo = {
+      url: sinon.stub().returns('https://test.bitgo.com/'),
+      post: sinon.stub(),
+    };
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  describe('signMessage', function () {
+    let ofc: Ofc;
+
+    beforeEach(function () {
+      mockBitGo.post.returnsThis();
+      mockBitGo.send = sinon.stub().returnsThis();
+      mockBitGo.result = sinon.stub().resolves({ signature: hexSignature });
+      ofc = new Ofc(mockBitGo);
+      mockBitGo.coin = sinon.stub().returns(ofc);
+    });
+
+    describe('with a Wallet instance', function () {
+      it('should delegate to wallet.toTradingAccount().signPayload() and return a Buffer', async function () {
+        const wallet = new Wallet(mockBitGo, ofc, walletData);
+
+        const message = 'test message';
+        const result = await ofc.signMessage(wallet, message);
+
+        mockBitGo.send.calledOnceWith({ payload: message }).should.be.true();
+        mockBitGo.result.calledOnce.should.be.true();
+        result.should.deepEqual(Buffer.from(hexSignature, 'hex'));
+      });
+    });
+
+    describe('with a prv key', function () {
+      it('should delegate to the base class signMessage with the exact key and message', async function () {
+        const key = {
+          prv: 'xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqhuCo36EkzGH6qiT9mJHBvuPKtLRYD4NxFb5hgXMQBB2LLT6mxLDHHo',
+        };
+        const message = 'test message';
+        const result = await ofc.signMessage(key, message);
+
+        signMessageStub.calledOnceWith(key, message).should.be.true();
+        result.should.equal(signatureBytes);
+      });
+    });
+  });
+
+  describe('signTransaction (OfcToken)', function () {
+    let ofcToken: OfcToken;
+    const payload = '{"amount":"100","from":"alice","to":"bob"}';
+
+    beforeEach(function () {
+      ofcToken = new OfcToken(mockBitGo, TEST_TOKEN_CONFIG);
+      mockBitGo.coin = sinon.stub().returns(ofcToken);
+    });
+
+    describe('with wallet and no prv (BitGo remote signing)', function () {
+      it('should POST to the wallet sign endpoint with the payload and return the halfSigned result', async function () {
+        const sendStub = sinon.stub();
+        const resultStub = sinon.stub().resolves({ signature: hexSignature });
+        sendStub.returns({ result: resultStub });
+        mockBitGo.post.returns({ send: sendStub });
+
+        const wallet = new Wallet(mockBitGo, ofcToken, walletData);
+        const expectedUrl = ofcToken.url('/wallet/' + walletData.id + '/tx/sign');
+        const result = await ofcToken.signTransaction({ txPrebuild: { payload }, wallet });
+
+        mockBitGo.post.calledOnceWith(expectedUrl).should.be.true();
+        sendStub.calledOnceWith({ payload }).should.be.true();
+        result.should.deepEqual({ halfSigned: { payload, signature: hexSignature } });
+      });
+    });
+
+    describe('with wallet and prv (local signing routed through wallet)', function () {
+      it('should pass prv directly to signPayload and sign via baseCoin.signMessage', async function () {
+        const prv = 'test-prv';
+        const wallet = new Wallet(mockBitGo, ofcToken, walletData);
+        const result = await ofcToken.signTransaction({ txPrebuild: { payload }, wallet, prv });
+
+        signMessageStub.calledOnceWith({ prv }, payload).should.be.true();
+        mockBitGo.post.called.should.be.false();
+        result.should.deepEqual({ halfSigned: { payload, signature: signatureBytes.toString('hex') } });
+      });
+    });
+
+    describe('with prv only (local signing without wallet)', function () {
+      it('should pass the prv to baseCoin.signMessage and return the correct halfSigned result', async function () {
+        const prv = 'test-prv';
+
+        const result = await ofcToken.signTransaction({ txPrebuild: { payload }, prv });
+
+        signMessageStub.calledOnceWith({ prv }, payload).should.be.true();
+        mockBitGo.post.called.should.be.false();
+        result.should.deepEqual({ halfSigned: { payload, signature: signatureBytes.toString('hex') } });
+      });
+    });
+
+    describe('with neither wallet nor prv', function () {
+      it('should throw an error', async function () {
+        await ofcToken
+          .signTransaction({ txPrebuild: { payload } } as SignTransactionOptions)
+          .should.be.rejectedWith('You must pass in either one of wallet or prv');
+      });
+    });
+  });
+});


### PR DESCRIPTION
allow wallet and coins object to sign using the BitGo key if the passphrase is not provided during signing

Ticket: WCN-217-2

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
