### PR TITLE
fix: correct sol:slx mint address typo

### DIFF
--- a/modules/statics/src/coins/solTokens.ts
+++ b/modules/statics/src/coins/solTokens.ts
@@ -3988,8 +3988,8 @@ export const solTokens = [
     'sol:slx',
     'Solstice',
     9,
-    'SLXdx4BUt2v9uJQNzWqSfzTJ9UKLUDsvxHFMEEdrfqq',
-    'SLXdx4BUt2v9uJQNzWqSfzTJ9UKLUDsvxHFMEEdrfqq',
+    'SLXdx4BUt2v9uJQNzWqSfzTJ9UKLUDsvxHFMEEdrfgq',
+    'SLXdx4BUt2v9uJQNzWqSfzTJ9UKLUDsvxHFMEEdrfgq',
     UnderlyingAsset['sol:slx'],
     SOL_TOKEN_FEATURES
   ),


### PR DESCRIPTION
TICKET: COINS-287

This pull request makes a small correction to the Solstice (SLX) token entry in the `solTokens` array. The change updates the token's address to the correct value.

* Corrected the Solstice (SLX) token address in the `solTokens` array in `solTokens.ts`.