### PR TITLE
fix(ci): retry yarn audit on transient network errors (WCN-865)

### DIFF
--- a/.github/workflows/npmjs-release.yml
+++ b/.github/workflows/npmjs-release.yml
@@ -242,7 +242,7 @@ jobs:
           targets: EricCrosson/retry@v1
 
       - name: Run yarn audit
-        run: retry --up-to 3x -- yarn run audit-high
+        run: retry --up-to 2x --every 3s -- yarn run audit-high --retry-on-network-failure
 
       - name: Run dependency check
         run: |

--- a/.github/workflows/npmjs-release.yml
+++ b/.github/workflows/npmjs-release.yml
@@ -236,9 +236,13 @@ jobs:
         run: |
           yarn install --frozen-lockfile
 
+      - name: Install retry
+        uses: BitGo/install-github-release-binary@v2
+        with:
+          targets: EricCrosson/retry@v1
+
       - name: Run yarn audit
-        run: |
-          yarn run audit-high
+        run: retry --up-to 3x -- yarn run audit-high
 
       - name: Run dependency check
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
           targets: EricCrosson/retry@v1
 
       - name: Audit Dependencies
-        run: retry --up-to 3x -- yarn run improved-yarn-audit --min-severity high
+        run: retry --up-to 2x --every 3s -- yarn run improved-yarn-audit --min-severity high --retry-on-network-failure
 
       - name: Set Environment Variable for Alpha
         if: github.ref != 'refs/heads/master' # only publish changes if on feature branches

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,8 +36,13 @@ jobs:
       - name: Install BitGoJS
         run: sfw yarn install --with-frozen-lockfile
 
+      - name: Install retry
+        uses: BitGo/install-github-release-binary@v2
+        with:
+          targets: EricCrosson/retry@v1
+
       - name: Audit Dependencies
-        run: yarn run improved-yarn-audit --min-severity high
+        run: retry --up-to 3x -- yarn run improved-yarn-audit --min-severity high
 
       - name: Set Environment Variable for Alpha
         if: github.ref != 'refs/heads/master' # only publish changes if on feature branches


### PR DESCRIPTION
## Summary

- `improved-yarn-audit` fails with `ERROR: Network error occurred when querying audit registry` on transient npm registry blips, blocking the release pipeline
- Added `EricCrosson/retry` (via `BitGo/install-github-release-binary@v2`, same pattern as build-system) wrapping the audit step with `--up-to 2x --every 3s`
- Also enabled `--retry-on-network-failure` built into `improved-yarn-audit` for a 1s inner retry, giving **4 total attempts** before failure

**Retry chain:**
1. `improved-yarn-audit` attempt 1 → network error → built-in 1s retry → attempt 2
2. If still failing, `EricCrosson/retry` waits 3s → attempt 3 → built-in retry → attempt 4

Applies to both `npmjs-release.yml` and `publish.yml`.

Fixes: https://github.com/BitGo/BitGoJS/actions/runs/27217754057/job/80364080072
Linear: [WCN-865](https://linear.app/bitgo/issue/WCN-865/fix-flaky-yarn-audit-ci-step-with-retry-logic)

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Confirm `improved-yarn-audit --help` shows `--retry-on-network-failure` flag (v3.0.4 ✓)
- [ ] Confirm `EricCrosson/retry` installs and `retry --up-to 2x --every 3s -- <cmd>` syntax is valid

🤖 Generated with [Claude Code](https://claude.ai/claude-code)