### PR TITLE
chore(statics): gate shvon for singapore

### DIFF
--- a/modules/statics/src/coins/erc20Coins.ts
+++ b/modules/statics/src/coins/erc20Coins.ts
@@ -14713,7 +14713,8 @@ export const erc20Coins = [
     'SHVon',
     18,
     '0x2d8b65306a6c23da6342cb94d4251fb4302a624f',
-    UnderlyingAsset['eth:shvon']
+    UnderlyingAsset['eth:shvon'],
+    AccountCoin.DEFAULT_FEATURES_EXCLUDE_SINGAPORE
   ),
   erc20(
     '9fff6a5f-b144-4e5b-9837-cbf1f53acc70',


### PR DESCRIPTION
## Summary
- Ungate `eth:shvon` (SHVon) token for all BitGo trusts except BitGo Singapore
- Adds `AccountCoin.DEFAULT_FEATURES_EXCLUDE_SINGAPORE` features to the token config
- Compliance clearance received for this token (CECHO-1630)

## Test plan
- [ ] Verify `eth:shvon` is available in BitGo Trust, MENA FZE, Europe APS, Frankfurt, and India
- [ ] Verify `eth:shvon` remains gated for BitGo Singapore

🤖 Generated with [Claude Code](https://claude.com/claude-code)