### PR TITLE
fix: rename baseeth:vbtc.b to baseeth:vbtcb

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -4807,11 +4807,11 @@ export const allCoinsAndTokens = [
   ),
   erc20Token(
     'de84435e-7312-40a6-8822-c50a17fd7729',
-    'baseeth:vbtc.b',
+    'baseeth:vbtcb',
     'Verified Bitcoin',
     8,
     '0x09096c6ebf35f0adaeec02d06a0de77e790f132d',
-    UnderlyingAsset['baseeth:vbtc.b'],
+    UnderlyingAsset['baseeth:vbtcb'],
     Networks.main.basechain
   ),
   erc20Token(

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -3365,7 +3365,7 @@ export enum UnderlyingAsset {
   'baseeth:bolt' = 'baseeth:bolt',
   'baseeth:gusdcq' = 'baseeth:gusdcq',
   'baseeth:laptop' = 'baseeth:laptop',
-  'baseeth:vbtc.b' = 'baseeth:vbtc.b',
+  'baseeth:vbtcb' = 'baseeth:vbtcb',
 
   // BaseETH testnet tokens
   'tbaseeth:usdc' = 'tbaseeth:usdc',

--- a/modules/statics/src/coins/ofcErc20Coins.ts
+++ b/modules/statics/src/coins/ofcErc20Coins.ts
@@ -4005,10 +4005,10 @@ export const ofcErc20Coins = [
   ),
   ofcerc20(
     '15d5e890-b5f0-427a-bc97-05f42d939d60',
-    'ofcbaseeth:vbtc.b',
+    'ofcbaseeth:vbtcb',
     'Verified Bitcoin',
     8,
-    UnderlyingAsset['baseeth:vbtc.b'],
+    UnderlyingAsset['baseeth:vbtcb'],
     undefined,
     undefined,
     '',


### PR DESCRIPTION
## Summary
Rename `baseeth:vbtc.b` → `baseeth:vbtcb` to comply with token naming convention (no dots in token identifiers), same approach as [#8095](https://github.com/BitGo/BitGoJS/pull/8095) (`sol:usdc.a` → `sol:usdca`).

## Changes
- `base.ts`: `UnderlyingAsset['baseeth:vbtc.b']` → `UnderlyingAsset['baseeth:vbtcb']`
- `allCoinsAndTokens.ts`: `baseeth:vbtc.b` → `baseeth:vbtcb`
- `ofcErc20Coins.ts`: `ofcbaseeth:vbtc.b` → `ofcbaseeth:vbtcb`

## Contract details (unchanged)
| Field | Value |
|-------|-------|
| Chain | Base |
| Address | `0x09096c6ebf35f0adaeec02d06a0de77e790f132d` |
| Display name | Verified Bitcoin |
| On-chain symbol | `vBTC.b` |
| Decimals | 8 |
| Token UUID | `de84435e-7312-40a6-8822-c50a17fd7729` |
| OFC UUID | `15d5e890-b5f0-427a-bc97-05f42d939d60` |

## Ticket
CGD-1836

## Test plan
- [x] `@bitgo/statics` build passes
- [x] `@bitgo/statics` unit tests pass
- [ ] AMS gatekeep / OFC configs updated to `baseeth:vbtcb` / `ofcbaseeth:vbtcb` if deployed with old symbol


