### PR TITLE
feat(sdk-core,abstract-utxo): add qr param and client-side output val…

### DIFF
--- a/modules/abstract-lightning/package.json
+++ b/modules/abstract-lightning/package.json
@@ -39,7 +39,7 @@
     ]
   },
   "dependencies": {
-    "@bitgo/public-types": "6.21.0",
+    "@bitgo/public-types": "6.22.0",
     "@bitgo/sdk-core": "^37.3.0",
     "@bitgo/statics": "^58.43.0",
     "@bitgo/utxo-lib": "^11.22.1",

--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -279,6 +279,7 @@ export interface TransactionParams extends BaseTransactionParams {
   rbfTxIds?: string[];
   /** Parameters for bridging intents (e.g. BTC -> sBTC peg-in), present when `type === 'bridging'`. */
   bridgingParams?: BridgingParams;
+  qr?: boolean;
 }
 
 export interface ParseTransactionOptions<TNumber extends number | bigint = number> extends BaseParseTransactionOptions {

--- a/modules/abstract-utxo/src/transaction/descriptor/verifyTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/descriptor/verifyTransaction.ts
@@ -94,7 +94,32 @@ export async function verifyTransaction<TNumber extends number | bigint>(
     );
   }
 
-  assertValidTransaction(psbt, descriptorMap, params.txParams.recipients ?? [], coin.name);
+  const parsedOutputs = toBaseParsedTransactionOutputsFromPsbt(
+    psbt,
+    descriptorMap,
+    params.txParams.recipients ?? [],
+    coin.name
+  );
+
+  if (params.txParams.qr) {
+    const allExternalOutputs = [...parsedOutputs.explicitExternalOutputs, ...parsedOutputs.implicitExternalOutputs];
+    if (allExternalOutputs.length > 0) {
+      const txExplanation = await TxIntentMismatchError.tryGetTxExplanation(
+        coin as unknown as IBaseCoin,
+        params.txPrebuild
+      );
+      throw new TxIntentMismatchError(
+        'quantum-resistant sweep transactions must only contain wallet-internal outputs',
+        params.reqId,
+        [params.txParams],
+        params.txPrebuild.txHex,
+        txExplanation
+      );
+    }
+    return true;
+  }
+
+  assertExpectedOutputDifference(parsedOutputs);
 
   return true;
 }

--- a/modules/abstract-utxo/src/transaction/fixedScript/verifyTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/verifyTransaction.ts
@@ -127,6 +127,17 @@ export async function verifyTransaction<TNumber extends bigint | number>(
     debug('successfully verified user public key and custom change key signatures');
   }
 
+  if (txParams.qr) {
+    const allExternalOutputs = [
+      ...parsedTransaction.explicitExternalOutputs,
+      ...parsedTransaction.implicitExternalOutputs,
+    ];
+    if (allExternalOutputs.length > 0) {
+      throwTxMismatch('quantum-resistant sweep transactions must only contain wallet-internal outputs');
+    }
+    return true;
+  }
+
   const missingOutputs = parsedTransaction.missingOutputs;
   if (missingOutputs.length !== 0) {
     // there are some outputs in the recipients list that have not made it into the actual transaction

--- a/modules/abstract-utxo/test/unit/transaction/descriptor/verifyTransactionQr.ts
+++ b/modules/abstract-utxo/test/unit/transaction/descriptor/verifyTransactionQr.ts
@@ -1,0 +1,93 @@
+import assert from 'assert';
+
+import * as testutils from '@bitgo/wasm-utxo/testutils';
+
+import { verifyTransaction } from '../../../../src/transaction/descriptor/verifyTransaction';
+import { getUtxoCoin } from '../../util';
+
+const { getDefaultXPubs, getDescriptor, getDescriptorMap, mockPsbt } = testutils.descriptor;
+
+describe('descriptor verifyTransaction - quantum-resistant sweep', function () {
+  const coin = getUtxoCoin('tbtc');
+
+  const xpubsSelf = getDefaultXPubs('a');
+  const xpubsOther = getDefaultXPubs('b');
+  const descriptorSelf = getDescriptor('Wsh2Of3', xpubsSelf);
+  const descriptorOther = getDescriptor('Wsh2Of3', xpubsOther);
+  const descriptorMap = getDescriptorMap('Wsh2Of3', xpubsSelf);
+
+  function buildPsbtAllInternal() {
+    return mockPsbt(
+      [
+        { descriptor: descriptorSelf, index: 0 },
+        { descriptor: descriptorSelf, index: 1, id: { vout: 1 } },
+      ],
+      [
+        { descriptor: descriptorSelf, index: 0, value: BigInt(4e5) },
+        { descriptor: descriptorSelf, index: 1, value: BigInt(4e5) },
+      ]
+    );
+  }
+
+  function buildPsbtWithExternal() {
+    return mockPsbt(
+      [
+        { descriptor: descriptorSelf, index: 0 },
+        { descriptor: descriptorSelf, index: 1, id: { vout: 1 } },
+      ],
+      [
+        { descriptor: descriptorOther, index: 0, value: BigInt(4e5), external: true },
+        { descriptor: descriptorSelf, index: 0, value: BigInt(4e5) },
+      ]
+    );
+  }
+
+  it('should reject when external outputs exist and qr is true', async function () {
+    const psbt = buildPsbtWithExternal();
+
+    await assert.rejects(
+      verifyTransaction(
+        coin,
+        {
+          txParams: { qr: true, recipients: [] },
+          txPrebuild: { txHex: Buffer.from(psbt.serialize()).toString('hex') },
+          wallet: {} as any,
+        },
+        descriptorMap
+      ),
+      /quantum-resistant sweep transactions must only contain wallet-internal outputs/
+    );
+  });
+
+  it('should pass when all outputs are internal and qr is true', async function () {
+    const psbt = buildPsbtAllInternal();
+
+    const result = await verifyTransaction(
+      coin,
+      {
+        txParams: { qr: true, recipients: [] },
+        txPrebuild: { txHex: Buffer.from(psbt.serialize()).toString('hex') },
+        wallet: {} as any,
+      },
+      descriptorMap
+    );
+
+    assert.strictEqual(result, true);
+  });
+
+  it('should not apply qr check when qr is not set (internal-only outputs pass normally)', async function () {
+    const psbt = buildPsbtAllInternal();
+
+    const result = await verifyTransaction(
+      coin,
+      {
+        txParams: { recipients: [] },
+        txPrebuild: { txHex: Buffer.from(psbt.serialize()).toString('hex') },
+        wallet: {} as any,
+      },
+      descriptorMap
+    );
+
+    assert.strictEqual(result, true);
+  });
+});

--- a/modules/abstract-utxo/test/unit/verifyTransaction.ts
+++ b/modules/abstract-utxo/test/unit/verifyTransaction.ts
@@ -465,6 +465,119 @@ describe('Verify Transaction', function () {
     coinMock.restore();
   });
 
+  describe('quantum-resistant sweep (qr: true)', function () {
+    it('should reject when explicit external outputs are present', async () => {
+      const coinMock = sinon.stub(coin, 'parseTransaction').resolves({
+        keychains: {} as any,
+        keySignatures: {},
+        outputs: [],
+        missingOutputs: [],
+        explicitExternalOutputs: [{ address: 'external_addr', amount: '5000' }],
+        implicitExternalOutputs: [],
+        changeOutputs: [{ address: 'change_addr', amount: '4000' }],
+        explicitExternalSpendAmount: 5000,
+        implicitExternalSpendAmount: 0,
+        needsCustomChangeKeySignatureVerification: false,
+      });
+
+      await assert.rejects(
+        coin.verifyTransaction({
+          txParams: { walletPassphrase: passphrase, qr: true },
+          txPrebuild: {},
+          wallet: unsignedSendingWallet as any,
+          verification: {},
+        }),
+        /quantum-resistant sweep transactions must only contain wallet-internal outputs/
+      );
+
+      coinMock.restore();
+    });
+
+    it('should reject when implicit external outputs are present', async () => {
+      const coinMock = sinon.stub(coin, 'parseTransaction').resolves({
+        keychains: {} as any,
+        keySignatures: {},
+        outputs: [],
+        missingOutputs: [],
+        explicitExternalOutputs: [],
+        implicitExternalOutputs: [{ address: 'paygo_addr', amount: '100' }],
+        changeOutputs: [{ address: 'change_addr', amount: '9900' }],
+        explicitExternalSpendAmount: 0,
+        implicitExternalSpendAmount: 100,
+        needsCustomChangeKeySignatureVerification: false,
+      });
+
+      await assert.rejects(
+        coin.verifyTransaction({
+          txParams: { walletPassphrase: passphrase, qr: true },
+          txPrebuild: {},
+          wallet: unsignedSendingWallet as any,
+          verification: {},
+        }),
+        /quantum-resistant sweep transactions must only contain wallet-internal outputs/
+      );
+
+      coinMock.restore();
+    });
+
+    it('should pass when all outputs are internal (change only)', async () => {
+      const coinMock = sinon.stub(coin, 'parseTransaction').resolves({
+        keychains: {} as any,
+        keySignatures: {},
+        outputs: [{ address: 'change_addr', amount: '10000' }],
+        missingOutputs: [],
+        explicitExternalOutputs: [],
+        implicitExternalOutputs: [],
+        changeOutputs: [{ address: 'change_addr', amount: '10000' }],
+        explicitExternalSpendAmount: 0,
+        implicitExternalSpendAmount: 0,
+        needsCustomChangeKeySignatureVerification: false,
+      });
+
+      const result = await coin.verifyTransaction({
+        txParams: { walletPassphrase: passphrase, qr: true },
+        txPrebuild: {},
+        wallet: unsignedSendingWallet as any,
+        verification: {},
+      });
+
+      assert.strictEqual(result, true);
+
+      coinMock.restore();
+    });
+
+    it('should not apply qr check when qr is not set', async () => {
+      const coinMock = sinon.stub(coin, 'parseTransaction').resolves({
+        keychains: {} as any,
+        keySignatures: {},
+        outputs: [],
+        missingOutputs: [],
+        explicitExternalOutputs: [{ address: 'external_addr', amount: '5000' }],
+        implicitExternalOutputs: [],
+        changeOutputs: [],
+        explicitExternalSpendAmount: 5000,
+        implicitExternalSpendAmount: 0,
+        needsCustomChangeKeySignatureVerification: false,
+      });
+
+      const bitcoinMock = sinon
+        .stub(coin, 'createTransactionFromHex')
+        .returns({ ins: [] } as unknown as utxolib.bitgo.UtxoTransaction);
+
+      const result = await coin.verifyTransaction({
+        txParams: { walletPassphrase: passphrase },
+        txPrebuild: { txHex: '00' },
+        wallet: unsignedSendingWallet as any,
+        verification: {},
+      });
+
+      assert.strictEqual(result, true);
+
+      coinMock.restore();
+      bitcoinMock.restore();
+    });
+  });
+
   it('should work with bigint amounts', async () => {
     // need a coin that uses bigint
     const bigintCoin = getUtxoCoin('tdoge');

--- a/modules/bitgo/package.json
+++ b/modules/bitgo/package.json
@@ -140,7 +140,7 @@
     "superagent": "^9.0.1"
   },
   "devDependencies": {
-    "@bitgo/public-types": "6.21.0",
+    "@bitgo/public-types": "6.22.0",
     "@bitgo/sdk-opensslbytes": "^2.1.0",
     "@bitgo/sdk-test": "^9.1.46",
     "@openpgp/web-stream-tools": "0.0.14",

--- a/modules/express/package.json
+++ b/modules/express/package.json
@@ -60,7 +60,7 @@
     "superagent": "^9.0.1"
   },
   "devDependencies": {
-    "@bitgo/public-types": "6.21.0",
+    "@bitgo/public-types": "6.22.0",
     "@bitgo/sdk-lib-mpc": "^10.14.0",
     "@bitgo/sdk-test": "^9.1.46",
     "@types/argparse": "^1.0.36",

--- a/modules/sdk-coin-flrp/package.json
+++ b/modules/sdk-coin-flrp/package.json
@@ -47,7 +47,7 @@
     "@bitgo/sdk-test": "^9.1.46"
   },
   "dependencies": {
-    "@bitgo/public-types": "6.21.0",
+    "@bitgo/public-types": "6.22.0",
     "@bitgo/sdk-core": "^37.3.0",
     "@bitgo/secp256k1": "^1.11.0",
     "@bitgo/statics": "^58.43.0",

--- a/modules/sdk-coin-sol/package.json
+++ b/modules/sdk-coin-sol/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@bitgo/logger": "^1.4.0",
-    "@bitgo/public-types": "6.21.0",
+    "@bitgo/public-types": "6.22.0",
     "@bitgo/sdk-core": "^37.3.0",
     "@bitgo/sdk-lib-mpc": "^10.14.0",
     "@bitgo/statics": "^58.43.0",

--- a/modules/sdk-core/package.json
+++ b/modules/sdk-core/package.json
@@ -40,7 +40,7 @@
     ]
   },
   "dependencies": {
-    "@bitgo/public-types": "6.21.0",
+    "@bitgo/public-types": "6.22.0",
     "@bitgo/sdk-lib-mpc": "^10.14.0",
     "@bitgo/secp256k1": "^1.11.0",
     "@bitgo/sjcl": "^1.1.0",

--- a/modules/sdk-core/src/bitgo/wallet/BuildParams.ts
+++ b/modules/sdk-core/src/bitgo/wallet/BuildParams.ts
@@ -38,6 +38,7 @@ export const BuildParamsUTXO = t.partial({
   rbfTxIds: t.array(t.string),
   isReplaceableByFee: t.boolean,
   messages: t.array(Bip322Message),
+  qr: t.boolean,
 });
 
 export const BuildParamsStacks = t.partial({

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -274,6 +274,7 @@ export interface PrebuildTransactionOptions {
   };
   txRequestId?: string;
   isTestTransaction?: boolean;
+  qr?: boolean;
   transferOfferId?: string;
   /**
    * Amount for intents that use a top-level amount instead of recipients (e.g. bridgeFunds).

--- a/yarn.lock
+++ b/yarn.lock
@@ -1063,10 +1063,10 @@
     monocle-ts "^2.3.13"
     newtype-ts "^0.3.5"
 
-"@bitgo/public-types@6.21.0":
-  version "6.21.0"
-  resolved "https://registry.npmjs.org/@bitgo/public-types/-/public-types-6.21.0.tgz#54120da43349514cb5f7c98013883fd25e40fdbb"
-  integrity sha512-Y5pVLb81bGUY4jZWvp92AZzpdCmI1qUpDbMOsPEdwMxwlFNwj8gHCjtbW3sNpXpr09m3v9IXUZxdNBdjeGs9/w==
+"@bitgo/public-types@6.22.0":
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/@bitgo/public-types/-/public-types-6.22.0.tgz#bbef2866c9b2d35e4a6179f7c400abc4f419d0ec"
+  integrity sha512-FueZVrrAKfevkoC9/TtKQLq5S19PzKfsNSj+0uHt1rEoKJ5vS1Icf/M/8pIwYVR11Kn3mjWzqbYJrJUZI/3FHQ==
   dependencies:
     fp-ts "^2.0.0"
     io-ts "npm:@bitgo-forks/io-ts@2.1.4"


### PR DESCRIPTION
…idation

Add the `qr` build parameter to the SDK and enforce client-side verification that quantum-resistant sweep transactions only contain wallet-internal outputs.

sdk-core:
- Add `qr: t.boolean` to `BuildParamsUTXO` io-ts codec
- Add `qr?: boolean` to `PrebuildTransactionOptions` interface

abstract-utxo:
- Add `qr?: boolean` to `TransactionParams` interface
- Fixed-script verifyTransaction: when qr is true, reject any transaction with explicit or implicit external outputs
- Descriptor verifyTransaction: same enforcement for descriptor wallets, throwing TxIntentMismatchError on external outputs
- 7 new tests covering both verification paths

Ticket: T1-3418

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
