### PR TITLE
refactor(abstract-utxo): inline toWasmBIP32 in signPsbtWasm

### DIFF
--- a/modules/abstract-utxo/src/transaction/fixedScript/signPsbtWasm.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/signPsbtWasm.ts
@@ -2,10 +2,12 @@ import assert from 'assert';
 
 import { BIP32, bip32, ECPair, fixedScriptWallet, getWasmUtxoVersion } from '@bitgo/wasm-utxo';
 
-import { toWasmBIP32 } from '../../wasmUtil';
-
 import { BulkSigningError, InputSigningError, TransactionSigningError } from './SigningError';
 import { Musig2Participant } from './musig2';
+
+function toWasmBIP32(key: bip32.BIP32Interface | BIP32): BIP32 {
+  return key instanceof BIP32 ? key : BIP32.fromBase58(key.toBase58());
+}
 
 export type ReplayProtectionKeys = {
   publicKeys: (Uint8Array | ECPair)[];


### PR DESCRIPTION
## Summary

Removes \`signPsbtWasm.ts\`'s dependency on the \`toWasmBIP32\` bridge in \`wasmUtil.ts\` by inlining a local helper that accepts either a wasm \`BIP32\` or a \`bip32.BIP32Interface\` (also from wasm-utxo) and returns a wasm \`BIP32\`. No utxolib types involved.

## PR group context

Part of an 8-PR fan-out removing \`@bitgo/utxo-lib\` from abstract-utxo runtime. Independent — file-disjoint from the other PRs in this group. Can merge in any order.

## Test plan

- [x] \`yarn tsc --noEmit\` clean in \`modules/abstract-utxo\`
- [x] \`yarn lint\` clean in \`modules/abstract-utxo\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)