### PR TITLE
feat: skip forceV1Auth when HMAC present for SSO

### DIFF
--- a/modules/sdk-api/src/bitgoAPI.ts
+++ b/modules/sdk-api/src/bitgoAPI.ts
@@ -1561,8 +1561,9 @@ export class BitGoAPI implements BitGoBase {
       const authUrl = this.microservicesUrl('/api/auth/v1/accesstoken');
       const request = this.post(authUrl);
 
-      if (!this._ecdhXprv) {
-        // without a private key, the user cannot decrypt the new access token the server will send
+      const strategyAuthenticated = this._hmacAuthStrategy.isAuthenticated?.() ?? false;
+      if (!this._ecdhXprv && !strategyAuthenticated) {
+        // No ECDH key and no authenticated HMAC strategy — fall back to V1 Bearer auth.
         request.forceV1Auth = true;
         debug('forcing v1 auth for adding access token using token %s', this._token?.substr(0, 8));
       }
@@ -1576,8 +1577,14 @@ export class BitGoAPI implements BitGoBase {
       // verify the authenticity of the server's response before proceeding any further
       await verifyResponseAsync(this, this._token, 'post', request, response, this._authVersion);
 
-      const responseDetails = await this.handleTokenIssuanceAsync(response.body);
-      response.body.token = responseDetails.token;
+      // When ecdhXprv is available, the server returns an ECDH-encrypted token that
+      // must be decrypted. When the HMAC strategy is authenticated but ecdhXprv is
+      // absent (e.g. SSO/WebCrypto users), the server includes the plain token
+      // directly in response.body.token — no decryption step needed.
+      if (this._ecdhXprv) {
+        const responseDetails = await this.handleTokenIssuanceAsync(response.body);
+        response.body.token = responseDetails.token;
+      }
 
       return handleResponseResult<AddAccessTokenResponse>()(response);
     } catch (e) {

--- a/modules/sdk-api/test/unit/bitgoAPI.ts
+++ b/modules/sdk-api/test/unit/bitgoAPI.ts
@@ -699,6 +699,94 @@ describe('Constructor', function () {
         setTokenStub.called.should.be.false();
       });
     });
+
+    describe('addAccessToken()', function () {
+      const validParams = {
+        label: 'test-token',
+        scope: ['wallet_view_all'],
+        duration: 3600,
+      };
+
+      it('should use HMAC auth when ecdhXprv is absent but hmacAuthStrategy is authenticated', async function () {
+        const { strategy } = makeStrategy({
+          isAuthenticated: sinon.stub().returns(true),
+        });
+        const bitgo = new BitGoAPI({ env: 'custom', customRootURI: ROOT, hmacAuthStrategy: strategy });
+        // Do NOT set _ecdhXprv — simulates SSO/WebCrypto session
+        // Set a v2x token so the request goes through the v2 auth path
+        bitgo.authenticateWithAccessToken({ accessToken: 'v2xstrategytoken' });
+
+        const scope = nock(ROOT).post('/api/auth/v1/accesstoken').reply(200, {
+          token: 'v2xnewplaintoken',
+          label: 'test-token',
+        });
+
+        const result = await bitgo.addAccessToken(validParams);
+
+        scope.isDone().should.be.true();
+        // forceV1Auth should NOT have been set, so no downgrade warning
+        (result as any).should.not.have.property('warning');
+        // The plain token from the response body should be returned directly
+        result.token.should.equal('v2xnewplaintoken');
+      });
+
+      it('should return plain token from response body when ecdhXprv is absent but strategyAuthenticated', async function () {
+        const handleTokenSpy = sinon.spy(BitGoAPI.prototype, 'handleTokenIssuanceAsync');
+        const { strategy } = makeStrategy({
+          isAuthenticated: sinon.stub().returns(true),
+        });
+        const bitgo = new BitGoAPI({ env: 'custom', customRootURI: ROOT, hmacAuthStrategy: strategy });
+        bitgo.authenticateWithAccessToken({ accessToken: 'v2xstrategytoken' });
+
+        nock(ROOT).post('/api/auth/v1/accesstoken').reply(200, {
+          token: 'v2xplaintoken',
+          label: 'test-token',
+        });
+
+        const result = await bitgo.addAccessToken(validParams);
+
+        // handleTokenIssuanceAsync should NOT be called — no ECDH decryption needed
+        handleTokenSpy.called.should.be.false();
+        result.token.should.equal('v2xplaintoken');
+
+        handleTokenSpy.restore();
+      });
+
+      it('should still force V1 auth when neither ecdhXprv nor strategy is authenticated', async function () {
+        const { strategy } = makeStrategy({
+          isAuthenticated: sinon.stub().returns(false),
+        });
+        const bitgo = new BitGoAPI({ env: 'custom', customRootURI: ROOT, hmacAuthStrategy: strategy });
+        bitgo.authenticateWithAccessToken({ accessToken: 'v2xlegacytoken' });
+
+        nock(ROOT).post('/api/auth/v1/accesstoken').reply(200, {
+          token: 'v2xlegacyresult',
+          label: 'test-token',
+        });
+
+        const result = await bitgo.addAccessToken(validParams);
+
+        // V1 auth path should add the downgrade warning
+        (result as any).warning.should.match(/protocol downgrade/);
+      });
+
+      it('should still force V1 auth when isAuthenticated is not defined on strategy', async function () {
+        const { strategy } = makeStrategy();
+        // strategy has no isAuthenticated method by default from makeStrategy
+        const bitgo = new BitGoAPI({ env: 'custom', customRootURI: ROOT, hmacAuthStrategy: strategy });
+        bitgo.authenticateWithAccessToken({ accessToken: 'v2xnoauthmethod' });
+
+        nock(ROOT).post('/api/auth/v1/accesstoken').reply(200, {
+          token: 'v2xresult',
+          label: 'test-token',
+        });
+
+        const result = await bitgo.addAccessToken(validParams);
+
+        // Without isAuthenticated, should fall back to V1 auth
+        (result as any).warning.should.match(/protocol downgrade/);
+      });
+    });
   });
 
   describe('constants parameter', function () {


### PR DESCRIPTION
Ticket: ANT-963
**Summary**                                                                                                                                                              
                                                                                                                                                                       
  - addAccessToken() unconditionally set forceV1Auth = true when _ecdhXprv was absent, causing it to send Authorization: Bearer undefined for SSO/WebCrypto users (who 
  authenticate via WebCryptoHmacStrategy but never receive a raw bearer token)                                                                                         
  - handleTokenIssuanceAsync was always called even for users without _ecdhXprv, which would fail since SSO users receive the plain token directly in                  
  response.body.token rather than an ECDH-encrypted envelope                                                                                                           

  **Fix**

  - Before forcing V1 auth, check hmacAuthStrategy.isAuthenticated?.() — if the strategy is already authenticated (e.g. SSO/WebCrypto users), skip forceV1Auth and let
  HMAC signing proceed normally
  - Guard handleTokenIssuanceAsync behind if (this._ecdhXprv) — users without an ECDH key use the plain token from the response directly

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
