### PR TITLE
fix(sdk-core,express): allow passwordless OFC wallet generation

### DIFF
--- a/modules/express/test/unit/typedRoutes/generateWallet.ts
+++ b/modules/express/test/unit/typedRoutes/generateWallet.ts
@@ -467,7 +467,6 @@ describe('Generate Wallet Typed Routes Tests', function () {
       const res = await agent.post(`/api/v2/${coin}/wallet/generate`).send({
         label,
         enterprise,
-        passphrase: 'test-passphrase',
         type: 'trading',
         userKeySigningRequired: false,
       });

--- a/modules/sdk-core/src/bitgo/wallet/iWallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallets.ts
@@ -295,20 +295,42 @@ export const GenerateLightningWalletOptionsCodec = t.intersection(
 );
 export type GenerateLightningWalletOptions = t.TypeOf<typeof GenerateLightningWalletOptionsCodec>;
 
+const GenerateGoAccountWalletBaseOptionsCodec = t.intersection([
+  t.strict({
+    label: t.string,
+    enterprise: t.string,
+    type: t.literal('trading'),
+  }),
+  t.partial({
+    // Codec intentionally accepts only 2: v1 is the implicit default and never sent on the wire.
+    encryptionVersion: t.literal(2),
+  }),
+]);
+
+const GenerateGoAccountWalletPasswordOptionsCodec = t.intersection([
+  t.strict({
+    passphrase: t.string,
+    passcodeEncryptionCode: t.string,
+  }),
+  t.partial({
+    userKeySigningRequired: t.boolean,
+  }),
+]);
+
+const GenerateGoAccountWalletPasswordlessOptionsCodec = t.intersection([
+  t.strict({
+    userKeySigningRequired: t.literal(false),
+  }),
+  t.partial({
+    passphrase: t.undefined,
+    passcodeEncryptionCode: t.undefined,
+  }),
+]);
+
 export const GenerateGoAccountWalletOptionsCodec = t.intersection(
   [
-    t.strict({
-      label: t.string,
-      passphrase: t.string,
-      enterprise: t.string,
-      passcodeEncryptionCode: t.string,
-      type: t.literal('trading'),
-    }),
-    t.partial({
-      // Codec intentionally accepts only 2: v1 is the implicit default and never sent on the wire.
-      encryptionVersion: t.literal(2),
-      userKeySigningRequired: t.boolean,
-    }),
+    GenerateGoAccountWalletBaseOptionsCodec,
+    t.union([GenerateGoAccountWalletPasswordOptionsCodec, GenerateGoAccountWalletPasswordlessOptionsCodec]),
   ],
   'GenerateGoAccountWalletOptions'
 );

--- a/modules/sdk-core/src/bitgo/wallet/wallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallets.ts
@@ -240,15 +240,18 @@ export class Wallets implements IWallets {
 
     const keychainParams: AddKeychainOptions = {
       pub: keychain.pub,
-      encryptedPrv: await this.bitgo.encrypt({
-        password: passphrase,
-        input: keychain.prv,
-        encryptionVersion,
-      }),
-      originalPasscodeEncryptionCode: passcodeEncryptionCode,
       keyType: 'independent',
       source: 'user',
     };
+
+    if (passphrase !== undefined && passcodeEncryptionCode !== undefined) {
+      keychainParams.encryptedPrv = await this.bitgo.encrypt({
+        password: passphrase,
+        input: keychain.prv,
+        encryptionVersion,
+      });
+      keychainParams.originalPasscodeEncryptionCode = passcodeEncryptionCode;
+    }
 
     const userKeychain = await this.baseCoin.keychains().add(keychainParams);
 
@@ -351,11 +354,13 @@ export class Wallets implements IWallets {
       );
 
       const walletData = await this.generateGoAccountWallet(options);
-      walletData.encryptedWalletPassphrase = await this.bitgo.encrypt({
-        input: options.passphrase,
-        password: options.passcodeEncryptionCode,
-        encryptionVersion: options.encryptionVersion,
-      });
+      if (options.passphrase !== undefined && options.passcodeEncryptionCode !== undefined) {
+        walletData.encryptedWalletPassphrase = await this.bitgo.encrypt({
+          input: options.passphrase,
+          password: options.passcodeEncryptionCode,
+          encryptionVersion: options.encryptionVersion,
+        });
+      }
       return walletData;
     }
 

--- a/modules/sdk-core/test/unit/bitgo/wallet/walletOptionsCodecs.ts
+++ b/modules/sdk-core/test/unit/bitgo/wallet/walletOptionsCodecs.ts
@@ -46,4 +46,42 @@ describe('wallet options codecs with encryptionVersion', () => {
   it('GenerateGoAccountWalletOptionsCodec works without encryptionVersion', () => {
     assert.ok(isRight(GenerateGoAccountWalletOptionsCodec.decode(goAccountBase)));
   });
+
+  it('GenerateGoAccountWalletOptionsCodec accepts password fields when user key signing is disabled', () => {
+    assert.ok(
+      isRight(
+        GenerateGoAccountWalletOptionsCodec.decode({
+          ...goAccountBase,
+          userKeySigningRequired: false,
+        })
+      )
+    );
+  });
+
+  it('GenerateGoAccountWalletOptionsCodec accepts omitted password fields when user key signing is disabled', () => {
+    assert.ok(
+      isRight(
+        GenerateGoAccountWalletOptionsCodec.decode({
+          label: 'test',
+          enterprise: 'ent',
+          type: 'trading',
+          userKeySigningRequired: false,
+        })
+      )
+    );
+  });
+
+  it('GenerateGoAccountWalletOptionsCodec rejects a single password field when user key signing is disabled', () => {
+    assert.ok(
+      isLeft(
+        GenerateGoAccountWalletOptionsCodec.decode({
+          label: 'test',
+          passphrase: 'pass',
+          enterprise: 'ent',
+          type: 'trading',
+          userKeySigningRequired: false,
+        })
+      )
+    );
+  });
 });

--- a/modules/sdk-core/test/unit/bitgo/wallet/walletsGoAccount.ts
+++ b/modules/sdk-core/test/unit/bitgo/wallet/walletsGoAccount.ts
@@ -17,7 +17,7 @@ describe('Wallets - GoAccount (OFC trading) wallet creation', function () {
   beforeEach(function () {
     mockKeychains = {
       create: sinon.stub().returns({ pub: userPub, prv: userPrv }),
-      add: sinon.stub().resolves({ id: 'user-key-id', pub: userPub, encryptedPrv: 'encrypted-prv' }),
+      add: sinon.stub().callsFake(async (params) => ({ id: 'user-key-id', ...params })),
     };
 
     const mockWalletData = { id: 'wallet-id', keys: ['user-key-id'] };
@@ -56,7 +56,7 @@ describe('Wallets - GoAccount (OFC trading) wallet creation', function () {
   });
 
   it('should forward userKeySigningRequired: false in coinSpecific when provided', async function () {
-    await wallets.generateWallet({
+    const result = await wallets.generateWallet({
       label: 'Test OFC Wallet',
       passphrase: 'test-passphrase',
       enterprise: 'enterprise-123',
@@ -69,6 +69,11 @@ describe('Wallets - GoAccount (OFC trading) wallet creation', function () {
     const sentParams = postChain.send.firstCall.args[0];
     sentParams.should.have.property('coinSpecific');
     sentParams.coinSpecific.should.have.property('userKeySigningRequired', false);
+
+    const keychainParams = mockKeychains.add.firstCall.args[0];
+    keychainParams.should.have.property('encryptedPrv', `encrypted:test-passphrase:${userPrv}`);
+    keychainParams.should.have.property('originalPasscodeEncryptionCode', 'pce-code');
+    result.should.have.property('encryptedWalletPassphrase', 'encrypted:pce-code:test-passphrase');
   });
 
   it('should forward userKeySigningRequired: true in coinSpecific when explicitly set', async function () {
@@ -96,5 +101,41 @@ describe('Wallets - GoAccount (OFC trading) wallet creation', function () {
 
     const sentParams = postChain.send.firstCall.args[0];
     sentParams.should.not.have.property('coinSpecific');
+  });
+
+  it('should generate a public-only user key when user key signing is disabled and password fields are omitted', async function () {
+    const result = await wallets.generateWallet({
+      label: 'Passwordless OFC Wallet',
+      enterprise: 'enterprise-123',
+      type: 'trading',
+      userKeySigningRequired: false,
+    });
+
+    assert.ok(mockKeychains.add.calledOnce, 'user key should be uploaded once');
+    const keychainParams = mockKeychains.add.firstCall.args[0];
+    keychainParams.should.have.property('pub', userPub);
+    keychainParams.should.not.have.property('encryptedPrv');
+    keychainParams.should.not.have.property('originalPasscodeEncryptionCode');
+
+    assert.ok(postChain.send.calledOnce, 'POST /wallet/add should be called once');
+    postChain.send.firstCall.args[0].coinSpecific.should.have.property('userKeySigningRequired', false);
+    result.should.not.have.property('encryptedWalletPassphrase');
+    result.should.not.have.property('warning');
+  });
+
+  it('should reject passwordless generation when only one password field is supplied', async function () {
+    await assert.rejects(
+      wallets.generateWallet({
+        label: 'Passwordless OFC Wallet',
+        enterprise: 'enterprise-123',
+        type: 'trading',
+        userKeySigningRequired: false,
+        passphrase: 'partial-password-input',
+      }),
+      /error\(s\) parsing generate go account request params/
+    );
+
+    assert.strictEqual(mockKeychains.add.called, false);
+    assert.strictEqual(postChain.send.called, false);
   });
 });


### PR DESCRIPTION
## Description

Allow OFC trading wallets created with `userKeySigningRequired: false` to omit `passphrase` and `passcodeEncryptionCode`.

The exported Go Account options codec now models both valid request shapes:

- password-backed generation requires both password fields and accepts `userKeySigningRequired` omitted, `true`, or `false`;
- passwordless generation requires `userKeySigningRequired: false` and omits both password fields.

Supplying only one password field is rejected. The passwordless path uploads a public-only structural user keychain and omits `encryptedWalletPassphrase`; the existing password-backed encryption behavior is unchanged.

## Issue Number

WCN-1859

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `yarn --cwd modules/express mocha --no-config --require tsx --timeout 60000 test/unit/typedRoutes/generateWallet.ts` — 22 passing
- `yarn --cwd modules/sdk-core nyc -- mocha test/unit/bitgo/wallet/walletOptionsCodecs.ts test/unit/bitgo/wallet/walletsGoAccount.ts` — 14 passing
- `yarn --cwd modules/sdk-core build --force`
- `yarn --cwd modules/express build`
- Complete Express suite: 1,915 passing with one transient `socket hang up` in the canonical-address suite; isolated rerun of that suite passed 60/60.

Tested with the repository-pinned Node.js 24.13.0.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly
- [x] My commits follow Conventional Commits
- [x] The ticket was included in the commit message
- [x] I have added tests that prove the fix is effective
- [x] Relevant existing and new unit tests pass locally