### PR TITLE
feat(sdk-coin-sol): add SPL getTokenType and SolCoin programId guardrails

### DIFF
--- a/modules/sdk-coin-sol/src/solToken.ts
+++ b/modules/sdk-coin-sol/src/solToken.ts
@@ -76,6 +76,14 @@ export class SolToken extends Sol {
   }
 
   /**
+   * Token standard for consolidation intents (wallet-platform).
+   * @returns {string} SPL token type identifier
+   */
+  getTokenType(): string {
+    return 'SPL';
+  }
+
+  /**
    * Flag for sending value of 0
    * @returns {boolean} True if okay to send 0 value, false otherwise
    */

--- a/modules/sdk-coin-sol/test/unit/solToken.ts
+++ b/modules/sdk-coin-sol/test/unit/solToken.ts
@@ -28,4 +28,12 @@ describe('SOL Token:', function () {
     solTokenCoin.tokenAddress.should.equal('J3NKxxXZcnNiMjKw9hYb2K4LUxgwB6t1FtPtQVsv3KFr');
     solTokenCoin.contractAddress.should.equal('J3NKxxXZcnNiMjKw9hYb2K4LUxgwB6t1FtPtQVsv3KFr');
   });
+
+  it('should return SPL token type for mainnet token', function () {
+    solTokenCoin.getTokenType().should.equal('SPL');
+  });
+
+  it('should return SPL token type for testnet token', function () {
+    (bitgo.coin('tsol:usdc') as SolToken).getTokenType().should.equal('SPL');
+  });
 });

--- a/modules/statics/test/unit/coins.ts
+++ b/modules/statics/test/unit/coins.ts
@@ -41,6 +41,7 @@ import {
   trimmedDynamicBaseChainConfig,
 } from './resources/amsTokenConfig';
 import { EthLikeErc20Token } from '../../../sdk-coin-evm/src';
+import { ProgramID } from '../../src/account';
 import { allCoinsAndTokens } from '../../src/allCoinsAndTokens';
 
 interface DuplicateCoinObject {
@@ -1010,6 +1011,15 @@ describe('Token contract address field defaults', () => {
         .forEach((coin) => {
           const solToken = coin as SolCoin;
           solToken.contractAddress.should.eql(solToken.tokenAddress);
+        });
+    });
+
+    it('have valid programId (SPL or Token-2022)', () => {
+      const validProgramIds = [ProgramID.TokenProgramId, ProgramID.Token2022ProgramId];
+      coins
+        .filter((coin) => coin.family === CoinFamily.SOL && coin instanceof SolCoin)
+        .forEach((coin) => {
+          validProgramIds.should.containEql((coin as SolCoin).programId);
         });
     });
   });


### PR DESCRIPTION
Ticket: [CHALO-506](https://linear.app/bitgo/issue/CHALO-506/bitgojs-add-sdk-changes-for-sol-single-asset-consolidation)

## Description

M1 BitGoJS prerequisites for SOL single-asset consolidation (Phase 1). Wallet-platform will gate behavior behind wallet-platform_sol-consolidation_single-asset-enable; this PR does not change consolidation runtime behavior in WP.

## Summary
- Add getTokenType(): 'SPL' on @bitgo/sdk-coin-sol SolToken for SDK parity with TRX/ERC-20 token coins (used by WP for consolidateToken intent routing when WP adds the same method on its SolToken).
- Add a statics regression test ensuring every SolCoin has a valid programId (classic SPL or Token-2022). WP resolves mint/programId at build time via coins.get(tokenName) — not via formatted SolTokenConfig.
## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Unit tests added in modules/sdk-coin-sol/test/unit/solToken.ts:
getTokenType() returns 'SPL' for mainnet (sol:spx) and testnet (tsol:usdc) via existing TestBitGo / bitgo.coin() setup

 - Unit test added in modules/statics/test/unit/coins.ts:
All SolCoin entries have programId ∈ { TokenProgramId, Token2022ProgramId }