### PR TITLE
chore: bump @bitgo/wasm-utxo to 4.16.0

### DIFF
--- a/modules/abstract-utxo/package.json
+++ b/modules/abstract-utxo/package.json
@@ -67,7 +67,7 @@
     "@bitgo/utxo-descriptors": "^1.3.0",
     "@bitgo/utxo-lib": "^11.22.1",
     "@bitgo/utxo-ord": "^1.32.0",
-    "@bitgo/wasm-utxo": "^4.14.1",
+    "@bitgo/wasm-utxo": "^4.16.0",
     "@types/lodash": "^4.14.121",
     "@types/superagent": "4.1.15",
     "bignumber.js": "^9.0.2",

--- a/modules/utxo-bin/package.json
+++ b/modules/utxo-bin/package.json
@@ -31,7 +31,7 @@
     "@bitgo/unspents": "^0.51.4",
     "@bitgo/utxo-core": "^1.39.0",
     "@bitgo/utxo-lib": "^11.22.1",
-    "@bitgo/wasm-utxo": "^4.14.1",
+    "@bitgo/wasm-utxo": "^4.16.0",
     "@noble/curves": "1.8.1",
     "archy": "^1.0.0",
     "bech32": "^2.0.0",

--- a/modules/utxo-core/package.json
+++ b/modules/utxo-core/package.json
@@ -81,7 +81,7 @@
     "@bitgo/secp256k1": "^1.11.0",
     "@bitgo/unspents": "^0.51.4",
     "@bitgo/utxo-lib": "^11.22.1",
-    "@bitgo/wasm-utxo": "^4.14.1",
+    "@bitgo/wasm-utxo": "^4.16.0",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
     "fast-sha256": "^1.3.0"
   },

--- a/modules/utxo-descriptors/package.json
+++ b/modules/utxo-descriptors/package.json
@@ -60,6 +60,6 @@
   },
   "dependencies": {
     "@bitgo/utxo-core": "^1.39.0",
-    "@bitgo/wasm-utxo": "^4.14.1"
+    "@bitgo/wasm-utxo": "^4.16.0"
   }
 }

--- a/modules/utxo-ord/package.json
+++ b/modules/utxo-ord/package.json
@@ -45,7 +45,7 @@
     "directory": "modules/utxo-ord"
   },
   "dependencies": {
-    "@bitgo/wasm-utxo": "^4.14.1"
+    "@bitgo/wasm-utxo": "^4.16.0"
   },
   "devDependencies": {
     "@bitgo/utxo-lib": "^11.22.1"

--- a/modules/utxo-staking/package.json
+++ b/modules/utxo-staking/package.json
@@ -63,7 +63,7 @@
     "@bitgo/babylonlabs-io-btc-staking-ts": "^3.5.0",
     "@bitgo/utxo-core": "^1.39.0",
     "@bitgo/utxo-lib": "^11.22.1",
-    "@bitgo/wasm-utxo": "^4.14.1",
+    "@bitgo/wasm-utxo": "^4.16.0",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
     "bip322-js": "^2.0.0",
     "bitcoinjs-lib": "^6.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1094,10 +1094,10 @@
   resolved "https://registry.npmjs.org/@bitgo/wasm-ton/-/wasm-ton-1.1.1.tgz"
   integrity sha512-Y4x2V2ZcYWlmx42v7dlrKDtT2DuUt8smk8E98mh7RhpiifJhLk2v5RmXDwBl0A3v9TzUOU6qMOnSS/iZ8Pq52w==
 
-"@bitgo/wasm-utxo@^4.14.1":
-  version "4.14.1"
-  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-4.14.1.tgz#bf709a98078f10f9c52900bcba24a6c6a9d0256e"
-  integrity sha512-cHGJzCNlPMpVXp/ydFIHQ0/GSRJLYG+cqzVYa6u7x2bbnKDzIqgn34hpWX1w/FfZ626U0S47HGo8ujmoWoUn2Q==
+"@bitgo/wasm-utxo@^4.16.0":
+  version "4.16.0"
+  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-4.16.0.tgz#6dc23f288b4abf52b5e34599e7488da8d8693c53"
+  integrity sha512-2hg8J1pkaPyf/baS8LQ4aarwbEBHuVuHeaSQpRzkBuCWezJAhqZsoTlx9WrDd4TQC/0oPcl34phg+Ny5c8wZUg==
 
 "@brandonblack/musig@^0.0.1-alpha.0":
   version "0.0.1-alpha.1"


### PR DESCRIPTION
bump `@bitgo/wasm-utxo` from `^4.13.0` to `^4.16.0` across all UTXO modules.

Ticket: BTC-0