### PR TITLE
feat(sdk-core): add v2 decryption support for gg18

### DIFF
--- a/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsa.ts
+++ b/modules/bitgo/test/v2/unit/internal/tssUtils/ecdsa.ts
@@ -426,6 +426,34 @@ describe('TSS Ecdsa Utils:', async function () {
       await Promise.all(testCasesPromises);
     });
 
+    it('createParticipantKeychain should produce a v2-encrypted encryptedPrv when encryptionVersion: 2', async function () {
+      const passphrase = 'test-passphrase';
+      // Stub keychains.add to capture the params sent to the API so we can inspect encryptedPrv
+      const addStub = sinon.stub(baseCoin.keychains(), 'add').resolves({ id: '1', pub: '', type: 'tss' } as Keychain);
+      try {
+        await tssUtils.createParticipantKeychain(
+          userGpgKey,
+          userLocalBackupGpgKey,
+          bitgoPublicKey,
+          1,
+          userKeyShare,
+          backupKeyShare,
+          nockedBitGoKeychain,
+          passphrase,
+          undefined,
+          undefined,
+          2 // encryptionVersion
+        );
+        sinon.assert.calledOnce(addStub);
+        const addParams = addStub.firstCall.args[0] as { encryptedPrv?: string };
+        assert.ok(addParams.encryptedPrv, 'encryptedPrv must be passed to keychains.add');
+        const envelope = JSON.parse(addParams.encryptedPrv!);
+        assert.strictEqual(envelope.v, 2, 'encryptedPrv must use v2 (Argon2id) envelope');
+      } finally {
+        addStub.restore();
+      }
+    });
+
     it('should fail to generate TSS keychains when received invalid number of wallet signatures', async function () {
       const bitgoKeychain = await generateBitgoKeychain({
         coin: coinName,
@@ -983,7 +1011,28 @@ describe('TSS Ecdsa Utils:', async function () {
           encryptedWShare: bitgo.encrypt({ input: JSON.stringify(wShare), password: mockPassword }),
           walletPassphrase: 'password1',
         })
-        .should.be.rejectedWith("password error - ccm: tag doesn't match");
+        .should.be.rejectedWith('incorrect password');
+    });
+
+    it('createOfflineMuDeltaShare should succeed with v2-encrypted wShare', async function () {
+      const mockPassword = 'password';
+      const alphaLength = 1536;
+      const deltaLength = 64;
+      const bitgo = TestBitGo.decorate(BitGo, { env: 'mock' });
+      const encryptedWShare = await bitgo.encryptAsync({
+        input: JSON.stringify(wShare),
+        password: mockPassword,
+        encryptionVersion: 2,
+      });
+      assert.strictEqual(JSON.parse(encryptedWShare).v, 2, 'pre-condition: wShare must be v2-encrypted');
+      const step2SigningMaterial = await tssUtils.createOfflineMuDeltaShare({
+        aShareFromBitgo: aShare,
+        bitgoChallenge: bitgoChallenges,
+        encryptedWShare,
+        walletPassphrase: mockPassword,
+      });
+      step2SigningMaterial.muDShare.muShare.alpha.length.should.equal(alphaLength);
+      step2SigningMaterial.muDShare.dShare.delta.length.should.equal(deltaLength);
     });
 
     it('createOfflineSShare should succeed', async function () {
@@ -998,6 +1047,32 @@ describe('TSS Ecdsa Utils:', async function () {
         },
         dShareFromBitgo: dShare,
         encryptedOShare: bitgo.encrypt({ input: JSON.stringify(oShare), password: mockPassword }),
+        walletPassphrase: mockPassword,
+        requestType: RequestType.tx,
+      });
+      step3SigningMaterial.R.length.should.equal(pubKeyLength);
+      step3SigningMaterial.y.length.should.equal(pubKeyLength);
+      step3SigningMaterial.s.length.should.equal(privKeyLength);
+    });
+
+    it('createOfflineSShare should succeed with v2-encrypted oShare', async function () {
+      const mockPassword = 'password';
+      const pubKeyLength = 66;
+      const privKeyLength = 64;
+      const bitgo = TestBitGo.decorate(BitGo, { env: 'mock' });
+      const encryptedOShare = await bitgo.encryptAsync({
+        input: JSON.stringify(oShare),
+        password: mockPassword,
+        encryptionVersion: 2,
+      });
+      assert.strictEqual(JSON.parse(encryptedOShare).v, 2, 'pre-condition: oShare must be v2-encrypted');
+      const step3SigningMaterial = await tssUtils.createOfflineSShare({
+        tssParams: {
+          txRequest: txRequest,
+          reqId: reqId,
+        },
+        dShareFromBitgo: dShare,
+        encryptedOShare,
         walletPassphrase: mockPassword,
         requestType: RequestType.tx,
       });

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
@@ -49,7 +49,7 @@ import {
   TxRequestChallengeResponse,
 } from '../../../tss/types';
 import { BaseEcdsaUtils } from './base';
-import { IRequestTracer } from '../../../../api';
+import { EncryptionVersion, IRequestTracer } from '../../../../api';
 
 const encryptNShare = ECDSAMethods.encryptNShare;
 
@@ -183,6 +183,7 @@ export class EcdsaUtils extends BaseEcdsaUtils {
     passphrase,
     originalPasscodeEncryptionCode,
     webauthnInfo,
+    encryptionVersion,
   }: CreateEcdsaKeychainParams): Promise<Keychain> {
     if (!passphrase) {
       throw new Error('Please provide a wallet passphrase');
@@ -198,7 +199,8 @@ export class EcdsaUtils extends BaseEcdsaUtils {
       bitgoKeychain,
       passphrase,
       originalPasscodeEncryptionCode,
-      webauthnInfo
+      webauthnInfo,
+      encryptionVersion
     );
   }
 
@@ -210,6 +212,7 @@ export class EcdsaUtils extends BaseEcdsaUtils {
     bitgoKeychain,
     bitgoPublicGpgKey,
     passphrase,
+    encryptionVersion,
   }: CreateEcdsaKeychainParams): Promise<Keychain> {
     assert(backupKeyShare.userHeldKeyShare);
     assert(passphrase);
@@ -221,7 +224,10 @@ export class EcdsaUtils extends BaseEcdsaUtils {
       userKeyShare,
       backupKeyShare.userHeldKeyShare,
       bitgoKeychain,
-      passphrase
+      passphrase,
+      undefined,
+      undefined,
+      encryptionVersion
     );
   }
 
@@ -312,7 +318,8 @@ export class EcdsaUtils extends BaseEcdsaUtils {
     bitgoKeychain: Keychain,
     passphrase: string,
     originalPasscodeEncryptionCode?: string,
-    webauthnInfo?: WebauthnKeyEncryptionInfo
+    webauthnInfo?: WebauthnKeyEncryptionInfo,
+    encryptionVersion?: EncryptionVersion
   ): Promise<Keychain> {
     const bitgoKeyShares = bitgoKeychain.keyShares;
     if (!bitgoKeyShares) {
@@ -402,9 +409,10 @@ export class EcdsaUtils extends BaseEcdsaUtils {
       keyType: 'tss' as KeyType,
       commonKeychain: bitgoKeychain.commonKeychain,
       prv: prv,
-      encryptedPrv: this.bitgo.encrypt({
+      encryptedPrv: await this.bitgo.encryptAsync({
         input: prv,
         password: passphrase,
+        encryptionVersion,
       }),
       originalPasscodeEncryptionCode,
       webauthnDevices:
@@ -499,7 +507,10 @@ export class EcdsaUtils extends BaseEcdsaUtils {
       userPublicGpgKey: userPublicGpgKey,
       kShare: userSignShare.kShare,
       wShare: params.walletPassphrase
-        ? this.bitgo.encrypt({ input: JSON.stringify(userSignShare.wShare), password: params.walletPassphrase })
+        ? await this.bitgo.encryptAsync({
+            input: JSON.stringify(userSignShare.wShare),
+            password: params.walletPassphrase,
+          })
         : userSignShare.wShare,
     };
   }
@@ -529,7 +540,7 @@ export class EcdsaUtils extends BaseEcdsaUtils {
         i: userGammaAndMuShares.muShare.i,
       },
       oShare: params.walletPassphrase
-        ? this.bitgo.encrypt({
+        ? await this.bitgo.encryptAsync({
             input: JSON.stringify(userOmicronAndDeltaShare.oShare),
             password: params.walletPassphrase,
           })
@@ -584,7 +595,10 @@ export class EcdsaUtils extends BaseEcdsaUtils {
     encryptedWShare: string;
     walletPassphrase: string;
   }): Promise<TssEcdsaStep2ReturnMessage> {
-    const decryptedWShare = this.bitgo.decrypt({ input: params.encryptedWShare, password: params.walletPassphrase });
+    const decryptedWShare = await this.bitgo.decryptAsync({
+      input: params.encryptedWShare,
+      password: params.walletPassphrase,
+    });
     return await this.createTssEcdsaStep2SigningMaterial({
       aShareFromBitgo: params.aShareFromBitgo,
       bitgoChallenge: params.bitgoChallenge,
@@ -618,7 +632,7 @@ export class EcdsaUtils extends BaseEcdsaUtils {
     } catch (err) {
       hash = undefined;
     }
-    const decryptedOShare = this.bitgo.decrypt({ input: encryptedOShare, password: walletPassphrase });
+    const decryptedOShare = await this.bitgo.decryptAsync({ input: encryptedOShare, password: walletPassphrase });
     const { i, R, s, y } = await ECDSAMethods.createUserSignatureShare(
       JSON.parse(decryptedOShare),
       dShareFromBitgo,


### PR DESCRIPTION
Ticket: WCN-283

This pull request adds support for Argon2id-based v2 encryption for TSS ECDSA key shares and keychains, updating both the SDK implementation and the test suite to ensure compatibility and correct behavior. The most important changes are outlined below.

---

**SDK Enhancements for v2 Encryption:**

* Updated the `EcdsaUtils` class in `ecdsa.ts` to support an optional `encryptionVersion` parameter, allowing key shares and keychains to be encrypted using the new v2 (Argon2id) envelope. All relevant key generation and signing methods now use asynchronous encryption/decryption methods (`encryptAsync`/`decryptAsync`) to support v2. [[1]](diffhunk://#diff-3e058e97cc95a245871d988eef95d673586e6912b8acaa3cdfdfc1e3db436ccdL52-R52) [[2]](diffhunk://#diff-3e058e97cc95a245871d988eef95d673586e6912b8acaa3cdfdfc1e3db436ccdR186) [[3]](diffhunk://#diff-3e058e97cc95a245871d988eef95d673586e6912b8acaa3cdfdfc1e3db436ccdL201-R203) [[4]](diffhunk://#diff-3e058e97cc95a245871d988eef95d673586e6912b8acaa3cdfdfc1e3db436ccdR215) [[5]](diffhunk://#diff-3e058e97cc95a245871d988eef95d673586e6912b8acaa3cdfdfc1e3db436ccdL224-R230) [[6]](diffhunk://#diff-3e058e97cc95a245871d988eef95d673586e6912b8acaa3cdfdfc1e3db436ccdL315-R322) [[7]](diffhunk://#diff-3e058e97cc95a245871d988eef95d673586e6912b8acaa3cdfdfc1e3db436ccdL405-R415) [[8]](diffhunk://#diff-3e058e97cc95a245871d988eef95d673586e6912b8acaa3cdfdfc1e3db436ccdL502-R513) [[9]](diffhunk://#diff-3e058e97cc95a245871d988eef95d673586e6912b8acaa3cdfdfc1e3db436ccdL532-R543) [[10]](diffhunk://#diff-3e058e97cc95a245871d988eef95d673586e6912b8acaa3cdfdfc1e3db436ccdL587-R601) [[11]](diffhunk://#diff-3e058e97cc95a245871d988eef95d673586e6912b8acaa3cdfdfc1e3db436ccdL621-R635)

---

**Test Suite Updates for v2 Encryption:**

* Added new tests to verify that `createParticipantKeychain`, `createOfflineMuDeltaShare`, and `createOfflineSShare` correctly handle and produce v2-encrypted key shares and keychains. These tests assert the correct envelope version and validate successful decryption and signing with v2-encrypted data. [[1]](diffhunk://#diff-6e32a6913d88c56c5298334e9fd0afceb434fffcd60b6a96904405af586546abR429-R456) [[2]](diffhunk://#diff-6e32a6913d88c56c5298334e9fd0afceb434fffcd60b6a96904405af586546abL986-R1035) [[3]](diffhunk://#diff-6e32a6913d88c56c5298334e9fd0afceb434fffcd60b6a96904405af586546abR1058-R1083)
* Updated error handling in tests to expect the new error message `'incorrect password'` when decryption fails, reflecting changes in the underlying encryption implementation.

---

These changes ensure that the BitGo TSS ECDSA implementation is compatible with both legacy and Argon2id-based key encryption, improving security and future-proofing the SDK.

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
