### PR TITLE
refactor(abstract-utxo): narrow descriptor PSBT type unions to wasm-only

### DIFF
--- a/modules/abstract-utxo/src/offlineVault/descriptor/transaction.ts
+++ b/modules/abstract-utxo/src/offlineVault/descriptor/transaction.ts
@@ -12,7 +12,6 @@ import {
 import { explainPsbt, signPsbt } from '../../transaction/descriptor';
 import { TransactionExplanation } from '../TransactionExplanation';
 import { UtxoCoinName } from '../../names';
-import { toWasmPsbt } from '../../wasmUtil';
 
 export const DescriptorTransaction = t.intersection(
   [OfflineVaultSignable, t.type({ descriptors: t.array(NamedDescriptor) })],
@@ -34,7 +33,7 @@ export function getDescriptorsFromDescriptorTransaction(tx: DescriptorTransactio
 }
 
 export function getHalfSignedPsbt(tx: DescriptorTransaction, prv: bip32.BIP32Interface, coinName: UtxoCoinName): Psbt {
-  const psbt = toWasmPsbt(Buffer.from(tx.coinSpecific.txHex, 'hex'));
+  const psbt = Psbt.deserialize(Buffer.from(tx.coinSpecific.txHex, 'hex'));
   const descriptorMap = getDescriptorsFromDescriptorTransaction(tx);
   signPsbt(psbt, descriptorMap, prv, { onUnknownInput: 'throw' });
   return psbt;
@@ -44,7 +43,7 @@ export function getTransactionExplanationFromPsbt(
   tx: DescriptorTransaction,
   coinName: UtxoCoinName
 ): TransactionExplanation<string> {
-  const psbt = toWasmPsbt(Buffer.from(tx.coinSpecific.txHex, 'hex'));
+  const psbt = Psbt.deserialize(Buffer.from(tx.coinSpecific.txHex, 'hex'));
   const descriptorMap = getDescriptorsFromDescriptorTransaction(tx);
   const { outputs, changeOutputs, fee } = explainPsbt(psbt, descriptorMap, coinName);
   return {

--- a/modules/abstract-utxo/src/transaction/descriptor/parse.ts
+++ b/modules/abstract-utxo/src/transaction/descriptor/parse.ts
@@ -9,8 +9,11 @@ import { IDescriptorWallet } from '../../descriptor/descriptorWallet';
 import { fromExtendedAddressFormatToScript, toExtendedAddressFormat } from '../recipient';
 import { outputDifferencesWithExpected, OutputDifferenceWithExpected } from '../outputDifference';
 import { UtxoCoinName } from '../../names';
-import { sumValues, toWasmPsbt, UtxoLibPsbt } from '../../wasmUtil';
 import { decodeDescriptorPsbt } from '../decode';
+
+function sumValues(arr: { value: bigint }[]): bigint {
+  return arr.reduce((sum, e) => sum + e.value, 0n);
+}
 
 type ParsedOutput = Omit<descriptorWallet.ParsedOutput, 'script'> & { script: Buffer };
 
@@ -88,12 +91,12 @@ function toBaseParsedTransactionOutputs(
 }
 
 export function toBaseParsedTransactionOutputsFromPsbt(
-  psbt: Psbt | UtxoLibPsbt | Uint8Array,
+  psbt: Psbt | Uint8Array,
   descriptorMap: descriptorWallet.DescriptorMap,
   recipients: ITransactionRecipient[],
   coinName: UtxoCoinName
 ): ParsedOutputsBigInt {
-  const wasmPsbt = toWasmPsbt(psbt);
+  const wasmPsbt = psbt instanceof Psbt ? psbt : Psbt.deserialize(psbt);
   return toBaseParsedTransactionOutputs(
     parseOutputsWithPsbt(
       wasmPsbt,

--- a/modules/abstract-utxo/src/transaction/descriptor/verifyTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/descriptor/verifyTransaction.ts
@@ -4,7 +4,6 @@ import type { Psbt, descriptorWallet } from '@bitgo/wasm-utxo';
 import { AbstractUtxoCoin, VerifyTransactionOptions } from '../../abstractUtxoCoin';
 import { BaseOutput, BaseParsedTransactionOutputs } from '../types';
 import { UtxoCoinName } from '../../names';
-import { UtxoLibPsbt } from '../../wasmUtil';
 import { decodeDescriptorPsbt } from '../decode';
 
 import { toBaseParsedTransactionOutputsFromPsbt } from './parse';
@@ -52,7 +51,7 @@ export function assertExpectedOutputDifference(
 }
 
 export function assertValidTransaction(
-  psbt: Psbt | UtxoLibPsbt | Uint8Array,
+  psbt: Psbt | Uint8Array,
   descriptors: descriptorWallet.DescriptorMap,
   recipients: ITransactionRecipient[],
   coinName: UtxoCoinName


### PR DESCRIPTION
## Summary

Narrows three function signatures in \`transaction/descriptor/{parse,verifyTransaction}.ts\` and \`offlineVault/descriptor/transaction.ts\` from \`Psbt | UtxoLibPsbt | Uint8Array\` to \`Psbt | Uint8Array\`. All call sites pass either a wasm \`Psbt\` or a buffer — never a utxolib PSBT (verified by grep). The bridge call \`toWasmPsbt(psbt)\` becomes an inline \`psbt instanceof Psbt ? psbt : Psbt.deserialize(psbt)\`.

Also inlines the trivial \`sumValues\` helper locally in \`parse.ts\` so it no longer pulls from \`wasmUtil.ts\`.

## PR group context

Part of an 8-PR fan-out removing \`@bitgo/utxo-lib\` from abstract-utxo runtime. Independent — file-disjoint from the other PRs in this group. Can merge in any order.

## Test plan

- [x] \`yarn tsc --noEmit\` clean in \`modules/abstract-utxo\`
- [x] \`yarn lint\` clean in \`modules/abstract-utxo\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)