### PR TITLE
fix(sdk-core): pass round to getBitgoSignatureShare helper

### DIFF
--- a/modules/sdk-core/src/bitgo/tss/common.ts
+++ b/modules/sdk-core/src/bitgo/tss/common.ts
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import openpgp from 'openpgp';
 
+import { MPCv2SigningState } from '@bitgo/public-types';
 import { BitGoBase } from '../bitgoBase';
 import { TxRequestChallengeResponse } from './types';
 import {
@@ -20,12 +21,21 @@ const debug = require('debug')('bitgo:tss:common');
 
 export function getBitgoSignatureShare(
   signatureShares: SignatureShareRecord[],
-  signerShareType: SignatureShareType
+  signerShareType: SignatureShareType,
+  shareType: MPCv2SigningState
 ): SignatureShareRecord {
-  const bitgoShare = signatureShares.find(
-    (share) => share.from === SignatureShareType.BITGO && share.to === signerShareType
-  );
-  assert(bitgoShare, 'Missing BitGo signature share');
+  const bitgoShare = signatureShares.find((share) => {
+    if (share.from !== SignatureShareType.BITGO || share.to !== signerShareType) {
+      return false;
+    }
+
+    try {
+      return JSON.parse(share.share).type === shareType;
+    } catch {
+      return false;
+    }
+  });
+  assert(bitgoShare, `Missing BitGo ${shareType} signature share`);
   return bitgoShare;
 }
 

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
@@ -469,7 +469,7 @@ export class EddsaMPCv2Utils extends BaseEddsaUtils {
         ? latestTxRequest.transactions![0].signatureShares
         : latestTxRequest.messages![0].signatureShares;
 
-    const bitgoShareRoundOne = getBitgoSignatureShare(signatureShares1, signerShareType);
+    const bitgoShareRoundOne = getBitgoSignatureShare(signatureShares1, signerShareType, 'round1Output');
     const parsedBitGoToUserSigShareRoundOne = decodeWithCodec(
       EddsaMPCv2SignatureShareRound1Output,
       JSON.parse(bitgoShareRoundOne.share),
@@ -508,7 +508,7 @@ export class EddsaMPCv2Utils extends BaseEddsaUtils {
         ? latestTxRequest.transactions![0].signatureShares
         : latestTxRequest.messages![0].signatureShares;
 
-    const bitgoShareRoundTwo = getBitgoSignatureShare(txRequestSignatureShares, signerShareType);
+    const bitgoShareRoundTwo = getBitgoSignatureShare(txRequestSignatureShares, signerShareType, 'round2Output');
     const parsedBitGoToUserSigShareRoundTwo = decodeWithCodec(
       EddsaMPCv2SignatureShareRound2Output,
       JSON.parse(bitgoShareRoundTwo.share),
@@ -649,7 +649,7 @@ export class EddsaMPCv2Utils extends BaseEddsaUtils {
     const signatureShares = transactions[0].signatureShares;
     assert(signatureShares, 'Missing signature shares in round 1 txRequest');
 
-    const bitgoShareRoundOne = getBitgoSignatureShare(signatureShares, SignatureShareType.USER);
+    const bitgoShareRoundOne = getBitgoSignatureShare(signatureShares, SignatureShareType.USER, 'round1Output');
     const parsedBitGoToUserSigShareRoundOne = decodeWithCodec(
       EddsaMPCv2SignatureShareRound1Output,
       JSON.parse(bitgoShareRoundOne.share),
@@ -754,18 +754,7 @@ export class EddsaMPCv2Utils extends BaseEddsaUtils {
     const signatureShares = transactions[0].signatureShares;
     assert(signatureShares, 'Missing signature shares in round 2 txRequest');
 
-    const bitgoShareRoundTwo = [...signatureShares].reverse().find((share) => {
-      if (share.from !== SignatureShareType.BITGO || share.to !== SignatureShareType.USER) {
-        return false;
-      }
-
-      try {
-        return JSON.parse(share.share).type === 'round2Output';
-      } catch {
-        return false;
-      }
-    });
-    assert(bitgoShareRoundTwo, 'Missing BitGo round 2 signature share');
+    const bitgoShareRoundTwo = getBitgoSignatureShare(signatureShares, SignatureShareType.USER, 'round2Output');
 
     const parsedBitGoToUserSigShareRoundTwo = decodeWithCodec(
       EddsaMPCv2SignatureShareRound2Output,

--- a/modules/sdk-core/test/unit/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
+++ b/modules/sdk-core/test/unit/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
@@ -32,6 +32,7 @@ import {
   verifyPeerMessageRoundOne,
   verifyPeerMessageRoundTwo,
 } from '../../../../../../src/bitgo/tss/eddsa/eddsaMPCv2';
+import { getBitgoSignatureShare } from '../../../../../../src/bitgo/tss/common';
 import { decodeWithCodec } from '../../../../../../src/bitgo/utils/codecs';
 import { generateGPGKeyPair } from '../../../../../../src/bitgo/utils/opengpgUtils';
 import { MPCv2PartiesEnum } from '../../../../../../src/bitgo/utils/tss/ecdsa/typesMPCv2';
@@ -799,7 +800,7 @@ describe('EddsaMPCv2Utils.createOfflineRound2Share', () => {
           encryptedUserGpgPrvKey: round1.encryptedUserGpgPrvKey,
           encryptedRound1Session: round1.encryptedRound1Session,
         }),
-      /Missing BitGo signature share/
+      /Missing BitGo round1Output signature share/
     );
   });
 
@@ -1114,7 +1115,7 @@ describe('EddsaMPCv2Utils.createOfflineRound3Share', () => {
           encryptedUserGpgPrvKey: round1.encryptedUserGpgPrvKey,
           encryptedRound2Session: round2.encryptedRound2Session,
         }),
-      /Missing BitGo round 2 signature share/
+      /Missing BitGo round2Output signature share/
     );
   });
 
@@ -1147,6 +1148,45 @@ describe('EddsaMPCv2Utils.createOfflineRound3Share', () => {
           encryptedRound2Session: round2.encryptedRound2Session,
         }),
       /Unable to find transactions in txRequest/
+    );
+  });
+});
+
+describe('getBitgoSignatureShare', () => {
+  const round1OutputShare: SignatureShareRecord = {
+    from: SignatureShareType.BITGO,
+    to: SignatureShareType.USER,
+    share: JSON.stringify({ type: 'round1Output', data: {} }),
+  };
+  const round2OutputShare: SignatureShareRecord = {
+    from: SignatureShareType.BITGO,
+    to: SignatureShareType.USER,
+    share: JSON.stringify({ type: 'round2Output', data: {} }),
+  };
+
+  it('selects the requested BitGo round output when multiple round outputs are present', () => {
+    const signatureShares = [round1OutputShare, round2OutputShare];
+
+    assert.strictEqual(
+      getBitgoSignatureShare(signatureShares, SignatureShareType.USER, 'round2Output'),
+      round2OutputShare
+    );
+    assert.strictEqual(
+      getBitgoSignatureShare(signatureShares, SignatureShareType.USER, 'round1Output'),
+      round1OutputShare
+    );
+  });
+
+  it('skips malformed share records while selecting the requested BitGo round output', () => {
+    const malformedShare: SignatureShareRecord = {
+      from: SignatureShareType.BITGO,
+      to: SignatureShareType.USER,
+      share: 'not-json',
+    };
+
+    assert.strictEqual(
+      getBitgoSignatureShare([malformedShare, round2OutputShare], SignatureShareType.USER, 'round2Output'),
+      round2OutputShare
     );
   });
 });


### PR DESCRIPTION
EdDSA MPCv2 signing can receive multiple BitGo-to-signer shares in a txRequest.
Selecting only by sender/recipient can pick a stale round-1 output during round 2.
- Add shareType param to getBitgoSignatureShare to filter by round output type.
- Update EdDSA MPCv2 callers to request round-1 or round-2 output explicitly.
- Remove inline reverse().find() in offline round-3 path in favour of the helper.
- Update tests to expect round-specific missing share error messages.

Ticket: WCI-626

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
