### PR TITLE
feat(abstract-utxo): implement deriveAddress for fixed-script UTXO wallets

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -41,6 +41,8 @@ import {
   Wallet,
   isValidPrv,
   isValidXprv,
+  DeriveAddressOptions,
+  DeriveAddressResult,
 } from '@bitgo/sdk-core';
 
 import {
@@ -75,7 +77,7 @@ import {
 } from './transaction/descriptor/verifyTransaction';
 import { assertDescriptorWalletAddress, getDescriptorMapFromWallet, isDescriptorWallet } from './descriptor';
 import { getFullNameFromCoinName, getMainnetCoinName, isMainnetCoin, UtxoCoinName, UtxoCoinNameMainnet } from './names';
-import { assertFixedScriptWalletAddress } from './address/fixedScript';
+import { assertFixedScriptWalletAddress, generateAddress } from './address/fixedScript';
 import { ParsedTransaction } from './transaction/types';
 import { decodeDescriptorPsbt, decodePsbt, encodeTransaction, stringToBufferTryFormats } from './transaction/decode';
 import { fetchKeychains, toBip32Triple, UtxoKeychain } from './keychains';
@@ -714,6 +716,35 @@ export abstract class AbstractUtxoCoin extends BaseCoin implements Musig2Partici
     });
 
     return true;
+  }
+
+  /**
+   * Locally derive a fixed-script (2-of-3 multisig) wallet receive address from the xpub triple
+   * and a chain/index, using public keys only (no private keys, no network access). This is the
+   * inverse of {@link isWalletAddress}, delegating to the same `generateAddress` used by the
+   * verification path, so derive and verify can never diverge.
+   *
+   * The `chain` code selects the script type (e.g. 0/1 = P2SH, 20/21 = P2WSH/bech32, 30/31 = P2TR);
+   * an optional `format` overrides the address encoding.
+   * @param params keychains (xpub triple via `pub`), chain, index, and optional format
+   * @returns the derived address and the chain/index used
+   */
+  async deriveAddress(params: DeriveAddressOptions): Promise<DeriveAddressResult> {
+    const { keychains, chain, index, format } = params;
+
+    if (!keychains) {
+      throw new Error('missing required param keychains');
+    }
+
+    const address = generateAddress(this.name, {
+      // fixed-script (multisig) coins derive from the xpub triple via `pub`
+      keychains: keychains as { pub: string }[],
+      chain,
+      index,
+      format,
+    });
+
+    return { address, chain, index };
   }
 
   /**

--- a/modules/abstract-utxo/test/unit/address.ts
+++ b/modules/abstract-utxo/test/unit/address.ts
@@ -5,7 +5,7 @@ import { fixedScriptWallet } from '@bitgo/wasm-utxo';
 
 import { assertFixedScriptWalletAddress, generateAddress } from '../../src';
 
-import { keychainsBase58 } from './util';
+import { getUtxoCoin, keychainsBase58 } from './util';
 
 const keychains = keychainsBase58.map((k) => ({ pub: k.pub }));
 
@@ -200,5 +200,32 @@ describe('assertFixedScriptWalletAddress', function () {
         UnexpectedAddressError
       );
     });
+  });
+});
+
+describe('AbstractUtxoCoin.deriveAddress', function () {
+  const coin = getUtxoCoin('btc');
+
+  // Bullish scope: legacy P2SH (chain 0) + bech32 P2WSH (chain 20).
+  for (const { label, chain } of [
+    { label: 'legacy P2SH', chain: 0 },
+    { label: 'bech32 P2WSH', chain: 20 },
+  ]) {
+    it(`derives the ${label} address (chain ${chain}) matching generateAddress`, async function () {
+      const result = await coin.deriveAddress({ keychains, chain, index: 0 });
+      result.address.should.equal(generateAddress('btc', { keychains, chain, index: 0 }));
+      result.chain!.should.equal(chain);
+      result.index!.should.equal(0);
+    });
+
+    it(`round-trips with isWalletAddress for ${label} (chain ${chain})`, async function () {
+      const { address } = await coin.deriveAddress({ keychains, chain, index: 3 });
+      const verified = await coin.isWalletAddress({ address, keychains, chain, index: 3 });
+      verified.should.equal(true);
+    });
+  }
+
+  it('throws if keychains are missing', async function () {
+    await assert.rejects(async () => coin.deriveAddress({ chain: 0, index: 0 }), /keychains/);
   });
 });


### PR DESCRIPTION
## Summary
Implements `deriveAddress` on `AbstractUtxoCoin` (Stage B), overriding the `BaseCoin` default. It locally derives a 2-of-3 multisig receive address from the xpub triple + chain/index, delegating to the existing `generateAddress` used by the `isWalletAddress` verification path — so derive and verify can never diverge. Offline and key-material-free (public keys only). The `chain` code selects the script type (P2SH, P2WSH/bech32, P2TR) with an optional `format` override.

## Context
FR-465 Phase 1, Stage B. Builds only on the merged primitive (WCN-912) — independent of the Express endpoint (WCN-914) and the other coin PRs. Per Bullish scope, tests focus on **legacy P2SH (chain 0)** and **bech32 P2WSH (chain 20)**; Taproot is supported by `generateAddress` for free but not exercised in fixtures.

- Linear: WCN-915 (child of WCN-864)

## Test plan
- [x] `tsc --noEmit` clean for `abstract-utxo`
- [x] `eslint` clean (0 errors)
- [x] 5 new `deriveAddress` tests pass: derived address matches `generateAddress` for P2SH (chain 0) and P2WSH (chain 20), **derive→verify round-trip** for both, and missing-keychains error.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)