### PR TITLE
feat(abstract-utxo): restrict utxolib backend to BTC and LTC

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -435,7 +435,7 @@ export abstract class AbstractUtxoCoin
   };
 
   protected supportedSdkBackends: { utxolib: boolean; 'wasm-utxo': boolean } = {
-    utxolib: this.isMainnet(),
+    utxolib: this.getChain() === 'btc' || this.getChain() === 'ltc',
     'wasm-utxo': true,
   };
 


### PR DESCRIPTION
Disable supportedSdkBackends.utxolib for all mainnet coins except BTC
and LTC, trialing the removal on lower-usage coins first.

Refs: T1-3280
Co-authored-by: llm-git <llm-git@ttll.de>