### PR TITLE
feat: add 'advanced' wallet generation in type

### DIFF
--- a/modules/sdk-core/src/bitgo/wallet/iWallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallets.ts
@@ -101,7 +101,7 @@ export interface GenerateWalletOptions {
   isDistributedCustody?: boolean;
   bitgoKeyId?: string;
   commonKeychain?: string;
-  type?: 'hot' | 'cold' | 'custodial' | 'trading';
+  type?: 'hot' | 'cold' | 'custodial' | 'trading' | 'advanced';
   subType?: 'lightningCustody' | 'lightningSelfCustody';
   evmKeyRingReferenceWalletId?: string;
   lightningProvider?: 'amboss' | 'voltage';

--- a/modules/sdk-core/test/unit/bitgo/wallet/walletsExternalSigner.ts
+++ b/modules/sdk-core/test/unit/bitgo/wallet/walletsExternalSigner.ts
@@ -102,6 +102,18 @@ describe('Wallets - external signer onchain wallet generation', function () {
       assert.strictEqual(result.bitgoKeychain.pub, bitgoPub);
     });
 
+    it('should pass advanced wallet type through to wallet/add', async function () {
+      await wallets.generateWalletWithExternalSigner({
+        label: 'Advanced Wallet',
+        enterprise: 'enterprise-id',
+        type: 'advanced',
+        createKeychainCallback,
+      });
+
+      const walletBody = sendStub.firstCall.args[0];
+      walletBody.type.should.equal('advanced');
+    });
+
     it('should reject when callback source does not match requested source', async function () {
       createKeychainCallback.withArgs({ source: 'user', coin: 'tbtc' }).resolves({
         pub: userPub,


### PR DESCRIPTION
Follow-up to [external-signer multisig wallet generation PR](https://github.com/BitGo/BitGoJS/pull/8956); adds `'advanced'` to the `GenerateWalletOptions.type` union so advanced-wallets can use `type: 'advanced'` without casting. Added a test.

Ticket: WCN-685