### PR TITLE
refactor(sdk-hmac): use native crypto for token SHA-256

### DIFF
--- a/modules/sdk-hmac/package.json
+++ b/modules/sdk-hmac/package.json
@@ -32,9 +32,6 @@
     "unit-test": "mocha",
     "prepare": "npm run build"
   },
-  "dependencies": {
-    "@bitgo/sjcl": "^1.1.0"
-  },
   "devDependencies": {
     "chai": "^4.3.6",
     "sinon": "^6.3.5"

--- a/modules/sdk-hmac/src/hmac.ts
+++ b/modules/sdk-hmac/src/hmac.ts
@@ -1,6 +1,5 @@
-import { type BinaryLike, type KeyObject } from 'crypto';
+import { type BinaryLike, createHash, type KeyObject } from 'crypto';
 import * as urlLib from 'url';
-import * as sjcl from '@bitgo/sjcl';
 import {
   CalculateHmacSubjectOptions,
   CalculateRequestHeadersOptions,
@@ -91,8 +90,7 @@ export function calculateRequestHeaders<T extends string | Buffer = string>(
   const hmac = calculateRequestHMAC({ url, text, timestamp, token, method, authVersion }, useOriginalPath);
 
   // calculate the SHA256 hash of the token
-  const hashDigest = sjcl.hash.sha256.hash(token);
-  const tokenHash = sjcl.codec.hex.fromBits(hashDigest);
+  const tokenHash = createHash('sha256').update(token).digest('hex');
   return {
     hmac,
     timestamp,

--- a/modules/sdk-hmac/test/hmac.ts
+++ b/modules/sdk-hmac/test/hmac.ts
@@ -7,7 +7,6 @@ import {
   calculateRequestHeaders,
   verifyResponse,
 } from '../src/hmac';
-import * as sjcl from '@bitgo/sjcl';
 import { createSecretKey } from 'crypto';
 
 // Mock Date.now for consistent timestamp values
@@ -203,8 +202,9 @@ describe('HMAC Utility Functions', () => {
         method: 'post',
         authVersion: 3,
       });
-      const hashDigest = sjcl.hash.sha256.hash('test-token');
-      const tokenHash = sjcl.codec.hex.fromBits(hashDigest);
+      // sha256('test-token'), asserted against a fixed known-good value so the
+      // test is independent of the implementation under test.
+      const tokenHash = '4c5dc9b7708905f77f5e5d16316b5dfb425e68cb326dcd55a860e90a7707031e';
 
       expect(headers).to.include({
         hmac: headers.hmac, // Verify hmac exists


### PR DESCRIPTION
Replace sjcl.hash.sha256 + sjcl.codec.hex with crypto.createHash('sha256'). Drops the @bitgo/sjcl dependency from sdk-hmac entirely.

TICKET: WCN-35

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
