### PR TITLE
feat(statics): add tbaseeth:kmusdc token on base-sepolia

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -4238,6 +4238,15 @@ export const allCoinsAndTokens = [
     Networks.test.basechain
   ),
   erc20Token(
+    'ce261382-b945-4966-bfbd-bfc68eaf8ee5',
+    'tbaseeth:kmusdc',
+    'Defi Test Token',
+    18,
+    '0x1c3e28e5048f30ab3aa8a5dc4e71a806ec97a6c4',
+    UnderlyingAsset['tbaseeth:kmusdc'],
+    Networks.test.basechain
+  ),
+  erc20Token(
     '439fb12d-fddf-4749-8a33-b7c79fefc1b4',
     'baseeth:wave',
     'Waveform',

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -3389,6 +3389,7 @@ export enum UnderlyingAsset {
   'tbaseeth:ctusd1cx' = 'tbaseeth:ctusd1cx',
   'tbaseeth:tusdl' = 'tbaseeth:tusdl',
   'tbaseeth:ttbills' = 'tbaseeth:ttbills',
+  'tbaseeth:kmusdc' = 'tbaseeth:kmusdc',
 
   // Og mainnet tokens
   'og:wog' = 'og:wog',


### PR DESCRIPTION
## Summary
- Adds `tbaseeth:kmusdc` (Defi Test Token) ERC-20 token on Base Sepolia testnet
- Contract address: `0x1c3e28e5048f30ab3aa8a5dc4e71a806ec97a6c4`
- Decimals: 18
- Network: `Networks.test.basechain`

## Changes
- `modules/statics/src/base.ts` — added `tbaseeth:kmusdc` to `UnderlyingAsset` enum
- `modules/statics/src/allCoinsAndTokens.ts` — added `erc20Token` entry with UUID `ce261382-b945-4966-bfbd-bfc68eaf8ee5`

## Test plan
- [ ] `yarn workspace @bitgo/statics build` passes ✅
- [ ] `yarn workspace @bitgo/statics unit-test` passes ✅
- [ ] After merge, trigger bitgo-beta release via [GitHub Actions](https://github.com/BitGo/BitGoJS/actions/workflows/publish.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)