### PR TITLE
feat(statics): add getTokenFeatures helper for AMS token feature diffs (CSHLD-935)

### DIFF
--- a/modules/statics/src/index.ts
+++ b/modules/statics/src/index.ts
@@ -41,7 +41,12 @@ export {
   Erc7984Coin,
 } from './account';
 export { CoinMap } from './map';
-export { networkFeatureMapForTokens, registerNetworkFeatures, getNetworkFeatures } from './networkFeatureMapForTokens';
+export {
+  networkFeatureMapForTokens,
+  registerNetworkFeatures,
+  getNetworkFeatures,
+  getTokenFeatures,
+} from './networkFeatureMapForTokens';
 export {
   generateErc20Coin,
   generateTestErc20Coin,

--- a/modules/statics/src/networkFeatureMapForTokens.ts
+++ b/modules/statics/src/networkFeatureMapForTokens.ts
@@ -29,6 +29,21 @@ export function getNetworkFeatures(family: string): CoinFeature[] | undefined {
   return networkFeatureMapForTokens[family as CoinFamily] ?? dynamicNetworkFeaturesMap.get(family);
 }
 
+/**
+ * Resolve the final feature list for a token: the family's default token features
+ * plus `additionalFeatures`, minus `excludedFeatures`. Used by generated bot-token
+ * lists to apply the per-token diff returned by AMS (`features=false`).
+ */
+export function getTokenFeatures(
+  family: string,
+  additionalFeatures: CoinFeature[] = [],
+  excludedFeatures: CoinFeature[] = []
+): CoinFeature[] {
+  const base = getNetworkFeatures(family) ?? [];
+  const excluded = new Set<CoinFeature>(excludedFeatures);
+  return [...new Set<CoinFeature>([...base, ...additionalFeatures])].filter((f) => !excluded.has(f));
+}
+
 export const networkFeatureMapForTokens: Partial<Record<CoinFamily, CoinFeature[]>> = {
   algo: AccountCoin.DEFAULT_FEATURES,
   apt: APT_FEATURES,


### PR DESCRIPTION
## Summary

Adds a small helper to `@bitgo-beta/statics`:

```ts
getTokenFeatures(
  family: string,
  additionalFeatures: CoinFeature[] = [],
  excludedFeatures: CoinFeature[] = [],
): CoinFeature[]
```

Resolves the final feature list for a token — family default features (via the existing `getNetworkFeatures` lookup) plus `additionalFeatures`, minus `excludedFeatures`.

Consumed by the generated `build/botTokens.ts` once the AMS bot token generator is switched to call AMS with `features=false` (AMS already returns the per-token add/excl diff in that mode — see `replaceWithFeatureDiffs` in AMS). Keeps the generated file a single `getTokenFeatures(...)` call per token instead of inline `new Set` / `.filter` expressions in the constructor args.

Linear: [CSHLD-935](https://linear.app/bitgo/issue/CSHLD-935/generate-bottokens-with-featuresfalse-per-token-diff-no-more-dropped)

## Test plan

- [ ] `getTokenFeatures('eth')` returns the same array as `networkFeatureMapForTokens['eth']`.
- [ ] `getTokenFeatures('eth', [CoinFeature.X])` includes X (deduped against family defaults).
- [ ] `getTokenFeatures('eth', [], [CoinFeature.Y])` removes Y from the family defaults.
- [ ] `getTokenFeatures('unknown-family')` returns `[]` (no throw).
- [ ] Statics package builds cleanly: \`yarn workspace @bitgo-beta/statics build\`.

## Follow-up

- AMS PR will switch `scripts/generate-botTokens.ts` to `features=false` and emit `getTokenFeatures(...)` calls in `build/botTokens.ts`. It depends on this one shipping first so the import resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)