### PR TITLE
fix(sdk-core): use decrypt/encrypt in createOfflineKeyGenRound1Share

### DIFF
--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
@@ -663,9 +663,7 @@ export class EddsaMPCv2Utils extends BaseEddsaUtils {
     const { walletPassphrase, encryptedUserGpgPrvKey, bitgoGpgPubKey, counterPartyGpgPubKey } = params;
     const partyId = params.partyId ?? MPCv2PartiesEnum.USER;
 
-    const decryptedGpgPrvKey = isV2Envelope(encryptedUserGpgPrvKey)
-      ? await this.bitgo.decryptAsync({ input: encryptedUserGpgPrvKey, password: walletPassphrase })
-      : this.bitgo.decrypt({ input: encryptedUserGpgPrvKey, password: walletPassphrase });
+    const decryptedGpgPrvKey = await this.bitgo.decrypt({ input: encryptedUserGpgPrvKey, password: walletPassphrase });
     const gpgPrvKey = await pgp.readPrivateKey({ armoredKey: decryptedGpgPrvKey });
 
     const [, ownSk] = await MPSComms.extractEd25519KeyPair(gpgPrvKey);
@@ -692,7 +690,7 @@ export class EddsaMPCv2Utils extends BaseEddsaUtils {
       ownMsgFrom: msg1.from,
     });
 
-    const encryptedRound1Session = await this.bitgo.encryptAsync({
+    const encryptedRound1Session = await this.bitgo.encrypt({
       input: sessionPayload,
       password: walletPassphrase,
       adata: `${EddsaMPCv2Utils.MPS_DKG_KEYGEN_ROUND1_STATE}:${partyId}`,


### PR DESCRIPTION
## What

Replace two non-existent method calls in `createOfflineKeyGenRound1Share` (`modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsaMPCv2.ts`):

- `this.bitgo.decryptAsync(...)` → `await this.bitgo.decrypt(...)`
- `this.bitgo.encryptAsync(...)` → `await this.bitgo.encrypt(...)`

Also removes the `isV2Envelope` branch — `decrypt` handles both envelope versions and already returns `Promise<string>`.

## Why

PR #9187 merged these non-existent methods to master, causing `TS2339` build failures in `@bitgo/sdk-core` and every downstream package. This unblocks all PRs currently failing CI with:

```
error TS2339: Property 'decryptAsync' does not exist on type 'BitGoBase'
error TS2339: Property 'encryptAsync' does not exist on type 'BitGoBase'
```

## Test plan

- [x] TypeScript build passes locally for `@bitgo/sdk-core`
- [x] Existing unit tests unaffected

Ticket: WCI-1023