### PR TITLE
feat(statics): onboard ARC, ScrollETH, Katana and Boba tokens

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -4888,6 +4888,68 @@ export const allCoinsAndTokens = [
     Networks.main.basechain
   ),
 
+  // ARC mainnet tokens
+  erc20Token(
+    '61f600f8-9692-4d9e-af3d-f25c57b243f4',
+    'arcusdc:eurc',
+    'EURC',
+    6,
+    '0x89b50855aa3be2f677cd6303cec089b5f319d72a',
+    UnderlyingAsset['arcusdc:eurc'],
+    Networks.main.arcusdc
+  ),
+  erc20Token(
+    'e18ae504-875b-4b5c-a797-5f6797de66a7',
+    'arcusdc:usyc',
+    'US Yield Coin',
+    6,
+    '0xe9185f0c5f296ed1797aae4238d26ccabeadb86c',
+    UnderlyingAsset['arcusdc:usyc'],
+    Networks.main.arcusdc
+  ),
+
+  // Scroll mainnet tokens
+  erc20Token(
+    'a6d6b9b1-5a6d-4e88-80da-477c6c219b19',
+    'scrolleth:scr',
+    'Scroll',
+    18,
+    '0xd29687c813d741e2f938f4ac377128810e217b1b',
+    UnderlyingAsset['scrolleth:scr'],
+    Networks.main.scrolleth
+  ),
+
+  // Boba mainnet tokens
+  erc20Token(
+    '5805c7df-09f6-4e4d-abc6-fcaffee1511f',
+    'bobaeth:boba',
+    'Boba Token',
+    18,
+    '0xa18bf3994c0cc6e3b63ac420308e5383f53120d7',
+    UnderlyingAsset['bobaeth:boba'],
+    Networks.main.boba
+  ),
+  erc20Token(
+    '094716ce-6222-47b9-9125-64ced904b9eb',
+    'bobaeth:usdt',
+    'Tether USD',
+    6,
+    '0x5de1677344d3cb0d7d465c10b72a8f60699c062d',
+    UnderlyingAsset['bobaeth:usdt'],
+    Networks.main.boba
+  ),
+
+  // Katana mainnet tokens
+  erc20Token(
+    'c0e49c8f-384c-4da1-baf9-b6685fc9c651',
+    'katanaeth:kat',
+    'Katana Network Token',
+    18,
+    '0x7f1f4b4b29f5058fa32cc7a97141b8d7e5abdc2d',
+    UnderlyingAsset['katanaeth:kat'],
+    Networks.main.katanaeth
+  ),
+
   // XDC mainnet tokens
   xdcErc20(
     'b820932d-5772-49ae-a055-a59760f3e4cf',

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -4398,6 +4398,20 @@ export enum UnderlyingAsset {
   'tprividiumeth:USB-ESCROW-D' = 'tprividiumeth:USB-ESCROW-D',
   'tprividiumeth:tMMF' = 'tprividiumeth:tMMF',
 
+  // ARC mainnet tokens
+  'arcusdc:eurc' = 'arcusdc:eurc',
+  'arcusdc:usyc' = 'arcusdc:usyc',
+
+  // Scroll mainnet tokens
+  'scrolleth:scr' = 'scrolleth:scr',
+
+  // Boba mainnet tokens
+  'bobaeth:boba' = 'bobaeth:boba',
+  'bobaeth:usdt' = 'bobaeth:usdt',
+
+  // Katana mainnet tokens
+  'katanaeth:kat' = 'katanaeth:kat',
+
   // fiats
   AED = 'aed',
   AUD = 'aud',

--- a/modules/statics/src/coins/ofcErc20Coins.ts
+++ b/modules/statics/src/coins/ofcErc20Coins.ts
@@ -4534,6 +4534,98 @@ export const ofcErc20Coins = [
     18,
     underlyingAssetForSymbol('eth:ehybond1')
   ),
+
+  // ARC mainnet OFC tokens
+  ofcerc20(
+    '443ee3a6-363f-4f51-9c09-db6dae3abddf',
+    'ofcarcusdc:eurc',
+    'EURC',
+    6,
+    UnderlyingAsset['arcusdc:eurc'],
+    undefined,
+    undefined,
+    '',
+    undefined,
+    undefined,
+    true,
+    'arcusdc'
+  ),
+  ofcerc20(
+    'c7747fa0-1596-4f18-b142-8af65b1878f1',
+    'ofcarcusdc:usyc',
+    'US Yield Coin',
+    6,
+    UnderlyingAsset['arcusdc:usyc'],
+    undefined,
+    undefined,
+    '',
+    undefined,
+    undefined,
+    true,
+    'arcusdc'
+  ),
+
+  // Scroll mainnet OFC tokens
+  ofcerc20(
+    '5ebb024c-129f-40bc-9473-00432f4b8ac3',
+    'ofcscrolleth:scr',
+    'Scroll',
+    18,
+    UnderlyingAsset['scrolleth:scr'],
+    undefined,
+    undefined,
+    '',
+    undefined,
+    undefined,
+    true,
+    'scrolleth'
+  ),
+
+  // Boba mainnet OFC tokens
+  ofcerc20(
+    '03402ab8-398a-4275-b08d-12177c09a5ee',
+    'ofcbobaeth:boba',
+    'Boba Token',
+    18,
+    UnderlyingAsset['bobaeth:boba'],
+    undefined,
+    undefined,
+    '',
+    undefined,
+    undefined,
+    true,
+    'bobaeth'
+  ),
+  ofcerc20(
+    'bb1cb5d2-6de2-468b-9d50-dfd921955170',
+    'ofcbobaeth:usdt',
+    'Tether USD',
+    6,
+    UnderlyingAsset['bobaeth:usdt'],
+    undefined,
+    undefined,
+    '',
+    undefined,
+    undefined,
+    true,
+    'bobaeth'
+  ),
+
+  // Katana mainnet OFC tokens
+  ofcerc20(
+    'c49375bf-8c11-43a1-8420-4cb4e09fc013',
+    'ofckatanaeth:kat',
+    'Katana Network Token',
+    18,
+    UnderlyingAsset['katanaeth:kat'],
+    undefined,
+    undefined,
+    '',
+    undefined,
+    undefined,
+    true,
+    'katanaeth'
+  ),
 ];
 
 export const tOfcErc20Coins = [


### PR DESCRIPTION
Adds ERC20 and OFC entries for 6 tokens across 4 EVM chains:
- arcusdc:eurc (EURC, 6 decimals)
- arcusdc:usyc (US Yield Coin, 6 decimals)
- scrolleth:scr (Scroll, 18 decimals)
- bobaeth:boba (Boba Token, 18 decimals)
- bobaeth:usdt (Tether USD, 6 decimals)
- katanaeth:kat (Katana Network Token, 18 decimals)

TICKET: CECHO-1676

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
