### PR TITLE
fix(sdk-coin-eth): fix verifyTransaction for zama TSS tx

### DIFF
--- a/modules/sdk-coin-eth/src/erc7984Token.ts
+++ b/modules/sdk-coin-eth/src/erc7984Token.ts
@@ -147,6 +147,10 @@ export class Erc7984Token extends Eth {
       verification?.consolidationToBaseAddress ||
       txPrebuild?.consolidateId ||
       txParams?.type === 'consolidate' ||
+      // TSS signing path: resolveEffectiveTxParams sets type from intent.intentType which is
+      // 'consolidateToken' for ERC-7984 token consolidations. txPrebuild has only txHex
+      // (no consolidateId) in this path.
+      txParams?.type === 'consolidateToken' ||
       txParams?.prebuildTx?.consolidateId
     );
   }

--- a/modules/sdk-coin-eth/test/unit/erc7984Token.ts
+++ b/modules/sdk-coin-eth/test/unit/erc7984Token.ts
@@ -1108,4 +1108,42 @@ describe('verifyTransaction – confidential consolidation (FlushERC7984Forwarde
       })
       .should.be.rejectedWith(/forwarder address mismatch/);
   });
+
+  // TSS MPCv2 signing path — resolveEffectiveTxParams sets type from intent.intentType ('consolidateToken'),
+  // and txPrebuild has only txHex (no consolidateId, no recipients). This was the broken path before
+  // isConsolidationTransaction was updated to recognise 'consolidateToken'.
+  it('should verify a valid direct callFromParent consolidation tx when type is consolidateToken (TSS MPCv2 signing path)', async function () {
+    const txHex = await buildDirectConsolidationTxHex();
+    const wallet = new Wallet(bitgo, coin, {
+      coinSpecific: { baseAddress: CONSOLIDATION_BASE_ADDRESS },
+    });
+
+    const result = await coin.verifyTransaction({
+      txParams: {
+        type: 'consolidateToken',
+        recipients: [{ address: CONSOLIDATION_FORWARDER, amount: '0' }],
+      } as any,
+      txPrebuild: { txHex } as any,
+      wallet,
+    });
+    result.should.equal(true);
+  });
+
+  it('should reject callFromParent consolidation with type consolidateToken when parent address does not match wallet base address', async function () {
+    const txHex = await buildDirectConsolidationTxHex();
+    const wallet = new Wallet(bitgo, coin, {
+      coinSpecific: { baseAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' },
+    });
+
+    await coin
+      .verifyTransaction({
+        txParams: {
+          type: 'consolidateToken',
+          recipients: [{ address: CONSOLIDATION_FORWARDER, amount: '0' }],
+        } as any,
+        txPrebuild: { txHex } as any,
+        wallet,
+      })
+      .should.be.rejectedWith(/parent address mismatch/);
+  });
 });


### PR DESCRIPTION
TICKET: CHALO-726

This pull request updates the logic for detecting ERC-7984 token consolidation transactions to support a new TSS MPCv2 signing path and adds corresponding unit tests to ensure correct behavior. The main focus is to recognize transactions with the type `consolidateToken` as valid consolidations, addressing a previously broken verification path.

**ERC-7984 Token Consolidation Improvements:**

* Updated the `isConsolidationTransaction` logic in `erc7984Token.ts` to recognize transactions where `txParams.type` is `'consolidateToken'`, ensuring support for the TSS MPCv2 signing path.

**Unit Test Enhancements:**

* Added tests in `erc7984Token.ts` to verify that transactions with `type: 'consolidateToken'` are correctly identified as consolidations and properly validated, including both acceptance and rejection scenarios based on address matching.

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
