### PR TITLE
feat(sdk-coin-sol): derive SPL token (ATA) deposit addresses

### DIFF
--- a/modules/express/src/typedRoutes/api/v2/deriveAddress.ts
+++ b/modules/express/src/typedRoutes/api/v2/deriveAddress.ts
@@ -40,6 +40,11 @@ export const DeriveAddressBody = {
   /** Wallet version, to disambiguate derivation strategy (e.g. EVM forwarder vs MPC) */
   walletVersion: optional(t.number),
   /**
+   * Token name (e.g. `sol:usdc`) to derive a token deposit address instead of the native one.
+   * For Solana this returns the wallet's Associated Token Account (ATA) for the token's mint.
+   */
+  tokenName: optional(t.string),
+  /**
    * Wallet base address (the wallet contract address for EVM wallets). Required to derive
    * per-index forwarder receive addresses for legacy multisig EVM wallets (versions 1/2/4).
    */

--- a/modules/sdk-coin-sol/src/sol.ts
+++ b/modules/sdk-coin-sol/src/sol.ts
@@ -728,7 +728,8 @@ export class Sol extends BaseCoin {
    * @returns the derived address, the index used, and the HD derivation path
    */
   async deriveAddress(params: DeriveAddressOptions): Promise<DeriveAddressResult> {
-    const { address, derivationPath } = await deriveMPCWalletAddress(
+    // Derive the native owner (wallet) address from the commonKeychain.
+    const { address: ownerAddress, derivationPath } = await deriveMPCWalletAddress(
       {
         // extractCommonKeychain validates the commonKeychain is present at runtime
         keychains: (params.keychains ?? []) as TssVerifyAddressOptions['keychains'],
@@ -739,6 +740,19 @@ export class Sol extends BaseCoin {
       },
       (publicKey) => this.getAddressFromPublicKey(publicKey)
     );
+
+    // No token requested: return the native SOL receive address.
+    if (!params.tokenName) {
+      return { address: ownerAddress, index: params.index, derivationPath };
+    }
+
+    // Token requested: the deposit address is the owner's Associated Token Account (ATA) for the
+    // token's mint, derived the same way SOL token addresses are produced elsewhere in this coin.
+    const token = getSolTokenFromTokenName(params.tokenName);
+    if (!token || token.tokenAddress === undefined || token.programId === undefined) {
+      throw new Error(`unknown or unsupported SOL token: ${params.tokenName}`);
+    }
+    const address = await getAssociatedTokenAccountAddress(token.tokenAddress, ownerAddress, true, token.programId);
 
     return { address, index: params.index, derivationPath };
   }

--- a/modules/sdk-coin-sol/test/unit/sol.ts
+++ b/modules/sdk-coin-sol/test/unit/sol.ts
@@ -4189,6 +4189,29 @@ describe('SOL:', function () {
     it('should throw if keychains are missing', async function () {
       await assert.rejects(async () => await basecoin.deriveAddress({ keychains: [], index: 0 }), /keychains/);
     });
+
+    it('should derive the SPL token (ATA) address when tokenName is given', async function () {
+      // owner = native address at index 1 (7YAesf…); ATA for sol:usdc:
+      const result = await basecoin.deriveAddress({ keychains, index: 1, tokenName: 'sol:usdc' });
+      result.address.should.equal('FG1XMJdXBQ5uYaNoKposABg6erxsvzbwC283W2ipnjQB');
+      result.address.should.not.equal(address); // not the native address
+      result.index.should.equal(1);
+    });
+
+    it('the derived token ATA matches getAssociatedTokenAccountAddress for the owner+mint', async function () {
+      const native = await basecoin.deriveAddress({ keychains, index: 3 });
+      const token = await basecoin.deriveAddress({ keychains, index: 3, tokenName: 'sol:usdc' });
+      const mint = (coins.get('sol:usdc') as unknown as { tokenAddress: string }).tokenAddress;
+      const expectedAta = await getAssociatedTokenAccountAddress(mint, native.address, true);
+      token.address.should.equal(expectedAta);
+    });
+
+    it('should throw for an unknown token name', async function () {
+      await assert.rejects(
+        async () => await basecoin.deriveAddress({ keychains, index: 1, tokenName: 'sol:not-a-real-token' }),
+        /unknown or unsupported SOL token/
+      );
+    });
   });
 
   describe('getAddressFromPublicKey', () => {

--- a/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
@@ -245,6 +245,13 @@ export interface DeriveAddressOptions
   /** Wallet version, used to disambiguate derivation strategy for some coin families. */
   walletVersion?: number;
   /**
+   * Token name (e.g. `sol:usdc`, `tsol:usdt`) to derive a token deposit address instead of the
+   * native receive address. For Solana this resolves to the SPL mint and returns the wallet's
+   * Associated Token Account (ATA) for that mint. Ignored by coins/tokens that reuse the native
+   * address (e.g. ERC-20 on EVM).
+   */
+  tokenName?: string;
+  /**
    * Wallet base address (the wallet contract address for EVM wallets). Required to derive
    * per-index forwarder (CREATE2) receive addresses for legacy multisig EVM wallets.
    */


### PR DESCRIPTION
## Summary
Extends SOL `deriveAddress` to support **SPL token deposit addresses**. When a `tokenName` (e.g. `sol:usdc`) is supplied, it derives the native owner address as before, then returns the owner's **Associated Token Account (ATA)** for that token's mint.

It reuses the existing `getAssociatedTokenAccountAddress` helper — same statics mint + `programId` lookup (token-2022 aware) that the rest of the SOL coin uses to build token addresses — so the derived value matches what BitGo assigns as the token receive address. No token requested → native address as before (unchanged).

## Changes
- **sdk-core:** add `tokenName` to `DeriveAddressOptions`.
- **sdk-coin-sol:** token (ATA) branch in `deriveAddress`.
- **express:** accept `tokenName` on the `address/derive` request body.
- **tests:** exact ATA for `sol:usdc` at a known index (`FG1XMJdXBQ5uYaNoKposABg6erxsvzbwC283W2ipnjQB`), parity check against `getAssociatedTokenAccountAddress`, and unknown-token error.

## Context
WCN-1054 (FR-465 Phase 2) — Bullish confirmed SPL tokens are needed. ERC-20 on EVM needs nothing extra (tokens reuse the wallet/forwarder address); this is Solana-specific because token deposits go to a per-mint ATA.

## Test plan
- [x] `tsc` clean (sdk-core, sdk-coin-sol, express)
- [x] `eslint` clean (0 errors)
- [x] 8 SOL `deriveAddress` unit tests pass (incl. 3 new token tests); ATA matches the independent `getAssociatedTokenAccountAddress` computation
- [x] OpenAPI regenerates; **vacuum 0 errors / 0 warnings** with the new `tokenName` field
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)