### PR TITLE
fix(abstract-substrate): blake2_256 prehash signablePayload over 256 bytes

### DIFF
--- a/modules/abstract-substrate/src/lib/constants.ts
+++ b/modules/abstract-substrate/src/lib/constants.ts
@@ -1,1 +1,7 @@
 export const DEFAULT_SUBSTRATE_PREFIX = 42;
+
+/**
+ * Substrate signs the raw encoded `ExtrinsicPayload` only when it is at most this many bytes;
+ * larger payloads are signed as their blake2_256 hash instead. See `getSubstrateSigningBytes`.
+ */
+export const MAX_RAW_SIGNING_PAYLOAD_BYTES = 256;

--- a/modules/abstract-substrate/src/lib/transaction.ts
+++ b/modules/abstract-substrate/src/lib/transaction.ts
@@ -9,7 +9,6 @@ import {
 } from '@bitgo/sdk-core';
 import { BaseCoin as CoinConfig } from '@bitgo/statics';
 import Keyring, { decodeAddress } from '@polkadot/keyring';
-import { u8aToBuffer } from '@polkadot/util';
 import { construct, decode } from '@substrate/txwrapper-polkadot';
 import { UnsignedTransaction } from '@substrate/txwrapper-core';
 import { TypeRegistry } from '@substrate/txwrapper-core/lib/types';
@@ -533,12 +532,21 @@ export class Transaction extends BaseTransaction {
     this._substrateTransaction = tx;
   }
 
-  /** @inheritdoc **/
+  /**
+   * @inheritdoc
+   *
+   * Returns the bytes that are actually signed for this transaction. Substrate signs the raw
+   * encoded `ExtrinsicPayload` when it is at most 256 bytes, but for payloads larger than 256
+   * bytes it signs the blake2_256 hash of those bytes instead (see Polkadot.js
+   * `@polkadot/types/extrinsic/util` and the HSM firmware). Returning the raw payload for large
+   * extrinsics (e.g. nominate with many validators) would make the user and the HSM sign different
+   * messages, causing TSS signature combination to fail.
+   */
   get signablePayload(): Buffer {
     const extrinsicPayload = this._registry.createType('ExtrinsicPayload', this._substrateTransaction, {
       version: EXTRINSIC_VERSION,
     });
-    return u8aToBuffer(extrinsicPayload.toU8a({ method: true }));
+    return utils.getSubstrateSigningBytes(extrinsicPayload.toU8a({ method: true }));
   }
 
   /**

--- a/modules/abstract-substrate/src/lib/utils.ts
+++ b/modules/abstract-substrate/src/lib/utils.ts
@@ -4,8 +4,8 @@ import { decodeAddress, encodeAddress, Keyring } from '@polkadot/keyring';
 import { decodePair } from '@polkadot/keyring/pair/decode';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { EXTRINSIC_VERSION } from '@polkadot/types/extrinsic/v4/Extrinsic';
-import { hexToU8a, isHex, u8aToHex, u8aToU8a } from '@polkadot/util';
-import { base64Decode, signatureVerify } from '@polkadot/util-crypto';
+import { hexToU8a, isHex, u8aToBuffer, u8aToHex, u8aToU8a } from '@polkadot/util';
+import { base64Decode, blake2AsU8a, signatureVerify } from '@polkadot/util-crypto';
 import { UnsignedTransaction } from '@substrate/txwrapper-core';
 import { DecodedSignedTx, DecodedSigningPayload, TypeRegistry } from '@substrate/txwrapper-core/lib/types';
 import { construct, decode } from '@substrate/txwrapper-polkadot';
@@ -31,6 +31,7 @@ import {
   MoveStakeArgs,
 } from './iface';
 import { SingletonRegistry } from './singletonRegistry';
+import { MAX_RAW_SIGNING_PAYLOAD_BYTES } from './constants';
 
 export class Utils implements BaseUtils {
   /** @inheritdoc */
@@ -342,6 +343,22 @@ export class Utils implements BaseUtils {
     } catch (error) {
       throw new Error(`Failed to decode transaction: ${error}`);
     }
+  }
+
+  /**
+   * Returns the bytes that Substrate actually signs for a given raw encoded `ExtrinsicPayload`.
+   *
+   * Substrate signs the raw payload as-is when it is at most {@link MAX_RAW_SIGNING_PAYLOAD_BYTES}
+   * bytes, but for larger payloads it signs the 32-byte blake2_256 hash of those bytes instead
+   * (see Polkadot.js `@polkadot/types/extrinsic/util` and the HSM firmware). Using this helper
+   * ensures the user and the HSM sign the same message, which is required for TSS signature
+   * combination to succeed on large extrinsics (e.g. nominate with many validators).
+   *
+   * @param {Uint8Array} raw The raw encoded extrinsic payload bytes.
+   * @returns {Buffer} The bytes to sign: the raw payload, or its blake2_256 hash when oversized.
+   */
+  getSubstrateSigningBytes(raw: Uint8Array): Buffer {
+    return u8aToBuffer(raw.length > MAX_RAW_SIGNING_PAYLOAD_BYTES ? blake2AsU8a(raw, 256) : raw);
   }
 }
 

--- a/modules/sdk-coin-polyx/test/unit/transactionBuilder/batchStakingBuilder.ts
+++ b/modules/sdk-coin-polyx/test/unit/transactionBuilder/batchStakingBuilder.ts
@@ -234,6 +234,38 @@ describe('Polyx Batch Builder', function () {
     });
   });
 
+  describe('signablePayload (Substrate 256-byte blake2 rule)', function () {
+    const buildBatchTx = async (numValidators: number) => {
+      const batchBuilder = factory.getBatchBuilder();
+      batchBuilder
+        .amount(testAmount)
+        .controller({ address: controllerAddress })
+        .payee('Staked')
+        .validators(Array(numValidators).fill(validatorAddress))
+        .sender({ address: senderAddress })
+        .validity({ firstValid: 3933, maxDuration: 64 })
+        .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
+        .sequenceId({ name: 'Nonce', keyword: 'nonce', value: 100 });
+      batchBuilder.material(utils.getMaterial(coins.get('tpolyx').network.type));
+      return batchBuilder.build();
+    };
+
+    it('should return raw payload bytes when the batch extrinsic is at most 256 bytes', async () => {
+      // bond + nominate with a single validator stays under the 256-byte threshold
+      const tx = await buildBatchTx(1);
+      const signablePayload = tx.signablePayload;
+      signablePayload.length.should.be.belowOrEqual(256);
+      signablePayload.length.should.not.equal(32);
+    });
+
+    it('should return the 32-byte blake2_256 hash when the batch extrinsic exceeds 256 bytes', async () => {
+      // bond + nominate with many validators pushes the batch over the 256-byte threshold
+      const tx = await buildBatchTx(6);
+      const signablePayload = tx.signablePayload;
+      should.equal(signablePayload.length, 32);
+    });
+  });
+
   describe('From Raw Transaction', function () {
     it('should rebuild from real batch transaction', async () => {
       // First build a transaction to get a real raw transaction

--- a/modules/sdk-coin-polyx/test/unit/transactionBuilder/nominateBuilder.ts
+++ b/modules/sdk-coin-polyx/test/unit/transactionBuilder/nominateBuilder.ts
@@ -179,6 +179,52 @@ describe('Polyx Nominate Builder', function () {
     });
   });
 
+  describe('signablePayload (Substrate 256-byte blake2 rule)', () => {
+    const buildNominateTx = async (validators: string[]) => {
+      const material = utils.getMaterial(coins.get('tpolyx').network.type);
+      const nominateBuilder = factory.getNominateBuilder();
+      nominateBuilder
+        .validators(validators)
+        .sender({ address: senderAddress })
+        .validity({ firstValid: 3933, maxDuration: 64 })
+        .referenceBlock('0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d')
+        .sequenceId({ name: 'Nonce', keyword: 'nonce', value: 15 })
+        .fee({ amount: 0, type: 'tip' })
+        .material(material);
+      return nominateBuilder.build();
+    };
+
+    it('should return raw payload bytes when the extrinsic is at most 256 bytes', async () => {
+      const tx = await buildNominateTx([validatorAddress, validatorAddress2]);
+      const signablePayload = tx.signablePayload;
+      // small nominate extrinsic stays under the 256-byte threshold, so it is signed as-is
+      signablePayload.length.should.be.belowOrEqual(256);
+      signablePayload.length.should.not.equal(32);
+    });
+
+    it('should return the 32-byte blake2_256 hash when the extrinsic exceeds 256 bytes', async () => {
+      // 6+ validators (~33 bytes each) pushes the nominate extrinsic over the 256-byte threshold
+      const manyValidators = Array(8).fill(validatorAddress);
+      const tx = await buildNominateTx(manyValidators);
+      const signablePayload = tx.signablePayload;
+      should.equal(signablePayload.length, 32);
+    });
+
+    // The 256-byte boundary is impractical to hit with a real extrinsic, so exercise the
+    // raw-vs-hash decision directly through the shared Substrate signing-bytes helper.
+    it('should keep payloads of exactly 256 bytes raw and only hash strictly larger ones', () => {
+      const at = utils.getSubstrateSigningBytes(new Uint8Array(256).fill(7));
+      should.equal(at.length, 256);
+      at.should.deepEqual(Buffer.alloc(256, 7));
+
+      const below = utils.getSubstrateSigningBytes(new Uint8Array(255).fill(7));
+      should.equal(below.length, 255);
+
+      const above = utils.getSubstrateSigningBytes(new Uint8Array(257).fill(7));
+      should.equal(above.length, 32);
+    });
+  });
+
   describe('factory routing', () => {
     it('should route raw nominate extrinsic to NominateBuilder', () => {
       const resolvedBuilder = factory.from(nominateTx.signed);


### PR DESCRIPTION
## Summary

Substrate signs the raw encoded `ExtrinsicPayload` only when it is at most 256 bytes; for payloads larger than 256 bytes it signs the `blake2_256` hash of those bytes instead (Polkadot.js `@polkadot/types/extrinsic/util`, mirrored in the HSM firmware).

The `signablePayload` getter in `@bitgo/abstract-substrate` always returned the raw payload. For large extrinsics — e.g. POLYX `switchValidator`/nominate with 6+ validators — the BitGoJS user signed the raw bytes while the HSM signed the hash, so the two parties signed different messages and TSS G-share combine failed with `InvalidSignature`.

This fix makes `signablePayload` return the bytes that are *actually* signed:
- `length <= 256` → raw bytes (unchanged)
- `length > 256` → `blake2_256(raw)` (32 bytes)

The decision is extracted into a shared `utils.getSubstrateSigningBytes(raw)` helper (with the threshold as the `MAX_RAW_SIGNING_PAYLOAD_BYTES` constant) so the rule lives in one documented place and gives the future DOT fix a copy-paste target. All downstream consumers (`sdk-coin-polyx`, recovery flows) then get the correct `signableHex` at the source, with no coin-specific logic needed in WP.

## Testing

- `sdk-coin-polyx` `nominateBuilder`: small nominate extrinsic returns raw bytes (≤256, not 32); 8-validator nominate returns a 32-byte hashed payload.
- `sdk-coin-polyx` `batchStakingBuilder`: `bond + nominate` with 1 validator stays raw (≤256); with 6 validators returns a 32-byte hash. The batch wraps `nominate` and crosses the threshold sooner, so it is covered explicitly.
- Boundary test through the helper: exactly 256 bytes stays raw, 255 stays raw, 257 hashes to 32 bytes (off-by-one guard).
- Existing POLYX MPC/TSS unit tests (including "should add TSS signature") pass with the updated semantics.

## Notes / follow-ups

- `sdk-coin-dot` has its own standalone `signablePayload` getter with the same raw-only bug, and the DOT wasm path (`wasmTx.signablePayload()`) needs separate verification. Both are out of scope here per the issue and tracked as a DOT follow-up; the new helper is the intended drop-in for that fix.
- This SDK change only fixes prod once WP bumps `@bitgo-beta/abstract-substrate`