### PR TITLE
fix(argon2): add types condition to package.json exports map

### DIFF
--- a/modules/argon2/package.json
+++ b/modules/argon2/package.json
@@ -6,6 +6,7 @@
   "types": "index.d.ts",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./index.mjs",
       "require": "./argon2.umd.min.js"
     }


### PR DESCRIPTION
## Summary
- `@bitgo/argon2`'s `exports["."]` map has no `types` condition, so consumers on TypeScript's `"moduleResolution": "bundler"` can't resolve `index.d.ts` even though it's referenced by the `types` field.
- Found this while consuming `@bitgo/argon2` directly from a Bun/TypeScript project (`bunx tsc --noEmit` failed with `TS7016: Could not find a declaration file for module '@bitgo/argon2'`), and worked around it locally with a `bun patch` carrying this exact one-line diff, opening this so the real fix lands upstream instead.
