### PR TITLE
feat(statics): onboard eth, sol, polygon, and baseeth assets

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -4247,6 +4247,15 @@ export const allCoinsAndTokens = [
     Networks.test.basechain
   ),
   erc20Token(
+    '79fcac64-cad2-4c17-b8fc-2930b7022384',
+    'tbaseeth:tpdd',
+    'MarketplacePDD ALPACA',
+    18,
+    '0x924928512fb9a1836111cb5214774a5f620be40a',
+    UnderlyingAsset['tbaseeth:tpdd'],
+    Networks.test.basechain
+  ),
+  erc20Token(
     '439fb12d-fddf-4749-8a33-b7c79fefc1b4',
     'baseeth:wave',
     'Waveform',
@@ -4866,6 +4875,15 @@ export const allCoinsAndTokens = [
     18,
     '0x632db1aaace73401a5dc8cde6e9062b8ec0fd819',
     UnderlyingAsset['baseeth:gldy'],
+    Networks.main.basechain
+  ),
+  erc20Token(
+    '78b46b24-ca4f-45e9-9dd8-f3be5b3a6070',
+    'baseeth:wpay',
+    'WPAY',
+    18,
+    '0x35e0966208f518371e79cc9fd35559112068ddad',
+    UnderlyingAsset['baseeth:wpay'],
     Networks.main.basechain
   ),
 

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -2503,6 +2503,7 @@ export enum UnderlyingAsset {
   'eth:bard' = 'eth:bard',
   'eth:sfp' = 'eth:sfp',
   'eth:aztec' = 'eth:aztec',
+  'eth:jpysc' = 'eth:jpysc',
 
   // Ondo Tokenized Assets
   'eth:qqqon' = 'qqqon',
@@ -3015,6 +3016,7 @@ export enum UnderlyingAsset {
   'polygon:colt' = 'polygon:colt',
   'polygon:bolt' = 'polygon:bolt',
   'polygon:gmc' = 'polygon:gmc',
+  'polygon:wpay' = 'polygon:wpay',
   // Polygon NFTs
   // generic NFTs
   'erc721:polygontoken' = 'erc721:polygontoken',
@@ -3380,6 +3382,7 @@ export enum UnderlyingAsset {
   'baseeth:laptop' = 'baseeth:laptop',
   'baseeth:vbtcb' = 'baseeth:vbtcb',
   'baseeth:gldy' = 'baseeth:gldy',
+  'baseeth:wpay' = 'baseeth:wpay',
 
   // BaseETH testnet tokens
   'tbaseeth:usdc' = 'tbaseeth:usdc',
@@ -3390,6 +3393,7 @@ export enum UnderlyingAsset {
   'tbaseeth:tusdl' = 'tbaseeth:tusdl',
   'tbaseeth:ttbills' = 'tbaseeth:ttbills',
   'tbaseeth:kmusdc' = 'tbaseeth:kmusdc',
+  'tbaseeth:tpdd' = 'tbaseeth:tpdd',
 
   // Og mainnet tokens
   'og:wog' = 'og:wog',
@@ -3825,6 +3829,7 @@ export enum UnderlyingAsset {
   'sol:tusdc' = 'sol:tusdc',
   'sol:slx' = 'sol:slx',
   'sol:ab1' = 'sol:ab1',
+  'sol:bils' = 'sol:bils',
 
   'tsol:txsgd' = 'sol:txsgd',
   'tsol:txusd' = 'sol:txusd',

--- a/modules/statics/src/coins/erc20Coins.ts
+++ b/modules/statics/src/coins/erc20Coins.ts
@@ -14939,6 +14939,14 @@ export const erc20Coins = [
     '0xf23043c848b642e69350fa7623af1c1e3e6fda9b',
     UnderlyingAsset['eth:scx']
   ),
+  erc20(
+    '31b2b1cc-f8af-44b5-91e6-29e9de4f7fdf',
+    'eth:jpysc',
+    'JPYSC',
+    18,
+    '0x6781d5631bfe47432b089e64e3eab3b6edd26177',
+    UnderlyingAsset['eth:jpysc']
+  ),
   terc20(
     '0c333619-e5a6-4f9d-8bbc-5b0e5dc64d03',
     'hteth:grtxp',

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -4436,6 +4436,13 @@ export const ofcCoins = [
     undefined,
     [CoinFeature.STABLECOIN]
   ),
+  ofcPolygonErc20(
+    'a8a7b8d6-8c38-4750-9f96-8b45f0611094',
+    'ofcpolygon:wpay',
+    'WPAY',
+    18,
+    UnderlyingAsset['polygon:wpay']
+  ),
 
   tofcPolygonErc20(
     '62f4329d-11cd-4875-b91b-9ceae66c9439',
@@ -5466,6 +5473,7 @@ export const ofcCoins = [
     9,
     UnderlyingAsset['sol:jsol']
   ),
+  ofcsolToken('a903ea3b-de91-4d57-9fc1-56fdf8b3b249', 'ofcsol:bils', 'BILS', 6, UnderlyingAsset['sol:bils']),
   ofcBscToken('3a9daeda-7e08-494d-a47c-d2c89dd1c735', 'ofcbsc:godl', 'GODL', 18, UnderlyingAsset['bsc:godl']),
   ofcBscToken('93a459bc-c661-4001-be26-9175046c9a36', 'ofcbsc:gdl', 'GDL', 18, UnderlyingAsset['bsc:gdl']),
   ofcBscToken('9febc919-85af-48eb-9821-e9d18e4cd98e', 'ofcbsc:usgd', 'USGD', 18, UnderlyingAsset['bsc:usgd']),

--- a/modules/statics/src/coins/ofcErc20Coins.ts
+++ b/modules/statics/src/coins/ofcErc20Coins.ts
@@ -6189,6 +6189,7 @@ export const tOfcErc20Coins = [
     18,
     UnderlyingAsset['eth:qncxt']
   ),
+  ofcerc20('7f4173d2-1638-4216-8d14-f97f56155c60', 'ofceth:jpysc', 'JPYSC', 18, UnderlyingAsset['eth:jpysc']),
 
   // MON Network tokens
   ofcerc20(
@@ -6937,6 +6938,20 @@ export const tOfcErc20Coins = [
     true,
     'baseeth'
   ),
+  ofcerc20(
+    'ca37bdc8-4dec-4a97-b659-98fe1863f046',
+    'ofcbaseeth:wpay',
+    'WPAY',
+    18,
+    UnderlyingAsset['baseeth:wpay'],
+    undefined,
+    undefined,
+    '',
+    undefined,
+    undefined,
+    true,
+    'baseeth'
+  ),
   tofcerc20(
     'b5277412-46b8-4da3-8fd2-5bf4557fcbd8',
     'ofctbaseeth:tusdl',
@@ -6977,6 +6992,20 @@ export const tOfcErc20Coins = [
     undefined,
     undefined,
     true,
+    'tbaseeth'
+  ),
+  tofcerc20(
+    '14d08f4c-cc9d-45b3-94ed-972e993fef30',
+    'ofctbaseeth:tpdd',
+    'MarketplacePDD ALPACA',
+    18,
+    UnderlyingAsset['tbaseeth:tpdd'],
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
     'tbaseeth'
   ),
 ];

--- a/modules/statics/src/coins/polygonTokens.ts
+++ b/modules/statics/src/coins/polygonTokens.ts
@@ -1636,6 +1636,15 @@ export const polygonTokens = [
     UnderlyingAsset['polygon:gmc'],
     [...POLYGON_TOKEN_FEATURES, CoinFeature.STABLECOIN]
   ),
+  polygonErc20(
+    '8dbecb0b-aa9c-4582-915f-729d20c0d296',
+    'polygon:wpay',
+    'WPAY',
+    18,
+    '0x7abe9edf5c544a04da83e9110cf46dbc4759170c',
+    UnderlyingAsset['polygon:wpay'],
+    POLYGON_TOKEN_FEATURES
+  ),
   tpolygonErc20(
     '13dd4ab7-2d94-493c-9a61-323f6300f7e5',
     'tpolygon:tusdl',

--- a/modules/statics/src/coins/solTokens.ts
+++ b/modules/statics/src/coins/solTokens.ts
@@ -4127,6 +4127,16 @@ export const solTokens = [
     [...SOL_TOKEN_FEATURES, CoinFeature.STABLECOIN],
     ProgramID.Token2022ProgramId
   ),
+  solToken(
+    '2eb90745-a24c-47d4-b2dd-876dc6208144',
+    'sol:bils',
+    'BILS',
+    6,
+    'CDxFUPSRK4dC68jWV7SCPezU1vNYXz87Y6fjhhRvsuhd',
+    'CDxFUPSRK4dC68jWV7SCPezU1vNYXz87Y6fjhhRvsuhd',
+    UnderlyingAsset['sol:bils'],
+    SOL_TOKEN_FEATURES
+  ),
   tsolToken(
     '5f4de23d-67b5-4a8f-bb31-9c1c72f62489',
     'tsol:gousd',


### PR DESCRIPTION
## Summary

- Adds `eth:jpysc` (JPYSC) ERC-20 token on Ethereum mainnet with OFC support
- Adds `sol:bils` (BILS) SPL token on Solana mainnet with OFC support
- Adds `polygon:wpay` (WPAY) token on Polygon mainnet with OFC support
- Adds `baseeth:wpay` (WPAY) token on Base mainnet and `tbaseeth:tpdd` (MarketplacePDD ALPACA) on Base testnet with OFC support

## Test plan

- [ ] Verify new `UnderlyingAsset` enum entries in `base.ts`
- [ ] Verify new token entries appear in `allCoinsAndTokens` and respective coin files
- [ ] Run `yarn unit-test --scope @bitgo/statics` to confirm no regressions

TICKET: CECHO-1630

🤖 Generated with [Claude Code](https://claude.com/claude-code)