### PR TITLE
feat(statics): onboard pol and baseeth assets

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -4257,6 +4257,24 @@ export const allCoinsAndTokens = [
     Networks.test.basechain
   ),
   erc20Token(
+    '83fc8008-9ac2-4a4f-a0e2-683f212fbd5b',
+    'tbaseeth:tnmr',
+    'AlpacaNMR',
+    18,
+    '0x443d8b40b2c44c696ef4833382ab948a9fbb8386',
+    UnderlyingAsset['tbaseeth:tnmr'],
+    Networks.test.basechain
+  ),
+  erc20Token(
+    '78c6bd98-0b93-462a-887b-fa6709eb662c',
+    'tbaseeth:tabeq',
+    'AlpacaABEQ',
+    18,
+    '0xb5f5c1bfb7e7501c13e13eb1ccc90126a7b568f2',
+    UnderlyingAsset['tbaseeth:tabeq'],
+    Networks.test.basechain
+  ),
+  erc20Token(
     '439fb12d-fddf-4749-8a33-b7c79fefc1b4',
     'baseeth:wave',
     'Waveform',

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -3090,6 +3090,7 @@ export enum UnderlyingAsset {
   'polygon:bolt' = 'polygon:bolt',
   'polygon:gmc' = 'polygon:gmc',
   'polygon:wpay' = 'polygon:wpay',
+  'polygon:seag' = 'polygon:seag',
   // Polygon NFTs
   // generic NFTs
   'erc721:polygontoken' = 'erc721:polygontoken',
@@ -3535,6 +3536,8 @@ export enum UnderlyingAsset {
   'tbaseeth:ttbills' = 'tbaseeth:ttbills',
   'tbaseeth:kmusdc' = 'tbaseeth:kmusdc',
   'tbaseeth:tpdd' = 'tbaseeth:tpdd',
+  'tbaseeth:tnmr' = 'tbaseeth:tnmr',
+  'tbaseeth:tabeq' = 'tbaseeth:tabeq',
 
   // Og mainnet tokens
   'og:wog' = 'og:wog',

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -4443,6 +4443,13 @@ export const ofcCoins = [
     18,
     UnderlyingAsset['polygon:wpay']
   ),
+  ofcPolygonErc20(
+    '941505f6-876c-4fa0-9a73-b38a6841bad2',
+    'ofcpolygon:seag',
+    'Seltene Erden AG',
+    0,
+    UnderlyingAsset['polygon:seag']
+  ),
 
   tofcPolygonErc20(
     '62f4329d-11cd-4875-b91b-9ceae66c9439',

--- a/modules/statics/src/coins/ofcErc20Coins.ts
+++ b/modules/statics/src/coins/ofcErc20Coins.ts
@@ -7099,6 +7099,34 @@ export const tOfcErc20Coins = [
     undefined,
     'tbaseeth'
   ),
+  tofcerc20(
+    '92facd39-816e-49c1-bd0f-29e9d33ae8e8',
+    'ofctbaseeth:tnmr',
+    'AlpacaNMR',
+    18,
+    UnderlyingAsset['tbaseeth:tnmr'],
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    'tbaseeth'
+  ),
+  tofcerc20(
+    'd9c3084d-0fe3-421d-b0a3-1c7a4d0a8d87',
+    'ofctbaseeth:tabeq',
+    'AlpacaABEQ',
+    18,
+    UnderlyingAsset['tbaseeth:tabeq'],
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    'tbaseeth'
+  ),
 ];
 
 function underlyingAssetForSymbol(underlyingAssetValue: string): UnderlyingAsset {

--- a/modules/statics/src/coins/polygonTokens.ts
+++ b/modules/statics/src/coins/polygonTokens.ts
@@ -1645,6 +1645,15 @@ export const polygonTokens = [
     UnderlyingAsset['polygon:wpay'],
     POLYGON_TOKEN_FEATURES
   ),
+  polygonErc20(
+    '351c2fb8-d567-4423-8ebb-3780cbc50a3b',
+    'polygon:seag',
+    'Seltene Erden AG',
+    0,
+    '0x23d239cd82ad06b17fc04983732b3fa4dc7e99a9',
+    UnderlyingAsset['polygon:seag'],
+    POLYGON_TOKEN_FEATURES
+  ),
   tpolygonErc20(
     '13dd4ab7-2d94-493c-9a61-323f6300f7e5',
     'tpolygon:tusdl',


### PR DESCRIPTION
TICKET: CECHO-1630

Adds polygon:seag (Seltene Erden AG) token on Polygon mainnet with OFC support
Adds tbaseeth:tnmr (AlpacaNMR) and tbaseeth:tabeq (AlpacaABEQ) on Base testnet with OFC support
