### PR TITLE
fix(sdk-coin-polyx): stub getMaterial in recovery unit tests

### DIFF
--- a/modules/sdk-coin-polyx/test/unit/polyx.ts
+++ b/modules/sdk-coin-polyx/test/unit/polyx.ts
@@ -3,6 +3,8 @@ import { TestBitGo, TestBitGoAPI } from '@bitgo/sdk-test';
 import { BitGoAPI } from '@bitgo/sdk-api';
 import { Polyx, Tpolyx } from '../../src';
 import { POLYX_ADDRESS_FORMAT, TPOLYX_ADDRESS_FORMAT } from '../../src/lib/constants';
+import utils from '../../src/lib/utils';
+import { coins } from '@bitgo/statics';
 import * as sinon from 'sinon';
 import * as testData from '../resources/wrwUsers';
 import { afterEach } from 'mocha';
@@ -36,11 +38,14 @@ describe('Polyx:', function () {
     let accountInfoCB;
     let headerInfoCB;
     let getFeeCB;
+    let getMaterialCB;
 
     beforeEach(function () {
       accountInfoCB = sandBox.stub(Polyx.prototype, 'getAccountInfo' as keyof Polyx);
       headerInfoCB = sandBox.stub(Polyx.prototype, 'getHeaderInfo' as keyof Polyx);
       getFeeCB = sandBox.stub(Polyx.prototype, 'getFee' as keyof Polyx);
+      getMaterialCB = sandBox.stub(Polyx.prototype, 'getMaterial' as keyof Polyx);
+      getMaterialCB.resolves(utils.getMaterial(coins.get('tpolyx').network.type));
     });
 
     afterEach(function () {


### PR DESCRIPTION
## Summary
- Stub `getMaterial` in POLYX recovery unit tests so transaction build and decode use the same bundled metadata
- Fixes CI failures in `@bitgo/sdk-coin-polyx` after Polymesh testnet upgraded to runtime v8 (`specVersion: 8000000`)
- Matches the existing pattern in `@bitgo/sdk-coin-dot` recovery tests
## Problem
`Recover Transactions` unit tests were failing:
- `should recover a tx for non-bitgo recoveries`
- `should recover a txn for unsigned-sweep recoveries`
`recover()` called live `getMaterial()` (v8 metadata from `wss://testnet-rpc.polymesh.live`) while `getBuilder().from(serializedTx)` decoded using bundled v7 metadata (`specVersion: 7002000`). The mismatch caused decode errors (e.g. `treasury.disbursement`, `system.killStorage`).
## Fix
Test-only change in `modules/sdk-coin-polyx/test/unit/polyx.ts`:
```typescript
getMaterialCB = sandBox.stub(Polyx.prototype, 'getMaterial' as keyof Polyx);
getMaterialCB.resolves(utils.getMaterial(coins.get('tpolyx').network.type));
Production recover() is unchanged and still fetches live metadata for real broadcasts.
```

Ticket : [CGD-1862](https://linear.app/bitgo/issue/CGD-1862/fix-polyx-recovery-unit-tests-failing-after-polymesh-testnet-v8)
