### PR TITLE
fix(sdk-coin-sol): migrate recover() and recoverCloseATA() to BIP32-E…

### DIFF
--- a/modules/sdk-coin-sol/src/sol.ts
+++ b/modules/sdk-coin-sol/src/sol.ts
@@ -1267,13 +1267,8 @@ export class Sol extends BaseCoin {
     const index = params.index || 0;
     const currPath = params.seed ? getDerivationPath(params.seed) + `/${index}` : `m/${index}`;
 
-    let accountId: string;
-    if (isMpcV2) {
-      accountId = deriveUnhardenedMps(bitgoKey, currPath).slice(0, 64);
-    } else {
-      const MPC = await EDDSAMethods.getInitializedMpcInstance();
-      accountId = MPC.deriveUnhardened(bitgoKey, currPath).slice(0, 64);
-    }
+    const MPC = await EDDSAMethods.getInitializedMpcInstance();
+    const accountId = MPC.deriveUnhardened(bitgoKey, currPath).slice(0, 64);
     const bs58EncodedPublicKey = new SolKeyPair({ pub: accountId }).getAddress();
 
     balance = await this.getAccountBalance(bs58EncodedPublicKey, params.apiKey);
@@ -1559,13 +1554,8 @@ export class Sol extends BaseCoin {
     const index = params.index || 0;
     const currPath = params.seed ? getDerivationPath(params.seed) + `/${index}` : `m/${index}`;
 
-    let accountId: string;
-    if (isMpcV2) {
-      accountId = deriveUnhardenedMps(bitgoKey, currPath).slice(0, 64);
-    } else {
-      const MPC = await EDDSAMethods.getInitializedMpcInstance();
-      accountId = MPC.deriveUnhardened(bitgoKey, currPath).slice(0, 64);
-    }
+    const MPC = await EDDSAMethods.getInitializedMpcInstance();
+    const accountId = MPC.deriveUnhardened(bitgoKey, currPath).slice(0, 64);
     const bs58EncodedPublicKey = new SolKeyPair({ pub: accountId }).getAddress();
 
     const accountBalance = await this.getAccountBalance(bs58EncodedPublicKey);

--- a/modules/sdk-coin-sol/test/unit/sol.ts
+++ b/modules/sdk-coin-sol/test/unit/sol.ts
@@ -3064,19 +3064,20 @@ describe('SOL:', function () {
       mpcV2UserKey = encrypt(walletPassphrase, userDkg.getReducedKeyShare().toString('base64'));
       mpcV2BackupKey = encrypt(walletPassphrase, backupDkg.getReducedKeyShare().toString('base64'));
       mpcV2CommonKeyChain = userDkg.getCommonKeychain();
+      const mpc = await EDDSAMethods.getInitializedMpcInstance();
       mpcV2WalletAddress = new KeyPair({
-        pub: deriveUnhardenedMps(mpcV2CommonKeyChain, 'm/0').slice(0, 64),
+        pub: mpc.deriveUnhardened(mpcV2CommonKeyChain, 'm/0').slice(0, 64),
       }).getAddress();
       mismatchedBitgoKey = otherUserDkg.getCommonKeychain();
       mismatchedWalletAddress = new KeyPair({
-        pub: deriveUnhardenedMps(mismatchedBitgoKey, 'm/0').slice(0, 64),
+        pub: mpc.deriveUnhardened(mismatchedBitgoKey, 'm/0').slice(0, 64),
       }).getAddress();
 
       mpcV2TokenUserKey = encrypt(walletPassphrase, tokenUserDkg.getReducedKeyShare().toString('base64'));
       mpcV2TokenBackupKey = encrypt(walletPassphrase, tokenBackupDkg.getReducedKeyShare().toString('base64'));
       mpcV2TokenCommonKeyChain = tokenUserDkg.getCommonKeychain();
       mpcV2TokenWalletAddress = new KeyPair({
-        pub: deriveUnhardenedMps(mpcV2TokenCommonKeyChain, 'm/0').slice(0, 64),
+        pub: mpc.deriveUnhardened(mpcV2TokenCommonKeyChain, 'm/0').slice(0, 64),
       }).getAddress();
 
       mpcV2RecoverParams = {
@@ -3959,10 +3960,11 @@ describe('SOL:', function () {
       mpcV2UserKey = encrypt(walletPassphrase, userDkg.getReducedKeyShare().toString('base64'));
       mpcV2BackupKey = encrypt(walletPassphrase, backupDkg.getReducedKeyShare().toString('base64'));
       mpcV2CommonKeyChain = userDkg.getCommonKeychain();
+      const mpc = await EDDSAMethods.getInitializedMpcInstance();
 
-      mpcV2Address1 = new KeyPair({ pub: deriveUnhardenedMps(mpcV2CommonKeyChain, 'm/1').slice(0, 64) }).getAddress();
-      mpcV2Address2 = new KeyPair({ pub: deriveUnhardenedMps(mpcV2CommonKeyChain, 'm/2').slice(0, 64) }).getAddress();
-      mpcV2Address3 = new KeyPair({ pub: deriveUnhardenedMps(mpcV2CommonKeyChain, 'm/3').slice(0, 64) }).getAddress();
+      mpcV2Address1 = new KeyPair({ pub: mpc.deriveUnhardened(mpcV2CommonKeyChain, 'm/1').slice(0, 64) }).getAddress();
+      mpcV2Address2 = new KeyPair({ pub: mpc.deriveUnhardened(mpcV2CommonKeyChain, 'm/2').slice(0, 64) }).getAddress();
+      mpcV2Address3 = new KeyPair({ pub: mpc.deriveUnhardened(mpcV2CommonKeyChain, 'm/3').slice(0, 64) }).getAddress();
 
       mpcV2TokenUserKey = encrypt(walletPassphrase, tokenUserDkg.getReducedKeyShare().toString('base64'));
       mpcV2TokenBackupKey = encrypt(walletPassphrase, tokenBackupDkg.getReducedKeyShare().toString('base64'));
@@ -3972,7 +3974,7 @@ describe('SOL:', function () {
         pub: deriveUnhardenedMps(mpcV2TokenCommonKeyChain, 'm/0').slice(0, 64),
       }).getAddress();
       mpcV2TokenAddress1 = new KeyPair({
-        pub: deriveUnhardenedMps(mpcV2TokenCommonKeyChain, 'm/1').slice(0, 64),
+        pub: mpc.deriveUnhardened(mpcV2TokenCommonKeyChain, 'm/1').slice(0, 64),
       }).getAddress();
     });
 
@@ -4105,7 +4107,7 @@ describe('SOL:', function () {
           .resolves(testData.SolResponses.getAccountBalanceResponseNoFunds);
       }
       const mpcV2Address4 = new KeyPair({
-        pub: deriveUnhardenedMps(mpcV2CommonKeyChain, 'm/4').slice(0, 64),
+        pub: (await EDDSAMethods.getInitializedMpcInstance()).deriveUnhardened(mpcV2CommonKeyChain, 'm/4').slice(0, 64),
       }).getAddress();
       callBack
         .withArgs({ payload: { id: '1', jsonrpc: '2.0', method: 'getBalance', params: [mpcV2Address4] } })


### PR DESCRIPTION
…d25519 derivation

Replace Silence Labs single-HMAC formula (deriveUnhardenedMps) with Eddsa.deriveUnhardened for MPCv2 account ID derivation in recover() and recoverCloseATA(). Both methods now use the same derivation path regardless of MPCv1/MPCv2.

Ticket: WCI-644

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
