### PR TITLE
fix(abstract-utxo): bump utxo-lib devDependency to 11.24.1

### DIFF
--- a/modules/abstract-utxo/package.json
+++ b/modules/abstract-utxo/package.json
@@ -78,7 +78,7 @@
   },
   "devDependencies": {
     "@bitgo/sdk-test": "^9.1.61",
-    "@bitgo/utxo-lib": "^11.24.0",
+    "@bitgo/utxo-lib": "^11.24.1",
     "mocha": "^10.2.0"
   },
   "gitHead": "18e460ddf02de2dbf13c2aa243478188fb539f0c"


### PR DESCRIPTION
## Summary
- The lerna version-consistency check fails: `@bitgo/abstract-utxo` declared `@bitgo/utxo-lib` as `^11.24.1` in `dependencies` but a stale `^11.24.0` in `devDependencies`.
- Bump the `devDependencies` pin to `^11.24.1` so both match the published `@bitgo/utxo-lib@11.24.1`.

## Test plan
- [ ] CI lerna dependency-consistency check passes (previously failing with `expected ... version 11.24.1, but found version 11.24.0`)

Ticket: BTC-000