### PR TITLE
feat(sdk-coin-sol): implement deriveAddress for SOL

### DIFF
--- a/modules/sdk-coin-sol/src/sol.ts
+++ b/modules/sdk-coin-sol/src/sol.ts
@@ -54,6 +54,9 @@ import {
   VerifyTransactionOptions,
   TssVerifyAddressOptions,
   verifyEddsaTssWalletAddress,
+  deriveMPCWalletAddress,
+  DeriveAddressOptions,
+  DeriveAddressResult,
   UnexpectedAddressError,
 } from '@bitgo/sdk-core';
 import { auditEddsaPrivateKey, getDerivationPath } from '@bitgo/sdk-lib-mpc';
@@ -712,6 +715,30 @@ export class Sol extends BaseCoin {
     }
 
     return true;
+  }
+
+  /**
+   * Locally derive a SOL wallet receive address from a derivation path, using the wallet's
+   * commonKeychain only (no private keys, no network access). This is the inverse of
+   * {@link isWalletAddress}: it *produces* the address via the same EdDSA TSS derivation that
+   * isWalletAddress checks against, so the two can never diverge.
+   * @param params keychains (commonKeychain), derivation index, and optional SMC seed
+   * @returns the derived address, the index used, and the HD derivation path
+   */
+  async deriveAddress(params: DeriveAddressOptions): Promise<DeriveAddressResult> {
+    const { address, derivationPath } = await deriveMPCWalletAddress(
+      {
+        // extractCommonKeychain validates the commonKeychain is present at runtime
+        keychains: (params.keychains ?? []) as TssVerifyAddressOptions['keychains'],
+        index: params.index,
+        derivedFromParentWithSeed: params.derivedFromParentWithSeed,
+        multisigTypeVersion: params.multisigTypeVersion,
+        keyCurve: 'ed25519',
+      },
+      (publicKey) => this.getAddressFromPublicKey(publicKey)
+    );
+
+    return { address, index: params.index, derivationPath };
   }
 
   /**

--- a/modules/sdk-coin-sol/test/unit/sol.ts
+++ b/modules/sdk-coin-sol/test/unit/sol.ts
@@ -3842,6 +3842,49 @@ describe('SOL:', function () {
     });
   });
 
+  describe('deriveAddress', () => {
+    // Same vector as the isWalletAddress tests above: commonKeychain @ index 1 -> address.
+    const address = '7YAesfwPk41VChUgr65bm8FEep7ymWqLSW5rpYB5zZPY';
+    const commonKeychain =
+      '8ea32ecacfc83effbd2e2790ee44fa7c59b4d86c29a12f09fb613d8195f93f4e21875cad3b98adada40c040c54c3569467df41a020881a6184096378701862bd';
+    const keychains = [{ id: '1', type: 'tss' as const, commonKeychain }];
+
+    it('should derive the expected address for a given commonKeychain and index', async function () {
+      const result = await basecoin.deriveAddress({ keychains, index: 1 });
+      result.address.should.equal(address);
+      result.index.should.equal(1);
+      assert.strictEqual(result.derivationPath, 'm/1');
+    });
+
+    it('should derive a different address for a different index', async function () {
+      const result = await basecoin.deriveAddress({ keychains, index: 2 });
+      result.address.should.not.equal(address);
+    });
+
+    it('round-trips with isWalletAddress (derived address verifies as true)', async function () {
+      const derived = await basecoin.deriveAddress({ keychains, index: 5 });
+      const verified = await basecoin.isWalletAddress({ keychains, address: derived.address, index: 5 });
+      verified.should.equal(true);
+    });
+
+    it('should use the SMC prefix path when derivedFromParentWithSeed is set', async function () {
+      const derivedFromParentWithSeed = 'smc-test-seed-123';
+      const derived = await basecoin.deriveAddress({ keychains, index: 1, derivedFromParentWithSeed });
+      // round-trips through the SMC verify path
+      const verified = await basecoin.isWalletAddress({
+        keychains,
+        address: derived.address,
+        index: 1,
+        derivedFromParentWithSeed,
+      });
+      verified.should.equal(true);
+    });
+
+    it('should throw if keychains are missing', async function () {
+      await assert.rejects(async () => await basecoin.deriveAddress({ keychains: [], index: 0 }), /keychains/);
+    });
+  });
+
   describe('getAddressFromPublicKey', () => {
     it('should convert public key to base58 address', function () {
       const publicKey = '61220a9394802b1d1df37b35f7a3197970f48081092cee011fc98f7b71b2bd43';


### PR DESCRIPTION
## Summary
Implements `deriveAddress` for SOL (Stage A — MPC/TSS), overriding the `BaseCoin` default. It locally derives a Solana receive address from the wallet's `commonKeychain` + `index`, reusing the shared `deriveMPCWalletAddress` (ed25519) helper. Offline and key-material-free (public keys only); supports the SMC prefix path via `derivedFromParentWithSeed`.

This is the inverse of `isWalletAddress` and shares its **exact** derivation path (`deriveMPCWalletAddress`), so derive and verify can never diverge.

## Context
Part of FR-465 (Bullish local address derivation), Phase 1 Stage A. Builds only on the already-merged primitive (WCN-912) and shared MPC engine (WCN-913) — independent of the Express endpoint (WCN-914) and the other coin PRs.

- Linear: WCN-917 (child of WCN-864)

## Test plan
- [x] `tsc --noEmit` clean for `sdk-coin-sol`
- [x] `eslint` clean (0 errors)
- [x] 5 new `deriveAddress` unit tests pass: exact-vector derivation, distinct address per index, **derive→verify round-trip**, SMC-seed round-trip, and missing-keychains error. Reuses the existing `isWalletAddress` test vector.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)