### PR TITLE
fix(statics): Etherlink and stableEVM display names (CECHO-1255)

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -404,7 +404,7 @@ export const allCoinsAndTokens = [
   account(
     '260a8571-1f89-40ad-af8d-c58a391581b5',
     'xtzevm',
-    'XTZ EVM',
+    'Etherlink',
     Networks.main.xtzevm,
     18,
     UnderlyingAsset.XTZEVM,
@@ -468,7 +468,7 @@ export const allCoinsAndTokens = [
   account(
     'e7fdbd6f-93ff-4dda-8a57-81580827188e',
     'txtzevm',
-    'Testnet XTZ EVM',
+    'Testnet Etherlink',
     Networks.test.xtzevm,
     18,
     UnderlyingAsset.XTZEVM,
@@ -1935,7 +1935,7 @@ export const allCoinsAndTokens = [
   account(
     '599ab8d6-ebda-460e-8527-677157f86021',
     'usdt0',
-    'USDT0',
+    'StableEVM',
     Networks.main.usdt0,
     18,
     UnderlyingAsset.USDT0,
@@ -1953,7 +1953,7 @@ export const allCoinsAndTokens = [
   account(
     'fd6b7af0-aff3-45fb-9a71-2d7100a1cd89',
     'tusdt0',
-    'Testnet USDT0',
+    'Testnet StableEVM',
     Networks.test.usdt0,
     18,
     UnderlyingAsset.USDT0,

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -234,11 +234,11 @@ export const ofcCoins = [
     UnderlyingAsset.SONIC,
     CoinKind.CRYPTO
   ),
-  ofc('13151b0b-3734-452d-8ad9-21af03a08bfe', 'ofcusdt0', 'USDT0', 18, UnderlyingAsset.USDT0, CoinKind.CRYPTO),
+  ofc('13151b0b-3734-452d-8ad9-21af03a08bfe', 'ofcusdt0', 'StableEVM', 18, UnderlyingAsset.USDT0, CoinKind.CRYPTO),
   tofc(
     '39a4dd77-b824-47b9-baff-b45398012511',
     'ofctusdt0',
-    'USDT0 Testnet',
+    'StableEVM Testnet',
     18,
     UnderlyingAsset.USDT0,
     CoinKind.CRYPTO
@@ -251,11 +251,11 @@ export const ofcCoins = [
     UnderlyingAsset.HYPEEVM,
     CoinKind.CRYPTO
   ),
-  ofc('dc825481-0a15-44ab-84e6-6f182b13eb87', 'ofcxtzevm', 'XTZ EVM', 18, UnderlyingAsset.XTZEVM, CoinKind.CRYPTO),
+  ofc('dc825481-0a15-44ab-84e6-6f182b13eb87', 'ofcxtzevm', 'Etherlink', 18, UnderlyingAsset.XTZEVM, CoinKind.CRYPTO),
   tofc(
     '0e42884b-c01e-461b-b108-1ed0d0fbbd7b',
     'ofctxtzevm',
-    'XTZ EVM Testnet',
+    'Etherlink Testnet',
     18,
     UnderlyingAsset.XTZEVM,
     CoinKind.CRYPTO

--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -735,7 +735,7 @@ class EthereumW extends Mainnet implements EthereumNetwork {
 }
 
 class XtzEvm extends Mainnet implements EthereumNetwork {
-  name = 'XTZ EVM';
+  name = 'Etherlink';
   family = CoinFamily.XTZEVM;
   explorerUrl = 'https://explorer.etherlink.com/tx/';
   accountExplorerUrl = 'https://explorer.etherlink.com/address/';
@@ -744,7 +744,7 @@ class XtzEvm extends Mainnet implements EthereumNetwork {
 }
 
 class XtzEvmTestnet extends Testnet implements EthereumNetwork {
-  name = 'Testnet XTZ EVM';
+  name = 'Testnet Etherlink';
   family = CoinFamily.XTZEVM;
   explorerUrl = 'https://shadownet.explorer.etherlink.com/tx/';
   accountExplorerUrl = 'https://shadownet.explorer.etherlink.com/address/';
@@ -2021,7 +2021,7 @@ class SonicTestnet extends Testnet implements EthereumNetwork {
 }
 
 class Usdt0 extends Mainnet implements EthereumNetwork {
-  name = 'USDT0';
+  name = 'StableEVM';
   family = CoinFamily.USDT0;
   explorerUrl = 'https://stablescan.xyz/tx/';
   accountExplorerUrl = 'https://stablescan.xyz/address/';
@@ -2030,7 +2030,7 @@ class Usdt0 extends Mainnet implements EthereumNetwork {
 }
 
 class Usdt0Testnet extends Testnet implements EthereumNetwork {
-  name = 'Testnet USDT0';
+  name = 'Testnet StableEVM';
   family = CoinFamily.USDT0;
   explorerUrl = 'https://testnet.stablescan.xyz/tx/';
   accountExplorerUrl = 'https://testnet.stablescan.xyz/address/';


### PR DESCRIPTION
## Summary
- Rename `xtzevm` / `txtzevm` display labels from **XTZ EVM** to **Etherlink** (and testnet variants).
- Rename `usdt0` / `tusdt0` display labels from **USDT0** to **stableEVM** (and testnet variants).
- Update matching OFC coin names and network definitions in statics.

Linear: https://linear.app/bitgo/issue/CECHO-1255/fix-xtzevm-and-usdt0-name

## Test plan
- [ ] Verify statics build passes
- [ ] Confirm `getCoin('xtzevm')` / `getCoin('usdt0')` return updated `name` fields
- [ ] Confirm OFC coins `ofcxtzevm` / `ofcusdt0` show correct labels in consumers after publish

Made with [Cursor](https://cursor.com)