### PR TITLE
Bind Express wallet signing to route identity

### DIFF
--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -549,6 +549,7 @@ export async function handleV2GenerateShareTSS(
 }
 
 export async function handleV2SignTSSWalletTx(req: ExpressApiRouteRequest<'express.wallet.signtxtss', 'post'>) {
+  assertWalletIdMatchesRoute(req.decoded.id, req.decoded.txPrebuild?.walletId);
   const bitgo = req.bitgo;
   const coin = bitgo.coin(req.decoded.coin);
   const wallet = await coin.wallets().get({ id: req.decoded.id });
@@ -868,9 +869,19 @@ async function handleV2AcceptWalletShare(req: express.Request) {
 }
 
 /**
+ * Ensure a prebuild cannot direct a wallet route to sign for a different wallet.
+ */
+function assertWalletIdMatchesRoute(routeWalletId: string, prebuildWalletId: string | undefined): void {
+  if (prebuildWalletId !== undefined && prebuildWalletId !== routeWalletId) {
+    throw new ApiResponseError('Wallet ID in txPrebuild does not match the route wallet ID', 400);
+  }
+}
+
+/**
  * handle wallet sign transaction
  */
 async function handleV2SignTxWallet(req: ExpressApiRouteRequest<'express.wallet.signtx', 'post'>) {
+  assertWalletIdMatchesRoute(req.decoded.id, req.decoded.txPrebuild?.walletId);
   const bitgo = req.bitgo;
   const coin = bitgo.coin(req.decoded.coin);
   const wallet = await coin.wallets().get({ id: req.decoded.id });

--- a/modules/express/test/unit/typedRoutes/walletSignTx.ts
+++ b/modules/express/test/unit/typedRoutes/walletSignTx.ts
@@ -34,6 +34,35 @@ describe('WalletSignTx codec tests', function () {
       sinon.restore();
     });
 
+    it('should reject a prebuild belonging to a different wallet', async function () {
+      const requestBody = {
+        txPrebuild: {
+          txHex: 'transaction',
+          walletId: 'different-wallet-id',
+        },
+        prv: 'xprv-test',
+      };
+
+      const mockWallet = {
+        signTransaction: sinon.stub().resolves(mockFullySignedResponse),
+      };
+      const walletsGetStub = sinon.stub().resolves(mockWallet);
+      sinon.stub(BitGo.prototype, 'coin').returns({
+        wallets: sinon.stub().returns({ get: walletsGetStub }),
+      } as any);
+
+      const result = await agent
+        .post(`/api/v2/${coin}/wallet/${walletId}/signtx`)
+        .set('Authorization', 'Bearer test_access_token_12345')
+        .set('Content-Type', 'application/json')
+        .send(requestBody);
+
+      assert.strictEqual(result.status, 400);
+      result.body.error.should.match(/does not match the route wallet ID/);
+      walletsGetStub.called.should.be.false();
+      mockWallet.signTransaction.called.should.be.false();
+    });
+
     it('should successfully sign a wallet transaction', async function () {
       const requestBody = {
         txPrebuild: {

--- a/modules/express/test/unit/typedRoutes/walletTxSignTSS.ts
+++ b/modules/express/test/unit/typedRoutes/walletTxSignTSS.ts
@@ -34,6 +34,36 @@ describe('WalletTxSignTSS codec tests', function () {
       sinon.restore();
     });
 
+    it('should reject a prebuild belonging to a different wallet', async function () {
+      const requestBody = {
+        txPrebuild: {
+          txHex: 'transaction',
+          walletId: 'different-wallet-id',
+        },
+        walletPassphrase: 'test_passphrase_12345',
+        apiVersion: 'lite' as const,
+      };
+
+      const mockWallet = {
+        ensureCleanSigSharesAndSignTransaction: sinon.stub().resolves(mockFullySignedResponse),
+      };
+      const walletsGetStub = sinon.stub().resolves(mockWallet);
+      sinon.stub(BitGo.prototype, 'coin').returns({
+        wallets: sinon.stub().returns({ get: walletsGetStub }),
+      } as any);
+
+      const result = await agent
+        .post(`/api/v2/${coin}/wallet/${walletId}/signtxtss`)
+        .set('Authorization', 'Bearer test_access_token_12345')
+        .set('Content-Type', 'application/json')
+        .send(requestBody);
+
+      assert.strictEqual(result.status, 400);
+      result.body.error.should.match(/does not match the route wallet ID/);
+      walletsGetStub.called.should.be.false();
+      mockWallet.ensureCleanSigSharesAndSignTransaction.called.should.be.false();
+    });
+
     it('should successfully sign a TSS wallet transaction', async function () {
       const requestBody = {
         txPrebuild: {


### PR DESCRIPTION
## Summary
- Reject wallet transaction signing requests whose `txPrebuild.walletId` differs from the route wallet ID.
- Apply the check to regular wallet and TSS wallet signing routes.
- Add regression coverage proving mismatches are rejected before wallet lookup or signing.

## Test plan
- [x] `git diff --check`
- [x] IDE linter diagnostics are clean
- [ ] Run targeted Express tests in CI; local Yarn/Mocha execution is unavailable because the checkout lacks Yarn and a workspace Mocha binary.

PT-000000