### PR TITLE
fix(sdk-core): exempt FLRP import from TSS recipient guard 

### DIFF
--- a/modules/sdk-coin-flrp/src/flrp.ts
+++ b/modules/sdk-coin-flrp/src/flrp.ts
@@ -96,9 +96,15 @@ export class Flrp extends BaseCoin {
     const explainedTx = tx.explainTransaction();
 
     const type = params.txParams.type;
-    // 'stake' is the intent-type alias for AddPermissionlessDelegator; normalize it
-    // so the TransactionType enum lookup succeeds.
-    const normalizedType = type === 'stake' ? 'AddPermissionlessDelegator' : type;
+    // WP intentType aliases (lowercase) must map to TransactionType enum keys.
+    const normalizedType =
+      type === 'stake'
+        ? 'AddPermissionlessDelegator'
+        : type === 'import'
+        ? 'Import'
+        : type === 'importtoc'
+        ? 'ImportToC'
+        : type;
 
     // When type is provided, verify it matches the parsed transaction.
     // When type is not provided (MPC/TSS intent flow where buildParams are unavailable),

--- a/modules/sdk-coin-flrp/test/unit/flrp.ts
+++ b/modules/sdk-coin-flrp/test/unit/flrp.ts
@@ -940,6 +940,19 @@ describe('Flrp test cases', function () {
         isVerified.should.equal(true);
       });
 
+      it('should verify MPC ImportInP transaction when txParams.type is the "import" intent alias', async () => {
+        const txHex = await buildUnsignedImportInP();
+        const txPrebuild = { txHex, txInfo: {} };
+        const txParams = {
+          recipients: [],
+          type: 'import',
+          locktime: 0,
+        };
+
+        const isVerified = await basecoin.verifyTransaction({ txParams, txPrebuild });
+        isVerified.should.equal(true);
+      });
+
       it('should verify MPC ExportInP transaction', async () => {
         const txHex = await buildUnsignedExportInP();
         const txPrebuild = { txHex, txInfo: {} };

--- a/modules/sdk-core/src/bitgo/utils/tss/recipientUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/recipientUtils.ts
@@ -117,7 +117,16 @@ export function resolveEffectiveTxParams(
   // Use its presence as a generic staking signal — no need to enumerate every intentType.
   const isStakingIntent = !!(txRequest.intent as PopulatedIntent)?.stakingRequestId;
 
-  if (!effectiveTxParams.recipients?.length && !isStakingIntent && !NO_RECIPIENT_TX_TYPES.has(txType)) {
+  // buildParams.type from the wallet UI is PascalCase ('Import'); intent.intentType from WP
+  // is lowercase ('import'). Either may be the source of truth depending on the signing path.
+  const intentType = (txRequest.intent as PopulatedIntent)?.intentType ?? '';
+
+  if (
+    !effectiveTxParams.recipients?.length &&
+    !isStakingIntent &&
+    !NO_RECIPIENT_TX_TYPES.has(txType) &&
+    !NO_RECIPIENT_TX_TYPES.has(intentType)
+  ) {
     throw new InvalidTransactionError(
       'Recipient details are required to verify this transaction before signing. Pass txParams with at least one recipient.'
     );

--- a/modules/sdk-core/test/unit/bitgo/utils/tss/recipientUtils.ts
+++ b/modules/sdk-core/test/unit/bitgo/utils/tss/recipientUtils.ts
@@ -126,6 +126,13 @@ describe('recipientUtils', function () {
       }
     });
 
+    it('does not throw when buildParams.type is PascalCase but intent.intentType is lowercase', function () {
+      // signTransactionTss passes txPrebuild.buildParams as txParams. Prebuild uses
+      // type: 'Import' while WP stores intentType: 'import' on the txRequest.
+      const txRequest = makeTxRequest({ intent: { intentType: 'import', recipients: [] } as any });
+      assert.doesNotThrow(() => resolveEffectiveTxParams(txRequest, { type: 'Import', recipients: [] }));
+    });
+
     it('throws InvalidTransactionError for unknown types with no recipients', function () {
       const txRequest = makeTxRequest();
       assert.throws(


### PR DESCRIPTION
signTransactionTss passes buildParams.type as 'Import' while WP stores intentType as 'import', so the WCN-151 recipient guard still threw after adding lowercase import to NO_RECIPIENT_TX_TYPES. Also check intentType when resolving the exemption.

Co-authored-by: Cursor <cursoragent@cursor.com>

TICKET: CECHO-1425

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
