### PR TITLE
feat(sdk-core): add pre-hashed signable support for Avalanche txn

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -136,6 +136,7 @@
 /modules/sdk-core/src/bitgo/lightning/ @BitGo/btc-team
 /modules/sdk-core/test/unit/bitgo/lightning/ @BitGo/btc-team
 /modules/sdk-core/test/unit/bitgo/wallet/resourceManagement.ts @BitGo/ethalt-team
+/modules/sdk-core/test/unit/bitgo/utils/tss/preHashedSignable.ts @BitGo/ethalt-team
 /modules/sdk-lib-mpc/ @BitGo/wallet-core @BitGo/wallet-core-india @BitGo/hsm
 /modules/deser-lib/ @BitGo/wallet-core @BitGo/wallet-core-india @BitGo/hsm
 /modules/sdk-rpc-wrapper @BitGo/ethalt-team

--- a/modules/sdk-coin-flrp/src/flrp.ts
+++ b/modules/sdk-coin-flrp/src/flrp.ts
@@ -19,6 +19,8 @@ import {
   BaseTransaction,
   SigningError,
   MethodNotImplementedError,
+  SignableTransaction,
+  isAvalancheAtomicTx,
 } from '@bitgo/sdk-core';
 import * as FlrpLib from './lib';
 import {
@@ -438,6 +440,15 @@ export class Flrp extends BaseCoin {
       message = Buffer.from(message, 'hex');
     }
     return FlrpLib.Utils.createSignature(this._staticsCoin.network as FlareNetwork, message, prv);
+  }
+
+  /**
+   * Returns true when the signableHex for this transaction is already the
+   * final signing hash (SHA-256 for Avalanche atomic txs), and the MPC
+   * signing flow should use it directly without additional hashing.
+   */
+  isSignablePreHashed(unsignedTx: SignableTransaction): boolean {
+    return isAvalancheAtomicTx(unsignedTx);
   }
 
   /** @inheritDoc */

--- a/modules/sdk-coin-flrp/test/unit/flrp.ts
+++ b/modules/sdk-coin-flrp/test/unit/flrp.ts
@@ -1,7 +1,7 @@
 import * as FlrpLib from '../../src/lib';
 import { TestBitGo, TestBitGoAPI } from '@bitgo/sdk-test';
 import { Flrp, TflrP } from '../../src/';
-import { randomBytes } from 'crypto';
+import { createHash, randomBytes } from 'crypto';
 import { BitGoAPI } from '@bitgo/sdk-api';
 import { coins } from '@bitgo/statics';
 import { SEED_ACCOUNT, ACCOUNT_1, ACCOUNT_2, ON_CHAIN_TEST_WALLET, CONTEXT } from '../resources/account';
@@ -1051,6 +1051,17 @@ describe('Flrp test cases', function () {
           walletType: 'tss',
         });
         isVerified.should.equal(true);
+      });
+
+      it('isSignablePreHashed should be true for Avalanche atomic txs', async () => {
+        const txHex = await buildUnsignedExportInP();
+        const rawHex = txHex.startsWith('0x') ? txHex.substring(2) : txHex;
+        const signableHex = createHash('sha256').update(Buffer.from(rawHex, 'hex')).digest('hex');
+
+        basecoin.isSignablePreHashed({ serializedTxHex: rawHex, signableHex }).should.equal(true);
+        basecoin
+          .isSignablePreHashed({ serializedTxHex: 'f86c808504a817c800825208', signableHex: 'f86c808504a817c800825208' })
+          .should.equal(false);
       });
 
       it('should verify signablePayload is SHA-256 of serialized tx (sandbox-verified)', async () => {

--- a/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
@@ -15,6 +15,7 @@ import { Hash } from 'crypto';
 import { TransactionType } from '../../account-lib';
 import { IInscriptionBuilder } from '../inscriptionBuilder';
 import { MessageStandardType, MPCTx, PopulatedIntent, TokenTransferRecipientParams, TokenType } from '../utils';
+import type { SignableTransaction } from '../utils/tss/baseTypes';
 import { IWebhooks } from '../webhook/iWebhooks';
 
 export const multisigTypes = {
@@ -657,6 +658,12 @@ export interface IBaseCoin {
    */
   buildNftTransferData(params: BuildNftTransferDataOptions): string | TokenTransferRecipientParams;
   getHashFunction(): Hash;
+  /**
+   * Returns true when signableHex is already the final signing hash for MPC signing
+   * (e.g. SHA-256 for Avalanche atomic cross-chain txs). Only implemented by coins
+   * that produce pre-hashed signable material.
+   */
+  isSignablePreHashed?(unsignedTx: SignableTransaction): boolean;
   broadcastTransaction(params: BaseBroadcastTransactionOptions): Promise<BaseBroadcastTransactionResult>;
   setCoinSpecificFieldsInIntent(intent: PopulatedIntent, params: PrebuildTransactionWithIntentOptions): void;
 

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
@@ -49,7 +49,9 @@ import {
   TssTxRecipientSource,
   TxRequest,
   isV2Envelope,
+  SignableTransaction,
 } from '../baseTypes';
+import { shouldUsePreHashedSignable } from '../preHashedSignable';
 import { BaseEcdsaUtils } from './base';
 import { EcdsaMPCv2KeyGenSendFn, KeyGenSenderForEnterprise } from './ecdsaMPCv2KeyGenSender';
 import { envRequiresBitgoPubGpgKeyConfig, isBitgoMpcPubKey } from '../../../tss/bitgoPubKeys';
@@ -837,8 +839,8 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
       //   serializedTxHex is the PVM/EVM atomic tx (codec prefix 0x0000).
       // For all other coins, signableHex IS the unsigned transaction (e.g. RLP bytes).
       const isIcp = this.baseCoin.getConfig().family === 'icp';
-      const isAvalancheAtomic = unsignedTx.serializedTxHex && unsignedTx.serializedTxHex.startsWith('0000');
-      if (isIcp || isAvalancheAtomic) {
+      const isPreHashed = shouldUsePreHashedSignable(this.baseCoin, unsignedTx);
+      if (isIcp || isPreHashed) {
         await this.baseCoin.verifyTransaction({
           txPrebuild: { txHex: unsignedTx.serializedTxHex, txInfo: unsignedTx.signableHex },
           txParams: params.txParams || { recipients: [] },
@@ -870,19 +872,7 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
     // pre-hashed digest.  Use it directly as the DKLS message hash instead of
     // applying the coin's hash function (keccak256 for EVM coins).
     // Same logic as getHashStringAndDerivationPath (external signer path).
-    let hashBuffer: Buffer;
-    if (serializedTxHex && serializedTxHex.startsWith('0000')) {
-      hashBuffer = bufferContent;
-      assert(hashBuffer.length === 32, `Avalanche pre-hashed signableHex must be 32 bytes, got ${hashBuffer.length}`);
-    } else {
-      let hash: Hash;
-      try {
-        hash = this.baseCoin.getHashFunction();
-      } catch (err) {
-        hash = createKeccakHash('keccak256') as Hash;
-      }
-      hashBuffer = hash.update(bufferContent).digest();
-    }
+    const hashBuffer = this.getMpcv2HashBuffer(serializedTxHex, txOrMessageToSign, bufferContent);
     const otherSigner = new DklsDsg.Dsg(
       userKeyShare,
       params.mpcv2PartyId !== undefined ? params.mpcv2PartyId : 0,
@@ -1059,18 +1049,27 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
       throw new Error('Invalid request type, got: ' + requestType);
     }
 
-    // For Avalanche atomic transactions (cross-chain export/import between
-    // C-chain and P-chain), signableHex is already SHA-256(txBody) — a 32-byte
-    // pre-hashed digest.  Use it directly as the DKLS message hash instead of
-    // applying the coin's hash function (keccak256 for EVM coins).
-    // This matches the WP/HSM BitGo-party behaviour (MPCv2Signer.isPreHashed)
-    // so both DKLS parties agree on the same message hash.
-    // Detection: Avalanche codec type ID prefix is 0x0000; standard EVM RLP
-    // starts with 0xf8xx, so there is no collision.
-    if (serializedTxHex && serializedTxHex.startsWith('0000')) {
-      const hashBuffer = Buffer.from(txToSign, 'hex');
-      assert(hashBuffer.length === 32, `Avalanche pre-hashed signableHex must be 32 bytes, got ${hashBuffer.length}`);
-      return { hashBuffer, derivationPath };
+    const hashBuffer = this.getMpcv2HashBuffer(serializedTxHex, txToSign, Buffer.from(txToSign, 'hex'));
+    return { hashBuffer, derivationPath };
+  }
+
+  /**
+   * Build the DKLS message hash for MPCv2 signing.
+   * For pre-hashed signable material (Avalanche atomic txs), signableHex is
+   * already SHA-256(txBody) and is used directly. Otherwise the coin hash
+   * function is applied (keccak256 for EVM coins by default).
+   */
+  private getMpcv2HashBuffer(serializedTxHex: string | undefined, signableHex: string, bufferContent: Buffer): Buffer {
+    const unsignedTx: SignableTransaction = {
+      serializedTxHex: serializedTxHex ?? '',
+      signableHex,
+    };
+    if (serializedTxHex && shouldUsePreHashedSignable(this.baseCoin, unsignedTx)) {
+      assert(
+        bufferContent.length === 32,
+        `Avalanche pre-hashed signableHex must be 32 bytes, got ${bufferContent.length}`
+      );
+      return bufferContent;
     }
 
     let hash: Hash;
@@ -1079,9 +1078,7 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
     } catch (err) {
       hash = createKeccakHash('keccak256') as Hash;
     }
-    const hashBuffer = hash.update(Buffer.from(txToSign, 'hex')).digest();
-
-    return { hashBuffer, derivationPath };
+    return hash.update(bufferContent).digest();
   }
 
   // #endregion

--- a/modules/sdk-core/src/bitgo/utils/tss/index.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/index.ts
@@ -15,3 +15,4 @@ export { ITssUtils, IEddsaUtils, TxRequest, EddsaUnsignedTransaction } from './e
 export * as BaseTssUtils from './baseTSSUtils';
 export * from './baseTypes';
 export * from './addressVerification';
+export * from './preHashedSignable';

--- a/modules/sdk-core/src/bitgo/utils/tss/preHashedSignable.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/preHashedSignable.ts
@@ -1,0 +1,36 @@
+import { IBaseCoin } from '../../baseCoin';
+import { SignableTransaction } from './baseTypes';
+
+export interface CoinWithPreHashedSignable {
+  /**
+   * Returns true when the signableHex for this transaction is already the
+   * final signing hash (SHA-256 for Avalanche atomic txs), and the MPC
+   * signing flow should use it directly without additional hashing.
+   */
+  isSignablePreHashed(unsignedTx: SignableTransaction): boolean;
+}
+
+export function isCoinWithPreHashedSignable(coin: unknown): coin is CoinWithPreHashedSignable {
+  return (
+    coin !== null &&
+    typeof coin === 'object' &&
+    typeof (coin as CoinWithPreHashedSignable).isSignablePreHashed === 'function'
+  );
+}
+
+/**
+ * Detect Avalanche atomic cross-chain transactions by codec prefix.
+ *
+ * Avalanche codec type IDs start with 0x00000000 (first 4 hex chars = '0000').
+ * Standard EVM RLP encoding starts with 0xf8xx — overlap is currently impossible.
+ *
+ * Note: The WP strips the '0x' prefix from serializedTxHex before storing,
+ * so we check for '0000' not '0x0000'.
+ */
+export function isAvalancheAtomicTx(unsignedTx: SignableTransaction): boolean {
+  return unsignedTx.serializedTxHex.startsWith('0000');
+}
+
+export function shouldUsePreHashedSignable(coin: IBaseCoin, unsignedTx: SignableTransaction): boolean {
+  return isCoinWithPreHashedSignable(coin) && coin.isSignablePreHashed(unsignedTx);
+}

--- a/modules/sdk-core/test/unit/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
+++ b/modules/sdk-core/test/unit/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
@@ -65,6 +65,7 @@ describe('ECDSA MPC v2', async () => {
 
     const mockCoin = {} as IBaseCoin;
     mockCoin.getHashFunction = sinon.stub().callsFake(() => createKeccakHash('keccak256') as Hash);
+    mockCoin.isSignablePreHashed = (unsignedTx) => unsignedTx.serializedTxHex?.startsWith('0000') ?? false;
 
     ecdsaMPCv2Utils = new EcdsaMPCv2Utils(mockBg, mockCoin);
   });
@@ -630,6 +631,8 @@ describe('ECDSA MPC v2', async () => {
       verifyTransaction: sinon.stub().resolves(true),
       getMPCAlgorithm: sinon.stub().returns('ecdsa'),
       getConfig: sinon.stub().returns({ family: 'flrp' }),
+      isSignablePreHashed: (unsignedTx: { serializedTxHex?: string }) =>
+        unsignedTx.serializedTxHex?.startsWith('0000') ?? false,
     } as unknown as IBaseCoin;
 
     const mockWallet = {
@@ -910,6 +913,7 @@ describe('ECDSA MPC v2', async () => {
 
       const mockCoin = {} as IBaseCoin;
       mockCoin.getHashFunction = sinon.stub().callsFake(() => createKeccakHash('keccak256') as Hash);
+      mockCoin.isSignablePreHashed = (unsignedTx) => unsignedTx.serializedTxHex?.startsWith('0000') ?? false;
       ecdsaMPCv2UtilsWithSpy = new EcdsaMPCv2Utils(mockBg, mockCoin);
     });
 

--- a/modules/sdk-core/test/unit/bitgo/utils/tss/preHashedSignable.ts
+++ b/modules/sdk-core/test/unit/bitgo/utils/tss/preHashedSignable.ts
@@ -1,0 +1,27 @@
+import * as assert from 'assert';
+import { isAvalancheAtomicTx, isCoinWithPreHashedSignable } from '../../../../../src/bitgo/utils/tss/preHashedSignable';
+
+describe('preHashedSignable', function () {
+  it('isAvalancheAtomicTx detects codec prefix 0000', function () {
+    assert.strictEqual(
+      isAvalancheAtomicTx({
+        serializedTxHex: '0000000000010000007278db5c',
+        signableHex: 'abc',
+      }),
+      true
+    );
+    assert.strictEqual(
+      isAvalancheAtomicTx({
+        serializedTxHex: 'f86c808504a817c800825208',
+        signableHex: 'f86c808504a817c800825208',
+      }),
+      false
+    );
+  });
+
+  it('isCoinWithPreHashedSignable type guard', function () {
+    assert.strictEqual(isCoinWithPreHashedSignable({ isSignablePreHashed: () => true }), true);
+    assert.strictEqual(isCoinWithPreHashedSignable({}), false);
+    assert.strictEqual(isCoinWithPreHashedSignable(null), false);
+  });
+});


### PR DESCRIPTION
Mirror WP's isSignablePreHashed flow so Avalanche atomic cross-chain transactions use SHA-256 signableHex directly instead of re-hashing with keccak256.

Co-authored-by: Cursor <cursoragent@cursor.com>

TICKET: CECHO-1295

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
