### PR TITLE
fix: detect shrinkwrap siblings by workspace, not @bitgo/ prefix

### DIFF
--- a/scripts/generate-bitgo-shrinkwrap.ts
+++ b/scripts/generate-bitgo-shrinkwrap.ts
@@ -9,21 +9,29 @@
  * BITGO_GENERATE_SHRINKWRAP=true (set by the release workflow) — otherwise a plain
  * local/offline `npm pack` would force a network install of the full dependency tree.
  *
- * `@bitgo/*` siblings are resolved as part of the same tree as everything else.
- * `lerna publish` publishes packages in dependency-topological order, so by the
- * time bitgo (which depends on every sibling) is packed, the sibling versions it
- * references are already live on the registry. Resolving them here — rather than
- * excluding them and patching their names back into the shrinkwrap metadata after
- * the fact — is what makes the generated `packages["node_modules/@bitgo/..."]`
- * entries (version/resolved/integrity) actually present, which is what npm uses to
- * populate node_modules for consumers. A shrinkwrap that lists a dependency in
- * `packages[''].dependencies` without a matching resolved `packages[...]` entry is
- * silently dropped from the install by npm rather than falling back to normal
- * resolution — that's what an earlier version of this script did, which broke
- * `npm install bitgo` for every consumer (siblings never landed in node_modules).
- * If a sibling version isn't resolvable yet, the `npm install` below fails loudly
- * and the release fails — which is correct: better a failed release than a
- * silently broken shrinkwrap.
+ * Workspace siblings are resolved as part of the same tree as everything else, not
+ * stripped out. Resolving them here — rather than excluding them and patching their
+ * names back into the shrinkwrap metadata after the fact — is what makes the
+ * generated `packages["node_modules/<sibling>"]` entries (version/resolved/integrity)
+ * actually present, which is what npm uses to populate node_modules for consumers.
+ * A shrinkwrap that lists a dependency in `packages[''].dependencies` without a
+ * matching resolved `packages[...]` entry is silently dropped from the install by
+ * npm rather than falling back to normal resolution — that's what an earlier version
+ * of this script did, which broke `npm install bitgo` for every consumer (siblings
+ * never landed in node_modules).
+ *
+ * This assumes sibling versions are already live on the registry when this script
+ * runs. That is NOT true of a single combined `lerna publish` — lerna runs every
+ * package's lifecycle hooks (bitgo's `prepack` included) before uploading any of
+ * them, so bitgo's siblings are not yet published at the point this script tries to
+ * resolve them. The release workflow is responsible for publishing siblings in a
+ * separate, earlier pass (with bitgo held back via `set-umbrella-publishable.ts`)
+ * before invoking a second pass that packs bitgo with generation enabled. If a
+ * sibling version genuinely isn't resolvable (wrong pass ordering, a sibling publish
+ * that itself failed, etc.), the `npm install` below fails loudly and the release
+ * fails — which is correct: better a failed release than a silently broken
+ * shrinkwrap. A short retry accounts for ordinary registry propagation lag right
+ * after a sibling publish; see `npmInstallWithRetry`.
  *
  * `npm shrinkwrap` isn't workspace-aware and modules/bitgo/.npmrc sets
  * `package-lock=false`, so generation happens in an isolated temp copy outside the
@@ -37,6 +45,64 @@ import execa from 'execa';
 
 const rootDir = path.resolve(__dirname, '..');
 const bitgoDir = path.join(rootDir, 'modules/bitgo');
+const modulesDir = path.join(rootDir, 'modules');
+
+/**
+ * Names of every package in the `modules/*` workspace, read from each package's own
+ * (possibly rescoped) package.json — e.g. `@bitgo/sdk-core` normally, `@bitgo-beta/sdk-core`
+ * on beta/alpha channels after `prepare-release.ts` re-scopes the workspace. Reading
+ * the current on-disk names, rather than hardcoding a scope prefix, is what makes
+ * sibling detection work regardless of which scope is active: `prepare-release.ts`
+ * rewrites both a module's own `name` and bitgo's `dependencies` keys to the same
+ * target scope, so intersecting bitgo's dependencies against this set matches
+ * correctly on every channel. A hardcoded `@bitgo/` prefix check matches nothing on
+ * alpha/beta (where everything is `@bitgo-beta/*`), which would make the safety check
+ * below silently verify zero siblings instead of catching a real problem.
+ */
+function getWorkspacePackageNames(): Set<string> {
+  const names = new Set<string>();
+  for (const entry of fs.readdirSync(modulesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const pkgPath = path.join(modulesDir, entry.name, 'package.json');
+    if (!fs.existsSync(pkgPath)) continue;
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    if (typeof pkg.name === 'string') names.add(pkg.name);
+  }
+  return names;
+}
+
+/**
+ * Runs `npm install --package-lock-only --ignore-scripts`, retrying a bounded number
+ * of times if the failure looks like a sibling that was *just* published not having
+ * propagated to the registry yet (ETARGET/E404) — the two-phase publish flow runs
+ * this immediately after the sibling-publish pass completes, so a brief propagation
+ * lag is expected occasionally, not a sign of a real problem. Any other failure (or
+ * exhausting the retries) is rethrown as-is.
+ */
+async function npmInstallWithRetry(cwd: string, attempts = 5, delayMs = 5000): Promise<void> {
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      const result = await execa('npm', ['install', '--package-lock-only', '--ignore-scripts'], { cwd });
+      if (result.stdout) process.stdout.write(result.stdout + '\n');
+      if (result.stderr) process.stderr.write(result.stderr + '\n');
+      return;
+    } catch (e) {
+      const err = e as execa.ExecaError;
+      if (err.stdout) process.stdout.write(err.stdout + '\n');
+      if (err.stderr) process.stderr.write(err.stderr + '\n');
+      const output = `${err.stdout ?? ''}\n${err.stderr ?? ''}\n${err.message ?? ''}`;
+      const looksLikePropagationLag = /\bETARGET\b/.test(output) || /\bE404\b/.test(output);
+      if (attempt === attempts || !looksLikePropagationLag) {
+        throw e;
+      }
+      console.log(
+        `npm install failed with what looks like a registry propagation delay ` +
+          `(attempt ${attempt}/${attempts}) — retrying in ${delayMs}ms.`
+      );
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+}
 
 async function main() {
   if (process.env.BITGO_GENERATE_SHRINKWRAP !== 'true') {
@@ -55,10 +121,19 @@ async function main() {
   console.log(`Generating npm-shrinkwrap.json for bitgo@${bitgoPackageJson.version} in ${tempDir}`);
 
   try {
-    const siblingNames = Object.keys(bitgoPackageJson.dependencies ?? {}).filter((name) => name.startsWith('@bitgo/'));
+    const workspacePackageNames = getWorkspacePackageNames();
+    const siblingNames = Object.keys(bitgoPackageJson.dependencies ?? {}).filter((name) =>
+      workspacePackageNames.has(name)
+    );
     if (siblingNames.length > 0) {
-      console.log(`Resolving ${siblingNames.length} @bitgo/* siblings as part of the shrinkwrap:`);
+      console.log(`Resolving ${siblingNames.length} workspace siblings as part of the shrinkwrap:`);
       siblingNames.forEach((name) => console.log(`  - ${name}`));
+    } else {
+      console.log(
+        'No workspace siblings found among bitgo dependencies — double check this is expected ' +
+          '(e.g. an intentionally sibling-free release), since a detection bug here would silently ' +
+          'skip the safety check below.'
+      );
     }
 
     const isolatedPackageJson: Record<string, unknown> = { ...bitgoPackageJson };
@@ -78,7 +153,7 @@ async function main() {
 
     fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify(isolatedPackageJson, null, 2) + '\n');
 
-    await execa('npm', ['install', '--package-lock-only', '--ignore-scripts'], { cwd: tempDir, stdio: 'inherit' });
+    await npmInstallWithRetry(tempDir);
     await execa('npm', ['shrinkwrap'], { cwd: tempDir, stdio: 'inherit' });
 
     const shrinkwrapPath = path.join(tempDir, 'npm-shrinkwrap.json');
@@ -88,19 +163,28 @@ async function main() {
 
     const shrinkwrap = JSON.parse(fs.readFileSync(shrinkwrapPath, 'utf-8'));
 
-    // Every @bitgo/* sibling must have a resolved node_modules entry — that's what
-    // npm actually installs from. A sibling present only in `packages[''].dependencies`
-    // (or missing entirely) would be silently skipped by consumers' installs.
-    const resolvedPackageNames = new Set(
-      Object.keys(shrinkwrap.packages ?? {})
-        .filter((key) => key.startsWith('node_modules/'))
-        .map((key) => key.slice('node_modules/'.length))
-    );
-    const unresolvedSiblings = siblingNames.filter((name) => !resolvedPackageNames.has(name));
+    // Every workspace sibling must have a fully-resolved node_modules entry — that's
+    // what npm actually installs from. A sibling present only in
+    // `packages[''].dependencies` (or missing entirely, or present but missing
+    // version/resolved/integrity) would be silently skipped or under-specified in
+    // consumers' installs. Checking only for key presence previously let this pass
+    // for entries npm still couldn't act on; require the actual install-relevant
+    // fields to be strings, not just truthy.
+    const packages = (shrinkwrap.packages ?? {}) as Record<string, Record<string, unknown>>;
+    const unresolvedSiblings = siblingNames.filter((name) => {
+      const entry = packages[`node_modules/${name}`];
+      return (
+        !entry ||
+        typeof entry.version !== 'string' ||
+        typeof entry.resolved !== 'string' ||
+        typeof entry.integrity !== 'string'
+      );
+    });
     if (unresolvedSiblings.length > 0) {
       throw new Error(
-        `The following @bitgo/* siblings have no resolved node_modules entry in the generated ` +
-          `shrinkwrap and would be silently missing from consumers' installs: ${unresolvedSiblings.join(', ')}`
+        `The following workspace siblings have no fully-resolved (version + resolved + integrity) ` +
+          `node_modules entry in the generated shrinkwrap and would be silently missing or ` +
+          `under-specified in consumers' installs: ${unresolvedSiblings.join(', ')}`
       );
     }
 

--- a/scripts/set-umbrella-publishable.ts
+++ b/scripts/set-umbrella-publishable.ts
@@ -1,0 +1,61 @@
+/**
+ * Toggles `private` on modules/bitgo/package.json so the release workflow can hold
+ * the `bitgo` umbrella package out of a `lerna publish` pass without permanently
+ * marking it private in the repo.
+ *
+ * Why a scripted toggle instead of lerna's `--include-private <names>` (which lets
+ * a named private package publish "by temporarily removing the private property
+ * from the package manifest" on its own): that would require `bitgo` to be
+ * permanently `private: true` in the committed manifest, and three separate checks
+ * in the release pipeline enumerate non-private packages to verify they exist/were
+ * published — a permanently-private bitgo would silently stop being covered by all
+ * three:
+ *   - the pre-publish existence check (trusted publishing depends on it)
+ *   - recovery verification
+ *   - beta verification / recovery auto-retry
+ *
+ * Flipping the flag off, running pass 1 (siblings only — bitgo is skipped because
+ * lerna filters private packages before packing), then flipping it back on before
+ * pass 2 (bitgo only) keeps every one of those checks seeing a normal, publishable
+ * package by the time they run. Callers MUST run the "restore" invocation (`true`)
+ * under `always()` in the workflow so a failed or cancelled pass 1 cannot leave the
+ * manifest flipped — this script does not track or restore state on its own, it
+ * just sets the field to whatever you tell it.
+ *
+ * Usage:
+ *   npx tsx scripts/set-umbrella-publishable.ts false   # hold back for pass 1
+ *   npx tsx scripts/set-umbrella-publishable.ts true    # restore for pass 2
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const bitgoPackageJsonPath = path.resolve(__dirname, '..', 'modules', 'bitgo', 'package.json');
+
+function parseArg(argv: string[]): boolean {
+  const raw = argv[2];
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  throw new Error(`Expected a single argument "true" or "false", got: ${JSON.stringify(raw)}`);
+}
+
+function main(): void {
+  const publishable = parseArg(process.argv);
+  const original = fs.readFileSync(bitgoPackageJsonPath, 'utf-8');
+  const pkg = JSON.parse(original);
+
+  if (publishable) {
+    delete pkg.private;
+  } else {
+    pkg.private = true;
+  }
+
+  fs.writeFileSync(bitgoPackageJsonPath, JSON.stringify(pkg, null, 2) + '\n');
+  console.log(
+    publishable
+      ? `Restored modules/bitgo/package.json to publishable (removed "private").`
+      : `Marked modules/bitgo/package.json as private — it will be skipped by the next lerna publish pass.`
+  );
+}
+
+main();


### PR DESCRIPTION
Ticket: WCI-1818

## Summary

Phase 1 of WCN-1818: fixes two latent bugs in `scripts/generate-bitgo-shrinkwrap.ts` (sibling detection breaks on alpha/beta, the resolved-entry safety check was weaker than it should be), adds a bounded retry for ordinary registry propagation lag, and adds a new standalone script (`set-umbrella-publishable.ts`) that phase 2 will use to implement the actual two-phase publish split. This PR does **not** change any workflow behavior and does **not** fix the underlying race condition on its own — see "What this PR does not fix" below.

## Background

PR #9404 (WCI-1200) fixed `npm install bitgo` shipping with zero `@bitgo/*` siblings by making `generate-bitgo-shrinkwrap.ts` actually resolve siblings into the shrinkwrap instead of stripping them. That PR assumed `lerna publish` publishes packages in dependency-topological order, so siblings would already be live on the registry by the time `bitgo` is packed.

That assumption is false. Lerna runs every package's lifecycle hooks (including `bitgo`'s `prepack`) before uploading any of them. The next prod release after #9404 merged failed exactly this way:
```
npm error notarget No matching version found for @bitgo/abstract-lightning@^8.2.3
lerna ERR! lifecycle "prepack" errored in "bitgo", exiting 1
```
Zero packages published in that run. WCN-1818 designed the real fix: split publishing into two passes — siblings first (with `bitgo` temporarily held out via a `private` flag), `bitgo` second, once siblings are actually live. This PR is the first of two phases implementing that design.

## What changed

### 1. `scripts/generate-bitgo-shrinkwrap.ts`

- **Sibling detection**: was `Object.keys(bitgoPackageJson.dependencies).filter(name => name.startsWith('@bitgo/'))`. Now reads every `modules/*/package.json` name from disk (`getWorkspacePackageNames()`) and intersects that with bitgo's dependencies. On the real `@bitgo/*` scope this produces the same 89 siblings as before (no behavior change). On alpha/beta, where `prepare-release.ts` rescopes everything to `@bitgo-beta/*`, the old check matched **zero** siblings — meaning the WCI-1200 safety check was silently verifying nothing on those channels. The new check is scope-agnostic because it reads the actual current names instead of assuming a fixed prefix.
- **Stronger resolved-entry guard**: was checking only that a `packages["node_modules/<name>"]` key existed. Now requires `version`, `resolved`, and `integrity` to each be present as strings. A key that exists but is missing install-relevant fields now correctly fails the check instead of passing it.
- **Bounded retry on resolution** (`npmInstallWithRetry`): wraps `npm install --package-lock-only --ignore-scripts` with up to 5 attempts / 5s backoff, but only when the failure looks like `ETARGET`/`E404` (i.e., "not found yet," not "will never exist"). This exists for phase 2: once siblings publish in their own pass immediately before bitgo's pass, there's a real possibility bitgo's resolution runs before the registry has fully propagated a just-published sibling. Any other error type is rethrown immediately with zero retries — confirmed in local testing.
- Updated the file's header comment to state the real ordering constraint instead of the disproven "topological order" claim, and to describe how phase 2's two-pass split is expected to satisfy it.

### 2. `scripts/set-umbrella-publishable.ts` (new)

Toggles `private` on `modules/bitgo/package.json`:
```
npx tsx scripts/set-umbrella-publishable.ts false   # mark private — lerna skips packing it
npx tsx scripts/set-umbrella-publishable.ts true    # restore — lerna packs it normally
```
This is the mechanism phase 2 will use to hold `bitgo` out of lerna's pack step during the siblings-only pass (lerna's `filterPrivatePkgUpdates` filters private packages before packing, confirmed against lerna 9.0.0's source in `node_modules/lerna/dist/commands/publish/index.js`). Deliberately a scripted *temporary* toggle rather than lerna's built-in `--include-private` (which would require `bitgo` to be permanently `private: true` in the committed manifest) — three separate pipeline checks (pre-publish existence check, recovery verification, beta verification/auto-retry) enumerate non-private packages, and a permanently-private `bitgo` would silently stop being covered by all three. The script itself holds no state and does not decide when to run — the workflow (phase 2) is responsible for calling the restore (`true`) under `always()` so a failed pass 1 can't leave the manifest stuck flipped.

## What this fixes

- The alpha/beta blind spot where the sibling-detection safety check verified nothing (silently), regardless of whether the underlying shrinkwrap was actually correct.
- A weaker-than-necessary resolved-entry check that could pass on a partially-specified entry.
- Provides the primitive (`set-umbrella-publishable.ts`) phase 2 needs, and hardens the resolution step against a known-expected side effect of phase 2's design (propagation lag) ahead of time.

## What this PR does **not** fix

The original race condition — `bitgo`'s `prepack` trying to resolve siblings before they're published, because both currently happen inside one combined `lerna publish` — is **unchanged** by this PR. Neither `.github/workflows/publish.yml` nor `.github/workflows/npmjs-release.yml` are touched here. If a prod release ran today with only this PR merged, it would still fail the same way as before (this is expected — see "Upcoming: Phase 2" below).

## How I tested this locally

All of the following were actually run, not just reasoned about. Working tree was clean before and after (temporary edits made during testing were reverted/diffed to confirm exact restoration).

**1. Type-check and lint the two files:**
```bash
npx tsc --noEmit --skipLibCheck --target es2020 --module commonjs --esModuleInterop --resolveJsonModule \
  scripts/generate-bitgo-shrinkwrap.ts scripts/set-umbrella-publishable.ts
npx eslint scripts/generate-bitgo-shrinkwrap.ts scripts/set-umbrella-publishable.ts
```
Result: 0 errors on both. Only pre-existing `no-sync`/`no-console` style warnings, same kind/count pattern as the rest of `scripts/`.

**2. `set-umbrella-publishable.ts` — both directions, plus invalid input:**
```bash
npx tsx scripts/set-umbrella-publishable.ts false   # -> "private": true appears
npx tsx scripts/set-umbrella-publishable.ts true    # -> "private" key removed
git diff --stat modules/bitgo/package.json          # -> empty; exact round-trip, no corruption
npx tsx scripts/set-umbrella-publishable.ts maybe   # -> throws: Expected a single argument "true" or "false", got: "maybe"
```

**3. Workspace-based sibling detection against the real repo** (standalone script comparing old vs. new detection logic against the actual `modules/` directory):
```bash
npx tsx /tmp/test-workspace-detection.ts
```
Result: both old and new logic found the same 89 siblings on the real `@bitgo/*` scope — confirms no regression.

**4. Simulated beta-rescoped state — reproducing the actual bug** (small script simulating `prepare-release.ts`'s rescoping of a few sample names/deps to `@bitgo-beta/*` in memory, no files touched):
```bash
npx tsx /tmp/test-beta-rescope.ts
```
Result: old prefix-based logic found **0/3** siblings on the simulated beta scope (the bug). New workspace-membership logic found **3/3** correctly.

**5. Retry/backoff logic, mocked runner, three scenarios:**
```bash
npx tsx /tmp/test-retry-logic.ts
```
- Fails twice with `ETARGET`-like text, then succeeds -> recovers on attempt 3.
- Fails with `ETARGET`-like text every time -> exhausts all 5 attempts, fails cleanly (no infinite loop).
- Fails with an unrelated error -> fails on attempt 1, zero wasted retries.

**6. Real end-to-end run against the live npm registry** (safe: resolution/read-only against the registry, only local temp-dir + `modules/bitgo/npm-shrinkwrap.json` writes, no publish):
```bash
BITGO_GENERATE_SHRINKWRAP=true npx tsx scripts/generate-bitgo-shrinkwrap.ts
```
- First attempt failed on an unrelated local issue: Node 20.18.3 vs. the `.nvmrc`-required 24.13.0, surfaced as `EBADENGINE` from a transitive dependency. Notably, this triggered **zero retry attempts** — real-world confirmation that the retry logic correctly classifies non-transient errors and doesn't waste time on them.
- After `nvm install 24.13.0 && nvm use 24.13.0` and re-running: exit code 0. Real `npm-shrinkwrap.json` generated. Spot-checked several sibling entries directly in the output — all had real `version`/`resolved`/`integrity`:
  ```
  @bitgo/sdk-core       -> version: 38.5.1  | resolved: true | integrity: true
  @bitgo/sdk-api        -> version: 2.2.2   | resolved: true | integrity: true
  @bitgo/sdk-coin-ada   -> version: 5.0.6   | resolved: true | integrity: true
  @bitgo/statics        -> version: 59.2.0  | resolved: true | integrity: true
  ```
  150 total `node_modules/@bitgo/*` entries (89 direct siblings + their own transitive `@bitgo/*` deps). Deleted the generated file afterward — it's a build artifact, not meant to be committed here.

**7. Fault injection — proving the strengthened guard actually catches breakage:**
```bash
cp modules/bitgo/package.json /tmp/bitgo-package.json.bak
# edited package.json: set the @bitgo/sdk-core dependency to the nonexistent "999.999.999"
BITGO_GENERATE_SHRINKWRAP=true npx tsx scripts/generate-bitgo-shrinkwrap.ts
```
Result: exit code 1. Because `ETARGET` looks like it could be propagation lag, retried 4 times (~20s) before correctly giving up and reporting the real error:
```
npm error notarget No matching version found for @bitgo/sdk-core@999.999.999.
```
Confirms the retry logic has a bounded cost even in the worst case (a version that will never resolve) and never masks a genuine failure — it just adds a small, fixed delay before reporting accurately.
```bash
cp /tmp/bitgo-package.json.bak modules/bitgo/package.json
diff /tmp/bitgo-package.json.bak modules/bitgo/package.json   # confirmed exact match
rm -f /tmp/bitgo-package.json.bak /tmp/test-*.ts /tmp/shrinkwrap-*.log
```

## How to verify this after merging

Since this PR doesn't change when/how publishing happens, there's no new end-to-end release behavior to verify yet. What's verifiable post-merge:

1. **Confirm it's still inert on beta.** The next normal `publish.yml` dispatch should still show:
   ```
   BITGO_GENERATE_SHRINKWRAP not set to "true" — skipping npm-shrinkwrap.json generation.
   ```
   confirming this PR didn't change the no-op path.
2. **If a prod release runs before phase 2 lands**, it will still fail the original way (siblings not live yet) — that's expected, not a regression. What to check in that failure's logs specifically:
   - The "Resolving N workspace siblings" line should list all 89 sibling names (proves detection still works correctly in the real prepack context, not just locally).
   - If it fails with `ETARGET`, the log should show a few "retrying in 5000ms" lines before the final failure (proves the retry wrapper is wired in and behaving as tested).
3. **Full confirmation of the original bug being fixed** requires phase 2 (the two-pass workflow split) to also land, then a real alpha dispatch or prod release actually succeeding with `_hasShrinkwrap: true` and a clean-directory `npm install bitgo` working. That's out of scope for this PR.

## Upcoming: Phase 2

Not included in this PR. Tracked in WCN-1818, planned as a follow-up PR:

1. **`.github/workflows/publish.yml`** (alpha/beta): split the single `Lerna Publish` step into:
   - `set-umbrella-publishable false` -> `lerna publish from-package` (siblings only, bitgo skipped)
   - `set-umbrella-publishable true` (`if: always()`, so a failed pass 1 can't leave bitgo stuck private)
   - `lerna publish from-package` with `BITGO_GENERATE_SHRINKWRAP=true` (bitgo only, siblings now live)
2. **`.github/workflows/npmjs-release.yml`** (prod): same split, applied to both the normal publish path and the recovery-mode path, on top of the existing (unchanged) `lerna version` step.
3. **Validation plan for phase 2:**
   - Dispatch an alpha publish from the phase 2 branch first — cheapest way to exercise the real code path against the real registry (`BITGO_GENERATE_SHRINKWRAP` would need to be set on that path for the test, unlike today's beta).
   - Confirm the published alpha `bitgo` has `_hasShrinkwrap: true` with fully-resolved entries for every sibling.
   - `npm install @bitgo-beta/bitgo@alpha` in a clean, empty directory — confirm siblings install and `require()` succeeds.
   - Only after that passes, attempt a real prod release — in **recovery mode**, not a normal run, since `rel/latest` already has an orphaned 52.4.2 version bump/tags from the original failed release that a normal run would skip past.
4. **Known gap to track separately**: `scripts/verify-release.ts`'s recovery-retry path doesn't set `BITGO_GENERATE_SHRINKWRAP`, so a beta package republished via that specific path would ship without a shrinkwrap. Not exploitable today (beta never ships one anyway, and prod doesn't use that script), but worth its own follow-up ticket rather than leaving it undocumented indefinitely.
5. Branch hygiene: `rel/latest` and `master` have diverged (one unpublished version-bump commit on `rel/latest`, three unrelated commits on `master` it doesn't have) and need reconciling before any real release attempt — tracked as a separate, pre-release-time task, not blocking this PR or phase 2's code review.

Ticket: WCN-1818
