### PR TITLE
ci(root): remove continue-on-error from audit dependencies

### DIFF
--- a/.github/workflows/npmjs-release.yml
+++ b/.github/workflows/npmjs-release.yml
@@ -268,7 +268,6 @@ jobs:
 
       - name: Audit Dependencies
         uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2  # v2.3.8
-        continue-on-error: true
         with:
           scan-args: |-
             --config=osv-scanner.toml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,6 @@ jobs:
 
       - name: Audit Dependencies
         uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2  # v2.3.8
-        continue-on-error: true
         with:
           scan-args: |-
             --config=osv-scanner.toml


### PR DESCRIPTION
Reverts the temporary `continue-on-error: true` added to the "Audit Dependencies" (osv-scanner) step in #9311, so this step blocks releases on vulnerability findings again as originally intended.

Note: osv-scanner currently finds real, unfiltered vulnerabilities on this repo (see run https://github.com/BitGo/BitGoJS/actions/runs/29832702327/job/88641140972), so `publish.yml` / `npmjs-release.yml` runs will be blocked by this check until those findings are triaged and resolved. Ownership of that triage is moving to a different team — this PR intentionally does not touch dependencies or `osv-scanner.toml`, only removes the `continue-on-error` escape hatch.

Related: #9310, #9311

TICKET: VL-7134