### PR TITLE
ci: flag internal-info leaks in PR review prompt

### DIFF
--- a/.github/prompts/code-review.md
+++ b/.github/prompts/code-review.md
@@ -8,6 +8,15 @@ You are an expert code reviewer for the BitGoJS cryptocurrency wallet SDK. Pleas
 - Proper validation of transaction parameters
 - Safe handling of private keys and sensitive data
 
+## Internal Information Leakage (Public Repository)
+Comments and strings should describe what the code does, not the dev process. Flag in comments, JSDoc, test names, and error/log strings:
+- Verification/testing metadata (dates, "dry-run confirmed", "verified/tested on", investigation notes)
+- Internal team/system names or codenames (e.g. "by WP"), infra, or tooling
+- Internal ticket IDs or links to internal-only docs
+- Rationale on how/why a change was made rather than code behavior
+
+For each, suggest a behavior-only rewrite.
+
 ## Code Quality & Architecture
 - Adherence to BitGoJS coding standards and patterns
 - TypeScript type safety and interface compliance
@@ -35,8 +44,9 @@ You are an expert code reviewer for the BitGoJS cryptocurrency wallet SDK. Pleas
 
 Please provide constructive feedback focusing on:
 1. Critical issues that must be addressed
-2. Suggestions for improvement
-3. Questions about design decisions
-4. Acknowledgment of good practices
+2. Internal-information leaks in comments or strings (must be removed before merge)
+3. Suggestions for improvement
+4. Questions about design decisions
+5. Acknowledgment of good practices
 
 Be thorough but concise, and explain the reasoning behind your suggestions.


### PR DESCRIPTION
ci: flag internal-info leaks in PR review prompt

Description: This PR adds a guardrail to the BitGoJS automated `@claude` code-review prompt (.github/prompts/code-review.md) to catch internal information that AI coding agents tend to leak into public source. Because BitGoJS is a public repository, agents frequently inject development-process narrative into comments—explaining when, how, or why a change was made—rather than describing what the code does. The change introduces a new "Internal Information Leakage" section instructing the reviewer to flag verification/testing metadata, internal team/system names and codenames, internal ticket IDs or doc links, and how/why rationale in comments, JSDoc, test names, and error/log strings—and to suggest a behavior-only rewrite for each—plus a dedicated item in the review's closing checklist so leaks are surfaced and removed before merge.

File changed: .github/prompts/code-review.md

Ticket: [WCN-850](https://linear.app/bitgo/issue/WCN-850/catch-internal-process-details-in-public-pr-reviews)