### PR TITLE
feat: onboard inketh tokens (CECHO-976)

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -2501,6 +2501,33 @@ export const allCoinsAndTokens = [
       CoinFeature.SUPPORTS_ERC20,
     ]
   ),
+  erc20Token(
+    '682de8f9-ffd2-478d-b106-8d8212043608',
+    'inketh:kbtc',
+    'KBTC',
+    8,
+    '0x73e0c0d45e048d25fc26fa3159b0aa04bfa4db98',
+    UnderlyingAsset['inketh:kbtc'],
+    Networks.main.inketh
+  ),
+  erc20Token(
+    '49e611fe-158d-4903-9e15-d6edd902fa30',
+    'inketh:usdc',
+    'USDC',
+    6,
+    '0x2d270e6886d130d724215a266106e6832161eaed',
+    UnderlyingAsset['inketh:usdc'],
+    Networks.main.inketh
+  ),
+  erc20Token(
+    'a9fb0064-51c0-48ad-bc01-603872cbb3cb',
+    'inketh:usdt0',
+    'USDT0',
+    6,
+    '0x0200c29006150606b650577bbe7b6248f58470c1',
+    UnderlyingAsset['inketh:usdt0'],
+    Networks.main.inketh
+  ),
   account(
     '68d22683-a8f2-47b3-8446-92e02a1963ae',
     'hemieth',

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -3401,6 +3401,11 @@ export enum UnderlyingAsset {
   'chiliz:spurs' = 'chiliz:spurs',
   'chiliz:tra' = 'chiliz:tra',
 
+  // Ink mainnet tokens
+  'inketh:kbtc' = 'inketh:kbtc',
+  'inketh:usdc' = 'inketh:usdc',
+  'inketh:usdt0' = 'inketh:usdt0',
+
   //world chain mainnet tokens
   'world:wld' = 'world:wld',
   'world:usdc' = 'world:usdc',

--- a/modules/statics/src/coins/ofcErc20Coins.ts
+++ b/modules/statics/src/coins/ofcErc20Coins.ts
@@ -3990,6 +3990,50 @@ export const ofcErc20Coins = [
     'baseeth'
   ),
 
+  // Ink Network tokens
+  ofcerc20(
+    'f6ccdf51-e2c8-4ad3-95b4-8c779096d30f',
+    'ofcinketh:kbtc',
+    'KBTC',
+    8,
+    underlyingAssetForSymbol('inketh:kbtc'),
+    undefined,
+    undefined,
+    '',
+    undefined,
+    undefined,
+    true,
+    'inketh'
+  ),
+  ofcerc20(
+    '200f34d6-521a-4ff9-a4c2-60c6fe3edaf4',
+    'ofcinketh:usdc',
+    'USDC',
+    6,
+    underlyingAssetForSymbol('inketh:usdc'),
+    undefined,
+    undefined,
+    '',
+    undefined,
+    undefined,
+    true,
+    'inketh'
+  ),
+  ofcerc20(
+    'e115bc45-6771-4088-82f3-aa3cdcaba416',
+    'ofcinketh:usdt0',
+    'USDT0',
+    6,
+    underlyingAssetForSymbol('inketh:usdt0'),
+    undefined,
+    undefined,
+    '',
+    undefined,
+    undefined,
+    true,
+    'inketh'
+  ),
+
   // Chiliz Network tokens
   ofcerc20(
     'e870395c-a5e0-41b2-b900-6bd1a1a38088',


### PR DESCRIPTION
## Summary
- Add Ink mainnet ERC-20 tokens to BitGoJS statics: `inketh:kbtc`, `inketh:usdc`, and `inketh:usdt0`
- Register `UnderlyingAsset` entries, `erc20Token` definitions on `Networks.main.inketh`, and corresponding OFC entries (`ofcinketh:*`)
- Follows the same pattern as [chiliz tokens PR #8270](https://github.com/BitGo/BitGoJS/pull/8270)

CECHO-976

| Token | Ticker | Decimals | Contract |
|-------|--------|----------|----------|
| KBTC | `inketh:kbtc` | 8 | `0x73e0c0d45e048d25fc26fa3159b0aa04bfa4db98` |
| USDC | `inketh:usdc` | 6 | `0x2d270e6886d130d724215a266106e6832161eaed` |
| USDT0 | `inketh:usdt0` | 6 | `0x0200c29006150606b650577bbe7b6248f58470c1` |

## Test plan
- [ ] CI passes on `modules/statics`
- [ ] Verify token entries resolve via statics (`inketh:kbtc`, `inketh:usdc`, `inketh:usdt0` and `ofcinketh:*` variants)


Made with [Cursor](https://cursor.com)