### PR TITLE
fix(sdk-core,sdk-coin-xlm): fix enabletoken approval failing with no operations

### DIFF
--- a/modules/bitgo/test/v2/unit/pendingApproval.ts
+++ b/modules/bitgo/test/v2/unit/pendingApproval.ts
@@ -382,4 +382,72 @@ describe('Pending Approvals:', () => {
       sandbox.verify();
     });
   });
+
+  describe('recreateAndSignTransaction', function () {
+    it('should preserve the verifyTokenEnablement verification flag when rebuilding an enabletoken pending approval (CSHLD-1358)', async () => {
+      const enableTokenPendingApprovalData: PendingApprovalData = {
+        id: 'pa-enabletoken',
+        info: {
+          type: Type.TRANSACTION_REQUEST,
+          transactionRequest: {
+            coinSpecific: {
+              [coin]: {},
+            },
+            recipients: [],
+            buildParams: {
+              type: 'enabletoken',
+            },
+            sourceWallet: walletId,
+          },
+        },
+        state: State.PENDING,
+        creator: 'test',
+      };
+      const pendingApproval = new PendingApproval(bitgo, basecoin, enableTokenPendingApprovalData, wallet);
+
+      const prebuildAndSignStub = sandbox
+        .stub(Wallet.prototype, 'prebuildAndSignTransaction')
+        .resolves({ txHex: 'signed-tx-hex' });
+      sandbox.stub(basecoin, 'parseTransaction').resolves({});
+
+      await pendingApproval.recreateAndSignTransaction({});
+
+      prebuildAndSignStub.calledOnce.should.be.true();
+      const prebuildParamsArg = prebuildAndSignStub.getCall(0).args[0]!;
+      prebuildParamsArg.verification!.should.have.property('verifyTokenEnablement', true);
+    });
+
+    it('should not set verifyTokenEnablement for non-enabletoken pending approvals', async () => {
+      const fanoutPendingApprovalData: PendingApprovalData = {
+        id: 'pa-fanout',
+        info: {
+          type: Type.TRANSACTION_REQUEST,
+          transactionRequest: {
+            coinSpecific: {
+              [coin]: {},
+            },
+            recipients: [],
+            buildParams: {
+              type: 'fanout',
+            },
+            sourceWallet: walletId,
+          },
+        },
+        state: State.PENDING,
+        creator: 'test',
+      };
+      const pendingApproval = new PendingApproval(bitgo, basecoin, fanoutPendingApprovalData, wallet);
+
+      const prebuildAndSignStub = sandbox
+        .stub(Wallet.prototype, 'prebuildAndSignTransaction')
+        .resolves({ txHex: 'signed-tx-hex' });
+      sandbox.stub(basecoin, 'parseTransaction').resolves({});
+
+      await pendingApproval.recreateAndSignTransaction({});
+
+      prebuildAndSignStub.calledOnce.should.be.true();
+      const prebuildParamsArg = prebuildAndSignStub.getCall(0).args[0]!;
+      (prebuildParamsArg.verification === undefined).should.be.true();
+    });
+  });
 });

--- a/modules/sdk-core/src/bitgo/pendingApproval/iPendingApproval.ts
+++ b/modules/sdk-core/src/bitgo/pendingApproval/iPendingApproval.ts
@@ -43,7 +43,7 @@ export interface PendingApprovalInfo {
     coinSpecific: { [key: string]: any };
     recipients: any;
     buildParams: {
-      type?: 'fanout' | 'consolidate';
+      type?: 'fanout' | 'consolidate' | 'enabletoken';
       [index: string]: any;
     };
     sourceWallet?: string;

--- a/modules/sdk-core/src/bitgo/pendingApproval/pendingApproval.ts
+++ b/modules/sdk-core/src/bitgo/pendingApproval/pendingApproval.ts
@@ -298,6 +298,14 @@ export class PendingApproval implements IPendingApproval {
       prebuildParams.hop = true;
     }
 
+    if (transactionRequest.buildParams && transactionRequest.buildParams.type === 'enabletoken') {
+      // preserve the verification mode used for the original enable-token build so that
+      // verifyTransaction() takes the trustline verification path instead of falling through
+      // to the generic createAccount/payment check, which has no matching operations to verify
+      // for a changeTrust transaction (see CSHLD-1358)
+      prebuildParams.verification = _.extend({}, prebuildParams.verification, { verifyTokenEnablement: true });
+    }
+
     const reqTracer = reqId || new RequestTracer();
     if (transactionRequest.buildParams && transactionRequest.buildParams.type === 'consolidate') {
       // consolidate tag is in the build params - this is a consolidation transaction, so


### PR DESCRIPTION
## Summary
- Approving a dual-approval Stellar enable-token (trustline) pending approval failed with `transaction prebuild does not have any operations`.
- `recreateAndSignTransaction()` rebuilds the tx during approval but didn't preserve `verification.verifyTokenEnablement`, so `Xlm.verifyTransaction()` fell through to the generic `createAccount`/`payment` check instead of the trustline verification path, and never recognized the `changeTrust` operation.
- `verifyTokenEnablement` is a coin-agnostic verification flag also used by `near`, `sol`, `algo`, `hbar`, and `xrp` to gate their own `enabletoken` verification branches, so this same gap affects those coins too, not just XLM.
- Fix: `recreateAndSignTransaction()` now sets `verifyTokenEnablement` when rebuilding an `enabletoken` pending approval, so it takes the correct verification path regardless of coin.

Fixes CSHLD-1358.

## Test plan
- [x] `yarn lint` clean on all changed files
- [x] `yarn prettier --check` clean on all changed files
- [x] Full monorepo `tsc` build clean
- [x] `sdk-coin-xlm` unit tests: 108 passing
- [x] `sdk-core` unit tests: 534 passing
- [x] `bitgo` `pendingApproval.ts` unit tests: 18 passing (incl. 2 new tests). 1 pre-existing failing test (`[tbtc] should recreate the transaction...`) confirmed unrelated — reproduces identically with this fix reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)