### PR TITLE
docs(express): clarify v1 ping endpoint description

### DIFF
--- a/modules/express/src/typedRoutes/api/v1/ping.ts
+++ b/modules/express/src/typedRoutes/api/v1/ping.ts
@@ -5,7 +5,7 @@ import { BitgoExpressError } from '../../schemas/error';
 /**
  * Ping (v1)
  *
- * Health check endpoint that returns 200 when the Express server is running.
+ * Health check endpoint that returns a 200 status code when the BitGo Express server is up and running.
  *
  * @operationId express.v1.ping
  * @tag Express


### PR DESCRIPTION
## Summary
- Reword the v1 `/api/v1/ping` endpoint doc-comment description for clarity.

Purely cosmetic doc-comment change in `modules/express/src/typedRoutes/api/v1/ping.ts` — no functional/behavioral change.

## Before / After
- **Before:** "Health check endpoint that returns 200 when the Express server is running."
- **After:** "Health check endpoint that returns a 200 status code when the BitGo Express server is up and running."

🤖 Generated with [Claude Code](https://claude.com/claude-code)