### PR TITLE
fix(statics): rename eth:aethwsteth to Aave Ethereum wstETH

### DIFF
--- a/modules/statics/src/coins/botTokens.ts
+++ b/modules/statics/src/coins/botTokens.ts
@@ -1279,7 +1279,7 @@ export const botTokens = [
   AccountCtors.erc20(
     'd15d88b2-3c20-4ff4-88c3-ca2d544fec21',
     'eth:aethwsteth',
-    'Wrapped liquid staked Ether 2.0',
+    'Aave Ethereum wstETH',
     18,
     '0x0b925ed163218f6662a35e0f0371ac234f9e9371',
     'eth:aethwsteth' as unknown as UnderlyingAsset,


### PR DESCRIPTION
## Summary
- Rename `eth:aethwsteth` fullName from `Wrapped liquid staked Ether 2.0` to `Aave Ethereum wstETH`
- Matches Aave receipt-token naming (`eth:aethweth` → `Aave Ethereum WETH`)

Linear: [DEFI-436](https://linear.app/bitgo/issue/DEFI-436/rename-ethaethwsteth-to-aave-ethereum-wsteth)

Companion: jobs mongo_query to update AMS DB (source of truth for TAT assets). Without that, AMS→statics bot can overwrite this name.

## Test plan
- [ ] Confirm `botTokens.ts` fullName for `eth:aethwsteth` is `Aave Ethereum wstETH`
- [ ] Merge + run jobs DEFI-436 prod mongo_query
- [ ] Verify AMS asset name/display_name updated
- [ ] Confirm next AMS bot sync does not revert


