### PR TITLE
feat(statics): onboard XRP MPT mainnet tokens xrp:kld and xrp:key

### DIFF
--- a/modules/sdk-coin-xrp/test/unit/xrpToken.ts
+++ b/modules/sdk-coin-xrp/test/unit/xrpToken.ts
@@ -58,6 +58,38 @@ describe('Xrp MPT Tokens', function () {
     names.should.containEql('txrp:feesec');
   });
 
+  it('should register mainnet MPT tokens xrp:kld and xrp:key', function () {
+    const names = XrpMptToken.createTokenConstructors().map(({ name }) => name);
+    names.should.containEql('xrp:kld');
+    names.should.containEql('xrp:key');
+  });
+
+  it('should return correct constants for xrp:kld', function () {
+    const kld = bitgo.coin('xrp:kld') as XrpMptToken;
+    kld.getChain().should.equal('xrp:kld');
+    kld.getBaseChain().should.equal('xrp');
+    kld.getFullName().should.equal('XRP MPT Token');
+    kld.getBaseFactor().should.equal(1000000); // assetScale 6 → 10^6
+    kld.coin.should.equal('xrp');
+    kld.network.should.equal('Mainnet');
+    kld.decimalPlaces.should.equal(6);
+    kld.contractAddress.should.equal('061B3FA2C51CC6B8BEF8E672C70638FCB4D474427155A753');
+    kld.canTransfer.should.equal(true);
+  });
+
+  it('should return correct constants for xrp:key', function () {
+    const key = bitgo.coin('xrp:key') as XrpMptToken;
+    key.getChain().should.equal('xrp:key');
+    key.getBaseChain().should.equal('xrp');
+    key.getFullName().should.equal('XRP MPT Token');
+    key.getBaseFactor().should.equal(1000000); // assetScale 6 → 10^6
+    key.coin.should.equal('xrp');
+    key.network.should.equal('Mainnet');
+    key.decimalPlaces.should.equal(6);
+    key.contractAddress.should.equal('0634CF15DADB8E4C44F8CEAFF89B3A9FED52604FEE1A184F');
+    key.canTransfer.should.equal(true);
+  });
+
   it('should return constants for txrp:sec0', function () {
     mptCoin.getChain().should.equal('txrp:sec0');
     mptCoin.getBaseChain().should.equal('txrp');

--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -53,6 +53,7 @@ import {
   tzkethErc20,
   vetNFTCollection,
   worldErc20,
+  xrpMptToken,
   xrpToken,
   zkethErc20,
 } from './account';
@@ -7778,6 +7779,24 @@ export const allCoinsAndTokens = [
     true,
     6,
     UnderlyingAsset['txrp:feesec']
+  ),
+  xrpMptToken(
+    '54e5efa7-1ef1-4d74-8ead-8248d387623c',
+    'xrp:kld',
+    'Kladia Liquidity Deflator',
+    '061B3FA2C51CC6B8BEF8E672C70638FCB4D474427155A753',
+    true,
+    6,
+    UnderlyingAsset['xrp:kld']
+  ),
+  xrpMptToken(
+    'fcfb6345-3dad-48a6-870c-67acfdbbc821',
+    'xrp:key',
+    'Keystone Protocol Token',
+    '0634CF15DADB8E4C44F8CEAFF89B3A9FED52604FEE1A184F',
+    true,
+    6,
+    UnderlyingAsset['xrp:key']
   ),
   suiToken(
     'f26941b7-1110-4aa7-a2bc-29807297a51c',

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -3858,6 +3858,9 @@ export enum UnderlyingAsset {
   'xrp:eurcv' = 'xrp:eurcv',
   'xrp:aau' = 'xrp:aau',
   'xrp:fiuaxrp' = 'xrp:fiuaxrp',
+  // XRP MPT mainnet tokens
+  'xrp:kld' = 'xrp:kld',
+  'xrp:key' = 'xrp:key',
   // XRP testnet tokens
   'txrp:xsgd' = 'txrp:xsgd',
   // XRP MPT testnet tokens


### PR DESCRIPTION
## Description

Onboards two XRP MPT (Multi-Purpose Token) mainnet tokens:

- **XRP:KLD** — Kladia Liquidity Deflator
  - MPT Issuance ID: `061B3FA2C51CC6B8BEF8E672C70638FCB4D474427155A753`
  - AssetScale: 6, canTransfer: true
- **XRP:KEY** — Keystone Protocol Token
  - MPT Issuance ID: `0634CF15DADB8E4C44F8CEAFF89B3A9FED52604FEE1A184F`
  - AssetScale: 6, canTransfer: true

Both tokens verified on-chain via XRPL ledger API. Decimal places and transferability flags confirmed from the MPTIssuance ledger objects.

Issue Number: CHALO-805

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Added unit tests for `xrp:kld` and `xrp:key` in `modules/sdk-coin-xrp/test/unit/xrpToken.ts`
- All 146 `sdk-coin-xrp` unit tests pass
- All 30801 `statics` unit tests pass
- Lint clean (no new errors)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My commits follow Conventional Commits
- [x] The ticket was included in the commit message (CHALO-805)
- [x] I have added tests that prove the feature works
- [x] New and existing unit tests pass locally