### PR TITLE
fix(statics): remove stale eth:at bot token colliding with live AMS

### DIFF
--- a/modules/statics/src/coins/botTokens.ts
+++ b/modules/statics/src/coins/botTokens.ts
@@ -29,18 +29,6 @@ export const botTokens = [
     Networks.test.hoodi
   ),
   AccountCtors.terc20(
-    '3b0d47ca-d5a9-49d6-a063-8946b88fb843',
-    'eth:at',
-    'APT',
-    18,
-    '0x0581ccdf2d9bca21baeff8b32b2551fd49cf70aa',
-    'eth:at' as unknown as UnderlyingAsset,
-    getTokenFeatures('eth'),
-    undefined,
-    undefined,
-    Networks.test.hoodi
-  ),
-  AccountCtors.terc20(
     '1f8f6be2-e97e-4f41-836d-c4420b8cc77b',
     'hteth:WBTC',
     'Wrapped BTC',


### PR DESCRIPTION
Addresses the **follow-up** in [CSHLD-976](https://linear.app/bitgo/issue/CSHLD-976): *"Confirm whether the static `eth:at` bot token (and AMS-served counterpart) is intended, or whether one side should be removed/renamed."*

> ⚠️ **Draft pending team confirmation.** This proposes removing the **statics** side. If the team decides the AMS record should be renamed/removed instead, close this in favor of that. Either way, the durable crash fix is **#8957** (skip-by-contract on merge) — this PR is data hygiene, not the crash fix.

## What

Removes the `eth:at` bot token from `botTokens.ts`:

```
'3b0d47ca-d5a9-49d6-a063-8946b88fb843' / 'eth:at' / 'APT' / 0x0581ccdf2d9bca21baeff8b32b2551fd49cf70aa / Networks.test.hoodi
```

## Why this entry is the stale side

- It's a **generated snapshot** of AMS (`asset-metadata-service` `generate-botTokens`), added by the asset-metadata-bot in #8885 (`@bitgo/statics@58.43.0`).
- It has **drifted** from live AMS: symbol `at` no longer matches fullName **`APT`**, and it sits in the **mainnet `eth:`** namespace though it lives on **hoodi testnet** (siblings use `hteth:`).
- Its contract collides with the live AMS-served token at the same address under a **different name** → `DuplicateContractAddressDefinitionError`.
- AMS dedupes by `family+contract`, so AMS holds exactly **one** record at that contract (the differently-named one) — meaning the statics `eth:at` is **orphaned**. Removing it is consistent with what `generate-botTokens` would now regenerate.
- Referenced **nowhere else** in the SDK.

## Verification
- `grep` confirms `eth:at` / the contract are gone from `botTokens.ts`.
- Applied the same deletion in a deps-enabled checkout: `tsc --build` clean, `mocha test/unit/coins.ts` → **28764 passing** (the 4 fewer vs. baseline are `eth:at`'s auto-generated per-coin tests).

## Related
- Root-cause durable fix: **#8957** (statics merge skips duplicate contract/NFT keys)
- UI defense-in-depth: **bitgo-retail #6934**

🤖 Generated with [Claude Code](https://claude.com/claude-code)