### PR TITLE
feat: thread encryptionVersion in SDK

### DIFF
--- a/modules/abstract-lightning/src/codecs/api/wallet.ts
+++ b/modules/abstract-lightning/src/codecs/api/wallet.ts
@@ -88,6 +88,7 @@ export const UpdateLightningWalletClientRequest = t.intersection([
     signerMacaroon: t.string,
     signerAdminMacaroon: t.string,
     signerTlsKey: t.string,
+    encryptionVersion: t.union([t.literal(1), t.literal(2)]),
   }),
 ]);
 

--- a/modules/abstract-lightning/src/wallet/selfCustodialLightning.ts
+++ b/modules/abstract-lightning/src/wallet/selfCustodialLightning.ts
@@ -24,6 +24,7 @@ async function encryptWalletUpdateRequest(
     requestWithEncryption.encryptedSignerTlsKey = await wallet.bitgo.encryptAsync({
       password: params.passphrase,
       input: params.signerTlsKey,
+      encryptionVersion: params.encryptionVersion,
     });
   }
 
@@ -31,6 +32,7 @@ async function encryptWalletUpdateRequest(
     requestWithEncryption.encryptedSignerAdminMacaroon = await wallet.bitgo.encryptAsync({
       password: params.passphrase,
       input: params.signerAdminMacaroon,
+      encryptionVersion: params.encryptionVersion,
     });
   }
 
@@ -38,6 +40,7 @@ async function encryptWalletUpdateRequest(
     requestWithEncryption.encryptedSignerMacaroon = await wallet.bitgo.encryptAsync({
       password: deriveLightningServiceSharedSecret(coinName, userAuthXprv).toString('hex'),
       input: params.signerMacaroon,
+      encryptionVersion: params.encryptionVersion,
     });
   }
 

--- a/modules/express/src/fetchEncryptedPrivKeys.ts
+++ b/modules/express/src/fetchEncryptedPrivKeys.ts
@@ -20,6 +20,7 @@ type Credentials = {
   walletId: string; // Id of the BitGo wallet.
   walletPassword: string; // Password used for the wallet.
   secret: string; // xprv of user key or backup key.
+  encryptionVersion?: 1 | 2;
 };
 
 type WalletIds = {
@@ -77,7 +78,11 @@ export async function fetchKeys(ids: WalletIds, token: string, accessToken?: str
 
       if (keychain.encryptedPrv === undefined) {
         if (typeof credential === 'object') {
-          const encryptedPrv = await bg.encryptAsync({ password: credential.walletPassword, input: credential.secret });
+          const encryptedPrv = await bg.encryptAsync({
+            password: credential.walletPassword,
+            input: credential.secret,
+            encryptionVersion: credential.encryptionVersion,
+          });
           output[id] = encryptedPrv;
         } else {
           console.warn(`could not find a ${coinName} encrypted user private key for wallet id ${id}, skipping`);

--- a/modules/key-card/src/generateQrData.ts
+++ b/modules/key-card/src/generateQrData.ts
@@ -138,8 +138,12 @@ function generatePasscodeQrData(passphrase: string, passcodeEncryptionCode: stri
   };
 }
 
-async function generatePasscodeQrDataAsync(passphrase: string, passcodeEncryptionCode: string): Promise<QrDataEntry> {
-  const encryptedWalletPasscode = await encryptAsync(passcodeEncryptionCode, passphrase);
+async function generatePasscodeQrDataAsync(
+  passphrase: string,
+  passcodeEncryptionCode: string,
+  encryptionVersion?: 1 | 2
+): Promise<QrDataEntry> {
+  const encryptedWalletPasscode = await encryptAsync(passcodeEncryptionCode, passphrase, { encryptionVersion });
   return {
     title: 'D: Encrypted wallet Password',
     description: 'This is the wallet password, encrypted client-side with a key held by BitGo.',
@@ -211,7 +215,11 @@ export async function generateQrDataAsync(params: GenerateQrDataParams): Promise
   const qrData = buildWalletQrData(params);
 
   if (params.passphrase && params.passcodeEncryptionCode) {
-    qrData.passcode = await generatePasscodeQrDataAsync(params.passphrase, params.passcodeEncryptionCode);
+    qrData.passcode = await generatePasscodeQrDataAsync(
+      params.passphrase,
+      params.passcodeEncryptionCode,
+      params.encryptionVersion
+    );
   }
 
   return qrData;
@@ -234,7 +242,11 @@ export async function generateLightningQrDataAsync(params: GenerateLightningQrDa
   const qrData = buildLightningQrData(params);
 
   if (params.passphrase && params.passcodeEncryptionCode) {
-    qrData.passcode = await generatePasscodeQrDataAsync(params.passphrase, params.passcodeEncryptionCode);
+    qrData.passcode = await generatePasscodeQrDataAsync(
+      params.passphrase,
+      params.passcodeEncryptionCode,
+      params.encryptionVersion
+    );
   }
 
   return qrData;

--- a/modules/key-card/src/types.ts
+++ b/modules/key-card/src/types.ts
@@ -1,4 +1,4 @@
-import { Keychain } from '@bitgo/sdk-core';
+import { EncryptionVersion, Keychain } from '@bitgo/sdk-core';
 import { BaseCoin, KeyCurve } from '@bitgo/statics';
 
 export interface GenerateQrDataBaseParams {
@@ -25,6 +25,7 @@ export interface GenerateQrDataCoinParams {
   // If both the passphrase and passcodeEncryptionCode are passed, then this code encrypts the passphrase with the
   // passcodeEncryptionCode and puts the result into Box D. Allows recoveries of the wallet password.
   passphrase?: string;
+  encryptionVersion?: EncryptionVersion;
 }
 
 export interface GenerateQrDataParams extends GenerateQrDataCoinParams {

--- a/modules/key-card/test/unit/generateQrData.ts
+++ b/modules/key-card/test/unit/generateQrData.ts
@@ -247,6 +247,72 @@ describe('generateQrDataAsync', function () {
     const decryptedData = await decryptAsync(passcodeEncryptionCode, qrData.passcode.data);
     decryptedData.should.equal(passphrase);
   });
+
+  it('produces a v1 Box D when encryptionVersion is not set', async function () {
+    const passphrase = 'testingIsFun';
+    const passcodeEncryptionCode = '123456';
+    const qrData = await generateQrDataAsync({
+      backupKeychain: createKeychain({ encryptedPrv: 'backupPrv' }),
+      bitgoKeychain: createKeychain({ pub: 'bitgoPub' }),
+      coin: coins.get('btc'),
+      passcodeEncryptionCode,
+      passphrase,
+      userKeychain: createKeychain({ encryptedPrv: 'userPrv' }),
+    });
+
+    assert.ok(qrData.passcode);
+    const envelope = JSON.parse(qrData.passcode.data);
+    assert.notStrictEqual(envelope.v, 2, 'should default to v1 envelope');
+  });
+
+  it('produces a v2 Box D when encryptionVersion: 2', async function () {
+    const passphrase = 'testingIsFun';
+    const passcodeEncryptionCode = '123456';
+    const qrData = await generateQrDataAsync({
+      backupKeychain: createKeychain({ encryptedPrv: 'backupPrv' }),
+      bitgoKeychain: createKeychain({ pub: 'bitgoPub' }),
+      coin: coins.get('btc'),
+      passcodeEncryptionCode,
+      passphrase,
+      userKeychain: createKeychain({ encryptedPrv: 'userPrv' }),
+      encryptionVersion: 2,
+    });
+
+    assert.ok(qrData.passcode);
+    const envelope = JSON.parse(qrData.passcode.data);
+    assert.strictEqual(envelope.v, 2, 'should produce v2 envelope');
+    const decryptedData = await decryptAsync(passcodeEncryptionCode, qrData.passcode.data);
+    decryptedData.should.equal(passphrase);
+  });
+
+  it('produces a v1 Box D when encryptionVersion: 1 is explicit', async function () {
+    const passphrase = 'testingIsFun';
+    const passcodeEncryptionCode = '123456';
+    const qrData = await generateQrDataAsync({
+      backupKeychain: createKeychain({ encryptedPrv: 'backupPrv' }),
+      bitgoKeychain: createKeychain({ pub: 'bitgoPub' }),
+      coin: coins.get('btc'),
+      passcodeEncryptionCode,
+      passphrase,
+      userKeychain: createKeychain({ encryptedPrv: 'userPrv' }),
+      encryptionVersion: 1,
+    });
+
+    assert.ok(qrData.passcode);
+    const envelope = JSON.parse(qrData.passcode.data);
+    assert.notStrictEqual(envelope.v, 2, 'should produce v1 envelope');
+  });
+
+  it('omits Box D when passphrase or passcodeEncryptionCode is missing', async function () {
+    const qrData = await generateQrDataAsync({
+      backupKeychain: createKeychain({ encryptedPrv: 'backupPrv' }),
+      bitgoKeychain: createKeychain({ pub: 'bitgoPub' }),
+      coin: coins.get('btc'),
+      userKeychain: createKeychain({ encryptedPrv: 'userPrv' }),
+      encryptionVersion: 2,
+    });
+    assert.strictEqual(qrData.passcode, undefined);
+  });
 });
 
 describe('generateLightningQrDataAsync', function () {
@@ -261,6 +327,24 @@ describe('generateLightningQrDataAsync', function () {
     });
 
     assert.ok(qrData.passcode);
+    const decryptedData = await decryptAsync(passcodeEncryptionCode, qrData.passcode.data);
+    decryptedData.should.equal(passphrase);
+  });
+
+  it('produces a v2 Box D when encryptionVersion: 2', async function () {
+    const passphrase = 'testingIsFun';
+    const passcodeEncryptionCode = '123456';
+    const qrData = await generateLightningQrDataAsync({
+      userAuthKeychain: createKeychain({ encryptedPrv: 'userAuthPrv' }),
+      coin: coins.get('lnbtc'),
+      passcodeEncryptionCode,
+      passphrase,
+      encryptionVersion: 2,
+    });
+
+    assert.ok(qrData.passcode);
+    const envelope = JSON.parse(qrData.passcode.data);
+    assert.strictEqual(envelope.v, 2);
     const decryptedData = await decryptAsync(passcodeEncryptionCode, qrData.passcode.data);
     decryptedData.should.equal(passphrase);
   });

--- a/modules/passkey-crypto/src/attachPasskeyToWallet.ts
+++ b/modules/passkey-crypto/src/attachPasskeyToWallet.ts
@@ -1,4 +1,4 @@
-import { BitGoBase, Keychain } from '@bitgo/sdk-core';
+import { BitGoBase, EncryptionVersion, Keychain } from '@bitgo/sdk-core';
 import { base64UrlToBuffer } from './base64url';
 import { deriveEnterpriseSalt } from './deriveEnterpriseSalt';
 import { derivePassword } from './derivePassword';
@@ -11,8 +11,9 @@ export async function attachPasskeyToWallet(params: {
   device: WebAuthnOtpDevice;
   existingPassphrase: string;
   provider: WebAuthnProvider;
+  encryptionVersion?: EncryptionVersion;
 }): Promise<Keychain> {
-  const { bitgo, coin, walletId, device, existingPassphrase, provider } = params;
+  const { bitgo, coin, walletId, device, existingPassphrase, provider, encryptionVersion } = params;
 
   // Throw early if PRF extension is not supported
   if (!device.prfSalt) {
@@ -66,7 +67,7 @@ export async function attachPasskeyToWallet(params: {
   }
 
   const prfPassword = derivePassword(authResult.prfResult);
-  const encryptedPrv = await bitgo.encryptAsync({ password: prfPassword, input: privateKey, encryptionVersion: 2 });
+  const encryptedPrv = await bitgo.encryptAsync({ password: prfPassword, input: privateKey, encryptionVersion });
 
   const updatedKeychain = await bitgo
     .put(bitgo.url(`/${coin}/key/${keychainId}`, 2))

--- a/modules/passkey-crypto/test/unit/attachPasskeyToWallet.test.ts
+++ b/modules/passkey-crypto/test/unit/attachPasskeyToWallet.test.ts
@@ -114,6 +114,7 @@ describe('attachPasskeyToWallet', function () {
       device,
       existingPassphrase,
       provider: mockProvider as unknown as WebAuthnProvider,
+      encryptionVersion: 2,
       ...overrides,
     });
   }

--- a/modules/sdk-api/src/bitgoAPI.ts
+++ b/modules/sdk-api/src/bitgoAPI.ts
@@ -10,6 +10,7 @@ import {
   DecryptOptions,
   defaultConstants,
   EcdhDerivedKeypair,
+  EncryptionVersion,
   EncryptOptions,
   EnvironmentName,
   generateRandomPassword,
@@ -1125,7 +1126,7 @@ export class BitGoAPI implements BitGoBase {
    * @returns {Promise<any>} - A promise that resolves with the new ECDH keychain data.
    * @throws {Error} - Throws an error if there is an issue creating the keychain.
    */
-  public async createUserEcdhKeychain(loginPassword: string): Promise<any> {
+  public async createUserEcdhKeychain(loginPassword: string, encryptionVersion?: EncryptionVersion): Promise<any> {
     const keyData = this.keychains().create();
     const hdNode = bitcoin.HDNode.fromBase58(keyData.xprv);
 
@@ -1139,6 +1140,7 @@ export class BitGoAPI implements BitGoBase {
       encryptedXprv: await this.encryptAsync({
         password: loginPassword,
         input: hdNode.toBase58(),
+        encryptionVersion,
       }),
     });
   }
@@ -1160,7 +1162,10 @@ export class BitGoAPI implements BitGoBase {
    * @returns {Promise<any>} - A promise that resolves with the user's settings ensuring we have the ecdhKeychain in there.
    * @throws {Error} - Throws an error if there is an issue creating the keychain or updating the user's settings.
    */
-  private async ensureUserEcdhKeychainIsCreated(loginPassword: string): Promise<any> {
+  private async ensureUserEcdhKeychainIsCreated(
+    loginPassword: string,
+    encryptionVersion?: EncryptionVersion
+  ): Promise<any> {
     /**
      * Get the user's current settings.
      */
@@ -1169,7 +1174,7 @@ export class BitGoAPI implements BitGoBase {
      * If the user's ECDH keychain does not exist, create a new keychain and update the user's settings.
      */
     if (!userSettings.settings.ecdhKeychain) {
-      const newKeychain = await this.createUserEcdhKeychain(loginPassword);
+      const newKeychain = await this.createUserEcdhKeychain(loginPassword, encryptionVersion);
       await this.updateUserSettings({
         settings: {
           ecdhKeychain: newKeychain.xpub,
@@ -1251,7 +1256,9 @@ export class BitGoAPI implements BitGoBase {
         await this._hmacAuthStrategy.setToken?.(this._token);
       }
 
-      const userSettings = params.ensureEcdhKeychain ? await this.ensureUserEcdhKeychainIsCreated(password) : undefined;
+      const userSettings = params.ensureEcdhKeychain
+        ? await this.ensureUserEcdhKeychainIsCreated(password, params.encryptionVersion)
+        : undefined;
       if (userSettings?.ecdhKeychain) {
         response.body.user.ecdhKeychain = userSettings.ecdhKeychain;
       }
@@ -1932,11 +1939,11 @@ export class BitGoAPI implements BitGoBase {
    * @param passwords
    * @param m
    */
-  async splitSecretAsync({ seed, passwords, m }: SplitSecretOptions): Promise<SplitSecret> {
+  async splitSecretAsync({ seed, passwords, m, encryptionVersion }: SplitSecretOptions): Promise<SplitSecret> {
     const n = validateSplitSecretInputs({ seed, passwords, m });
     const secrets: string[] = shamir.share(seed, n, m);
     const shards = await Promise.all(
-      secrets.map((shard, i) => this.encryptAsync({ input: shard, password: passwords[i] }))
+      secrets.map((shard, i) => this.encryptAsync({ input: shard, password: passwords[i], encryptionVersion }))
     );
     return buildSplitSecretResult(seed, shards, m, n);
   }

--- a/modules/sdk-api/src/types.ts
+++ b/modules/sdk-api/src/types.ts
@@ -1,4 +1,4 @@
-import { EnvironmentName, IRequestTracer, V1Network } from '@bitgo/sdk-core';
+import { EncryptionVersion, EnvironmentName, IRequestTracer, V1Network } from '@bitgo/sdk-core';
 import { ECPairInterface } from '@bitgo/utxo-lib';
 import { type Agent } from 'http';
 
@@ -104,6 +104,11 @@ export interface AuthenticateOptions {
    * It is highly recommended that this is always set to avoid any issues when using a BitGo wallet
    */
   ensureEcdhKeychain?: boolean;
+  /**
+   * Encryption version to use when creating the ECDH keychain if it does not already exist.
+   * Only applies when `ensureEcdhKeychain` is true and no ECDH keychain exists for the user yet.
+   */
+  encryptionVersion?: EncryptionVersion;
   forReset2FA?: boolean;
   /**
    * The initial stage fingerprint hash used for device identification and verification.
@@ -226,6 +231,7 @@ export interface SplitSecretOptions {
   seed: string;
   passwords: string[];
   m: number;
+  encryptionVersion?: EncryptionVersion;
 }
 
 export interface SplitSecret {

--- a/modules/sdk-api/src/v1/keychains.ts
+++ b/modules/sdk-api/src/v1/keychains.ts
@@ -13,7 +13,7 @@
 
 import { bip32 } from '@bitgo/utxo-lib';
 import { randomBytes } from 'crypto';
-import { common, Util, sanitizeLegacyPath } from '@bitgo/sdk-core';
+import { common, isV2Envelope, Util, sanitizeLegacyPath } from '@bitgo/sdk-core';
 const _ = require('lodash');
 
 //
@@ -194,7 +194,12 @@ Keychains.prototype.updatePassword = function (params, callback) {
           input: oldEncryptedXprv as string,
           password: params.oldPassword,
         });
-        const newEncryptedPrv = await self.bitgo.encryptAsync({ input: decryptedPrv, password: params.newPassword });
+        const encryptionVersion = isV2Envelope(oldEncryptedXprv as string) ? 2 : 1;
+        const newEncryptedPrv = await self.bitgo.encryptAsync({
+          input: decryptedPrv,
+          password: params.newPassword,
+          encryptionVersion,
+        });
         newKeychains[xpub] = newEncryptedPrv;
       } catch (e) {
         // decrypting the keychain with the old password didn't work so we just keep it the way it is

--- a/modules/sdk-api/src/v1/travelRule.ts
+++ b/modules/sdk-api/src/v1/travelRule.ts
@@ -270,6 +270,7 @@ TravelRule.prototype.prepareParamsAsync = async function (params) {
   const encryptedTravelInfo = await this.bitgo.encryptAsync({
     input: prepared.travelInfoJSON,
     password: prepared.sharedSecret,
+    encryptionVersion: params.encryptionVersion,
   });
 
   return buildTravelRuleSendParams(prepared, encryptedTravelInfo);

--- a/modules/sdk-api/src/v1/wallet.ts
+++ b/modules/sdk-api/src/v1/wallet.ts
@@ -2318,7 +2318,11 @@ Wallet.prototype.shareWallet = function (params, callback) {
 
             const eckey = makeRandomKey();
             const secret = getSharedSecret(eckey, Buffer.from(sharing.pubkey, 'hex')).toString('hex');
-            const newEncryptedXprv = await self.bitgo.encryptAsync({ password: secret, input: keychain.xprv });
+            const newEncryptedXprv = await self.bitgo.encryptAsync({
+              password: secret,
+              input: keychain.xprv,
+              encryptionVersion: params.encryptionVersion,
+            });
 
             sharedKeychain = {
               xpub: keychain.xpub,

--- a/modules/sdk-api/src/v1/wallets.ts
+++ b/modules/sdk-api/src/v1/wallets.ts
@@ -275,6 +275,7 @@ Wallets.prototype.acceptShare = function (params, callback) {
         encryptedXprv = await self.bitgo.encryptAsync({
           password: newWalletPassphrase,
           input: decryptedSharedWalletXprv,
+          encryptionVersion: params.encryptionVersion,
         });
 
         // Carry on to the next block where we will post the acceptance of the share with the encrypted xprv
@@ -368,7 +369,13 @@ Wallets.prototype.createWalletWithKeychains = function (params, callback) {
   let bitgoKeychain;
 
   return Promise.resolve()
-    .then(() => self.bitgo.encryptAsync({ password: params.passphrase, input: userKeychain.xprv }))
+    .then(() =>
+      self.bitgo.encryptAsync({
+        password: params.passphrase,
+        input: userKeychain.xprv,
+        encryptionVersion: params.encryptionVersion,
+      })
+    )
     .then(function (encryptedXprv) {
       userKeychain.encryptedXprv = encryptedXprv;
 

--- a/modules/sdk-api/test/unit/bitgoAPI.ts
+++ b/modules/sdk-api/test/unit/bitgoAPI.ts
@@ -1,3 +1,4 @@
+import * as assert from 'assert';
 import 'should';
 import { BitGoAPI } from '../../src/bitgoAPI';
 import { ProxyAgent } from 'proxy-agent';
@@ -1038,6 +1039,84 @@ describe('Constructor', function () {
       await bitgo.changePassword({ oldPassword: 'oldpw', newPassword: 'newpw' });
 
       legacyScope.isDone().should.be.true();
+    });
+  });
+
+  describe('createUserEcdhKeychain - encryptionVersion threading', function () {
+    const ROOT = 'https://app.bitgo-test.com';
+    let bitgo: BitGoAPI;
+
+    beforeEach(function () {
+      bitgo = new BitGoAPI({ env: 'test' });
+    });
+
+    afterEach(function () {
+      nock.cleanAll();
+      sinon.restore();
+    });
+
+    it('passes encryptionVersion: 2 to encryptAsync', async function () {
+      const encryptAsyncSpy = sinon.spy(bitgo, 'encryptAsync');
+      nock(ROOT).post('/api/v1/keychain').reply(200, { xpub: 'xpub123', id: 'key-id' });
+
+      await bitgo.createUserEcdhKeychain('loginPassword', 2);
+
+      assert.ok(encryptAsyncSpy.calledOnce);
+      assert.strictEqual(encryptAsyncSpy.firstCall.args[0].encryptionVersion, 2);
+    });
+
+    it('passes encryptionVersion: undefined when not set (defaults to v1)', async function () {
+      const encryptAsyncSpy = sinon.spy(bitgo, 'encryptAsync');
+      nock(ROOT).post('/api/v1/keychain').reply(200, { xpub: 'xpub123', id: 'key-id' });
+
+      await bitgo.createUserEcdhKeychain('loginPassword');
+
+      assert.ok(encryptAsyncSpy.calledOnce);
+      assert.strictEqual(encryptAsyncSpy.firstCall.args[0].encryptionVersion, undefined);
+    });
+  });
+
+  describe('splitSecretAsync - encryptionVersion threading', function () {
+    let bitgo: BitGoAPI;
+
+    beforeEach(function () {
+      bitgo = new BitGoAPI({ env: 'test' });
+    });
+
+    afterEach(function () {
+      sinon.restore();
+    });
+
+    it('passes encryptionVersion: 2 to every encryptAsync shard call', async function () {
+      const encryptAsyncSpy = sinon.spy(bitgo, 'encryptAsync');
+      const passwords = ['pw1', 'pw2', 'pw3'];
+
+      await bitgo.splitSecretAsync({
+        seed: 'a'.repeat(64),
+        passwords,
+        m: 2,
+        encryptionVersion: 2,
+      });
+
+      assert.strictEqual(encryptAsyncSpy.callCount, 3, 'should encrypt each shard');
+      for (const call of encryptAsyncSpy.getCalls()) {
+        assert.strictEqual(call.args[0].encryptionVersion, 2);
+      }
+    });
+
+    it('passes encryptionVersion: undefined when not set', async function () {
+      const encryptAsyncSpy = sinon.spy(bitgo, 'encryptAsync');
+
+      await bitgo.splitSecretAsync({
+        seed: 'b'.repeat(64),
+        passwords: ['pw1', 'pw2'],
+        m: 2,
+      });
+
+      assert.strictEqual(encryptAsyncSpy.callCount, 2);
+      for (const call of encryptAsyncSpy.getCalls()) {
+        assert.strictEqual(call.args[0].encryptionVersion, undefined);
+      }
     });
   });
 });

--- a/modules/sdk-core/src/api/types.ts
+++ b/modules/sdk-core/src/api/types.ts
@@ -40,7 +40,11 @@ export interface EncryptOptions {
 /** Sync encrypt callback — used by v1 (SJCL) code paths. */
 export type EncryptFn = (params: { input: string; password: string }) => string;
 /** Async encrypt callback — used by v2 (Argon2id) code paths. */
-export type EncryptFnAsync = (params: { input: string; password: string }) => Promise<string>;
+export type EncryptFnAsync = (params: {
+  input: string;
+  password: string;
+  encryptionVersion?: EncryptionVersion;
+}) => Promise<string>;
 
 export interface GetSharingKeyOptions {
   email: string;

--- a/modules/sdk-core/src/bitgo/internal/keycard.ts
+++ b/modules/sdk-core/src/bitgo/internal/keycard.ts
@@ -6,7 +6,7 @@
  */
 import { isUndefined } from 'lodash';
 import { Keychain } from '../keychain';
-import { EncryptFn, EncryptFnAsync } from '../../api';
+import { EncryptFn, EncryptFnAsync, EncryptionVersion } from '../../api';
 
 /**
  * Return the list of questions that will appear on the second page of the keycard
@@ -95,6 +95,7 @@ interface GetKeyDataOptions {
 
 type GetKeyDataAsyncOptions = Omit<GetKeyDataOptions, 'encrypt'> & {
   encrypt: EncryptFnAsync;
+  encryptionVersion?: EncryptionVersion;
 };
 
 interface BuildKeycardQrDataOptions {
@@ -216,12 +217,13 @@ function getKeyData(options: GetKeyDataOptions): any {
  * @param options
  */
 async function getKeyDataAsync(options: GetKeyDataAsyncOptions): Promise<any> {
-  const { encrypt, backupKeychain, passphrase, passcodeEncryptionCode, ...qrOptions } = options;
+  const { encrypt, backupKeychain, passphrase, passcodeEncryptionCode, encryptionVersion, ...qrOptions } = options;
 
   if (backupKeychain.prv && passphrase) {
     backupKeychain.encryptedPrv = await encrypt({
       input: backupKeychain.prv,
       password: passphrase,
+      encryptionVersion,
     });
   }
 
@@ -230,6 +232,7 @@ async function getKeyDataAsync(options: GetKeyDataAsyncOptions): Promise<any> {
     encryptedWalletPasscode = await encrypt({
       input: passphrase,
       password: passcodeEncryptionCode,
+      encryptionVersion,
     });
   }
 
@@ -250,6 +253,7 @@ interface DrawKeycardOptions extends GetKeyDataOptions, DrawKeycardLayoutOptions
 
 export type DrawKeycardAsyncOptions = Omit<DrawKeycardOptions, 'encrypt'> & {
   encrypt: EncryptFnAsync;
+  encryptionVersion?: EncryptionVersion;
 };
 
 /**
@@ -465,6 +469,7 @@ export async function drawKeycardAsync(options: DrawKeycardAsyncOptions): Promis
     activationCode,
     walletLabel,
     coinName,
+    encryptionVersion,
   } = options;
 
   // Get the data for the first page (qr codes)
@@ -478,6 +483,7 @@ export async function drawKeycardAsync(options: DrawKeycardAsyncOptions): Promis
     userKeychain,
     bitgoKeychain,
     backupKeychain,
+    encryptionVersion,
   });
 
   return renderKeycardPdf({ jsPDF, QRCode, activationCode, walletLabel, coinName }, keyData);

--- a/modules/sdk-core/src/bitgo/keychain/iKeychains.ts
+++ b/modules/sdk-core/src/bitgo/keychain/iKeychains.ts
@@ -110,6 +110,7 @@ export type RotateKeychainOptions =
       id: string;
       password: string;
       reqId?: IRequestTracer;
+      encryptionVersion?: EncryptionVersion;
     }
   | {
       id: string;
@@ -254,6 +255,6 @@ export interface IKeychains {
   createMpc(params: CreateMpcOptions): Promise<KeychainsTriplet>;
   recreateMpc(params: RecreateMpcOptions): Promise<KeychainsTriplet>;
   createTssBitGoKeyFromOvcShares(ovcOutput: OvcToBitGoJSON, enterprise?: string): Promise<BitGoKeyFromOvcShares>;
-  createUserKeychain(userPassword: string): Promise<Keychain>;
+  createUserKeychain(userPassword: string, encryptionVersion?: EncryptionVersion): Promise<Keychain>;
   rotateKeychain(params: RotateKeychainOptions): Promise<Keychain>;
 }

--- a/modules/sdk-core/src/bitgo/keychain/keychains.ts
+++ b/modules/sdk-core/src/bitgo/keychain/keychains.ts
@@ -567,7 +567,7 @@ export class Keychains implements IKeychains {
    * @param walletPassphrase
    * @returns Keychain including the decrypted private key
    */
-  async createUserKeychain(walletPassphrase: string): Promise<Keychain> {
+  async createUserKeychain(walletPassphrase: string, encryptionVersion?: EncryptionVersion): Promise<Keychain> {
     const keychains = this.baseCoin.keychains();
     const newKeychain = keychains.create();
     const originalPasscodeEncryptionCode = generateRandomPassword(5);
@@ -575,6 +575,7 @@ export class Keychains implements IKeychains {
     const encryptedPrv = await this.bitgo.encryptAsync({
       password: walletPassphrase,
       input: newKeychain.prv,
+      encryptionVersion,
     });
 
     return {
@@ -614,7 +615,11 @@ export class Keychains implements IKeychains {
         throw Error('Expected a public key to be generated');
       }
       pub = keyPub;
-      encryptedPrv = await this.bitgo.encryptAsync({ input: keyPrv, password: params.password });
+      encryptedPrv = await this.bitgo.encryptAsync({
+        input: keyPrv,
+        password: params.password,
+        encryptionVersion: params.encryptionVersion,
+      });
     }
 
     return this.bitgo

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsa.ts
@@ -110,6 +110,7 @@ export class EcdsaUtils extends BaseEcdsaUtils {
     enterprise?: string | undefined;
     originalPasscodeEncryptionCode?: string | undefined;
     webauthnInfo?: WebauthnKeyEncryptionInfo;
+    encryptionVersion?: EncryptionVersion;
   }): Promise<KeychainsTriplet> {
     const MPC = new Ecdsa();
     const m = 2;
@@ -143,6 +144,7 @@ export class EcdsaUtils extends BaseEcdsaUtils {
       passphrase: params.passphrase,
       originalPasscodeEncryptionCode: params.originalPasscodeEncryptionCode,
       webauthnInfo: params.webauthnInfo,
+      encryptionVersion: params.encryptionVersion,
     });
     const backupKeychainPromise = this.createBackupKeychain({
       userGpgKey,
@@ -152,6 +154,7 @@ export class EcdsaUtils extends BaseEcdsaUtils {
       backupKeyShare,
       bitgoKeychain,
       passphrase: params.passphrase,
+      encryptionVersion: params.encryptionVersion,
     });
 
     const [userKeychain, backupKeychain] = await Promise.all([userKeychainPromise, backupKeychainPromise]);
@@ -424,6 +427,7 @@ export class EcdsaUtils extends BaseEcdsaUtils {
                 encryptedPrv: await this.bitgo.encryptAsync({
                   input: prv,
                   password: webauthnInfo.passphrase,
+                  encryptionVersion,
                 }),
               },
             ]
@@ -444,6 +448,7 @@ export class EcdsaUtils extends BaseEcdsaUtils {
     prv: string;
     derivationPath: string;
     walletPassphrase?: string;
+    encryptionVersion?: EncryptionVersion;
   }): Promise<TssEcdsaStep1ReturnMessage> {
     const { challenges, derivationPath, prv } = params;
     const userSigningMaterial: ECDSAMethodTypes.SigningMaterial = JSON.parse(prv);
@@ -510,6 +515,7 @@ export class EcdsaUtils extends BaseEcdsaUtils {
         ? await this.bitgo.encryptAsync({
             input: JSON.stringify(userSignShare.wShare),
             password: params.walletPassphrase,
+            encryptionVersion: params.encryptionVersion,
           })
         : userSignShare.wShare,
     };
@@ -520,6 +526,7 @@ export class EcdsaUtils extends BaseEcdsaUtils {
     wShare: WShare;
     aShareFromBitgo: Omit<AShare, 'h1' | 'h2' | 'ntilde'>;
     walletPassphrase?: string;
+    encryptionVersion?: EncryptionVersion;
   }): Promise<TssEcdsaStep2ReturnMessage> {
     // Append the BitGo challenge to the Ashare to be used in subsequent proofs
     const bitgoToUserAShareWithNtilde: AShare = {
@@ -543,6 +550,7 @@ export class EcdsaUtils extends BaseEcdsaUtils {
         ? await this.bitgo.encryptAsync({
             input: JSON.stringify(userOmicronAndDeltaShare.oShare),
             password: params.walletPassphrase,
+            encryptionVersion: params.encryptionVersion,
           })
         : userOmicronAndDeltaShare.oShare,
     };
@@ -563,6 +571,7 @@ export class EcdsaUtils extends BaseEcdsaUtils {
     requestType: RequestType;
     prv: string;
     walletPassphrase: string;
+    encryptionVersion?: EncryptionVersion;
   }): Promise<TssEcdsaStep1ReturnMessage> {
     const { tssParams, prv, requestType, challenges } = params;
     assert(typeof tssParams.txRequest !== 'string', 'Invalid txRequest type');
@@ -586,6 +595,7 @@ export class EcdsaUtils extends BaseEcdsaUtils {
       challenges: challenges,
       derivationPath: derivationPath,
       walletPassphrase: params.walletPassphrase,
+      encryptionVersion: params.encryptionVersion,
     });
   }
 
@@ -594,6 +604,7 @@ export class EcdsaUtils extends BaseEcdsaUtils {
     bitgoChallenge: TxRequestChallengeResponse;
     encryptedWShare: string;
     walletPassphrase: string;
+    encryptionVersion?: EncryptionVersion;
   }): Promise<TssEcdsaStep2ReturnMessage> {
     const decryptedWShare = await this.bitgo.decryptAsync({
       input: params.encryptedWShare,
@@ -604,6 +615,7 @@ export class EcdsaUtils extends BaseEcdsaUtils {
       bitgoChallenge: params.bitgoChallenge,
       wShare: JSON.parse(decryptedWShare),
       walletPassphrase: params.walletPassphrase,
+      encryptionVersion: params.encryptionVersion,
     });
   }
 

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
@@ -335,7 +335,8 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
         params.passphrase,
         params.originalPasscodeEncryptionCode,
         params.webauthnInfo,
-        encryptionSession
+        encryptionSession,
+        params.encryptionVersion
       );
       const backupKeychainPromise = this.addBackupKeychain(
         bitgoCommonKeychain,
@@ -343,7 +344,8 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
         backupReducedPrivateMaterial,
         params.passphrase,
         params.originalPasscodeEncryptionCode,
-        encryptionSession
+        encryptionSession,
+        params.encryptionVersion
       );
       const bitgoKeychainPromise = this.addBitgoKeychain(bitgoCommonKeychain);
 
@@ -377,7 +379,8 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
       encrypt(plaintext: string): Promise<string>;
       decrypt(ciphertext: string): Promise<string>;
       destroy(): void;
-    }
+    },
+    encryptionVersion?: EncryptionVersion
   ): Promise<Keychain> {
     let source: string;
     let encryptedPrv: string | undefined = undefined;
@@ -400,6 +403,7 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
           encryptedPrv = await this.bitgo.encryptAsync({
             input: privateMaterialBase64,
             password: passphrase,
+            encryptionVersion,
           });
           // Encrypts the CBOR-encoded ReducedKeyShare (which contains the party's private
           // scalar s_i) with the wallet passphrase. The result is stored as reducedEncryptedPrv
@@ -410,6 +414,7 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
             // The browser deals with a Buffer as Uint8Array, therefore in the browser .toString('base64') just creates a comma seperated string of the array values.
             input: btoa(String.fromCharCode.apply(null, Array.from(new Uint8Array(reducedPrivateMaterial)))),
             password: passphrase,
+            encryptionVersion,
           });
         }
         break;
@@ -437,6 +442,7 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
           encryptedPrv: await this.bitgo.encryptAsync({
             input: privateMaterialBase64,
             password: webauthnInfo.passphrase,
+            encryptionVersion,
           }),
         },
       ];
@@ -567,7 +573,8 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
       encrypt(plaintext: string): Promise<string>;
       decrypt(ciphertext: string): Promise<string>;
       destroy(): void;
-    }
+    },
+    encryptionVersion?: EncryptionVersion
   ): Promise<Keychain> {
     return this.createParticipantKeychain(
       MPCv2PartiesEnum.USER,
@@ -577,7 +584,8 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
       passphrase,
       originalPasscodeEncryptionCode,
       webauthnInfo,
-      encryptionSession
+      encryptionSession,
+      encryptionVersion
     );
   }
 
@@ -591,7 +599,8 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
       encrypt(plaintext: string): Promise<string>;
       decrypt(ciphertext: string): Promise<string>;
       destroy(): void;
-    }
+    },
+    encryptionVersion?: EncryptionVersion
   ): Promise<Keychain> {
     return this.createParticipantKeychain(
       MPCv2PartiesEnum.BACKUP,
@@ -601,7 +610,8 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
       passphrase,
       originalPasscodeEncryptionCode,
       undefined,
-      encryptionSession
+      encryptionSession,
+      encryptionVersion
     );
   }
 
@@ -1214,11 +1224,13 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
       input: sessionData,
       password: walletPassphrase,
       adata: `${EcdsaMPCv2Utils.DKLS23_SIGNING_ROUND1_STATE}:${adata}`,
+      encryptionVersion: 1,
     });
     const encryptedUserGpgPrvKey = await this.bitgo.encryptAsync({
       input: userGpgKey.privateKey,
       password: walletPassphrase,
       adata: `${EcdsaMPCv2Utils.DKLS23_SIGNING_USER_GPG_KEY}:${adata}`,
+      encryptionVersion: 1,
     });
 
     return { signatureShareRound1, userGpgPubKey, encryptedRound1Session, encryptedUserGpgPrvKey };
@@ -1315,6 +1327,7 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
       input: sessionData,
       password: walletPassphrase,
       adata: `${EcdsaMPCv2Utils.DKLS23_SIGNING_ROUND2_STATE}:${adata}`,
+      encryptionVersion: 1,
     });
 
     return {

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
@@ -134,6 +134,7 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
     originalPasscodeEncryptionCode,
     webauthnInfo,
     encryptionSession,
+    encryptionVersion,
   }: CreateEddsaKeychainParams): Promise<Keychain> {
     const MPC = await Eddsa.initialize();
     const bitgoKeyShares = bitgoKeychain.keyShares;
@@ -196,6 +197,7 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
         userKeychainParams.encryptedPrv = await this.bitgo.encryptAsync({
           input: JSON.stringify(userSigningMaterial),
           password: passphrase,
+          encryptionVersion,
         });
       }
     }
@@ -207,6 +209,7 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
           encryptedPrv: await this.bitgo.encryptAsync({
             input: JSON.stringify(userSigningMaterial),
             password: webauthnInfo.passphrase,
+            encryptionVersion,
           }),
         },
       ];
@@ -234,6 +237,7 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
     bitgoKeychain,
     passphrase,
     encryptionSession,
+    encryptionVersion,
   }: CreateEddsaKeychainParams): Promise<Keychain> {
     const MPC = await Eddsa.initialize();
     const bitgoKeyShares = bitgoKeychain.keyShares;
@@ -295,7 +299,7 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
       if (encryptionSession) {
         params.encryptedPrv = await encryptionSession.encrypt(prv);
       } else {
-        params.encryptedPrv = await this.bitgo.encryptAsync({ input: prv, password: passphrase });
+        params.encryptedPrv = await this.bitgo.encryptAsync({ input: prv, password: passphrase, encryptionVersion });
       }
     }
 
@@ -407,6 +411,7 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
         originalPasscodeEncryptionCode: params.originalPasscodeEncryptionCode,
         webauthnInfo: params.webauthnInfo,
         encryptionSession,
+        encryptionVersion: params.encryptionVersion,
       });
       const backupKeychainPromise = this.createBackupKeychain({
         userGpgKey,
@@ -416,6 +421,7 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
         bitgoKeychain,
         passphrase: params.passphrase,
         encryptionSession,
+        encryptionVersion: params.encryptionVersion,
       });
       const [userKeychain, backupKeychain] = await Promise.all([userKeychainPromise, backupKeychainPromise]);
 
@@ -489,7 +495,11 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
         session.destroy();
       }
     } else {
-      encryptedRShare = await this.bitgo.encryptAsync({ input: stringifiedRShare, password: params.walletPassphrase });
+      encryptedRShare = await this.bitgo.encryptAsync({
+        input: stringifiedRShare,
+        password: params.walletPassphrase,
+        encryptionVersion: 1,
+      });
     }
     const encryptedUserToBitgoRShare = this.createUserToBitgoEncryptedRShare(encryptedRShare);
 

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
@@ -40,6 +40,7 @@ import {
   TxRequest,
   isV2Envelope,
 } from '../baseTypes';
+import { EncryptionVersion } from '../../../../api';
 import { BaseEddsaUtils } from './base';
 import { EddsaMPCv2KeyGenSendFn, KeyGenSenderForEnterprise } from './eddsaMPCv2KeyGenSender';
 
@@ -68,6 +69,7 @@ export class EddsaMPCv2Utils extends BaseEddsaUtils {
     enterprise: string;
     originalPasscodeEncryptionCode?: string;
     webauthnInfo?: WebauthnKeyEncryptionInfo;
+    encryptionVersion?: EncryptionVersion;
   }): Promise<KeychainsTriplet> {
     const userKeyPair = await generateGPGKeyPair('ed25519');
     const userGpgKey = await pgp.readPrivateKey({ armoredKey: userKeyPair.privateKey });
@@ -192,14 +194,16 @@ export class EddsaMPCv2Utils extends BaseEddsaUtils {
       userReducedPrivateMaterial,
       params.passphrase,
       params.originalPasscodeEncryptionCode,
-      params.webauthnInfo
+      params.webauthnInfo,
+      params.encryptionVersion
     );
     const backupKeychainPromise = this.addBackupKeychain(
       backupCommonKeychain,
       backupPrivateMaterial,
       backupReducedPrivateMaterial,
       params.passphrase,
-      params.originalPasscodeEncryptionCode
+      params.originalPasscodeEncryptionCode,
+      params.encryptionVersion
     );
     const bitgoKeychainPromise = this.addBitgoKeychain(userCommonKeychain);
 
@@ -225,7 +229,8 @@ export class EddsaMPCv2Utils extends BaseEddsaUtils {
     reducedPrivateMaterial?: Buffer,
     passphrase?: string,
     originalPasscodeEncryptionCode?: string,
-    webauthnInfo?: WebauthnKeyEncryptionInfo
+    webauthnInfo?: WebauthnKeyEncryptionInfo,
+    encryptionVersion?: EncryptionVersion
   ): Promise<Keychain> {
     let source: string;
     let encryptedPrv: string | undefined = undefined;
@@ -243,6 +248,7 @@ export class EddsaMPCv2Utils extends BaseEddsaUtils {
         encryptedPrv = await this.bitgo.encryptAsync({
           input: privateMaterialBase64,
           password: passphrase,
+          encryptionVersion,
         });
         // Encrypts the CBOR-encoded ReducedKeyShare (which contains the party's public
         // key) with the wallet passphrase. The result is stored as reducedEncryptedPrv
@@ -253,6 +259,7 @@ export class EddsaMPCv2Utils extends BaseEddsaUtils {
           // The browser deals with a Buffer as Uint8Array, therefore in the browser .toString('base64') just creates a comma separated string of the array values.
           input: btoa(String.fromCharCode.apply(null, Array.from(new Uint8Array(reducedPrivateMaterial)))),
           password: passphrase,
+          encryptionVersion,
         });
         break;
       case MPCv2PartiesEnum.BITGO:
@@ -279,6 +286,7 @@ export class EddsaMPCv2Utils extends BaseEddsaUtils {
           encryptedPrv: await this.bitgo.encryptAsync({
             input: privateMaterialBase64,
             password: webauthnInfo.passphrase,
+            encryptionVersion,
           }),
         },
       ];
@@ -294,7 +302,8 @@ export class EddsaMPCv2Utils extends BaseEddsaUtils {
     reducedPrivateMaterial: Buffer,
     passphrase: string,
     originalPasscodeEncryptionCode?: string,
-    webauthnInfo?: WebauthnKeyEncryptionInfo
+    webauthnInfo?: WebauthnKeyEncryptionInfo,
+    encryptionVersion?: EncryptionVersion
   ): Promise<Keychain> {
     return this.createParticipantKeychain(
       MPCv2PartiesEnum.USER,
@@ -303,7 +312,8 @@ export class EddsaMPCv2Utils extends BaseEddsaUtils {
       reducedPrivateMaterial,
       passphrase,
       originalPasscodeEncryptionCode,
-      webauthnInfo
+      webauthnInfo,
+      encryptionVersion
     );
   }
 
@@ -312,7 +322,8 @@ export class EddsaMPCv2Utils extends BaseEddsaUtils {
     privateMaterial: Buffer,
     reducedPrivateMaterial: Buffer,
     passphrase: string,
-    originalPasscodeEncryptionCode?: string
+    originalPasscodeEncryptionCode?: string,
+    encryptionVersion?: EncryptionVersion
   ): Promise<Keychain> {
     return this.createParticipantKeychain(
       MPCv2PartiesEnum.BACKUP,
@@ -320,7 +331,9 @@ export class EddsaMPCv2Utils extends BaseEddsaUtils {
       privateMaterial,
       reducedPrivateMaterial,
       passphrase,
-      originalPasscodeEncryptionCode
+      originalPasscodeEncryptionCode,
+      undefined,
+      encryptionVersion
     );
   }
 
@@ -604,11 +617,13 @@ export class EddsaMPCv2Utils extends BaseEddsaUtils {
       input: sessionPayload,
       password: walletPassphrase,
       adata: `${EddsaMPCv2Utils.MPS_DSG_SIGNING_ROUND1_STATE}:${adata}`,
+      encryptionVersion: 1,
     });
     const encryptedUserGpgPrvKey = await this.bitgo.encryptAsync({
       input: userGpgKey.privateKey,
       password: walletPassphrase,
       adata: `${EddsaMPCv2Utils.MPS_DSG_SIGNING_USER_GPG_KEY}:${adata}`,
+      encryptionVersion: 1,
     });
 
     return { signatureShareRound1, userGpgPubKey, encryptedRound1Session, encryptedUserGpgPrvKey };
@@ -715,6 +730,7 @@ export class EddsaMPCv2Utils extends BaseEddsaUtils {
       input: sessionPayload,
       password: walletPassphrase,
       adata: `${EddsaMPCv2Utils.MPS_DSG_SIGNING_ROUND2_STATE}:${adata}`,
+      encryptionVersion: 1,
     });
 
     return { signatureShareRound2, encryptedRound2Session };

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -1,4 +1,4 @@
-import { IRequestTracer } from '../../api';
+import { EncryptionVersion, IRequestTracer } from '../../api';
 import { CreateLightningInvoiceParams, LightningInvoiceResponse } from '../../lightning';
 import {
   IBaseCoin,
@@ -771,6 +771,7 @@ export interface ShareWalletOptions {
    */
   skipKeychain?: boolean;
   disableEmail?: boolean;
+  encryptionVersion?: EncryptionVersion;
 }
 
 export interface BulkCreateShareOption {
@@ -787,6 +788,7 @@ export interface BulkWalletShareOptions {
     path: string;
     permissions: string[];
   }>;
+  encryptionVersion?: EncryptionVersion;
 }
 
 export type WalletShareState = 'active' | 'accepted' | 'canceled' | 'rejected' | 'pendingapproval';
@@ -1057,6 +1059,7 @@ export interface DownloadKeycardOptions {
   activationCode?: string;
   walletKeyID?: string;
   backupKeyID?: string;
+  encryptionVersion?: EncryptionVersion;
 }
 
 export interface ChallengeVerifiers {

--- a/modules/sdk-core/src/bitgo/wallet/iWallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallets.ts
@@ -155,6 +155,7 @@ export interface AcceptShareOptions {
   walletShareId?: string;
   userPassword?: string;
   newWalletPassphrase?: string;
+  encryptionVersion?: EncryptionVersion;
 }
 
 export interface BulkAcceptShareOptions {
@@ -162,6 +163,7 @@ export interface BulkAcceptShareOptions {
   userLoginPassword: string;
   newWalletPassphrase?: string;
   webauthnInfo?: WebauthnKeyEncryptionInfo;
+  encryptionVersion?: EncryptionVersion;
 }
 
 export interface AcceptShareOptionsRequest {
@@ -188,6 +190,7 @@ export interface BulkUpdateWalletShareOptions {
   }[];
   userLoginPassword?: string;
   newWalletPassphrase?: string;
+  encryptionVersion?: EncryptionVersion;
 }
 
 export interface BulkUpdateWalletShareOptionsRequest {

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import BigNumber from 'bignumber.js';
 import * as t from 'io-ts';
 import * as _ from 'lodash';
-import { IRequestTracer } from '../../api';
+import { EncryptionVersion, IRequestTracer } from '../../api';
 import * as common from '../../common';
 import { AddressBook, IAddressBook } from '../address-book';
 import {
@@ -1850,7 +1850,8 @@ export class Wallet implements IWallet {
           decryptedKeychain.prv,
           decryptedKeychain.pub,
           shareOption.pubKey,
-          shareOption.path
+          shareOption.path,
+          params.encryptionVersion
         );
 
         bulkCreateShareOptions.push({
@@ -1990,11 +1991,12 @@ export class Wallet implements IWallet {
     decryptedPrv: string,
     pub: string,
     userPubkey: string,
-    path: string
+    path: string,
+    encryptionVersion?: EncryptionVersion
   ): Promise<BulkWalletShareKeychain> {
     const eckey = makeRandomKey();
     const secret = getSharedSecret(eckey, Buffer.from(userPubkey, 'hex')).toString('hex');
-    const newEncryptedPrv = await this.bitgo.encryptAsync({ password: secret, input: decryptedPrv });
+    const newEncryptedPrv = await this.bitgo.encryptAsync({ password: secret, input: decryptedPrv, encryptionVersion });
 
     const keychain: BulkWalletShareKeychain = {
       pub,
@@ -2025,14 +2027,21 @@ export class Wallet implements IWallet {
   async prepareSharedKeychain(
     walletPassphrase: string | undefined,
     pubkey: string,
-    path: string
+    path: string,
+    encryptionVersion?: EncryptionVersion
   ): Promise<SharedKeyChain> {
     try {
       const decryptedKeychain = await this.getDecryptedKeychainForSharing(walletPassphrase);
       if (!decryptedKeychain) {
         return {};
       }
-      return await this.encryptPrvForUserAsync(decryptedKeychain.prv, decryptedKeychain.pub, pubkey, path);
+      return await this.encryptPrvForUserAsync(
+        decryptedKeychain.prv,
+        decryptedKeychain.pub,
+        pubkey,
+        path,
+        encryptionVersion
+      );
     } catch (e) {
       if (e instanceof MissingEncryptedKeychainError) {
         // ignore this error because this looks like a cold wallet
@@ -2078,7 +2087,12 @@ export class Wallet implements IWallet {
     })) as any;
     let sharedKeychain;
     if (needsKeychain) {
-      sharedKeychain = await this.prepareSharedKeychain(params.walletPassphrase, sharing.pubkey, sharing.path);
+      sharedKeychain = await this.prepareSharedKeychain(
+        params.walletPassphrase,
+        sharing.pubkey,
+        sharing.path,
+        params.encryptionVersion
+      );
     }
 
     const options: CreateShareOptions = {
@@ -3441,6 +3455,7 @@ export class Wallet implements IWallet {
       backupKeyID,
       activationCode,
     } = validateDownloadKeycardParams(params);
+    const { encryptionVersion } = params;
 
     const coinShortName = this.baseCoin.type;
     const coinName = this.baseCoin.getFullName();
@@ -3449,7 +3464,8 @@ export class Wallet implements IWallet {
     const doc = await drawKeycardAsync({
       jsPDF,
       QRCode,
-      encrypt: (p: { input: string; password: string }) => this.bitgo.encryptAsync(p),
+      encrypt: (p) => this.bitgo.encryptAsync(p),
+      encryptionVersion,
       coinShortName,
       coinName,
       activationCode,

--- a/modules/sdk-core/src/bitgo/wallet/wallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallets.ts
@@ -7,7 +7,7 @@ import { bip32 } from '@bitgo/utxo-lib';
 import * as _ from 'lodash';
 import { CoinFeature } from '@bitgo/statics';
 
-import { sanitizeLegacyPath } from '../../api';
+import { EncryptionVersion, sanitizeLegacyPath } from '../../api';
 import * as common from '../../common';
 import { IBaseCoin, KeychainsTriplet, SupplementGenerateWalletOptions } from '../baseCoin';
 import { BitGoBase } from '../bitgoBase';
@@ -873,7 +873,11 @@ export class Wallets implements IWallets {
    * @param walletId
    * @param userPassword
    */
-  async reshareWalletWithSpenders(walletId: string, userPassword: string): Promise<void> {
+  async reshareWalletWithSpenders(
+    walletId: string,
+    userPassword: string,
+    encryptionVersion?: EncryptionVersion
+  ): Promise<void> {
     const wallet = await this.get({ id: walletId });
     if (!wallet?._wallet?.enterprise) {
       throw new Error('Enterprise not found for the wallet');
@@ -899,6 +903,7 @@ export class Wallets implements IWallets {
             email: userObject.email.email,
             reshare: true,
             skipKeychain: false,
+            encryptionVersion,
           };
           await wallet.shareWallet(shareParams);
         }
@@ -934,6 +939,7 @@ export class Wallets implements IWallets {
       const encryptedPrv = await this.bitgo.encryptAsync({
         password: params.newWalletPassphrase || params.userPassword,
         input: walletKeychain.prv,
+        encryptionVersion: params.encryptionVersion,
       });
 
       const updateParams: UpdateShareOptions = {
@@ -958,7 +964,9 @@ export class Wallets implements IWallets {
         throw new Error('userPassword param must be provided to decrypt shared key');
       }
 
-      const walletKeychain = await this.baseCoin.keychains().createUserKeychain(params.userPassword);
+      const walletKeychain = await this.baseCoin
+        .keychains()
+        .createUserKeychain(params.userPassword, params.encryptionVersion);
       if (_.isUndefined(walletKeychain.encryptedPrv)) {
         throw new Error('encryptedPrv was not found on wallet keychain');
       }
@@ -986,7 +994,7 @@ export class Wallets implements IWallets {
       // If the wallet share was accepted successfully (changed=true), reshare the wallet with the spenders
       if (response.changed && response.state === 'accepted') {
         try {
-          await this.reshareWalletWithSpenders(walletShare.wallet, params.userPassword);
+          await this.reshareWalletWithSpenders(walletShare.wallet, params.userPassword, params.encryptionVersion);
         } catch (e) {
           // TODO: PX-3826
           // Do nothing
@@ -1035,6 +1043,7 @@ export class Wallets implements IWallets {
     encryptedPrv = await this.bitgo.encryptAsync({
       password: newWalletPassphrase,
       input: decryptedSharedWalletPrv,
+      encryptionVersion: params.encryptionVersion,
     });
     const updateParams: UpdateShareOptions = {
       walletShareId: params.walletShareId,
@@ -1108,6 +1117,7 @@ export class Wallets implements IWallets {
             const encryptedPrv = await this.bitgo.encryptAsync({
               password: newWalletPassphrase,
               input: walletKeychain.prv,
+              encryptionVersion: params.encryptionVersion,
             });
             return [
               {
@@ -1134,6 +1144,7 @@ export class Wallets implements IWallets {
           const newEncryptedPrv = await this.bitgo.encryptAsync({
             password: newWalletPassphrase,
             input: decryptedSharedWalletPrv,
+            encryptionVersion: params.encryptionVersion,
           });
           const entry: AcceptShareOptionsRequest = {
             walletShareId: walletShare.id,
@@ -1146,6 +1157,7 @@ export class Wallets implements IWallets {
               encryptedPrv: await this.bitgo.encryptAsync({
                 password: webauthnInfo.passphrase,
                 input: decryptedSharedWalletPrv,
+                encryptionVersion: params.encryptionVersion,
               }),
             };
           }
@@ -1208,7 +1220,7 @@ export class Wallets implements IWallets {
     }
     assert(params.shares.length > 0, 'no shares are passed');
 
-    const { shares: inputShares, userLoginPassword, newWalletPassphrase } = params;
+    const { shares: inputShares, userLoginPassword, newWalletPassphrase, encryptionVersion } = params;
 
     const allWalletShares = await this.listSharesV2();
 
@@ -1275,7 +1287,8 @@ export class Wallets implements IWallets {
             walletShare,
             userLoginPassword,
             newWalletPassphrase,
-            sharingKeychainPrv
+            sharingKeychainPrv,
+            encryptionVersion
           );
         }
 
@@ -1317,7 +1330,7 @@ export class Wallets implements IWallets {
         if (specialOverrideCases.has(walletShareId)) {
           const walletId = specialOverrideCases.get(walletShareId);
           try {
-            await this.reshareWalletWithSpenders(walletId, userLoginPassword);
+            await this.reshareWalletWithSpenders(walletId, userLoginPassword, encryptionVersion);
           } catch (e) {
             // Log error but continue processing other shares
             console.error(`Error resharing wallet ${walletId} with spenders: ${e?.message}`);
@@ -1353,7 +1366,8 @@ export class Wallets implements IWallets {
     walletShare: WalletShare,
     userLoginPassword?: string,
     newWalletPassphrase?: string,
-    sharingKeychainPrv?: string
+    sharingKeychainPrv?: string,
+    encryptionVersion?: EncryptionVersion
   ): Promise<BulkUpdateWalletShareOptionsRequest[]> {
     // Special override case: requires user keychain and signing
     if (
@@ -1367,7 +1381,7 @@ export class Wallets implements IWallets {
 
       const walletKeychain = await this.baseCoin
         .keychains()
-        .createUserKeychain(newWalletPassphrase || userLoginPassword);
+        .createUserKeychain(newWalletPassphrase || userLoginPassword, encryptionVersion);
       if (!walletKeychain.encryptedPrv) {
         throw new Error('encryptedPrv was not found on wallet keychain');
       }
@@ -1406,6 +1420,7 @@ export class Wallets implements IWallets {
       const encryptedPrv = await this.bitgo.encryptAsync({
         password: newWalletPassphrase || userLoginPassword,
         input: walletKeychain.prv,
+        encryptionVersion,
       });
 
       return [
@@ -1451,6 +1466,7 @@ export class Wallets implements IWallets {
     const encryptedPrv = await this.bitgo.encryptAsync({
       password: newWalletPassphrase || userLoginPassword,
       input: decryptedPrv,
+      encryptionVersion,
     });
 
     return [

--- a/modules/sdk-core/test/unit/bitgo/utils/tss/ecdsa/ecdsaEncryptionVersion.ts
+++ b/modules/sdk-core/test/unit/bitgo/utils/tss/ecdsa/ecdsaEncryptionVersion.ts
@@ -1,0 +1,74 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { EcdsaUtils } from '../../../../../../src/bitgo/utils/tss/ecdsa/ecdsa';
+import { BitGoBase, IBaseCoin } from '../../../../../../src';
+
+/**
+ * Regression tests for the ECDSA MPCv1 createKeychains encryptionVersion bug.
+ *
+ * Previously, EcdsaUtils.createKeychains dropped `encryptionVersion` silently —
+ * it was not declared in the params and was never forwarded to createUserKeychain
+ * or createBackupKeychain, causing a version mismatch within a wallet: v2 for
+ * encryptedWalletPassphrase but v1 for the user/backup keychains.
+ */
+describe('EcdsaUtils.createKeychains - encryptionVersion forwarding', function () {
+  let ecdsaUtils: EcdsaUtils;
+  let createUserKeychainStub: sinon.SinonStub;
+  let createBackupKeychainStub: sinon.SinonStub;
+
+  const fakeKeychain = { id: 'key-id', pub: 'pub', commonKeychain: 'ckc', type: 'tss' as const };
+  const fakeGpgKey = { publicKey: 'pub', privateKey: 'prv' };
+  const fakeKeyShare = { userHeldKeyShare: {} };
+
+  beforeEach(function () {
+    const mockBitgo = { getEnv: sinon.stub().returns('test') } as unknown as BitGoBase;
+    const mockCoin = {} as unknown as IBaseCoin;
+
+    ecdsaUtils = new EcdsaUtils(mockBitgo, mockCoin);
+
+    createUserKeychainStub = sinon.stub(ecdsaUtils, 'createUserKeychain').resolves(fakeKeychain);
+    createBackupKeychainStub = sinon.stub(ecdsaUtils, 'createBackupKeychain').resolves(fakeKeychain);
+    sinon.stub(ecdsaUtils, 'createBitgoKeychain').resolves(fakeKeychain);
+    sinon.stub(ecdsaUtils, 'createBackupKeyShares').resolves(fakeKeyShare as any);
+    sinon.stub(ecdsaUtils, 'getBitgoGpgPubkeyBasedOnFeatureFlags').resolves({ mpcv2PublicKey: undefined } as any);
+
+    sinon.stub(ecdsaUtils as any, 'getBackupGpgPubKey').resolves(fakeGpgKey);
+    sinon.stub(require('../../../../../../src/bitgo/utils/opengpgUtils'), 'generateGPGKeyPair').resolves(fakeGpgKey);
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it('forwards encryptionVersion: 2 to createUserKeychain', async function () {
+    await ecdsaUtils.createKeychains({ passphrase: 'pass', encryptionVersion: 2 });
+
+    assert.ok(createUserKeychainStub.calledOnce);
+    const userParams = createUserKeychainStub.firstCall.args[0];
+    assert.strictEqual(userParams.encryptionVersion, 2);
+  });
+
+  it('forwards encryptionVersion: 2 to createBackupKeychain', async function () {
+    await ecdsaUtils.createKeychains({ passphrase: 'pass', encryptionVersion: 2 });
+
+    assert.ok(createBackupKeychainStub.calledOnce);
+    const backupParams = createBackupKeychainStub.firstCall.args[0];
+    assert.strictEqual(backupParams.encryptionVersion, 2);
+  });
+
+  it('forwards encryptionVersion: undefined when not set', async function () {
+    await ecdsaUtils.createKeychains({ passphrase: 'pass' });
+
+    assert.ok(createUserKeychainStub.calledOnce);
+    assert.ok(createBackupKeychainStub.calledOnce);
+    assert.strictEqual(createUserKeychainStub.firstCall.args[0].encryptionVersion, undefined);
+    assert.strictEqual(createBackupKeychainStub.firstCall.args[0].encryptionVersion, undefined);
+  });
+
+  it('forwards encryptionVersion: 1 explicitly', async function () {
+    await ecdsaUtils.createKeychains({ passphrase: 'pass', encryptionVersion: 1 });
+
+    assert.strictEqual(createUserKeychainStub.firstCall.args[0].encryptionVersion, 1);
+    assert.strictEqual(createBackupKeychainStub.firstCall.args[0].encryptionVersion, 1);
+  });
+});

--- a/modules/sdk-core/test/unit/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
+++ b/modules/sdk-core/test/unit/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
@@ -880,6 +880,66 @@ describe('ECDSA MPC v2', async () => {
     assert.strictEqual(sigParts[1].length, 64, 'Signature R must be 32 bytes hex');
     assert.strictEqual(sigParts[2].length, 64, 'Signature S must be 32 bytes hex');
   });
+
+  describe('createOfflineRound1Share and createOfflineRound2Share - encryptionVersion: 1 in v1 path', async () => {
+    let ecdsaMPCv2UtilsWithSpy: EcdsaMPCv2Utils;
+    let encryptAsyncSpy: sinon.SinonStub;
+
+    before(async () => {
+      const mockBg = {} as BitGoBase;
+      mockBg.getEnv = sinon.stub().returns('test');
+      const encryptImpl = (params: { password: string; input: string; adata?: string }) => {
+        const salt = randomBytes(8);
+        const iv = randomBytes(16);
+        return sjcl.encrypt(params.password, params.input, {
+          salt: [bytesToWord(salt.subarray(0, 4)), bytesToWord(salt.subarray(4))],
+          iv: [
+            bytesToWord(iv.subarray(0, 4)),
+            bytesToWord(iv.subarray(4, 8)),
+            bytesToWord(iv.subarray(8, 12)),
+            bytesToWord(iv.subarray(12, 16)),
+          ],
+          adata: params.adata,
+        });
+      };
+      encryptAsyncSpy = sinon.stub().callsFake(async (params) => encryptImpl(params));
+      mockBg.encrypt = sinon.stub().callsFake(encryptImpl);
+      mockBg.encryptAsync = encryptAsyncSpy;
+      mockBg.decrypt = sinon.stub().callsFake((params) => sjcl.decrypt(params.password, params.input));
+      mockBg.decryptAsync = sinon.stub().callsFake(async (params) => sjcl.decrypt(params.password, params.input));
+
+      const mockCoin = {} as IBaseCoin;
+      mockCoin.getHashFunction = sinon.stub().callsFake(() => createKeccakHash('keccak256') as Hash);
+      ecdsaMPCv2UtilsWithSpy = new EcdsaMPCv2Utils(mockBg, mockCoin);
+    });
+
+    it('createOfflineRound1Share uses encryptionVersion: 1 in v1 (non-v2 envelope) path', async () => {
+      const txRequest = {
+        txRequestId: 'req-id',
+        walletId: walletID,
+        transactions: [{ unsignedTx: { signableHex: 'deadbeef01', derivationPath: 'm/0', serializedTxHex: '' } }],
+        apiVersion: 'full',
+      } as any;
+
+      encryptAsyncSpy.resetHistory();
+
+      await ecdsaMPCv2UtilsWithSpy.createOfflineRound1Share({
+        txRequest,
+        prv: Buffer.from(userShare).toString('base64'),
+        walletPassphrase,
+        encryptedPrv: undefined,
+      });
+
+      assert.ok(encryptAsyncSpy.called, 'encryptAsync should be called in v1 path');
+      for (const call of encryptAsyncSpy.getCalls()) {
+        assert.strictEqual(
+          call.args[0].encryptionVersion,
+          1,
+          'encryptionVersion should be hardcoded to 1 in the v1 signing session path'
+        );
+      }
+    });
+  });
 });
 
 function bytesToWord(bytes?: Uint8Array | number[]): number {

--- a/modules/sdk-core/test/unit/bitgo/wallet/walletsEncryptionVersion.ts
+++ b/modules/sdk-core/test/unit/bitgo/wallet/walletsEncryptionVersion.ts
@@ -1,0 +1,226 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import 'should';
+import { Wallets } from '../../../../src/bitgo/wallet/wallets';
+import { Wallet } from '../../../../src/bitgo/wallet/wallet';
+
+describe('Wallets - encryptionVersion threading', function () {
+  let wallets: Wallets;
+  let mockBitGo: any;
+  let mockBaseCoin: any;
+  let mockKeychains: any;
+
+  const userPrv = 'xprvSomeUserPrivateKey';
+  const userPub =
+    'xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8';
+
+  beforeEach(function () {
+    mockKeychains = {
+      create: sinon.stub().returns({ pub: userPub, prv: userPrv }),
+      add: sinon.stub().resolves({ id: 'user-key-id', pub: userPub, encryptedPrv: 'encrypted-prv' }),
+    };
+
+    mockBitGo = {
+      encryptAsync: sinon
+        .stub()
+        .callsFake(async ({ password, input }: { password: string; input: string }) => `enc:${password}:${input}`),
+      decryptAsync: sinon.stub().resolves('decryptedPrv'),
+      get: sinon.stub().returns({ result: sinon.stub(), query: sinon.stub().returnsThis() }),
+      post: sinon.stub().returns({ send: sinon.stub().returns({ result: sinon.stub().resolves({}) }) }),
+      put: sinon.stub().returns({
+        send: sinon
+          .stub()
+          .returns({ result: sinon.stub().resolves({ acceptedWalletShares: [], walletShareUpdateErrors: [] }) }),
+      }),
+      getECDHKeychain: sinon.stub().resolves({ encryptedXprv: 'encXprv' }),
+      setRequestTracer: sinon.stub(),
+      url: sinon.stub().returns('/test/url'),
+    };
+
+    mockBaseCoin = {
+      keychains: sinon.stub().returns(mockKeychains),
+      url: sinon.stub().callsFake((path: string) => path),
+      getFamily: sinon.stub().returns('btc'),
+      getChain: sinon.stub().returns('btc'),
+      supportsTss: sinon.stub().returns(false),
+      getMPCAlgorithm: sinon.stub().returns('ecdsa'),
+    };
+
+    wallets = new Wallets(mockBitGo, mockBaseCoin);
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  describe('acceptShare', function () {
+    it('passes encryptionVersion: 2 to encryptAsync on the multiUserKeyRotationRequired path', async function () {
+      mockBitGo.get.returns({
+        result: sinon.stub().resolves({
+          userMultiKeyRotationRequired: true,
+          keychain: null,
+          permissions: ['spend'],
+          wallet: 'wallet-id',
+        }),
+      });
+
+      await wallets.acceptShare({
+        walletShareId: 'share-id',
+        userPassword: 'my-password',
+        encryptionVersion: 2,
+      });
+
+      assert.ok(mockBitGo.encryptAsync.called, 'encryptAsync should have been called');
+      const call = mockBitGo.encryptAsync.firstCall;
+      assert.strictEqual(call.args[0].encryptionVersion, 2);
+    });
+
+    it('passes encryptionVersion: undefined when not set', async function () {
+      mockBitGo.get.returns({
+        result: sinon.stub().resolves({
+          userMultiKeyRotationRequired: true,
+          keychain: null,
+          permissions: ['spend'],
+          wallet: 'wallet-id',
+        }),
+      });
+
+      await wallets.acceptShare({
+        walletShareId: 'share-id',
+        userPassword: 'my-password',
+      });
+
+      assert.ok(mockBitGo.encryptAsync.called);
+      const call = mockBitGo.encryptAsync.firstCall;
+      assert.strictEqual(call.args[0].encryptionVersion, undefined);
+    });
+  });
+
+  describe('bulkAcceptShare', function () {
+    const walletSharesList = {
+      incoming: [
+        {
+          id: 'share-id',
+          userMultiKeyRotationRequired: true,
+          keychain: null,
+          permissions: ['spend'],
+        },
+      ],
+      outgoing: [],
+    };
+
+    beforeEach(function () {
+      mockBitGo.get.returns({ result: sinon.stub().resolves(walletSharesList) });
+    });
+
+    it('passes encryptionVersion: 2 to encryptAsync on the multiUserKeyRotationRequired path', async function () {
+      await wallets.bulkAcceptShare({
+        walletShareIds: ['share-id'],
+        userLoginPassword: 'login-password',
+        encryptionVersion: 2,
+      });
+
+      assert.ok(mockBitGo.encryptAsync.called);
+      const call = mockBitGo.encryptAsync.firstCall;
+      assert.strictEqual(call.args[0].encryptionVersion, 2);
+    });
+
+    it('passes encryptionVersion: undefined when not set', async function () {
+      await wallets.bulkAcceptShare({
+        walletShareIds: ['share-id'],
+        userLoginPassword: 'login-password',
+      });
+
+      assert.ok(mockBitGo.encryptAsync.called);
+      const call = mockBitGo.encryptAsync.firstCall;
+      assert.strictEqual(call.args[0].encryptionVersion, undefined);
+    });
+  });
+
+  describe('Wallet.shareWallet / createBulkWalletShare', function () {
+    let wallet: Wallet;
+
+    beforeEach(function () {
+      const mockWalletData = {
+        id: 'wallet-id',
+        keys: ['key-1', 'key-2', 'key-3'],
+        coin: 'btc',
+        label: 'Test Wallet',
+        users: [],
+        multisigType: 'onchain',
+        type: 'hot',
+      };
+      mockBaseCoin.supportsTss = sinon.stub().returns(false);
+      mockBaseCoin.getMPCAlgorithm = sinon.stub().returns('ecdsa');
+      wallet = new Wallet(mockBitGo, mockBaseCoin, mockWalletData);
+    });
+
+    it('shareWallet passes encryptionVersion to prepareSharedKeychain', async function () {
+      const prepareStub = sinon.stub(wallet, 'prepareSharedKeychain').resolves({});
+      mockBitGo.getSharingKey = sinon.stub().resolves({ userId: 'user-id', pubkey: 'recvPub', path: 'm/0' });
+      mockBitGo.post.returns({ send: sinon.stub().returns({ result: sinon.stub().resolves({}) }) });
+
+      await wallet.shareWallet({
+        email: 'test@test.com',
+        permissions: 'spend',
+        walletPassphrase: 'passphrase',
+        encryptionVersion: 2,
+      });
+
+      assert.ok(prepareStub.calledOnce, 'prepareSharedKeychain should be called');
+      assert.strictEqual(prepareStub.firstCall.args[3], 2, 'encryptionVersion should be forwarded');
+    });
+
+    it('shareWallet passes encryptionVersion: undefined when not set', async function () {
+      const prepareStub = sinon.stub(wallet, 'prepareSharedKeychain').resolves({});
+      mockBitGo.getSharingKey = sinon.stub().resolves({ userId: 'user-id', pubkey: 'recvPub', path: 'm/0' });
+      mockBitGo.post.returns({ send: sinon.stub().returns({ result: sinon.stub().resolves({}) }) });
+
+      await wallet.shareWallet({
+        email: 'test@test.com',
+        permissions: 'spend',
+        walletPassphrase: 'passphrase',
+      });
+
+      assert.ok(prepareStub.calledOnce);
+      assert.strictEqual(prepareStub.firstCall.args[3], undefined);
+    });
+
+    it('createBulkWalletShare passes encryptionVersion to encryptPrvForUserAsync', async function () {
+      const encryptPrvStub = sinon
+        .stub(wallet, 'encryptPrvForUserAsync')
+        .resolves({ encryptedPrv: 'enc', pub: 'pub', fromPubKey: 'fpk', toPubKey: 'tpk', path: 'm/0' });
+      sinon
+        .stub(wallet as any, 'getDecryptedKeychainForSharing')
+        .resolves({ prv: 'prv', pub: 'pub', encryptedPrv: 'encPrv' });
+      sinon.stub(wallet as any, 'createBulkKeyShares').resolves({ shares: [] });
+
+      await wallet.createBulkWalletShare({
+        walletPassphrase: 'passphrase',
+        keyShareOptions: [{ userId: 'user-1', pubKey: 'pubKey', path: 'm/0', permissions: ['spend'] }],
+        encryptionVersion: 2,
+      });
+
+      assert.ok(encryptPrvStub.calledOnce);
+      assert.strictEqual(encryptPrvStub.firstCall.args[4], 2, 'encryptionVersion should be forwarded');
+    });
+
+    it('createBulkWalletShare passes encryptionVersion: undefined when not set', async function () {
+      const encryptPrvStub = sinon
+        .stub(wallet, 'encryptPrvForUserAsync')
+        .resolves({ encryptedPrv: 'enc', pub: 'pub', fromPubKey: 'fpk', toPubKey: 'tpk', path: 'm/0' });
+      sinon
+        .stub(wallet as any, 'getDecryptedKeychainForSharing')
+        .resolves({ prv: 'prv', pub: 'pub', encryptedPrv: 'encPrv' });
+      sinon.stub(wallet as any, 'createBulkKeyShares').resolves({ shares: [] });
+
+      await wallet.createBulkWalletShare({
+        walletPassphrase: 'passphrase',
+        keyShareOptions: [{ userId: 'user-1', pubKey: 'pubKey', path: 'm/0', permissions: ['spend'] }],
+      });
+
+      assert.ok(encryptPrvStub.calledOnce);
+      assert.strictEqual(encryptPrvStub.firstCall.args[4], undefined);
+    });
+  });
+});


### PR DESCRIPTION
Ticket: WCN-774

This pull request introduces support for selecting an encryption version (either v1 or v2) across various wallet operations, including key encryption, wallet sharing, QR data generation, and secret splitting. The changes add an optional `encryptionVersion` parameter to relevant APIs, types, and internal calls, ensuring that encryption can be consistently upgraded or specified throughout the codebase. Comprehensive tests are added to verify correct behavior for both v1 and v2 encryption envelopes.

**Encryption Version Support Across Modules**

* Added optional `encryptionVersion` parameter to key encryption functions and types in `sdk-api`, `key-card`, `passkey-crypto`, and `express` modules, allowing callers to specify which encryption version to use. [[1]](diffhunk://#diff-75fda077c72c7a131085d35f11f812ebf403fa66eca1e05f9603712690e5dbe8R23) [[2]](diffhunk://#diff-df16a39a5dd8ff3e08c35c03e392be8cc23c2f37954fd970edeb418502e77432L1128-R1129) [[3]](diffhunk://#diff-1d2ae31cd001d64c09e95b239a60e42f5711bceb7b3cd2ab59403107005bb81dR229) [[4]](diffhunk://#diff-5a6ee71c18e3cacc1cbb435cde3753c150a2a13c08822129c5ed6c67e0274028R14-R16) [[5]](diffhunk://#diff-ca331280fee147ecf67051e855d143211b9e6120b9a6040a2687e02d2e8301f9R28)
* Updated all internal calls to `encryptAsync` and related encryption operations to pass through the `encryptionVersion` parameter where provided. [[1]](diffhunk://#diff-df16a39a5dd8ff3e08c35c03e392be8cc23c2f37954fd970edeb418502e77432R1143) [[2]](diffhunk://#diff-df16a39a5dd8ff3e08c35c03e392be8cc23c2f37954fd970edeb418502e77432L1935-R1941) [[3]](diffhunk://#diff-5ebb8a1480d369e9299e33e04b32a72090a10f20379a2e44db6e03b6aad33dbfL197-R201) [[4]](diffhunk://#diff-f6b7c680bc6d1f7fb6504f1bbebb7daa1b9a380e46c663358bf80f1e5fdb5248R273) [[5]](diffhunk://#diff-3822cf711e5cf0fd49663f13cc271b888965989418f41646376f82a404b024f0L2321-R2325) [[6]](diffhunk://#diff-e71d6ef5636b1c25172995f664a40908a39a78db115cd9a6f8b8745ac774e3d1R278) [[7]](diffhunk://#diff-e71d6ef5636b1c25172995f664a40908a39a78db115cd9a6f8b8745ac774e3d1L371-R378) [[8]](diffhunk://#diff-75fda077c72c7a131085d35f11f812ebf403fa66eca1e05f9603712690e5dbe8L80-R85) [[9]](diffhunk://#diff-61479098b1e5609d01c5eee8792585a691dfb92888a4beac83580636d278d7cbR27-R43) [[10]](diffhunk://#diff-5a6ee71c18e3cacc1cbb435cde3753c150a2a13c08822129c5ed6c67e0274028L69-R70) [[11]](diffhunk://#diff-d18ba4c22f2a35529c6c40fb6d69656074c2701799163e57547e28b7a31b347fL141-R146) [[12]](diffhunk://#diff-d18ba4c22f2a35529c6c40fb6d69656074c2701799163e57547e28b7a31b347fL214-R222) [[13]](diffhunk://#diff-d18ba4c22f2a35529c6c40fb6d69656074c2701799163e57547e28b7a31b347fL237-R249)

**API and Type Updates**

* Extended API request/response codecs and parameter interfaces (e.g., `UpdateLightningWalletClientRequest`, `GenerateQrDataCoinParams`, `SplitSecretOptions`) to include the `encryptionVersion` field. [[1]](diffhunk://#diff-d66ad0c88ef6c1345cfda5622b3e0c0bf6c0800fcfa1cec0694758935d8b635eR91) [[2]](diffhunk://#diff-ca331280fee147ecf67051e855d143211b9e6120b9a6040a2687e02d2e8301f9R28) [[3]](diffhunk://#diff-1d2ae31cd001d64c09e95b239a60e42f5711bceb7b3cd2ab59403107005bb81dR229)
* Propagated `encryptionVersion` through wallet update, sharing, and keychain creation flows. [[1]](diffhunk://#diff-df16a39a5dd8ff3e08c35c03e392be8cc23c2f37954fd970edeb418502e77432L1128-R1129) [[2]](diffhunk://#diff-df16a39a5dd8ff3e08c35c03e392be8cc23c2f37954fd970edeb418502e77432R1143) [[3]](diffhunk://#diff-5a6ee71c18e3cacc1cbb435cde3753c150a2a13c08822129c5ed6c67e0274028R14-R16) [[4]](diffhunk://#diff-5a6ee71c18e3cacc1cbb435cde3753c150a2a13c08822129c5ed6c67e0274028L69-R70)

**QR Data Generation Enhancements**

* Updated QR data generation functions to accept and utilize `encryptionVersion`, ensuring that the passphrase envelope (Box D) is created with the correct version. [[1]](diffhunk://#diff-d18ba4c22f2a35529c6c40fb6d69656074c2701799163e57547e28b7a31b347fL141-R146) [[2]](diffhunk://#diff-d18ba4c22f2a35529c6c40fb6d69656074c2701799163e57547e28b7a31b347fL214-R222) [[3]](diffhunk://#diff-d18ba4c22f2a35529c6c40fb6d69656074c2701799163e57547e28b7a31b347fL237-R249)

**Testing and Validation**

* Added and expanded unit tests to verify that QR data generation produces the correct envelope version depending on the `encryptionVersion` parameter, and that Box D is omitted when required fields are missing. [[1]](diffhunk://#diff-7311e5426a7b595d1c277aea614f0ce3cfc3efc26af298389e72a7f94cbb38f5R250-R315) [[2]](diffhunk://#diff-7311e5426a7b595d1c277aea614f0ce3cfc3efc26af298389e72a7f94cbb38f5R333-R350)

**Dependency and Import Updates**

* Updated imports to include the new `EncryptionVersion` type where needed. [[1]](diffhunk://#diff-ca331280fee147ecf67051e855d143211b9e6120b9a6040a2687e02d2e8301f9L1-R1) [[2]](diffhunk://#diff-5a6ee71c18e3cacc1cbb435cde3753c150a2a13c08822129c5ed6c67e0274028L1-R1) [[3]](diffhunk://#diff-df16a39a5dd8ff3e08c35c03e392be8cc23c2f37954fd970edeb418502e77432R13) [[4]](diffhunk://#diff-1d2ae31cd001d64c09e95b239a60e42f5711bceb7b3cd2ab59403107005bb81dL1-R1)

These changes collectively ensure that encryption versioning is handled robustly and consistently throughout the codebase, improving security flexibility and future-proofing wallet operations.

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
