### PR TITLE
fix(sdk-coin-polyx): route v8 token transfers with dropped sender.did to v8 builder

### DIFF
--- a/modules/sdk-coin-polyx/src/lib/transactionBuilderFactory.ts
+++ b/modules/sdk-coin-polyx/src/lib/transactionBuilderFactory.ts
@@ -202,6 +202,17 @@ export class TransactionBuilderFactory extends BaseTransactionBuilderFactory {
       return this.getPreApproveAssetBuilder();
     } else if (methodName === MethodNames.AddAndAffirmWithMediators) {
       const args = decodedTxn.method.args as AddAndAffirmWithMediatorsArgs;
+      // v8 wraps leg sender/receiver in an AssetHolder enum (`{ portfolio: { did, kind } }`)
+      // instead of the bare v7 `{ did, kind }`. The call index is unchanged between v7/v8, so
+      // decoding a v8-encoded payload with v7 metadata does not throw — it just silently drops
+      // `sender.did`. Detect that here and retry with v8 material instead of proceeding with a
+      // builder that will fail schema validation on the missing field.
+      if (!args.legs?.[0]?.fungible?.sender?.did) {
+        const v8Builder = this.tryGetV8Builder(rawTxn);
+        if (v8Builder) {
+          return v8Builder;
+        }
+      }
       if (utils.isNewMemoEncoding(args.instructionMemo)) {
         return this.getHexTokenTransferBuilder();
       }

--- a/modules/sdk-coin-polyx/test/unit/transactionBuilder/transactionBuilderFactory.ts
+++ b/modules/sdk-coin-polyx/test/unit/transactionBuilder/transactionBuilderFactory.ts
@@ -1,8 +1,14 @@
 import { coins } from '@bitgo/statics';
 import should from 'should';
-import { TransactionBuilderFactory, TransferBuilder, V8TransferBuilder, V8HexTransferBuilder } from '../../../src/lib';
+import {
+  TransactionBuilderFactory,
+  TransferBuilder,
+  V8TransferBuilder,
+  V8HexTransferBuilder,
+  V8TokenTransferBuilder,
+} from '../../../src/lib';
 import { Interface } from '../../../src';
-import { rawTx, accounts } from '../../resources';
+import { rawTx, accounts, mockTssSignature } from '../../resources';
 import * as materialData from '../../resources/materialData.json';
 import { buildTestConfig } from './base';
 
@@ -98,6 +104,104 @@ describe('Tao Transaction Builder Factory', function () {
       const factoryInst = new TransactionBuilderFactory(buildTestConfig());
       const builder = factoryInst.from(rawTx.transfer.signed);
       should.ok(builder instanceof TransferBuilder, 'expected TransferBuilder for v7 txHex');
+    });
+  });
+
+  // Regression test for the bug where getBuilder() decoded a v8 addAndAffirmWithMediators
+  // payload with v7 metadata (same call index, so no throw), silently lost sender.did, then
+  // routed to the v7 TokenTransferBuilder — causing Joi to throw
+  // 'legs[0].fungible.sender.did is required'.
+  describe('v8 token transfer routing regression', function () {
+    const FROM_DID = '0x1208d7851e6698249aea40742701ee1ef6cdcced260a7c49c1cca1a9db836342';
+    const TO_DID = '0xbc6f7ec808f361c1353ab9dc88c3cc54b98d9eb60fed9c063e67a40925b8ef61';
+    const ASSET_ID = '0x780602887b358cf48989d0d9aa6c8d28';
+    const VALIDITY = { firstValid: 3933, maxDuration: 64 };
+    const REF_BLOCK = '0x149799bc9602cb5cf201f3425fb8d253b2d4e61fc119dcab3249f307f594754d';
+
+    let unsignedHex: string;
+    let signedHex: string;
+
+    before(async function () {
+      const config = buildTestConfig();
+
+      // unsigned (no signature attached)
+      const unsignedTx = await new V8TokenTransferBuilder(config)
+        .assetId(ASSET_ID)
+        .amount('1000000')
+        .fromDID(FROM_DID)
+        .toDID(TO_DID)
+        .memo('0')
+        .sender({ address: sender.address })
+        .validity(VALIDITY)
+        .referenceBlock(REF_BLOCK)
+        .sequenceId({ name: 'Nonce', keyword: 'nonce', value: 1 })
+        .fee({ amount: 0, type: 'tip' })
+        .build();
+      unsignedHex = unsignedTx.toBroadcastFormat();
+
+      // signed
+      const signedBuilder = new V8TokenTransferBuilder(config)
+        .assetId(ASSET_ID)
+        .amount('1000000')
+        .fromDID(FROM_DID)
+        .toDID(TO_DID)
+        .memo('0')
+        .sender({ address: sender.address })
+        .validity(VALIDITY)
+        .referenceBlock(REF_BLOCK)
+        .sequenceId({ name: 'Nonce', keyword: 'nonce', value: 1 })
+        .fee({ amount: 0, type: 'tip' });
+      signedBuilder.addSignature({ pub: sender.publicKey }, Buffer.from(mockTssSignature, 'hex'));
+      const signedTx = await signedBuilder.build();
+      signedHex = signedTx.toBroadcastFormat();
+    });
+
+    it('routes a v8 token transfer tx to V8TokenTransferBuilder (not TokenTransferBuilder)', function () {
+      // The call index for addAndAffirmWithMediators is identical in v7 and v8, so the v7 decode
+      // path "succeeds" but drops sender.did. The fix in getBuilder() detects the missing field
+      // and redirects to tryGetV8Builder() before Joi validation fires.
+      const factoryInst = new TransactionBuilderFactory(buildTestConfig());
+      const builder = factoryInst.from(signedHex);
+      should.ok(
+        builder instanceof V8TokenTransferBuilder,
+        'expected V8TokenTransferBuilder — v8 payload must not be silently mis-routed to v7 TokenTransferBuilder'
+      );
+      // V8TokenTransferBuilder extends TokenTransferBuilder; verify it is the v8 subclass
+      // specifically (constructor name) so a future refactor that breaks the class hierarchy
+      // is caught here rather than silently allowing a plain TokenTransferBuilder through.
+      should.equal(
+        builder.constructor.name,
+        'V8TokenTransferBuilder',
+        'constructor must be V8TokenTransferBuilder, not plain TokenTransferBuilder'
+      );
+    });
+
+    it('rebuilds from unsigned v8 token transfer hex with correct fields and matching raw output', async function () {
+      const factoryInst = new TransactionBuilderFactory(buildTestConfig());
+      const builder = factoryInst.from(unsignedHex);
+      builder.validity(VALIDITY).referenceBlock(REF_BLOCK).sender({ address: sender.address });
+      const rebuilt = await builder.build();
+
+      const json = rebuilt.toJson();
+      should.equal(json.assetId, ASSET_ID);
+      should.equal(json.amount, '1000000');
+      should.equal(json.fromDID, FROM_DID);
+      should.equal(json.toDID, TO_DID);
+      should.equal(rebuilt.toBroadcastFormat(), unsignedHex, 'unsigned round-trip hex must match original');
+    });
+
+    it('rebuilds from signed v8 token transfer hex with correct fields and matching raw output', async function () {
+      const factoryInst = new TransactionBuilderFactory(buildTestConfig());
+      const builder = factoryInst.from(signedHex);
+      builder.validity(VALIDITY).referenceBlock(REF_BLOCK);
+      const rebuilt = await builder.build();
+
+      const json = rebuilt.toJson();
+      should.equal(json.assetId, ASSET_ID);
+      should.equal(json.amount, '1000000');
+      should.equal(json.fromDID, FROM_DID);
+      should.equal(json.toDID, TO_DID);
+      should.equal(rebuilt.toBroadcastFormat(), signedHex, 'signed round-trip hex must match original');
     });
   });
 });


### PR DESCRIPTION
## Description

Fixes token withdrawals (Polymesh `settlement.addAndAffirmWithMediators`) failing on the v7/v8 chain migration with:
```
Invalid transaction: "legs[0].fungible.sender.did" is required
```

`TransactionBuilderFactory.getBuilder()` decodes the raw tx against **v7 metadata first** and only retries against v8 material if that decode *throws*. v8 wraps leg `sender`/`receiver` in an `AssetHolder` enum (`{ portfolio: { did, kind } }`) instead of the bare v7 `{ did, kind }`, but the call index for `addAndAffirmWithMediators` is unchanged between v7/v8 — so decoding a v8-encoded token transfer with v7 metadata does **not** throw, it just silently produces a decoded transaction missing `legs[0].fungible.sender.did`. The factory then proceeds with the v7 `TokenTransferBuilder`, whose schema requires that field directly, and `validateDecodedTransaction` rejects the transaction during `wallet-platform`'s build-time round-trip re-parse of the withdrawal.

Native transfers (`transferWithMemo`) are unaffected because that call's v7/v8 arg shape didn't change.

## Fix

On the v7 decode-success path for `AddAndAffirmWithMediators`, detect a missing `legs[0].fungible.sender.did` and retry via the existing `tryGetV8Builder()` (which already correctly routes to `V8TokenTransferBuilder`/`V8HexTokenTransferBuilder`) before falling through to the v7 builder.

## Issue Number

TICKET: CECHO-1471

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `npx tsc --noEmit` in `modules/sdk-coin-polyx` — clean
- `npx mocha test/unit/transactionBuilder/*TokenTransfer*` — 31 passing
- `npx mocha test/unit/transactionBuilder/transactionBuilderFactory.ts` — 248 passing, 2 pending
- Root-caused against live staging logs (Loki/wallet-platform) reproducing the exact `sender.did` failure for a `TPOLYX:NVBITGOT` withdrawal on testnet Polymesh v8.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] My commits follow Conventional Commits
- [x] The ticket was included in the commit message as a reference
- [ ] I have added tests that prove my fix is effective — **TODO before merge**: add a regression test to `transactionBuilderFactory.ts`'s suite covering "v7 decode succeeds but sender.did missing → routes to v8 builder"
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)