### PR TITLE
feat(abstract-utxo): restrict legacy format and utxolib backend to BTC only

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -436,11 +436,11 @@ export abstract class AbstractUtxoCoin
 
   protected supportedTxFormats: { psbt: boolean; legacy: boolean } = {
     psbt: true,
-    legacy: this.getChain() === 'btc' || this.getChain() === 'ltc',
+    legacy: this.getChain() === 'btc',
   };
 
   protected supportedSdkBackends: { utxolib: boolean; 'wasm-utxo': boolean } = {
-    utxolib: this.getChain() === 'btc' || this.getChain() === 'ltc',
+    utxolib: this.getChain() === 'btc',
     'wasm-utxo': true,
   };
 


### PR DESCRIPTION
Remove LTC from supportedTxFormats.legacy and supportedSdkBackends.utxolib,
narrowing the trial from BTC+LTC to BTC only.

Refs: T1-3245, T1-3280
Co-authored-by: llm-git <llm-git@ttll.de>