### PR TITLE
fix(sdk-coin-sol): migrate remaining recovery methods to BIP32-Ed25519

### DIFF
--- a/modules/sdk-coin-sol/src/sol.ts
+++ b/modules/sdk-coin-sol/src/sol.ts
@@ -61,7 +61,7 @@ import {
   UnexpectedAddressError,
   EDDSAUtils,
 } from '@bitgo/sdk-core';
-import { auditEddsaPrivateKey, deriveUnhardenedMps, getDerivationPath } from '@bitgo/sdk-lib-mpc';
+import { auditEddsaPrivateKey, getDerivationPath } from '@bitgo/sdk-lib-mpc';
 import { BaseNetwork, CoinFamily, coins, SolCoin, BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 import {
   KeyPair as SolKeyPair,
@@ -1705,9 +1705,9 @@ export class Sol extends BaseCoin {
 
     const index = params.index || 0;
     const currPath = params.seed ? getDerivationPath(params.seed) + `/${index}` : `m/${index}`;
-    const accountId = isMpcV2
-      ? deriveUnhardenedMps(bitgoKey, currPath).slice(0, 64)
-      : (await EDDSAMethods.getInitializedMpcInstance()).deriveUnhardened(bitgoKey, currPath).slice(0, 64);
+    const accountId = (await EDDSAMethods.getInitializedMpcInstance())
+      .deriveUnhardened(bitgoKey, currPath)
+      .slice(0, 64);
     const bs58EncodedPublicKey = new SolKeyPair({ pub: accountId }).getAddress();
 
     const blockhash = await this.getBlockhash(params.apiKey);
@@ -1826,9 +1826,9 @@ export class Sol extends BaseCoin {
     const baseAddressPath = params.seed
       ? getDerivationPath(params.seed) + `/${baseAddressIndex}`
       : `m/${baseAddressIndex}`;
-    const baseAccountId = isMpcV2
-      ? deriveUnhardenedMps(bitgoKey, baseAddressPath).slice(0, 64)
-      : (await EDDSAMethods.getInitializedMpcInstance()).deriveUnhardened(bitgoKey, baseAddressPath).slice(0, 64);
+    const baseAccountId = (await EDDSAMethods.getInitializedMpcInstance())
+      .deriveUnhardened(bitgoKey, baseAddressPath)
+      .slice(0, 64);
     const baseAddress = new SolKeyPair({ pub: baseAccountId }).getAddress();
 
     let durableNoncePubKeysIndex = 0;

--- a/modules/sdk-coin-sol/test/unit/sol.ts
+++ b/modules/sdk-coin-sol/test/unit/sol.ts
@@ -23,7 +23,7 @@ import {
   Wallet,
   WalletCoinSpecific,
 } from '@bitgo/sdk-core';
-import { deriveUnhardenedMps, MPSUtil } from '@bitgo/sdk-lib-mpc';
+import { MPSUtil } from '@bitgo/sdk-lib-mpc';
 import { TestBitGo, TestBitGoAPI } from '@bitgo/sdk-test';
 import { coins } from '@bitgo/statics';
 import {
@@ -3971,7 +3971,7 @@ describe('SOL:', function () {
       mpcV2TokenCommonKeyChain = tokenUserDkg.getCommonKeychain();
 
       mpcV2TokenBaseAddress = new KeyPair({
-        pub: deriveUnhardenedMps(mpcV2TokenCommonKeyChain, 'm/0').slice(0, 64),
+        pub: mpc.deriveUnhardened(mpcV2TokenCommonKeyChain, 'm/0').slice(0, 64),
       }).getAddress();
       mpcV2TokenAddress1 = new KeyPair({
         pub: mpc.deriveUnhardened(mpcV2TokenCommonKeyChain, 'm/1').slice(0, 64),


### PR DESCRIPTION
Replace Silence Labs single-HMAC formula (deriveUnhardenedMps) with Eddsa.deriveUnhardened for MPCv2 account ID derivation in recoverNestedAta() and recoverConsolidations().

Ticket: WCI-644

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
