### PR TITLE
feat(abstract-utxo): restrict legacy tx format to BTC and LTC

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -431,7 +431,7 @@ export abstract class AbstractUtxoCoin
 
   protected supportedTxFormats: { psbt: boolean; legacy: boolean } = {
     psbt: true,
-    legacy: this.isMainnet(),
+    legacy: this.getChain() === 'btc' || this.getChain() === 'ltc',
   };
 
   protected supportedSdkBackends: { utxolib: boolean; 'wasm-utxo': boolean } = {


### PR DESCRIPTION
Enable legacy transaction format only for Bitcoin and Litecoin chains
instead of all mainnet coins, trialing this change on coins with lower
usage.

Refs: T1-3245
Co-authored-by: llm-git <llm-git@ttll.de>