### PR TITLE
feat: add cantonCommand intent to prebuild

### DIFF
--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -18,6 +18,7 @@ import { IPendingApproval, PendingApprovalData } from '../pendingApproval';
 import { IGoStakingWallet, IStakingWallet } from '../staking';
 import { ITradingAccount } from '../trading';
 import {
+  CantonCommandParams,
   CustomCommitmentGeneratingFunction,
   CustomEddsaMPCv2SigningRound1GeneratingFunction,
   CustomEddsaMPCv2SigningRound2GeneratingFunction,
@@ -291,6 +292,10 @@ export interface PrebuildTransactionOptions {
    * Used with type: 'bridging' for cross-chain bridging operations.
    */
   bridgingParams?: BridgingParams;
+  /**
+   * Parameters for executing DAML commands on Canton.
+   */
+  cantonCommandParams?: CantonCommandParams;
 }
 
 export interface PrebuildAndSignTransactionOptions extends PrebuildTransactionOptions, WalletSignTransactionOptions {

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -4292,6 +4292,23 @@ export class Wallet implements IWallet {
         );
         break;
       }
+      case 'cantonCommand': {
+        if (!params.cantonCommandParams) {
+          throw new Error('cantonCommandParams is required for cantonCommand intent');
+        }
+        txRequest = await this.tssUtils!.prebuildTxWithIntent(
+          {
+            reqId,
+            intentType: 'cantonCommand',
+            cantonCommandParams: params.cantonCommandParams,
+            sequenceId: params.sequenceId,
+            comment: params.comment,
+          },
+          apiVersion,
+          params.preview
+        );
+        break;
+      }
       case 'customTx':
         txRequest = await this.tssUtils!.prebuildTxWithIntent(
           {


### PR DESCRIPTION
## Summary
Adds support for the `cantonCommand` intent type in `prebuildTransaction`, enabling us to execute DAML commands (CreateCommand / ExerciseCommand) on Canton through the standard wallet prebuild flow

## Changes:

- Added `cantonCommandParams` to `PrebuildTransactionOptions` interface
- Added `cantonCommand` case to the intent routing in `wallet.prebuildTransaction()`

Ticket: SCAAS-9604