### PR TITLE
fix(express): fix sfw flake and reduce Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.git
 node_modules/
 .gitignore
 .npmignore

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,16 @@
   "extends": ["github>BitGo/gha-renovate-bot//presets/default"],
   "baseBranches": ["master"],
   "enabledManagers": ["github-actions", "regex", "npm"],
+  "customManagers": [
+    {
+      "description": "Track sfw version pinned in Dockerfile",
+      "customType": "regex",
+      "fileMatch": ["(^|/)Dockerfile$"],
+      "matchStrings": ["sfw@(?<currentValue>[\\d.]+)"],
+      "depNameTemplate": "sfw",
+      "datasourceTemplate": "npm"
+    }
+  ],
   "packageRules": [
     {
       "description": "Disable all npm dependencies by default",

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM node:22.22.0-bookworm-slim@sha256:f86be15afa9a8277608e141ce2a8aa55d3d9c4084
 ARG SOCKET_SECURITY_MODE=monitor
 ENV SOCKET_SECURITY_MODE=${SOCKET_SECURITY_MODE}
 RUN apt-get update && apt-get install -y git python3 make g++ libtool autoconf automake
-RUN npm i -g sfw
+RUN npm i -g --no-fund sfw@2.0.6 && sfw true
 WORKDIR /tmp/bitgo
 COPY --from=filter-packages-json /tmp/bitgo .
 # (skip postinstall) https://github.com/yarnpkg/yarn/issues/4100#issuecomment-388944260


### PR DESCRIPTION
## Summary

Three small changes to harden and speed up the Express Docker build.

## Changes

### 1. `Dockerfile` — pin `sfw` and pre-cache its binary

```dockerfile
- RUN npm i -g sfw
+ RUN npm i -g --no-fund sfw@2.0.6 && sfw true
```

`npm i -g sfw` only installs a JS wrapper; the native firewall binary is fetched lazily on first invocation. Because the first call to `sfw` is on line 23 (after `COPY`, invalidated on every `yarn.lock` change), the binary was re-downloaded from GitHub releases on every hot build. A transient network hiccup in the BuildKit worker → hard CI failure.

`sfw true` immediately after install forces the binary download into this cached layer, so subsequent builds never re-fetch it. Pinning to `2.0.6` (current latest stable, no known vulnerabilities) prevents a new release from silently busting the cache.

### 2. `.dockerignore` — exclude `.git`

```
+ .git
```

`.git` was not excluded, so the entire 222 MB git history was sent to the BuildKit daemon on every build. No Dockerfile step needs it — `GIT_HASH`/`VERSION` are passed in as build args externally.

### 3. `.github/renovate.json` — track `sfw` version automatically

```json
"customManagers": [{
  "customType": "regex",
  "fileMatch": ["(^|/)Dockerfile$"],
  "matchStrings": ["sfw@(?<currentValue>[\\d.]+)"],
  "depNameTemplate": "sfw",
  "datasourceTemplate": "npm"
}]
```

Renovate will now open a PR automatically when a new `sfw` version is published to npm, keeping the pin from going stale.

## Test plan

- [ ] Docker build completes successfully on CI
- [ ] Confirm the `.git` exclusion doesn't affect the build (`GIT_HASH` is injected externally, not read from inside the container)

Closes [WCN-972](https://linear.app/bitgo/issue/WCN-972)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)