### PR TITLE
fix(statics): update hoodeth:week display name (CECHO-1183)

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -3378,7 +3378,7 @@ export const allCoinsAndTokens = [
   erc20Token(
     'ea09a0ff-059b-4527-8e7b-75dfc750218b',
     'hoodeth:week',
-    'Weekly Options/Index tracker asset',
+    'Weekly T-Bill ETF',
     18,
     '0xc93a8c440cea26d7445df01729f193b27965099f',
     UnderlyingAsset['hoodeth:week'],

--- a/modules/statics/src/coins/ofcErc20Coins.ts
+++ b/modules/statics/src/coins/ofcErc20Coins.ts
@@ -4433,7 +4433,7 @@ export const ofcErc20Coins = [
   ofcerc20(
     '43fb356f-8b1e-4569-b6b8-982f8bfb0465',
     'ofchoodeth:week',
-    'Weekly Options/Index tracker asset',
+    'Weekly T-Bill ETF',
     18,
     underlyingAssetForSymbol('hoodeth:week'),
     undefined,


### PR DESCRIPTION
## Summary
- Updates `hoodeth:week` / `ofchoodeth:week` display name to **Weekly T-Bill ETF** in statics (base + OFC), matching the approved Robinhood naming from [CECHO-1183](https://linear.app/bitgo/issue/CECHO-1183/priority-tokens-requested-for-onboarding-batch-0526).
- Follow-up to #8881; ticker (`hoodeth:week`) and contract address are unchanged.

## Context
Priority scope for CECHO-1183 includes HoodETH:WEEK for testing. Merged statics still used the placeholder name "Weekly Options/Index tracker asset".

## Test plan
- [ ] CI passes on `modules/statics`
- [ ] Verify `hoodeth:week` and `ofchoodeth:week` resolve with display name "Weekly T-Bill ETF"


Made with [Cursor](https://cursor.com)