### PR TITLE
feat(sdk-core): add webauthnInfo param to AddKeychainOptions for atom…

### DIFF
--- a/modules/sdk-core/src/bitgo/keychain/iKeychains.ts
+++ b/modules/sdk-core/src/bitgo/keychain/iKeychains.ts
@@ -141,8 +141,13 @@ export interface AddKeychainOptions {
   // indicates if the key is MPCv2 or not
   isMPCv2?: boolean;
   coinSpecific?: { [coinName: string]: unknown };
-  /** WebAuthn devices that have an additional encrypted copy of the private key, keyed by PRF-derived passphrases. */
+  /** WebAuthn devices that have an additional encrypted copy of the private key, keyed by PRF-derived passphrases.
+   *  @deprecated Use {@link webauthnInfo} instead — the backend reads `webauthnInfo` (single object), not `webauthnDevices`. */
   webauthnDevices?: WebauthnInfo[];
+  /** Single webauthn device to atomically attach during key creation.
+   *  Sent as `webauthnInfo` in the POST /key body so the backend can link
+   *  the passkey to the keychain in the same request. */
+  webauthnInfo?: WebauthnInfo;
 }
 
 export interface ApiKeyShare {

--- a/modules/sdk-core/src/bitgo/keychain/keychains.ts
+++ b/modules/sdk-core/src/bitgo/keychain/keychains.ts
@@ -307,6 +307,7 @@ export class Keychains implements IKeychains {
         isMPCv2: params.isMPCv2,
         coinSpecific: params.coinSpecific,
         webauthnDevices: params.webauthnDevices,
+        webauthnInfo: params.webauthnInfo,
       })
       .result();
   }


### PR DESCRIPTION
The backend POST /api/v2/:coin/key handler reads `req.body.webauthnInfo` (single object) to atomically attach a passkey during key creation, but the SDK only sent `webauthnDevices` (array) which the backend ignores. This caused passkey attachment to require a separate best-effort PUT call that could fail, leaving wallets in an inconsistent state.

Add `webauthnInfo` field to `AddKeychainOptions` and pass it through in `keychains.add()` so callers can atomically link a passkey to a keychain during creation.

Deprecate `webauthnDevices` on `AddKeychainOptions` since the backend never reads it on the POST path.

WCN-127

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
