### PR TITLE
chore: add DeFi team as CODEOWNERS for defi module files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -112,6 +112,10 @@
 /examples/ts/btc/ @BitGo/btc-team
 /examples/ts/stablecoin @Bitgo/stablecoins
 
+# DeFi
+/modules/sdk-core/src/bitgo/defi/ @BitGo/defi_team
+/modules/sdk-core/test/unit/bitgo/defi/ @BitGo/defi_team
+
 # Trade
 /modules/sdk-core/src/bitgo/address-book/ @BitGo/prime
 /modules/sdk-core/src/bitgo/trading/ @BitGo/prime


### PR DESCRIPTION
## Summary
- Add `@BitGo/defi_team` as code owner for `/modules/sdk-core/src/bitgo/defi/`
- Add `@BitGo/defi_team` as code owner for `/modules/sdk-core/test/unit/bitgo/defi/`

## Test plan
- [ ] Verify CODEOWNERS syntax is valid (GitHub parses it correctly on PR open)
- [ ] Confirm DeFi team members are auto-requested for review on PRs touching defi paths

CLOSES TICKET: DEFI-340