### PR TITLE
fix(sdk-coin-eth): complete sepeth registration and fix testnet coin resolution

### DIFF
--- a/modules/sdk-coin-eth/src/erc20Token.ts
+++ b/modules/sdk-coin-eth/src/erc20Token.ts
@@ -31,7 +31,7 @@ export class Erc20Token extends Eth {
   };
 
   constructor(bitgo: BitGoBase, tokenConfig: Erc20TokenConfig) {
-    const staticsCoin = coins.get(Erc20Token.coinNames[tokenConfig.network]);
+    const staticsCoin = coins.get(tokenConfig.coin);
     super(bitgo, staticsCoin);
     this.tokenConfig = tokenConfig;
     this.sendMethodName = 'sendMultiSigToken';

--- a/modules/sdk-coin-eth/src/erc7984Token.ts
+++ b/modules/sdk-coin-eth/src/erc7984Token.ts
@@ -33,7 +33,7 @@ export class Erc7984Token extends Eth {
   };
 
   constructor(bitgo: BitGoBase, tokenConfig: Erc7984TokenConfig) {
-    const staticsCoin = coins.get(Erc7984Token.coinNames[tokenConfig.network]);
+    const staticsCoin = coins.get(tokenConfig.coin);
     super(bitgo, staticsCoin);
     this.tokenConfig = tokenConfig;
     // ERC7984 confidential transfers use sendMultiSig (not sendMultiSigToken) because

--- a/modules/sdk-coin-eth/src/register.ts
+++ b/modules/sdk-coin-eth/src/register.ts
@@ -5,6 +5,7 @@ import { Erc7984Token } from './erc7984Token';
 import { Eth } from './eth';
 import { Gteth } from './gteth';
 import { Hteth } from './hteth';
+import { Sepeth } from './sepeth';
 import { Teth } from './teth';
 import { type CoinMap, getFormattedErc20Tokens, getFormattedErc7984Tokens } from '@bitgo/statics';
 
@@ -13,6 +14,7 @@ export const register = (sdk: BitGoBase): void => {
   sdk.register('gteth', Gteth.createInstance);
   sdk.register('teth', Teth.createInstance);
   sdk.register('hteth', Hteth.createInstance);
+  sdk.register('sepeth', Sepeth.createInstance);
   Erc20Token.createTokenConstructors().forEach(({ name, coinConstructor }) => {
     sdk.register(name, coinConstructor);
   });
@@ -29,6 +31,7 @@ export const registerWithCoinMap = (sdk: BitGoBase, coinMap: CoinMap): void => {
   sdk.register('gteth', Gteth.createInstance);
   sdk.register('teth', Teth.createInstance);
   sdk.register('hteth', Hteth.createInstance);
+  sdk.register('sepeth', Sepeth.createInstance);
   Erc721Token.createTokenConstructors().forEach(({ name, coinConstructor }) => {
     sdk.register(name, coinConstructor);
   });

--- a/modules/sdk-coin-eth/src/sepeth.ts
+++ b/modules/sdk-coin-eth/src/sepeth.ts
@@ -1,0 +1,13 @@
+import { BaseCoin, BitGoBase } from '@bitgo/sdk-core';
+import { BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
+import { Eth } from './eth';
+
+export class Sepeth extends Eth {
+  protected constructor(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>) {
+    super(bitgo, staticsCoin);
+  }
+
+  static createInstance(bitgo: BitGoBase, staticsCoin?: Readonly<StaticsBaseCoin>): BaseCoin {
+    return new Sepeth(bitgo, staticsCoin);
+  }
+}

--- a/modules/sdk-coin-eth/test/unit/register.ts
+++ b/modules/sdk-coin-eth/test/unit/register.ts
@@ -35,12 +35,13 @@ describe('ETH Register', function () {
       assert.ok(registeredNames.includes('gteth'));
       assert.ok(registeredNames.includes('teth'));
       assert.ok(registeredNames.includes('hteth'));
+      assert.ok(registeredNames.includes('sepeth'));
 
       // ERC20, ERC721 and ERC7984 tokens should be registered
       const erc20Count = Erc20Token.createTokenConstructors().length;
       const erc721Count = Erc721Token.createTokenConstructors().length;
       const erc7984Count = Erc7984Token.createTokenConstructors().length;
-      assert.strictEqual(registerSpy.callCount, 4 + erc20Count + erc721Count + erc7984Count);
+      assert.strictEqual(registerSpy.callCount, 5 + erc20Count + erc721Count + erc7984Count);
     });
   });
 
@@ -55,6 +56,7 @@ describe('ETH Register', function () {
       assert.ok(registeredNames.includes('gteth'));
       assert.ok(registeredNames.includes('teth'));
       assert.ok(registeredNames.includes('hteth'));
+      assert.ok(registeredNames.includes('sepeth'));
     });
 
     it('should add dynamic ERC20 tokens to the global coin map', function () {

--- a/modules/statics/src/tokenConfig.ts
+++ b/modules/statics/src/tokenConfig.ts
@@ -332,6 +332,9 @@ function getErc20TokenConfig(coin: Erc20Coin): Erc20TokenConfig {
     case Networks.test.hoodi.name:
       baseCoin = 'hteth';
       break;
+    case Networks.test.sepolia.name:
+      baseCoin = 'sepeth';
+      break;
     default:
       throw new Error(`Erc20 token ${coin.name} has an unsupported network`);
   }
@@ -369,6 +372,9 @@ function getErc7984TokenConfig(coin: Erc7984Coin): Erc7984TokenConfig {
     case Networks.test.holesky.name:
     case Networks.test.hoodi.name:
       baseCoin = 'hteth';
+      break;
+    case Networks.test.sepolia.name:
+      baseCoin = 'sepeth';
       break;
     default:
       throw new Error(`ERC-7984 token ${coin.name} has an unsupported network`);


### PR DESCRIPTION
## Summary
- Register `sepeth` (Sepolia Ethereum) as an SDK coin — was missing, blocking Sepolia wallet creation (follow-up to #9377, #9389).
- Add `Networks.test.sepolia` → `sepeth` mapping in `getErc20TokenConfig()` and `getErc7984TokenConfig()` in statics.
- Fix base coin resolution for Eth-family testnet tokens in `erc20Token.ts`/`erc7984Token.ts`:
  - `Erc20Token`/`Erc7984Token` picked their base `staticsCoin` via `coinNames[tokenConfig.network]`, where `coinNames = { Mainnet: 'eth', Testnet: 'hteth' }`. Since `tokenConfig.network` is only ever the generic bucket `'Mainnet'` or `'Testnet'` (never the specific chain), **every** testnet token — Holesky, Hoodi, or Sepolia — resolved to the same fixed `'hteth'`.
  - This worked by coincidence while `hteth` was the only Eth testnet with live tokens. With `sepeth` now active, a Sepolia token would have silently built/signed transactions using `hteth`'s chain data (chainId 17000 instead of 11155111, wrong wallet/forwarder contract addresses).
  - Fix: resolve `staticsCoin` from `tokenConfig.coin` instead, which is already set per-network by `getErc20TokenConfig()`/`getErc7984TokenConfig()` (`'hteth'`, `'sepeth'`, etc.).
  - Mainnet is unaffected — `tokenConfig.coin` is `'eth'` for mainnet tokens, same value the old `coinNames.Mainnet` lookup produced.

## Test plan
- [x] `yarn tsc --noEmit` clean for `sdk-coin-eth` and `statics`
- [x] `sdk-coin-eth` full unit suite passing (382 tests)
- [x] `statics` tokenConfig-related tests passing
- [x] Updated `register.ts` unit test to account for new `sepeth` base coin registration

Ticket: CECHO-1721
