### PR TITLE
feat(abstract-eth): derive legacy multisig forwarder addresses (v1/v2/v4)

### DIFF
--- a/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
+++ b/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
@@ -3056,28 +3056,65 @@ export abstract class AbstractEthLikeNewCoins extends AbstractEthLikeCoin {
    * @returns the derived address, the index used, and the HD derivation path
    */
   async deriveAddress(params: DeriveAddressOptions): Promise<DeriveAddressResult> {
-    const isMpcWallet = params.walletVersion === 3 || params.walletVersion === 5 || params.walletVersion === 6;
-    if (!isMpcWallet) {
-      throw new Error(
-        `deriveAddress currently supports only MPC/TSS ETH wallets (wallet versions 3, 5, 6). ` +
-          `Legacy BIP32 forwarder wallets (versions 1, 2, 4) are not yet supported. ` +
-          `Got walletVersion ${params.walletVersion}.`
+    const { walletVersion, index } = params;
+    const forwarderVersion = params.coinSpecific?.forwarderVersion;
+
+    // Mirrors isWalletAddress's branching:
+    // - MPC/TSS receive addresses: v3 & v6 (every index), and the v5 *base* address (index 0).
+    // - Forwarder (CREATE2) receive addresses: legacy v1/v2/v4 wallets, and v5 forwarders (index > 0).
+    const useMpc = walletVersion === 3 || walletVersion === 6 || (walletVersion === 5 && index === 0);
+    if (useMpc) {
+      const { address, derivationPath } = await deriveMPCWalletAddress(
+        {
+          // extractCommonKeychain validates the commonKeychain is present at runtime
+          keychains: (params.keychains ?? []) as TssVerifyAddressOptions['keychains'],
+          index,
+          derivedFromParentWithSeed: params.derivedFromParentWithSeed,
+          multisigTypeVersion: params.multisigTypeVersion,
+          keyCurve: 'secp256k1',
+        },
+        (pubKey) => new KeyPairLib({ pub: pubKey }).getAddress()
       );
+
+      return { address, index, derivationPath };
     }
 
-    const { address, derivationPath } = await deriveMPCWalletAddress(
-      {
-        // extractCommonKeychain validates the commonKeychain is present at runtime
-        keychains: (params.keychains ?? []) as TssVerifyAddressOptions['keychains'],
-        index: params.index,
-        derivedFromParentWithSeed: params.derivedFromParentWithSeed,
-        multisigTypeVersion: params.multisigTypeVersion,
-        keyCurve: 'secp256k1',
-      },
-      (pubKey) => new KeyPairLib({ pub: pubKey }).getAddress()
-    );
+    // Forwarder (CREATE2) derivation for legacy multisig / v5 forwarder receive addresses.
+    if (forwarderVersion === 0) {
+      throw new Error(
+        'Forwarder version 0 addresses cannot be derived: the nonce required for address derivation is not stored.'
+      );
+    }
+    if (forwarderVersion === 1 || forwarderVersion === 2 || forwarderVersion === 4) {
+      const { baseAddress, coinSpecific } = params;
+      if (!baseAddress) {
+        throw new Error('baseAddress is required to derive a forwarder address');
+      }
+      const feeAddress = coinSpecific?.feeAddress ?? '';
+      if (forwarderVersion === 4 && !feeAddress) {
+        throw new Error('coinSpecific.feeAddress is required to derive a v4 forwarder address');
+      }
 
-    return { address, index: params.index, derivationPath };
+      const { forwarderFactoryAddress, forwarderImplementationAddress } =
+        this.getForwarderFactoryAddressesAndForwarderImplementationAddress(forwarderVersion);
+      // For BitGo forwarders the per-address salt is the derivation index, so the forwarder
+      // address is reproducible from (baseAddress, index) plus the network factory/implementation.
+      const address = this.generateForwarderAddress(
+        baseAddress,
+        feeAddress,
+        forwarderFactoryAddress,
+        forwarderImplementationAddress,
+        index
+      );
+
+      return { address, index, coinSpecific: { forwarderVersion } };
+    }
+
+    throw new Error(
+      `deriveAddress: could not determine an ETH derivation strategy. Provide an MPC wallet ` +
+        `(walletVersion 3/5/6 with commonKeychain), or a legacy forwarder (coinSpecific.forwarderVersion ` +
+        `1/2/4 with baseAddress). Got walletVersion=${walletVersion}, forwarderVersion=${forwarderVersion}.`
+    );
   }
 
   /**

--- a/modules/express/src/typedRoutes/api/v2/deriveAddress.ts
+++ b/modules/express/src/typedRoutes/api/v2/deriveAddress.ts
@@ -40,6 +40,21 @@ export const DeriveAddressBody = {
   /** Wallet version, to disambiguate derivation strategy (e.g. EVM forwarder vs MPC) */
   walletVersion: optional(t.number),
   /**
+   * Wallet base address (the wallet contract address for EVM wallets). Required to derive
+   * per-index forwarder receive addresses for legacy multisig EVM wallets (versions 1/2/4).
+   */
+  baseAddress: optional(t.string),
+  /**
+   * Coin-specific derivation inputs. For EVM legacy forwarder wallets:
+   * `forwarderVersion` (1/2/4) selects the forwarder factory, and `feeAddress` is required for v4.
+   */
+  coinSpecific: optional(
+    t.partial({
+      forwarderVersion: t.number,
+      feeAddress: t.string,
+    })
+  ),
+  /**
    * Seed from the user keychain's derivedFromParentWithSeed field (SMC TSS wallets);
    * makes the derivation path `{prefix}/{index}` instead of `m/{index}`.
    */

--- a/modules/express/test/unit/typedRoutes/deriveAddress.ts
+++ b/modules/express/test/unit/typedRoutes/deriveAddress.ts
@@ -93,6 +93,21 @@ describe('DeriveAddress codec tests', function () {
       assert.strictEqual(decoded.derivedFromParentWithSeed, 'my-unique-smc-seed-123');
     });
 
+    it('should validate an EVM legacy-forwarder body with baseAddress and coinSpecific', function () {
+      const validBody = {
+        keychains: [{ pub: 'xpub1...' }, { pub: 'xpub2...' }, { pub: 'xpub3...' }],
+        index: 117,
+        walletVersion: 5,
+        baseAddress: '0xf1e3d30798acdf3a12fa5beb5fad8efb23d5be11',
+        coinSpecific: { forwarderVersion: 4, feeAddress: '0xb1e725186990b86ca8efed08a3ccda9c9f400f09' },
+      };
+
+      const decoded = assertDecode(t.type(DeriveAddressBody), validBody);
+      assert.strictEqual(decoded.baseAddress, validBody.baseAddress);
+      assert.strictEqual(decoded.coinSpecific?.forwarderVersion, 4);
+      assert.strictEqual(decoded.coinSpecific?.feeAddress, validBody.coinSpecific.feeAddress);
+    });
+
     it('should reject body with missing index', function () {
       assert.throws(() => {
         assertDecode(t.type(DeriveAddressBody), { keychains: [{ pub: 'xpub1...' }] });

--- a/modules/sdk-coin-eth/test/unit/eth.ts
+++ b/modules/sdk-coin-eth/test/unit/eth.ts
@@ -1519,11 +1519,12 @@ describe('ETH:', function () {
           verified.should.equal(true);
         });
 
-        it('should throw for legacy BIP32 forwarder wallet versions (1/2/4)', async function () {
+        it('should throw when neither MPC nor forwarder inputs are provided', async function () {
           const coin = bitgo.coin('teth') as Teth;
+          // walletVersion 1 with no coinSpecific.forwarderVersion and no baseAddress is ambiguous
           await assert.rejects(
             async () => coin.deriveAddress({ keychains, index: 0, walletVersion: 1 }),
-            /only MPC\/TSS ETH wallets/
+            /could not determine an ETH derivation strategy/
           );
         });
 
@@ -1532,6 +1533,89 @@ describe('ETH:', function () {
           await assert.rejects(
             async () => coin.deriveAddress({ keychains: [], index: 0, walletVersion: 3 }),
             /keychains/
+          );
+        });
+      });
+
+      describe('deriveAddress (forwarder)', function () {
+        // Same vectors as the forwarder isWalletAddress tests above (coin: hteth).
+        // salt == index for BitGo forwarders, so deriving by index reproduces the address.
+        it('derives the exact v1 forwarder address and round-trips', async function () {
+          const coin = bitgo.coin('hteth') as Hteth;
+          const baseAddress = '0xe1253bcce7d87db522fbceec6e55c9f78c376d9f';
+          const result = await coin.deriveAddress({
+            baseAddress,
+            index: 7,
+            walletVersion: 1,
+            coinSpecific: { forwarderVersion: 1 },
+          });
+          result.address.should.equal('0x6069a4baf2360bf67a6d02a7fc43d8f3910016ae');
+
+          const verified = await coin.isWalletAddress({
+            address: result.address,
+            baseAddress,
+            index: 7,
+            walletVersion: 1,
+            coinSpecific: { salt: '0x7', forwarderVersion: 1 },
+          } as unknown as TssVerifyEthAddressOptions);
+          verified.should.equal(true);
+        });
+
+        it('derives the exact v2 forwarder address', async function () {
+          const coin = bitgo.coin('hteth') as Hteth;
+          const result = await coin.deriveAddress({
+            baseAddress: '0xdc485da076ed4a2b19584e9a1fdbb974f89b60f4',
+            index: 23,
+            walletVersion: 2,
+            coinSpecific: { forwarderVersion: 2 },
+          });
+          result.address.should.equal('0xf636ceddffe41d106586875c0e56dc8feb6268f7');
+        });
+
+        it('derives the exact v4 forwarder address (wallet v5, needs feeAddress)', async function () {
+          const coin = bitgo.coin('hteth') as Hteth;
+          const result = await coin.deriveAddress({
+            baseAddress: '0xf1e3d30798acdf3a12fa5beb5fad8efb23d5be11',
+            index: 117,
+            walletVersion: 5,
+            coinSpecific: { forwarderVersion: 4, feeAddress: '0xb1e725186990b86ca8efed08a3ccda9c9f400f09' },
+          });
+          result.address.should.equal('0xd63b5e2b8d1b4fba3625460508900bf2a0499a4d');
+        });
+
+        it('throws if baseAddress is missing for a forwarder', async function () {
+          const coin = bitgo.coin('hteth') as Hteth;
+          await assert.rejects(
+            async () => coin.deriveAddress({ index: 7, walletVersion: 1, coinSpecific: { forwarderVersion: 1 } }),
+            /baseAddress is required/
+          );
+        });
+
+        it('throws if feeAddress is missing for a v4 forwarder', async function () {
+          const coin = bitgo.coin('hteth') as Hteth;
+          await assert.rejects(
+            async () =>
+              coin.deriveAddress({
+                baseAddress: '0xf1e3d30798acdf3a12fa5beb5fad8efb23d5be11',
+                index: 117,
+                walletVersion: 5,
+                coinSpecific: { forwarderVersion: 4 },
+              }),
+            /feeAddress is required/
+          );
+        });
+
+        it('throws for forwarder version 0 (not derivable)', async function () {
+          const coin = bitgo.coin('hteth') as Hteth;
+          await assert.rejects(
+            async () =>
+              coin.deriveAddress({
+                baseAddress: '0xe1253bcce7d87db522fbceec6e55c9f78c376d9f',
+                index: 0,
+                walletVersion: 1,
+                coinSpecific: { forwarderVersion: 0 },
+              }),
+            /version 0 addresses cannot be derived/
           );
         });
       });

--- a/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
@@ -244,6 +244,16 @@ export interface DeriveAddressOptions
   keychains?: ({ pub: string } | { commonKeychain: string })[];
   /** Wallet version, used to disambiguate derivation strategy for some coin families. */
   walletVersion?: number;
+  /**
+   * Wallet base address (the wallet contract address for EVM wallets). Required to derive
+   * per-index forwarder (CREATE2) receive addresses for legacy multisig EVM wallets.
+   */
+  baseAddress?: string;
+  /**
+   * Coin-specific derivation inputs. For EVM legacy forwarder wallets this carries
+   * `forwarderVersion` (1/2/4) and, for v4, `feeAddress`.
+   */
+  coinSpecific?: AddressCoinSpecific;
 }
 
 /**
@@ -487,6 +497,8 @@ export interface AddressCoinSpecific {
   baseAddress?: string;
   pendingChainInitialization?: boolean;
   forwarderVersion?: number;
+  /** Fee address for v4 EVM forwarders (used when deriving/verifying v4 forwarder addresses). */
+  feeAddress?: string;
 }
 
 export interface FullySignedTransaction {


### PR DESCRIPTION
## Summary
Completes Stage C of FR-465: `deriveAddress` now derives **legacy multisig ETH forwarder receive addresses** (forwarder versions **1, 2, 4**, plus v5 forwarders), in addition to the MPC/TSS support already shipped.

It reuses the existing `generateForwarderAddress` + `getForwarderFactoryAddressesAndForwarderImplementationAddress` helpers — no new crypto. The branching mirrors `isWalletAddress`:
- **MPC/TSS** for wallet versions 3 & 6 (every index) and the **v5 base address** (index 0);
- **forwarder / CREATE2** otherwise (legacy v1/v2/v4 and v5 forwarder addresses).

For BitGo forwarders the per-address **salt == index**, so a forwarder address is reproducible from `(baseAddress, index)` + the network factory/implementation; **v4** also requires `coinSpecific.feeAddress`. **Forwarder version 0 is not derivable** (no stored nonce) and returns a clear error.

## Changes
- **sdk-core:** add `baseAddress` + `coinSpecific` to `DeriveAddressOptions`; add `feeAddress` to `AddressCoinSpecific`.
- **abstract-eth:** forwarder branch in `deriveAddress`.
- **express:** accept `baseAddress` + `coinSpecific` (`forwarderVersion`, `feeAddress`) on the `address/derive` body.
- **tests:** exact-match derivation for v1/v2/v4 against the existing `isWalletAddress` fixtures (hteth) + a v1 derive→verify round-trip + error cases (missing baseAddress/feeAddress, v0); express codec test for the new fields.

## Context
WCN-932 (FR-465 Phase 1, Stage C). Effort was low because the address computation + a v4 runtime precedent (`generateForwarderAddress`, used by consolidation recovery) already existed; all 3 versions share one code path differing only by factory address (+ v4 feeAddress).

## Test plan
- [x] `tsc` clean (sdk-core, abstract-eth, express, sdk-coin-eth)
- [x] `eslint` clean (0 errors)
- [x] 10 ETH `deriveAddress` unit tests pass (4 MPC + 6 forwarder), incl. exact v1/v2/v4 addresses + round-trip
- [x] OpenAPI spec regenerates; **vacuum audit 0 errors / 0 warnings** (project ruleset) with the new schema fields
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)