### PR TITLE
feat(statics): onboard polygon:infra, hoodeth:cashcat, ada:usdr/susdr, rename cETH

### DIFF
--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -2083,6 +2083,7 @@ export enum UnderlyingAsset {
   'hoodeth:zs' = 'hoodeth:zs',
   'hoodeth:spcx' = 'hoodeth:spcx',
   'hoodeth:skhy' = 'hoodeth:skhy',
+  'hoodeth:cashcat' = 'hoodeth:cashcat',
   'hemieth:hemi' = 'hemieth:hemi',
   'hemieth:hemibtc' = 'hemieth:hemibtc',
   'usdt0:stable' = 'usdt0:stable',
@@ -3108,6 +3109,7 @@ export enum UnderlyingAsset {
   'polygon:gmc' = 'polygon:gmc',
   'polygon:wpay' = 'polygon:wpay',
   'polygon:seag' = 'polygon:seag',
+  'polygon:infra' = 'polygon:infra',
   // Polygon NFTs
   // generic NFTs
   'erc721:polygontoken' = 'erc721:polygontoken',
@@ -4264,6 +4266,8 @@ export enum UnderlyingAsset {
   'ada:lcc' = 'ada:lcc',
   'ada:awlf' = 'ada:awlf',
   'ada:asnek' = 'ada:asnek',
+  'ada:usdr' = 'ada:usdr',
+  'ada:susdr' = 'ada:susdr',
 
   // Canton testnet tokens
   'tcanton:testcoin1' = 'tcanton:testcoin1',

--- a/modules/statics/src/coins/adaTokens.ts
+++ b/modules/statics/src/coins/adaTokens.ts
@@ -1,5 +1,5 @@
 import { tadaToken, adaToken } from '../account';
-import { UnderlyingAsset } from '../base';
+import { CoinFeature, UnderlyingAsset } from '../base';
 import { ADA_TOKEN_FEATURES, ADA_TOKEN_FEATURES_EXCLUDE_SINGAPORE } from '../coinFeatures';
 
 export const adaTokens = [
@@ -145,5 +145,27 @@ export const adaTokens = [
     'asset19e9dq59euafqysqugza92jdvwfx882gt2hq5rm',
     UnderlyingAsset['ada:asnek'],
     ADA_TOKEN_FEATURES
+  ),
+  adaToken(
+    '397a7ea8-0439-4f10-a73e-ba02b0d3fa56',
+    'ada:usdr',
+    'RealFi USDr',
+    6,
+    '7d9e4a0ee1a3f5d5ff8159ea91a83310cf2795ee7a87170c7aea05ae',
+    'USDr',
+    'asset19k6sv4ry9cu7pd25lry27k0crt3x3hyc5zgv3g',
+    UnderlyingAsset['ada:usdr'],
+    [...ADA_TOKEN_FEATURES, CoinFeature.STABLECOIN]
+  ),
+  adaToken(
+    'e9d2b3bb-a668-404d-a6bf-bf2dfefed4d2',
+    'ada:susdr',
+    'RealFi sUSDr',
+    6,
+    '7d9e4a0ee1a3f5d5ff8159ea91a83310cf2795ee7a87170c7aea05ae',
+    'sUSDr',
+    'asset1n3yafcjhhu6dg9hgfs3s7vklz0avg4ygp8dt7z',
+    UnderlyingAsset['ada:susdr'],
+    [...ADA_TOKEN_FEATURES, CoinFeature.STABLECOIN]
   ),
 ];

--- a/modules/statics/src/coins/cantonTokens.ts
+++ b/modules/statics/src/coins/cantonTokens.ts
@@ -66,7 +66,7 @@ export const cantonTokens = [
   cantonToken(
     '204a82d0-3043-41a5-a029-81fd6cfdcc68',
     'canton:ceth',
-    'cETH',
+    'Canton Ethereum',
     10,
     'https://api.utilities.digitalasset.com/api/token-standard/v0/registrars/',
     'rails-cethMain-1::12200350ba6e96e3b701c3048b5aa013a8c1c08833e8ebf54339cff581055c29003a:cETH',

--- a/modules/statics/src/coins/hoodethTokens.ts
+++ b/modules/statics/src/coins/hoodethTokens.ts
@@ -1034,6 +1034,16 @@ export const hoodethTokens = [
     EVM_ERC20_TOKEN_FEATURES_EXCLUDE_SINGAPORE
   ),
   erc20Token(
+    '744a1738-6b93-41ae-8884-2faa8f1419f5',
+    'hoodeth:cashcat',
+    'Cash Cat',
+    18,
+    '0x020bfc650a365f8bb26819deaabf3e21291018b4',
+    UnderlyingAsset['hoodeth:cashcat'],
+    Networks.main.hoodeth,
+    EVM_ERC20_TOKEN_FEATURES_EXCLUDE_SINGAPORE
+  ),
+  erc20Token(
     '3493d608-fd3e-45dc-926d-783d54a8fe4d',
     'thoodeth:amzn',
     'Amazon',

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -4458,6 +4458,13 @@ export const ofcCoins = [
     0,
     UnderlyingAsset['polygon:seag']
   ),
+  ofcPolygonErc20(
+    '2fc2db43-5e57-48f3-9ac6-e90963ebd23e',
+    'ofcpolygon:infra',
+    'INFRACOINN',
+    18,
+    UnderlyingAsset['polygon:infra']
+  ),
 
   tofcPolygonErc20(
     '62f4329d-11cd-4875-b91b-9ceae66c9439',
@@ -6048,7 +6055,13 @@ export const ofcCoins = [
     10,
     UnderlyingAsset['canton:ibenji']
   ),
-  ofcCantonToken('784c76fb-59c6-4826-b72e-20e996a35739', 'ofccanton:ceth', 'cETH', 10, UnderlyingAsset['canton:ceth']),
+  ofcCantonToken(
+    '784c76fb-59c6-4826-b72e-20e996a35739',
+    'ofccanton:ceth',
+    'Canton Ethereum',
+    10,
+    UnderlyingAsset['canton:ceth']
+  ),
   ofcCantonToken(
     '092883f7-c65d-446d-8a92-ad25c39e6e93',
     'ofccanton:usd1',
@@ -6331,6 +6344,8 @@ export const ofcCoins = [
     UnderlyingAsset['ada:wmtx']
   ),
   ofcAdaToken('e8f2a1b3-4c5d-4e6f-8a0b-1c2d3e4f5a6b', 'ofcada:usdcx', 'USDCx', 6, UnderlyingAsset['ada:usdcx']),
+  ofcAdaToken('ed2484fd-0dc1-4737-bd40-361a9ed091de', 'ofcada:usdr', 'RealFi USDr', 6, UnderlyingAsset['ada:usdr']),
+  ofcAdaToken('c2c5cac2-a642-4acf-926b-6923412105cb', 'ofcada:susdr', 'RealFi sUSDr', 6, UnderlyingAsset['ada:susdr']),
   tofcAdaToken(
     '1f4e7747-f825-4107-a71f-766e847d557b',
     'ofctada:water',

--- a/modules/statics/src/coins/ofcHoodethTokens.ts
+++ b/modules/statics/src/coins/ofcHoodethTokens.ts
@@ -1473,4 +1473,18 @@ export const ofcHoodethTokens = [
     true,
     'hoodeth'
   ),
+  ofcerc20(
+    '45200a7c-7641-46c4-93df-41321bd4cab3',
+    'ofchoodeth:cashcat',
+    'Cash Cat',
+    18,
+    UnderlyingAsset['hoodeth:cashcat'],
+    undefined,
+    undefined,
+    '',
+    undefined,
+    undefined,
+    true,
+    'hoodeth'
+  ),
 ];

--- a/modules/statics/src/coins/polygonTokens.ts
+++ b/modules/statics/src/coins/polygonTokens.ts
@@ -1654,6 +1654,15 @@ export const polygonTokens = [
     UnderlyingAsset['polygon:seag'],
     POLYGON_TOKEN_FEATURES
   ),
+  polygonErc20(
+    '032cece7-7437-4a05-ab0d-a0766be74c0e',
+    'polygon:infra',
+    'INFRACOINN',
+    18,
+    '0x2fc03e5fe153f4b547571d996e942a07f77440e3',
+    UnderlyingAsset['polygon:infra'],
+    POLYGON_TOKEN_FEATURES
+  ),
   tpolygonErc20(
     '13dd4ab7-2d94-493c-9a61-323f6300f7e5',
     'tpolygon:tusdl',


### PR DESCRIPTION
Ticket: [CHALO-1051](https://linear.app/bitgo/issue/CHALO-1051/client-requested-tokens-to-onboard-priority-batch-0724)

Summary
-------

*   Add `polygon:infra` (INFRACOINN) ERC20 token to `polygonTokens.ts`
*   Add `hoodeth:cashcat` (Cash Cat) token to `hoodethTokens.ts` on the Robinhood Chain
*   Add `ada:usdr` and `ada:susdr` (RealFi) Cardano native tokens to `adaTokens.ts`, flagged `STABLECOIN` per the $1.00 peg
*   Add corresponding `UnderlyingAsset` enum entries in `base.ts`
*   Rename `canton:ceth` full name from `cETH` to `Canton Ethereum` in `cantonTokens.ts` and its OFC counterpart in `ofcCoins.ts`

Tokens added
------------

| Symbol | Display Name | Chain | Contract / Asset |
|--------|--------------|-------|----------|
| `polygon:infra` | INFRACOINN | Polygon | `0x2fc03e5fe153f4b547571d996e942a07f77440e3` |
| `hoodeth:cashcat` | Cash Cat | Robinhood Chain | `0x020bfc650a365f8bb26819deaabf3e21291018b4` |
| `ada:usdr` | RealFi USDr | Cardano | policy `7d9e4a0ee1a3f5d5ff8159ea91a83310cf2795ee7a87170c7aea05ae`, asset `USDr` |
| `ada:susdr` | RealFi sUSDr | Cardano | policy `7d9e4a0ee1a3f5d5ff8159ea91a83310cf2795ee7a87170c7aea05ae`, asset `sUSDr` |


Test plan
---------

*   `yarn workspace @bitgo/statics build` passes
*   `yarn unit-test --scope @bitgo/statics` passes
*   Each token resolves correctly via the coin factory
