### PR TITLE
feat(sdk-core): add PolyxSwitchValidatorOptions for multi-nomination 

### DIFF
--- a/modules/sdk-core/src/bitgo/staking/iStakingWallet.ts
+++ b/modules/sdk-core/src/bitgo/staking/iStakingWallet.ts
@@ -227,6 +227,12 @@ export interface TaoSwitchValidatorOptions extends SwitchValidatorOptions {
   netUID: string;
 }
 
+export interface PolyxSwitchValidatorOptions {
+  delegationId: string;
+  validators: string[];
+  clientId?: string;
+}
+
 export interface ClaimRewardsOptions {
   amount: string;
   clientId?: string;
@@ -322,7 +328,9 @@ export interface IStakingWallet {
     options: StakeOptions | TronStakeOptions | TaoStakeOptions | VetStakeOptions | StoryStakeOptions | XdcStakeOptions
   ): Promise<StakingRequest>;
   unstake(options: UnstakeOptions | EthUnstakeOptions): Promise<StakingRequest>;
-  switchValidator(options: SwitchValidatorOptions | TaoSwitchValidatorOptions): Promise<StakingRequest>;
+  switchValidator(
+    options: SwitchValidatorOptions | TaoSwitchValidatorOptions | PolyxSwitchValidatorOptions
+  ): Promise<StakingRequest>;
   claimRewards(options: ClaimRewardsOptions): Promise<StakingRequest>;
   getStakingRequest(stakingRequestId: string): Promise<StakingRequest>;
   getTransactionsReadyToSign(stakingRequestId: string): Promise<TransactionsReadyToSign>;

--- a/modules/sdk-core/src/bitgo/staking/stakingWallet.ts
+++ b/modules/sdk-core/src/bitgo/staking/stakingWallet.ts
@@ -23,6 +23,7 @@ import {
   TronStakeOptions,
   TaoStakeOptions,
   TaoSwitchValidatorOptions,
+  PolyxSwitchValidatorOptions,
   VetStakeOptions,
   StoryStakeOptions,
   XdcStakeOptions,
@@ -84,7 +85,9 @@ export class StakingWallet implements IStakingWallet {
    * @param options - switch validator options
    * @return StakingRequest
    */
-  async switchValidator(options: SwitchValidatorOptions | TaoSwitchValidatorOptions): Promise<StakingRequest> {
+  async switchValidator(
+    options: SwitchValidatorOptions | TaoSwitchValidatorOptions | PolyxSwitchValidatorOptions
+  ): Promise<StakingRequest> {
     return await this.createStakingRequest(options, 'SWITCH_VALIDATOR');
   }
 
@@ -325,6 +328,7 @@ export class StakingWallet implements IStakingWallet {
       | TronStakeOptions
       | TaoStakeOptions
       | TaoSwitchValidatorOptions
+      | PolyxSwitchValidatorOptions
       | VetStakeOptions
       | StoryStakeOptions
       | XdcStakeOptions,


### PR DESCRIPTION

TICKET: SI-842

## Summary

- Add `PolyxSwitchValidatorOptions` to `@bitgo/sdk-core` for POLYX multi-validator nomination switch requests
- Widen `IStakingWallet.switchValidator()` and `StakingWallet.switchValidator()` to accept the new options type
- Include `PolyxSwitchValidatorOptions` in the internal `createStakingRequest()` options union

POLYX switch-validator replaces the full nomination set and does not use `validator` or `amount`. The staking-service already accepts `{ delegationId, validators }`; this change aligns the SDK types with that contract so UI callers no longer need `as SwitchValidatorOptions`.

## Motivation

`bitgo-ui` / `bitgo-retail` currently type-assert the switch-validator payload when submitting POLYX multi-nomination requests, because `SwitchValidatorOptions` requires `validator` and `amount`. This follows the same approach as `TaoSwitchValidatorOptions` for coin-specific switch payloads.

## Changes

| File | Change |
|------|--------|
| `modules/sdk-core/src/bitgo/staking/iStakingWallet.ts` | Add `PolyxSwitchValidatorOptions`; update `switchValidator` signature |
| `modules/sdk-core/src/bitgo/staking/stakingWallet.ts` | Import new type; update `switchValidator` + `createStakingRequest` union |

No runtime behavior change — `createStakingRequest` already forwards options as-is to staking-service.

## Follow-up (separate PRs)

After this SDK version is published and bumped:

1. **bitgo-ui** — remove `payload as SwitchValidatorOptions` in `useCreateSwitchValidatorRequestMutation.ts`; use `PolyxSwitchValidatorOptions` in the payload union
2. **bitgo-retail** — same cleanup if applicable
3. **bitgo-microservices** — no WP/SDK route changes expected; staking-service already supports the payload

## Test plan

- [ ] `yarn compile` in `modules/sdk-core`
- [ ] Existing `stakingWalletCommon` switch-validator test still passes (no new test added — consistent with no dedicated test for `TaoSwitchValidatorOptions`)
- [ ] After SDK bump in UI: POLYX multi-nomination switch validator submits without type assertion