### PR TITLE
ci(root): fix osv-scanner-action uses path

### DIFF
--- a/.github/workflows/npmjs-release.yml
+++ b/.github/workflows/npmjs-release.yml
@@ -267,7 +267,7 @@ jobs:
           yarn install --frozen-lockfile
 
       - name: Audit Dependencies
-        uses: google/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2  # v2.3.8
+        uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2  # v2.3.8
         with:
           scan-args: |-
             --config=osv-scanner.toml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
         run: sfw yarn install --with-frozen-lockfile
 
       - name: Audit Dependencies
-        uses: google/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2  # v2.3.8
+        uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2  # v2.3.8
         with:
           scan-args: |-
             --config=osv-scanner.toml


### PR DESCRIPTION
## Description
Fixes a broken `uses:` reference introduced in #9263 and carried forward in #9307. The root `action.yml` of `google/osv-scanner-action` only contains metadata (no `runs:` section) — the actual composite action lives at the `osv-scanner-action` subpath in that repo. This broke the publish workflow: https://github.com/BitGo/BitGoJS/actions/runs/29822821704/job/88609181185

## Issue Number
TICKET: VL-7134

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Change
- `google/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2` -> `google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2` in `publish.yml` and `npmjs-release.yml`

## How Has This Been Tested?
CI on this PR should exercise the fixed action path.