### PR TITLE
fix(statics): update FLR explorer URLs to flarescan.com

### DIFF
--- a/modules/sdk-coin-flr/src/flr.ts
+++ b/modules/sdk-coin-flr/src/flr.ts
@@ -4,7 +4,7 @@
  * - Doc: https://docs.flare.network/user/wallets/
  *
  * @coinFullName Flare
- * @coinWebsite https://flare-explorer.flare.network
+ * @coinWebsite https://flarescan.com
  */
 
 import { BigNumber } from 'bignumber.js';

--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -2367,9 +2367,9 @@ export class FlarePTestnet extends Testnet implements FlareNetwork {
 export class Flare extends Mainnet implements EthereumNetwork {
   name = 'Flarechain';
   family = CoinFamily.FLR;
-  explorerUrl = 'https://flare-explorer.flare.network/tx/';
-  accountExplorerUrl = 'https://flare-explorer.flare.network/address/';
-  flarePublicUrl = 'https://flare-explorer.flare.network';
+  explorerUrl = 'https://flarescan.com/tx/';
+  accountExplorerUrl = 'https://flarescan.com/blockchain/address/';
+  flarePublicUrl = 'https://flarescan.com';
   chainId = 14;
   nativeCoinOperationHashPrefix = '14';
   walletFactoryAddress = '0x809ee567e413543af1caebcdb247f6a67eafc8dd';
@@ -2382,8 +2382,8 @@ export class Flare extends Mainnet implements EthereumNetwork {
 export class FlareTestnet extends Testnet implements EthereumNetwork {
   name = 'FlarechainTestnet';
   family = CoinFamily.FLR;
-  explorerUrl = 'https://coston2-explorer.flare.network/tx/';
-  accountExplorerUrl = 'https://coston2-explorer.flare.network/address/';
+  explorerUrl = 'https://coston2.testnet.flarescan.com/tx/';
+  accountExplorerUrl = 'https://coston2.testnet.flarescan.com/blockchain/address/';
   chainId = 114;
   nativeCoinOperationHashPrefix = '114';
   walletFactoryAddress = '0x809ee567e413543af1caebcdb247f6a67eafc8dd';


### PR DESCRIPTION
## Summary

- Replace deprecated `flare-explorer.flare.network` with `flarescan.com` for FLR C-chain explorer links
- FLR mainnet: `explorerUrl` → `https://flarescan.com/tx/`, `accountExplorerUrl` → `https://flarescan.com/blockchain/address/`
- TFLR testnet: `explorerUrl` → `https://coston2.testnet.flarescan.com/tx/`, `accountExplorerUrl` → `https://coston2.testnet.flarescan.com/blockchain/address/`
- FLRP P-chain already uses `flarescan.com` — no change needed

## Test plan

- [x] Verified TFLRP P-chain tx links open correctly (`/blockchain/pvm/tx/{hash}`)
- [x] Verified TFLR C-chain tx links open correctly (`/tx/{hash}`) on staging
- [x] Statics unit tests pass (30,494 passing)

Fixes CECHO-1443