### PR TITLE
fix(statics): add SUPPORTS_ERC20 to arcusdc/tarcusdc

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -3530,6 +3530,7 @@ export const allCoinsAndTokens = [
       CoinFeature.EVM_COMPATIBLE_UI,
       CoinFeature.EVM_NON_BITGO_RECOVERY,
       CoinFeature.EVM_UNSIGNED_SWEEP_RECOVERY,
+      CoinFeature.SUPPORTS_ERC20,
       CoinFeature.EVM_COMPATIBLE_WP,
     ]
   ),
@@ -3549,6 +3550,7 @@ export const allCoinsAndTokens = [
       CoinFeature.EVM_COMPATIBLE_UI,
       CoinFeature.EVM_NON_BITGO_RECOVERY,
       CoinFeature.EVM_UNSIGNED_SWEEP_RECOVERY,
+      CoinFeature.SUPPORTS_ERC20,
       CoinFeature.EVM_COMPATIBLE_WP,
     ]
   ),


### PR DESCRIPTION
## Summary
- Arc (Circle's L1) is EVM-compatible and supports ERC-20 deployment.
- The `arcusdc`/`tarcusdc` base coin entries were missing `CoinFeature.SUPPORTS_ERC20`, which excludes the family from WP's ERC20-automation pipeline (`evmChains` in `config/env/defaults/ethUtils.ts`) even once mainnet tokens exist.


## Test plan
- [ ] `yarn unit-test --scope @bitgo/statics`
- [ ] Confirm `arcusdc`/`tarcusdc` now appear in WP's ERC20-automation coin discovery once WP bumps this statics version

Ticket: CECHO-1676