### PR TITLE
feat(abstract-eth): expose getSignablePayload for ETH coin classes (CGD-1083)

### DIFF
--- a/modules/abstract-eth/src/abstractEthLikeCoin.ts
+++ b/modules/abstract-eth/src/abstractEthLikeCoin.ts
@@ -27,7 +27,7 @@ import {
 } from '@bitgo/sdk-core';
 import BigNumber from 'bignumber.js';
 
-import { isValidEthAddress, KeyPair as EthKeyPair, TransactionBuilder } from './lib';
+import { isValidEthAddress, KeyPair as EthKeyPair, Transaction as EthTransaction, TransactionBuilder } from './lib';
 import { VerifyEthAddressOptions } from './abstractEthLikeNewCoins';
 import { auditEcdsaPrivateKey } from '@bitgo/sdk-lib-mpc';
 
@@ -228,6 +228,14 @@ export abstract class AbstractEthLikeCoin extends BaseCoin {
       changeAmount: '0', // account base does not make change
       fee: params.feeInfo,
     };
+  }
+
+  /** @inheritDoc */
+  async getSignablePayload(serializedTx: string): Promise<Buffer> {
+    const txBuilder = this.getTransactionBuilder();
+    txBuilder.from(serializedTx);
+    const tx = (await txBuilder.build()) as EthTransaction;
+    return tx.signablePayload;
   }
 
   /**

--- a/modules/abstract-eth/src/ethLikeToken.ts
+++ b/modules/abstract-eth/src/ethLikeToken.ts
@@ -399,6 +399,11 @@ export class EthLikeToken extends AbstractEthLikeNewCoins {
     return txPrebuild.coin === this.tokenConfig.coin && txPrebuild.token === this.tokenConfig.type;
   }
 
+  /** @inheritDoc */
+  async getSignablePayload(serializedTx: string): Promise<Buffer> {
+    return Buffer.from(serializedTx);
+  }
+
   /**
    * Create a new transaction builder for the current chain
    * @return a new transaction builder

--- a/modules/abstract-eth/src/lib/iface.ts
+++ b/modules/abstract-eth/src/lib/iface.ts
@@ -91,6 +91,11 @@ export interface EthLikeTransactionData {
    * Return the hex string serialization of this transaction
    */
   toSerialized(): string;
+
+  /**
+   * Return the keccak256 hash of the unsigned transaction — the 32-byte digest an external signer must sign
+   */
+  getSignablePayload(): Buffer;
 }
 
 export interface SignatureParts {

--- a/modules/abstract-eth/src/lib/transaction.ts
+++ b/modules/abstract-eth/src/lib/transaction.ts
@@ -170,6 +170,14 @@ export class Transaction extends BaseTransaction {
   }
 
   /** @inheritdoc */
+  get signablePayload(): Buffer {
+    if (!this._transactionData) {
+      throw new InvalidTransactionError('No transaction data to sign');
+    }
+    return this._transactionData.getSignablePayload();
+  }
+
+  /** @inheritdoc */
   toBroadcastFormat(): string {
     if (this._transactionData) {
       return this._transactionData.toSerialized();

--- a/modules/abstract-eth/src/lib/types.ts
+++ b/modules/abstract-eth/src/lib/types.ts
@@ -91,6 +91,10 @@ export class EthTransactionData implements EthLikeTransactionData {
     this.tx = this.tx.sign(privateKey);
   }
 
+  getSignablePayload(): Buffer {
+    return Buffer.from(this.tx.getMessageToSign(true));
+  }
+
   /** @inheritdoc */
   toJson(): TxData {
     const result: BaseTxData = {

--- a/modules/abstract-eth/test/unit/transaction.ts
+++ b/modules/abstract-eth/test/unit/transaction.ts
@@ -57,5 +57,20 @@ export function runTransactionTests(coinName: string, testData: any, common: Com
         should.equal(tx.toBroadcastFormat(), testData.ENCODED_TRANSACTION);
       });
     });
+
+    describe('signablePayload', () => {
+      it('should throw on an empty transaction', () => {
+        const tx = getTransaction();
+        should.throws(() => tx.signablePayload);
+      });
+
+      it('should return a 32-byte keccak256 hash for an unsigned transaction', () => {
+        const tx = getTransaction();
+        tx.setTransactionData(testData.TXDATA);
+        const payload = tx.signablePayload;
+        payload.should.be.instanceof(Buffer);
+        payload.length.should.equal(32);
+      });
+    });
   });
 }

--- a/modules/sdk-coin-bsc/test/unit/bscToken.ts
+++ b/modules/sdk-coin-bsc/test/unit/bscToken.ts
@@ -29,4 +29,16 @@ describe('Bsc Token:', function () {
     bscTokenCoin.network.should.equal('Testnet');
     bscTokenCoin.decimalPlaces.should.equal(18);
   });
+
+  describe('getSignablePayload', function () {
+    // Tokens are out of scope for CGD-1083; EthLikeToken intentionally preserves
+    // the pre-PR behavior of returning the raw serialized tx bytes rather than
+    // the keccak256 hash returned by the parent chain coin.
+    it('should return the raw serialized bytes unchanged', async function () {
+      const serializedTx =
+        '0xf86b808504a817c80082520894eeaf0f05f37891ab4a21208b105a0687d12c5af7880de0b6b3a76400008025a0';
+      const payload = await bscTokenCoin.getSignablePayload(serializedTx);
+      payload.should.deepEqual(Buffer.from(serializedTx));
+    });
+  });
 });

--- a/modules/sdk-coin-eth/test/unit/eth.ts
+++ b/modules/sdk-coin-eth/test/unit/eth.ts
@@ -2593,4 +2593,58 @@ describe('ETH:', function () {
       });
     });
   });
+
+  describe('getSignablePayload', function () {
+    let coin: Teth;
+
+    before(function () {
+      coin = bitgo.coin('teth') as Teth;
+    });
+
+    it('should return a 32-byte keccak256 hash for a Legacy transaction', async function () {
+      const txBuilder = getBuilder('teth') as TransactionBuilder;
+      txBuilder.type(TransactionType.Send);
+      txBuilder.fee({ fee: '10000000000', gasLimit: '7000000' });
+      txBuilder.counter(1);
+      txBuilder.contract('0x8Ce59c2d1702844F8EdED451AA103961bC37B4e8');
+      const transferBuilder = txBuilder.transfer() as TransferBuilder;
+      transferBuilder
+        .coin('teth')
+        .expirationTime(Math.floor(Date.now() / 1000) + 3600)
+        .amount('100000')
+        .to('0xeeaf0F05f37891ab4a21208B105A0687d12c5aF7')
+        .contractSequenceId(1);
+      const tx = await txBuilder.build();
+      const serializedTx = tx.toBroadcastFormat();
+
+      const payload = await coin.getSignablePayload(serializedTx);
+      assert.ok(Buffer.isBuffer(payload));
+      assert.strictEqual(payload.length, 32);
+    });
+
+    it('should return a 32-byte keccak256 hash for an EIP1559 transaction', async function () {
+      const txBuilder = getBuilder('teth') as TransactionBuilder;
+      txBuilder.type(TransactionType.Send);
+      txBuilder.fee({
+        fee: '280000000000',
+        gasLimit: '7000000',
+        eip1559: { maxFeePerGas: '7593123', maxPriorityFeePerGas: '150' },
+      });
+      txBuilder.counter(1);
+      txBuilder.contract('0x8Ce59c2d1702844F8EdED451AA103961bC37B4e8');
+      const transferBuilder = txBuilder.transfer() as TransferBuilder;
+      transferBuilder
+        .coin('teth')
+        .expirationTime(Math.floor(Date.now() / 1000) + 3600)
+        .amount('100000')
+        .to('0xeeaf0F05f37891ab4a21208B105A0687d12c5aF7')
+        .contractSequenceId(1);
+      const tx = await txBuilder.build();
+      const serializedTx = tx.toBroadcastFormat();
+
+      const payload = await coin.getSignablePayload(serializedTx);
+      assert.ok(Buffer.isBuffer(payload));
+      assert.strictEqual(payload.length, 32);
+    });
+  });
 });

--- a/modules/sdk-coin-eth/test/unit/transaction.ts
+++ b/modules/sdk-coin-eth/test/unit/transaction.ts
@@ -61,4 +61,28 @@ describe('ETH Transaction', () => {
       });
     });
   });
+
+  describe('signablePayload', () => {
+    it('should throw on an empty transaction', () => {
+      const tx = getTransaction();
+      assert.throws(() => tx.signablePayload);
+    });
+
+    testParams.map(([txnType, txData]) => {
+      it(`should return the keccak256 signing hash for a ${txnType} transaction`, () => {
+        const tx = getTransaction(txData);
+        const payload = tx.signablePayload;
+        assert.ok(Buffer.isBuffer(payload));
+        assert.strictEqual(payload.length, 32);
+        // txData.id is set from getMessageToSign() in toJson() — must match the signing payload
+        assert.strictEqual('0x' + payload.toString('hex'), txData.id);
+      });
+    });
+
+    it('should produce distinct payloads for Legacy and EIP1559 transactions', () => {
+      const legacy = getTransaction(testData.LEGACY_TXDATA).signablePayload;
+      const eip1559 = getTransaction(testData.EIP1559_TXDATA).signablePayload;
+      assert.notStrictEqual(legacy.toString('hex'), eip1559.toString('hex'));
+    });
+  });
 });


### PR DESCRIPTION
## Description

Overrides `getSignablePayload(serializedTx)` on `AbstractEthLikeCoin` so that ETH and all ETH-like coins return the correct 32-byte keccak256 signing digest, rather than falling through to the base-class no-op that returns raw serialized bytes.

This is required to unblock AKM's external signing endpoint (`POST /sign`), which needs the correct hash to sign — not the raw transaction bytes.

## Changes

- **`AbstractEthLikeCoin.getSignablePayload`** — new override: deserializes via the transaction builder, casts to `EthTransaction`, and returns `tx.signablePayload`
- **`EthLikeTransactionData` interface** — adds `getSignablePayload(): Buffer`
- **`EthTransactionData`** — implements `getSignablePayload()` via `tx.getMessageToSign(true)` (keccak256 hash, same primitive used internally for TSS signing)
- **`Transaction.signablePayload` getter** — overrides `BaseTransaction`'s `NotImplementedError` default; throws `InvalidTransactionError` if no transaction data is set
- **`EthLikeToken.getSignablePayload`** — preserves pre-PR behavior (returns raw serialized bytes); tokens are out of scope for this ticket
- Inherited by **all non-token `AbstractEthLikeNewCoins` descendants** (Eth, Polygon, Arbeth, Opeth, BSC, AvaxC, EVM, etc.) and legacy `AbstractEthLikeCoin` descendants (Rbtc, Celo, Etc)

## Issue

CGD-1083 (unblocks WCN-397)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Unit tests added in:
- `modules/abstract-eth/test/unit/transaction.ts` — throws on empty tx; returns 32-byte hash for unsigned tx
- `modules/sdk-coin-eth/test/unit/transaction.ts` — hash pinned against `txData.id` fixture for both Legacy and EIP1559; distinct-payload check between tx types
- `modules/sdk-coin-eth/test/unit/eth.ts` — end-to-end `coin.getSignablePayload(serializedTx)` for Legacy and EIP1559 via `Teth`

Existing TSS signing flows are unaffected — they use `signableHex` from the unsigned tx object directly (`abstractEthLikeNewCoins.ts:2444`), not `getSignablePayload`.