### PR TITLE
fix(sdk-coin-sol): fall back to custom instruction on decode failure

### DIFF
--- a/modules/sdk-coin-sol/src/lib/utils.ts
+++ b/modules/sdk-coin-sol/src/lib/utils.ts
@@ -15,6 +15,7 @@ import {
   TOKEN_PROGRAM_ID,
   TOKEN_2022_PROGRAM_ID,
   decodeInstruction,
+  DecodedInstruction,
   TokenInstruction,
   TransferFeeInstruction,
 } from '@solana/spl-token';
@@ -414,7 +415,18 @@ export function getInstructionType(instruction: TransactionInstruction): ValidIn
       ) {
         return 'TokenTransfer';
       }
-      const decodedInstruction = decodeInstruction(instruction, instruction.programId);
+      let decodedInstruction: DecodedInstruction;
+      try {
+        decodedInstruction = decodeInstruction(instruction, instruction.programId);
+      } catch (e) {
+        // decodeInstruction only supports the base token instruction set —
+        // extension-family instructions (Pause, PermissionedBurn, transfer
+        // fee ops, ...) throw TokenInvalidInstructionTypeError at EVERY
+        // @solana/spl-token version. Those must not crash classification:
+        // fall back to CustomInstruction, the same path used below for
+        // decodable-but-unmapped instruction types.
+        return 'CustomInstruction';
+      }
       const instructionTypeMap: Map<TokenInstruction, ValidInstructionTypes> = new Map();
       instructionTypeMap.set(TokenInstruction.CloseAccount, 'CloseAssociatedTokenAccount');
       instructionTypeMap.set(TokenInstruction.Burn, 'Burn');

--- a/modules/sdk-coin-sol/test/unit/utils.ts
+++ b/modules/sdk-coin-sol/test/unit/utils.ts
@@ -255,6 +255,25 @@ describe('SOL util library', function () {
       });
       Utils.getInstructionType(invalidInstruction).should.equal('CustomInstruction');
     });
+    it('should fallback to customInstruction for token instructions that cannot be decoded', function () {
+      // decodeInstruction only covers the base token instruction set;
+      // extension-family instructions (e.g. PermissionedBurnExtension = 46,
+      // PausableExtension = 44) throw TokenInvalidInstructionTypeError at
+      // every @solana/spl-token version. They must classify as
+      // CustomInstruction instead of crashing customTx validation.
+      const permissionedBurnChecked = new TransactionInstruction({
+        keys: [
+          { pubkey: new PublicKey(testData.authAccount.pub), isSigner: false, isWritable: true },
+          { pubkey: new PublicKey(testData.nonceAccount.pub), isSigner: false, isWritable: true },
+          { pubkey: new PublicKey(testData.authAccount.pub), isSigner: true, isWritable: false },
+          { pubkey: new PublicKey(testData.authAccount.pub), isSigner: true, isWritable: false },
+        ],
+        programId: TOKEN_2022_PROGRAM_ID,
+        // [46 = PermissionedBurnExtension, 2 = BurnChecked, u64 amount, u8 decimals]
+        data: Buffer.from([46, 2, 0, 202, 154, 59, 0, 0, 0, 0, 9]),
+      });
+      Utils.getInstructionType(permissionedBurnChecked).should.equal('CustomInstruction');
+    });
     it('should succeed for ComputeBudget SetComputeUnitLimit instruction', function () {
       const setComputeUnitLimitInstruction = ComputeBudgetProgram.setComputeUnitLimit({
         units: 300000,


### PR DESCRIPTION
decodeInstruction from @solana/spl-token cannot decode Token-2022 extension-family instructions (Pause, PermissionedBurn, transfer fee ops, ...) at any published version and throws
TokenInvalidInstructionTypeError, crashing customTx validation client- and server-side. Wrap the call in try/catch and return CustomInstruction, the same path already used for
decodable-but-unmapped instructions.

Ticket: SCAAS-10578

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
