### PR TITLE
feat(sdk-coin-canton): handle ISO timestamp vs microsecond mismatch in assertDeepCantonMatch

### DIFF
--- a/modules/sdk-coin-canton/src/lib/utils.ts
+++ b/modules/sdk-coin-canton/src/lib/utils.ts
@@ -637,6 +637,17 @@ export class Utils implements BaseUtils {
         }
         return;
       }
+      // ISO 8601 input vs microsecond-since-epoch encoding in the prepared-transaction protobuf.
+      if (this.isIsoTimestamp(expected) && this.isIntegerString(actual)) {
+        const expectedMicroseconds = new BigNumber(new Date(expected).getTime()).multipliedBy(1000);
+        if (!expectedMicroseconds.isEqualTo(new BigNumber(actual))) {
+          throw new Error(
+            `Canton command timestamp mismatch at '${currentPath || '<root>'}': ` +
+              `expected '${expected}' (${expectedMicroseconds.toFixed(0)} µs), got '${actual}'`
+          );
+        }
+        return;
+      }
       if (expected !== actual) {
         throw new Error(
           `Canton command mismatch at '${currentPath || '<root>'}': expected '${expected}', got '${actual}'`
@@ -852,6 +863,17 @@ export class Utils implements BaseUtils {
   private areNumericStrings(a: string, b: string): boolean {
     const numericRe = /^-?\d+(\.\d+)?$/;
     return numericRe.test(a) && numericRe.test(b);
+  }
+
+  private isIsoTimestamp(value: string): boolean {
+    if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z$/.test(value)) {
+      return false;
+    }
+    return Number.isFinite(Date.parse(value));
+  }
+
+  private isIntegerString(value: string): boolean {
+    return /^\d+$/.test(value);
   }
 
   private describeType(value: unknown): string {

--- a/modules/sdk-coin-canton/test/unit/utils.ts
+++ b/modules/sdk-coin-canton/test/unit/utils.ts
@@ -508,5 +508,65 @@ describe('Canton Utils - CantonCommand helpers', function () {
     it('should throw on type mismatch', function () {
       assert.throws(() => utils.assertDeepCantonMatch({ a: 'str' }, { a: 42 }, noInject), /mismatch/);
     });
+
+    describe('ISO timestamp vs microsecond string normalisation', function () {
+      const isoTs = '2026-06-12T10:00:00.000Z';
+      const isoTsUs = String(new Date(isoTs).getTime() * 1000);
+
+      it('should pass when ISO timestamp (expected) equals microseconds (actual)', function () {
+        assert.doesNotThrow(() => utils.assertDeepCantonMatch(isoTs, isoTsUs, noInject));
+      });
+
+      it('should throw timestamp mismatch when microseconds do not correspond to the ISO value', function () {
+        const wrongUs = String(new Date(isoTs).getTime() * 1000 + 1_000_000);
+        assert.throws(() => utils.assertDeepCantonMatch(isoTs, wrongUs, noInject), /timestamp mismatch/);
+      });
+
+      it('should pass for ISO timestamp nested inside a mint-like choiceArgument object', function () {
+        const executeBefore = '2026-06-13T10:00:00.000Z';
+        const executeBeforeUs = String(new Date(executeBefore).getTime() * 1000);
+
+        const expected = {
+          expectedAdmin: 'registrar::1220abc',
+          mint: {
+            instrumentId: { admin: 'registrar::1220abc', id: 'STGUSD1' },
+            amount: '1000000.0',
+            holder: 'registrar::1220abc',
+            reference: 'mint-stgusd1-12345',
+            requestedAt: isoTs,
+            executeBefore: executeBefore,
+            meta: { values: {} },
+          },
+        };
+
+        const actual = {
+          expectedAdmin: 'registrar::1220abc',
+          mint: {
+            instrumentId: { admin: 'registrar::1220abc', id: 'STGUSD1' },
+            amount: '1000000.0000000000',
+            holder: 'registrar::1220abc',
+            reference: 'mint-stgusd1-12345',
+            requestedAt: isoTsUs,
+            executeBefore: executeBeforeUs,
+            meta: { values: {} },
+          },
+        };
+
+        assert.doesNotThrow(() => utils.assertDeepCantonMatch(expected, actual, noInject));
+      });
+
+      it('should throw when ISO timestamp in nested object does not match microseconds', function () {
+        const wrongUs = String(new Date(isoTs).getTime() * 1000 + 5_000_000);
+
+        const expected = { mint: { requestedAt: isoTs } };
+        const actual = { mint: { requestedAt: wrongUs } };
+
+        assert.throws(() => utils.assertDeepCantonMatch(expected, actual, noInject), /timestamp mismatch/);
+      });
+
+      it('should not treat an arbitrary non-timestamp ISO-like string as a timestamp', function () {
+        assert.throws(() => utils.assertDeepCantonMatch('not-a-timestamp', isoTsUs, noInject), /mismatch/);
+      });
+    });
   });
 });


### PR DESCRIPTION
# Problem

When a Canton command is built, the caller supplies timestamps as ISO 8601 strings (e.g. `"2026-06-11T20:59:15.363Z"`) because that is what Canton's JSON API requires. However, when the prepared transaction is encoded as a protobuf (`txHex`) and then decoded for verification, those same timestamps come back as microseconds since epoch (e.g. `"1781211555363000"`).

`assertDeepCantonMatch` — the function that compares the user's original intent against the decoded protobuf — was doing a strict string equality check, causing every mint and burn `verifyTransaction` call to throw a false mismatch:

```
transaction prebuild failed local validation: Canton command mismatch at 'mint.requestedAt':
expected '2026-06-11T20:59:15.363Z', got '1749722400000000'
```

# Fix

Added a normalisation branch inside `assertDeepCantonMatch`: when the expected value looks like an ISO 8601 UTC timestamp and the actual value is a plain integer string, the ISO value is converted to microseconds and the two are compared numerically. Any genuine discrepancy still throws an error with a clear timestamp mismatch message.

Two small private helpers support this:

- `isIsoTimestamp(value)` — matches `YYYY-MM-DDTHH:MM:SS[.sss]Z`  
- `isIntegerString(value)` — matches strings that are purely numeric (protobuf microsecond values)

Ticket: SCAAS-9727