### PR TITLE
feat(sdk-core): export PrebuildTransactionFeeInfo type

### DIFF
--- a/modules/express/src/typedRoutes/api/v2/prebuildAndSignTransaction.ts
+++ b/modules/express/src/typedRoutes/api/v2/prebuildAndSignTransaction.ts
@@ -217,7 +217,7 @@ export const AddressVerificationData = t.partial({
 });
 
 /**
- * Fee information
+ * Fee information — codec for {@link PrebuildTransactionFeeInfo} from sdk-core.
  */
 export const FeeInfo = t.partial({
   /** Fee amount */
@@ -225,6 +225,7 @@ export const FeeInfo = t.partial({
   /** Fee as string */
   feeString: t.string,
 });
+export type FeeInfo = t.TypeOf<typeof FeeInfo>;
 
 /**
  * Consolidation details for sweep/consolidation transactions

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -2,7 +2,7 @@ import { Key, SerializedKeyPair } from 'openpgp';
 import { EncryptionVersion, IEncryptionSession, IRequestTracer } from '../../../api';
 import { type ITransactionRecipient, KeychainsTriplet, ParsedTransaction, TransactionParams } from '../../baseCoin';
 import { ApiKeyShare, Keychain, WebauthnKeyEncryptionInfo } from '../../keychain';
-import { ApiVersion, Memo, WalletType } from '../../wallet';
+import { ApiVersion, Memo, WalletType, type PrebuildTransactionFeeInfo } from '../../wallet';
 import { EDDSA, GShare, Signature, SignShare } from '../../../account-lib/mpc/tss';
 import { Signature as EcdsaSignature } from '../../../account-lib/mpc/tss/ecdsa/types';
 import { KeyShare } from './ecdsa';
@@ -531,10 +531,7 @@ export type UnsignedTransactionTss = SignableTransaction & {
   // derivation path of the signer
   derivationPath: string;
   // transaction fees
-  feeInfo?: {
-    fee: number;
-    feeString: string;
-  };
+  feeInfo?: Required<PrebuildTransactionFeeInfo>;
   coinSpecific?: Record<string, unknown>;
   parsedTx?: unknown;
   eip1559?: EIP1559FeeOptions;
@@ -769,10 +766,7 @@ export interface MPCTx {
   signableHex?: string;
   derivationPath?: string;
   parsedTx?: ParsedTransaction;
-  feeInfo?: {
-    fee: number;
-    feeString: string;
-  };
+  feeInfo?: Required<PrebuildTransactionFeeInfo>;
   coinSpecific?: {
     firstValid?: number;
     maxDuration?: number;

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -323,7 +323,13 @@ export interface PrebuildAndSignTransactionOptions extends PrebuildTransactionOp
   verification?: VerificationOptions;
 }
 
-export interface PrebuildTransactionResult extends TransactionPrebuild {
+/** Fee fields returned on {@link PrebuildTransactionResult} (withdraw / send previews). */
+export type PrebuildTransactionFeeInfo = {
+  fee?: number;
+  feeString?: string;
+};
+
+export type PrebuildTransactionResult = TransactionPrebuild & {
   walletId: string;
   // Consolidate ID is used for consolidate account transactions and indicates if this is
   // a consolidation and what consolidate group it should be referenced by.
@@ -332,16 +338,13 @@ export interface PrebuildTransactionResult extends TransactionPrebuild {
   consolidationDetails?: {
     senderAddressIndex: number;
   };
-  feeInfo?: {
-    fee?: number;
-    feeString?: string;
-  };
+  feeInfo?: PrebuildTransactionFeeInfo;
   pendingApprovalId?: string;
   reqId?: IRequestTracer;
   payload?: string;
   stakingParams?: unknown;
   recipients?: ITransactionRecipient[];
-}
+};
 
 export interface CustomSigningFunction {
   (params: {

--- a/modules/sdk-core/test/unit/bitgo/wallet/prebuildTransactionTypes.ts
+++ b/modules/sdk-core/test/unit/bitgo/wallet/prebuildTransactionTypes.ts
@@ -1,0 +1,19 @@
+import assert from 'assert';
+
+import type { PrebuildTransactionFeeInfo, PrebuildTransactionResult } from '../../../../src/bitgo/wallet/iWallet';
+
+describe('PrebuildTransactionFeeInfo', () => {
+  it('assigns feeInfo on PrebuildTransactionResult', () => {
+    const feeInfo: PrebuildTransactionFeeInfo = {
+      fee: 1000,
+      feeString: '1000',
+    };
+
+    const prebuild: Pick<PrebuildTransactionResult, 'walletId' | 'feeInfo'> = {
+      walletId: 'wallet-id',
+      feeInfo,
+    };
+
+    assert.strictEqual(prebuild.feeInfo?.feeString, '1000');
+  });
+});


### PR DESCRIPTION
## Summary
- Export `PrebuildTransactionFeeInfo` from `iWallet.ts` and convert `PrebuildTransactionResult` from `interface` to `type`.
- Reuse it in TSS `UnsignedTransactionTss` / `MPCTx` (`Required<PrebuildTransactionFeeInfo>`) and Express `FeeInfo` codec/type alias.
- Not from `@bitgo/public-types` — existing public-types `feeInfo` shapes differ (required fields / `fee: string | number` on unsigned tx).

## Out of scope (different shapes)
- `iBaseCoin` `UnsignedTransaction.feeInfo` (`fee: number | BigNumber`)
- coin-specific `FeeInfo` (XRP, TRX, UTXO recovery, go-staking)
- bitgo-ui `PrebuildTransactionResultDetails.feeInfo` (adds `payGoFee`, `gas*`, etc.)

## Test plan
- [ ] `yarn unit-test --scope @bitgo/sdk-core` (or the prebuildTransactionTypes suite)
- [x] `yarn tsc --noEmit` in `modules/sdk-core`

No ticket — local side improvement (`WEB-000`).