### PR TITLE
fix(statics): correct sol:slx mint address typo

### DIFF
--- a/modules/statics/src/coins/solTokens.ts
+++ b/modules/statics/src/coins/solTokens.ts
@@ -3988,8 +3988,8 @@ export const solTokens = [
     'sol:slx',
     'Solstice',
     9,
-    'SLXdx4BUt2v9uJQNzWqSfzTJ9UKLUDsvxHFMEEdrfqq',
-    'SLXdx4BUt2v9uJQNzWqSfzTJ9UKLUDsvxHFMEEdrfqq',
+    'SLXdx4BUt2v9uJQNzWqSfzTJ9UKLUDsvxHFMEEdrfgq',
+    'SLXdx4BUt2v9uJQNzWqSfzTJ9UKLUDsvxHFMEEdrfgq',
     UnderlyingAsset['sol:slx'],
     SOL_TOKEN_FEATURES
   ),


### PR DESCRIPTION
TICKET: COIN-287

This pull request makes a minor update to the Solstice (SLX) token definition in the Solana token list. The change corrects the token address for both the mint and program fields in the `solTokens` array.

* Corrected the Solstice (SLX) token address in both the mint and program fields in `solTokens.ts` to fix a typo.