### PR TITLE
refactor: update titles and descriptions in QR keycard data gen

### DIFF
--- a/modules/key-card/src/generateQrData.ts
+++ b/modules/key-card/src/generateQrData.ts
@@ -113,9 +113,8 @@ function generateBitGoQrData(bitgoKeychain: Keychain): QrDataEntry {
   assert.ok(bitgoData);
 
   return {
-    title: 'C: BitGo Public Key',
-    description:
-      'This is the public part of the key that BitGo will use to ' + 'co-sign transactions\r\nwith you on your wallet.',
+    title: 'C: BitGo Key',
+    description: 'This is the public part of the key held by BitGo.',
     data: bitgoData,
   };
 }
@@ -132,7 +131,7 @@ function generateUserMasterPublicKeyQRData(publicKey: string): MasterPublicKeyQr
 function generatePasscodeQrData(passphrase: string, passcodeEncryptionCode: string): QrDataEntry {
   const encryptedWalletPasscode = encrypt(passcodeEncryptionCode, passphrase);
   return {
-    title: 'D: Encrypted wallet Password',
+    title: 'D: Encrypted Wallet Password',
     description: 'This is the wallet password, encrypted client-side with a key held by BitGo.',
     data: encryptedWalletPasscode,
   };
@@ -145,7 +144,7 @@ async function generatePasscodeQrDataAsync(
 ): Promise<QrDataEntry> {
   const encryptedWalletPasscode = await encryptAsync(passcodeEncryptionCode, passphrase, { encryptionVersion });
   return {
-    title: 'D: Encrypted wallet Password',
+    title: 'D: Encrypted Wallet Password',
     description: 'This is the wallet password, encrypted client-side with a key held by BitGo.',
     data: encryptedWalletPasscode,
   };

--- a/modules/key-card/test/unit/generateQrData.ts
+++ b/modules/key-card/test/unit/generateQrData.ts
@@ -71,14 +71,12 @@ describe('generateQrData', function () {
     qrData.backup.data.should.equal(backupEncryptedPrv);
 
     assert.ok(qrData.bitgo);
-    qrData.bitgo.title.should.equal('C: BitGo Public Key');
-    qrData.bitgo.description.should.equal(
-      'This is the public part of the key that BitGo will use to ' + 'co-sign transactions\r\nwith you on your wallet.'
-    );
+    qrData.bitgo.title.should.equal('C: BitGo Key');
+    qrData.bitgo.description.should.equal('This is the public part of the key held by BitGo.');
     qrData.bitgo.data.should.equal(bitgoPub);
 
     assert.ok(qrData.passcode);
-    qrData.passcode.title.should.equal('D: Encrypted wallet Password');
+    qrData.passcode.title.should.equal('D: Encrypted Wallet Password');
     qrData.passcode.description.should.equal(
       'This is the wallet password, encrypted client-side with a key held by BitGo.'
     );
@@ -163,7 +161,7 @@ describe('generateQrData', function () {
       should.not.exist(qrData.bitgo);
 
       assert.ok(qrData.passcode);
-      qrData.passcode.title.should.equal('D: Encrypted wallet Password');
+      qrData.passcode.title.should.equal('D: Encrypted Wallet Password');
       const decryptedData = decrypt(passcodeEncryptionCode, qrData.passcode.data);
       decryptedData.should.equal(passphrase);
     });

--- a/modules/sdk-core/src/bitgo/internal/keycard.ts
+++ b/modules/sdk-core/src/bitgo/internal/keycard.ts
@@ -126,15 +126,13 @@ function buildKeycardQrData(options: BuildKeycardQrDataOptions, encryptedWalletP
       data: backupKeychain.encryptedPrv,
     },
     bitgo: {
-      title: 'C: BitGo Public Key',
-      desc:
-        'This is the public part of the key that BitGo will use to ' +
-        'co-sign transactions\r\nwith you on your wallet.',
+      title: 'C: BitGo Key',
+      desc: 'This is the public part of the key held by BitGo.',
       data: bitgoKeychain.pub,
     },
     passcode: {
       title: 'D: Encrypted Wallet Password',
-      desc: 'This is the wallet  password, encrypted client-side ' + 'with a key held by\r\nBitGo.',
+      desc: 'This is the wallet password, encrypted client-side ' + 'with a key held by\r\nBitGo.',
       data: encryptedWalletPasscode,
     },
   };


### PR DESCRIPTION
Updating verbiage on keycard PDF (old `sdk-core` path and new `key-card` module) as per ticket

- C: BitGo Public Key — This is the public part of the key that BitGo will use to co-sign transactions with you on your wallet.
- C: BitGo Key — This is the public part of the key held by BitGo.

and

- D: Encrypted wallet Password
- D: Encrypted Wallet Password

See example of the updated copy here (data is fake):

<img width="558" height="322" alt="image" src="https://github.com/user-attachments/assets/5f9fa218-b888-40be-8f2b-ecb17164442c" />

Ticket: WCN-520

Minor notes: fixed pre-existing double space in old `sdk-core` keycard.
