### PR TITLE
feat(statics): onboard tbaseeth:ctbtccx_99e833 vault share token

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -4250,6 +4250,16 @@ export const allCoinsAndTokens = [
     [...AccountCoin.DEFAULT_FEATURES, CoinFeature.EIP1559, CoinFeature.RECEIPT_TOKEN]
   ),
   erc20Token(
+    'e7cfe8e5-e35c-4fe9-9aaf-9ca4b1e33f1c',
+    'tbaseeth:ctbtccx_99e833',
+    'Concrete BTCcx 99e833 Share',
+    18,
+    '0x878c6221a0ed90f1d857f192ef75e6c060b037be',
+    UnderlyingAsset['tbaseeth:ctbtccx_99e833'],
+    Networks.test.basechain,
+    [...AccountCoin.DEFAULT_FEATURES, CoinFeature.EIP1559, CoinFeature.RECEIPT_TOKEN]
+  ),
+  erc20Token(
     '79fcac64-cad2-4c17-b8fc-2930b7022384',
     'tbaseeth:tpdd',
     'MarketplacePDD ALPACA',

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -3553,6 +3553,7 @@ export enum UnderlyingAsset {
   'tbaseeth:tpdd' = 'tbaseeth:tpdd',
   'tbaseeth:tnmr' = 'tbaseeth:tnmr',
   'tbaseeth:tabeq' = 'tbaseeth:tabeq',
+  'tbaseeth:ctbtccx_99e833' = 'tbaseeth:ctbtccx_99e833',
 
   // Og mainnet tokens
   'og:wog' = 'og:wog',


### PR DESCRIPTION
## Summary
- Onboard the Concrete BTCcx 99e833 vault share token `tbaseeth:ctbtccx_99e833` to `@bitgo/statics` so the BitGoJS SDK can resolve it for DeFi vault withdraw flows on Base testnet.
- Mirrors the existing receipt token `tbaseeth:kmusdc`:
  - Add `UnderlyingAsset` enum entry in `modules/statics/src/base.ts`
  - Add an `erc20Token` entry in `modules/statics/src/allCoinsAndTokens.ts` with 18 decimals, contract address `0x878c6221a0ed90f1d857f192ef75e6c060b037be` (the ERC-4626 vault contract, which is itself the share token), and `CoinFeature.RECEIPT_TOKEN`.

## Context
This is the **SDK side** of onboarding the share token for Concrete BTCcx vault `e52a3200-855b-464d-b05d-ec0caa1703c0` (protocol `concrete_btccx`). Before this change, `wallet.defi.withdrawFromVault` on the position wallet failed with `Coin unsupported: tbaseeth:ctbtccx_99e833` because the statics registry had no entry for the share token. With this entry, the SDK resolves the token and sends the correct name to the wallet-platform prebuild.

The server-side WP/AMS token registration (so the prebuild accepts the token) is tracked separately in DEFI-494.

## Test plan
- [x] `@bitgo/statics` rebuilt and `coins.get('tbaseeth:ctbtccx_99e833')` resolves: name, 18 decimals, contract address, `receipt-token` feature all present.
- [ ] CI: statics unit tests pass.

CLOSES TICKET: DEFI-494
