### PR TITLE
feat(abstract-substrate): expose rawExtrinsicPayload separate from signablePayload

### DIFF
--- a/modules/abstract-substrate/src/lib/transaction.ts
+++ b/modules/abstract-substrate/src/lib/transaction.ts
@@ -533,6 +533,21 @@ export class Transaction extends BaseTransaction {
   }
 
   /**
+   * Returns the full raw encoded `ExtrinsicPayload` bytes (including the method) for this
+   * transaction, without applying the Substrate 256-byte blake2_256 signing rule.
+   *
+   * These are the bytes the HSM signs on the `polyx/signtx` path. They differ from
+   * {@link signablePayload} once the payload exceeds 256 bytes, where {@link signablePayload}
+   * is the blake2_256 hash instead of the raw bytes.
+   */
+  get rawExtrinsicPayload(): Uint8Array {
+    const extrinsicPayload = this._registry.createType('ExtrinsicPayload', this._substrateTransaction, {
+      version: EXTRINSIC_VERSION,
+    });
+    return extrinsicPayload.toU8a({ method: true });
+  }
+
+  /**
    * @inheritdoc
    *
    * Returns the bytes that are actually signed for this transaction. Substrate signs the raw
@@ -543,10 +558,7 @@ export class Transaction extends BaseTransaction {
    * messages, causing TSS signature combination to fail.
    */
   get signablePayload(): Buffer {
-    const extrinsicPayload = this._registry.createType('ExtrinsicPayload', this._substrateTransaction, {
-      version: EXTRINSIC_VERSION,
-    });
-    return utils.getSubstrateSigningBytes(extrinsicPayload.toU8a({ method: true }));
+    return utils.getSubstrateSigningBytes(this.rawExtrinsicPayload);
   }
 
   /**

--- a/modules/sdk-coin-polyx/src/lib/iface.ts
+++ b/modules/sdk-coin-polyx/src/lib/iface.ts
@@ -14,6 +14,13 @@ export interface TxData extends Interface.TxData {
   toDID?: string;
   instructionId?: string;
   portfolioDID?: string;
+  /**
+   * Hex of the full raw encoded `ExtrinsicPayload` (see `Transaction.rawExtrinsicPayload`).
+   * Surfaced alongside the MPC/combine `signableHex` so consumers that need the raw payload
+   * (e.g. the HSM `polyx/signtx` path) can use it for extrinsics larger than 256 bytes, where
+   * the signing bytes are the blake2_256 hash rather than the raw payload.
+   */
+  rawSignableHex?: string;
 }
 
 /**

--- a/modules/sdk-coin-polyx/src/lib/transaction.ts
+++ b/modules/sdk-coin-polyx/src/lib/transaction.ts
@@ -71,6 +71,7 @@ export class Transaction extends SubstrateTransaction {
       eraPeriod: decodedTx.eraPeriod,
       chainName: this._chainName,
       tip: decodedTx.tip ? Number(decodedTx.tip) : 0,
+      rawSignableHex: Buffer.from(this.rawExtrinsicPayload).toString('hex'),
     };
 
     const txMethod = decodedTx.method.args;
@@ -99,7 +100,9 @@ export class Transaction extends SubstrateTransaction {
       result.portfolioDID = rejectInstructionArgs.portfolio.did as string;
       result.amount = '0'; // Reject instruction does not transfer any value
     } else {
-      return super.toJson() as TxData;
+      const baseResult = super.toJson() as TxData;
+      baseResult.rawSignableHex = result.rawSignableHex;
+      return baseResult;
     }
 
     return result;

--- a/modules/sdk-coin-polyx/test/unit/transactionBuilder/nominateBuilder.ts
+++ b/modules/sdk-coin-polyx/test/unit/transactionBuilder/nominateBuilder.ts
@@ -1,7 +1,7 @@
 import { decode } from '@substrate/txwrapper-polkadot';
 import { coins } from '@bitgo/statics';
 import should from 'should';
-import { TransactionBuilderFactory, NominateBuilder, BatchBuilder } from '../../../src/lib';
+import { TransactionBuilderFactory, NominateBuilder, BatchBuilder, PolyxTransaction } from '../../../src/lib';
 import { TransactionType } from '@bitgo/sdk-core';
 import utils from '../../../src/lib/utils';
 import { accounts, nominateTx, nominateValidators, stakingTx } from '../../resources';
@@ -191,7 +191,7 @@ describe('Polyx Nominate Builder', function () {
         .sequenceId({ name: 'Nonce', keyword: 'nonce', value: 15 })
         .fee({ amount: 0, type: 'tip' })
         .material(material);
-      return nominateBuilder.build();
+      return (await nominateBuilder.build()) as PolyxTransaction;
     };
 
     it('should return raw payload bytes when the extrinsic is at most 256 bytes', async () => {
@@ -200,14 +200,31 @@ describe('Polyx Nominate Builder', function () {
       // small nominate extrinsic stays under the 256-byte threshold, so it is signed as-is
       signablePayload.length.should.be.belowOrEqual(256);
       signablePayload.length.should.not.equal(32);
+      // for a sub-256-byte payload, signablePayload is exactly the raw extrinsic payload
+      const rawExtrinsicPayload = Buffer.from(tx.rawExtrinsicPayload);
+      rawExtrinsicPayload.should.deepEqual(signablePayload);
+      // toJson surfaces the full raw payload as rawSignableHex even when it equals signablePayload
+      should.equal(tx.toJson().rawSignableHex, rawExtrinsicPayload.toString('hex'));
     });
 
     it('should return the 32-byte blake2_256 hash when the extrinsic exceeds 256 bytes', async () => {
-      // 6+ validators (~33 bytes each) pushes the nominate extrinsic over the 256-byte threshold
-      const manyValidators = Array(8).fill(validatorAddress);
+      // Each nominate target adds a 33-byte MultiAddress (1-byte variant + 32-byte account id) on
+      // top of 79 bytes of fixed signing-payload overhead (call index, era, nonce, tip,
+      // spec/transaction versions, genesis + block hash). So 5 targets stay raw at 244 bytes and
+      // 6 already cross to 277 bytes (hashed). 8 would also exceed the threshold; this uses 9 to
+      // mirror the multi-nomination scenario from SI-926 with margin (376 bytes).
+      const manyValidators = Array(9).fill(validatorAddress);
       const tx = await buildNominateTx(manyValidators);
       const signablePayload = tx.signablePayload;
       should.equal(signablePayload.length, 32);
+      // the raw extrinsic payload stays full-length and diverges from the hashed signablePayload
+      const rawExtrinsicPayload = Buffer.from(tx.rawExtrinsicPayload);
+      rawExtrinsicPayload.length.should.be.greaterThan(256);
+      rawExtrinsicPayload.should.not.deepEqual(signablePayload);
+      // signablePayload is the blake2_256 hash of the raw extrinsic payload
+      utils.getSubstrateSigningBytes(tx.rawExtrinsicPayload).should.deepEqual(signablePayload);
+      // toJson surfaces the full raw payload as rawSignableHex for the HSM signing path
+      should.equal(tx.toJson().rawSignableHex, rawExtrinsicPayload.toString('hex'));
     });
 
     // The 256-byte boundary is impractical to hit with a real extrinsic, so exercise the


### PR DESCRIPTION
## Summary

POLYX TSS follows Substrate signing rules: extrinsics over 256 bytes are signed as a `blake2_256` hash rather than the raw payload. `signablePayload` already applies this (correct for user MPC/combine), but nothing exposed the raw `ExtrinsicPayload` bytes that the HSM `polyx/signtx` path needs. Large nominate/switch-validator txs (e.g. 9 validators) therefore broke signing on prod.

This exposes the raw payload separately while keeping `signablePayload` as the correct MPC/combine signing bytes.

## Changes

- **`abstract-substrate`**: add a `rawExtrinsicPayload` getter (full `ExtrinsicPayload.toU8a({ method: true })`), and refactor `signablePayload` to derive from it via `utils.getSubstrateSigningBytes` — no duplicated 256-byte logic in `transaction.ts`.
- **`sdk-coin-polyx`**: surface the raw payload as `rawSignableHex` in the polyx `toJson` output, so consumers needing the raw bytes can read it alongside `signableHex`. The field is declared on the polyx-specific `TxData` (not the shared `abstract-substrate` one), so other Substrate coins (tao, dot, etc.) are unaffected.

## Testing

`yarn unit-test` for the nominate builder. New cases assert:
- ≤256B nominate: `signablePayload` equals the raw `rawExtrinsicPayload` bytes, and `toJson().rawSignableHex` matches the raw hex.
- &gt;256B nominate (9 validators): `signablePayload` is the 32-byte blake2_256 hash, `rawExtrinsicPayload` is the full raw payload (&gt;256B), and `toJson().rawSignableHex` matches the raw hex. (Each target adds 33 bytes over 79 bytes of fixed overhead, so the extrinsic crosses 256B from 6 targets up; 9 mirrors the SI-926 scenario.)