### PR TITLE
test(sdk-lib-mpc): add DKLS replay/stale-round negative tests

### DIFF
--- a/modules/sdk-lib-mpc/test/unit/tss/ecdsa/dklsDsg.ts
+++ b/modules/sdk-lib-mpc/test/unit/tss/ecdsa/dklsDsg.ts
@@ -443,6 +443,122 @@ describe('DKLS Dsg 2x3', function () {
     convertedSignature.split(':').length.should.equal(4);
   });
 
+  it('should fail when round messages from an independent, concurrent sign session are replayed into another session for the same message', async function () {
+    const vector = vectors[0];
+    const buildParty = (partyIdx: number) =>
+      new DklsDsg.Dsg(
+        fs.readFileSync(shareFiles[partyIdx]),
+        partyIdx,
+        vector.derivationPath,
+        crypto.createHash('sha256').update(Buffer.from(vector.msgToSign, 'hex')).digest()
+      );
+
+    // Session A and Session B are two independent DSG sessions signing the *same* message with the
+    // *same* parties, as would happen if two concurrent sign attempts were made for one request.
+    const partyA1 = buildParty(vector.party1);
+    const partyA2 = buildParty(vector.party2);
+    const [, partyA2Round2Messages] = (await executeTillRound(2, partyA1, partyA2)) as DeserializedMessages[];
+
+    const partyB1 = buildParty(vector.party1);
+    const partyB2 = buildParty(vector.party2);
+    const [partyB1Round2Messages] = (await executeTillRound(2, partyB1, partyB2)) as DeserializedMessages[];
+
+    const serializeMessages = (messages: DeserializedMessages) =>
+      JSON.stringify({
+        p2pMessages: messages.p2pMessages.map((message) => ({
+          payload: Buffer.from(message.payload).toString('hex'),
+          from: message.from,
+          to: message.to,
+        })),
+        broadcastMessages: messages.broadcastMessages.map((message) => ({
+          payload: Buffer.from(message.payload).toString('hex'),
+          from: message.from,
+        })),
+      });
+
+    serializeMessages(partyA2Round2Messages).should.not.equal(serializeMessages(partyB1Round2Messages));
+
+    // A fresh copy of session B accepts its own round-2 output, proving the rejection below is caused
+    // by replaying session A's messages rather than by malformed or otherwise invalid input.
+    const partyBControl1 = buildParty(vector.party1);
+    const partyBControl2 = buildParty(vector.party2);
+    const [, partyBControl2Round2Messages] = (await executeTillRound(
+      2,
+      partyBControl1,
+      partyBControl2
+    )) as DeserializedMessages[];
+    partyBControl1.handleIncomingMessages({
+      p2pMessages: partyBControl2Round2Messages.p2pMessages,
+      broadcastMessages: partyBControl2Round2Messages.broadcastMessages,
+    });
+
+    // Replay session A's round-2 output into session B's round-3 step, in place of session B's own
+    // round-2 output. A captured/replayed message from an unrelated session must not be silently
+    // accepted as if it belonged to this session.
+    let err: Error | undefined;
+    try {
+      partyB1.handleIncomingMessages({
+        p2pMessages: partyA2Round2Messages.p2pMessages,
+        broadcastMessages: partyA2Round2Messages.broadcastMessages,
+      });
+    } catch (e) {
+      err = e;
+    }
+    should.exist(err);
+    err!.message.should.match(/Error while creating messages|Signing aborted/);
+  });
+
+  it('should fail if a stale round-3 message is replayed after the session has already advanced to round 4', async function () {
+    const vector = vectors[0];
+    const party1 = new DklsDsg.Dsg(
+      fs.readFileSync(shareFiles[vector.party1]),
+      vector.party1,
+      vector.derivationPath,
+      crypto.createHash('sha256').update(Buffer.from(vector.msgToSign, 'hex')).digest()
+    );
+    const party2 = new DklsDsg.Dsg(
+      fs.readFileSync(shareFiles[vector.party2]),
+      vector.party2,
+      vector.derivationPath,
+      crypto.createHash('sha256').update(Buffer.from(vector.msgToSign, 'hex')).digest()
+    );
+
+    const party1Round1Message = await party1.init();
+    const party2Round1Message = await party2.init();
+    const party2Round2Messages = party2.handleIncomingMessages({
+      p2pMessages: [],
+      broadcastMessages: [party1Round1Message],
+    });
+    const party1Round2Messages = party1.handleIncomingMessages({
+      p2pMessages: [],
+      broadcastMessages: [party2Round1Message],
+    });
+    const party2Round3Messages = party2.handleIncomingMessages({
+      p2pMessages: party1Round2Messages.p2pMessages,
+      broadcastMessages: [],
+    });
+    // Capture the exact round-3 input that legitimately advances party1 to round 4.
+    const staleRound3Input = {
+      p2pMessages: party2Round2Messages.p2pMessages,
+      broadcastMessages: [] as DeserializedMessages['broadcastMessages'],
+    };
+    party1.handleIncomingMessages(staleRound3Input);
+    const roundAfterFirstReplay = decode(new Uint8Array(Buffer.from(party1.getSession(), 'base64'))).round;
+    (typeof roundAfterFirstReplay === 'object' && 'WaitMsg4' in roundAfterFirstReplay).should.equal(true);
+    // party1 is now in round 4, expecting a combine-shaped message. Replaying the same round-3
+    // input again (as an attacker who captured it in transit might attempt) must not be
+    // reprocessed as if it were still valid for the current round.
+    let err: Error | undefined;
+    try {
+      party1.handleIncomingMessages(staleRound3Input);
+    } catch (e) {
+      err = e;
+    }
+    should.exist(err);
+    err!.message.should.match(/Error while creating messages|Signing aborted/);
+    void party2Round3Messages;
+  });
+
   it('should handle WaitMsg4 round in _deserializeState without throwing', async function () {
     const vector = vectors[0];
     const party1 = new DklsDsg.Dsg(


### PR DESCRIPTION
## Summary
- (TPA-08 audit follow-up): add negative tests for the DKLS (ECDSA MPCv2) signing session covering two adversarial scenarios flagged as a coverage gap:
  - round messages replayed from an **independent, concurrent** sign session into an unrelated session signing the same message
  - a **stale round-3 message replayed** into a session that has already advanced to round 4
- Both new tests confirm the wasm bindings reject these inputs (throw) rather than silently accepting them.

## Test plan
- [x] Ran `modules/sdk-lib-mpc` DKLS Dsg suite locally (`mocha --require tsx --node-option experimental-wasm-modules`, filtered via `--grep`): both new tests pass, along with all 11 pre-existing cases in the file.
- [x] Ran the same suite unfiltered multiple times to check for regressions.

## Note on suite-wide flakiness (not caused by this change)
While verifying, the broader `sdk-lib-mpc` test suite intermittently throws `Uncaught Error: recursive use of an object detected which would lead to unsafe aliasing in rust` from the DKLS wasm bindings' `FinalizationRegistry` callback. This reproduces in **unrelated** files (`test/unit/curves/secp256k1.ts`, `test/unit/tss/ecdsa/dlogproofs.ts`) both with and without this PR's changes — it's a pre-existing GC-timing race in the wasm session cleanup, not something introduced here. This matches a gap already called out in the architecture audit (TPA-08: "review exception paths for WASM/session cleanup... whether serialized session state is always encrypted and integrity-protected"). Flagging here for visibility; not in scope for this test-only PR.