### PR TITLE
refactor(abstract-utxo): remove utxolib runtime dependency from abstractUtxoCoin

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -3,7 +3,7 @@ import { randomBytes } from 'crypto';
 
 import _ from 'lodash';
 import * as utxolib from '@bitgo/utxo-lib';
-import { BIP32, fixedScriptWallet, hasPsbtMagic } from '@bitgo/wasm-utxo';
+import { address as wasmAddress, BIP32, fixedScriptWallet, hasPsbtMagic } from '@bitgo/wasm-utxo';
 import { bitgo } from '@bitgo/utxo-lib';
 import {
   AddressCoinSpecific,
@@ -498,15 +498,20 @@ export abstract class AbstractUtxoCoin extends BaseCoin implements Musig2Partici
     // At the time of writing, the only additional address format is bch cashaddr.
     const anyFormat = (param as { anyFormat: boolean } | undefined)?.anyFormat ?? true;
     try {
-      // Find out if the address is valid for any format. Tries all supported formats by default.
-      // Throws if address cannot be decoded with any format.
-      const [format, script] = utxolib.addressFormat.toOutputScriptAndFormat(address, this.network);
-      // unless anyFormat is set, only 'default' is allowed.
-      if (!anyFormat && format !== 'default') {
-        return false;
+      const script = wasmAddress.toOutputScriptWithCoin(address, this.name);
+      // Determine which format the input address was in by round-tripping
+      // through each candidate and checking byte-equality. 'default' is tried
+      // first so canonical default-format addresses early-exit.
+      for (const format of ['default', 'cashaddr'] as const) {
+        try {
+          if (wasmAddress.fromOutputScriptWithCoin(script, this.name, format) === address) {
+            return anyFormat || format === 'default';
+          }
+        } catch {
+          // coin doesn't support this format; try the next one
+        }
       }
-      // make sure that address is in normal representation for given format.
-      return address === utxolib.addressFormat.fromOutputScriptWithFormat(script, format, this.network);
+      return false;
     } catch (e) {
       return false;
     }

--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -4,7 +4,7 @@ import { randomBytes } from 'crypto';
 import _ from 'lodash';
 import * as utxolib from '@bitgo/utxo-lib';
 import { BIP32, fixedScriptWallet, hasPsbtMagic } from '@bitgo/wasm-utxo';
-import { bitgo, getMainnet } from '@bitgo/utxo-lib';
+import { bitgo } from '@bitgo/utxo-lib';
 import {
   AddressCoinSpecific,
   BaseCoin,
@@ -336,11 +336,6 @@ type UtxoBaseSignTransactionOptions<TNumber extends number | bigint = number> = 
    */
   isLastSignature?: boolean;
   /**
-   * If true, allows signing a non-segwit input with a witnessUtxo instead requiring a previous
-   * transaction (nonWitnessUtxo)
-   */
-  allowNonSegwitSigningWithoutPrevTx?: boolean;
-  /**
    * When true, the signed transaction will be converted from PSBT to legacy format before returning.
    * Set automatically by presignTransaction() when the caller explicitly requested txFormat: 'legacy'.
    */
@@ -455,13 +450,8 @@ export abstract class AbstractUtxoCoin extends BaseCoin implements Musig2Partici
   /** Indicates whether the coin supports a block target */
   supportsBlockTarget(): boolean {
     // FIXME: the SDK does not seem to use this anywhere so it is unclear what the purpose of this method is
-    switch (getMainnet(this.network)) {
-      case utxolib.networks.bitcoin:
-      case utxolib.networks.dogecoin:
-        return true;
-      default:
-        return false;
-    }
+    const mainnet = getMainnetCoinName(this.name);
+    return mainnet === 'btc' || mainnet === 'doge';
   }
 
   sweepWithSendMany(): boolean {
@@ -755,7 +745,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin implements Musig2Partici
    * @returns true iff coin supports spending from unspentType
    */
   supportsAddressType(addressType: ScriptType2Of3): boolean {
-    return utxolib.bitgo.outputScripts.isSupportedScriptType(this.network, addressType);
+    return fixedScriptWallet.supportsScriptType(this.name, addressType);
   }
 
   /** inherited doc */
@@ -1057,17 +1047,6 @@ export abstract class AbstractUtxoCoin extends BaseCoin implements Musig2Partici
     }
 
     const returnLegacyFormat = (params as Record<string, unknown>).txFormat === 'legacy';
-
-    // In the case that we have a 'psbt-lite' transaction format, we want to indicate in signing to not fail
-    const txHex = (params.txHex ?? params.txPrebuild?.txHex) as string;
-    if (
-      txHex &&
-      utxolib.bitgo.isPsbt(txHex as string) &&
-      utxolib.bitgo.isPsbtLite(utxolib.bitgo.createPsbtFromHex(txHex, this.network)) &&
-      params.allowNonSegwitSigningWithoutPrevTx === undefined
-    ) {
-      return { ...params, allowNonSegwitSigningWithoutPrevTx: true, returnLegacyFormat };
-    }
     return { ...params, returnLegacyFormat };
   }
 

--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -599,12 +599,6 @@ export abstract class AbstractUtxoCoin extends BaseCoin implements Musig2Partici
     return isChainCode(addressDetails.chain) ? scriptTypeForChain(addressDetails.chain) : null;
   }
 
-  createTransactionFromHex<TNumber extends number | bigint = number>(
-    hex: string
-  ): utxolib.bitgo.UtxoTransaction<TNumber> {
-    return utxolib.bitgo.createTransactionFromHex<TNumber>(hex, this.network, this.amountType);
-  }
-
   decodeTransaction(input: Buffer | string): fixedScriptWallet.BitGoPsbt {
     const buffer = typeof input === 'string' ? stringToBufferTryFormats(input, ['hex', 'base64']) : input;
     if (!hasPsbtMagic(buffer)) {

--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -75,14 +75,7 @@ import {
   ErrorImplicitExternalOutputs,
 } from './transaction/descriptor/verifyTransaction';
 import { assertDescriptorWalletAddress, getDescriptorMapFromWallet, isDescriptorWallet } from './descriptor';
-import {
-  getFullNameFromCoinName,
-  getMainnetCoinName,
-  getNetworkFromCoinName,
-  isMainnetCoin,
-  UtxoCoinName,
-  UtxoCoinNameMainnet,
-} from './names';
+import { getFullNameFromCoinName, getMainnetCoinName, isMainnetCoin, UtxoCoinName, UtxoCoinNameMainnet } from './names';
 import { assertFixedScriptWalletAddress } from './address/fixedScript';
 import { ParsedTransaction } from './transaction/types';
 import { decodeDescriptorPsbt, decodePsbt, encodeTransaction, stringToBufferTryFormats } from './transaction/decode';
@@ -412,14 +405,6 @@ export abstract class AbstractUtxoCoin extends BaseCoin implements Musig2Partici
   protected constructor(bitgo: BitGoBase, amountType: 'number' | 'bigint' = 'number') {
     super(bitgo);
     this.amountType = amountType;
-  }
-
-  /**
-   * @deprecated - will be removed when we drop support for utxolib
-   * Use `name` property instead.
-   */
-  get network(): utxolib.Network {
-    return getNetworkFromCoinName(this.name);
   }
 
   getChain(): UtxoCoinName {

--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -4,7 +4,6 @@ import { randomBytes } from 'crypto';
 import _ from 'lodash';
 import * as utxolib from '@bitgo/utxo-lib';
 import { address as wasmAddress, BIP32, fixedScriptWallet, hasPsbtMagic } from '@bitgo/wasm-utxo';
-import { bitgo } from '@bitgo/utxo-lib';
 import {
   AddressCoinSpecific,
   BaseCoin,
@@ -62,7 +61,6 @@ import { getReplayProtectionPubkeys, isReplayProtectionUnspent } from './transac
 import { supportedCrossChainRecoveries } from './config';
 import {
   assertValidTransactionRecipient,
-  DecodedTransaction,
   explainTx,
   fromExtendedAddressFormat,
   isScriptRecipient,
@@ -142,28 +140,21 @@ type UtxoCustomSigningFunction<TNumber extends number | bigint> = {
   }): Promise<SignedTransaction>;
 };
 
-const { isChainCode, scriptTypeForChain, outputScripts } = bitgo;
+const { ChainCode } = fixedScriptWallet;
 
 /**
  * Check if a decoded transaction has at least one taproot key path spend (MuSig2) input.
- * Works for both utxolib UtxoPsbt and wasm-utxo BitGoPsbt.
  */
-function hasKeyPathSpendInput<TNumber extends number | bigint>(
-  tx: DecodedTransaction<TNumber>,
+function hasKeyPathSpendInput(
+  tx: fixedScriptWallet.BitGoPsbt,
   pubs: string[] | undefined,
   coinName: UtxoCoinName
 ): boolean {
-  if (tx instanceof bitgo.UtxoPsbt) {
-    return bitgo.isTransactionWithKeyPathSpendInput(tx);
-  }
-  if (tx instanceof fixedScriptWallet.BitGoPsbt) {
-    assert(pubs && isTriple(pubs), 'pub triple is required to check for key path spend inputs in wasm-utxo PSBT');
-    const rootWalletKeys = fixedScriptWallet.RootWalletKeys.fromXpubs(pubs);
-    const replayProtection = { publicKeys: getReplayProtectionPubkeys(coinName) };
-    const parsed = tx.parseTransactionWithWalletKeys(rootWalletKeys, { replayProtection });
-    return parsed.inputs.some((input) => input.scriptType === 'p2trMusig2KeyPath');
-  }
-  return false;
+  assert(pubs && isTriple(pubs), 'pub triple is required to check for key path spend inputs in wasm-utxo PSBT');
+  const rootWalletKeys = fixedScriptWallet.RootWalletKeys.fromXpubs(pubs);
+  const replayProtection = { publicKeys: getReplayProtectionPubkeys(coinName) };
+  const parsed = tx.parseTransactionWithWalletKeys(rootWalletKeys, { replayProtection });
+  return parsed.inputs.some((input) => input.scriptType === 'p2trMusig2KeyPath');
 }
 
 /**
@@ -216,8 +207,6 @@ function convertValidationErrorToTxIntentMismatch(
 
 export type { DecodedTransaction } from './transaction/types';
 
-export type RootWalletKeys = bitgo.RootWalletKeys;
-
 export type UtxoCoinSpecific = AddressCoinSpecific | DescriptorAddressCoinSpecific;
 
 export interface VerifyAddressOptions<TCoinSpecific extends UtxoCoinSpecific> extends BaseVerifyAddressOptions {
@@ -251,8 +240,6 @@ export interface DecoratedExplainTransactionOptions<TNumber extends number | big
   extends ExplainTransactionOptions<TNumber> {
   changeInfo?: { address: string; chain: number; index: number }[];
 }
-
-export type UtxoNetwork = utxolib.Network;
 
 export interface TransactionPrebuild<TNumber extends number | bigint = number> extends BaseTransactionPrebuild {
   txInfo?: TransactionInfo<TNumber>;
@@ -460,7 +447,7 @@ export abstract class AbstractUtxoCoin extends BaseCoin implements Musig2Partici
 
   /** @deprecated */
   static get validAddressTypes(): ScriptType2Of3[] {
-    return [...outputScripts.scriptTypes2Of3];
+    return ['p2sh', 'p2shP2wsh', 'p2wsh', 'p2tr', 'p2trMusig2'];
   }
 
   /**
@@ -591,7 +578,9 @@ export abstract class AbstractUtxoCoin extends BaseCoin implements Musig2Partici
    * @param addressDetails
    */
   static inferAddressType(addressDetails: { chain: number }): ScriptType2Of3 | null {
-    return isChainCode(addressDetails.chain) ? scriptTypeForChain(addressDetails.chain) : null;
+    return fixedScriptWallet.ChainCode.is(addressDetails.chain)
+      ? (fixedScriptWallet.ChainCode.scriptType(addressDetails.chain) as ScriptType2Of3)
+      : null;
   }
 
   decodeTransaction(input: Buffer | string): fixedScriptWallet.BitGoPsbt {
@@ -763,7 +752,10 @@ export abstract class AbstractUtxoCoin extends BaseCoin implements Musig2Partici
    * @return true iff coin supports spending from chain
    */
   supportsAddressChain(chain: number): boolean {
-    return isChainCode(chain) && this.supportsAddressType(utxolib.bitgo.scriptTypeForChain(chain));
+    return (
+      fixedScriptWallet.ChainCode.is(chain) &&
+      this.supportsAddressType(fixedScriptWallet.ChainCode.scriptType(chain) as ScriptType2Of3)
+    );
   }
 
   keyIdsForSigning(): number[] {

--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -2,7 +2,6 @@ import assert from 'assert';
 import { randomBytes } from 'crypto';
 
 import _ from 'lodash';
-import * as utxolib from '@bitgo/utxo-lib';
 import { address as wasmAddress, BIP32, fixedScriptWallet, hasPsbtMagic } from '@bitgo/wasm-utxo';
 import {
   AddressCoinSpecific,
@@ -87,7 +86,7 @@ import { isUtxoWalletData, UtxoWallet } from './wallet';
 import { isDescriptorWalletData } from './descriptor/descriptorWallet';
 import type { Unspent } from './unspent';
 
-import ScriptType2Of3 = utxolib.bitgo.outputScripts.ScriptType2Of3;
+type ScriptType2Of3 = 'p2sh' | 'p2shP2wsh' | 'p2wsh' | 'p2tr' | 'p2trMusig2';
 
 export type TxFormat =
   // This is a legacy transaction format based around the bitcoinjs-lib serialization of unsigned transactions
@@ -132,8 +131,6 @@ type UtxoCustomSigningFunction<TNumber extends number | bigint> = {
     signingStep?: 'signerNonce' | 'signerSignature' | 'cosignerNonce';
   }): Promise<SignedTransaction>;
 };
-
-const { ChainCode } = fixedScriptWallet;
 
 /**
  * Check if a decoded transaction has at least one taproot key path spend (MuSig2) input.

--- a/modules/abstract-utxo/src/impl/doge/doge.ts
+++ b/modules/abstract-utxo/src/impl/doge/doge.ts
@@ -1,5 +1,4 @@
 import { BitGoBase, HalfSignedUtxoTransaction, SignedTransaction } from '@bitgo/sdk-core';
-import { bitgo } from '@bitgo/utxo-lib';
 
 import {
   AbstractUtxoCoin,
@@ -74,10 +73,6 @@ export class Doge extends AbstractUtxoCoin {
   /* amountType is set in constructor. Functions below override the default TNumber of AbstractUtxoCoin to bigint */
 
   /* postProcessPrebuild, isBitGoTaintedUnspent, verifyCustomChangeKeySignatures do not care whether they receive number or bigint */
-
-  createTransactionFromHex<TNumber extends number | bigint = bigint>(hex: string): bitgo.UtxoTransaction<TNumber> {
-    return super.createTransactionFromHex<TNumber>(hex);
-  }
 
   async parseTransaction<TNumber extends number | bigint = bigint>(
     params: ParseTransactionOptions<TNumber>

--- a/modules/abstract-utxo/src/names.ts
+++ b/modules/abstract-utxo/src/names.ts
@@ -1,5 +1,3 @@
-import * as utxolib from '@bitgo/utxo-lib';
-
 export const utxoCoinsMainnet = ['btc', 'bch', 'bcha', 'bsv', 'btg', 'dash', 'doge', 'ltc', 'zec'] as const;
 export const utxoCoinsTestnet = [
   'tbtc',
@@ -46,107 +44,6 @@ export function getMainnetCoinName(coinName: UtxoCoinName): UtxoCoinNameMainnet 
   }
 }
 
-function getNetworkName(n: utxolib.Network): utxolib.NetworkName {
-  const name = utxolib.getNetworkName(n);
-  if (!name) {
-    throw new Error('Unknown network');
-  }
-  return name;
-}
-
-/**
- * @deprecated - will be removed when we drop support for utxolib
- * @param n
- * @returns the family name for a network. Testnets and mainnets of the same coin share the same family name.
- */
-export function getFamilyFromNetwork(n: utxolib.Network): UtxoCoinNameMainnet {
-  switch (getNetworkName(n)) {
-    case 'bitcoin':
-    case 'testnet':
-    case 'bitcoinPublicSignet':
-    case 'bitcoinTestnet4':
-    case 'bitcoinBitGoSignet':
-      return 'btc';
-    case 'bitcoincash':
-    case 'bitcoincashTestnet':
-      return 'bch';
-    case 'ecash':
-    case 'ecashTest':
-      return 'bcha';
-    case 'bitcoingold':
-    case 'bitcoingoldTestnet':
-      return 'btg';
-    case 'bitcoinsv':
-    case 'bitcoinsvTestnet':
-      return 'bsv';
-    case 'dash':
-    case 'dashTest':
-      return 'dash';
-    case 'dogecoin':
-    case 'dogecoinTest':
-      return 'doge';
-    case 'litecoin':
-    case 'litecoinTest':
-      return 'ltc';
-    case 'zcash':
-    case 'zcashTest':
-      return 'zec';
-  }
-}
-
-/**
- * @deprecated - will be removed when we drop support for utxolib
- * Get the chain name for a network.
- * The chain is different for every network.
- */
-export function getCoinName(n: utxolib.Network): UtxoCoinName {
-  switch (getNetworkName(n)) {
-    case 'bitcoinPublicSignet':
-      return 'tbtcsig';
-    case 'bitcoinTestnet4':
-      return 'tbtc4';
-    case 'bitcoinBitGoSignet':
-      return 'tbtcbgsig';
-    case 'bitcoin':
-    case 'testnet':
-    case 'bitcoincash':
-    case 'bitcoincashTestnet':
-    case 'ecash':
-    case 'ecashTest':
-    case 'bitcoingold':
-    case 'bitcoingoldTestnet':
-    case 'bitcoinsv':
-    case 'bitcoinsvTestnet':
-    case 'dash':
-    case 'dashTest':
-    case 'dogecoin':
-    case 'dogecoinTest':
-    case 'litecoin':
-    case 'litecoinTest':
-    case 'zcash':
-    case 'zcashTest':
-      const mainnetName = getFamilyFromNetwork(n);
-      return utxolib.isTestnet(n) ? `t${mainnetName}` : mainnetName;
-  }
-}
-
-/**
- * @deprecated - will be removed when we drop support for utxolib
- * @param coinName - the name of the coin (e.g. 'btc', 'bch', 'ltc'). Also called 'chain' in some contexts.
- * @returns the network for a coin. This is the mainnet network for the coin.
- */
-export function getNetworkFromCoinName(coinName: string): utxolib.Network {
-  for (const network of utxolib.getNetworkList()) {
-    if (getCoinName(network) === coinName) {
-      return network;
-    }
-  }
-  throw new Error(`Unknown coin name ${coinName}`);
-}
-
-/** @deprecated - use getNetworkFromCoinName instead */
-export const getNetworkFromChain = getNetworkFromCoinName;
-
 function getBaseNameFromMainnet(coinName: UtxoCoinNameMainnet): string {
   switch (coinName) {
     case 'btc':
@@ -187,11 +84,6 @@ export function getFullNameFromCoinName(coinName: UtxoCoinName): string {
   }
 
   return prefix + getBaseNameFromMainnet(getMainnetCoinName(coinName));
-}
-
-/** @deprecated - use getFullNameFromCoinName instead */
-export function getFullNameFromNetwork(n: utxolib.Network): string {
-  return getFullNameFromCoinName(getCoinName(n));
 }
 
 export function isTestnetCoin(coinName: UtxoCoinName): boolean {

--- a/modules/abstract-utxo/src/recovery/backupKeyRecovery.ts
+++ b/modules/abstract-utxo/src/recovery/backupKeyRecovery.ts
@@ -8,7 +8,7 @@ import {
   krsProviders,
   Triple,
 } from '@bitgo/sdk-core';
-import { BIP32, fixedScriptWallet } from '@bitgo/wasm-utxo';
+import { BIP32, fixedScriptWallet, Transaction } from '@bitgo/wasm-utxo';
 
 import { AbstractUtxoCoin } from '../abstractUtxoCoin';
 import { signAndVerifyPsbt } from '../transaction/fixedScript/signTransaction';
@@ -172,8 +172,8 @@ async function queryBlockchainUnspentsPath(
               // json parse won't parse it correctly, so we requery the txid for the tx hex to decode here
               if (!Number.isSafeInteger(u.value)) {
                 const txHex = await getPrevTx(txid);
-                const tx = coin.createTransactionFromHex<bigint>(txHex);
-                val = tx.outs[vout].value;
+                const tx = Transaction.fromBytes(Buffer.from(txHex, 'hex'));
+                val = tx.getOutputs()[vout].value;
               }
             }
             // the api may return cashaddr's instead of legacy for BCH and BCHA

--- a/modules/abstract-utxo/src/transaction/decode.ts
+++ b/modules/abstract-utxo/src/transaction/decode.ts
@@ -1,7 +1,6 @@
-import * as utxolib from '@bitgo/utxo-lib';
-import { fixedScriptWallet, hasPsbtMagic, Psbt as WasmPsbt, utxolibCompat } from '@bitgo/wasm-utxo';
+import { fixedScriptWallet, hasPsbtMagic, Psbt as WasmPsbt } from '@bitgo/wasm-utxo';
 
-import { getNetworkFromCoinName, UtxoCoinName } from '../names';
+import { UtxoCoinName } from '../names';
 
 import { BitGoPsbt } from './types';
 
@@ -22,20 +21,11 @@ export function stringToBufferTryFormats(input: string, formats: BufferEncoding[
   throw new Error('input must be a valid hex or base64 string');
 }
 
-function toNetworkName(coinName: UtxoCoinName): utxolibCompat.UtxolibName {
-  const network = getNetworkFromCoinName(coinName);
-  const networkName = utxolib.getNetworkName(network);
-  if (!networkName) {
-    throw new Error(`Invalid coinName: ${coinName}`);
-  }
-  return networkName;
-}
-
 export function decodePsbt(psbt: string | Buffer, coinName: UtxoCoinName): BitGoPsbt {
   if (typeof psbt === 'string') {
     psbt = Buffer.from(psbt, 'hex');
   }
-  return fixedScriptWallet.BitGoPsbt.fromBytes(psbt, toNetworkName(coinName));
+  return fixedScriptWallet.BitGoPsbt.fromBytes(psbt, coinName);
 }
 
 export type PrebuildLike = {

--- a/modules/abstract-utxo/src/transaction/fixedScript/signTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/fixedScript/signTransaction.ts
@@ -33,8 +33,6 @@ export async function signTransaction(
     txInfo: { unspents?: Unspent<bigint | number>[] } | undefined;
     isLastSignature: boolean;
     signingStep: 'signerNonce' | 'cosignerNonce' | 'signerSignature' | undefined;
-    /** deprecated */
-    allowNonSegwitSigningWithoutPrevTx: boolean;
     pubs: string[] | undefined;
     cosignerPub: string | undefined;
     /** When true (default), extract finalized PSBT to legacy transaction format. When false, return finalized PSBT. */

--- a/modules/abstract-utxo/src/transaction/signTransaction.ts
+++ b/modules/abstract-utxo/src/transaction/signTransaction.ts
@@ -65,7 +65,6 @@ export async function signTransaction<TNumber extends number | bigint>(
       txInfo: params.txPrebuild.txInfo,
       isLastSignature: params.isLastSignature ?? false,
       signingStep: params.signingStep,
-      allowNonSegwitSigningWithoutPrevTx: params.allowNonSegwitSigningWithoutPrevTx ?? false,
       pubs: params.pubs,
       cosignerPub: params.cosignerPub,
       extractTransaction: params.extractTransaction,

--- a/modules/abstract-utxo/test/unit/buildSignSendLegacyFormat.ts
+++ b/modules/abstract-utxo/test/unit/buildSignSendLegacyFormat.ts
@@ -11,6 +11,7 @@ import {
   encryptKeychain,
   getDefaultWalletKeys,
   getMinUtxoCoins,
+  getNetworkForCoinName,
   getUtxoWallet,
   keychainsBase58,
   getScriptTypes,
@@ -46,12 +47,17 @@ describe('prebuildAndSign-returnLegacyFormat', function () {
     const outputAmount = BigInt(inputScripts.length) * BigInt(1e8) - fee;
     const outputScriptType: utxolib.bitgo.outputScripts.ScriptType = 'p2sh';
     const outputChain = utxolib.bitgo.getExternalChainCode(outputScriptType);
-    const outputAddress = utxolib.bitgo.getWalletAddress(rootWalletKeys, outputChain, 0, coin.network);
+    const outputAddress = utxolib.bitgo.getWalletAddress(
+      rootWalletKeys,
+      outputChain,
+      0,
+      getNetworkForCoinName(coin.name)
+    );
     recipient = { address: outputAddress, amount: outputAmount.toString() };
     prebuild = utxolib.testutil.constructPsbt(
       inputScripts.map((s) => ({ scriptType: s, value: BigInt(1e8) })),
       [{ scriptType: outputScriptType, value: outputAmount }],
-      coin.network,
+      getNetworkForCoinName(coin.name),
       rootWalletKeys,
       'unsigned'
     );

--- a/modules/abstract-utxo/test/unit/customSigner.ts
+++ b/modules/abstract-utxo/test/unit/customSigner.ts
@@ -3,7 +3,14 @@ import nock = require('nock');
 import * as sinon from 'sinon';
 import { CustomSigningFunction, common } from '@bitgo/sdk-core';
 
-import { defaultBitGo, getDefaultWalletKeys, getUtxoCoin, getUtxoWallet, assertHasProperty } from './util';
+import {
+  defaultBitGo,
+  getDefaultWalletKeys,
+  getNetworkForCoinName,
+  getUtxoCoin,
+  getUtxoWallet,
+  assertHasProperty,
+} from './util';
 
 nock.disableNetConnect();
 
@@ -56,7 +63,7 @@ describe('UTXO Custom Signer Function', function () {
     const psbt = utxoLib.testutil.constructPsbt(
       [{ scriptType: 'taprootKeyPathSpend', value: BigInt(1000) }],
       [{ scriptType: 'p2sh', value: BigInt(900) }],
-      basecoin.network,
+      getNetworkForCoinName(basecoin.name),
       rootWalletKey,
       'unsigned'
     );
@@ -72,7 +79,7 @@ describe('UTXO Custom Signer Function', function () {
     const psbt = utxoLib.testutil.constructPsbt(
       [{ scriptType: 'p2wsh', value: BigInt(1000) }],
       [{ scriptType: 'p2sh', value: BigInt(900) }],
-      basecoin.network,
+      getNetworkForCoinName(basecoin.name),
       rootWalletKey,
       'unsigned'
     );

--- a/modules/abstract-utxo/test/unit/prebuildAndSign.ts
+++ b/modules/abstract-utxo/test/unit/prebuildAndSign.ts
@@ -12,6 +12,7 @@ import {
   defaultBitGo,
   getDefaultWalletKeys,
   getMinUtxoCoins,
+  getNetworkForCoinName,
   getUtxoWallet,
   keychainsBase58,
   getScriptTypes,
@@ -62,7 +63,7 @@ function run(coin: AbstractUtxoCoin, inputScripts: ScriptType[]): void {
     const psbt = utxolib.testutil.constructPsbt(
       inputs as utxolib.testutil.Input[],
       outputs,
-      coin.network,
+      getNetworkForCoinName(coin.name),
       rootWalletKeys,
       'unsigned',
       {
@@ -178,7 +179,12 @@ function run(coin: AbstractUtxoCoin, inputScripts: ScriptType[]): void {
       const outputAmount = BigInt(inputScripts.length) * BigInt(1e8) - fee;
       const outputScriptType: utxolib.bitgo.outputScripts.ScriptType = 'p2sh';
       const outputChain = utxolib.bitgo.getExternalChainCode(outputScriptType);
-      const outputAddress = utxolib.bitgo.getWalletAddress(rootWalletKeys, outputChain, 0, coin.network);
+      const outputAddress = utxolib.bitgo.getWalletAddress(
+        rootWalletKeys,
+        outputChain,
+        0,
+        getNetworkForCoinName(coin.name)
+      );
 
       recipient = {
         address: outputAddress,
@@ -222,7 +228,7 @@ function run(coin: AbstractUtxoCoin, inputScripts: ScriptType[]): void {
 
       nocks.forEach((nock) => assert.ok(nock.isDone()));
 
-      assertSignable(res.txHex, inputScripts, coin.network);
+      assertSignable(res.txHex, inputScripts, getNetworkForCoinName(coin.name));
     });
 
     [true, false].forEach((selfSend) => {
@@ -254,7 +260,7 @@ function run(coin: AbstractUtxoCoin, inputScripts: ScriptType[]): void {
 
         nocks.forEach((nock) => assert.ok(nock.isDone()));
 
-        assertSignable(res.txHex, inputScripts, coin.network);
+        assertSignable(res.txHex, inputScripts, getNetworkForCoinName(coin.name));
       });
     });
   });

--- a/modules/abstract-utxo/test/unit/signTransaction.ts
+++ b/modules/abstract-utxo/test/unit/signTransaction.ts
@@ -9,7 +9,14 @@ import { common, Triple } from '@bitgo/sdk-core';
 import { getReplayProtectionPubkeys, ErrorDeprecatedTxFormat } from '../../src';
 import type { Unspent } from '../../src/unspent';
 
-import { getUtxoWallet, getDefaultWalletKeys, getUtxoCoin, keychainsBase58, defaultBitGo } from './util';
+import {
+  getUtxoWallet,
+  getDefaultWalletKeys,
+  getNetworkForCoinName,
+  getUtxoCoin,
+  keychainsBase58,
+  defaultBitGo,
+} from './util';
 
 describe('signTransaction', function () {
   const bgUrl = common.Environments[defaultBitGo.getEnv()].uri;
@@ -21,7 +28,7 @@ describe('signTransaction', function () {
   const pubs = keychainsBase58.map((v) => v.pub) as Triple<string>;
 
   function validatePsbt(txHex: string, targetSigCount: 0 | 1, targetNonceCount?: 1 | 2) {
-    const psbt = utxolib.bitgo.createPsbtFromHex(txHex, coin.network);
+    const psbt = utxolib.bitgo.createPsbtFromHex(txHex, getNetworkForCoinName(coin.name));
     psbt.data.inputs.forEach((input, index) => {
       const parsed = utxolib.bitgo.parsePsbtInput(input);
       if (parsed.scriptType === 'taprootKeyPathSpend') {
@@ -38,7 +45,7 @@ describe('signTransaction', function () {
   }
 
   function validateTx(txHex: string, unspents: Unspent<bigint>[], targetSigCount: 0 | 1) {
-    const tx = utxolib.bitgo.createTransactionFromHex(txHex, coin.network);
+    const tx = utxolib.bitgo.createTransactionFromHex(txHex, getNetworkForCoinName(coin.name));
     unspents.forEach((u, i) => {
       const sigCount = utxolib.bitgo.getStrictSignatureCount(tx.ins[i]);
       const expectedSigCount = utxolib.bitgo.isWalletUnspent(u) && !!targetSigCount ? 1 : 0;
@@ -56,7 +63,7 @@ describe('signTransaction', function () {
     const txHex = tx.toHex();
 
     function nockSignPsbt(psbtHex: string): nock.Scope {
-      const psbt = utxolib.bitgo.createPsbtFromHex(psbtHex, coin.network);
+      const psbt = utxolib.bitgo.createPsbtFromHex(psbtHex, getNetworkForCoinName(coin.name));
       return nock(bgUrl)
         .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/signpsbt`, (body) => body.psbt)
         .reply(200, { psbt: psbt.setAllInputsMusig2NonceHD(rootWalletKeys.bitgo).toHex() });
@@ -147,7 +154,7 @@ describe('signTransaction', function () {
       .map((scriptType) => ({ scriptType, value: BigInt(1000) }));
     const unspentSum = inputs.reduce((prev: bigint, curr) => prev + curr.value, BigInt(0));
     const outputs: testutil.Output[] = [{ scriptType: 'p2sh', value: unspentSum - BigInt(1000) }];
-    const psbt = testutil.constructPsbt(inputs, outputs, coin.network, rootWalletKeys, 'unsigned', {
+    const psbt = testutil.constructPsbt(inputs, outputs, getNetworkForCoinName(coin.name), rootWalletKeys, 'unsigned', {
       p2shP2pkKey: replayProtectionKey,
     });
 
@@ -163,7 +170,7 @@ describe('signTransaction', function () {
       .map((scriptType) => ({ scriptType, value: BigInt(1000) }));
     const unspentSum = inputs.reduce((prev: bigint, cur) => prev + cur.value, BigInt(0));
     const outputs: testutil.Output[] = [{ scriptType: 'p2sh', value: unspentSum - BigInt(1000) }];
-    const psbt = testutil.constructPsbt(inputs, outputs, coin.network, rootWalletKeys, 'unsigned', {
+    const psbt = testutil.constructPsbt(inputs, outputs, getNetworkForCoinName(coin.name), rootWalletKeys, 'unsigned', {
       p2shP2pkKey: replayProtectionKey,
     });
 
@@ -181,8 +188,16 @@ describe('signTransaction', function () {
       }));
     const unspentSum = inputs.reduce((prev: bigint, curr) => prev + curr.value, BigInt(0));
     const outputs: testutil.TxnOutput<bigint>[] = [{ scriptType: 'p2sh', value: unspentSum - BigInt(1000) }];
-    const txBuilder = testutil.constructTxnBuilder(inputs, outputs, coin.network, rootWalletKeys, 'unsigned');
-    const unspents = inputs.map((v, i) => testutil.toTxnUnspent(v, i, coin.network, rootWalletKeys));
+    const txBuilder = testutil.constructTxnBuilder(
+      inputs,
+      outputs,
+      getNetworkForCoinName(coin.name),
+      rootWalletKeys,
+      'unsigned'
+    );
+    const unspents = inputs.map((v, i) =>
+      testutil.toTxnUnspent(v, i, getNetworkForCoinName(coin.name), rootWalletKeys)
+    );
 
     // Legacy format transactions are now deprecated and should throw ErrorDeprecatedTxFormat
     await assert.rejects(async () => {
@@ -194,7 +209,7 @@ describe('signTransaction', function () {
     const inputs: testutil.Input[] = [{ scriptType: 'taprootKeyPathSpend', value: BigInt(1000) }];
     const unspentSum = inputs.reduce((prev: bigint, curr) => prev + curr.value, BigInt(0));
     const outputs: testutil.Output[] = [{ scriptType: 'p2sh', value: unspentSum - BigInt(1000) }];
-    const psbt = testutil.constructPsbt(inputs, outputs, coin.network, rootWalletKeys, 'unsigned');
+    const psbt = testutil.constructPsbt(inputs, outputs, getNetworkForCoinName(coin.name), rootWalletKeys, 'unsigned');
 
     await assert.rejects(
       async () => {

--- a/modules/abstract-utxo/test/unit/transaction.ts
+++ b/modules/abstract-utxo/test/unit/transaction.ts
@@ -31,6 +31,7 @@ import {
   getWalletKeys,
   defaultBitGo,
   getMinUtxoCoins,
+  getNetworkForCoinName,
   getScriptTypes,
 } from './util';
 
@@ -60,7 +61,7 @@ function run<TNumber extends number | bigint = number>(
         return testutil.toUnspent(
           { scriptType: t, value: t === 'p2shP2pk' ? BigInt(1000) : BigInt(value) },
           index,
-          coin.network,
+          getNetworkForCoinName(coin.name),
           walletKeys
         );
       });
@@ -72,7 +73,7 @@ function run<TNumber extends number | bigint = number>(
 
     function getUnspents(): Unspent<TNumber>[] {
       return inputScripts.map((type, i) =>
-        mockUnspent<TNumber>(coin.network, walletKeys, toTxnInputScriptType(type), i, value)
+        mockUnspent<TNumber>(getNetworkForCoinName(coin.name), walletKeys, toTxnInputScriptType(type), i, value)
       );
     }
 
@@ -113,7 +114,9 @@ function run<TNumber extends number | bigint = number>(
         scope = nock(bgUrl)
           .post(`/api/v2/${wallet.coin()}/wallet/${wallet.id()}/tx/signpsbt`, (body) => body.psbt)
           .reply(200, (_uri: string, requestBody: unknown) => {
-            const networkName = utxolib.getNetworkName(coin.network) as fixedScriptWallet.NetworkName;
+            const networkName = utxolib.getNetworkName(
+              getNetworkForCoinName(coin.name)
+            ) as fixedScriptWallet.NetworkName;
             const reqBytes = Buffer.from((requestBody as { psbt: string }).psbt, 'hex');
             const reqPsbt = fixedScriptWallet.BitGoPsbt.fromBytes(reqBytes, networkName);
             const cosignerWasm = BIP32.fromBase58(cosigner.toBase58());
@@ -166,7 +169,7 @@ function run<TNumber extends number | bigint = number>(
       const outputs: testutil.Output[] = [
         { address: getOutputAddress(getWalletKeys('test')), value: unspentSum - BigInt(1000) },
       ];
-      const psbt = testutil.constructPsbt(inputs, outputs, coin.network, walletKeys, 'unsigned', {
+      const psbt = testutil.constructPsbt(inputs, outputs, getNetworkForCoinName(coin.name), walletKeys, 'unsigned', {
         p2shP2pkKey: getReplayProtectionPubkeys(coin.name)[0],
       });
       utxolib.bitgo.addXpubsToPsbt(psbt, walletKeys);
@@ -177,7 +180,11 @@ function run<TNumber extends number | bigint = number>(
       const prebuild =
         txFormat === 'psbt'
           ? createPrebuildPsbt()
-          : createPrebuildTransaction<TNumber>(coin.network, getUnspents(), getOutputAddress(walletKeys));
+          : createPrebuildTransaction<TNumber>(
+              getNetworkForCoinName(coin.name),
+              getUnspents(),
+              getOutputAddress(walletKeys)
+            );
 
       const halfSignedUserBitGo = await createHalfSignedTransaction(prebuild, walletKeys.user, walletKeys.bitgo);
       const fullSignedUserBitGo =
@@ -225,7 +232,7 @@ function run<TNumber extends number | bigint = number>(
             ? undefined
             : v instanceof utxolib.bitgo.UtxoTransaction
             ? transactionToObj<TNumber>(v)
-            : transactionHexToObj(v.txHex, coin.network, amountType)
+            : transactionHexToObj(v.txHex, getNetworkForCoinName(coin.name), amountType)
         ) as TransactionObjStages;
       }
 
@@ -240,7 +247,7 @@ function run<TNumber extends number | bigint = number>(
     });
 
     function testPsbtValidSignatures(tx: HalfSignedUtxoTransaction, signedBy: BIP32Interface[]) {
-      const psbt = utxolib.bitgo.createPsbtFromHex(tx.txHex, coin.network);
+      const psbt = utxolib.bitgo.createPsbtFromHex(tx.txHex, getNetworkForCoinName(coin.name));
       const unspents = getUnspentsForPsbt();
       psbt.data.inputs.forEach((input, index) => {
         const unspent = unspents[index];
@@ -278,7 +285,7 @@ function run<TNumber extends number | bigint = number>(
 
       const transaction = utxolib.bitgo.createTransactionFromBuffer<TNumber>(
         Buffer.from(tx.txHex, 'hex'),
-        coin.network,
+        getNetworkForCoinName(coin.name),
         { amountType }
       );
       transaction.ins.forEach((input, index) => {

--- a/modules/abstract-utxo/test/unit/transaction/fixedScript/parsePsbt.ts
+++ b/modules/abstract-utxo/test/unit/transaction/fixedScript/parsePsbt.ts
@@ -8,10 +8,9 @@ import { fixedScriptWallet } from '@bitgo/wasm-utxo';
 import { parseTransaction } from '../../../../src/transaction/fixedScript/parseTransaction';
 import { ParsedTransaction } from '../../../../src/transaction/types';
 import { UtxoWallet } from '../../../../src/wallet';
-import { getUtxoCoin } from '../../util';
+import { getCoinNameForNetwork, getUtxoCoin } from '../../util';
 import { explainPsbtWasm } from '../../../../src/transaction/fixedScript';
 import type { TransactionExplanation } from '../../../../src/transaction/fixedScript/explainTransaction';
-import { getCoinName } from '../../../../src/names';
 import { TransactionPrebuild } from '../../../../src/abstractUtxoCoin';
 
 function getTxParamsFromExplanation(
@@ -78,7 +77,7 @@ function describeParseTransactionWith(
     let stubExplainTransaction: sinon.SinonStub;
 
     before('prepare', async function () {
-      const coinName = getCoinName(acidTest.network);
+      const coinName = getCoinNameForNetwork(acidTest.network);
       coin = getUtxoCoin(coinName);
 
       // Create PSBT and explanation

--- a/modules/abstract-utxo/test/unit/verifyTransaction.ts
+++ b/modules/abstract-utxo/test/unit/verifyTransaction.ts
@@ -1,6 +1,5 @@
 import assert from 'assert';
 
-import * as utxolib from '@bitgo/utxo-lib';
 import * as sinon from 'sinon';
 import { Wallet } from '@bitgo/sdk-core';
 
@@ -217,10 +216,6 @@ describe('Verify Transaction', function () {
       needsCustomChangeKeySignatureVerification: false,
     });
 
-    const bitcoinMock = sinon
-      .stub(coin, 'createTransactionFromHex')
-      .returns({ ins: [] } as unknown as utxolib.bitgo.UtxoTransaction);
-
     const result = await coin.verifyTransaction({
       txParams: {
         walletPassphrase: passphrase,
@@ -234,7 +229,6 @@ describe('Verify Transaction', function () {
     assert.strictEqual(result, true);
 
     coinMock.restore();
-    bitcoinMock.restore();
   });
 
   it('should not allow any implicit external outputs if paygo outputs are disallowed', async () => {
@@ -284,10 +278,6 @@ describe('Verify Transaction', function () {
       needsCustomChangeKeySignatureVerification: false,
     });
 
-    const bitcoinMock = sinon
-      .stub(coin, 'createTransactionFromHex')
-      .returns({ ins: [] } as unknown as utxolib.bitgo.UtxoTransaction);
-
     const result = await coin.verifyTransaction({
       txParams: {
         walletPassphrase: passphrase,
@@ -302,7 +292,6 @@ describe('Verify Transaction', function () {
     assert.strictEqual(result, true);
 
     coinMock.restore();
-    bitcoinMock.restore();
   });
 
   it('should verify a bridging transaction whose implicit external output matches the bridge amount', async () => {
@@ -329,10 +318,6 @@ describe('Verify Transaction', function () {
       needsCustomChangeKeySignatureVerification: false,
     });
 
-    const bitcoinMock = sinon
-      .stub(coin, 'createTransactionFromHex')
-      .returns({ ins: [] } as unknown as utxolib.bitgo.UtxoTransaction);
-
     const result = await coin.verifyTransaction({
       txParams: {
         walletPassphrase: passphrase,
@@ -349,7 +334,6 @@ describe('Verify Transaction', function () {
     assert.strictEqual(result, true);
 
     coinMock.restore();
-    bitcoinMock.restore();
   });
 
   it('should reject a bridging transaction whose implicit external output does not match the bridge amount', async () => {
@@ -560,10 +544,6 @@ describe('Verify Transaction', function () {
         needsCustomChangeKeySignatureVerification: false,
       });
 
-      const bitcoinMock = sinon
-        .stub(coin, 'createTransactionFromHex')
-        .returns({ ins: [] } as unknown as utxolib.bitgo.UtxoTransaction);
-
       const result = await coin.verifyTransaction({
         txParams: { walletPassphrase: passphrase },
         txPrebuild: { txHex: '00' },
@@ -574,7 +554,6 @@ describe('Verify Transaction', function () {
       assert.strictEqual(result, true);
 
       coinMock.restore();
-      bitcoinMock.restore();
     });
   });
 
@@ -605,10 +584,6 @@ describe('Verify Transaction', function () {
       needsCustomChangeKeySignatureVerification: false,
     });
 
-    const bitcoinMock = sinon
-      .stub(bigintCoin, 'createTransactionFromHex')
-      .returns({ ins: [] } as unknown as utxolib.bitgo.UtxoTransaction);
-
     const result = await bigintCoin.verifyTransaction({
       txParams: {
         walletPassphrase: passphrase,
@@ -623,6 +598,5 @@ describe('Verify Transaction', function () {
     assert.strictEqual(result, true);
 
     coinMock.restore();
-    bitcoinMock.restore();
   });
 });

--- a/modules/abstract-utxo/test/unit/wallet.ts
+++ b/modules/abstract-utxo/test/unit/wallet.ts
@@ -5,7 +5,7 @@ import nock = require('nock');
 import * as _ from 'lodash';
 import { Wallet, ManageUnspentsOptions, common } from '@bitgo/sdk-core';
 
-import { defaultBitGo, getDefaultWalletKeys, toKeychainObjects, getUtxoCoin } from './util';
+import { defaultBitGo, getDefaultWalletKeys, getNetworkForCoinName, toKeychainObjects, getUtxoCoin } from './util';
 
 const bgUrl = common.Environments[defaultBitGo.getEnv()].uri;
 const bitgo = defaultBitGo;
@@ -35,7 +35,7 @@ describe('manage unspents', function () {
       utxoLib.testutil.constructPsbt(
         [{ scriptType, value: BigInt(1000) }],
         [{ scriptType, value: BigInt(900) }],
-        basecoin.network,
+        getNetworkForCoinName(basecoin.name),
         rootWalletKey,
         'unsigned'
       )
@@ -74,7 +74,7 @@ describe('manage unspents', function () {
     const psbt = utxoLib.testutil.constructPsbt(
       [{ scriptType: 'p2wsh', value: BigInt(1000) }],
       [{ scriptType: 'p2shP2wsh', value: BigInt(900) }],
-      basecoin.network,
+      getNetworkForCoinName(basecoin.name),
       rootWalletKey,
       'unsigned'
     );


### PR DESCRIPTION
## Summary

Removes all `@bitgo/utxo-lib` runtime call sites from `modules/abstract-utxo/src/abstractUtxoCoin.ts`, replacing them with `@bitgo/wasm-utxo` or plain `coinName`-based equivalents. By the end of this PR, `abstractUtxoCoin.ts` carries no `utxolib` import at all.

Changes land in stack order (lowest first):

1. **remove `createTransactionFromHex` from `AbstractUtxoCoin`** — the only remaining caller was the already-deleted `fetchInputs`; the Doge override just delegated to `super`. Removes the method and the stale sinon stubs from `verifyTransaction` tests.
2. **pass `coinName` directly to `BitGoPsbt.fromBytes`** — `BitGoPsbt.fromBytes` already accepts `CoinName | UtxolibName`, so the `utxolib.getNetworkName` round-trip in `decode.ts` is unnecessary. Drops the `utxolib` import from `decode.ts`.
3. **replace 3 utxolib network/script helpers** — `supportsBlockTarget` now compares `coinName` strings; `isSupportedScriptType` delegates to `fixedScriptWallet.supportsScriptType` (wasm-utxo); `postProcessPrebuild` drops the dead psbt-lite detection block and the `allowNonSegwitSigningWithoutPrevTx` flag (wasm-utxo signing never consulted it).
4. **migrate `isValidAddress` off `utxolib.addressFormat`** — replaces `toOutputScriptAndFormat` / `fromOutputScriptWithFormat` with wasm-utxo's `address.toOutputScriptWithCoin` / `fromOutputScriptWithCoin`, detecting format by round-trip equality.
5. **replace `utxolib.bitgo` helpers and drop dead branches** — `isChainCode`/`scriptTypeForChain` → `ChainCode.is`/`ChainCode.scriptType` (wasm-utxo); removes the unreachable `UtxoPsbt` branch in `hasKeyPathSpendInput`; inlines the 2-of-3 script type list instead of `utxolib.outputScripts.scriptTypes2Of3`; drops unused `RootWalletKeys`/`UtxoNetwork` re-exports.
6. **remove deprecated `network` getter and `getNetworkFromCoinName`** — drops the deprecated `coin.network` getter from `AbstractUtxoCoin` and the `getNetworkFromCoinName` helper from `names.ts`. Tests that called `coin.network` now use a test-local `getNetworkForCoinName(coin.name)`. With this, `names.ts` no longer depends on `utxolib`.
7. **inline `ScriptType2Of3` type definition** — replaces the `utxolib.bitgo.outputScripts.ScriptType2Of3` type re-export with a local literal union (`'p2sh' | 'p2shP2wsh' | 'p2wsh' | 'p2tr' | 'p2trMusig2'`), removing the last `utxolib` type reference and the top-level `utxolib` import from `abstractUtxoCoin.ts`.

The downstream PR ([#8986](https://github.com/BitGo/BitGoJS/pull/8986)) updates `keychains.ts`; [#8987](https://github.com/BitGo/BitGoJS/pull/8987) deletes `wasmUtil.ts` and demotes `@bitgo/utxo-lib` to `devDependencies`.

Followed by #8986

## Test plan

- [x] `yarn tsc --noEmit` clean in `modules/abstract-utxo`
- [x] `yarn lint` clean in `modules/abstract-utxo`
- [x] All abstract-utxo unit tests pass

Refs: T1-3279

🤖 Generated with [Claude Code](https://claude.com/claude-code)