### PR TITLE
feat(sol): warn when recovery is called without durable nonce (SIMD-525)

### DIFF
--- a/modules/sdk-coin-sol/src/sol.ts
+++ b/modules/sdk-coin-sol/src/sol.ts
@@ -1283,6 +1283,16 @@ export class Sol extends BaseCoin {
     let totalFee = new BigNumber(0);
     let totalFeeForTokenRecovery = new BigNumber(0);
 
+    // Warn if durable nonce is not provided for SOL recovery.
+    // With SIMD-525 (200ms slots), the blockhash validity window drops from ~60s to ~30s.
+    // Recovery flows that don't use durable nonce must complete build-sign-broadcast within that window.
+    if (!params.durableNonce) {
+      logger.warn(
+        'SOL recovery without durable nonce: transaction must be signed and broadcast within the blockhash validity window (~30s at 200ms slots). ' +
+          'Provide params.durableNonce for flows that may exceed this window.'
+      );
+    }
+
     // check for possible token recovery, recover the token provide by user
     if (params.tokenContractAddress) {
       let isUnsupportedToken = false;


### PR DESCRIPTION
<!--

Ticket: CHALO-1077

Test URL: TBD

## Changes:

- Added `logger.warn` in `recover()` when `params.durableNonce` is not provided.
- No behavioral change — pure observability improvement.

## Context

With SIMD-525 (200ms slot times), the blockhash validity window drops from ~60s to ~30s. Recovery flows that don't use durable nonce must complete build-sign-broadcast within that window, which is tight for MPC recovery involving key decryption and multi-party signing.

The warning alerts operators that the flow is time-constrained and should provide `params.durableNonce` for flows that may exceed the window.

## Test:

- Existing recovery tests in `modules/sdk-coin-sol/test/unit/sol.ts` continue to pass — the warning is a side-effect-only addition with no assertions on log output.
-->