### PR TITLE
feat(abstract-utxo): disable legacy tx format and utxolib backend for all coins

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -436,11 +436,11 @@ export abstract class AbstractUtxoCoin
 
   protected supportedTxFormats: { psbt: boolean; legacy: boolean } = {
     psbt: true,
-    legacy: this.getChain() === 'btc',
+    legacy: false,
   };
 
   protected supportedSdkBackends: { utxolib: boolean; 'wasm-utxo': boolean } = {
-    utxolib: this.getChain() === 'btc',
+    utxolib: false,
     'wasm-utxo': true,
   };
 


### PR DESCRIPTION
Set supportedTxFormats.legacy and supportedSdkBackends.utxolib to false
unconditionally, completing the rollout to all coins.

Refs: T1-3245, T1-3280
Co-authored-by: llm-git <llm-git@ttll.de>