### PR TITLE
feat(statics): add ofcbaseeth:usdc and ofctbaseeth:usdc

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -45,6 +45,7 @@ module.exports = {
         'FAC-',
         'GNA-',
         'GO-',
+        'GOA-',
         'GRC-',
         'HSM-',
         'INC-',

--- a/modules/bitgo/test/v2/unit/coins/ofcToken.ts
+++ b/modules/bitgo/test/v2/unit/coins/ofcToken.ts
@@ -298,6 +298,27 @@ describe('OFC:', function () {
     });
   });
 
+  describe('check ofc tokens for Base USDC', function () {
+    const tokenMain = 'ofcbaseeth:usdc';
+    const tokenTest = 'ofctbaseeth:usdc';
+    describe('for main network', function () {
+      it(`should have the correct values for ${tokenMain}`, function () {
+        const ofcCoin = bitgo.coin(tokenMain);
+        ofcCoin.getChain().should.equal(tokenMain);
+        ofcCoin.getFullName().should.equal('Base USD Coin');
+        ofcCoin.getBaseFactor().should.equal(PRECISION_6);
+      });
+    });
+    describe('for test network', function () {
+      it(`should have the correct values for ${tokenTest}`, function () {
+        const ofcCoin = bitgo.coin(tokenTest);
+        ofcCoin.getChain().should.equal(tokenTest);
+        ofcCoin.getFullName().should.equal('Test Base USD Coin');
+        ofcCoin.getBaseFactor().should.equal(PRECISION_6);
+      });
+    });
+  });
+
   describe('check ofc tokens for Stellar USDC', function () {
     const tokenMain = 'ofcxlm:usdc';
     const tokenTest = 'ofctxlm:tst';

--- a/modules/statics/src/coins/ofcErc20Coins.ts
+++ b/modules/statics/src/coins/ofcErc20Coins.ts
@@ -7104,6 +7104,20 @@ export const tOfcErc20Coins = [
     true,
     'baseeth'
   ),
+  ofcerc20(
+    'daab4576-031c-4bf2-b0bf-7ff4d23f0465',
+    'ofcbaseeth:usdc',
+    'Base USD Coin',
+    6,
+    UnderlyingAsset['baseeth:usdc'],
+    undefined,
+    [CoinFeature.STABLECOIN],
+    '',
+    undefined,
+    undefined,
+    true,
+    'baseeth'
+  ),
   tofcerc20(
     'b5277412-46b8-4da3-8fd2-5bf4557fcbd8',
     'ofctbaseeth:tusdl',
@@ -7130,6 +7144,20 @@ export const tOfcErc20Coins = [
     undefined,
     undefined,
     undefined,
+    'tbaseeth'
+  ),
+  tofcerc20(
+    'b9b5fc44-0e0a-45ec-8fde-6400ee036af6',
+    'ofctbaseeth:usdc',
+    'Test Base USD Coin',
+    6,
+    UnderlyingAsset['tbaseeth:usdc'],
+    undefined,
+    [CoinFeature.STABLECOIN],
+    '',
+    undefined,
+    undefined,
+    true,
     'tbaseeth'
   ),
 ];


### PR DESCRIPTION
## Summary
- Add `ofcbaseeth:usdc` (Base USDC OFC token, mainnet) via `ofcerc20()` with `addressCoin: 'baseeth'`
- Add `ofctbaseeth:usdc` (Base USDC OFC token, testnet) via `tofcerc20()` with `addressCoin: 'tbaseeth'`
- Add unit tests in `modules/bitgo/test/v2/unit/coins/ofcToken.ts` mirroring the Hedera USDC pattern

No new factories, enum entries, or coin-module changes needed — all underlying infrastructure (`UnderlyingAsset['baseeth:usdc']`, on-chain ERC20 registrations, parent OFC family symbols) was already in place.

## Test plan
- [ ] `cd modules/statics && yarn build` passes (TypeScript compiles cleanly)
- [ ] `yarn unit-test --scope bitgo -- --grep "Base USDC"` passes
- [ ] Verify tokens resolve: `coins.get('ofcbaseeth:usdc')` and `coins.get('ofctbaseeth:usdc')` return correct name, decimals (6), and addressCoin

🤖 Generated with [Claude Code](https://claude.com/claude-code)