### PR TITLE
feat(statics): onboard Zama confidential tokens (CHALO-1131)

### DIFF
--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -4391,8 +4391,11 @@ export enum UnderlyingAsset {
   'eth:drv' = 'eth:drv',
   'eth:prn' = 'eth:prn',
   'eth:zama' = 'eth:zama',
-  // ERC-7984 confidential tokens (Zama fhEVM - mainnet, contract addresses TBD pending Zama mainnet launch)
+  // ERC-7984 confidential tokens (Zama fhEVM - mainnet)
   'eth:czama' = 'eth:czama',
+  'eth:cxaut' = 'eth:cxaut',
+  'eth:ctgbp' = 'eth:ctgbp',
+  'eth:cweth' = 'eth:cweth',
   'eth:cusdt' = 'eth:cusdt',
   'eth:cusdc' = 'eth:cusdc',
   // ERC-7984 confidential tokens (Zama fhEVM - testnet / hteth)

--- a/modules/statics/src/coins/erc7984Tokens.ts
+++ b/modules/statics/src/coins/erc7984Tokens.ts
@@ -8,7 +8,6 @@ import { UnderlyingAsset } from '../base';
  * Balances are stored as encrypted ciphertexts; plaintext amounts require ACL-delegated
  * decryption via the Zama Gateway before they can be displayed.
  *
- * Mainnet contract addresses are TBD pending Zama fhEVM mainnet launch.
  * Testnet tokens (hteth:*) are deployed on Hoodi using Zama's cleartext FHE stack.
  *   Hoodi ACL: 0x6D3FAf6f86e1fF9F3B0831Dda920AbA1cBd5bd68  (Networks.test.hoodi.zamaAclContractAddress)
  *   Hoodi RPC: https://rpc.hoodi.ethpandaops.io  (chain ID 560048)
@@ -18,14 +17,38 @@ import { UnderlyingAsset } from '../base';
  *   cUSDT: 0x4E7B06D78965594eB5EF5414c357ca21E1554491
  */
 export const erc7984Tokens = [
-  // Mainnet tokens (contract addresses TBD pending Zama fhEVM mainnet launch)
+  // Mainnet tokens
   erc7984(
     'f47ac10b-58cc-4372-a567-0e02b2c3d479',
     'eth:czama',
-    'Zama Test Token',
+    'Confidential Zama',
     6,
-    '0xeb5015ff021db115ace010f23f55c2591059bba0', // https://etherscan.io/address/0xeb5015ff021db115ace010f23f55c2591059bba0
+    '0x80cb147fd86dc6dee3eee7e4cee33d1397d98071', // https://etherscan.io/token/0x80CB147Fd86dC6dEe3Eee7e4Cee33d1397d98071
     UnderlyingAsset['eth:czama']
+  ),
+  erc7984(
+    'c9d5d51b-15b7-4d93-b079-9af313160e66',
+    'eth:cxaut',
+    'Zama Confidential XAUT',
+    6,
+    '0x73cc9af9d6befdb3c3faf8a5e8c05cb95fdaeef1', // https://etherscan.io/token/0x73cc9aF9d6BEFdb3c3fAf8a5E8c05Cb95FdaEEf1
+    UnderlyingAsset['eth:cxaut']
+  ),
+  erc7984(
+    '0d1b01c8-ee4a-4ca4-a1af-2ab3132d91ee',
+    'eth:ctgbp',
+    'Zama Confidential TGBP',
+    6,
+    '0xa873750ccbafd5ec7dd13bfd5237d7129832edd9', // https://etherscan.io/token/0xa873750ccBafD5ec7Dd13bfD5237d7129832eDD9
+    UnderlyingAsset['eth:ctgbp']
+  ),
+  erc7984(
+    '2fbf960e-9747-4d38-b93b-28029e78b5d4',
+    'eth:cweth',
+    'Zama Confidential WETH',
+    6,
+    '0xda9396b82634ea99243ce51258b6a5ae512d4893', // https://etherscan.io/token/0xda9396b82634Ea99243cE51258B6A5Ae512D4893
+    UnderlyingAsset['eth:cweth']
   ),
   erc7984(
     'f47ac10b-58cc-4372-a567-0e02b2c3d480',

--- a/modules/statics/src/coins/ofcErc20Coins.ts
+++ b/modules/statics/src/coins/ofcErc20Coins.ts
@@ -7037,6 +7037,34 @@ export const tOfcErc20Coins = [
   ),
   ofcerc20('66f600c7-5858-482f-9e5f-823930b1f4f4', 'ofceth:zama', 'Zama', 18, UnderlyingAsset['eth:zama']),
   ofcerc20(
+    '903139a4-b3f0-4d2f-8d0c-0680635685dc',
+    'ofceth:czama',
+    'Confidential Zama',
+    6,
+    UnderlyingAsset['eth:czama']
+  ),
+  ofcerc20(
+    'c89917e6-3ffd-4213-b80c-76d868da5969',
+    'ofceth:cxaut',
+    'Zama Confidential XAUT',
+    6,
+    UnderlyingAsset['eth:cxaut']
+  ),
+  ofcerc20(
+    '11477fe1-6056-4fd8-8389-39f1e7290360',
+    'ofceth:ctgbp',
+    'Zama Confidential TGBP',
+    6,
+    UnderlyingAsset['eth:ctgbp']
+  ),
+  ofcerc20(
+    '6878ebf2-d2b5-412c-a367-5fd64029e150',
+    'ofceth:cweth',
+    'Zama Confidential WETH',
+    6,
+    UnderlyingAsset['eth:cweth']
+  ),
+  ofcerc20(
     'b2efa51c-3628-419b-ae40-249c27c677ab',
     'ofceth:mony',
     'My OnChain Net Yield Fund',

--- a/modules/statics/src/coins/ofcErc20Coins.ts
+++ b/modules/statics/src/coins/ofcErc20Coins.ts
@@ -7037,34 +7037,6 @@ export const tOfcErc20Coins = [
   ),
   ofcerc20('66f600c7-5858-482f-9e5f-823930b1f4f4', 'ofceth:zama', 'Zama', 18, UnderlyingAsset['eth:zama']),
   ofcerc20(
-    '903139a4-b3f0-4d2f-8d0c-0680635685dc',
-    'ofceth:czama',
-    'Confidential Zama',
-    6,
-    UnderlyingAsset['eth:czama']
-  ),
-  ofcerc20(
-    'c89917e6-3ffd-4213-b80c-76d868da5969',
-    'ofceth:cxaut',
-    'Zama Confidential XAUT',
-    6,
-    UnderlyingAsset['eth:cxaut']
-  ),
-  ofcerc20(
-    '11477fe1-6056-4fd8-8389-39f1e7290360',
-    'ofceth:ctgbp',
-    'Zama Confidential TGBP',
-    6,
-    UnderlyingAsset['eth:ctgbp']
-  ),
-  ofcerc20(
-    '6878ebf2-d2b5-412c-a367-5fd64029e150',
-    'ofceth:cweth',
-    'Zama Confidential WETH',
-    6,
-    UnderlyingAsset['eth:cweth']
-  ),
-  ofcerc20(
     'b2efa51c-3628-419b-ae40-249c27c677ab',
     'ofceth:mony',
     'My OnChain Net Yield Fund',


### PR DESCRIPTION
## Summary
- Updates `eth:czama` mainnet contract address and display name to Confidential Zama (`0x80cb147f...`)
- Adds ERC-7984 mainnet tokens: `eth:cxaut`, `eth:ctgbp`, `eth:cweth`
- Adds corresponding `UnderlyingAsset` enum entries in `base.ts`

## Tokens

| Symbol | Name | Contract | Decimals |
|--------|------|----------|----------|
| eth:czama | Confidential Zama | `0x80cb147fd86dc6dee3eee7e4cee33d1397d98071` | 6 |
| eth:cxaut | Zama Confidential XAUT | `0x73cc9af9d6befdb3c3faf8a5e8c05cb95fdaeef1` | 6 |
| eth:ctgbp | Zama Confidential TGBP | `0xa873750ccbafd5ec7dd13bfd5237d7129832edd9` | 6 |
| eth:cweth | Zama Confidential WETH | `0xda9396b82634ea99243ce51258b6a5ae512d4893` | 6 |

## Test plan
- [ ] Confirm tokens load from `@bitgo/statics` (`coins.get('eth:czama'|… )`)
- [ ] Confirm contract addresses are lowercase and match Etherscan
- [ ] Confirm no CoinMap duplicate-address collisions
- [ ] After merge: publish bitgo-beta and proceed with AMS/BGMS bumps

TICKET: [CHALO-1131](https://bitgoinc.atlassian.net/browse/CHALO-1131)