### PR TITLE
fix(sdk-coin-eth): add enable token support for zama

### DIFF
--- a/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
+++ b/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
@@ -3109,9 +3109,15 @@ export abstract class AbstractEthLikeNewCoins extends AbstractEthLikeCoin {
         txParams.prebuildTx?.consolidateId ||
         txPrebuild?.consolidateId ||
         (txParams.type &&
-          ['acceleration', 'fillNonce', 'transferToken', 'tokenApproval', 'consolidate', 'bridgeFunds'].includes(
-            txParams.type
-          ))
+          [
+            'acceleration',
+            'fillNonce',
+            'transferToken',
+            'tokenApproval',
+            'consolidate',
+            'bridgeFunds',
+            'enabletoken',
+          ].includes(txParams.type))
       )
     ) {
       throw new Error('missing txParams');

--- a/modules/sdk-coin-eth/src/erc7984Token.ts
+++ b/modules/sdk-coin-eth/src/erc7984Token.ts
@@ -1,7 +1,7 @@
 /**
  * @prettier
  */
-import { BitGoBase, CoinConstructor, MPCAlgorithm, NamedCoinConstructor, TokenEnablementConfig } from '@bitgo/sdk-core';
+import { BitGoBase, CoinConstructor, MPCAlgorithm, NamedCoinConstructor } from '@bitgo/sdk-core';
 
 import { coins, Erc7984TokenConfig, EthereumNetwork, tokens } from '@bitgo/statics';
 import {
@@ -119,14 +119,6 @@ export class Erc7984Token extends Eth {
 
   protected getTransactionBuilder(): TransactionBuilder {
     return new TransactionBuilder(coins.get(this.getBaseChain()));
-  }
-
-  /** @inheritDoc */
-  getTokenEnablementConfig(): TokenEnablementConfig {
-    return {
-      requiresTokenEnablement: true,
-      supportsMultipleTokenEnablements: true,
-    };
   }
 
   /** @inheritDoc */

--- a/modules/sdk-coin-eth/src/eth.ts
+++ b/modules/sdk-coin-eth/src/eth.ts
@@ -18,6 +18,7 @@ import {
   multisigTypes,
   Recipient,
   Util,
+  TokenEnablementConfig,
 } from '@bitgo/sdk-core';
 import {
   AbstractEthLikeNewCoins,
@@ -90,6 +91,14 @@ export class Eth extends AbstractEthLikeNewCoins {
 
   getMPCAlgorithm(): MPCAlgorithm {
     return 'ecdsa';
+  }
+
+  /** @inheritDoc */
+  getTokenEnablementConfig(): TokenEnablementConfig {
+    return {
+      requiresTokenEnablement: true,
+      supportsMultipleTokenEnablements: true,
+    };
   }
 
   /**

--- a/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
@@ -243,6 +243,13 @@ export abstract class MpcUtils {
             feeToken: params.feeToken,
             nonce: params.nonce,
           };
+        case 'enableToken':
+          return {
+            ...baseIntent,
+            enableTokens: params.enableTokens,
+            feeOptions: params.feeOptions,
+            feeToken: params.feeToken,
+          };
         default:
           throw new Error(`Unsupported intent type ${params.intentType}`);
       }


### PR DESCRIPTION
TICKET: CHALO-472

This pull request primarily updates the handling of token enablement transactions for Ethereum-like coins. The main changes include adding support for a new transaction type (`enabletoken`), centralizing token enablement configuration in the base `Eth` class, and updating transaction intent handling to support token enablement.

**Token Enablement Support:**

- Added `'enabletoken'` to the list of supported transaction types in `AbstractEthLikeNewCoins`, allowing the system to recognize and process token enablement transactions.
- Moved the `getTokenEnablementConfig` implementation from `Erc7984Token` to the base `Eth` class, ensuring consistent token enablement configuration across all Ethereum-like coins. [[1]](diffhunk://#diff-93be6a664d77cbdc25800e610a5be8e6cc670916ad029e0fa72c96e2c6f768a7L124-L131) [[2]](diffhunk://#diff-c547a196ebf97e9ea52de13c7f02be26fafa2503a84c9778a2b75031ae75e518R96-R103) [[3]](diffhunk://#diff-c547a196ebf97e9ea52de13c7f02be26fafa2503a84c9778a2b75031ae75e518R21) [[4]](diffhunk://#diff-93be6a664d77cbdc25800e610a5be8e6cc670916ad029e0fa72c96e2c6f768a7L4-R4)

**Transaction Intent Handling:**

- Updated `MpcUtils` to handle the new `'enableToken'` intent type, supporting the necessary parameters for token enablement transactions.
