### PR TITLE
docs(utxo): deprecate in README, point to @bitgo/wasm-utxo

### DIFF
--- a/modules/utxo-bin/README.md
+++ b/modules/utxo-bin/README.md
@@ -1,3 +1,15 @@
+> **⚠️ Deprecated.** `@bitgo/utxo-bin` is deprecated. Its successor is
+> [`wasm-utxo-cli`][wasm-cli], the command-line interface shipped with
+> `@bitgo/wasm-utxo` in the [BitGoWASM][bitgowasm] repository, which provides
+> address encoding/decoding and PSBT inspection for UTXO-based coins.
+>
+> `wasm-utxo-cli` is a native binary built from Rust (`cargo install --path .`
+> from `BitGoWASM/packages/wasm-utxo/cli`); it is not published as an npm
+> package. Migrate any `utxo-bin` usage to `wasm-utxo-cli`.
+>
+> [wasm-cli]: https://github.com/BitGo/BitGoWASM/tree/main/packages/wasm-utxo/cli
+> [bitgowasm]: https://github.com/BitGo/BitGoWASM
+
 # `utxo-bin`
 
 This repository contains a CLI tool for parsing BitGo wallet transactions (withdrawals) and

--- a/modules/utxo-core/README.md
+++ b/modules/utxo-core/README.md
@@ -1,3 +1,12 @@
+> **⚠️ Deprecated.** `@bitgo/utxo-core` — the glue/types layer between
+> SDK-dependent modules and low-level UTXO libraries — is deprecated. Its
+> functionality has been absorbed by [`@bitgo/wasm-utxo`][wasm-utxo] in the
+> [BitGoWASM][bitgowasm] repository, which now owns the core UTXO types and
+> primitives. New code should depend on `@bitgo/wasm-utxo`.
+>
+> [wasm-utxo]: https://github.com/BitGo/BitGoWASM/tree/main/packages/wasm-utxo
+> [bitgowasm]: https://github.com/BitGo/BitGoWASM
+
 # utxo-core
 
 This repository contains core types and functions for Bitcoin-like UTXO-based cryptocurrencies.

--- a/modules/utxo-lib/README.md
+++ b/modules/utxo-lib/README.md
@@ -1,3 +1,19 @@
+> **⚠️ Deprecated.** `@bitgo/utxo-lib` is deprecated and no longer under active
+> development. Its successor is [`@bitgo/wasm-utxo`][wasm-utxo] (in the
+> [BitGoWASM][bitgowasm] repository), which provides WebAssembly bindings for
+> `rust-bitcoin` and `rust-miniscript` and is now the primary UTXO library
+> across the BitGo Wallet Platform.
+>
+> New code should depend on `@bitgo/wasm-utxo`. Existing address generation,
+> PSBT signing, transaction building, recovery, and BIP-322 flows have already
+> been migrated off `@bitgo/utxo-lib` in `abstract-utxo` (see Linear project
+> [Remove utxolib from abstract-utxo][linear-project]). Do not build new
+> integrations against this package.
+>
+> [wasm-utxo]: https://github.com/BitGo/BitGoWASM/tree/main/packages/wasm-utxo
+> [bitgowasm]: https://github.com/BitGo/BitGoWASM
+> [linear-project]: https://linear.app/bitgo/project/remove-utxolib-from-abstract-utxo-0deba0897979
+
 # BitGo UTXO library
 
 This library is a wrapper around [bitcoinjs-lib](https://github.com/bitcoinjs/bitcoinjs-lib) adding altcoin support.

--- a/modules/utxo-lib/README.md
+++ b/modules/utxo-lib/README.md
@@ -6,13 +6,11 @@
 >
 > New code should depend on `@bitgo/wasm-utxo`. Existing address generation,
 > PSBT signing, transaction building, recovery, and BIP-322 flows have already
-> been migrated off `@bitgo/utxo-lib` in `abstract-utxo` (see Linear project
-> [Remove utxolib from abstract-utxo][linear-project]). Do not build new
+> been migrated off `@bitgo/utxo-lib` in `abstract-utxo`. Do not build new
 > integrations against this package.
 >
 > [wasm-utxo]: https://github.com/BitGo/BitGoWASM/tree/main/packages/wasm-utxo
 > [bitgowasm]: https://github.com/BitGo/BitGoWASM
-> [linear-project]: https://linear.app/bitgo/project/remove-utxolib-from-abstract-utxo-0deba0897979
 
 # BitGo UTXO library
 

--- a/modules/utxo-ord/README.md
+++ b/modules/utxo-ord/README.md
@@ -1,3 +1,10 @@
+> **⚠️ Deprecated.** `@bitgo/utxo-ord` — helpers for Bitcoin Ordinals and
+> inscriptions — is deprecated. Ordinals inscription support is now built into
+> [`@bitgo/wasm-utxo`][wasm-utxo]. New code should use `@bitgo/wasm-utxo` for
+> inscription creation.
+>
+> [wasm-utxo]: https://github.com/BitGo/BitGoWASM/tree/main/packages/wasm-utxo
+
 # utxo-ord
 
 This package contains some helpers for dealing with ordinals and inscriptions.


### PR DESCRIPTION
Prepend a deprecation banner to `modules/utxo-ord/README.md`. Ordinals and
inscription helper support is now built into `@bitgo/wasm-utxo` (T1-3265).
Existing README content is left intact below the banner.