### PR TITLE
fix(sdk-coin-flr): support FLR C->P atomic TSS signing

### DIFF
--- a/modules/sdk-coin-flr/src/flr.ts
+++ b/modules/sdk-coin-flr/src/flr.ts
@@ -19,10 +19,12 @@ import {
   common,
   FeeEstimateOptions,
   IWallet,
+  isAvalancheAtomicTx,
   MPCAlgorithm,
   MultisigType,
   multisigTypes,
   Recipient,
+  SignableTransaction,
   TransactionExplanation,
   Entry,
 } from '@bitgo/sdk-core';
@@ -83,6 +85,16 @@ export class Flr extends AbstractEthLikeNewCoins {
   /** @inheritDoc */
   getMPCAlgorithm(): MPCAlgorithm {
     return 'ecdsa';
+  }
+
+  /**
+   * Returns true when the signableHex for this transaction is already the
+   * final signing hash. Cross-chain export atomic transactions from FLR
+   * C-chain to FLRP P-chain are pre-hashed with SHA-256(txBody); the MPC
+   * signing flow must use that digest directly without applying keccak256.
+   */
+  isSignablePreHashed(unsignedTx: SignableTransaction): boolean {
+    return isAvalancheAtomicTx(unsignedTx);
   }
 
   protected async buildUnsignedSweepTxnTSS(params: RecoverOptions): Promise<OfflineVaultTxInfo | UnsignedSweepTxMPCv2> {

--- a/modules/sdk-coin-flr/test/unit/flr.ts
+++ b/modules/sdk-coin-flr/test/unit/flr.ts
@@ -97,6 +97,26 @@ describe('flr', function () {
     });
   });
 
+  describe('isSignablePreHashed', function () {
+    it('returns true for Avalanche atomic txs (codec prefix 0000)', function () {
+      // C->P cross-chain export atomic tx — signableHex is already SHA-256(txBody).
+      // The MPC layer must use this digest directly, not re-hash with keccak256,
+      // otherwise the user and BitGo signature shares will not combine.
+      const signableHex = 'a'.repeat(64);
+      flrCoin.isSignablePreHashed({ serializedTxHex: '0000' + 'b'.repeat(20), signableHex }).should.equal(true);
+    });
+
+    it('returns false for standard EVM RLP transactions', function () {
+      // EIP-1559 / RLP serialized transactions start with 0x02 or 0xf8 — never 0x0000.
+      flrCoin
+        .isSignablePreHashed({
+          serializedTxHex: '02f17281d902850ba43b740283061a80',
+          signableHex: '02f17281d902850ba43b740283061a80',
+        })
+        .should.equal(false);
+    });
+  });
+
   describe('Address Validation', function () {
     it('should validate valid eth address', function () {
       const address = '0x1374a2046661f914d1687d85dbbceb9ac7910a29';

--- a/modules/sdk-core/src/bitgo/utils/tss/recipientUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/recipientUtils.ts
@@ -57,6 +57,13 @@ export const NO_RECIPIENT_TX_TYPES = new Set([
   'transferOfferWithdrawn',
   'cantonCommand',
   'pledge',
+
+  // Avalanche / Flare cross-chain atomic imports — recipients are not supplied
+  // by the client because the import consumes UTXOs already owned by the
+  // wallet; the destination address is the wallet itself. WP issues these
+  // with intentType 'import' (P-chain) or 'importtoc' (C-chain).
+  'import',
+  'importtoc',
 ]);
 
 /**

--- a/modules/sdk-core/test/unit/bitgo/utils/tss/recipientUtils.ts
+++ b/modules/sdk-core/test/unit/bitgo/utils/tss/recipientUtils.ts
@@ -49,6 +49,9 @@ describe('recipientUtils', function () {
         'transferOfferWithdrawn',
         'cantonCommand',
         'pledge',
+        // Avalanche / Flare cross-chain atomic imports
+        'import',
+        'importtoc',
       ];
       expected.forEach((t) => assert.ok(NO_RECIPIENT_TX_TYPES.has(t), `${t} should be in NO_RECIPIENT_TX_TYPES`));
       assert.strictEqual(NO_RECIPIENT_TX_TYPES.size, expected.length);
@@ -104,9 +107,22 @@ describe('recipientUtils', function () {
         'stake',
         'createAccount',
         'pledge',
+        'import',
+        'importtoc',
       ]) {
         const txRequest = makeTxRequest();
         assert.doesNotThrow(() => resolveEffectiveTxParams(txRequest, { type: txType }));
+      }
+    });
+
+    it('does not throw for Avalanche cross-chain imports resolved from intent.intentType', function () {
+      // P-chain and C-chain import intents legitimately carry no recipients —
+      // the wallet imports its own UTXOs and the destination address is the
+      // wallet itself. The intentType lives only on the intent (txParams.type
+      // is unset on the MPC signing call) so the guard must read it from there.
+      for (const intentType of ['import', 'importtoc']) {
+        const txRequest = makeTxRequest({ intent: { intentType } as any });
+        assert.doesNotThrow(() => resolveEffectiveTxParams(txRequest, {}));
       }
     });
 


### PR DESCRIPTION
FLR C-chain to P-chain export (and the matching P-chain import) fails during the MPC signing ceremony because:

1. sdk-coin-flr does not declare isSignablePreHashed, so the MPCv2 signing flow re-hashes the Avalanche atomic signableHex with keccak256. The signableHex is already SHA-256(txBody), so the user's signature share is computed over a different digest from BitGo's, surfacing as "Failed to combine signature shares" on the send-transaction endpoint.

2. The TSS recipient guard rejects intent types 'import' and 'importtoc' (Avalanche / Flare cross-chain atomic imports), even though those intents legitimately have no client-supplied recipients — the wallet imports its own UTXOs and the destination is the wallet itself. That surfaces as "Recipient details are required to verify this transaction before signing".

Add isSignablePreHashed to Flr mirroring the Flrp implementation, and add 'import' / 'importtoc' to NO_RECIPIENT_TX_TYPES so the pre-signing verifier no longer blocks the flow.

Ticket: CECHO-1425

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
