### PR TITLE
fix(root): bump js-yaml 4.3.0 -> 4.3.1 to unblock release (HIGH osv finding)

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "sigstore": "4.1.1",
     "**/bn.js": "5.2.3",
     "uuid": "11.1.1",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "ip-address": "10.4.0",
     "socket.io-parser": "4.2.7"
   },
@@ -216,7 +216,7 @@
     "sigstore": "4.1.1",
     "bn.js": "5.2.3",
     "uuid": "11.1.1",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "ip-address": "10.4.0",
     "socket.io-parser": "4.2.7",
     "cliui": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13883,10 +13883,10 @@ js-xdr@^1.1.3:
     lodash "^4.17.5"
     long "^2.2.3"
 
-js-yaml@4.1.0, js-yaml@4.3.0, js-yaml@^3.13.1, js-yaml@^3.14.1, js-yaml@^4.1.0:
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
-  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
+js-yaml@4.1.0, js-yaml@4.3.1, js-yaml@^3.13.1, js-yaml@^3.14.1, js-yaml@^4.1.0:
+  version "4.3.1"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
## Summary
- The BitGoJS release severity gate (`.github/workflows/publish.yml` → `osv-severity-gate`) fails: **1 of 37 advisory groups is ≥ CVSS 7.0**. The gate fails only on HIGH/CRITICAL; the other 36 are sub-threshold.
- The sole blocker is **`js-yaml@4.3.0`** — `GHSA-5p4m-2wfm-xmqj`, **CVSS 7.5 (HIGH)**: quadratic CPU consumption in `!!omap` resolution (`objectKeys.indexOf` linear scan inside the per-element loop → event-loop DoS). Affected `>=4.0.0 <4.3.1`; first patched **4.3.1**.
- Root `resolutions`/`overrides` already pinned js-yaml to `4.3.0` (itself vulnerable). This bumps both pins to `4.3.1` (same v4 API) and updates the single `yarn.lock` block. js-yaml is **dev-tooling only** here (lerna, eslint, depcheck, cosmiconfig, mocha, nyc) — no runtime path.

## Test plan
- [x] `yarn install --frozen-lockfile` passes (matches CI's `sfw yarn install --with-frozen-lockfile`)
- [x] `yarn check-deps` passes
- [x] `yarn why js-yaml` → `4.3.1`; no js-yaml `< 4.3.1` remains in `yarn.lock`
- [x] lockfile diff is the js-yaml block only (no unrelated re-resolution)
- [ ] CI `osv-severity-gate` reports 0 groups ≥ 7.0

## Out of scope
Four advisory groups sit at **CVSS 6.9** (`http-proxy-middleware`, `react-router-dom`, `tar`, `valibot`); a rescore of any one re-blocks the release. Tracked in WCN-2047 as follow-up.

Ticket: WCN-2047

🤖 Generated with [Claude Code](https://claude.com/claude-code)