### PR TITLE
feat(statics): add tsol:trump and ofctsol:trump testnet tokens

### DIFF
--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -1960,6 +1960,14 @@ export const ofcCoins = [
     [...SOL_TOKEN_FEATURES, CoinFeature.STABLECOIN]
   ),
   tofcsolToken(
+    'c9ee21a5-d000-45b6-a045-cb307810434b',
+    'ofctsol:trump',
+    'Test OFFICIAL TRUMP',
+    6,
+    UnderlyingAsset['sol:trump'],
+    SOL_TOKEN_FEATURES
+  ),
+  tofcsolToken(
     'ad6d7d4e-894b-4cf9-bb66-e4341717969a',
     'ofctsol:txsgd',
     'Test StraitsX SGD',

--- a/modules/statics/src/coins/solTokens.ts
+++ b/modules/statics/src/coins/solTokens.ts
@@ -3617,6 +3617,16 @@ export const solTokens = [
     UnderlyingAsset['sol:usd1'],
     [...SOL_TOKEN_FEATURES, CoinFeature.STABLECOIN]
   ),
+  tsolToken(
+    '78909b86-75e8-4e8d-b326-5b209c4508eb',
+    'tsol:trump',
+    'OFFICIAL TRUMP',
+    6,
+    'APQkhGVxBZyXkj2hRYDukgAQcqwQCAJ7kTGmVAW1yVRx',
+    'APQkhGVxBZyXkj2hRYDukgAQcqwQCAJ7kTGmVAW1yVRx',
+    UnderlyingAsset['sol:trump'],
+    SOL_TOKEN_FEATURES
+  ),
   solToken(
     '6dea72c2-bef1-4dee-8d8c-5f55bbb1d01b',
     'sol:xyo',


### PR DESCRIPTION
## Summary

Adds `tsol:trump` and `ofctsol:trump` to BitGoJS statics for Solana devnet, enabling Go Accounts testnet support for the OFFICIAL TRUMP token.

## Changes

**`modules/statics/src/coins/solTokens.ts`**
- `tsolToken()` for `tsol:trump` — devnet mint `APQkhGVxBZyXkj2hRYDukgAQcqwQCAJ7kTGmVAW1yVRx`, 6 decimals, references `UnderlyingAsset['sol:trump']`

**`modules/statics/src/coins/ofcCoins.ts`**
- `tofcsolToken()` for `ofctsol:trump` — OFC wrapper, 6 decimals, references `UnderlyingAsset['sol:trump']`

## Context

`sol:trump` already exists in production statics. This PR adds the testnet equivalents following the same pattern as `tsol:usd1` / `tsol:sofid`.

Devnet mint was deployed via `coins-sandbox/sol/tokens/createTrumpMint.js` (new script using `@solana/spl-token` v0.4.x API, reusing an existing funded wallet to avoid devnet airdrop rate limits).

## Companion PR

prime-microservices config changes: BitGo/prime-microservices (CAAS-1659 branch) — depends on this being published as a new `@bitgo-beta/statics` release.

## Test plan

- [x] `modules/statics` build: clean
- [x] `coins.get('tsol:trump')` — found, 6 decimals, testnet network ✓
- [x] `coins.get('ofctsol:trump')` — found ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)