### PR TITLE
fix(sdk-core): preserve tss build params after presign

### DIFF
--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -7,6 +7,7 @@ import * as sinon from 'sinon';
 import '../lib/asserts';
 import nock = require('nock');
 import * as _ from 'lodash';
+import * as assert from 'assert';
 
 import {
   BaseTssUtils,
@@ -2541,6 +2542,46 @@ describe('V2 Wallet:', function () {
 
     afterEach(function () {
       sandbox.verifyAndRestore();
+    });
+
+    it('should preserve tss txPrebuild buildParams when presign replaces the txPrebuild', async function () {
+      const recipients = [
+        {
+          address: '6DadkZcx9JZgeQUDbHh12cmqCpaqehmVxv6sGy49jrah',
+          amount: '1000',
+        },
+      ];
+      const buildParams = {
+        recipients,
+        type: 'transfer',
+      };
+
+      sandbox.stub(tsol, 'presignTransaction').callsFake(async (presignParams) => {
+        return {
+          ...presignParams,
+          txPrebuild: {
+            txRequestId: 'id',
+            txHex: 'refreshed-tx-hex',
+          },
+        };
+      });
+      const signTxRequest = sandbox.stub(TssUtils.prototype, 'signTxRequest').resolves(txRequest);
+
+      await tssSolWallet.signTransaction({
+        txPrebuild: {
+          txRequestId: 'id',
+          txHex: 'original-tx-hex',
+          buildParams,
+        },
+        prv: 'user-prv',
+      });
+
+      signTxRequest.should.have.been.calledOnce();
+      const firstSignTxRequestCall = signTxRequest.firstCall;
+      assert.ok(firstSignTxRequestCall);
+      const signTxRequestParams = firstSignTxRequestCall.args[0];
+      assert.ok(signTxRequestParams);
+      should(signTxRequestParams.txParams).deepEqual(buildParams);
     });
 
     describe('preBuildAndSignTransaction', async function () {

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -2235,6 +2235,19 @@ export class Wallet implements IWallet {
       tssUtils: this.tssUtils,
     });
 
+    if (
+      this.multisigType() === 'tss' &&
+      this.multisigTypeVersion() === 'MPCv2' &&
+      this.baseCoin.getMPCAlgorithm() === 'eddsa' &&
+      typeof params.txPrebuild === 'object' &&
+      typeof presign.txPrebuild === 'object' &&
+      params.txPrebuild.buildParams &&
+      !presign.txPrebuild.buildParams
+    ) {
+      // Sol presign hook refreshes txPrebuild, but buildParams is SDK-local intent metadata.
+      presign.txPrebuild.buildParams = params.txPrebuild.buildParams;
+    }
+
     if (this.multisigType() === 'tss') {
       return this.signTransactionTss({
         ...presign,


### PR DESCRIPTION
## Description

Preserve `txPrebuild.buildParams` across TSS presign flows in `sdk-core`.

Some coin level `presignTransaction` implementations can replace `txPrebuild` before TSS signing. For TSS wallets, `buildParams` carries SDK-local transaction intent metadata such as recipients and transaction type. If that metadata is dropped, downstream TSS signing and verification can receive empty or missing `txParams`, causing transaction verification failures.

This was observed in the `EdDSA MPCv2` Solana signing path. Solana’s presign flow can refresh the `txPrebuild` from the tx request and drop SDK-local `buildParams`. EdDSA MPCv2 then performs TSS signing with those missing params, which can cause recipient verification to fail before the transaction reaches the intended signing path.

This change restores the original `txPrebuild.buildParams` after presign when the presigned TSS prebuild omits them.

## Issue Number

WCI-505

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)