### PR TITLE
feat(express): add POST /api/v2/:coin/address/derive endpoint

### DIFF
--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -722,6 +722,20 @@ export async function handleV2IsWalletAddress(
 }
 
 /**
+ * handle v2 deriveAddress - locally derive and return a wallet receive address from a
+ * derivation path, using public key material only.
+ *
+ * Offline by design: operates purely on the request body (keychains + chain/index), with no
+ * `wallets().get` lookup and no network access. The inverse of {@link handleV2IsWalletAddress}.
+ * @param req
+ */
+export async function handleV2DeriveAddress(req: ExpressApiRouteRequest<'express.v2.address.derive', 'post'>) {
+  const bitgo = req.bitgo;
+  const coin = bitgo.coin(req.decoded.coin);
+  return await coin.deriveAddress(req.decoded as any);
+}
+
+/**
  * handle v2 approve transaction
  * @param req
  */
@@ -1963,6 +1977,7 @@ export function setupAPIRoutes(app: express.Application, config: Config): void {
     prepareBitGo(config),
     typedPromiseWrapper(handleV2IsWalletAddress),
   ]);
+  router.post('express.v2.address.derive', [prepareBitGo(config), typedPromiseWrapper(handleV2DeriveAddress)]);
 
   router.post('express.wallet.share', [prepareBitGo(config), typedPromiseWrapper(handleV2ShareWallet)]);
   app.post(

--- a/modules/express/src/typedRoutes/api/index.ts
+++ b/modules/express/src/typedRoutes/api/index.ts
@@ -58,6 +58,7 @@ import { PostWalletEnableTokens } from './v2/walletEnableTokens';
 import { PostWalletSweep } from './v2/walletSweep';
 import { PostWalletAccelerateTx } from './v2/walletAccelerateTx';
 import { PostIsWalletAddress } from './v2/isWalletAddress';
+import { PostDeriveAddress } from './v2/deriveAddress';
 import { GetAccountResources } from './v2/accountResources';
 import { GetResourceDelegations } from './v2/resourceDelegations';
 import { PostDelegateResources } from './v2/delegateResources';
@@ -235,6 +236,12 @@ export const ExpressV2WalletIsWalletAddressApiSpec = apiSpec({
   },
 });
 
+export const ExpressV2AddressDeriveApiSpec = apiSpec({
+  'express.v2.address.derive': {
+    post: PostDeriveAddress,
+  },
+});
+
 export const ExpressV2WalletSendManyApiSpec = apiSpec({
   'express.wallet.sendmany': {
     post: PostSendMany,
@@ -399,6 +406,7 @@ export type ExpressApi = typeof ExpressPingApiSpec &
   typeof ExpressWalletFanoutUnspentsApiSpec &
   typeof ExpressV2WalletCreateAddressApiSpec &
   typeof ExpressV2WalletIsWalletAddressApiSpec &
+  typeof ExpressV2AddressDeriveApiSpec &
   typeof ExpressKeychainLocalApiSpec &
   typeof ExpressKeychainChangePasswordApiSpec &
   typeof ExpressLightningWalletPaymentApiSpec &
@@ -444,6 +452,7 @@ export const ExpressApi: ExpressApi = {
   ...ExpressV2WalletCreateAddressApiSpec,
   ...ExpressV2WalletConsolidateAccountApiSpec,
   ...ExpressV2WalletIsWalletAddressApiSpec,
+  ...ExpressV2AddressDeriveApiSpec,
   ...ExpressKeychainLocalApiSpec,
   ...ExpressKeychainChangePasswordApiSpec,
   ...ExpressLightningWalletPaymentApiSpec,

--- a/modules/express/src/typedRoutes/api/v2/deriveAddress.ts
+++ b/modules/express/src/typedRoutes/api/v2/deriveAddress.ts
@@ -1,0 +1,96 @@
+import * as t from 'io-ts';
+import { httpRoute, httpRequest, optional } from '@api-ts/io-ts-http';
+import { BitgoExpressError } from '../../schemas/error';
+import { CreateAddressFormat } from '../../schemas/address';
+
+/**
+ * Path parameters for locally deriving a wallet address
+ */
+export const DeriveAddressParams = {
+  /** Blockchain identifier (e.g., 'btc', 'eth', 'tbtc', 'teth', 'sol') */
+  coin: t.string,
+} as const;
+
+/**
+ * A keychain entry for local derivation. Public key material only — no private keys.
+ * Modelled as a union so a keychain must carry at least one of `pub` / `commonKeychain`:
+ * - `pub` (xpub) for BIP32 multisig coins (UTXO, legacy EVM)
+ * - `commonKeychain` for TSS/MPC coins (SOL, EVM MPC) — identical across keychains
+ *
+ * (A keychain may legitimately carry both; TSS keychains commonly do.)
+ */
+export const DeriveAddressKeychainCodec = t.union([t.type({ pub: t.string }), t.type({ commonKeychain: t.string })]);
+
+/**
+ * Request body for locally deriving a wallet receive address
+ */
+export const DeriveAddressBody = {
+  /**
+   * Keychains for derivation (public key material only).
+   * BIP32 multisig: the user/backup/bitgo xpub triple via `pub`.
+   * TSS/MPC: the `commonKeychain`.
+   */
+  keychains: t.array(DeriveAddressKeychainCodec),
+  /** Derivation index for the address (caller-supplied; the endpoint is stateless) */
+  index: t.number,
+  /** Derivation chain code: UTXO script-type / external(0) vs internal(1) selector */
+  chain: optional(t.number),
+  /** Address format override (e.g. 'p2sh', 'p2wsh' for UTXO; 'cashaddr' / 'base58') */
+  format: optional(CreateAddressFormat),
+  /** Wallet version, to disambiguate derivation strategy (e.g. EVM forwarder vs MPC) */
+  walletVersion: optional(t.number),
+  /**
+   * Seed from the user keychain's derivedFromParentWithSeed field (SMC TSS wallets);
+   * makes the derivation path `{prefix}/{index}` instead of `m/{index}`.
+   */
+  derivedFromParentWithSeed: optional(t.string),
+} as const;
+
+/**
+ * Response for locally deriving a wallet address
+ */
+export const DeriveAddressResponse = {
+  /** The derived address and related derivation info */
+  200: t.intersection([
+    t.type({
+      /** The derived address */
+      address: t.string,
+      /** The derivation index used */
+      index: t.number,
+    }),
+    t.partial({
+      /** The derivation chain code used */
+      chain: t.number,
+      /** Coin-specific address data (e.g. redeemScript/witnessScript for UTXO) */
+      coinSpecific: t.UnknownRecord,
+      /** The HD derivation path actually used */
+      derivationPath: t.string,
+    }),
+  ]),
+  /** Invalid request parameters or derivation failed */
+  400: BitgoExpressError,
+} as const;
+
+/**
+ * Locally derive and return a wallet receive address from a derivation path.
+ *
+ * Unlike `iswalletaddress` (which checks a candidate address), this *produces* the address
+ * offline from public key material only — the xpub triple for BIP32 multisig coins, or the
+ * commonKeychain for TSS/MPC coins. No private keys, no wallet lookup, and no network access:
+ * the handler operates purely on the request body and can run in an air-gapped Express.
+ *
+ * Pairs with `iswalletaddress` for a derive→verify round-trip: derive the address here, then
+ * verify it against the same keychains to independently confirm correctness.
+ *
+ * @operationId express.v2.address.derive
+ * @tag Express
+ */
+export const PostDeriveAddress = httpRoute({
+  path: '/api/v2/{coin}/address/derive',
+  method: 'POST',
+  request: httpRequest({
+    params: DeriveAddressParams,
+    body: DeriveAddressBody,
+  }),
+  response: DeriveAddressResponse,
+});

--- a/modules/express/test/unit/typedRoutes/deriveAddress.ts
+++ b/modules/express/test/unit/typedRoutes/deriveAddress.ts
@@ -1,0 +1,272 @@
+import * as assert from 'assert';
+import * as t from 'io-ts';
+import {
+  DeriveAddressBody,
+  DeriveAddressParams,
+  DeriveAddressResponse,
+  DeriveAddressKeychainCodec,
+  PostDeriveAddress,
+} from '../../../src/typedRoutes/api/v2/deriveAddress';
+import { assertDecode } from './common';
+import 'should';
+import 'should-http';
+import 'should-sinon';
+import * as sinon from 'sinon';
+import { BitGo } from 'bitgo';
+import { setupAgent } from '../../lib/testutil';
+
+describe('DeriveAddress codec tests', function () {
+  const commonKeychain =
+    '033b02aac4f038fef5118350b77d302ec6202931ca2e7122aad88994ffefcbc70a6069e662436236abb1619195232c41580204cb202c22357ed8f53e69eac5c69e';
+
+  describe('DeriveAddressKeychainCodec', function () {
+    it('should validate a keychain with pub only (BIP32 multisig)', function () {
+      const decoded = assertDecode(DeriveAddressKeychainCodec, { pub: 'xpub1...' });
+      assert.strictEqual((decoded as { pub: string }).pub, 'xpub1...');
+    });
+
+    it('should validate a keychain with commonKeychain only (TSS/MPC)', function () {
+      const decoded = assertDecode(DeriveAddressKeychainCodec, { commonKeychain });
+      assert.strictEqual((decoded as { commonKeychain: string }).commonKeychain, commonKeychain);
+    });
+
+    it('should validate a keychain carrying both pub and commonKeychain (TSS keychains commonly do)', function () {
+      const decoded = assertDecode(DeriveAddressKeychainCodec, { pub: 'user_pub', commonKeychain });
+      assert.strictEqual((decoded as { pub: string }).pub, 'user_pub');
+    });
+
+    it('should reject a keychain with neither pub nor commonKeychain', function () {
+      assert.throws(() => {
+        assertDecode(DeriveAddressKeychainCodec, { ethAddress: '0xf45dadce751a317957f2a247ff37cb764b97620d' });
+      });
+    });
+  });
+
+  describe('DeriveAddressParams', function () {
+    it('should validate params with coin', function () {
+      const decoded = assertDecode(t.type(DeriveAddressParams), { coin: 'btc' });
+      assert.strictEqual(decoded.coin, 'btc');
+    });
+
+    it('should reject params with missing coin', function () {
+      assert.throws(() => {
+        assertDecode(t.type(DeriveAddressParams), {});
+      });
+    });
+  });
+
+  describe('DeriveAddressBody', function () {
+    it('should validate body with the minimum required fields (keychains and index)', function () {
+      const validBody = {
+        keychains: [{ pub: 'xpub1...' }, { pub: 'xpub2...' }, { pub: 'xpub3...' }],
+        index: 42,
+      };
+
+      const decoded = assertDecode(t.type(DeriveAddressBody), validBody);
+      assert.strictEqual(decoded.keychains.length, 3);
+      assert.strictEqual(decoded.index, 42);
+    });
+
+    it('should validate a UTXO body with chain and format', function () {
+      const validBody = {
+        keychains: [{ pub: 'xpub1...' }, { pub: 'xpub2...' }, { pub: 'xpub3...' }],
+        index: 0,
+        chain: 20,
+        format: 'base58',
+      };
+
+      const decoded = assertDecode(t.type(DeriveAddressBody), validBody);
+      assert.strictEqual(decoded.chain, 20);
+      assert.strictEqual(decoded.format, 'base58');
+    });
+
+    it('should validate a TSS/MPC body with commonKeychain and SMC seed', function () {
+      const validBody = {
+        keychains: [{ commonKeychain }, { commonKeychain }, { commonKeychain }],
+        index: 7,
+        walletVersion: 6,
+        derivedFromParentWithSeed: 'my-unique-smc-seed-123',
+      };
+
+      const decoded = assertDecode(t.type(DeriveAddressBody), validBody);
+      assert.strictEqual(decoded.walletVersion, 6);
+      assert.strictEqual(decoded.derivedFromParentWithSeed, 'my-unique-smc-seed-123');
+    });
+
+    it('should reject body with missing index', function () {
+      assert.throws(() => {
+        assertDecode(t.type(DeriveAddressBody), { keychains: [{ pub: 'xpub1...' }] });
+      });
+    });
+
+    it('should reject body with missing keychains', function () {
+      assert.throws(() => {
+        assertDecode(t.type(DeriveAddressBody), { index: 0 });
+      });
+    });
+
+    it('should reject body with a non-numeric index', function () {
+      assert.throws(() => {
+        assertDecode(t.type(DeriveAddressBody), { keychains: [{ pub: 'xpub1...' }], index: '0' });
+      });
+    });
+
+    it('should reject body with non-array keychains', function () {
+      assert.throws(() => {
+        assertDecode(t.type(DeriveAddressBody), { keychains: 'not-an-array', index: 0 });
+      });
+    });
+  });
+
+  describe('DeriveAddressResponse', function () {
+    it('should validate a 200 response with the minimum fields', function () {
+      const decoded = assertDecode(DeriveAddressResponse[200], { address: 'bc1qxyz', index: 0 });
+      assert.strictEqual(decoded.address, 'bc1qxyz');
+      assert.strictEqual(decoded.index, 0);
+    });
+
+    it('should validate a 200 response with chain, coinSpecific and derivationPath', function () {
+      const decoded = assertDecode(DeriveAddressResponse[200], {
+        address: 'bc1qxyz',
+        index: 42,
+        chain: 20,
+        coinSpecific: { witnessScript: '00...' },
+        derivationPath: 'm/42',
+      });
+      assert.strictEqual(decoded.derivationPath, 'm/42');
+    });
+
+    it('should reject a 200 response missing the address', function () {
+      assert.throws(() => {
+        assertDecode(DeriveAddressResponse[200], { index: 0 });
+      });
+    });
+  });
+
+  describe('PostDeriveAddress route definition', function () {
+    it('should have the correct path (no wallet id — operates on body only)', function () {
+      assert.strictEqual(PostDeriveAddress.path, '/api/v2/{coin}/address/derive');
+    });
+
+    it('should have the correct HTTP method', function () {
+      assert.strictEqual(PostDeriveAddress.method, 'POST');
+    });
+
+    it('should have the correct response types', function () {
+      assert.ok(PostDeriveAddress.response[200]);
+      assert.ok(PostDeriveAddress.response[400]);
+    });
+  });
+
+  // ==========================================
+  // SUPERTEST INTEGRATION TESTS
+  // ==========================================
+
+  describe('Supertest Integration Tests', function () {
+    const agent = setupAgent();
+
+    afterEach(function () {
+      sinon.restore();
+    });
+
+    it('should derive a UTXO address from keychains + chain/index (no wallet lookup)', async function () {
+      const requestBody = {
+        keychains: [{ pub: 'xpub1...' }, { pub: 'xpub2...' }, { pub: 'xpub3...' }],
+        chain: 20,
+        index: 42,
+      };
+
+      const deriveAddressStub = sinon.stub().resolves({
+        address: 'bc1qderivedaddress',
+        chain: 20,
+        index: 42,
+        derivationPath: 'm/42',
+      });
+      // Note: the handler calls coin.deriveAddress directly — there is no wallets().get,
+      // so the mock coin intentionally exposes no wallets() method.
+      const mockCoin = { deriveAddress: deriveAddressStub };
+      sinon.stub(BitGo.prototype, 'coin').returns(mockCoin as any);
+
+      const result = await agent
+        .post('/api/v2/btc/address/derive')
+        .set('Authorization', 'Bearer test_access_token_12345')
+        .set('Content-Type', 'application/json')
+        .send(requestBody);
+
+      assert.strictEqual(result.status, 200);
+      assert.strictEqual(result.body.address, 'bc1qderivedaddress');
+      assert.strictEqual(result.body.index, 42);
+
+      sinon.assert.calledOnce(deriveAddressStub);
+      const callArgs = deriveAddressStub.firstCall.args[0];
+      assert.strictEqual(callArgs.index, 42);
+      assert.strictEqual(callArgs.chain, 20);
+    });
+
+    it('should derive a TSS/MPC address and pass derivedFromParentWithSeed through', async function () {
+      const requestBody = {
+        keychains: [{ commonKeychain }, { commonKeychain }, { commonKeychain }],
+        index: 1,
+        derivedFromParentWithSeed: 'smc-seed-abc',
+      };
+
+      const deriveAddressStub = sinon.stub().resolves({
+        address: '7YAesfwPk41VChUgr65bm8FEep7ymWqLSW5rpYB5zZPY',
+        index: 1,
+        derivationPath: 'm/999999/0/0/1',
+      });
+      const mockCoin = { deriveAddress: deriveAddressStub };
+      sinon.stub(BitGo.prototype, 'coin').returns(mockCoin as any);
+
+      const result = await agent
+        .post('/api/v2/sol/address/derive')
+        .set('Authorization', 'Bearer test_access_token_12345')
+        .set('Content-Type', 'application/json')
+        .send(requestBody);
+
+      assert.strictEqual(result.status, 200);
+      assert.strictEqual(result.body.address, '7YAesfwPk41VChUgr65bm8FEep7ymWqLSW5rpYB5zZPY');
+
+      sinon.assert.calledOnce(deriveAddressStub);
+      const callArgs = deriveAddressStub.firstCall.args[0];
+      assert.strictEqual(callArgs.derivedFromParentWithSeed, 'smc-seed-abc');
+    });
+
+    it('should return 400 for missing index', async function () {
+      const result = await agent
+        .post('/api/v2/btc/address/derive')
+        .set('Authorization', 'Bearer test_access_token_12345')
+        .set('Content-Type', 'application/json')
+        .send({ keychains: [{ pub: 'xpub1...' }] });
+
+      assert.strictEqual(result.status, 400);
+      assert.ok(result.body.error);
+    });
+
+    it('should return 400 for missing keychains', async function () {
+      const result = await agent
+        .post('/api/v2/btc/address/derive')
+        .set('Authorization', 'Bearer test_access_token_12345')
+        .set('Content-Type', 'application/json')
+        .send({ index: 0 });
+
+      assert.strictEqual(result.status, 400);
+      assert.ok(result.body.error);
+    });
+
+    it('should surface derivation errors (coin.deriveAddress throws)', async function () {
+      const deriveAddressStub = sinon.stub().rejects(new Error('deriveAddress is not supported for this coin'));
+      const mockCoin = { deriveAddress: deriveAddressStub };
+      sinon.stub(BitGo.prototype, 'coin').returns(mockCoin as any);
+
+      const result = await agent
+        .post('/api/v2/xrp/address/derive')
+        .set('Authorization', 'Bearer test_access_token_12345')
+        .set('Content-Type', 'application/json')
+        .send({ keychains: [{ commonKeychain }], index: 0 });
+
+      assert.strictEqual(result.status, 500);
+      result.body.should.have.property('error');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds an **offline** BitGo Express endpoint that locally **derives and returns** a wallet receive address from a derivation path — the inverse of `iswalletaddress`.

```
POST /api/v2/{coin}/address/derive
```

The handler operates purely on the request body (`keychains` + `chain`/`index`) via `coin.deriveAddress(...)` — **no `wallets().get` lookup and no network access**, so it can run in an air-gapped Express. It's **stateless**: the caller supplies the index; the endpoint never allocates server-side. Pairs with `iswalletaddress` for a client **derive→verify** round-trip.

## Context
Builds on the merged `deriveAddress` primitive (WCN-912) and shared `deriveMPCWalletAddress` (WCN-913). This is the Phase-0 endpoint for FR-465 (Bullish local address derivation). Per-coin `deriveAddress` implementations (BTC/ETH/SOL) land in follow-up tickets; until a coin implements it, the base `deriveAddress` throws `NotImplementedError` (surfaced as a 500 here, covered by a test).

- Linear: WCN-914 (child of WCN-864)

## Changes
- `modules/express/src/typedRoutes/api/v2/deriveAddress.ts` — typed route schema (params/body/response). Keychain modelled as a `{ pub } | { commonKeychain }` union so a keychain with neither is rejected.
- `typedRoutes/api/index.ts` — registered the spec (import, apiSpec, type intersection, spread).
- `clientRoutes.ts` — `handleV2DeriveAddress` + route registration (uses existing `prepareBitGo` auth middleware; no extra access control).

## Test plan
- [x] `tsc --noEmit` clean for `modules/express` (the only errors are pre-existing `@iota/*` dependency `.d.ts` noise handled by the build's `skipLibCheck`; 0 in app source)
- [x] `eslint` clean (0 errors)
- [x] New codec + supertest integration tests (24): UTXO + TSS/MPC derive, `derivedFromParentWithSeed` passthrough, 400 on missing `index`/`keychains`, 500 when derivation throws. Success cases assert the offline path (mock coin exposes no `wallets()`).
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)