### PR TITLE
feat: add needsXpubsForColdSigning capability method

### DIFF
--- a/modules/abstract-utxo/src/abstractUtxoCoin.ts
+++ b/modules/abstract-utxo/src/abstractUtxoCoin.ts
@@ -7,6 +7,7 @@ import {
   AddressCoinSpecific,
   BaseCoin,
   BitGoBase,
+  ColdTransactionPrebuild,
   CreateAddressFormat,
   ExtraPrebuildParamsOptions,
   HalfSignedUtxoTransaction,
@@ -17,6 +18,7 @@ import {
   IRequestTracer,
   isTriple,
   IWallet,
+  Keychain,
   KeychainsTriplet,
   KeyIndices,
   MismatchedRecipient,
@@ -1066,6 +1068,17 @@ export abstract class AbstractUtxoCoin extends BaseCoin implements Musig2Partici
 
   valuelessTransferAllowed(): boolean {
     return false;
+  }
+
+  prepareColdTransaction<T extends BaseTransactionPrebuild>(
+    txPrebuild: T,
+    keychains: Triple<Keychain>
+  ): T & ColdTransactionPrebuild {
+    // PSBTs already carry BIP-32 derivation info inline, so offline signers do not need the extra information
+    if (typeof txPrebuild.txHex === 'string' && hasPsbtMagic(stringToBufferTryFormats(txPrebuild.txHex, ['hex']))) {
+      return txPrebuild as T & ColdTransactionPrebuild;
+    }
+    return super.prepareColdTransaction(txPrebuild, keychains);
   }
 
   getRecoveryProvider(apiToken?: string): RecoveryProvider {

--- a/modules/sdk-core/src/bitgo/baseCoin/baseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/baseCoin.ts
@@ -13,7 +13,7 @@ import { signMessage } from '../bip32util';
 import { NotImplementedError } from '../../account-lib';
 import { BitGoBase } from '../bitgoBase';
 import { Enterprises } from '../enterprise';
-import { Keychains, KeyIndices } from '../keychain';
+import { ApiKeyShare, Keychain, Keychains, KeyIndices } from '../keychain';
 import { Markets } from '../market';
 import { PendingApprovals } from '../pendingApproval';
 import { IWallet, Wallet, Wallets } from '../wallet';
@@ -22,6 +22,7 @@ import {
   BaseBroadcastTransactionOptions,
   BaseBroadcastTransactionResult,
   BuildNftTransferDataOptions,
+  ColdTransactionPrebuild,
   DeriveKeyWithSeedOptions,
   ExtraPrebuildParamsOptions,
   FeeEstimateOptions,
@@ -57,6 +58,7 @@ import {
   PopulatedIntent,
   PrebuildTransactionWithIntentOptions,
   TokenTransferRecipientParams,
+  Triple,
 } from '../utils';
 
 export abstract class BaseCoin implements IBaseCoin {
@@ -242,6 +244,44 @@ export abstract class BaseCoin implements IBaseCoin {
    */
   supportsBlsDkg(): boolean {
     return false;
+  }
+
+  /**
+   * Prepare a built transaction for cold (offline) signing by attaching the
+   * xpubs / xpub derivation paths the offline signer (OVC) needs in order to
+   * sign it. Coins whose tx format already carries this information inline
+   * (e.g. PSBT) can override this to skip attaching it.
+   * @param txPrebuild The built transaction JSON returned by the platform
+   * @param keychains The user/backup/bitgo keychains for this wallet, in that order
+   * @returns The txPrebuild JSON, augmented with `pubs` and `xpubsWithDerivationPath`
+   */
+  prepareColdTransaction<T extends TransactionPrebuild>(
+    txPrebuild: T,
+    keychains: Triple<Keychain>
+  ): T & ColdTransactionPrebuild {
+    const [user, backup, bitgo] = keychains;
+    const sources: Array<[ApiKeyShare['from'], Keychain]> = [
+      ['user', user],
+      ['backup', backup],
+      ['bitgo', bitgo],
+    ];
+    const pubs: string[] = [];
+    const xpubsWithDerivationPath: NonNullable<ColdTransactionPrebuild['xpubsWithDerivationPath']> = {};
+    for (const [source, keychain] of sources) {
+      // MPC keychains only have a commonKeychain, not a pub - skip those.
+      if (keychain.pub) {
+        pubs.push(keychain.pub);
+        xpubsWithDerivationPath[source] = {
+          xpub: keychain.pub,
+          derivedFromParentWithSeed: keychain.derivedFromParentWithSeed,
+        };
+      }
+    }
+    return {
+      ...txPrebuild,
+      pubs,
+      xpubsWithDerivationPath,
+    };
   }
 
   /**

--- a/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
@@ -2,7 +2,7 @@ import { BaseTokenConfig, BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 import BigNumber from 'bignumber.js';
 import { IRequestTracer } from '../../api';
 import { IEnterprises } from '../enterprise';
-import { IKeychains, Keychain } from '../keychain';
+import { ApiKeyShare, IKeychains, Keychain } from '../keychain';
 import { IMarkets } from '../market';
 import { IPendingApprovals } from '../pendingApproval';
 import { InitiateRecoveryOptions } from '../recovery';
@@ -14,7 +14,7 @@ import { TokenEnablement } from '@bitgo/public-types';
 import { Hash } from 'crypto';
 import { TransactionType } from '../../account-lib';
 import { IInscriptionBuilder } from '../inscriptionBuilder';
-import { MessageStandardType, MPCTx, PopulatedIntent, TokenTransferRecipientParams, TokenType } from '../utils';
+import { MessageStandardType, MPCTx, PopulatedIntent, TokenTransferRecipientParams, TokenType, Triple } from '../utils';
 import type { SignableTransaction } from '../utils/tss/baseTypes';
 import { IWebhooks } from '../webhook/iWebhooks';
 
@@ -442,6 +442,16 @@ export interface TransactionPrebuild extends BaseSignable {
   txInfo?: unknown;
 }
 
+export interface XpubWithDerivationPath {
+  xpub: string;
+  derivedFromParentWithSeed?: string;
+}
+
+export interface ColdTransactionPrebuild {
+  pubs?: string[];
+  xpubsWithDerivationPath?: Partial<Record<ApiKeyShare['from'], XpubWithDerivationPath>>;
+}
+
 export interface Message extends BaseSignable {
   messageRaw: string;
   messageEncoded?: string;
@@ -672,6 +682,10 @@ export interface IBaseCoin {
   supportsDeriveKeyWithSeed(): boolean;
   isEVM(): boolean;
   supportsBlsDkg(): boolean;
+  prepareColdTransaction<T extends TransactionPrebuild>(
+    txPrebuild: T,
+    keychains: Triple<Keychain>
+  ): T & ColdTransactionPrebuild;
   getBaseFactor(): number | string;
   baseUnitsToBigUnits(baseUnits: string | number): string;
   bigUnitsToBaseUnits(bigUnits: string | number): string;


### PR DESCRIPTION
Adds a coin-level capability so callers can check whether a built transaction requires xpubs/derivation paths for cold signing instead of sniffing tx format themselves. PSBT transactions carry BIP-32 derivation info inline, so xpubs are only needed for legacy UTXO txs.

TICKET: WCN-1799

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
