### PR TITLE
fix(scripts): skip overrides that are already direct bitgo deps

### DIFF
--- a/scripts/generate-bitgo-shrinkwrap.ts
+++ b/scripts/generate-bitgo-shrinkwrap.ts
@@ -59,7 +59,17 @@ async function main() {
     isolatedPackageJson.dependencies = Object.fromEntries(
       Object.entries(bitgoPackageJson.dependencies ?? {}).filter(([name]) => !name.startsWith('@bitgo/'))
     );
-    isolatedPackageJson.overrides = rootPackageJson.overrides;
+    const directDeps = new Set(Object.keys(bitgoPackageJson.dependencies ?? {}));
+    const filteredOverrides = Object.fromEntries(
+      Object.entries(rootPackageJson.overrides as Record<string, unknown>).filter(
+        ([name, value]) => typeof value !== 'string' || !directDeps.has(name)
+      )
+    );
+    const filteredCount = Object.keys(rootPackageJson.overrides).length - Object.keys(filteredOverrides).length;
+    if (filteredCount > 0) {
+      console.log(`Skipping ${filteredCount} override(s) already pinned as direct bitgo dependencies.`);
+    }
+    isolatedPackageJson.overrides = filteredOverrides;
 
     fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify(isolatedPackageJson, null, 2) + '\n');
 


### PR DESCRIPTION
## Summary
- When generating \`npm-shrinkwrap.json\`, flat overrides for packages already in bitgo's direct \`dependencies\` are redundant — filter them out
- Nested (scoped) overrides are always kept since their top-level key is a parent context, not the pinned package
- With the current overrides block this drops \`lodash\` and \`bignumber.js\` from the shrinkwrap's overrides

## Test plan
- [ ] Verify \`BITGO_GENERATE_SHRINKWRAP=true npx ts-node scripts/generate-bitgo-shrinkwrap.ts\` logs the skipped count
- [ ] Confirm generated \`npm-shrinkwrap.json\` omits \`lodash\`/\`bignumber.js\` from its overrides block

TICKET: WCN-604

🤖 Generated with [Claude Code](https://claude.com/claude-code)