### PR TITLE
CECHO-1177: Fix incorrect FLRP P-chain transaction explorer URLs

### DIFF
--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -2297,7 +2297,7 @@ export class FlareP extends Mainnet implements FlareNetwork {
   assetId = 'Flare';
   name = 'FlareP';
   family = CoinFamily.FLRP;
-  explorerUrl = 'https://flarescan.com/blockchain/pvm/transactions/';
+  explorerUrl = 'https://flarescan.com/blockchain/pvm/tx/';
   accountExplorerUrl = 'https://flarescan.com/blockchain/pvm/address/';
   blockchainID = '11111111111111111111111111111111LpoYY';
   cChainBlockchainID = '2q9e4r6Mu3U68nU1fYjgbR6JvwrRx36CohpAX5UQxse55x1Q5';
@@ -2331,7 +2331,7 @@ export class FlareP extends Mainnet implements FlareNetwork {
 export class FlarePTestnet extends Testnet implements FlareNetwork {
   name = 'FlarePTestnet';
   family = CoinFamily.FLRP;
-  explorerUrl = 'https://coston2.testnet.flarescan.com/blockchain/pvm/transactions';
+  explorerUrl = 'https://coston2.testnet.flarescan.com/blockchain/pvm/tx/';
   accountExplorerUrl = 'https://coston2.testnet.flarescan.com/blockchain/pvm/address/';
   flarePublicUrl = 'https://coston2.testnet.flare.network';
   blockchainID = '11111111111111111111111111111111LpoYY';

--- a/modules/statics/test/unit/networks.ts
+++ b/modules/statics/test/unit/networks.ts
@@ -70,6 +70,17 @@ Object.entries(Networks).forEach(([category, networks]) => {
         Networks.test.near.accountExplorerUrl.should.equal('https://testnet.nearblocks.io/address/');
       });
     });
+
+    describe('FlareP Network', function () {
+      it('should have correct explorer URLs', function () {
+        Networks.main.flrP.explorerUrl.should.equal('https://flarescan.com/blockchain/pvm/tx/');
+        Networks.main.flrP.accountExplorerUrl.should.equal('https://flarescan.com/blockchain/pvm/address/');
+        Networks.test.flrP.explorerUrl.should.equal('https://coston2.testnet.flarescan.com/blockchain/pvm/tx/');
+        Networks.test.flrP.accountExplorerUrl.should.equal(
+          'https://coston2.testnet.flarescan.com/blockchain/pvm/address/'
+        );
+      });
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Updates `FlareP` and `FlarePTestnet` `explorerUrl` in statics from `/blockchain/pvm/transactions` to `/blockchain/pvm/tx/`
- Fixes malformed transaction links in the FLRP wallet UI that were concatenating the txid directly onto `.../transactions`, producing 404s on Flarescan (e.g. `.../transactions2tZm6...` on testnet)
- Adds unit test coverage for FlareP explorer URLs

## Root cause
`@bitgo-beta/statics` had outdated Flarescan P-chain transaction URL paths. The UI builds explorer links as `network.explorerUrl + txid`, so the testnet base URL missing the `/tx/` segment caused broken links.

## Test plan
- [x] `npx mocha modules/statics/test/unit/networks.ts --grep "FlareP Network"`
- [ ] After statics publish, bump `@bitgo-beta/statics` in bitgo-ui and verify FLRP wallet tx hash link opens the correct Flarescan page on staging

Ticket: CECHO-1177

Made with [Cursor](https://cursor.com)