### PR TITLE
feat: add v2 encrypt/decrypt for passkey

### DIFF
--- a/modules/passkey-crypto/src/attachPasskeyToWallet.ts
+++ b/modules/passkey-crypto/src/attachPasskeyToWallet.ts
@@ -44,7 +44,7 @@ export async function attachPasskeyToWallet(params: {
   const prfSalt = deriveEnterpriseSalt(device.prfSalt, enterpriseId);
 
   // Decrypt private key with existing passphrase
-  const privateKey = bitgo.decrypt({ password: existingPassphrase, input: keychain.encryptedPrv });
+  const privateKey = await bitgo.decryptAsync({ password: existingPassphrase, input: keychain.encryptedPrv });
 
   // Decode credentialId from base64url to ArrayBuffer for allowCredentials.
   // The WebAuthn spec requires allowCredentials to be non-empty when using evalByCredential,
@@ -66,7 +66,7 @@ export async function attachPasskeyToWallet(params: {
   }
 
   const prfPassword = derivePassword(authResult.prfResult);
-  const encryptedPrv = bitgo.encrypt({ password: prfPassword, input: privateKey });
+  const encryptedPrv = await bitgo.encryptAsync({ password: prfPassword, input: privateKey, encryptionVersion: 2 });
 
   const updatedKeychain = await bitgo
     .put(bitgo.url(`/${coin}/key/${keychainId}`, 2))

--- a/modules/passkey-crypto/src/removePasskeyFromWallet.ts
+++ b/modules/passkey-crypto/src/removePasskeyFromWallet.ts
@@ -1,4 +1,4 @@
-import { BitGoBase, decryptKeychainPrivateKey } from '@bitgo/sdk-core';
+import { BitGoBase, decryptKeychainPrivateKeyAsync } from '@bitgo/sdk-core';
 import { WebAuthnOtpDevice } from './webAuthnTypes';
 
 export async function removePasskeyFromWallet(params: {
@@ -20,7 +20,7 @@ export async function removePasskeyFromWallet(params: {
   const keychain = await baseCoin.keychains().get({ id: keychainId });
 
   // Verify passphrase before any mutation
-  const decrypted = decryptKeychainPrivateKey(bitgo, keychain, walletPassphrase);
+  const decrypted = await decryptKeychainPrivateKeyAsync(bitgo, keychain, walletPassphrase);
   if (!decrypted) {
     throw new Error('Incorrect wallet passphrase. Passkey removal aborted to prevent lockout.');
   }

--- a/modules/passkey-crypto/test/unit/attachPasskeyToWallet.test.ts
+++ b/modules/passkey-crypto/test/unit/attachPasskeyToWallet.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { attachPasskeyToWallet } from '../../src/attachPasskeyToWallet';
+import { derivePassword } from '../../src/derivePassword';
 import { WebAuthnOtpDevice, PasskeyAuthResult, WebAuthnProvider } from '../../src/webAuthnTypes';
 
 describe('attachPasskeyToWallet', function () {
@@ -53,8 +54,8 @@ describe('attachPasskeyToWallet', function () {
     url: sinon.SinonStub;
     coin: sinon.SinonStub;
     put: sinon.SinonStub;
-    decrypt: sinon.SinonStub;
-    encrypt: sinon.SinonStub;
+    decryptAsync: sinon.SinonStub;
+    encryptAsync: sinon.SinonStub;
   };
 
   let mockProvider: {
@@ -83,8 +84,8 @@ describe('attachPasskeyToWallet', function () {
         .callsFake((path, version) => `/api/v${version ?? 1}${path}`),
       coin: sinon.stub().returns(mockBaseCoin),
       put: sinon.stub(),
-      decrypt: sinon.stub(),
-      encrypt: sinon.stub(),
+      decryptAsync: sinon.stub(),
+      encryptAsync: sinon.stub(),
     };
 
     mockProvider = {
@@ -92,8 +93,8 @@ describe('attachPasskeyToWallet', function () {
       get: sinon.stub(),
     };
 
-    mockBitGo.decrypt.returns(decryptedPrv);
-    mockBitGo.encrypt.returns(reEncryptedPrv);
+    mockBitGo.decryptAsync.resolves(decryptedPrv);
+    mockBitGo.encryptAsync.resolves(reEncryptedPrv);
 
     const putSendStub = sinon.stub().returns({ result: sinon.stub().resolves(updatedKeychain) });
     mockBitGo.put.returns({ send: putSendStub });
@@ -124,8 +125,8 @@ describe('attachPasskeyToWallet', function () {
     sinon.assert.calledWith(mockWallets.get, { id: walletId });
     sinon.assert.calledOnce(mockWallet.type);
     sinon.assert.calledOnce(mockWallet.getEncryptedUserKeychain);
-    sinon.assert.calledOnce(mockBitGo.decrypt);
-    sinon.assert.calledWithExactly(mockBitGo.decrypt, { password: existingPassphrase, input: encryptedPrv });
+    sinon.assert.calledOnce(mockBitGo.decryptAsync);
+    sinon.assert.calledWithExactly(mockBitGo.decryptAsync, { password: existingPassphrase, input: encryptedPrv });
 
     // provider.get called with evalByCredential keyed on device.credentialId
     sinon.assert.calledOnce(mockProvider.get);
@@ -151,7 +152,28 @@ describe('attachPasskeyToWallet', function () {
     assert.match(putBody.webauthnInfo.prfSalt, /^[A-Za-z0-9\-_]+$/);
     assert.strictEqual(typeof putBody.webauthnInfo.encryptedPrv, 'string');
 
+    // encryptAsync must be called with encryptionVersion 2
+    sinon.assert.calledOnce(mockBitGo.encryptAsync);
+    sinon.assert.calledWithMatch(mockBitGo.encryptAsync, { encryptionVersion: 2 });
+
     assert.strictEqual(result.id, keychainId);
+  });
+
+  it('should re-encrypt the private key as a v2 Argon2id envelope', async function () {
+    const expectedPrfPassword = derivePassword(prfResultBuffer);
+
+    await callAttach();
+
+    // The PRF-derived password and the decrypted xprv must be passed to encryptAsync
+    sinon.assert.calledWithMatch(mockBitGo.encryptAsync, {
+      password: expectedPrfPassword,
+      input: decryptedPrv,
+      encryptionVersion: 2,
+    });
+
+    // The v2 blob returned by encryptAsync is what gets stored on the server
+    const putBody = mockBitGo.put.firstCall.returnValue.send.firstCall.args[0];
+    assert.strictEqual(putBody.webauthnInfo.encryptedPrv, reEncryptedPrv);
   });
 
   it('should decode credentialId containing base64url-specific characters (- and _)', async function () {
@@ -223,7 +245,7 @@ describe('attachPasskeyToWallet', function () {
   });
 
   it('should propagate decrypt errors', async function () {
-    mockBitGo.decrypt.throws(new Error('decryption failed'));
+    mockBitGo.decryptAsync.rejects(new Error('decryption failed'));
 
     await assert.rejects(
       () => callAttach(),

--- a/modules/passkey-crypto/test/unit/removePasskeyFromWallet.test.ts
+++ b/modules/passkey-crypto/test/unit/removePasskeyFromWallet.test.ts
@@ -39,7 +39,7 @@ describe('removePasskeyFromWallet', function () {
         wallets: sinon.stub().returns(mockWallets),
         keychains: sinon.stub().returns(mockKeychains),
       }),
-      decrypt: sinon.stub().returns('xprv-decrypted'),
+      decryptAsync: sinon.stub().resolves('xprv-decrypted'),
       del: sinon.stub().returns({
         result: sinon.stub().resolves({}),
       }),
@@ -75,7 +75,7 @@ describe('removePasskeyFromWallet', function () {
   });
 
   it('should throw and not call DELETE if passphrase is wrong', async function () {
-    mockBitGo.decrypt = sinon.stub().throws(new Error('decryption failed'));
+    mockBitGo.decryptAsync = sinon.stub().resolves(undefined);
 
     await assert.rejects(
       () =>


### PR DESCRIPTION
Ticket: WCN-412

This pull request updates the passkey-crypto module to use asynchronous encryption and decryption methods for improved security and future compatibility. It also updates the relevant unit tests to mock and assert the new async methods, and ensures the new encryption uses the latest version. The most important changes are grouped below:

### Core Logic Updates

* Replaced synchronous `bitgo.decrypt` and `bitgo.encrypt` calls with their asynchronous counterparts `bitgo.decryptAsync` and `bitgo.encryptAsync` in `attachPasskeyToWallet.ts`, and set `encryptionVersion: 2` for the new encryption to use the latest Argon2id envelope format. [[1]](diffhunk://#diff-5a6ee71c18e3cacc1cbb435cde3753c150a2a13c08822129c5ed6c67e0274028L47-R47) [[2]](diffhunk://#diff-5a6ee71c18e3cacc1cbb435cde3753c150a2a13c08822129c5ed6c67e0274028L69-R69)
* Updated `removePasskeyFromWallet.ts` to use `decryptKeychainPrivateKeyAsync` instead of the synchronous version for verifying the wallet passphrase. [[1]](diffhunk://#diff-88740a8dffcf9f071d47caf9863ad1752df072ab8d81e7002534d8b74fec2d25L1-R1) [[2]](diffhunk://#diff-88740a8dffcf9f071d47caf9863ad1752df072ab8d81e7002534d8b74fec2d25L23-R23)

### Unit Test Updates

* Updated `attachPasskeyToWallet.test.ts` and `removePasskeyFromWallet.test.ts` to mock and assert the new async encryption and decryption methods (`decryptAsync`, `encryptAsync`) instead of the old synchronous ones. This includes checking that `encryptionVersion: 2` is passed and that errors are properly propagated. [[1]](diffhunk://#diff-077cda0fc85de7a4f9745d0cc8eb8db89bed2d2af1fe65ce5560b19d1c83e2c8L56-R58) [[2]](diffhunk://#diff-077cda0fc85de7a4f9745d0cc8eb8db89bed2d2af1fe65ce5560b19d1c83e2c8L86-R97) [[3]](diffhunk://#diff-077cda0fc85de7a4f9745d0cc8eb8db89bed2d2af1fe65ce5560b19d1c83e2c8L127-R129) [[4]](diffhunk://#diff-077cda0fc85de7a4f9745d0cc8eb8db89bed2d2af1fe65ce5560b19d1c83e2c8R155-R178) [[5]](diffhunk://#diff-077cda0fc85de7a4f9745d0cc8eb8db89bed2d2af1fe65ce5560b19d1c83e2c8L226-R248) [[6]](diffhunk://#diff-d8ad71c7c2ef57e14ee156f078873e0a0e04c187253606ce8975730767edef5bL42-R42) [[7]](diffhunk://#diff-d8ad71c7c2ef57e14ee156f078873e0a0e04c187253606ce8975730767edef5bL78-R78)

### Additional Test Coverage

* Added a new test case to ensure that the private key is re-encrypted using the v2 Argon2id envelope and that the correct parameters are passed to `encryptAsync`.

These changes modernize our cryptographic operations and ensure our tests accurately reflect the new async code paths.

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
