### PR TITLE
feat(sdk-core): add v2 decryption support to password change

### DIFF
--- a/modules/bitgo/test/v2/unit/keychains.ts
+++ b/modules/bitgo/test/v2/unit/keychains.ts
@@ -212,6 +212,61 @@ describe('V2 Keychains', function () {
         );
       });
 
+      it('to update the password for a single keychain (async)', async function () {
+        await keychains
+          .updateSingleKeychainPasswordAsync({ newPassword: '5678' })
+          .should.be.rejectedWith('expected old password to be a string');
+
+        await keychains
+          .updateSingleKeychainPasswordAsync({ oldPassword: 1234, newPassword: '5678' })
+          .should.be.rejectedWith('expected old password to be a string');
+
+        await keychains
+          .updateSingleKeychainPasswordAsync({ oldPassword: '1234' })
+          .should.be.rejectedWith('expected new password to be a string');
+
+        await keychains
+          .updateSingleKeychainPasswordAsync({ oldPassword: '1234', newPassword: 5678 })
+          .should.be.rejectedWith('expected new password to be a string');
+
+        await keychains
+          .updateSingleKeychainPasswordAsync({ oldPassword: '1234', newPassword: '5678' })
+          .should.be.rejectedWith('expected keychain to be an object with an encryptedPrv property');
+
+        await keychains
+          .updateSingleKeychainPasswordAsync({ oldPassword: '1234', newPassword: '5678', keychain: {} })
+          .should.be.rejectedWith('expected keychain to be an object with an encryptedPrv property');
+
+        await keychains
+          .updateSingleKeychainPasswordAsync({
+            oldPassword: '1234',
+            newPassword: '5678',
+            keychain: { encryptedPrv: 123 },
+          })
+          .should.be.rejectedWith('expected keychain to be an object with an encryptedPrv property');
+
+        // wrong password — decrypt fails
+        const keychain = { encryptedPrv: bitgo.encrypt({ input: 'xprv1', password: otherPassword }) };
+        await keychains
+          .updateSingleKeychainPasswordAsync({ oldPassword, newPassword, keychain })
+          .should.be.rejectedWith('failed to update keychain password: incorrect password');
+
+        // invalid JSON in encryptedPrv
+        await keychains
+          .updateSingleKeychainPasswordAsync({ oldPassword, newPassword, keychain: { encryptedPrv: 'not-valid-json' } })
+          .should.be.rejectedWith('failed to update keychain password: decrypt: ciphertext is not valid JSON');
+
+        // unknown envelope version
+        const unknownVersionEnvelope = JSON.stringify({ v: 99, ct: 'abc' });
+        await keychains
+          .updateSingleKeychainPasswordAsync({
+            oldPassword,
+            newPassword,
+            keychain: { encryptedPrv: unknownVersionEnvelope },
+          })
+          .should.be.rejectedWith('failed to update keychain password: decrypt: unknown envelope version 99');
+      });
+
       it('on any other error', async function () {
         nock(bgUrl)
           .get('/api/v2/tltc/key')
@@ -225,7 +280,7 @@ describe('V2 Keychains', function () {
             ],
           });
 
-        sandbox.stub(keychains, 'updateSingleKeychainPassword').throws('error', 'some random error');
+        sandbox.stub(keychains, 'updateSingleKeychainPasswordAsync').throws('error', 'some random error');
 
         await keychains.updatePassword({ oldPassword, newPassword }).should.be.rejectedWith('some random error');
       });
@@ -313,17 +368,76 @@ describe('V2 Keychains', function () {
         validateKeys(keys, newPassword, 3);
       });
 
-      it('single keychain password update', () => {
+      it('single keychain password update', async () => {
         const prv = 'xprvtest';
         const keychain = {
           xpub: 'xpub123',
           encryptedPrv: bitgo.encrypt({ input: prv, password: oldPassword }),
         };
 
-        const newKeychain = keychains.updateSingleKeychainPassword({ keychain, oldPassword, newPassword });
+        const newKeychain = await keychains.updateSingleKeychainPassword({ keychain, oldPassword, newPassword });
 
         const decryptedPrv = bitgo.decrypt({ input: newKeychain.encryptedPrv, password: newPassword });
         decryptedPrv.should.equal(prv);
+      });
+
+      it('single keychain password update preserves v2 (Argon2id) envelope', async () => {
+        const prv = 'xprvtest-v2';
+        const encryptedPrv = await bitgo.encryptAsync({ input: prv, password: oldPassword, encryptionVersion: 2 });
+        const envelope = JSON.parse(encryptedPrv);
+        envelope.v.should.equal(2, 'pre-condition: keychain must be v2-encrypted');
+
+        const keychain = { xpub: 'xpub123', encryptedPrv };
+        const newKeychain = await keychains.updateSingleKeychainPasswordAsync({ keychain, oldPassword, newPassword });
+
+        const newEnvelope = JSON.parse(newKeychain.encryptedPrv);
+        newEnvelope.v.should.equal(2, 're-encrypted keychain must still be v2');
+
+        const decryptedPrv = await bitgo.decryptAsync({ input: newKeychain.encryptedPrv, password: newPassword });
+        decryptedPrv.should.equal(prv, 'new password must decrypt to original prv');
+
+        await bitgo.decryptAsync({ input: newKeychain.encryptedPrv, password: oldPassword }).should.be.rejected();
+      });
+
+      it('updatePassword handles a mix of v1 and v2 keychains', async function () {
+        const v1Prv = 'xprv-v1';
+        const v2Prv = 'xprv-v2';
+
+        nock(bgUrl)
+          .get('/api/v2/tltc/key')
+          .query(true)
+          .reply(200, {
+            keys: [
+              {
+                pub: 'xpub-v1',
+                encryptedPrv: bitgo.encrypt({ input: v1Prv, password: oldPassword }),
+              },
+              {
+                pub: 'xpub-v2',
+                encryptedPrv: await bitgo.encryptAsync({ input: v2Prv, password: oldPassword, encryptionVersion: 2 }),
+              },
+              {
+                pub: 'xpub-other',
+                encryptedPrv: bitgo.encrypt({ input: 'xprv-other', password: 'different-password' }),
+              },
+            ],
+          });
+
+        const updatedKeys = await keychains.updatePassword({ oldPassword, newPassword });
+
+        assert.strictEqual(Object.keys(updatedKeys).length, 2, 'only the two matching keychains should be updated');
+
+        const updatedV1 = updatedKeys['xpub-v1'];
+        const updatedV2 = updatedKeys['xpub-v2'];
+        assert.ok(updatedV1, 'v1 keychain must be in the result');
+        assert.ok(updatedV2, 'v2 keychain must be in the result');
+
+        bitgo.decrypt({ input: updatedV1, password: newPassword }).should.equal(v1Prv);
+
+        const updatedV2Envelope = JSON.parse(updatedV2);
+        updatedV2Envelope.v.should.equal(2, 'v2 keychain must remain v2 after password change');
+        const decryptedV2 = await bitgo.decryptAsync({ input: updatedV2, password: newPassword });
+        decryptedV2.should.equal(v2Prv);
       });
 
       it('should return the updated keys with ids', async function () {
@@ -502,7 +616,7 @@ describe('V2 Keychains', function () {
             },
           });
 
-        sandbox.stub(BitGo.prototype, 'decrypt').returns(decryptResult);
+        sandbox.stub(bitgo, 'decryptAsync').resolves(decryptResult);
       });
 
       afterEach(function () {

--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -1247,7 +1247,7 @@ export async function handleKeychainChangePassword(
     );
   }
 
-  const updatedKeychain = coin.keychains().updateSingleKeychainPassword({
+  const updatedKeychain = await coin.keychains().updateSingleKeychainPasswordAsync({
     keychain,
     oldPassword,
     newPassword,

--- a/modules/express/test/unit/clientRoutes/changeKeychainPassword.ts
+++ b/modules/express/test/unit/clientRoutes/changeKeychainPassword.ts
@@ -16,7 +16,7 @@ describe('Change Wallet Password', function () {
   const newPassword = 'newPasswordString';
 
   const keychainBaseCoinStub = {
-    keychains: () => ({ updateSingleKeychainPassword: () => Promise.resolve({ result: 'stubbed' }) }),
+    keychains: () => ({ updateSingleKeychainPasswordAsync: () => Promise.resolve({ result: 'stubbed' }) }),
   };
 
   it('should change wallet password', async function () {
@@ -27,7 +27,7 @@ describe('Change Wallet Password', function () {
     const coinStub = {
       keychains: () => ({
         get: () => Promise.resolve(keychainStub),
-        updateSingleKeychainPassword: () => ({ result: 'stubbed' }),
+        updateSingleKeychainPasswordAsync: () => Promise.resolve({ result: 'stubbed' }),
       }),
       url: () => 'url',
     };
@@ -82,7 +82,7 @@ describe('Change Wallet Password', function () {
       const coinStub = {
         keychains: () => ({
           get: () => Promise.resolve(keychainStub),
-          updateSingleKeychainPassword: () => ({ result: 'stubbed' }),
+          updateSingleKeychainPasswordAsync: () => Promise.resolve({ result: 'stubbed' }),
         }),
         url: () => 'url',
       };
@@ -136,7 +136,7 @@ describe('Change Wallet Password', function () {
       const coinStub = {
         keychains: () => ({
           get: () => Promise.resolve(keychainStub),
-          updateSingleKeychainPassword: () => ({ result: 'stubbed' }),
+          updateSingleKeychainPasswordAsync: () => Promise.resolve({ result: 'stubbed' }),
         }),
         url: () => 'url',
       };
@@ -189,7 +189,7 @@ describe('Change Wallet Password', function () {
       const coinStub = {
         keychains: () => ({
           get: () => Promise.resolve(keychainStub),
-          updateSingleKeychainPassword: () => ({ result: 'stubbed' }),
+          updateSingleKeychainPasswordAsync: () => Promise.resolve({ result: 'stubbed' }),
         }),
         url: () => 'url',
       };

--- a/modules/sdk-core/src/bitgo/keychain/iKeychains.ts
+++ b/modules/sdk-core/src/bitgo/keychain/iKeychains.ts
@@ -240,6 +240,7 @@ export interface IKeychains {
   list(params?: ListKeychainOptions): Promise<ListKeychainsResult>;
   updatePassword(params: UpdatePasswordOptions): Promise<ChangedKeychains>;
   updateSingleKeychainPassword(params?: UpdateSingleKeychainPasswordOptions): Keychain;
+  updateSingleKeychainPasswordAsync(params?: UpdateSingleKeychainPasswordOptions): Promise<Keychain>;
   create(params?: { seed?: Buffer; isRootKey?: boolean }): KeyPair;
   add(params?: AddKeychainOptions): Promise<Keychain>;
   createBitGo(params?: CreateBitGoOptions): Promise<Keychain>;

--- a/modules/sdk-core/src/bitgo/keychain/keychains.ts
+++ b/modules/sdk-core/src/bitgo/keychain/keychains.ts
@@ -24,6 +24,7 @@ import {
   UpdateSingleKeychainPasswordOptions,
 } from './iKeychains';
 import { BitGoKeyFromOvcShares, BitGoToOvcJSON, OvcToBitGoJSON } from './ovcJsonCodec';
+import { EncryptionVersion } from '../../api';
 
 export class Keychains implements IKeychains {
   private readonly bitgo: BitGoBase;
@@ -113,7 +114,7 @@ export class Keychains implements IKeychains {
           continue;
         }
         try {
-          const updatedKeychain = this.updateSingleKeychainPassword({
+          const updatedKeychain = await this.updateSingleKeychainPasswordAsync({
             keychain: key,
             oldPassword: params.oldPassword,
             newPassword: params.newPassword,
@@ -145,12 +146,14 @@ export class Keychains implements IKeychains {
   }
 
   /**
-   * Update the password used to decrypt a single keychain
+   * TODO: Deprecate this function in favor of updateSingleKeychainPasswordAsync once v2 encryption is default
+   * Update the password used to decrypt a single keychain.
+   * Handles v1 (SJCL) envelopes only. For v2 (Argon2id) support use {@link updateSingleKeychainPasswordAsync}.
    * @param params
    * @param params.keychain - The keychain whose password should be updated
    * @param params.oldPassword - The old password used for encrypting the key
    * @param params.newPassword - The new password to be used for encrypting the key
-   * @returns {object}
+   * @returns {Keychain}
    */
   updateSingleKeychainPassword(params: UpdateSingleKeychainPasswordOptions = {}): Keychain {
     if (!_.isString(params.oldPassword)) {
@@ -173,6 +176,65 @@ export class Keychains implements IKeychains {
     } catch (e) {
       // catching an error here means that the password was incorrect or, less likely, the input to decrypt is corrupted
       throw new Error('password used to decrypt keychain private key is incorrect');
+    }
+  }
+
+  /**
+   * Helper function to determine the encryption version of a ciphertext by parsing it as JSON and checking the "v" field.
+   * Return undefined if the ciphertext is not a valid JSON or does not contain a supported "v" field.
+   */
+  private getEncryptionVersion(ciphertext: string): EncryptionVersion | undefined {
+    try {
+      const envelope = JSON.parse(ciphertext);
+      switch (envelope.v) {
+        case 1:
+          return 1;
+        case 2:
+          return 2;
+        default:
+          return undefined;
+      }
+    } catch (_) {
+      return undefined;
+    }
+  }
+
+  /**
+   * Update the password used to decrypt a single keychain, with support for v2 (Argon2id) envelopes.
+   * Automatically detects and preserves the envelope version — a v2-encrypted key stays v2 after the password change.
+   * @param params
+   * @param params.keychain - The keychain whose password should be updated
+   * @param params.oldPassword - The old password used for encrypting the key
+   * @param params.newPassword - The new password to be used for encrypting the key
+   * @returns {Promise<Keychain>}
+   */
+  async updateSingleKeychainPasswordAsync(params: UpdateSingleKeychainPasswordOptions = {}): Promise<Keychain> {
+    if (!_.isString(params.oldPassword)) {
+      throw new Error('expected old password to be a string');
+    }
+
+    if (!_.isString(params.newPassword)) {
+      throw new Error('expected new password to be a string');
+    }
+
+    if (!_.isObject(params.keychain) || !_.isString(params.keychain.encryptedPrv)) {
+      throw new Error('expected keychain to be an object with an encryptedPrv property');
+    }
+
+    const oldEncryptedPrv = params.keychain.encryptedPrv;
+    try {
+      const decryptedPrv = await this.bitgo.decryptAsync({ input: oldEncryptedPrv, password: params.oldPassword });
+      const encryptionVersion = this.getEncryptionVersion(oldEncryptedPrv);
+      const newEncryptedPrv = await this.bitgo.encryptAsync({
+        input: decryptedPrv,
+        password: params.newPassword,
+        encryptionVersion,
+      });
+      return _.assign({}, params.keychain, { encryptedPrv: newEncryptedPrv });
+    } catch (e) {
+      // catching an error here means that the password was incorrect or, less likely, the input to decrypt is corrupted
+      const errorDetail = e instanceof Error ? e.message : String(e);
+      throw new Error(`failed to update keychain password: ${errorDetail}`);
     }
   }
 
@@ -359,17 +421,17 @@ export class Keychains implements IKeychains {
       throw new Error('failed to get recovery info');
     }
 
-    const decryptedWalletPassphrase = this.bitgo.decrypt({
+    const decryptedWalletPassphrase = await this.bitgo.decryptAsync({
       input: params.encryptedMaterial.encryptedWalletPassphrase,
       password: recoveryInfo.passcodeEncryptionCode,
     });
 
-    const decryptedUserKey = this.bitgo.decrypt({
+    const decryptedUserKey = await this.bitgo.decryptAsync({
       input: params.encryptedMaterial.encryptedUserKey,
       password: decryptedWalletPassphrase,
     });
 
-    const decryptedBackupKey = this.bitgo.decrypt({
+    const decryptedBackupKey = await this.bitgo.decryptAsync({
       input: params.encryptedMaterial.encryptedBackupKey,
       password: decryptedWalletPassphrase,
     });


### PR DESCRIPTION
Ticket: WCN-281

This pull request adds support for updating passwords on both v1 (SJCL) and v2 (Argon2id) encrypted keychains, ensuring that the encryption version is preserved during password changes. It introduces the new asynchronous method `updateSingleKeychainPasswordAsync`, updates tests to cover mixed-version keychains, and refactors code to use the new async methods where appropriate.

### Keychain password update enhancements

* Added `updateSingleKeychainPasswordAsync` to the `Keychains` class, which supports both v1 and v2 (Argon2id) keychain envelopes and preserves the encryption version during password updates.
* Updated the `updatePassword` method and related code paths to use `updateSingleKeychainPasswordAsync` for asynchronous and version-aware password changes. [[1]](diffhunk://#diff-e6ac710d741cfd1fe9011193555f041636fd2d09bff7af2dc889c5ed333594cdL116-R117) [[2]](diffhunk://#diff-851997953dfe5ce12d4c10bbabf8afa6bc49777505aae9197b0bcc6534da6677L1250-R1250)

### Interface and documentation updates

* Extended the `IKeychains` interface to include the new `updateSingleKeychainPasswordAsync` method and clarified documentation for both sync and async methods. [[1]](diffhunk://#diff-6e98cd0a9bfec578ba7f74f652e3f74b55ed5b08a647f6716d918bc780e39e16R243) [[2]](diffhunk://#diff-e6ac710d741cfd1fe9011193555f041636fd2d09bff7af2dc889c5ed333594cdL148-R155)

### Test improvements

* Added and updated tests in `keychains.ts` to verify that password updates work with both v1 and v2 keychains, including cases with mixed keychain versions and ensuring the encryption version is preserved.
* Refactored stubs and mocks in tests to use the new async methods and ensure correct error handling. [[1]](diffhunk://#diff-56ed62ecf02f9a3d5f4880c1668f80f05e775e8bd2964decca5c6f5a17c381d9L228-R228) [[2]](diffhunk://#diff-56ed62ecf02f9a3d5f4880c1668f80f05e775e8bd2964decca5c6f5a17c381d9L505-R564)

### Refactoring for async cryptography

* Replaced synchronous `decrypt` calls with `decryptAsync` in keychain-related code to ensure compatibility with Argon2id and asynchronous cryptographic operations.

### Dependency updates

* Imported `EncryptionVersion` where needed to support version detection and preservation logic.

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I ran a script locally that
- created a wallet with v2 encryptions
- changed the password
- attempted to decrypt
-Before these changes it would throw an error, with them it succeeds

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
This pull request introduces support for updating passwords on both v1 (SJCL) and v2 (Argon2id) encrypted keychains, ensuring that v2 keychains retain their encryption version after a password change. It adds an asynchronous method for updating a single keychain password, refactors code to use this method where appropriate, and enhances tests to cover mixed-version scenarios.

### Keychain password update enhancements

* Added a new method `updateSingleKeychainPasswordAsync` to the `Keychains` class, which supports updating passwords for both v1 and v2 (Argon2id) keychains while preserving the encryption version.
* Updated `updatePassword` and related code paths to use the new asynchronous method, ensuring compatibility with both keychain versions. [[1]](diffhunk://#diff-e6ac710d741cfd1fe9011193555f041636fd2d09bff7af2dc889c5ed333594cdL116-R117) [[2]](diffhunk://#diff-851997953dfe5ce12d4c10bbabf8afa6bc49777505aae9197b0bcc6534da6677L1250-R1250)

### Interface and API changes

* Extended the `IKeychains` interface to include the new `updateSingleKeychainPasswordAsync` method.
* Improved documentation for both the synchronous and asynchronous single keychain password update methods. [[1]](diffhunk://#diff-e6ac710d741cfd1fe9011193555f041636fd2d09bff7af2dc889c5ed333594cdL148-R155) [[2]](diffhunk://#diff-e6ac710d741cfd1fe9011193555f041636fd2d09bff7af2dc889c5ed333594cdR181-R227)

### Test improvements

* Enhanced tests to verify that password updates preserve v2 envelopes and correctly handle a mix of v1 and v2 keychains. Refactored tests to use the async method and updated stubs accordingly. [[1]](diffhunk://#diff-56ed62ecf02f9a3d5f4880c1668f80f05e775e8bd2964decca5c6f5a17c381d9L228-R228) [[2]](diffhunk://#diff-56ed62ecf02f9a3d5f4880c1668f80f05e775e8bd2964decca5c6f5a17c381d9L316-R387) [[3]](diffhunk://#diff-56ed62ecf02f9a3d5f4880c1668f80f05e775e8bd2964decca5c6f5a17c381d9L505-R564)

### Internal refactoring

* Refactored decryption calls in keychain-related methods to use the asynchronous `decryptAsync` method for consistency and improved error handling.
* Added necessary imports and minor code cleanups to support the new functionality.