### PR TITLE
fix(ci): pin EricCrosson/retry to exact version and SHA256 digest

### DIFF
--- a/.github/workflows/npmjs-release.yml
+++ b/.github/workflows/npmjs-release.yml
@@ -239,7 +239,7 @@ jobs:
       - name: Install retry
         uses: BitGo/install-github-release-binary@v2
         with:
-          targets: EricCrosson/retry@v1
+          targets: EricCrosson/retry@v1.4.8:sha256-15224553f40d5d16dcc1a696798741227c79670a41f43e522002e634aa1d7c64
 
       - name: Run yarn audit
         run: retry --up-to 2x --every 3s -- yarn run audit-high --retry-on-network-failure

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install retry
         uses: BitGo/install-github-release-binary@v2
         with:
-          targets: EricCrosson/retry@v1
+          targets: EricCrosson/retry@v1.4.8:sha256-15224553f40d5d16dcc1a696798741227c79670a41f43e522002e634aa1d7c64
 
       - name: Audit Dependencies
         run: retry --up-to 2x --every 3s -- yarn run improved-yarn-audit --min-severity high --retry-on-network-failure


### PR DESCRIPTION
## Summary

Follow-up to #8975: addresses supply-chain security concern raised by @Louis-Varin in code review.

- Pins `EricCrosson/retry` from floating `@v1` to exact `@v1.4.8` in both `npmjs-release.yml` and `publish.yml`
- Adds SHA256 digest (`sha256-15224553...`) of the `x86_64-unknown-linux-gnu` binary so `BitGo/install-github-release-binary` verifies the download before executing it

**Note:** `BitGo/retry` is `@bitgo-private/retry`, a TypeScript npm library with no binary release assets — it cannot be used as a target for `install-github-release-binary`. Pinning the EricCrosson binary with a digest is the equivalent supply-chain control.

Linear: [WCN-865](https://linear.app/bitgo/issue/WCN-865/fix-flaky-yarn-audit-ci-step-with-retry-logic)

## Test plan

- [ ] CI passes on this PR
- [ ] Confirm `install-github-release-binary` checksum validation passes on the runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)