### PR TITLE
[STACK tzpnlvnu] refactor(abstract-utxo): drop utxolib RootWalletKeys from keychains.ts

### DIFF
--- a/modules/abstract-utxo/src/keychains.ts
+++ b/modules/abstract-utxo/src/keychains.ts
@@ -1,7 +1,6 @@
 import assert from 'assert';
 
 import * as t from 'io-ts';
-import { bitgo } from '@bitgo/utxo-lib';
 import { IRequestTracer, IWallet, KeyIndices, promiseProps, Triple } from '@bitgo/sdk-core';
 import { BIP32, bip32, fixedScriptWallet } from '@bitgo/wasm-utxo';
 
@@ -48,10 +47,10 @@ export function toKeychainTriple(keychains: UtxoNamedKeychains): Triple<UtxoKeyc
 }
 
 export function toBip32Triple(
-  keychains: bitgo.RootWalletKeys | UtxoNamedKeychains | Triple<{ pub: string }> | string[]
+  keychains: fixedScriptWallet.RootWalletKeys | UtxoNamedKeychains | Triple<{ pub: string }> | string[]
 ): Triple<BIP32> {
-  if (keychains instanceof bitgo.RootWalletKeys) {
-    return keychains.triple.map((k) => BIP32.fromBase58(k.toBase58())) as Triple<BIP32>;
+  if (keychains instanceof fixedScriptWallet.RootWalletKeys) {
+    return [keychains.userKey(), keychains.backupKey(), keychains.bitgoKey()];
   }
   if (Array.isArray(keychains)) {
     if (keychains.length !== 3) {


### PR DESCRIPTION
## Summary

Switches the `instanceof` check and `Triple<BIP32>` conversion path in keychains.ts to use `fixedScriptWallet.RootWalletKeys` from `@bitgo/wasm-utxo`. The other input shapes (`UtxoNamedKeychains`, `Triple<{pub}>`, `string[]`) continue to work via the existing `toKeychainTriple` / string-array branches.

Stacked on #8915 (jj: tzpnlvnu)
Followed by #8987

## PR group context

Stack: `master → #8915 (abstract-utxo-replacements) → this PR (keychains-drop-utxolib) → abstract-utxo-terminal`

Refs: T1-3279

## Test plan

- [ ] `yarn tsc --noEmit` clean in `modules/abstract-utxo`
- [ ] `yarn lint` clean in `modules/abstract-utxo`
- [ ] All abstract-utxo unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)