### PR TITLE
feat(statics): give Sepolia testnet its own underlying asset (sepETH)

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -407,7 +407,7 @@ export const allCoinsAndTokens = [
     'Sepolia Testnet Ethereum',
     Networks.test.sepolia,
     18,
-    UnderlyingAsset.ETH,
+    UnderlyingAsset.SEPETH,
     BaseUnit.ETH,
     [
       ...ETH_FEATURES_WITH_STAKING_AND_MMI,

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -728,6 +728,7 @@ export enum UnderlyingAsset {
   SCROLLETH = 'scrolleth', // Scroll L2
   SEI = 'sei',
   SEIEVM = 'seievm',
+  SEPETH = 'sepeth', // Sepolia Ethereum testnet
   SGB = 'sgb',
   SOL = 'sol',
   SOMI = 'somi', // Somnia Chain

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -846,7 +846,7 @@ export const ofcCoins = [
     'ofctsepeth',
     'Test Sepolia Ether',
     18,
-    UnderlyingAsset.ETH,
+    UnderlyingAsset.SEPETH,
     CoinKind.CRYPTO
   ),
   tofc(

--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -874,7 +874,7 @@ class Sepolia extends Testnet implements EthereumNetwork {
   chainId = 11155111;
   nativeCoinOperationHashPrefix = 'ETHER';
   tokenOperationHashPrefix = 'ERC20';
-  // TODO: add batcher/forwarder/wallet contract addresses once deployed on Sepolia
+  // TODO: [CECHO-1729] add batcher/forwarder/wallet contract addresses once deployed on Sepolia
 }
 
 class EthereumClassic extends Mainnet implements EthereumNetwork {


### PR DESCRIPTION
## Summary
- Onboards Sepolia (chain ID `11155111`) as a testnet-only network for Ethereum, following the existing `gteth`/`hteth` pattern (`CoinFamily.ETH`, no mainnet counterpart since Sepolia is Ethereum's own test network).
- Gives the coin its own `UnderlyingAsset.SEPETH` instead of reusing `UnderlyingAsset.ETH`, so it's distinguishable as its own asset while still sharing the `eth` family/signing implementation.
- Coin code: `sepeth` ("Sepolia Testnet Ethereum"). OFC entry: `ofctsepeth` (kept `ofct`-prefixed to satisfy the OFC testnet naming-convention test).

## Notes
- `batcherContractAddress` / `forwarderFactoryAddress` / `forwarderImplementationAddress` are intentionally omitted (optional fields on `EthereumNetwork`) since BitGo's forwarder/batcher contracts haven't been deployed on Sepolia yet — to be added once contract deployment is complete.
- Considered making `SEPETH` a fully standalone `CoinFamily`, but reverted: `getEthLikeTokens` (AMS token config tooling) requires every family with an EVM-feature coin to have a canonical mainnet coin named exactly like the family, which a testnet-only chain can't satisfy without adding a fake mainnet entry. Keeping `family = CoinFamily.ETH` avoids that while still giving Sepolia its own asset identity.
- No changes needed to `networkFeatureMapForTokens.ts` (already covers the `eth` family) or `environments.ts` (its explorer config is a single shared endpoint per environment, not per-testnet).

## CI fix (unrelated to Sepolia)
- `unit-test` was failing in `@bitgo/sdk-coin-stx` (`Invalid character in hello`) after `bn.js` was bumped to `5.2.3` (WCN-1224 / #9349).
- `@stacks/transactions` `signWithKey` passes the message to elliptic as **hex**. Test fixture `message2 = 'hello'` is not valid hex; it only passed when elliptic resolved its nested lenient `bn.js@4`.
- Fix: test-only change in `sdk-coin-stx` fixtures — `message2` → valid hex `deadbeef`, regenerated `expectedSignature2`. No production signing behavior change.

TICKET: CECHO-1721

## Test plan
- [x] `yarn workspace @bitgo/statics run unit-test` — all 33k+ tests passing
- [x] `tsc --noEmit` typecheck clean for `modules/statics`
- [ ] `yarn workspace @bitgo/sdk-coin-stx run unit-test` — sign/verify fixtures pass under bn.js@5
- [ ] Contract deployment + forwarder address wiring (follow-up)