### PR TITLE
fix(sdk-core): populate recipients in buildTokenEnablements for TSS wallets

### DIFF
--- a/modules/sdk-coin-near/test/unit/tokenEnablementValidation.ts
+++ b/modules/sdk-coin-near/test/unit/tokenEnablementValidation.ts
@@ -612,6 +612,57 @@ describe('NEAR Token Enablement Validation', function () {
         );
     });
 
+    it('should populate recipients from enableTokens in buildParams for TSS wallets', async function () {
+      // Regression test: before the fix, buildTokenEnablements on TSS wallets did not populate
+      // buildParams.recipients — only buildParams.enableTokens was set. This caused verifyTransaction
+      // to throw "missing token name in transaction parameters" because it reads from
+      // txParams.recipients[0].tokenName (where txParams = { ...txPrebuild.buildParams, ...params }).
+      const bgUrl = common.Environments['test'].uri;
+
+      nock(bgUrl)
+        .post(`/api/v2/wallet/${tssWallet.id()}/txrequests`)
+        .reply(200, {
+          txRequestId: 'test-request-id',
+          apiVersion: 'full',
+          transactions: [
+            {
+              state: 'pending',
+              unsignedTx: {
+                serializedTxHex: testData.rawTx.selfStorageDeposit.unsigned,
+                signableHex: testData.rawTx.selfStorageDeposit.unsigned,
+                derivationPath: 'm/0',
+                feeInfo: { fee: 1160407, feeString: '1160407' },
+              },
+              signatureShares: [],
+            },
+          ],
+        });
+
+      const buildResult = await tssWallet.buildTokenEnablements({
+        enableTokens: [{ name: 'tnear:tnep24dp' }],
+      });
+
+      const txPrebuild = buildResult[0] as any;
+
+      // Verify buildParams.recipients is populated — this is what flows into txParams
+      // via { ...txPrebuild.buildParams, ...params } inside prebuildAndSignTransaction
+      txPrebuild.buildParams.should.have.property('recipients');
+      txPrebuild.buildParams.recipients.should.have.length(1);
+      txPrebuild.buildParams.recipients[0].tokenName.should.equal('tnear:tnep24dp');
+      txPrebuild.buildParams.recipients[0].address.should.equal(testData.accounts.account1.address);
+
+      // Simulate the txParams construction that prebuildAndSignTransaction performs,
+      // then confirm verifyTransaction no longer throws "missing token name"
+      const txParams = { ...txPrebuild.buildParams };
+      await basecoin.verifyTransaction({
+        txParams,
+        txPrebuild,
+        wallet: tssWallet as any,
+        verification: { verifyTokenEnablement: true },
+        walletType: 'tss',
+      });
+    });
+
     it('should validate correct storage deposit in TSS wallet flow', async function () {
       const bgUrl = common.Environments['test'].uri;
 

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -3961,6 +3961,20 @@ export class Wallet implements IWallet {
     }
     // Check if we build with intent
     if (this._wallet.multisigType === 'tss') {
+      // Populate recipients from enableTokens so verifyTransaction can access tokenName.
+      // enableTokens is kept (not deleted) since the server needs it to build the transaction.
+      buildParams.recipients = params.enableTokens.map((token) => {
+        const address =
+          token.address || this._wallet.coinSpecific?.baseAddress || this._wallet.coinSpecific?.rootAddress;
+        if (!address) {
+          throw new Error('Wallet does not have base address, must specify with token param');
+        }
+        return {
+          tokenName: token.name,
+          address,
+          amount: '0',
+        };
+      });
       return [await this.prebuildTransaction(buildParams)];
     } else {
       // Rewrite tokens into recipients for buildTransaction


### PR DESCRIPTION
## Summary

- **Bug**: Enabling a NEAR token on a TSS/MPC hot wallet failed with `"Error on token enablements: missing token name in transaction parameters"`
- **Root cause**: `buildTokenEnablements` in `wallet.ts` had two paths — the non-TSS path correctly mapped `enableTokens → recipients` (with `tokenName`) before calling `prebuildTransaction`, but the TSS path skipped this and called `prebuildTransaction` directly. When `verifyTransaction` later ran with `txParams = { ...txPrebuild.buildParams, ...params }`, `txParams.recipients` was `undefined`, causing `near.ts:validateRawReceiver` to throw
- **Fix**: The TSS path now also maps `enableTokens → recipients` before calling `prebuildTransaction`. Unlike non-TSS, `enableTokens` is kept (not deleted) since the server needs it to build the `enableToken` intent
- **History**: Gap introduced in `dde3a952b4` (Aug 2022, "add enable token support for sol") and lay dormant until `21500242aa` (Sep 2025, "token enablement transaction validation") added validation that read `txParams.recipients[0].tokenName`. The existing TSS tests passed because they manually hardcoded `recipients` in `txParams` instead of using `txPrebuild.buildParams`

## Linear

[CECHO-1296](https://linear.app/bitgo/issue/CECHO-1296/fix-near-tss-token-enablement-fails-with-missing-token-name-in)

## Files changed

- `modules/sdk-core/src/bitgo/wallet/wallet.ts` — populate `recipients` in the TSS branch of `buildTokenEnablements`
- `modules/sdk-coin-near/test/unit/tokenEnablementValidation.ts` — regression test that exercises the real production path (`txParams = { ...txPrebuild.buildParams }`) rather than manually constructing `txParams` with recipients

## Test plan

- [ ] New regression test: `should populate recipients from enableTokens in buildParams for TSS wallets` — verifies `txPrebuild.buildParams.recipients[0].tokenName` is set, then calls `verifyTransaction` using `buildParams` as `txParams` (mirroring the production flow)
- [ ] Existing TSS token enablement tests continue to pass
- [ ] Existing non-TSS token enablement tests unaffected (no changes to the `else` branch)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)