### PR TITLE
fix(sdk-coin-trx): emit canonical AccountCreate raw_data_hex

### DIFF
--- a/modules/sdk-coin-trx/src/lib/accountCreateTxBuilder.ts
+++ b/modules/sdk-coin-trx/src/lib/accountCreateTxBuilder.ts
@@ -15,8 +15,6 @@ import {
 } from './utils';
 import { ACCOUNT_CREATE_TYPE_URL } from './constants';
 
-import ContractType = protocol.Transaction.Contract.ContractType;
-
 export class AccountCreateTxBuilder extends TransactionBuilder {
   protected _signingKeys: BaseKey[];
   // Stored as hex address, consistent with _ownerAddress
@@ -148,8 +146,13 @@ export class AccountCreateTxBuilder extends TransactionBuilder {
     };
     const accountCreateContract = protocol.AccountCreateContract.fromObject(rawContract);
     const accountCreateContractBytes = protocol.AccountCreateContract.encode(accountCreateContract).finish();
+    // AccountCreateContract is enum value 0 — the proto3 default. TRON's node
+    // re-serializes raw_data from broadcast JSON and omits default-valued
+    // fields, producing a different raw_data_hex (and txID) than the SDK if
+    // we encode the type field explicitly. Skip it so signing and broadcast
+    // hashes match. See freezeBalanceTxBuilder.ts:175-181 for the same class
+    // of issue on the inner `resource` field.
     const txContract = {
-      type: ContractType.AccountCreateContract,
       parameter: {
         value: accountCreateContractBytes,
         type_url: ACCOUNT_CREATE_TYPE_URL,

--- a/modules/sdk-coin-trx/test/unit/transactionBuilder/accountCreateTxBuilder.ts
+++ b/modules/sdk-coin-trx/test/unit/transactionBuilder/accountCreateTxBuilder.ts
@@ -115,6 +115,38 @@ describe('Tron AccountCreate builder', function () {
 
       assert.equal(tx2.toJson().txID, originalTxId);
     });
+
+    // Regression test: AccountCreateContract's enum value is 0, which is the
+    // proto3 default for the outer Transaction.Contract.type field. When the
+    // SDK explicitly encoded `type: 0`, the wire format included the 2-byte
+    // tag `0800` inside the contract envelope. TRON's node re-serializes
+    // raw_data from broadcast JSON and omits default-valued fields, producing
+    // a 2-byte-shorter canonical raw_data_hex and a different txID. The TSS
+    // signature was valid for the SDK's hash but recovered to a garbage
+    // pubkey under TRON's canonical hash, so AccountCreate broadcasts failed
+    // with SIGERROR "signed by <random T...> but not contained of permission".
+    it('produces raw_data_hex without the proto3 default-valued type field', async () => {
+      const timestamp = 1779455020653;
+      const expiration = 1779465820653;
+      const txBuilder = initTxBuilder();
+      txBuilder.timestamp(timestamp);
+      txBuilder.expiration(expiration);
+      const tx = await txBuilder.build();
+      const rawDataHex = tx.toJson().raw_data_hex;
+
+      // The buggy encoding had `5a68 0800 1264` (contract tag, length 0x68,
+      // type=0, parameter tag, length 0x64). The canonical encoding TRON
+      // re-serializes to drops the `0800` and decrements the contract length
+      // by 2 -> `5a66 1264`.
+      assert.ok(
+        !rawDataHex.includes('5a68080012'),
+        `raw_data_hex must not include the proto3-default \`type: 0\` tag (0800). Got: ${rawDataHex}`
+      );
+      assert.ok(
+        rawDataHex.includes('5a661264'),
+        `raw_data_hex must use the canonical contract framing (5a66...1264). Got: ${rawDataHex}`
+      );
+    });
   });
 
   describe('should validate', () => {


### PR DESCRIPTION
## Summary

- `AccountCreateContract`'s enum value is `0` — the proto3 default for the outer `Transaction.Contract.type` field. The SDK explicitly encoded it, so `raw_data_hex` carried a stray 2-byte `0800` tag inside the contract envelope.
- TRON's node re-serializes `raw_data` from broadcast JSON under strict proto3 semantics, which omits default-valued fields. Its canonical `raw_data_hex` is 2 bytes shorter, with a different `sha256` (= `txID`).
- For **TSS wallets** the signature is computed over `sha256(SDK_raw_data_hex)` but TRON validates against `sha256(canonical_raw_data_hex)`. ECDSA recovery against the mismatched digest returns an unrelated pubkey, whose TRON address is not in the wallet's permission set, and broadcast fails with:

  ```
  SIGERROR Validate signature error: <sig> is signed by <random T…> but it is not contained of permission
  ```

  Hot-wallet flows sign-and-recover locally against the same buggy bytes and so don't trip this.

## Why only AccountCreate

| Builder | `type` enum value | Affected? |
|---|---|---|
| **AccountCreateContract** | **0** (proto3 default) | **yes** |
| TransferContract | 1 | no |
| FreezeBalanceV2Contract | 11 | no |
| VoteWitnessContract | 4 | no |
| DelegateResourceContract | 57 | no |

Every other commonly-used TRON contract type has a non-default enum value, so the SDK's encoding happens to match TRON's canonical re-serialization. The analogous proto3-default guard for the inner `resource: BANDWIDTH=0` field is already present in `freezeBalanceTxBuilder.ts:175-181` with an explanatory comment — this PR applies the same idea to the outer `type` field for AccountCreate.

## Fix

In `getAccountCreateTxRawDataHex`, omit the explicit `type` field from the `txContract` literal so protobufjs doesn't emit the default-valued tag. The decoded protobuf still reports `type = AccountCreateContract` because that's the field's default value.

Also removes the now-unused `ContractType` import.

## Verification

Re-encoding the failure-case inputs (real production broadcast bytes) with the fix produces the canonical 132-byte `raw_data_hex`, and ECDSA-recovering the production signature against `sha256(canonical)` returns exactly the address TRON's error reported (`TMAFWDcE5hpDvcQVn89gGB5oACwGXZKZqV`) — confirming the diagnosis is precisely the failure mechanism.

## Test plan

- [ ] `npm test -w modules/sdk-coin-trx -- --grep "proto3 default"` — new regression test asserts `raw_data_hex` does **not** contain `5a68080012` (buggy framing with the default-valued enum tag) and **does** contain `5a661264` (canonical framing).
- [ ] Existing AccountCreate builder tests pass unchanged (build, sign, round-trip, extendValidTo, multi-sign, txID stability).
- [ ] End-to-end: TSS AccountCreate broadcast on testnet for an MPC wallet should now succeed (previously failed with the SIGERROR above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)