### PR TITLE
fix(sdk-coin-starknet): normalize signableHex and widen verifyTransaction guard

### DIFF
--- a/modules/sdk-coin-starknet/src/lib/transaction.ts
+++ b/modules/sdk-coin-starknet/src/lib/transaction.ts
@@ -50,7 +50,9 @@ export class Transaction extends BaseTransaction {
   }
 
   get signableHex(): string {
-    return this._starknetTransactionData?.transactionHash || '';
+    const hash = this._starknetTransactionData?.transactionHash;
+    if (!hash) return '';
+    return hash.replace(/^0x/i, '').padStart(64, '0');
   }
 
   get signedTransaction(): string | undefined {

--- a/modules/sdk-coin-starknet/src/starknet.ts
+++ b/modules/sdk-coin-starknet/src/starknet.ts
@@ -74,7 +74,7 @@ export class Starknet extends BaseCoin {
     // 0x-prefixed txHex means this is the Starknet transaction hash (signableHex), not the
     // full serialized transaction. Recipient verification already happened in prebuildAndSignTransaction
     // using serializedTxHex — nothing to verify from a hash alone.
-    if (!txHex || txHex.startsWith('0x')) {
+    if (!txHex || txHex.startsWith('0x') || /^[0-9a-f]{64}$/i.test(txHex)) {
       return true;
     }
 

--- a/modules/sdk-coin-starknet/test/unit/starknet.ts
+++ b/modules/sdk-coin-starknet/test/unit/starknet.ts
@@ -126,6 +126,15 @@ describe('Starknet', function () {
       result.should.equal(true);
     });
 
+    it('should return true when txHex is a 64-character unprefixed signableHex', async function () {
+      const result = await basecoin.verifyTransaction({
+        txParams: { recipients: [] },
+        txPrebuild: { txHex: 'deadbeefcafe1234567890abcdefdeadbeefcafe1234567890abcdef12345678' },
+        wallet: {} as any,
+      });
+      result.should.equal(true);
+    });
+
     it('should return true when txHex is absent', async function () {
       const result = await basecoin.verifyTransaction({
         txParams: { recipients: [] },

--- a/modules/sdk-coin-starknet/test/unit/transferBuilder.ts
+++ b/modules/sdk-coin-starknet/test/unit/transferBuilder.ts
@@ -39,7 +39,7 @@ describe('Starknet TransferBuilder', () => {
         .amount('1000000000000000000');
 
       const tx = (await builder.build()) as Transaction;
-      tx.signableHex.should.equal(tx.starknetTransactionData.transactionHash);
+      tx.signableHex.should.equal(tx.starknetTransactionData.transactionHash!.replace(/^0x/i, '').padStart(64, '0'));
       tx.id.should.equal(tx.starknetTransactionData.transactionHash);
     });
 

--- a/modules/sdk-coin-starknet/test/unit/walletInitializationBuilder.ts
+++ b/modules/sdk-coin-starknet/test/unit/walletInitializationBuilder.ts
@@ -37,7 +37,7 @@ describe('Starknet WalletInitializationBuilder', () => {
       builder.fromPublicKey(Accounts.account1.publicKey).nonce('0x0').chainId(chainId);
 
       const tx = (await builder.build()) as Transaction;
-      tx.signableHex.should.equal(tx.starknetTransactionData.transactionHash);
+      tx.signableHex.should.equal(tx.starknetTransactionData.transactionHash!.replace(/^0x/i, '').padStart(64, '0'));
       tx.id.should.equal(tx.starknetTransactionData.transactionHash);
     });
 


### PR DESCRIPTION
Node's hex decoder under Node 24+ rejects '0x' prefixes in Buffer.from, producing empty buffers. This caused the Starknet deploy account signing path to send empty hashes to the keyserver, resulting in 400 validation errors.

- Stripped '0x' prefix and left-padded signableHex to 64 characters to conform with standard BitGo raw hex convention.
- Widened verifyTransaction short-circuit to support raw 64-character hex hashes, preventing runtime JSON parsing crashes.
- Updated builder unit tests and added verification test case.

TICKET: CECHO-1376

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
