### PR TITLE
ci(root): fix osv-scanner severity flag and continue on error

### DIFF
--- a/.github/workflows/npmjs-release.yml
+++ b/.github/workflows/npmjs-release.yml
@@ -268,11 +268,10 @@ jobs:
 
       - name: Audit Dependencies
         uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2  # v2.3.8
+        continue-on-error: true
         with:
           scan-args: |-
             --config=osv-scanner.toml
-            --severity=HIGH
-            --severity=CRITICAL
             ./
 
       - name: Run dependency check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,11 +38,10 @@ jobs:
 
       - name: Audit Dependencies
         uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2  # v2.3.8
+        continue-on-error: true
         with:
           scan-args: |-
             --config=osv-scanner.toml
-            --severity=HIGH
-            --severity=CRITICAL
             ./
 
       - name: Set Environment Variable for Alpha


### PR DESCRIPTION
## Problem

The "Audit Dependencies" step in `publish.yml` and `npmjs-release.yml` fails with exit 127 because osv-scanner v2.3.8 no longer supports the `--severity=HIGH` / `--severity=CRITICAL` flag that was being passed as scan-args.

Failing run: https://github.com/BitGo/BitGoJS/actions/runs/29828802882/job/88628278879

## Fix

- Removed the invalid `--severity` scan-args from the Audit Dependencies step in both workflows.
- Added `continue-on-error: true` to that step (explicit request) so releases are never blocked by audit failures while the audit setup is iterated on.

Related prior fix attempt: #9310

TICKET: VL-7134