### PR TITLE
fix(abstract-eth): allow defi TSS tx verification

### DIFF
--- a/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
+++ b/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
@@ -3158,6 +3158,8 @@ export abstract class AbstractEthLikeNewCoins extends AbstractEthLikeCoin {
             'consolidate',
             'bridgeFunds',
             'enabletoken',
+            'defiApprove',
+            'defiDeposit',
           ].includes(txParams.type))
       )
     ) {

--- a/modules/sdk-coin-eth/test/unit/eth.ts
+++ b/modules/sdk-coin-eth/test/unit/eth.ts
@@ -867,6 +867,76 @@ describe('ETH:', function () {
       isTransactionVerified.should.equal(true);
     });
 
+    it('should verify TSS transaction with defiApprove type', async function () {
+      const coin = bitgo.coin('hteth') as Hteth;
+      const baseAddress = '0x174cfd823af8ce27ed0afee3fcf3c3ba259116be';
+      const wallet = new Wallet(bitgo, coin, {
+        coinSpecific: {
+          baseAddress: baseAddress,
+        },
+      });
+
+      // DeFi deposit flow is intent-based: recipients/calldata are built server-side
+      // from defiParams, so txParams has no recipients (see CGD-1815).
+      const txParams = {
+        type: 'defiApprove',
+        defiParams: { vaultId: 'hteth-usdc-test', amount: '10' },
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+      };
+
+      const txPrebuild = {
+        txHex: '0x',
+        coin: 'hteth',
+        walletId: 'fakeWalletId',
+      };
+
+      const verification = {};
+
+      const isTransactionVerified = await coin.verifyTransaction({
+        txParams: txParams as any,
+        txPrebuild: txPrebuild as any,
+        wallet,
+        verification,
+        walletType: 'tss',
+      });
+      isTransactionVerified.should.equal(true);
+    });
+
+    it('should verify TSS transaction with defiDeposit type', async function () {
+      const coin = bitgo.coin('hteth') as Hteth;
+      const baseAddress = '0x174cfd823af8ce27ed0afee3fcf3c3ba259116be';
+      const wallet = new Wallet(bitgo, coin, {
+        coinSpecific: {
+          baseAddress: baseAddress,
+        },
+      });
+
+      const txParams = {
+        type: 'defiDeposit',
+        defiParams: { vaultId: 'hteth-usdc-test', amount: '10', operationId: 'fakeOperationId' },
+        wallet: wallet,
+        walletPassphrase: 'fakeWalletPassphrase',
+      };
+
+      const txPrebuild = {
+        txHex: '0x',
+        coin: 'hteth',
+        walletId: 'fakeWalletId',
+      };
+
+      const verification = {};
+
+      const isTransactionVerified = await coin.verifyTransaction({
+        txParams: txParams as any,
+        txPrebuild: txPrebuild as any,
+        wallet,
+        verification,
+        walletType: 'tss',
+      });
+      isTransactionVerified.should.equal(true);
+    });
+
     describe('consolidationToBaseAddress verification', function () {
       it('should verify consolidation when recipient matches base address', async function () {
         const coin = bitgo.coin('hteth') as Hteth;


### PR DESCRIPTION
verifyTssTransaction rejected DeFi vault deposit intents with "missing txParams" because defiApprove/defiDeposit were missing from the allowlist of recipient-less transaction types. These are intent-based txs whose recipient and calldata are built server-side from defiParams, so they carry no client recipients, like bridgeFunds and tokenApproval.

Add both types to the allowlist and cover them with TSS verification tests.

CGD-1815

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
