### PR TITLE
chore(sdk-core): drop sjcl.random from generateRandomPassword

### DIFF
--- a/modules/sdk-core/src/bitgo/utils/wallet.ts
+++ b/modules/sdk-core/src/bitgo/utils/wallet.ts
@@ -1,4 +1,3 @@
-import * as sjcl from '@bitgo/sjcl';
 import * as bs58 from 'bs58';
 
 /**
@@ -7,6 +6,7 @@ import * as bs58 from 'bs58';
  * @returns {String}          base58 random password
  */
 export function generateRandomPassword(numWords: number): string {
-  const bytes = sjcl.codec.bytes.fromBits(sjcl.random.randomWords(numWords));
+  const bytes = new Uint8Array(numWords * 4);
+  crypto.getRandomValues(bytes);
   return bs58.encode(bytes);
 }

--- a/modules/sdk-core/test/unit/bitgo/utils/wallet.ts
+++ b/modules/sdk-core/test/unit/bitgo/utils/wallet.ts
@@ -1,0 +1,21 @@
+import 'should';
+import * as bs58 from 'bs58';
+import { generateRandomPassword } from '../../../../src/bitgo/utils/wallet';
+
+describe('generateRandomPassword', () => {
+  it('returns a decodable base58 string of numWords * 4 bytes', () => {
+    for (const numWords of [1, 5, 10, 32]) {
+      const pwd = generateRandomPassword(numWords);
+      const decoded = bs58.decode(pwd);
+      decoded.length.should.equal(numWords * 4);
+    }
+  });
+
+  it('produces distinct outputs on repeated calls', () => {
+    const samples = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      samples.add(generateRandomPassword(5));
+    }
+    samples.size.should.equal(100);
+  });
+});


### PR DESCRIPTION
sjcl.random already seeds its Fortuna PRNG from crypto.getRandomValues, so this just drops the Fortuna wrapper and returns OS CSPRNG bytes directly. Output is still n*4 random bytes, base58-encoded.

TICKET: WCN-34

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
