### PR TITLE
fix(root): clear osv-scanner HIGH/CRITICAL findings blocking release

### DIFF
--- a/modules/sdk-coin-atom/package.json
+++ b/modules/sdk-coin-atom/package.json
@@ -53,7 +53,7 @@
     "@bitgo/sdk-api": "^2.1.2",
     "@bitgo/sdk-test": "^9.1.60",
     "@types/lodash": "^4.14.183",
-    "axios": "1.16.1"
+    "axios": "1.18.0"
   },
   "gitHead": "18e460ddf02de2dbf13c2aa243478188fb539f0c",
   "files": [

--- a/modules/sdk-coin-sui/package.json
+++ b/modules/sdk-coin-sui/package.json
@@ -56,7 +56,7 @@
     "@bitgo/sdk-api": "^2.1.2",
     "@bitgo/sdk-test": "^9.1.60",
     "@types/lodash": "^4.14.183",
-    "axios": "1.16.1",
+    "axios": "1.18.0",
     "debug": "^4.3.4"
   },
   "gitHead": "18e460ddf02de2dbf13c2aa243478188fb539f0c",

--- a/modules/sdk-core/package.json
+++ b/modules/sdk-core/package.json
@@ -69,7 +69,7 @@
     "strip-hex-prefix": "^1.0.0",
     "superagent": "^9.0.1",
     "tweetnacl": "^1.0.3",
-    "uuid": "^8.3.2"
+    "uuid": "11.1.1"
   },
   "devDependencies": {
     "@bitgo/sdk-opensslbytes": "^2.1.0",

--- a/modules/utxo-lib/package.json
+++ b/modules/utxo-lib/package.json
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@types/fs-extra": "^9.0.12",
     "@types/node": "^24.10.9",
-    "axios": "1.16.1",
+    "axios": "1.18.0",
     "debug": "^3.1.0",
     "fs-extra": "^9.1.0"
   },

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -53,3 +53,15 @@ reason = "protobufjs DoS via unbounded Any expansion (parseAny recursion); trans
 [[IgnoredVulns]]
 id = "GHSA-7c78-jf6q-g5cm"
 reason = "tmp path traversal via type-confusion in _assertPath (non-string args); transitive via cypress/karma/lerna/nx (dev-time only, never in production); all prefix/postfix/template args are hard-coded string constants — type-confusion vector does not apply"
+
+[[IgnoredVulns]]
+id = "GHSA-23hp-3jrh-7fpw"
+reason = "tar decompression/parse DoS via unlimited input; transitive via lerna/yeoman-generator/swarm-js requiring tar <7.5.19; fix only in tar 7.5.19+ which breaks lerna packDirectory (same constraint as GHSA-8qq5-rm4j-mr97); our usage is archive PACKING only, not extraction of untrusted archives"
+
+[[IgnoredVulns]]
+id = "GHSA-8x88-c5mf-7j5w"
+reason = "tar infinite loop via negative entry size; transitive via lerna/yeoman-generator/swarm-js requiring tar <7.5.18; fix only in tar 7.5.18+ which breaks lerna packDirectory (same constraint as GHSA-8qq5-rm4j-mr97); our usage is archive PACKING only, not extraction"
+
+[[IgnoredVulns]]
+id = "GHSA-v2hh-gcrm-f6hx"
+reason = "fast-uri host confusion via literal backslash authority (CVE-2026-16221); fixed in 3.1.4 but that release is held for SafeChain. Pinning 3.1.3 clears GHSA-4c8g-83qw-93j6 / CVE-2026-13676. Re-evaluate on 2026-07-26: bump to 3.1.4 and remove this temporary exclusion (security team guidance, WCI-1125)"

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@polkadot/keyring": "13.5.6",
     "elliptic": "^6.6.1",
     "cookie": "^0.7.1",
-    "axios": "1.16.1",
+    "axios": "1.18.0",
     "canvg": "4.0.3",
     "**/stellar-sdk/**/bignumber.js": "4.1.0",
     "**/stellar-base/**/bignumber.js": "4.1.0",
@@ -128,7 +128,7 @@
     "flatted": "3.4.2",
     "sjcl": "npm:@bitgo/sjcl@1.0.1",
     "picomatch": ">=2.3.2",
-    "fast-uri": "3.1.2",
+    "fast-uri": "3.1.3",
     "@babel/plugin-transform-modules-systemjs": "7.29.4",
     "protobufjs": "7.6.4",
     "@protobufjs/fetch": "1.1.0",
@@ -145,7 +145,9 @@
     "caniuse-lite": "1.0.30001799",
     "electron-to-chromium": "1.5.380",
     "baseline-browser-mapping": "2.10.40",
-    "sigstore": "4.1.1"
+    "sigstore": "4.1.1",
+    "uuid": "11.1.1",
+    "js-yaml": "4.3.0"
   },
   "overrides": {
     "qs": "6.15.2",
@@ -183,7 +185,7 @@
     "@polkadot/keyring": "13.5.6",
     "elliptic": "^6.6.1",
     "cookie": "^0.7.1",
-    "axios": "1.16.1",
+    "axios": "1.18.0",
     "canvg": "4.0.3",
     "bignumber.js": "9.1.2",
     "form-data": "^4.0.4",
@@ -197,12 +199,14 @@
     "flatted": "3.4.2",
     "sjcl": "npm:@bitgo/sjcl@1.0.1",
     "picomatch": ">=2.3.2",
-    "fast-uri": "3.1.2",
+    "fast-uri": "3.1.3",
     "@babel/plugin-transform-modules-systemjs": "7.29.4",
     "protobufjs": "7.6.4",
     "@protobufjs/fetch": "1.1.0",
     "@protobufjs/inquire": "1.1.0",
     "sigstore": "4.1.1",
+    "uuid": "11.1.1",
+    "js-yaml": "4.3.0",
     "cliui": {
       "strip-ansi": "6.0.1",
       "string-width": "4.2.3"
@@ -292,7 +296,7 @@
     "test:scripts": "mocha './scripts/tests/**/*.test.js'"
   },
   "dependencies": {
-    "axios": "1.16.1",
+    "axios": "1.18.0",
     "terser": "^5.14.2",
     "tmp": "^0.2.3",
     "bigint-buffer": "npm:@trufflesuite/bigint-buffer@1.1.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6578,7 +6578,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/ws@^8.2.2", "@types/ws@^8.5.10":
+"@types/ws@^8.2.2", "@types/ws@^8.5.10", "@types/ws@^8.5.12":
   version "8.18.1"
   resolved "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz"
   integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
@@ -7250,9 +7250,9 @@ are-we-there-yet@^3.0.0:
     delegates "^1.0.0"
     readable-stream "^3.6.0"
 
-argparse@^1.0.10, argparse@^1.0.7:
+argparse@^1.0.10:
   version "1.0.10"
-  resolved "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz"
+  resolved "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
@@ -7592,10 +7592,10 @@ aws4@^1.8.0:
   resolved "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz"
   integrity sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==
 
-axios@0.25.0, axios@0.27.2, axios@1.16.1, axios@1.7.4, axios@^0.21.2, axios@^0.26.1, axios@^1.6.0, axios@^1.8.3:
-  version "1.16.1"
-  resolved "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz#517e29291d19d6e8cf919ff264f4fe157261ba12"
-  integrity sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==
+axios@0.25.0, axios@0.27.2, axios@1.18.0, axios@1.7.4, axios@^0.21.2, axios@^0.26.1, axios@^1.6.0, axios@^1.8.3:
+  version "1.18.0"
+  resolved "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz#8a7f8854af280fcaae063272df2ed9f3837d2398"
+  integrity sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==
   dependencies:
     follow-redirects "^1.16.0"
     form-data "^4.0.5"
@@ -8114,17 +8114,17 @@ borsh@^0.7.0:
     text-encoding-utf-8 "^1.0.2"
 
 brace-expansion@^1.1.7:
-  version "1.1.12"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz"
-  integrity sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==
+  version "1.1.16"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz#723d3a30c0558c225abc9fc479a73e14e26c3c2f"
+  integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 brace-expansion@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz"
-  integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz#0bba2271feb7d458b0d31ad13625aaa4754431e2"
+  integrity sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==
   dependencies:
     balanced-match "^1.0.0"
 
@@ -9145,7 +9145,7 @@ compression@^1.7.4:
 
 concat-map@0.0.1:
   version "0.0.1"
-  resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+  resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
 concat-stream@^1.6.1:
@@ -9847,7 +9847,7 @@ debug@^3.1.0, debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debug@~4.3.1, debug@~4.3.2, debug@~4.3.4:
+debug@~4.3.2, debug@~4.3.4:
   version "4.3.7"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz"
   integrity sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==
@@ -10502,19 +10502,20 @@ engine.io-parser@~5.2.1:
   integrity sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==
 
 engine.io@~6.6.0:
-  version "6.6.4"
-  resolved "https://registry.npmjs.org/engine.io/-/engine.io-6.6.4.tgz"
-  integrity sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==
+  version "6.6.7"
+  resolved "https://registry.npmjs.org/engine.io/-/engine.io-6.6.7.tgz#60efa5b5b67167cdf93d64430c40a68bae9e4f21"
+  integrity sha512-DgOngfDKM2EviOH3Mr9m7ks1q8roetLy/IMmYthAYzbpInMbYc/GS+fWFA3rl1gvwKVsQrVV61fo5emD1y3OJQ==
   dependencies:
     "@types/cors" "^2.8.12"
     "@types/node" ">=10.0.0"
+    "@types/ws" "^8.5.12"
     accepts "~1.3.4"
     base64id "2.0.0"
     cookie "~0.7.2"
     cors "~2.8.5"
-    debug "~4.3.1"
+    debug "~4.4.1"
     engine.io-parser "~5.2.1"
-    ws "~8.17.1"
+    ws "~8.18.3"
 
 enhanced-resolve@5.24.1, enhanced-resolve@^5.0.0, enhanced-resolve@^5.22.0:
   version "5.24.1"
@@ -11061,7 +11062,7 @@ espree@^7.3.0, espree@^7.3.1:
     acorn-jsx "^5.3.1"
     eslint-visitor-keys "^1.3.0"
 
-esprima@^4.0.0, esprima@^4.0.1:
+esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -11601,10 +11602,10 @@ fast-text-encoding@^1.0.6:
   resolved "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz"
   integrity sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==
 
-fast-uri@3.1.2, fast-uri@^3.0.1:
-  version "3.1.2"
-  resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
-  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
+fast-uri@3.1.3, fast-uri@^3.0.1:
+  version "3.1.3"
+  resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz#f695a40f006aba505631573a0021ddb21194ad11"
+  integrity sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==
 
 fastest-levenshtein@^1.0.12:
   version "1.0.16"
@@ -13901,20 +13902,12 @@ js-xdr@^1.1.3:
     lodash "^4.17.5"
     long "^2.2.3"
 
-js-yaml@4.1.0, js-yaml@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz"
-  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+js-yaml@4.1.0, js-yaml@4.3.0, js-yaml@^3.10.0, js-yaml@^3.13.1, js-yaml@^3.14.1, js-yaml@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
+  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
   dependencies:
     argparse "^2.0.1"
-
-js-yaml@^3.10.0, js-yaml@^3.13.1, js-yaml@^3.14.1:
-  version "3.14.1"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz"
-  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
 
 jsbn@1.1.0:
   version "1.1.0"
@@ -18741,15 +18734,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@^1.6.1:
-  version "1.8.3"
-  resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz"
-  integrity sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==
-
-shell-quote@^1.8.4:
-  version "1.8.4"
-  resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz#2edd9a4dcefc96649e2e2cb12f637b1f1d92a190"
-  integrity sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==
+shell-quote@^1.6.1, shell-quote@^1.8.4:
+  version "1.9.0"
+  resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz#e108b1a136586d5964edb3300016d4bedba0fe57"
+  integrity sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==
 
 shelljs@^0.8.5:
   version "0.8.5"
@@ -20722,20 +20710,10 @@ utrie@^1.0.2:
   dependencies:
     base64-arraybuffer "^1.0.2"
 
-uuid@8.0.0:
-  version "8.0.0"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz"
-  integrity sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==
-
-uuid@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz"
-  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
-
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@11.1.1, uuid@8.0.0, uuid@^11.1.0, uuid@^8.3.2:
+  version "11.1.1"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 v8-compile-cache@^2.0.3:
   version "2.4.0"
@@ -21320,7 +21298,7 @@ ws@5.2.4:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@7.4.6, ws@8.18.3, ws@8.8.0, ws@^8.13.0, ws@^8.18.0, ws@^8.5.0, ws@^8.8.1:
+ws@7.4.6, ws@8.18.3, ws@8.8.0, ws@^8.13.0, ws@^8.18.0, ws@^8.5.0, ws@^8.8.1, ws@~8.18.3:
   version "8.18.3"
   resolved "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz"
   integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==


### PR DESCRIPTION
## Summary
Unblocks BitGoJS release after the osv-scanner audit gate failed on HIGH/CRITICAL dependency findings.
**Why the release failed**
- Release run: https://github.com/BitGo/BitGoJS/actions/runs/29863557661/job/88746171991
- Step **Audit Dependencies** failed with: `Total 41 packages affected by 70 known vulnerabilities (3 Critical, 16 High, …)`
- Context: yarn audit → osv-scanner (VL-7134 / #9263); `#9311` removed unsupported `--severity`; `#9313` removed `continue-on-error`, so audit blocks release again.
This PR targets **HIGH/CRITICAL**. 
## Bumps (and why)
| Package | Change | Why |
|---|---|---|
| `axios` | `1.16.1` → `1.18.0` (root `resolutions`/`overrides` + root `dependencies`) | HIGH [GHSA-gcfj-64vw-6mp9](https://github.com/advisories/GHSA-gcfj-64vw-6mp9) — Node HTTP adapter can use an inherited proxy after interceptor cloning. Same-major patch. |
| `axios` (modules) | `1.16.1` → `1.18.0` in `@bitgo/sdk-coin-atom`, `@bitgo/sdk-coin-sui`, `@bitgo/utxo-lib` | Align direct deps with the root pin. |
| `fast-uri` | `3.1.2` → `3.1.4` | HIGH [GHSA-4c8g-83qw-93j6](https://github.com/advisories/GHSA-4c8g-83qw-93j6) + [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx); transitive via `ajv`. |
| `uuid` | force `11.1.1` (root) | [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq); no patched 8.x; first_patched is `11.1.1`. |
| `uuid` (`@bitgo/sdk-core`) | `^8.3.2` → `11.1.1` | Direct dep; match resolved/published version. |
| `js-yaml` | force `4.3.0` (root) | HIGH [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m). Lerna pins `4.1.0`; resolution overrides to `4.3.0` (same major). |
## Exclusions (`osv-scanner.toml`)
| GHSA | Package | Why |
|---|---|---|
| [GHSA-23hp-3jrh-7fpw](https://github.com/advisories/GHSA-23hp-3jrh-7fpw) | `tar` (Critical) | Fix needs `tar@7.5.19+`; breaks lerna `packDirectory`. Packing-only usage. |
| [GHSA-8x88-c5mf-7j5w](https://github.com/advisories/GHSA-8x88-c5mf-7j5w) | `tar` (High) | Fix needs `tar@7.5.18+`; same lerna/tar constraint. |
## Test plan
- [x] osv-scanner → 0 Critical, 0 High
- [x] `yarn check-deps`
- [x] `yarn lerna run build`
- [ ] CI green
- [ ] Re-run BitGoJS Release
TICKET: WCI-1125

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
