### PR TITLE
ci(root): add path filters to skip irrelevant jobs per PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,41 @@ env:
   SOCKET_SECURITY_MODE: monitor  # Options: monitor (non-blocking) or block (fails on vulnerabilities)
 
 jobs:
+  # Detect which file groups changed so downstream jobs can skip when irrelevant.
+  # Only runs on pull_request — on push/workflow_dispatch it is skipped, which causes
+  # downstream jobs (via `needs.changes.result == 'skipped'`) to run unconditionally.
+  changes:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      source: ${{ steps.filter.outputs.source }}
+      docker: ${{ steps.filter.outputs.docker }}
+      vendor: ${{ steps.filter.outputs.vendor }}
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            source:
+              - 'modules/**'
+              - 'package.json'
+              - 'yarn.lock'
+              - 'tsconfig*.json'
+              - 'lerna.json'
+            docker:
+              - 'Dockerfile'
+              - '.dockerignore'
+              - 'modules/**'
+              - 'package.json'
+              - 'yarn.lock'
+              - 'lerna.json'
+            vendor:
+              - 'modules/argon2/**'
+
   unit-test:
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.source == 'true')
 
     strategy:
       fail-fast: false
@@ -146,6 +179,8 @@ jobs:
 
   browser-test:
     runs-on: ubuntu-22.04
+    needs: [changes]
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.source == 'true')
 
     steps:
       - uses: socketdev/action@v1
@@ -242,6 +277,8 @@ jobs:
 
   docker-build:
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.docker == 'true')
 
     steps:
       - uses: actions/checkout@v6
@@ -314,6 +351,8 @@ jobs:
 
   verify-vendor-integrity:
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.vendor == 'true')
 
     steps:
       - uses: actions/checkout@v6
@@ -336,6 +375,8 @@ jobs:
 
   dockerfile-check:
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.docker == 'true')
 
     steps:
       - uses: socketdev/action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,3 +413,27 @@ jobs:
             git diff -- . ':!yarn.lock'
             exit 1
           fi
+
+  # Umbrella job that branch protection should require instead of individual jobs.
+  # Passes when every dependency either succeeded or was intentionally skipped,
+  # so CI-only PRs (where tests are skipped by path filters) can still merge.
+  # `changes` is included in needs so a failure there (not a skip) is caught and
+  # blocks the merge — preventing test jobs from being falsely skipped.
+  all-checks:
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - changes
+      - unit-test
+      - browser-test
+      - docker-build
+      - dockerfile-check
+      - verify-vendor-integrity
+      - verify-npm-packages
+      - code-quality
+    steps:
+      - name: All checks passed or skipped
+        run: |
+          results='${{ toJSON(needs) }}'
+          echo "$results"
+          echo "$results" | jq -e '[.[].result] | all(. == "success" or . == "skipped")'


### PR DESCRIPTION
## Summary

Adds a `changes` job using `dorny/paths-filter` that detects which file groups changed on a PR. Downstream jobs declare `needs: [changes]` and skip when their relevant files are untouched. An `all-checks` umbrella job aggregates all results so branch protection has a single, reliable gate.

## How it works

```mermaid
flowchart TD
    PR([pull_request event]):::event --> changes

    changes["changes\ndorny/paths-filter\n─────────────────\noutputs: source / docker / vendor"]:::filter

    changes -->|source=true| unit-test
    changes -->|source=true| browser-test
    changes -->|docker=true| docker-build
    changes -->|docker=true| dockerfile-check
    changes -->|vendor=true| verify-vendor-integrity
    changes -. always runs .-> verify-npm-packages
    changes -. always runs .-> code-quality

    unit-test:::job --> all-checks
    browser-test:::job --> all-checks
    docker-build:::job --> all-checks
    dockerfile-check:::job --> all-checks
    verify-vendor-integrity:::job --> all-checks
    verify-npm-packages:::job --> all-checks
    code-quality:::job --> all-checks
    changes --> all-checks

    all-checks{"all-checks\nif: always()\n──────────────────────────────\n✅ pass → all results are success or skipped\n❌ fail → any result is failure or cancelled"}:::gate

    classDef event fill:#6366f1,color:#fff,stroke:none
    classDef filter fill:#0ea5e9,color:#fff,stroke:none
    classDef job fill:#64748b,color:#fff,stroke:none
    classDef gate fill:#16a34a,color:#fff,stroke:none
```

On `push` to master or `workflow_dispatch`, the `changes` job is **skipped** (its `if:` condition excludes non-PR events). Every downstream job sees `needs.changes.result == 'skipped'` and runs unconditionally — full CI on every master merge, no exceptions.

## What skips and when (PR events only)

| Job | Skips when |
|-----|-----------|
| `unit-test` (×3 Node versions) | only `Dockerfile`, `.dockerignore`, `.github/**`, `renovate.json`, etc. changed |
| `browser-test` | same as above |
| `docker-build` | no `Dockerfile`, `.dockerignore`, or `modules/**` changes |
| `dockerfile-check` | same as `docker-build` |
| `verify-vendor-integrity` | no `modules/argon2/**` changes |
| `code-quality` | never skipped |
| `verify-npm-packages` | never skipped |

## Why `all-checks` is secure

`all-checks` explicitly `needs: [changes]`. This means:

- If a test job **fails** → its result is `failure` → jq check rejects it → `all-checks` fails ❌
- If a test job is **skipped by path filter** → result is `skipped` → jq check accepts it → `all-checks` passes ✅
- If `changes` itself **errors** → its result is `failure` (not `skipped`) → `all-checks` catches it and fails ❌

GitHub job results are exactly one of `success | failure | cancelled | skipped`. Only `success` and `skipped` pass. A real failure can never sneak through.

## Required: branch protection update (admin action)

Branch protection currently requires the individual job names. To make this work, a repo admin needs to **replace** those with `all-checks` as the single required check. The individual jobs still run and report status — they just aren't the merge gate anymore.

## Expected savings on infra-only PRs

Before: ~12 min wall time (blocked on `docker-build` + `browser-test` + `unit-test` ×3)  
After: ~3 min wall time (only `changes` + `code-quality` + `verify-npm-packages` run)

## Test plan

- [ ] Open a PR touching only `Dockerfile` — verify `unit-test` and `browser-test` are skipped, `docker-build` runs, `all-checks` passes
- [ ] Open a PR touching only `modules/sdk-core/src` — verify `docker-build` is skipped, `unit-test` and `browser-test` run, `all-checks` passes
- [ ] Force-fail a test job — verify `all-checks` fails and blocks merge
- [ ] Merge to master — verify all jobs run unconditionally

Closes [WCN-974](https://linear.app/bitgo/issue/WCN-974)