### PR TITLE
feat(sdk-core): add withdrawFromVault() to DefiVault

### DIFF
--- a/examples/ts/defi-vault-deposit.ts
+++ b/examples/ts/defi-vault-deposit.ts
@@ -1,0 +1,62 @@
+/**
+ * Deposit into a DeFi ERC-4626 vault on staging.
+ *
+ * Usage:
+ *   STAGING_ACCESS_TOKEN=<token> \
+ *   STAGING_WALLET_ID=<walletId> \
+ *   STAGING_WALLET_PASSPHRASE=<passphrase> \
+ *   DEFI_VAULT_ID=<vaultId> \
+ *   DEFI_DEPOSIT_AMOUNT=<amountInBaseUnits> \
+ *   npx ts-node examples/ts/defi-vault-deposit.ts
+ *
+ * Copyright 2026, BitGo, Inc.  All Rights Reserved.
+ */
+import { BitGo } from 'bitgo';
+
+require('dotenv').config({ path: '../../.env' });
+
+const config = {
+  accessToken: '',
+  env: 'staging',
+  walletId: '',
+  vaultId: 'tbaseeth-usdc-test',
+  amount: 1000000, // 1 USDC
+  passphrase: '',
+  coin: 'tbaseeth',
+  otp: '000000',
+};
+
+const bitgoTest = new BitGo({
+  env: 'staging',
+});
+
+//bitgo.register('tbaseeth', TethLikeCoin.createInstance);
+
+async function main() {
+  console.log('Connecting to staging...');
+  bitgoTest.authenticateWithAccessToken({ accessToken: config.accessToken });
+  //await bitgoTest.unlock({ otp: config.otp, duration: 3600 });
+  const wallet = await bitgoTest.coin('tbaseeth').wallets().get({ id: config.walletId });
+  console.log('Wallet ID   :', wallet.id());
+  console.log('Vault ID    :', config.vaultId);
+  console.log('Amount      :', config.amount, '(base units)');
+
+  console.log('\nStarting deposit...');
+  const result = await wallet.defi.depositToVault({
+    vaultId: config.vaultId,
+    amount: config.amount.toString(),
+    ...(config.passphrase ? { walletPassphrase: config.passphrase } : {}),
+  });
+
+  console.log('\nDeposit complete:');
+  console.log('  operationId         :', result.operationId);
+  console.log('  approve txRequestId :', result.txRequestIds.approve);
+  console.log('  deposit txRequestId :', result.txRequestIds.deposit);
+  console.log('\nFull result:', JSON.stringify(result, null, 2));
+}
+
+main().catch((e) => {
+  console.error('Error:', e.message);
+  if (e.stack) console.error(e.stack);
+  process.exit(1);
+});

--- a/examples/ts/defi-vault-withdraw.ts
+++ b/examples/ts/defi-vault-withdraw.ts
@@ -1,0 +1,63 @@
+/**
+ * Withdraw vault shares from a DeFi ERC-4626 vault on staging.
+ *
+ * Run the deposit script first, then use this to withdraw.
+ *
+ * Usage:
+ *   STAGING_ACCESS_TOKEN=<token> \
+ *   STAGING_WALLET_ID=<walletId> \
+ *   STAGING_WALLET_PASSPHRASE=<passphrase> \
+ *   DEFI_VAULT_ID=<vaultId> \
+ *   DEFI_WITHDRAW_AMOUNT=<shareTokenAmountInBaseUnits> \
+ *   npx ts-node examples/ts/defi-vault-withdraw.ts
+ *
+ * Copyright 2026, BitGo, Inc.  All Rights Reserved.
+ */
+import { BitGo } from 'bitgo';
+
+require('dotenv').config({ path: '../../.env' });
+
+const config = {
+  accessToken: '',
+  env: 'staging',
+  walletId: '',
+  vaultId: 'tbaseeth-usdc-test',
+  amount: 1000000, // vault share base units
+  passphrase: '',
+  coin: 'tbaseeth',
+  otp: '000000',
+};
+
+const bitgoTest = new BitGo({
+  env: 'staging',
+});
+
+//bitgo.register('tbaseeth', TethLikeCoin.createInstance);
+
+async function main() {
+  console.log('Connecting to staging...');
+  bitgoTest.authenticateWithAccessToken({ accessToken: config.accessToken });
+  //await bitgoTest.unlock({ otp: config.otp, duration: 3600 });
+  const wallet = await bitgoTest.coin('tbaseeth').wallets().get({ id: config.walletId });
+  console.log('Wallet ID   :', wallet.id());
+  console.log('Vault ID    :', config.vaultId);
+  console.log('Amount      :', config.amount, '(vault share base units)');
+
+  console.log('\nStarting withdrawal...');
+  const result = await wallet.defi.withdrawFromVault({
+    vaultId: config.vaultId,
+    amount: config.amount.toString(),
+    ...(config.passphrase ? { walletPassphrase: config.passphrase } : {}),
+  });
+
+  console.log('\nWithdrawal complete:');
+  console.log('  operationId  :', result.operationId);
+  console.log('  txRequestId  :', result.txRequestId);
+  console.log('\nFull result:', JSON.stringify(result, null, 2));
+}
+
+main().catch((e) => {
+  console.error('Error:', e.message);
+  if (e.stack) console.error(e.stack);
+  process.exit(1);
+});

--- a/modules/sdk-core/src/bitgo/defi/defiVault.ts
+++ b/modules/sdk-core/src/bitgo/defi/defiVault.ts
@@ -15,6 +15,8 @@ import {
   IDefiVault,
   ListOperationsOptions,
   ResumeDepositOptions,
+  WithdrawFromVaultOptions,
+  WithdrawResult,
 } from './iDefiVault';
 import { IWallet } from '../wallet';
 import { BitGoBase } from '../bitgoBase';
@@ -76,7 +78,6 @@ export class DefiVault implements IDefiVault {
    *
    * @param params.vaultId - DeFi-service vault identifier
    * @param params.amount - amount in base units of the underlying asset
-   * @param params.clientIdempotencyKey - optional client idempotency key
    * @param params.walletPassphrase - required for hot wallets, omit for custody
    */
   async depositToVault(params: DepositToVaultOptions): Promise<DepositResult> {
@@ -139,7 +140,6 @@ export class DefiVault implements IDefiVault {
       defiParams: {
         vaultId: params.vaultId,
         amount: params.amount,
-        ...(params.clientIdempotencyKey ? { clientIdempotencyKey: params.clientIdempotencyKey } : {}),
       },
       ...(params.walletPassphrase ? { walletPassphrase: params.walletPassphrase } : {}),
     });
@@ -158,7 +158,6 @@ export class DefiVault implements IDefiVault {
         vaultId: params.vaultId,
         amount: params.amount,
         operationId,
-        ...(params.clientIdempotencyKey ? { clientIdempotencyKey: params.clientIdempotencyKey } : {}),
       },
       ...(params.walletPassphrase ? { walletPassphrase: params.walletPassphrase } : {}),
     });
@@ -252,6 +251,44 @@ export class DefiVault implements IDefiVault {
     if (params.cursor) query.cursor = params.cursor;
 
     return await this.bitgo.get(this.bitgo.microservicesUrl(this.operationsUrl())).query(query).result();
+  }
+
+  /**
+   * Withdraw vault shares from a DeFi vault.
+   *
+   * Issues a single sendMany call (defiWithdraw) and returns the operationId
+   * and txRequestId. The state machine for withdrawal is simpler than deposit:
+   * CREATED → WITHDRAW_TX_REQUESTED → WITHDRAW_SIGNED → WITHDRAW_CONFIRMED → COMPLETED
+   *
+   * @param params.vaultId - DeFi-service vault identifier
+   * @param params.amount - amount in base units of the vault share token
+   * @param params.walletPassphrase - required for hot wallets, omit for custody
+   */
+  async withdrawFromVault(params: WithdrawFromVaultOptions): Promise<WithdrawResult> {
+    if (!params.vaultId) {
+      throw new Error('vaultId is required');
+    }
+    if (!params.amount) {
+      throw new Error('amount is required');
+    }
+
+    const withdrawResult = await this.wallet.sendMany({
+      type: 'defiWithdraw',
+      defiParams: {
+        vaultId: params.vaultId,
+        amount: params.amount,
+      },
+      ...(params.walletPassphrase ? { walletPassphrase: params.walletPassphrase } : {}),
+    });
+
+    const txRequestId = this.extractTxRequestId(withdrawResult);
+    const operationId = this.extractOperationId(withdrawResult);
+
+    if (!operationId) {
+      throw new Error('operationId not found in withdraw txRequest response');
+    }
+
+    return { operationId, txRequestId };
   }
 
   // ── Internal helpers ────────────────────────────────────────────────

--- a/modules/sdk-core/src/bitgo/defi/iDefiVault.ts
+++ b/modules/sdk-core/src/bitgo/defi/iDefiVault.ts
@@ -9,8 +9,6 @@ export interface DepositToVaultOptions {
   vaultId: string;
   /** Amount in base units of the underlying asset */
   amount: string;
-  /** Optional client-supplied idempotency key */
-  clientIdempotencyKey?: string;
   /** Wallet passphrase — required for hot wallets, omit for custody */
   walletPassphrase?: string;
 }
@@ -68,10 +66,25 @@ export interface DefiOperationListResult {
   nextCursor?: string;
 }
 
+export interface WithdrawFromVaultOptions {
+  /** DeFi-service vault identifier */
+  vaultId: string;
+  /** Amount in base units of the vault share token */
+  amount: string;
+  /** Wallet passphrase — required for hot wallets, omit for custody */
+  walletPassphrase?: string;
+}
+
+export interface WithdrawResult {
+  operationId: string;
+  txRequestId: string;
+}
+
 export interface IDefiVault {
   depositToVault(params: DepositToVaultOptions): Promise<DepositResult>;
   resumeDeposit(params: ResumeDepositOptions): Promise<DepositResult>;
   getOperation(params: GetOperationOptions): Promise<DefiOperation>;
   listOperations(params: ListOperationsOptions): Promise<DefiOperationListResult>;
   getVaultConfig(params: GetVaultConfigOptions): Promise<GetVaultResponse>;
+  withdrawFromVault(params: WithdrawFromVaultOptions): Promise<WithdrawResult>;
 }

--- a/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
@@ -221,6 +221,7 @@ export abstract class MpcUtils {
         'cantonParticipantOnboardingRequest',
         'defi-approve',
         'defi-deposit',
+        'defi-withdraw',
       ].includes(params.intentType)
     ) {
       assert(params.recipients, `'recipients' is a required parameter for ${params.intentType} intent`);
@@ -322,9 +323,15 @@ export abstract class MpcUtils {
             vaultId: params.defiParams.vaultId,
             amount: params.defiParams.amount,
             ...(params.defiParams.operationId && { operationId: params.defiParams.operationId }),
-            ...(params.defiParams.clientIdempotencyKey && {
-              clientIdempotencyKey: params.defiParams.clientIdempotencyKey,
-            }),
+          };
+        }
+        case 'defi-withdraw': {
+          assert(params.defiParams, `'defiParams' is required for ${params.intentType} intent`);
+          return {
+            ...baseIntent,
+            vaultId: params.defiParams.vaultId,
+            // DefiWithdrawIntent uses shareTokenAmount (vault shares, base units)
+            shareTokenAmount: params.defiParams.amount,
           };
         }
         default:

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -287,8 +287,9 @@ interface IntentOptionsBase {
 export interface DefiIntentFields {
   vaultId?: string;
   amount?: { value: string; symbol: string } | string;
+  /** Vault share token amount for defi-withdraw intent (base units) */
+  shareTokenAmount?: { value: string; symbol: string } | string;
   operationId?: string;
-  clientIdempotencyKey?: string;
 }
 
 /** DeFi-specific intent parameters (input container for defiParams). */
@@ -296,7 +297,6 @@ export interface DefiIntentParams {
   vaultId: string;
   amount: string;
   operationId?: string;
-  clientIdempotencyKey?: string;
 }
 
 export interface IntentOptionsForMessage extends IntentOptionsBase {

--- a/modules/sdk-core/src/bitgo/utils/tss/recipientUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/recipientUtils.ts
@@ -30,6 +30,7 @@ export const NO_RECIPIENT_TX_TYPES = new Set([
   // DeFi vault operations — recipients/calldata built server-side from defiParams
   'defiApprove',
   'defiDeposit',
+  'defiWithdraw',
   // Smart contract invocations with no explicit SDK-level recipients
   'contractCall',
 

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -942,7 +942,6 @@ export interface SendManyOptions extends PrebuildAndSignTransactionOptions {
     amount?: string | number;
     actionType?: string;
     operationId?: string;
-    clientIdempotencyKey?: string;
   };
 }
 

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -6,6 +6,7 @@ import { CoinFamily } from '@bitgo/statics';
 import assert from 'assert';
 import BigNumber from 'bignumber.js';
 import * as t from 'io-ts';
+import { BigIntFromString } from 'io-ts-types';
 import * as _ from 'lodash';
 import { EncryptionVersion, IRequestTracer } from '../../api';
 import * as common from '../../common';
@@ -51,6 +52,7 @@ import {
   TokenType,
   TxRequest,
 } from '../utils';
+import { decodeWithCodec } from '../utils/codecs';
 import { postWithCodec } from '../utils/postWithCodec';
 import { txParamsFromIntent } from '../utils/tss/baseTSSUtils';
 import { EcdsaMPCv2Utils, EcdsaUtils } from '../utils/tss/ecdsa';
@@ -4445,7 +4447,6 @@ export class Wallet implements IWallet {
             defiParams: params.defiParams as {
               vaultId: string;
               amount: string;
-              clientIdempotencyKey?: string;
             },
           },
           apiVersion,
@@ -4461,13 +4462,29 @@ export class Wallet implements IWallet {
               vaultId: string;
               amount: string;
               operationId?: string;
-              clientIdempotencyKey?: string;
             },
           },
           apiVersion,
           params.preview
         );
         break;
+      case 'defiWithdraw': {
+        const defiWithdrawParams = decodeWithCodec(
+          t.type({ vaultId: t.string, amount: BigIntFromString }),
+          params.defiParams,
+          'defiWithdraw.defiParams'
+        );
+        txRequest = await this.tssUtils!.prebuildTxWithIntent(
+          {
+            reqId,
+            intentType: 'defi-withdraw',
+            defiParams: { ...defiWithdrawParams, amount: defiWithdrawParams.amount.toString() },
+          },
+          apiVersion,
+          params.preview
+        );
+        break;
+      }
       default:
         throw new Error(`transaction type not supported: ${params.type}`);
     }

--- a/modules/sdk-core/test/unit/bitgo/defi/defiVault.ts
+++ b/modules/sdk-core/test/unit/bitgo/defi/defiVault.ts
@@ -353,41 +353,16 @@ describe('DefiVault', function () {
         mockBitGo.del.called.should.be.false();
       });
 
-      it('should pass clientIdempotencyKey and walletPassphrase when provided', async function () {
-        mockBitGo.get.returns(mockRequest(makeMorphoVault('vlt-galaxy-usdc')));
-
-        const operationId = 'op-uuid-789';
-
-        const sendManyStub = sinon.stub(wallet, 'sendMany');
-        sendManyStub.onFirstCall().resolves({
-          txRequest: {
-            txRequestId: 'txreq-approve-3',
-            intent: { intentType: 'defi-approve' },
-            transactions: [{ unsignedTx: { coinSpecific: { operationId } } }],
-          },
+      it('should throw if vaultId is missing', async function () {
+        await assert.rejects(() => defiVault.depositToVault({ vaultId: '', amount: '1000000' }), {
+          message: 'vaultId is required',
         });
-        sendManyStub.onSecondCall().resolves({
-          txRequest: {
-            txRequestId: 'txreq-deposit-3',
-            intent: { intentType: 'defi-deposit' },
-            transactions: [{ unsignedTx: { coinSpecific: { operationId } } }],
-          },
+      });
+
+      it('should throw if amount is missing', async function () {
+        await assert.rejects(() => defiVault.depositToVault({ vaultId: 'vlt-1', amount: '' }), {
+          message: 'amount is required',
         });
-
-        await defiVault.depositToVault({
-          vaultId: 'vlt-galaxy-usdc',
-          amount: '1000000',
-          clientIdempotencyKey: 'idem-key-123',
-          walletPassphrase: 'test-passphrase',
-        });
-
-        const approveArgs: any = sendManyStub.firstCall.args[0];
-        approveArgs.defiParams.clientIdempotencyKey.should.equal('idem-key-123');
-        approveArgs.walletPassphrase.should.equal('test-passphrase');
-
-        const depositArgs: any = sendManyStub.secondCall.args[0];
-        depositArgs.defiParams.clientIdempotencyKey.should.equal('idem-key-123');
-        depositArgs.walletPassphrase.should.equal('test-passphrase');
       });
     });
 
@@ -541,6 +516,129 @@ describe('DefiVault', function () {
 
     it('should throw if vaultId is missing', async function () {
       await assert.rejects(() => defiVault.listOperations({ vaultId: '' }), { message: 'vaultId is required' });
+    });
+  });
+
+  describe('withdrawFromVault', function () {
+    it('should call sendMany with defiWithdraw and return operationId + txRequestId', async function () {
+      const operationId = 'op-withdraw-1';
+
+      const sendManyStub = sinon.stub(wallet, 'sendMany');
+      sendManyStub.resolves({
+        txRequest: {
+          txRequestId: 'txreq-withdraw-1',
+          transactions: [{ unsignedTx: { coinSpecific: { operationId } } }],
+        },
+      });
+
+      const result = await defiVault.withdrawFromVault({
+        vaultId: 'vlt-galaxy-usdc',
+        amount: '500000',
+      });
+
+      result.operationId.should.equal(operationId);
+      result.txRequestId.should.equal('txreq-withdraw-1');
+
+      sendManyStub.calledOnce.should.be.true();
+      const args: any = sendManyStub.firstCall.args[0];
+      args.type.should.equal('defiWithdraw');
+      args.defiParams.vaultId.should.equal('vlt-galaxy-usdc');
+      args.defiParams.amount.should.equal('500000');
+    });
+
+    it('should extract operationId from lite apiVersion coinSpecific', async function () {
+      const operationId = 'op-withdraw-lite';
+
+      const sendManyStub = sinon.stub(wallet, 'sendMany');
+      sendManyStub.resolves({
+        txRequest: {
+          txRequestId: 'txreq-withdraw-lite',
+          unsignedTxs: [{ coinSpecific: { operationId } }],
+        },
+      });
+
+      const result = await defiVault.withdrawFromVault({ vaultId: 'vlt-galaxy-usdc', amount: '500000' });
+
+      result.operationId.should.equal(operationId);
+      result.txRequestId.should.equal('txreq-withdraw-lite');
+    });
+
+    it('should throw when operationId is absent from the withdraw txRequest response', async function () {
+      const sendManyStub = sinon.stub(wallet, 'sendMany');
+      sendManyStub.resolves({
+        txRequest: {
+          txRequestId: 'txreq-withdraw-missing',
+          transactions: [{ unsignedTx: { coinSpecific: {} } }],
+        },
+      });
+
+      await assert.rejects(() => defiVault.withdrawFromVault({ vaultId: 'vlt-galaxy-usdc', amount: '500000' }), {
+        message: 'operationId not found in withdraw txRequest response',
+      });
+    });
+
+    it('should pass walletPassphrase when provided', async function () {
+      const operationId = 'op-withdraw-opts';
+
+      const sendManyStub = sinon.stub(wallet, 'sendMany');
+      sendManyStub.resolves({
+        txRequest: {
+          txRequestId: 'txreq-withdraw-opts',
+          transactions: [{ unsignedTx: { coinSpecific: { operationId } } }],
+        },
+      });
+
+      await defiVault.withdrawFromVault({
+        vaultId: 'vlt-galaxy-usdc',
+        amount: '500000',
+        walletPassphrase: 'test-passphrase',
+      });
+
+      const args: any = sendManyStub.firstCall.args[0];
+      args.walletPassphrase.should.equal('test-passphrase');
+    });
+
+    it('should throw if vaultId is missing', async function () {
+      await assert.rejects(() => defiVault.withdrawFromVault({ vaultId: '', amount: '500000' }), {
+        message: 'vaultId is required',
+      });
+    });
+
+    it('should throw if amount is missing', async function () {
+      await assert.rejects(() => defiVault.withdrawFromVault({ vaultId: 'vlt-1', amount: '' }), {
+        message: 'amount is required',
+      });
+    });
+
+    describe('prebuildTransactionTxRequests defiWithdraw defiParams validation', function () {
+      it('should throw when defiParams is missing', async function () {
+        await assert.rejects(
+          () => (wallet as any).prebuildTransactionTxRequests({ type: 'defiWithdraw' }),
+          /defiWithdraw\.defiParams/
+        );
+      });
+
+      it('should throw when vaultId is not a string', async function () {
+        await assert.rejects(
+          () =>
+            (wallet as any).prebuildTransactionTxRequests({
+              type: 'defiWithdraw',
+              defiParams: { vaultId: 123, amount: '500000' },
+            }),
+          /defiWithdraw\.defiParams/
+        );
+      });
+
+      it('should throw when amount is not a string', async function () {
+        await assert.rejects(
+          () =>
+            (wallet as any).prebuildTransactionTxRequests({
+              type: 'defiWithdraw',
+              defiParams: { vaultId: 'vlt-1', amount: 500000 },
+            }),
+          /defiWithdraw\.defiParams/
+        );
+      });
     });
   });
 

--- a/modules/sdk-core/test/unit/bitgo/utils/tss/recipientUtils.ts
+++ b/modules/sdk-core/test/unit/bitgo/utils/tss/recipientUtils.ts
@@ -29,6 +29,7 @@ describe('recipientUtils', function () {
         'customTx',
         'defiApprove',
         'defiDeposit',
+        'defiWithdraw',
         'contractCall',
         // Staking
         'delegate',


### PR DESCRIPTION
## Description

Adds `withdrawFromVault()` to the `DefiVault` SDK class, completing the ERC-4626 vault lifecycle alongside the existing `depositToVault()` / `resumeDeposit()` methods.

**What changed:**

- **`DefiVault.withdrawFromVault(params)`** — issues a single `sendMany` call with `type: 'defiWithdraw'` and returns `{ operationId, txRequestId }`. The withdrawal state machine is simpler than deposit (no approve step): `CREATED → WITHDRAW_TX_REQUESTED → WITHDRAW_SIGNED → WITHDRAW_CONFIRMED → COMPLETED`.
- **`IDefiVault`** — new `withdrawFromVault` method signature; new `WithdrawFromVaultOptions` and `WithdrawResult` types exported from `iDefiVault.ts`.
- **`mpcUtils.ts`** — added `defi-withdraw` intent case. Maps SDK `amount` → `shareTokenAmount` per the `DefiWithdrawIntent` schema in `public-types` (vault share tokens, not underlying asset units).
- **`recipientUtils.ts`** — added `defiWithdraw` to `NO_RECIPIENT_TX_TYPES` (recipients/calldata are built server-side from `defiParams`).
- **`wallet.ts`** — added `defiWithdraw` case in `sendMany` intent dispatch.
- **`baseTypes.ts`** — added `shareTokenAmount?: string` to `DefiIntentFields`; removed `clientIdempotencyKey` (cleanup).
- **`commitlint.config.js`** — added `DEFI-` to recognized issue prefixes.
- **Examples** — added `examples/ts/defi-vault-deposit.ts` and `examples/ts/defi-vault-withdraw.ts` for manual staging tests.

**Removed:** `clientIdempotencyKey` from the deposit flow (not used server-side, cleaned up to reduce surface area).

## Issue

DEFI-237

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Unit tests added in `modules/sdk-core/test/unit/bitgo/defi/defiVault.ts` covering:
  - Happy path: `sendMany` called with correct `defiWithdraw` args; `operationId` + `txRequestId` returned
  - Lite `apiVersion` (`unsignedTxs`) `operationId` extraction path
  - Missing `operationId` in response throws
  - `walletPassphrase` forwarded correctly
  - Guard throws for missing `vaultId` / `amount`
- Manual end-to-end verified on staging using the example script (`examples/ts/defi-vault-withdraw.ts`)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The ticket `DEFI-237` was included in the commit message as a reference
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes