### PR TITLE
feat(statics): add CGD-1836 mainnet and testnet token configs

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -4153,7 +4153,7 @@ export const allCoinsAndTokens = [
     '941e3bbc-aaa4-4e06-837d-3511c9c09e5c',
     'tbaseeth:ttbills',
     'Test TBILLS',
-    6,
+    18,
     '0x52ae479d8b7ef0f3c27a3eb0072fb3995bdb77ca',
     UnderlyingAsset['tbaseeth:ttbills'],
     Networks.test.basechain
@@ -4751,6 +4751,24 @@ export const allCoinsAndTokens = [
     UnderlyingAsset['baseeth:frnt'],
     Networks.main.basechain,
     [...AccountCoin.DEFAULT_FEATURES, CoinFeature.STABLECOIN]
+  ),
+  erc20Token(
+    'de84435e-7312-40a6-8822-c50a17fd7729',
+    'baseeth:vbtc.b',
+    'Verified Bitcoin',
+    8,
+    '0x09096c6ebf35f0adaeec02d06a0de77e790f132d',
+    UnderlyingAsset['baseeth:vbtc.b'],
+    Networks.main.basechain
+  ),
+  erc20Token(
+    '33bde2a5-9082-47b3-9f56-de4900914bcc',
+    'baseeth:laptop',
+    'Laptop',
+    18,
+    '0xb095274743941e953c746f9c228da9c18bb6ec29',
+    UnderlyingAsset['baseeth:laptop'],
+    Networks.main.basechain
   ),
 
   // XDC mainnet tokens
@@ -6931,6 +6949,70 @@ export const allCoinsAndTokens = [
     '0x5e817f2abccb9095585d26c2a3ce234a440574fc',
     UnderlyingAsset['arbeth:frnt'],
     [...AccountCoin.DEFAULT_FEATURES, CoinFeature.STABLECOIN]
+  ),
+  arbethErc20(
+    'f0d99eb4-941d-4ed9-abe5-612be2c5a2c2',
+    'arbeth:opsbtc',
+    'Enhanced BTC Long Short Momentum',
+    18,
+    '0xc6900e6cdee6e46380289c0c854551f9896cbf5c',
+    UnderlyingAsset['arbeth:opsbtc']
+  ),
+  arbethErc20(
+    '90ec0b8b-8224-4c96-8392-835adba0cb17',
+    'arbeth:argt',
+    'Argentine Peso token',
+    18,
+    '0x59863989d080b22476db95656d0c3cc18be92214',
+    UnderlyingAsset['arbeth:argt']
+  ),
+  arbethErc20(
+    'ad5ad62d-e6dd-440c-b7e9-ea12a85dbf4e',
+    'arbeth:brat',
+    'Brazilian Real token',
+    18,
+    '0xc4ed6aba5373d78e160f4df39e011f078be54df8',
+    UnderlyingAsset['arbeth:brat']
+  ),
+  arbethErc20(
+    '6f154207-f173-464a-b797-89918f982509',
+    'arbeth:colt',
+    'Colombian Peso token',
+    18,
+    '0xa16d5db80a45157e0e451750b81ff0cc0b61d558',
+    UnderlyingAsset['arbeth:colt']
+  ),
+  arbethErc20(
+    '652367a5-29ef-4653-8568-a2da29ec3781',
+    'arbeth:mext',
+    'Mexican Peso token',
+    18,
+    '0xb96aa6babccd738d6644add4912fe5efbebf5a25',
+    UnderlyingAsset['arbeth:mext']
+  ),
+  arbethErc20(
+    'f0c16b09-762e-4e0a-b420-7e3732036fb1',
+    'arbeth:chlt',
+    'Chilean Peso token',
+    18,
+    '0xe8dbc4680235ccaeff48e4c0b0eaceebb89e5e17',
+    UnderlyingAsset['arbeth:chlt']
+  ),
+  arbethErc20(
+    '95de709e-8b1b-4aa4-987e-ff8b7e826647',
+    'arbeth:bolt',
+    'Bolivian Boliviano token',
+    18,
+    '0x1edf5e61b6a4fe19fef3a695328f61aaa07728ea',
+    UnderlyingAsset['arbeth:bolt']
+  ),
+  arbethErc20(
+    '323823d0-d249-4d1a-b770-e82963855022',
+    'arbeth:pert',
+    'Peruvian Sol Token',
+    18,
+    '0x899438713f62b04d6cd8e8709986f7256fb6e3d9',
+    UnderlyingAsset['arbeth:pert']
   ),
 
   opethErc20(

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -2142,6 +2142,7 @@ export enum UnderlyingAsset {
   'sol:usdc' = 'sol:usdc',
   'sol:agri' = 'sol:agri',
   'sol:usdca' = 'sol:usdca',
+  'sol:usde' = 'sol:usde',
   'sol:sonic' = 'sol:sonic',
   'sol:crdt' = 'sol:crdt',
   'sol:epxc' = 'sol:epxc',
@@ -2997,6 +2998,7 @@ export enum UnderlyingAsset {
   'polygon:pert' = 'polygon:pert',
   'polygon:colt' = 'polygon:colt',
   'polygon:bolt' = 'polygon:bolt',
+  'polygon:gmc' = 'polygon:gmc',
   // Polygon NFTs
   // generic NFTs
   'erc721:polygontoken' = 'erc721:polygontoken',
@@ -3191,6 +3193,8 @@ export enum UnderlyingAsset {
   'bsc:t-ibiton' = 'bsc:t-ibiton',
   'bsc:t-ivvon' = 'bsc:t-ivvon',
   'bsc:sqd' = 'bsc:sqd',
+  'bsc:skyai' = 'bsc:skyai',
+  'bsc:zktc' = 'bsc:zktc',
 
   // BSC NFTs
   // generic NFTs
@@ -3290,6 +3294,14 @@ export enum UnderlyingAsset {
   'arbeth:testpltr' = 'arbeth:testpltr',
   'arbeth:testnflx' = 'arbeth:testnflx',
   'arbeth:week' = 'arbeth:week',
+  'arbeth:opsbtc' = 'arbeth:opsbtc',
+  'arbeth:argt' = 'arbeth:argt',
+  'arbeth:brat' = 'arbeth:brat',
+  'arbeth:colt' = 'arbeth:colt',
+  'arbeth:mext' = 'arbeth:mext',
+  'arbeth:chlt' = 'arbeth:chlt',
+  'arbeth:bolt' = 'arbeth:bolt',
+  'arbeth:pert' = 'arbeth:pert',
 
   // BaseETH mainnet tokens
   'baseeth:aero' = 'baseeth:aero',
@@ -3346,6 +3358,8 @@ export enum UnderlyingAsset {
   'baseeth:colt' = 'baseeth:colt',
   'baseeth:bolt' = 'baseeth:bolt',
   'baseeth:gusdcq' = 'baseeth:gusdcq',
+  'baseeth:laptop' = 'baseeth:laptop',
+  'baseeth:vbtc.b' = 'baseeth:vbtc.b',
 
   // BaseETH testnet tokens
   'tbaseeth:usdc' = 'tbaseeth:usdc',
@@ -3728,6 +3742,7 @@ export enum UnderlyingAsset {
   'sol:alch' = 'sol:alch',
   'sol:launchcoin' = 'sol:launchcoin',
   'sol:stik' = 'sol:stik',
+  'sol:stampy' = 'sol:stampy',
   'sol:chill' = 'sol:chill',
   'sol:zbcn' = 'sol:zbcn',
   'sol:zaru' = 'sol:zaru',

--- a/modules/statics/src/coins/bscTokens.ts
+++ b/modules/statics/src/coins/bscTokens.ts
@@ -1715,6 +1715,24 @@ export const bscTokens = [
     UnderlyingAsset['bsc:hybond'],
     BSC_TOKEN_FEATURES
   ),
+  bscToken(
+    '20996d6a-c0f6-46cc-8912-9381c0ad08d0',
+    'bsc:zktc',
+    'Zakat Coin',
+    18,
+    '0x30437efebb55d190aadea63430fc2f4a7cf8991d',
+    UnderlyingAsset['bsc:zktc'],
+    BSC_TOKEN_FEATURES
+  ),
+  bscToken(
+    'b4e855e4-0132-4fb2-80a4-620d3ed4c123',
+    'bsc:skyai',
+    'SKYAI',
+    18,
+    '0x92aa03137385f18539301349dcfc9ebc923ffb10',
+    UnderlyingAsset['bsc:skyai'],
+    BSC_TOKEN_FEATURES
+  ),
   tbscToken(
     '2d4e4f61-1acd-416c-9d38-3d80d95a38d4',
     'tbsc:stgscaasacme',

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -1051,6 +1051,18 @@ export const ofcCoins = [
     UnderlyingAsset['sol:blsh'],
     SOL_OFC_TOKEN_FEATURES
   ),
+  ofcsolToken('57b9f83c-8699-49af-a8a0-377ed9ea1066', 'ofcsol:usde', 'Ethena USDe', 9, UnderlyingAsset['sol:usde'], [
+    ...SOL_OFC_TOKEN_FEATURES,
+    CoinFeature.STABLECOIN,
+  ]),
+  ofcsolToken(
+    '749387d9-c5b0-4ed2-91ae-56c6bdef6eda',
+    'ofcsol:stampy',
+    'Stampede',
+    6,
+    UnderlyingAsset['sol:stampy'],
+    SOL_OFC_TOKEN_FEATURES
+  ),
   ofcsolToken('e792c18a-05d1-4622-a8db-192f431b70a2', 'ofcsol:usdg', 'Global Dollar', 6, UnderlyingAsset['sol:usdg'], [
     CoinFeature.STABLECOIN,
   ]),
@@ -2454,6 +2466,62 @@ export const ofcCoins = [
     undefined,
     [CoinFeature.STABLECOIN]
   ),
+  ofcArbethErc20(
+    '088c42ee-cd8d-4984-a69e-f5cda577bf35',
+    'ofcarbeth:opsbtc',
+    'Enhanced BTC Long Short Momentum',
+    18,
+    UnderlyingAsset['arbeth:opsbtc']
+  ),
+  ofcArbethErc20(
+    'e6c3c234-5bae-4c81-85b6-44ee76d391b8',
+    'ofcarbeth:argt',
+    'Argentine Peso token',
+    18,
+    UnderlyingAsset['arbeth:argt']
+  ),
+  ofcArbethErc20(
+    '3b0588c7-4c88-4561-8004-40edc4dae30f',
+    'ofcarbeth:brat',
+    'Brazilian Real token',
+    18,
+    UnderlyingAsset['arbeth:brat']
+  ),
+  ofcArbethErc20(
+    'b740ab2e-339a-4252-a6a6-bf3d1d7f211e',
+    'ofcarbeth:colt',
+    'Colombian Peso token',
+    18,
+    UnderlyingAsset['arbeth:colt']
+  ),
+  ofcArbethErc20(
+    '973b2d0f-4117-47a5-ac20-8873e8788873',
+    'ofcarbeth:mext',
+    'Mexican Peso token',
+    18,
+    UnderlyingAsset['arbeth:mext']
+  ),
+  ofcArbethErc20(
+    'da83022e-aecc-41b3-819f-13634635dd36',
+    'ofcarbeth:chlt',
+    'Chilean Peso token',
+    18,
+    UnderlyingAsset['arbeth:chlt']
+  ),
+  ofcArbethErc20(
+    '537a23e6-1f3c-40ed-b89b-c8ab98a4d206',
+    'ofcarbeth:bolt',
+    'Bolivian Boliviano token',
+    18,
+    UnderlyingAsset['arbeth:bolt']
+  ),
+  ofcArbethErc20(
+    '27e7407b-3ae2-4058-91d4-48755257488d',
+    'ofcarbeth:pert',
+    'Peruvian Sol Token',
+    18,
+    UnderlyingAsset['arbeth:pert']
+  ),
 
   ofcAvaxErc20('2bd6201d-c46c-481e-b82d-7cf3601679cb', 'ofcavaxc:aave-e', 'Aave', 18, UnderlyingAsset['avaxc:aave']),
   ofcAvaxErc20(
@@ -2778,6 +2846,8 @@ export const ofcCoins = [
   ),
   ofcBscToken('f6c6ffed-f153-40ea-8fbe-768c4975c525', 'ofcbsc:dusk', 'Dusk Network', 18, UnderlyingAsset['bsc:dusk']),
   ofcBscToken('1421a7b9-cae3-4291-9211-68c9de1d0b5d', 'ofcbsc:hybond', 'HYBOND', 18, UnderlyingAsset['bsc:hybond']),
+  ofcBscToken('a7383921-3475-4ce9-b8c6-6a1c420213c3', 'ofcbsc:zktc', 'Zakat Coin', 18, UnderlyingAsset['bsc:zktc']),
+  ofcBscToken('a877ca78-c4df-45ab-ba16-d21cf2c2bed6', 'ofcbsc:skyai', 'SKYAI', 18, UnderlyingAsset['bsc:skyai']),
   ofcBscToken(
     '89dfd19c-d241-45e2-94b1-8a9bcdb9c09b',
     'ofcbsc:parti',
@@ -4352,6 +4422,15 @@ export const ofcCoins = [
     'Bolivian Boliviano Token',
     18,
     UnderlyingAsset['polygon:bolt']
+  ),
+  ofcPolygonErc20(
+    'c1276d10-6247-4da1-a295-2bc3988883a6',
+    'ofcpolygon:gmc',
+    'GameChips',
+    18,
+    UnderlyingAsset['polygon:gmc'],
+    undefined,
+    [CoinFeature.STABLECOIN]
   ),
 
   tofcPolygonErc20(

--- a/modules/statics/src/coins/ofcErc20Coins.ts
+++ b/modules/statics/src/coins/ofcErc20Coins.ts
@@ -4003,6 +4003,34 @@ export const ofcErc20Coins = [
     true,
     'baseeth'
   ),
+  ofcerc20(
+    '15d5e890-b5f0-427a-bc97-05f42d939d60',
+    'ofcbaseeth:vbtc.b',
+    'Verified Bitcoin',
+    8,
+    UnderlyingAsset['baseeth:vbtc.b'],
+    undefined,
+    undefined,
+    '',
+    undefined,
+    undefined,
+    true,
+    'baseeth'
+  ),
+  ofcerc20(
+    '1ddf8597-52b1-4995-abe8-58db12509f59',
+    'ofcbaseeth:laptop',
+    'Laptop',
+    18,
+    UnderlyingAsset['baseeth:laptop'],
+    undefined,
+    undefined,
+    '',
+    undefined,
+    undefined,
+    true,
+    'baseeth'
+  ),
 
   // Ink Network tokens
   ofcerc20(
@@ -6898,7 +6926,7 @@ export const tOfcErc20Coins = [
     'db419053-4226-4dd3-8fce-f0f2c28fafaa',
     'ofctbaseeth:ttbills',
     'Test TBILLS',
-    6,
+    18,
     UnderlyingAsset['tbaseeth:ttbills'],
     undefined,
     undefined,

--- a/modules/statics/src/coins/polygonTokens.ts
+++ b/modules/statics/src/coins/polygonTokens.ts
@@ -1624,6 +1624,15 @@ export const polygonTokens = [
     UnderlyingAsset['polygon:wots0'],
     POLYGON_TOKEN_FEATURES_EXCLUDE_SINGAPORE
   ),
+  polygonErc20(
+    '704cbc32-a299-428e-8b58-7b4b69715419',
+    'polygon:gmc',
+    'GameChips',
+    18,
+    '0x77ed728a4bcf7707a72a6a60a8e4ec95853311e2',
+    UnderlyingAsset['polygon:gmc'],
+    [...POLYGON_TOKEN_FEATURES, CoinFeature.STABLECOIN]
+  ),
   tpolygonErc20(
     '13dd4ab7-2d94-493c-9a61-323f6300f7e5',
     'tpolygon:tusdl',

--- a/modules/statics/src/coins/solTokens.ts
+++ b/modules/statics/src/coins/solTokens.ts
@@ -4100,6 +4100,27 @@ export const solTokens = [
     ProgramID.Token2022ProgramId
   ),
   solToken(
+    '2615f1bc-9514-45a6-acc1-7c6d6fa0213a',
+    'sol:usde',
+    'Ethena USDe',
+    9,
+    'DEkqHyPN7GMRJ5cArtQFAWefqbZb33Hyf6s5iCwjEonT', // https://solscan.io/token/DEkqHyPN7GMRJ5cArtQFAWefqbZb33Hyf6s5iCwjEonT
+    'DEkqHyPN7GMRJ5cArtQFAWefqbZb33Hyf6s5iCwjEonT',
+    UnderlyingAsset['sol:usde'],
+    [...SOL_TOKEN_FEATURES, CoinFeature.STABLECOIN]
+  ),
+  solToken(
+    'a17c6aff-5123-4c27-9c30-a7224f16a794',
+    'sol:stampy',
+    'Stampede',
+    6,
+    'EhTpqkdEXVhLHd1ufVVTKmH5XUQbJWDT3i1s5nvDSUvV', // https://solscan.io/token/EhTpqkdEXVhLHd1ufVVTKmH5XUQbJWDT3i1s5nvDSUvV
+    'EhTpqkdEXVhLHd1ufVVTKmH5XUQbJWDT3i1s5nvDSUvV',
+    UnderlyingAsset['sol:stampy'],
+    SOL_TOKEN_FEATURES,
+    ProgramID.Token2022ProgramId
+  ),
+  solToken(
     '7b7edb2a-3952-4083-8df9-cf16baa8d82c',
     'sol:gousd',
     'goUSD',


### PR DESCRIPTION
## Summary

Add mainnet and testnet token configs 

## Tokens added

### Base (`baseeth`)
- `baseeth:vbtc.b` — Verified Bitcoin
- `baseeth:laptop` — Laptop

### Solana (`sol`)
- `sol:usde` — Ethena USDe
- `sol:stampy` — Stampede

### Polygon (`polygon`)
- `polygon:gmc` — GameChips

### BSC (`bsc`)
- `bsc:zktc` — Zakat Coin
- `bsc:skyai` — SKYAI

### Arbitrum (`arbeth`)
- `arbeth:opsbtc` — Enhanced BTC Long Short Momentum
- `arbeth:argt` — Argentine Peso token
- `arbeth:brat` — Brazilian Real token
- `arbeth:colt` — Colombian Peso token
- `arbeth:mext` — Mexican Peso token
- `arbeth:chlt` — Chilean Peso token
- `arbeth:bolt` — Bolivian Boliviano token
- `arbeth:pert` — Peruvian Sol Token

### Base testnet (`tbaseeth`)
- `tbaseeth:ttbills` — Treasury Bills *(existing token; decimals updated to 18)*


Ticket: CGD-1836