### PR TITLE
refactor(abstract-utxo): import descriptor types directly from @bitgo/wasm-utxo

### DIFF
--- a/modules/abstract-utxo/src/descriptor/descriptorWallet.ts
+++ b/modules/abstract-utxo/src/descriptor/descriptorWallet.ts
@@ -2,10 +2,11 @@ import * as t from 'io-ts';
 import { IWallet, WalletCoinSpecific } from '@bitgo/sdk-core';
 
 import { UtxoWallet, UtxoWalletData } from '../wallet';
-import type { DescriptorMap } from '../wasmUtil';
 
 import { NamedDescriptor } from './NamedDescriptor';
 import { DescriptorValidationPolicy, KeyTriple, toDescriptorMapValidate } from './validatePolicy';
+
+import type { DescriptorMap } from './index';
 
 type DescriptorWalletCoinSpecific = {
   descriptors: NamedDescriptor[];

--- a/modules/abstract-utxo/src/descriptor/index.ts
+++ b/modules/abstract-utxo/src/descriptor/index.ts
@@ -1,5 +1,7 @@
+import type { descriptorWallet } from '@bitgo/wasm-utxo';
+
 export { Miniscript, Descriptor } from '@bitgo/wasm-utxo';
-export type { DescriptorMap } from '../wasmUtil';
+export type DescriptorMap = descriptorWallet.DescriptorMap;
 export { assertDescriptorWalletAddress } from './assertDescriptorWalletAddress';
 export {
   NamedDescriptor,

--- a/modules/abstract-utxo/src/descriptor/validatePolicy.ts
+++ b/modules/abstract-utxo/src/descriptor/validatePolicy.ts
@@ -1,10 +1,10 @@
 import { EnvironmentName, Triple } from '@bitgo/sdk-core';
 import { bip32, descriptorWallet } from '@bitgo/wasm-utxo';
 
-import type { DescriptorMap } from '../wasmUtil';
-
 import { parseDescriptor } from './builder';
 import { hasValidSignature, NamedDescriptor, NamedDescriptorNative, toNamedDescriptorNative } from './NamedDescriptor';
+
+import type { DescriptorMap } from './index';
 
 export type KeyTriple = Triple<bip32.BIP32Interface>;
 

--- a/modules/abstract-utxo/src/transaction/descriptor/explainPsbt.ts
+++ b/modules/abstract-utxo/src/transaction/descriptor/explainPsbt.ts
@@ -3,7 +3,10 @@ import { Psbt, descriptorWallet } from '@bitgo/wasm-utxo';
 
 import type { TransactionExplanationDescriptor } from '../fixedScript/explainTransaction';
 import { UtxoCoinName } from '../../names';
-import { sumValues } from '../../wasmUtil';
+
+function sumValues(arr: { value: bigint }[]): bigint {
+  return arr.reduce((sum, e) => sum + e.value, 0n);
+}
 
 function toRecipient(output: descriptorWallet.ParsedOutput, coinName: UtxoCoinName): ITransactionRecipient {
   const address = output.address ?? `scriptPubKey:${Buffer.from(output.script).toString('hex')}`;

--- a/modules/abstract-utxo/src/transaction/descriptor/index.ts
+++ b/modules/abstract-utxo/src/transaction/descriptor/index.ts
@@ -1,4 +1,4 @@
-export type { DescriptorMap } from '../../wasmUtil';
+export type { DescriptorMap } from '../../descriptor';
 export { explainPsbt } from './explainPsbt';
 export { parse } from './parse';
 export { parseToAmountType } from './parseToAmountType';

--- a/modules/abstract-utxo/src/transaction/descriptor/signPsbt.ts
+++ b/modules/abstract-utxo/src/transaction/descriptor/signPsbt.ts
@@ -1,6 +1,6 @@
 import { Psbt, descriptorWallet } from '@bitgo/wasm-utxo';
 
-import type { SignerKey } from '../../wasmUtil';
+type SignerKey = Parameters<typeof descriptorWallet.signWithKey>[1];
 
 export class ErrorUnknownInput extends Error {
   constructor(public vin: number) {


### PR DESCRIPTION
## Summary

Drops the \`DescriptorMap\`, \`SignerKey\`, and \`sumValues\` re-exports/wrappers from \`wasmUtil.ts\` by importing the underlying types directly from \`@bitgo/wasm-utxo\` in:

- \`src/descriptor/{descriptorWallet,index,validatePolicy}.ts\` — \`DescriptorMap\` now sourced from \`descriptorWallet.DescriptorMap\`
- \`src/transaction/descriptor/{explainPsbt,index,signPsbt}.ts\` — same plus \`SignerKey\` typed as \`Parameters<typeof descriptorWallet.signWithKey>[1]\` locally; trivial \`sumValues\` inlined

No behavior change — just removes a redundant indirection layer.

## PR group context

Part of an 8-PR fan-out removing \`@bitgo/utxo-lib\` from abstract-utxo runtime. Independent — file-disjoint from the other PRs in this group. Can merge in any order.

## Test plan

- [x] \`yarn tsc --noEmit\` clean in \`modules/abstract-utxo\`
- [x] \`yarn lint\` clean in \`modules/abstract-utxo\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)