### PR TITLE
fix: update npmjs-release.yml to use _hasShrinkwrap

### DIFF
--- a/.github/workflows/npmjs-release.yml
+++ b/.github/workflows/npmjs-release.yml
@@ -333,7 +333,7 @@ jobs:
 
       # bitgo's `prepack` script generates npm-shrinkwrap.json at pack time (see
       # scripts/generate-bitgo-shrinkwrap.ts). npm only honors a shipped shrinkwrap
-      # for installers when the registry's own metadata says hasShrinkwrap: true —
+      # for installers when the registry's version metadata says _hasShrinkwrap: true —
       # confirm that here so a silent registry-side omission fails the release
       # instead of shipping a package whose shrinkwrap consumers won't get.
       - name: Verify bitgo package has shrinkwrap metadata
@@ -343,13 +343,13 @@ jobs:
           # Registry metadata can lag briefly right after publish, so retry before
           # failing the release on what might just be propagation delay.
           if ! retry --up-to 5x --every 5s -- bash -c "
-            has_shrinkwrap=\$(curl -sL 'https://registry.npmjs.org/bitgo/${version}' | jq -r '.dist.hasShrinkwrap // false')
+            has_shrinkwrap=\$(curl -sL 'https://registry.npmjs.org/bitgo/${version}' | jq -r '._hasShrinkwrap // false')
             [ \"\$has_shrinkwrap\" = 'true' ]
           "; then
-            echo "::error::Published bitgo@${version} is missing hasShrinkwrap metadata on the npm registry."
+            echo "::error::Published bitgo@${version} is missing _hasShrinkwrap metadata on the npm registry."
             exit 1
           fi
-          echo "✅ bitgo@${version} published with hasShrinkwrap: true."
+          echo "✅ bitgo@${version} published with _hasShrinkwrap: true."
 
       - name: Generate version bump summary
         id: version-bump-summary


### PR DESCRIPTION
Fix `.github/workflows/npmjs-release.yml` to query correct `._hasShrinkwrap` instead of `.dist.hasShrinkwrap`

Ticket: WCN-1422