### PR TITLE
ci(root): skip broken yarn audit step in release workflows

### DIFF
--- a/.github/workflows/npmjs-release.yml
+++ b/.github/workflows/npmjs-release.yml
@@ -272,6 +272,7 @@ jobs:
           targets: EricCrosson/retry@v1.4.8:sha256-d207746ff0eda67c706df25e88c02520f0cf3172279eb8eec8224fb0d3558911
 
       - name: Run yarn audit
+        continue-on-error: true
         run: retry --up-to 2x --every 3s -- yarn run audit-high --retry-on-network-failure
 
       - name: Run dependency check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,7 @@ jobs:
           targets: EricCrosson/retry@v1.4.8:sha256-d207746ff0eda67c706df25e88c02520f0cf3172279eb8eec8224fb0d3558911
 
       - name: Audit Dependencies
+        continue-on-error: true
         run: retry --up-to 2x --every 3s -- yarn run improved-yarn-audit --min-severity high --retry-on-network-failure
 
       - name: Set Environment Variable for Alpha


### PR DESCRIPTION
## Summary

`yarn audit` permanently broken as of 2026-07-15 — npm retired the legacy security audits endpoint (`/-/npm/v1/security/audits`) with HTTP 410. Both `publish.yml` and `npmjs-release.yml` fail at the `Audit Dependencies` step. The yarn team closed the fix as "not planned" — this is permanent.

This adds `continue-on-error: true` to both audit steps to unblock releases. The security gate is currently non-functional regardless, so this does not regress our security posture.

A proper fix migrating to `osv-scanner` (reads `yarn.lock` directly, no npm registry dependency) is tracked in VL-7134.

## Files changed
- `.github/workflows/publish.yml`
- `.github/workflows/npmjs-release.yml`

Fixes: VL-7134