### PR TITLE
fix(sdk-coin-polyx): forward caller material into v8 batch staking builder on rebuild [SI-1034]

### DIFF
--- a/modules/sdk-coin-polyx/src/lib/transactionBuilderFactory.ts
+++ b/modules/sdk-coin-polyx/src/lib/transactionBuilderFactory.ts
@@ -228,7 +228,14 @@ export class TransactionBuilderFactory extends BaseTransactionBuilderFactory {
           // throwing, so tryGetV8Builder never fires. See SI-981.
           const bondArgs = args.calls[0].args as { controller?: unknown };
           if (bondArgs.controller === undefined) {
-            return this.getV8BatchStakingBuilder();
+            // Forward the factory's material (set by the caller, e.g. wallet-platform's
+            // getSignedTx via `.material(liveMaterial).from(...)`). Unlike the v7 getters,
+            // getV8BatchStakingBuilder() does NOT forward this._material and would otherwise
+            // keep the builder's static getV8Material(). On the decode-success path this._material
+            // is the material that just decoded the tx, so it is the correct one to rebuild with —
+            // without this, a rebuild uses stale static specVersion and the signable no longer
+            // matches the HSM-signed bytes (InvalidSignature on combine). See SI-1034.
+            return this.getV8BatchStakingBuilder().material(this._material);
           }
           return this.getBatchBuilder();
         }

--- a/modules/sdk-coin-polyx/test/unit/transactionBuilder/v8BatchStakingBuilder.ts
+++ b/modules/sdk-coin-polyx/test/unit/transactionBuilder/v8BatchStakingBuilder.ts
@@ -10,6 +10,7 @@ import {
   V8WithdrawUnbondedBuilder,
   V8NominateBuilder,
   SingletonRegistry,
+  Interface,
 } from '../../../src/lib';
 import { BatchArgs, NominateArgs, V8BondArgs } from '../../../src/lib/iface';
 import utils from '../../../src/lib/utils';
@@ -169,6 +170,50 @@ describe('V8BatchStakingBuilder', function () {
       const v8Factory = new TransactionBuilderFactory(coins.get('tpolyx')).material(v8Material);
       const builder = v8Factory.from(rawTxHex);
       should.ok(builder instanceof V8BatchStakingBuilder);
+    });
+
+    it('factory.material(liveMaterial).from(...) forwards the live material into the rebuilt v8 batch staking builder (SI-1034)', async () => {
+      // Reproduces the custodial staking incident: the HSM signs against LIVE chain material
+      // (e.g. a specVersion bump after a runtime upgrade), but wallet-platform's getSignedTx
+      // re-verifies by calling `factory.material(liveMaterial).from(serializedTxHex)`. On the
+      // decode-success path, `getBuilder()` used to return `getV8BatchStakingBuilder()` without
+      // forwarding `this._material`, so the rebuild silently fell back to the builder's static
+      // `getV8Material()` (stale specVersion) instead of the caller's live material. Because
+      // specVersion is embedded in the raw ExtrinsicPayload bytes that are actually signed, the
+      // rebuilt signable payload would then diverge from the one the HSM signed, producing
+      // `InvalidSignature: invalid key signature` at Trust approval.
+      //
+      // Simulate a "live" chain that has moved past the pinned static testnet v8 material by
+      // bumping specVersion on a copy of it.
+      const liveMaterial = {
+        ...testnetV8Material,
+        specVersion: testnetV8Material.specVersion + 10,
+      } as unknown as Interface.Material;
+
+      const originalTx = await new V8BatchStakingBuilder(buildTestConfig())
+        .material(liveMaterial)
+        .amount(bondAmount)
+        .payee('Staked')
+        .validators([validator])
+        .sender({ address: stash })
+        .validity({ firstValid, maxDuration: 64 })
+        .referenceBlock(referenceBlock)
+        .sequenceId({ name: 'Nonce', keyword: 'nonce', value: nonce })
+        .build();
+      const rawTxHex = originalTx.toBroadcastFormat();
+      const originalSignablePayload = originalTx.signablePayload.toString('hex');
+
+      const rebuiltBuilder = new TransactionBuilderFactory(coins.get('tpolyx')).material(liveMaterial).from(rawTxHex);
+      // The raw signing payload does not carry the sender address or the raw `firstValid` block
+      // number (only the encoded era), so — like any real caller re-verifying a decoded
+      // transaction — they must be supplied again before build() can run.
+      (rebuiltBuilder as V8BatchStakingBuilder).sender({ address: stash }).validity({ firstValid, maxDuration: 64 });
+      const rebuiltTx = await rebuiltBuilder.build();
+      const rebuiltSignablePayload = rebuiltTx.signablePayload.toString('hex');
+
+      // Without the SI-1034 fix, this fails: the rebuild uses the static material (specVersion
+      // 8000000) instead of liveMaterial (specVersion 8000010), so the payloads differ.
+      should.equal(rebuiltSignablePayload, originalSignablePayload);
     });
   });
 });


### PR DESCRIPTION
## Summary
Custodial Polymesh **v8 stake** fails at Trust approval with `InvalidSignature: invalid key signature` in `TPOLYX.getSignedTx`, while custodial transfers on the same wallet succeed.

**Root cause (proven from staging Loki + payload decode):** the tx is signed by the HSM against **live** chain material (specVersion `8000010`) but re-verified against **stale static** material (`getV8Material()`, specVersion `8000000`). In `TransactionBuilderFactory.getBuilder()`, the v8 `batchAll(bond,nominate)` decode-success path returned `getV8BatchStakingBuilder()` **without forwarding `this._material`** — unlike every v7 getter. So `factory.material(liveMaterial).from(serializedTxHex)` (what wallet-platform's `getSignedTx` does) silently dropped the live material; the rebuilt signable payload used a stale `specVersion` and no longer matched the signed bytes.

Transfers work because their getters (`getTransferBuilder`/`getHexTransferBuilder`) already forward `this._material`.

## Change
One line, on the decode-success path only:
```diff
-            return this.getV8BatchStakingBuilder();
+            return this.getV8BatchStakingBuilder().material(this._material);
```
The v8 getters and the `tryGetV8Builder()` decode-failure catch path are intentionally left untouched — that path relies on the static v8 default when `this._material` cannot decode the tx.

## Test
New unit test in `v8BatchStakingBuilder.ts`: bumps `specVersion` by 10 on a copy of `testnetV8Material` (simulating the real `8000000 → 8000010` chain upgrade), builds → serializes → rebuilds via `factory.material(liveMaterial).from(...)`, and asserts the rebuilt `signablePayload` equals the original.

- **Without the fix:** fails with the exact production byte diff — `…00127a00…` (static 8000000) vs `…0a127a00…` (live 8000010), rest of payload byte-identical.
- **With the fix:** 29 passing in the v8 batch staking suite.

## Notes
- Draft. Depends on the SI-981 routing commit (`c22ca5c633`), which is included in this branch's diff until SI-981 lands on `master`.
- **Must deploy to staging and retest** custodial stake (1-validator and multi-validator) before merging.
- Follow-up (separate): refresh the stale static `testnetV8Material`/`mainnetV8Material` specVersion so the decode-failure catch path stays valid across future runtime upgrades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
