### PR TITLE
feat(statics): add liquid-staking to sol:jsol and sol:stsol

### DIFF
--- a/modules/statics/src/coins/solTokens.ts
+++ b/modules/statics/src/coins/solTokens.ts
@@ -1298,7 +1298,7 @@ export const solTokens = [
     '7Q2afV64in6N6SeZsAAB81TJzwDoD6zpqmHkzi9Dcavn',
     '7Q2afV64in6N6SeZsAAB81TJzwDoD6zpqmHkzi9Dcavn',
     UnderlyingAsset['sol:jsol'],
-    SOL_TOKEN_FEATURES
+    [...SOL_TOKEN_FEATURES, CoinFeature.LIQUID_STAKING]
   ),
   solToken(
     'f98eb4de-23c4-475d-80f2-382808e8d350',
@@ -1348,7 +1348,7 @@ export const solTokens = [
     '7dHbWXmci3dT8UFYWYZweBLXgycu7Y3iL6trKn1Y7ARj',
     '7dHbWXmci3dT8UFYWYZweBLXgycu7Y3iL6trKn1Y7ARj',
     UnderlyingAsset.STSOL,
-    SOL_TOKEN_FEATURES
+    [...SOL_TOKEN_FEATURES, CoinFeature.LIQUID_STAKING]
   ),
   solToken(
     '039d4c7d-3e48-40b3-896d-512fcfe60f1e',

--- a/modules/statics/test/unit/coins.ts
+++ b/modules/statics/test/unit/coins.ts
@@ -1328,6 +1328,15 @@ describe('Eip1559 coins', () => {
   });
 });
 
+describe('Liquid Staking Features', () => {
+  it('should have LIQUID_STAKING feature for sol:jsol and sol:stsol', () => {
+    ['sol:jsol', 'sol:stsol'].forEach((coinName) => {
+      const coin = coins.get(coinName);
+      coin.features.includes(CoinFeature.LIQUID_STAKING).should.eql(true);
+    });
+  });
+});
+
 describe('create token map using config details', () => {
   it('should create a valid token map from AmsTokenConfig', () => {
     const tokenMap = createTokenMapUsingConfigDetails(amsTokenConfig);


### PR DESCRIPTION
## Summary
- Add `CoinFeature.LIQUID_STAKING` to `sol:jsol` (JPool) and `sol:stsol` (Lido)
- Unit test asserts both tokens expose the feature

Linear: [DEFI-435](https://linear.app/bitgo/issue/DEFI-435/add-liquid-staking-feature-for-soljsol-and-solstsol-lido)

## Test plan
- [ ] `yarn unit-test --grep 'LIQUID_STAKING feature for sol:jsol'` in `modules/statics` passes
- [ ] After statics publish: AMS bump + statics migration for `sol:jsol`, `sol:stsol`
- [ ] Confirm `features` includes `liquid-staking` via AMS assets list


