### PR TITLE
ci(root): use bash retry loop for shrinkwrap verify step

### DIFF
--- a/.github/workflows/npmjs-release.yml
+++ b/.github/workflows/npmjs-release.yml
@@ -342,14 +342,16 @@ jobs:
           version=$(jq -r '.version' modules/bitgo/package.json)
           # Registry metadata can lag briefly right after publish, so retry before
           # failing the release on what might just be propagation delay.
-          if ! retry --up-to 5x --every 5s -- bash -c "
-            has_shrinkwrap=\$(curl -sL 'https://registry.npmjs.org/bitgo/${version}' | jq -r '._hasShrinkwrap // false')
-            [ \"\$has_shrinkwrap\" = 'true' ]
-          "; then
-            echo "::error::Published bitgo@${version} is missing _hasShrinkwrap metadata on the npm registry."
-            exit 1
-          fi
-          echo "✅ bitgo@${version} published with _hasShrinkwrap: true."
+          for attempt in 1 2 3 4 5; do
+            has_shrinkwrap=$(curl -sL "https://registry.npmjs.org/bitgo/${version}" | jq -r '._hasShrinkwrap // false')
+            if [ "$has_shrinkwrap" = 'true' ]; then
+              echo "✅ bitgo@${version} published with _hasShrinkwrap: true."
+              exit 0
+            fi
+            [ "$attempt" -lt 5 ] && sleep 5
+          done
+          echo "::error::Published bitgo@${version} is missing _hasShrinkwrap metadata on the npm registry."
+          exit 1
 
       - name: Generate version bump summary
         id: version-bump-summary


### PR DESCRIPTION
## Summary
- The `Verify bitgo package has shrinkwrap metadata` step in `npmjs-release.yml` calls the `retry` binary, whose `Install retry` step was removed in 1c04950294 (VL-7134) on the assumption it was only used by improved-yarn-audit. It missed that the shrinkwrap-verify step (added in 23ec271ccc) also depends on it.
- Under `bash -e`, `retry` exits 127 (`command not found`), so `! retry ...` is true and the step false-fails with a misleading "missing _hasShrinkwrap metadata" message. The 2026-07-22 release (`bitgo@52.3.0`) went red here even though the package published correctly (`_hasShrinkwrap: true` on the registry).
- Replace the `retry` wrapper with a plain bash loop, matching the adjacent `Create GitHub release` step, so the check no longer depends on a third-party binary in the post-publish window.

## Evidence
Runner log (run 29952850612, job "Release BitGoJS"):
```
line 4: retry: command not found                                        <- real failure
##[error]Published bitgo@52.3.0 is missing _hasShrinkwrap metadata...   <- misleading
```
```
curl -sL https://registry.npmjs.org/bitgo/52.3.0 | jq '._hasShrinkwrap'  # -> true
```

## Test plan
- [ ] Release workflow verify step passes on a real publish
- [ ] Step still fails correctly when `_hasShrinkwrap` is genuinely absent

Ticket: WCN-1584

🤖 Generated with [Claude Code](https://claude.com/claude-code)