### PR TITLE
feat(statics): onboard polygon, avaxc, tempo

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -3544,6 +3544,20 @@ export const allCoinsAndTokens = [
       CoinFeature.EVM_UNSIGNED_SWEEP_RECOVERY,
     ]
   ),
+  tip20Token(
+    '9dd63f8e-3f35-4d10-a623-fe7358ad66a4',
+    'tempo:usdt0',
+    'USDT0',
+    6,
+    '0x20c00000000000000000000014f22ca97301eb73',
+    UnderlyingAsset['tempo:usdt0'],
+    [
+      ...TEMPO_FEATURES,
+      CoinFeature.STABLECOIN,
+      CoinFeature.EVM_NON_BITGO_RECOVERY,
+      CoinFeature.EVM_UNSIGNED_SWEEP_RECOVERY,
+    ]
+  ),
   // Tempo TIP20 testnet tokens
   ttip20Token(
     'e1872fd8-14ee-4dc9-bc5e-fd52552d9c60',

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -2823,6 +2823,7 @@ export enum UnderlyingAsset {
   'avaxc:emdx' = 'avaxc:emdx',
   'avaxc:eurc' = 'avaxc:eurc',
   'avaxc:ausd' = 'avaxc:ausd',
+  'avaxc:mxnd' = 'avaxc:mxnd',
   // End FTX missing AVAXC tokens
 
   // polygon Token ERC-20
@@ -2982,6 +2983,7 @@ export enum UnderlyingAsset {
   'polygon:vio0' = 'polygon:vio0',
   'polygon:wots0' = 'polygon:wots0',
   'polygon:mext' = 'polygon:mext',
+  'polygon:mxnd' = 'polygon:mxnd',
   'polygon:pert' = 'polygon:pert',
   'polygon:colt' = 'polygon:colt',
   'polygon:bolt' = 'polygon:bolt',
@@ -4058,6 +4060,7 @@ export enum UnderlyingAsset {
   'tempo:pathusd' = 'tempo:pathusd',
   'tempo:usdc' = 'tempo:usdc',
   'tempo:usd1' = 'tempo:usd1',
+  'tempo:usdt0' = 'tempo:usdt0',
 
   // Tempo testnet tokens
   'ttempo:pathusd' = 'ttempo:pathusd',

--- a/modules/statics/src/coins/avaxTokens.ts
+++ b/modules/statics/src/coins/avaxTokens.ts
@@ -752,6 +752,14 @@ export const avaxTokens = [
     UnderlyingAsset['avaxc:frnt'],
     [...AccountCoin.DEFAULT_FEATURES, CoinFeature.STABLECOIN]
   ),
+  avaxErc20(
+    '7efffcb6-b961-428b-9eed-41cea87e97b8',
+    'avaxc:mxnd',
+    'Mexican Digital Peso',
+    6,
+    '0x6122c5964d39416c3f34475d00ceb37f50700314',
+    UnderlyingAsset['avaxc:mxnd']
+  ),
   // End FTX missing AVAXC tokens
   tavaxErc20(
     'cd107316-6e78-4936-946f-70e8fd5d8040',

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -2559,6 +2559,13 @@ export const ofcCoins = [
     undefined,
     [CoinFeature.STABLECOIN]
   ),
+  ofcAvaxErc20(
+    '475bfba5-3fd2-4f3c-8f0c-bb740e722f4d',
+    'ofcavaxc:mxnd',
+    'Mexican Digital Peso',
+    6,
+    UnderlyingAsset['avaxc:mxnd']
+  ),
   ofcAvaxErc20('9fb77e47-8916-4dcb-ac10-e11fa07172fb', 'ofcavaxc:nxpc', 'NEXPACE', 18, UnderlyingAsset['avaxc:nxpc']),
   ofcOpethErc20('10259b23-2e2e-4574-b146-b49f1119600f', 'ofcopeth:op', 'Optimism', 18, UnderlyingAsset['opeth:op']),
   ofcOpethErc20(
@@ -3379,6 +3386,13 @@ export const ofcCoins = [
     'XSGD',
     6,
     UnderlyingAsset['polygon:xsgd']
+  ),
+  ofcPolygonErc20(
+    '76d1f5d9-b848-4a06-b541-bbb4c86dcfad',
+    'ofcpolygon:mxnd',
+    'Mexican Digital Peso',
+    6,
+    UnderlyingAsset['polygon:mxnd']
   ),
   ofcPolygonErc20(
     '26eda2a9-0559-4f18-9bb7-547c2682b742',
@@ -5090,6 +5104,7 @@ export const ofcCoins = [
   ),
   ofcTempoToken('c9a90ee0-6546-413c-9cbe-94fdc14985c5', 'ofctempo:usdc', 'USDC', 6, UnderlyingAsset['tempo:usdc']),
   ofcTempoToken('05ac1283-5e72-4cba-8b0f-38cbd23a25c6', 'ofctempo:usd1', 'USD1', 6, UnderlyingAsset['tempo:usd1']),
+  ofcTempoToken('554f9084-4ac8-466a-8675-3de33ffd47d7', 'ofctempo:usdt0', 'USDT0', 6, UnderlyingAsset['tempo:usdt0']),
   // Tempo testnet OFC tokens
   tofcTempoToken(
     '7912e76e-5a5c-4f1b-86e9-1fc2a51f5a98',

--- a/modules/statics/src/coins/polygonTokens.ts
+++ b/modules/statics/src/coins/polygonTokens.ts
@@ -1182,6 +1182,15 @@ export const polygonTokens = [
     POLYGON_TOKEN_FEATURES_EXCLUDE_SINGAPORE
   ),
   polygonErc20(
+    'eee6f253-4490-46cd-92b3-59d8288a46a2',
+    'polygon:mxnd',
+    'Mexican Digital Peso',
+    6,
+    '0xa4a4fcb23ffcd964346d2e4ecdf5a8c15c69b219',
+    UnderlyingAsset['polygon:mxnd'],
+    POLYGON_TOKEN_FEATURES
+  ),
+  polygonErc20(
     'cb393313-9ce5-44aa-aec0-f07c0ab13d76',
     'polygon:pert',
     'Peruvian Sol Token',


### PR DESCRIPTION
Ticket: CSHLD-1024

Description:
onboard POLYGON:MXND, AVAXC:MXND, and TEMPO:USDT0
Add mainnet tokens and OFC equivalents for Go Accounts support.
