### PR TITLE
feat(sdk-coin-canton): forward token and make choiceArgument optional

### DIFF
--- a/modules/sdk-coin-canton/src/lib/cantonCommandBuilder.ts
+++ b/modules/sdk-coin-canton/src/lib/cantonCommandBuilder.ts
@@ -17,6 +17,7 @@ export class CantonCommandBuilder extends TransactionBuilder {
   private _readAs: string[] = [];
   private _command: CantonCommand;
   private _resolveContracts: CantonCommandResolveContractSpec[] = [];
+  private _token?: string;
 
   constructor(_coinConfig: Readonly<CoinConfig>) {
     super(_coinConfig);
@@ -138,6 +139,21 @@ export class CantonCommandBuilder extends TransactionBuilder {
   }
 
   /**
+   * Sets the Canton token identifier (e.g. 'tcanton:stgusd1') forwarded to IMS for
+   * choice-context resolution on token-specific commands such as mint and burn.
+   *
+   * @param name - Registered BitGo canton token name
+   * @returns The current builder instance for chaining.
+   */
+  token(name: string): this {
+    if (typeof name !== 'string' || !name.trim()) {
+      throw new Error('token must be a non-empty string');
+    }
+    this._token = name.trim();
+    return this;
+  }
+
+  /**
    * Builds and returns the CantonCommandRequest from the builder's internal state.
    *
    * @returns {CantonCommandRequest}
@@ -146,13 +162,17 @@ export class CantonCommandBuilder extends TransactionBuilder {
   toRequestObject(): CantonCommandRequest {
     this.validate();
 
-    return {
+    const req: CantonCommandRequest = {
       commandId: this._commandId,
       actAs: this._actAs,
       readAs: this._readAs ?? [],
       command: this._command,
       resolveContracts: this._resolveContracts ?? [],
     };
+    if (this._token) {
+      req.token = this._token;
+    }
+    return req;
   }
 
   private validate(): void {

--- a/modules/sdk-coin-canton/src/lib/iface.ts
+++ b/modules/sdk-coin-canton/src/lib/iface.ts
@@ -231,6 +231,7 @@ export interface CantonCommandRequest {
   readAs?: string[];
   command: CantonCommand;
   resolveContracts?: CantonCommandResolveContractSpec[];
+  token?: string;
 }
 
 // Root command decoded from the prepared Canton transaction protobuf, used during verifyTransaction.

--- a/modules/sdk-coin-canton/test/unit/builder/cantonCommand/cantonCommandBuilder.ts
+++ b/modules/sdk-coin-canton/test/unit/builder/cantonCommand/cantonCommandBuilder.ts
@@ -138,6 +138,38 @@ describe('CantonCommandBuilder', () => {
     });
   });
 
+  describe('token()', () => {
+    it('should set the token', function () {
+      const builder = new CantonCommandBuilder(coins.get('tcanton'));
+      const tx = new Transaction(coins.get('tcanton'));
+      builder.initBuilder(tx);
+      builder.commandId('cmd-tok-1').actAs([PARTY_A]).command(sampleExerciseCommand).token('tcanton:testtoken');
+      assert.equal(builder.toRequestObject().token, 'tcanton:testtoken');
+    });
+
+    it('should trim whitespace', function () {
+      const builder = new CantonCommandBuilder(coins.get('tcanton'));
+      const tx = new Transaction(coins.get('tcanton'));
+      builder.initBuilder(tx);
+      builder.commandId('cmd-tok-2').actAs([PARTY_A]).command(sampleExerciseCommand).token('  tcanton:testtoken  ');
+      assert.equal(builder.toRequestObject().token, 'tcanton:testtoken');
+    });
+
+    it('should throw on empty string', function () {
+      const builder = new CantonCommandBuilder(coins.get('tcanton'));
+      const tx = new Transaction(coins.get('tcanton'));
+      builder.initBuilder(tx);
+      assert.throws(() => builder.token(''), /token must be a non-empty string/);
+    });
+
+    it('should throw on whitespace-only string', function () {
+      const builder = new CantonCommandBuilder(coins.get('tcanton'));
+      const tx = new Transaction(coins.get('tcanton'));
+      builder.initBuilder(tx);
+      assert.throws(() => builder.token('   '), /token must be a non-empty string/);
+    });
+  });
+
   describe('resolveContracts()', () => {
     it('should set the spec array', function () {
       const spec = [{ templateId: TEMPLATE_ID, actAs: [PARTY_A], injectAs: 'command.ExerciseCommand.contractId' }];
@@ -205,6 +237,24 @@ describe('CantonCommandBuilder', () => {
       builder.commandId('cmd-002').actAs([PARTY_A]).command(sampleCreateCommand);
       const req = builder.toRequestObject();
       assert.deepEqual(req.resolveContracts, []);
+    });
+
+    it('should include token when set', function () {
+      const builder = new CantonCommandBuilder(coins.get('tcanton'));
+      const tx = new Transaction(coins.get('tcanton'));
+      builder.initBuilder(tx);
+      builder.commandId('cmd-003').actAs([PARTY_A]).command(sampleExerciseCommand).token('tcanton:testtoken');
+      const req = builder.toRequestObject();
+      assert.equal(req.token, 'tcanton:testtoken');
+    });
+
+    it('should not include token key when not set', function () {
+      const builder = new CantonCommandBuilder(coins.get('tcanton'));
+      const tx = new Transaction(coins.get('tcanton'));
+      builder.initBuilder(tx);
+      builder.commandId('cmd-004').actAs([PARTY_A]).command(sampleExerciseCommand);
+      const req = builder.toRequestObject();
+      assert.ok(!('token' in req));
     });
   });
 

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -93,7 +93,7 @@ export interface CantonExerciseCommand {
     templateId: string;
     contractId?: string;
     choice: string;
-    choiceArgument: Record<string, unknown>;
+    choiceArgument?: Record<string, unknown>;
   };
 }
 

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -4301,6 +4301,7 @@ export class Wallet implements IWallet {
             reqId,
             intentType: 'cantonCommand',
             cantonCommandParams: params.cantonCommandParams,
+            tokenName: params.tokenName,
             sequenceId: params.sequenceId,
             comment: params.comment,
           },


### PR DESCRIPTION
## Changes:

1. Forward token to IMS.
Canton mint/burn commands are built server-side by IMS, which needs to know which token the command targets to resolve the registrar. A Canton token shares the base-coin wallet (tcanton), so the token cannot be inferred — it must be passed explicitly. The cantonCommand branch now forwards params.tokenName, which populateIntent maps to intent.token. Without this, IMS fails with token is required for choice context resolution.

2. Make choiceArgument optional.
No-argument Canton choices (e.g. CredentialOffer_AcceptFree) have an empty choiceArgument: {}. Mongoose minimize strips empty objects on persist, so rebuilding such a command forwards it to IMS without choiceArgument, which previously caused a 400. Making it optional here is the type-level half of the fix; IMS materializes {} before /prepare.

No change for existing flows — callers that don't pass tokenName are unaffected.



Ticket: SCAAS-9624
