### PR TITLE
fix(sdk-coin-polyx): encode memo as UTF-8 bytes right-padded with null bytes

### DIFF
--- a/modules/sdk-coin-polyx/src/lib/tokenTransferBuilder.ts
+++ b/modules/sdk-coin-polyx/src/lib/tokenTransferBuilder.ts
@@ -84,14 +84,25 @@ export class TokenTransferBuilder extends PolyxBaseBuilder<TxMethod, Transaction
 
   /**
    * Sets the memo for the transaction.
-   * Pads the memo on the left with zeros to ensure it is 32 characters long.
+   * Encodes the memo as UTF-8 bytes right-padded with zero bytes to 32 bytes,
+   * matching the Polymesh Memo type ([u8; 32]).
    *
    * @param {string} memo - The memo for the transaction.
    * @returns {this} The current instance of the builder.
    */
   memo(memo: string): this {
-    const paddedMemo = memo.padStart(32, '0');
-    this._memo = paddedMemo;
+    // fromImplementation passes the decoded on-chain hex (0x + 64 hex chars) — pass through unchanged
+    if (/^0x[0-9a-fA-F]{64}$/.test(memo)) {
+      this._memo = memo;
+      return this;
+    }
+    const memoBytes = Buffer.from(memo, 'utf8');
+    if (memoBytes.length > 32) {
+      throw new Error('Memo must be 32 bytes or fewer when UTF-8 encoded');
+    }
+    const paddedBuffer = Buffer.alloc(32, 0);
+    memoBytes.copy(paddedBuffer, 0);
+    this._memo = '0x' + paddedBuffer.toString('hex');
     return this;
   }
 

--- a/modules/sdk-coin-polyx/src/lib/transferBuilder.ts
+++ b/modules/sdk-coin-polyx/src/lib/transferBuilder.ts
@@ -69,14 +69,25 @@ export class TransferBuilder extends PolyxBaseBuilder<TxMethod, Transaction> {
 
   /**
    * The memo to attach to the transfer transaction.
-   * Pads the memo on the left with zeros to ensure it is 32 characters long.
+   * Encodes the memo as UTF-8 bytes right-padded with zero bytes to 32 bytes,
+   * matching the Polymesh Memo type ([u8; 32]).
    *
    * @param {string} memo The memo string to include.
    * @returns {TransferBuilder} This transfer builder.
    */
   memo(memo: string): this {
-    const paddedMemo = memo.padStart(32, '0');
-    this._memo = paddedMemo;
+    // fromImplementation passes the decoded on-chain hex (0x + 64 hex chars) — pass through unchanged
+    if (/^0x[0-9a-fA-F]{64}$/.test(memo)) {
+      this._memo = memo;
+      return this;
+    }
+    const memoBytes = Buffer.from(memo, 'utf8');
+    if (memoBytes.length > 32) {
+      throw new Error('Memo must be 32 bytes or fewer when UTF-8 encoded');
+    }
+    const paddedBuffer = Buffer.alloc(32, 0);
+    memoBytes.copy(paddedBuffer, 0);
+    this._memo = '0x' + paddedBuffer.toString('hex');
     return this;
   }
 

--- a/modules/sdk-coin-polyx/test/unit/transactionBuilder/tokenTransferBuilder.ts
+++ b/modules/sdk-coin-polyx/test/unit/transactionBuilder/tokenTransferBuilder.ts
@@ -40,7 +40,7 @@ describe('Polyx token transfer Builder - Testnet', () => {
       should.deepEqual(txJson.fromDID, senderDID);
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.assetId, assetId);
-      should.deepEqual(txJson.memo, '0x3030303030303030303030303030303030303030303030303030303030303030');
+      should.deepEqual(txJson.memo, '0x3000000000000000000000000000000000000000000000000000000000000000');
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
       should.deepEqual(txJson.genesisHash, genesisHash);
@@ -79,7 +79,7 @@ describe('Polyx token transfer Builder - Testnet', () => {
       should.deepEqual(txJson.fromDID, senderDID);
       should.deepEqual(txJson.sender, sender.address);
       should.deepEqual(txJson.assetId, assetId);
-      should.deepEqual(txJson.memo, '0x3030303030303030303030303030303030303030303030303030303030303030');
+      should.deepEqual(txJson.memo, '0x3000000000000000000000000000000000000000000000000000000000000000');
       should.deepEqual(txJson.blockNumber, 3933);
       should.deepEqual(txJson.referenceBlock, '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d');
       should.deepEqual(txJson.genesisHash, genesisHash);


### PR DESCRIPTION
Polymesh Memo is [u8; 32] — UTF-8 bytes right-padded with 0x00 bytes to 32 bytes. Both TransferBuilder and TokenTransferBuilder were using padStart(32, '0') which left-pads with ASCII '0' characters (0x30), causing exchanges like Binance to receive '00000000000000000000000102329716' instead of '102329716' and fail to match the deposit memo.

COINS-447

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

TICKET: COINS-447

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
