### PR TITLE
feat(sdk-core): extract signEddsaMpcV2RecoveryTx and helpers into shared utils

### DIFF
--- a/modules/abstract-substrate/src/abstractSubstrateCoin.ts
+++ b/modules/abstract-substrate/src/abstractSubstrateCoin.ts
@@ -27,6 +27,8 @@ import {
   VerifyTransactionOptions,
   EDDSAUtils,
   decryptKeychainPrivateKey,
+  isMpcV2Keycard as sharedIsMpcV2Keycard,
+  EddsaSigningMaterial,
 } from '@bitgo/sdk-core';
 import { CoinFamily, BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
 import { KeyPair as SubstrateKeyPair, Transaction } from './lib';
@@ -39,12 +41,6 @@ import BigNumber from 'bignumber.js';
 import { ApiPromise } from '@polkadot/api';
 
 export const DEFAULT_SCAN_FACTOR = 20;
-
-/**
- * Discriminated union carrying keycard version and decrypted V1 user key (to avoid re-decryption).
- * V1 keycards are JSON; V2 keycards are CBOR-encoded reduced key shares.
- */
-type SubstrateSigningMaterial = { version: 'v1'; userPrv: string } | { version: 'v2'; encryptedUserKey: string };
 
 export class SubstrateCoin extends BaseCoin {
   protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
@@ -520,23 +516,8 @@ export class SubstrateCoin extends BaseCoin {
     return prv;
   }
 
-  /**
-   * Probes the key format and returns a discriminated union so callers avoid a second decrypt.
-   * V1 keycards are JSON; V2 keycards are CBOR-encoded reduced key shares.
-   */
-  protected async isMpcV2Keycard(userKey: string, walletPassphrase: string): Promise<SubstrateSigningMaterial> {
-    const normalized = userKey.replace(/\s/g, '');
-    let isV1: boolean;
-    try {
-      isV1 = await EDDSAUtils.isEddsaMpcV1SigningMaterial(normalized, walletPassphrase, this.bitgo);
-    } catch (e) {
-      throw new Error(`Error decrypting user keychain: ${e instanceof Error ? e.message : String(e)}`);
-    }
-    if (isV1) {
-      const userPrv = await this.decryptKeychain(normalized, walletPassphrase, 'user');
-      return { version: 'v1', userPrv };
-    }
-    return { version: 'v2', encryptedUserKey: normalized };
+  protected async isMpcV2Keycard(userKey: string, walletPassphrase: string): Promise<EddsaSigningMaterial> {
+    return sharedIsMpcV2Keycard(userKey, walletPassphrase, this.bitgo);
   }
 
   // Protected so tests can stub via instance overrides without adding new test dependencies.
@@ -569,7 +550,7 @@ export class SubstrateCoin extends BaseCoin {
    */
   protected async addSubstrateRecoverySignature(
     txBuilder: NativeTransferBuilder,
-    signingMaterial: SubstrateSigningMaterial,
+    signingMaterial: EddsaSigningMaterial,
     backupKey: string,
     walletPassphrase: string,
     unsignedTransaction: Transaction,

--- a/modules/abstract-substrate/src/abstractSubstrateCoin.ts
+++ b/modules/abstract-substrate/src/abstractSubstrateCoin.ts
@@ -26,7 +26,7 @@ import {
   verifyEddsaTssWalletAddress,
   VerifyTransactionOptions,
   decryptKeychainPrivateKey,
-  isMpcV2Keycard as sharedIsMpcV2Keycard,
+  getEddsaSigningMaterial as sharedGetEddsaSigningMaterial,
   signEddsaMpcV2RecoveryTx,
   EddsaSigningMaterial,
 } from '@bitgo/sdk-core';
@@ -360,7 +360,7 @@ export class SubstrateCoin extends BaseCoin {
         throw new Error('missing wallet passphrase');
       }
 
-      const signingMaterial = await this.isMpcV2Keycard(params.userKey!, params.walletPassphrase!);
+      const signingMaterial = await this.getEddsaSigningMaterial(params.userKey!, params.walletPassphrase!);
       await this.addSubstrateRecoverySignature(
         txBuilder,
         signingMaterial,
@@ -505,8 +505,8 @@ export class SubstrateCoin extends BaseCoin {
     return { transactions: consolidationTransactions, lastScanIndex };
   }
 
-  protected async isMpcV2Keycard(userKey: string, walletPassphrase: string): Promise<EddsaSigningMaterial> {
-    return sharedIsMpcV2Keycard(userKey, walletPassphrase, this.bitgo);
+  protected async getEddsaSigningMaterial(userKey: string, walletPassphrase: string): Promise<EddsaSigningMaterial> {
+    return sharedGetEddsaSigningMaterial(userKey, walletPassphrase, this.bitgo);
   }
 
   // Protected so tests can stub via instance overrides — direct module function bindings

--- a/modules/abstract-substrate/src/abstractSubstrateCoin.ts
+++ b/modules/abstract-substrate/src/abstractSubstrateCoin.ts
@@ -25,9 +25,9 @@ import {
   UnexpectedAddressError,
   verifyEddsaTssWalletAddress,
   VerifyTransactionOptions,
-  EDDSAUtils,
   decryptKeychainPrivateKey,
   isMpcV2Keycard as sharedIsMpcV2Keycard,
+  signEddsaMpcV2RecoveryTx,
   EddsaSigningMaterial,
 } from '@bitgo/sdk-core';
 import { CoinFamily, BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
@@ -505,42 +505,14 @@ export class SubstrateCoin extends BaseCoin {
     return { transactions: consolidationTransactions, lastScanIndex };
   }
 
-  /**
-   * Decrypts an encrypted keychain value, wrapping errors with a descriptive message.
-   */
-  private async decryptKeychain(encryptedKey: string, passphrase: string, label: string): Promise<string> {
-    const prv = await decryptKeychainPrivateKey(this.bitgo, { encryptedPrv: encryptedKey }, passphrase);
-    if (!prv) {
-      throw new Error(`Error decrypting ${label} keychain: invalid password or corrupted key`);
-    }
-    return prv;
-  }
-
   protected async isMpcV2Keycard(userKey: string, walletPassphrase: string): Promise<EddsaSigningMaterial> {
     return sharedIsMpcV2Keycard(userKey, walletPassphrase, this.bitgo);
   }
 
-  // Protected so tests can stub via instance overrides without adding new test dependencies.
-  protected async getEddsaMpcV2RecoveryKeyShares(
-    encryptedUserKey: string,
-    encryptedBackupKey: string,
-    walletPassphrase: string
-  ): ReturnType<typeof EDDSAUtils.getEddsaMpcV2RecoveryKeySharesFromReducedKey> {
-    return EDDSAUtils.getEddsaMpcV2RecoveryKeySharesFromReducedKey(
-      encryptedUserKey,
-      encryptedBackupKey,
-      walletPassphrase,
-      this.bitgo
-    );
-  }
-
-  // Protected so tests can stub via instance overrides without adding new test dependencies.
-  protected async signEddsaMpcV2Recovery(
-    signablePayload: Buffer,
-    currPath: string,
-    ...args: Parameters<typeof EDDSAUtils.signRecoveryEddsaMPCv2> extends [Buffer, string, ...infer R] ? R : never
-  ): Promise<Buffer> {
-    return EDDSAUtils.signRecoveryEddsaMPCv2(signablePayload, currPath, ...args);
+  // Protected so tests can stub via instance overrides — direct module function bindings
+  // cannot be intercepted by sinon after import.
+  protected async signSubstrateMpcV2Recovery(params: Parameters<typeof signEddsaMpcV2RecoveryTx>[0]): Promise<Buffer> {
+    return signEddsaMpcV2RecoveryTx(params);
   }
 
   /**
@@ -562,26 +534,23 @@ export class SubstrateCoin extends BaseCoin {
     const substrateKeyPair = new SubstrateKeyPair({ pub: accountId });
 
     if (signingMaterial.version === 'v2') {
-      const { userKeyShare, backupKeyShare, commonKeyChain } = await this.getEddsaMpcV2RecoveryKeyShares(
-        signingMaterial.encryptedUserKey,
+      const rawSig = await this.signSubstrateMpcV2Recovery({
+        message: unsignedTransaction.signablePayload,
+        userKey: signingMaterial.encryptedUserKey,
         backupKey,
-        walletPassphrase
-      );
-      if (commonKeyChain.toLowerCase() !== bitgoKey.toLowerCase()) {
-        throw new Error('EdDSA MPCv2 recovery: commonKeyChain from keycard does not match bitgoKey');
-      }
-      const rawSig = await this.signEddsaMpcV2Recovery(
-        unsignedTransaction.signablePayload,
-        currPath,
-        userKeyShare,
-        backupKeyShare,
-        commonKeyChain
-      );
+        walletPassphrase,
+        bitgoKey,
+        derivationPath: currPath,
+        bitgo: this.bitgo,
+      });
       const substrateSig = Buffer.concat([Buffer.from([ED25519_MULTI_SIGNATURE_PREFIX]), rawSig]);
       txBuilder.addSignature({ pub: substrateKeyPair.getKeys().pub }, substrateSig);
     } else {
       const userSigningMaterial = JSON.parse(signingMaterial.userPrv) as EDDSAMethodTypes.UserSigningMaterial;
-      const backupPrv = await this.decryptKeychain(backupKey, walletPassphrase, 'backup');
+      const backupPrv = await decryptKeychainPrivateKey(this.bitgo, { encryptedPrv: backupKey }, walletPassphrase);
+      if (!backupPrv) {
+        throw new Error('Error decrypting backup keychain: invalid password or corrupted key');
+      }
       const backupSigningMaterial = JSON.parse(backupPrv) as EDDSAMethodTypes.BackupSigningMaterial;
 
       const signatureHex = await EDDSAMethods.getTSSSignature(

--- a/modules/abstract-substrate/test/unit/abstractSubstrateCoin.ts
+++ b/modules/abstract-substrate/test/unit/abstractSubstrateCoin.ts
@@ -5,7 +5,7 @@ import * as sdkCore from '@bitgo/sdk-core';
 import { Ttao } from '../../../sdk-coin-tao/src';
 
 interface SubstrateCoinTestAccessor {
-  isMpcV2Keycard(userKey: string, walletPassphrase: string): Promise<{ version: 'v1' | 'v2' }>;
+  getEddsaSigningMaterial(userKey: string, walletPassphrase: string): Promise<{ version: 'v1' | 'v2' }>;
   addSubstrateRecoverySignature(
     txBuilder: unknown,
     signingMaterial: unknown,
@@ -42,16 +42,16 @@ describe('SubstrateCoin MPCv2 recovery helpers:', function () {
     sandBox.restore();
   });
 
-  describe('isMpcV2Keycard()', function () {
+  describe('getEddsaSigningMaterial()', function () {
     it('should return version v2 for a CBOR (MPCv2) keycard', async function () {
       // Non-JSON decrypted value → V2 CBOR keycard
       decryptStub.resolves('not-json-cbor-bytes');
-      const result = await basecoin.isMpcV2Keycard('encryptedKey', 'passphrase');
+      const result = await basecoin.getEddsaSigningMaterial('encryptedKey', 'passphrase');
       result.version.should.equal('v2');
     });
 
     it('should return version v1 for a JSON (MPCv1) keycard', async function () {
-      // isMpcV2Keycard checks uShare.seed + bitgoYShare.u + backupYShare.u
+      // getEddsaSigningMaterial checks uShare.seed + bitgoYShare.u + backupYShare.u
       decryptStub.resolves(
         JSON.stringify({
           uShare: { seed: 'deadbeef' },
@@ -59,14 +59,14 @@ describe('SubstrateCoin MPCv2 recovery helpers:', function () {
           backupYShare: { u: 'ddeeff' },
         })
       );
-      const result = await basecoin.isMpcV2Keycard('encryptedKey', 'passphrase');
+      const result = await basecoin.getEddsaSigningMaterial('encryptedKey', 'passphrase');
       result.version.should.equal('v1');
     });
 
     it('should throw with a descriptive message when decryption fails', async function () {
       decryptStub.rejects(new Error('bad password'));
       await basecoin
-        .isMpcV2Keycard('encryptedKey', 'wrong-passphrase')
+        .getEddsaSigningMaterial('encryptedKey', 'wrong-passphrase')
         .should.be.rejectedWith(/Error decrypting user keychain/);
     });
   });
@@ -105,25 +105,6 @@ describe('SubstrateCoin MPCv2 recovery helpers:', function () {
       const sig: Buffer = addSignatureStub.firstCall.args[1];
       sig[0].should.equal(0x00);
       sig.slice(1).should.deepEqual(rawSig);
-    });
-
-    it('should throw when commonKeyChain does not match bitgoKey on MPCv2 path', async function () {
-      sinon
-        .stub(coin as unknown, 'signSubstrateMpcV2Recovery')
-        .rejects(new Error('EdDSA MPCv2 recovery: commonKeyChain from keycard does not match bitgoKey'));
-
-      await coin
-        .addSubstrateRecoverySignature(
-          { addSignature: addSignatureStub },
-          { version: 'v2', encryptedUserKey: 'encKey' },
-          'encBackupKey',
-          'passphrase',
-          MOCK_UNSIGNED_TX,
-          'm/0',
-          MOCK_BITGO_KEY,
-          MOCK_ACCOUNT_ID
-        )
-        .should.be.rejectedWith(/commonKeyChain from keycard does not match bitgoKey/);
     });
 
     it('should call getTSSSignature and pass result to addSignature on MPCv1 path', async function () {

--- a/modules/abstract-substrate/test/unit/abstractSubstrateCoin.ts
+++ b/modules/abstract-substrate/test/unit/abstractSubstrateCoin.ts
@@ -72,10 +72,9 @@ describe('SubstrateCoin MPCv2 recovery helpers:', function () {
   });
 
   describe('addSubstrateRecoverySignature()', function () {
-    // EDDSAUtils.* are exported via `export * as Namespace`, compiling to non-configurable
-    // property getters — sinon cannot replace them. Instead, SubstrateCoin exposes
-    // getEddsaMpcV2RecoveryKeyShares() and signEddsaMpcV2Recovery() as protected methods
-    // so they can be stubbed on the instance (own property shadows the prototype).
+    // signEddsaMpcV2RecoveryTx is a directly-imported module binding — sinon cannot intercept
+    // it after import. SubstrateCoin exposes signSubstrateMpcV2Recovery() as a protected
+    // wrapper so tests can stub it on the instance (own property shadows the prototype).
     // EDDSAMethods.getTSSSignature is a regular writable property — sinon can stub it directly.
     let addSignatureStub: sinon.SinonStub;
     let coin: SubstrateCoinTestAccessor;
@@ -89,12 +88,7 @@ describe('SubstrateCoin MPCv2 recovery helpers:', function () {
 
     it('should prepend ED25519 0x00 discriminant on MPCv2 path', async function () {
       const rawSig = Buffer.alloc(64, 0xab);
-      sinon.stub(coin as unknown, 'getEddsaMpcV2RecoveryKeyShares').resolves({
-        userKeyShare: 'ks1',
-        backupKeyShare: 'ks2',
-        commonKeyChain: MOCK_BITGO_KEY,
-      });
-      sinon.stub(coin as unknown, 'signEddsaMpcV2Recovery').resolves(rawSig);
+      sinon.stub(coin as unknown, 'signSubstrateMpcV2Recovery').resolves(rawSig);
 
       await coin.addSubstrateRecoverySignature(
         { addSignature: addSignatureStub },
@@ -114,11 +108,9 @@ describe('SubstrateCoin MPCv2 recovery helpers:', function () {
     });
 
     it('should throw when commonKeyChain does not match bitgoKey on MPCv2 path', async function () {
-      sinon.stub(coin as unknown, 'getEddsaMpcV2RecoveryKeyShares').resolves({
-        userKeyShare: 'ks1',
-        backupKeyShare: 'ks2',
-        commonKeyChain: 'mismatch',
-      });
+      sinon
+        .stub(coin as unknown, 'signSubstrateMpcV2Recovery')
+        .rejects(new Error('EdDSA MPCv2 recovery: commonKeyChain from keycard does not match bitgoKey'));
 
       await coin
         .addSubstrateRecoverySignature(

--- a/modules/sdk-coin-sol/src/sol.ts
+++ b/modules/sdk-coin-sol/src/sol.ts
@@ -59,7 +59,8 @@ import {
   DeriveAddressOptions,
   DeriveAddressResult,
   UnexpectedAddressError,
-  EDDSAUtils,
+  isMpcV2Keycard,
+  signEddsaMpcV2RecoveryTx,
 } from '@bitgo/sdk-core';
 import { auditEddsaPrivateKey, getDerivationPath } from '@bitgo/sdk-lib-mpc';
 import { BaseNetwork, CoinFamily, coins, SolCoin, BaseCoin as StaticsBaseCoin } from '@bitgo/statics';
@@ -1700,7 +1701,7 @@ export class Sol extends BaseCoin {
     const userKey = params.userKey?.replace(/\s/g, '') ?? '';
 
     const isMpcV2 = params.walletPassphrase
-      ? !(await EDDSAUtils.isEddsaMpcV1SigningMaterial(userKey, params.walletPassphrase, this.bitgo))
+      ? (await isMpcV2Keycard(userKey, params.walletPassphrase, this.bitgo)).version === 'v2'
       : false;
 
     const index = params.index || 0;
@@ -1819,7 +1820,7 @@ export class Sol extends BaseCoin {
     // Detect once at the top to avoid decrypting the keycard on every iteration of the scan loop.
     // For unsigned sweep (no passphrase), isMpcV2 is false — cold MPCv2 is out of scope.
     const isMpcV2 = params.walletPassphrase
-      ? !(await EDDSAUtils.isEddsaMpcV1SigningMaterial(userKey, params.walletPassphrase, this.bitgo))
+      ? (await isMpcV2Keycard(userKey, params.walletPassphrase, this.bitgo)).version === 'v2'
       : false;
 
     const baseAddressIndex = 0;
@@ -1963,25 +1964,15 @@ export class Sol extends BaseCoin {
       );
       txBuilder.addSignature({ pub: bs58EncodedPublicKey } as PublicKey, signatureHex);
     } else {
-      const { userKeyShare, backupKeyShare, commonKeyChain } =
-        await EDDSAUtils.getEddsaMpcV2RecoveryKeySharesFromReducedKey(
-          userKey,
-          backupKey,
-          params.walletPassphrase!,
-          this.bitgo
-        );
-
-      if (commonKeyChain.toLowerCase() !== bitgoKey.toLowerCase()) {
-        throw new Error('EdDSA MPCv2 recovery: commonKeyChain from keycard does not match bitgoKey');
-      }
-
-      const signature = await EDDSAUtils.signRecoveryEddsaMPCv2(
-        unsignedTransaction.signablePayload,
-        currPath,
-        userKeyShare,
-        backupKeyShare,
-        commonKeyChain
-      );
+      const signature = await signEddsaMpcV2RecoveryTx({
+        message: unsignedTransaction.signablePayload,
+        userKey,
+        backupKey,
+        walletPassphrase: params.walletPassphrase!,
+        bitgoKey,
+        derivationPath: currPath,
+        bitgo: this.bitgo,
+      });
       txBuilder.addSignature({ pub: bs58EncodedPublicKey } as PublicKey, signature);
     }
   }
@@ -1991,29 +1982,11 @@ export class Sol extends BaseCoin {
     backupKey?: string,
     walletPassphrase?: string
   ): Promise<boolean> {
-    let isMpcV2 = false;
-    if (walletPassphrase) {
-      if (!userKey) {
-        throw new Error('missing userKey');
-      }
-      if (!backupKey) {
-        throw new Error('missing backupKey');
-      }
-      // Detect MPCv2 keycards — will throw if decryption fails (e.g., wrong password).
-      // MPCv1 keycards decrypt to JSON with uShare/bitgoYShare; MPCv2 keycards are CBOR.
-      try {
-        const isV1 = await EDDSAUtils.isEddsaMpcV1SigningMaterial(
-          userKey.replace(/\s/g, ''),
-          walletPassphrase,
-          this.bitgo
-        );
-        isMpcV2 = !isV1;
-      } catch (e) {
-        // Re-wrap decryption errors with context
-        throw new Error(`Error decrypting user keychain: ${e instanceof Error ? e.message : String(e)}`);
-      }
-    }
-    return isMpcV2;
+    if (!walletPassphrase) return false;
+    if (!userKey) throw new Error('missing userKey');
+    if (!backupKey) throw new Error('missing backupKey');
+    const material = await isMpcV2Keycard(userKey.replace(/\s/g, ''), walletPassphrase, this.bitgo);
+    return material.version === 'v2';
   }
 
   async broadcastTransaction({

--- a/modules/sdk-coin-sol/src/sol.ts
+++ b/modules/sdk-coin-sol/src/sol.ts
@@ -59,7 +59,7 @@ import {
   DeriveAddressOptions,
   DeriveAddressResult,
   UnexpectedAddressError,
-  isMpcV2Keycard,
+  getEddsaSigningMaterial,
   signEddsaMpcV2RecoveryTx,
 } from '@bitgo/sdk-core';
 import { auditEddsaPrivateKey, getDerivationPath } from '@bitgo/sdk-lib-mpc';
@@ -1701,7 +1701,7 @@ export class Sol extends BaseCoin {
     const userKey = params.userKey?.replace(/\s/g, '') ?? '';
 
     const isMpcV2 = params.walletPassphrase
-      ? (await isMpcV2Keycard(userKey, params.walletPassphrase, this.bitgo)).version === 'v2'
+      ? (await getEddsaSigningMaterial(userKey, params.walletPassphrase, this.bitgo)).version === 'v2'
       : false;
 
     const index = params.index || 0;
@@ -1820,7 +1820,7 @@ export class Sol extends BaseCoin {
     // Detect once at the top to avoid decrypting the keycard on every iteration of the scan loop.
     // For unsigned sweep (no passphrase), isMpcV2 is false — cold MPCv2 is out of scope.
     const isMpcV2 = params.walletPassphrase
-      ? (await isMpcV2Keycard(userKey, params.walletPassphrase, this.bitgo)).version === 'v2'
+      ? (await getEddsaSigningMaterial(userKey, params.walletPassphrase, this.bitgo)).version === 'v2'
       : false;
 
     const baseAddressIndex = 0;
@@ -1985,7 +1985,7 @@ export class Sol extends BaseCoin {
     if (!walletPassphrase) return false;
     if (!userKey) throw new Error('missing userKey');
     if (!backupKey) throw new Error('missing backupKey');
-    const material = await isMpcV2Keycard(userKey.replace(/\s/g, ''), walletPassphrase, this.bitgo);
+    const material = await getEddsaSigningMaterial(userKey.replace(/\s/g, ''), walletPassphrase, this.bitgo);
     return material.version === 'v2';
   }
 

--- a/modules/sdk-coin-ton/src/ton.ts
+++ b/modules/sdk-coin-ton/src/ton.ts
@@ -7,7 +7,9 @@ import {
   BitGoBase,
   decryptKeychainPrivateKey,
   EDDSAMethods,
-  EDDSAUtils,
+  isMpcV2Keycard as sharedIsMpcV2Keycard,
+  signEddsaMpcV2RecoveryTx,
+  EddsaSigningMaterial,
   InvalidAddressError,
   KeyPair,
   MPCAlgorithm,
@@ -45,8 +47,6 @@ export interface TonParseTransactionOptions extends ParseTransactionOptions {
   fromAddressBounceable?: boolean;
   toAddressBounceable?: boolean;
 }
-
-type TonSigningMaterial = { version: 'v1'; userPrv: string } | { version: 'v2'; encryptedUserKey: string };
 
 export class Ton extends BaseCoin {
   protected readonly _staticsCoin: Readonly<StaticsBaseCoin>;
@@ -323,19 +323,8 @@ export class Ton extends BaseCoin {
    * Discriminated union carrying keycard version and decrypted V1 user key (to avoid re-decryption).
    * V1 keycards are JSON; V2 keycards are CBOR-encoded reduced key shares.
    */
-  private async isMpcV2Keycard(userKey: string, walletPassphrase: string): Promise<TonSigningMaterial> {
-    const normalized = userKey.replace(/\s/g, '');
-    let isV1: boolean;
-    try {
-      isV1 = await EDDSAUtils.isEddsaMpcV1SigningMaterial(normalized, walletPassphrase, this.bitgo);
-    } catch (e) {
-      throw new Error(`Error decrypting user keychain: ${e instanceof Error ? e.message : String(e)}`);
-    }
-    if (isV1) {
-      const userPrv = await this.decryptKeychain(normalized, walletPassphrase, 'user');
-      return { version: 'v1', userPrv };
-    }
-    return { version: 'v2', encryptedUserKey: normalized };
+  private async isMpcV2Keycard(userKey: string, walletPassphrase: string): Promise<EddsaSigningMaterial> {
+    return sharedIsMpcV2Keycard(userKey, walletPassphrase, this.bitgo);
   }
 
   private async decryptKeychain(encryptedKey: string, passphrase: string, label: string): Promise<string> {
@@ -347,7 +336,7 @@ export class Ton extends BaseCoin {
   }
 
   private async addRecoverySignature(
-    signingMaterial: TonSigningMaterial,
+    signingMaterial: EddsaSigningMaterial,
     txBuilder: TransactionBuilder,
     senderAddr: string,
     unsignedTransaction: any,
@@ -357,23 +346,15 @@ export class Ton extends BaseCoin {
     walletPassphrase: string
   ): Promise<void> {
     if (signingMaterial.version === 'v2') {
-      const { userKeyShare, backupKeyShare, commonKeyChain } =
-        await EDDSAUtils.getEddsaMpcV2RecoveryKeySharesFromReducedKey(
-          signingMaterial.encryptedUserKey,
-          backupKey,
-          walletPassphrase,
-          this.bitgo
-        );
-      if (commonKeyChain.toLowerCase() !== bitgoKey.toLowerCase()) {
-        throw new Error('EdDSA MPCv2 recovery: commonKeyChain from keycard does not match bitgoKey');
-      }
-      const signature = await EDDSAUtils.signRecoveryEddsaMPCv2(
-        unsignedTransaction.signablePayload,
-        currPath,
-        userKeyShare,
-        backupKeyShare,
-        commonKeyChain
-      );
+      const signature = await signEddsaMpcV2RecoveryTx({
+        message: unsignedTransaction.signablePayload,
+        userKey: signingMaterial.encryptedUserKey,
+        backupKey,
+        walletPassphrase,
+        bitgoKey,
+        derivationPath: currPath,
+        bitgo: this.bitgo,
+      });
       txBuilder.addSignature({ pub: senderAddr } as PublicKey, signature);
     } else {
       const userSigningMaterial = JSON.parse(signingMaterial.userPrv) as EDDSAMethodTypes.UserSigningMaterial;

--- a/modules/sdk-coin-ton/src/ton.ts
+++ b/modules/sdk-coin-ton/src/ton.ts
@@ -7,7 +7,7 @@ import {
   BitGoBase,
   decryptKeychainPrivateKey,
   EDDSAMethods,
-  isMpcV2Keycard as sharedIsMpcV2Keycard,
+  getEddsaSigningMaterial as sharedGetEddsaSigningMaterial,
   signEddsaMpcV2RecoveryTx,
   EddsaSigningMaterial,
   InvalidAddressError,
@@ -323,8 +323,8 @@ export class Ton extends BaseCoin {
    * Discriminated union carrying keycard version and decrypted V1 user key (to avoid re-decryption).
    * V1 keycards are JSON; V2 keycards are CBOR-encoded reduced key shares.
    */
-  private async isMpcV2Keycard(userKey: string, walletPassphrase: string): Promise<EddsaSigningMaterial> {
-    return sharedIsMpcV2Keycard(userKey, walletPassphrase, this.bitgo);
+  private async getEddsaSigningMaterial(userKey: string, walletPassphrase: string): Promise<EddsaSigningMaterial> {
+    return sharedGetEddsaSigningMaterial(userKey, walletPassphrase, this.bitgo);
   }
 
   private async decryptKeychain(encryptedKey: string, passphrase: string, label: string): Promise<string> {
@@ -499,7 +499,7 @@ export class Ton extends BaseCoin {
       assert(params.userKey, 'missing userKey');
       assert(params.backupKey, 'missing backupKey');
       assert(params.walletPassphrase, 'missing wallet passphrase');
-      const signingMaterial = await this.isMpcV2Keycard(params.userKey, params.walletPassphrase);
+      const signingMaterial = await this.getEddsaSigningMaterial(params.userKey, params.walletPassphrase);
       await this.addRecoverySignature(
         signingMaterial,
         txBuilder,

--- a/modules/sdk-coin-ton/test/unit/ton.ts
+++ b/modules/sdk-coin-ton/test/unit/ton.ts
@@ -715,7 +715,7 @@ describe('TON:', function () {
       };
 
       sandbox.stub(Tonweb, 'HttpProvider').returns(mockProvider);
-      sandbox.stub(basecoin as any, 'isMpcV2Keycard').resolves({
+      sandbox.stub(basecoin as any, 'getEddsaSigningMaterial').resolves({
         version: 'v1',
         userPrv: JSON.stringify({ dummy: 'userSigningMaterial' }),
       });
@@ -955,7 +955,7 @@ describe('TON:', function () {
       });
 
       it('should use MPCv1 path when signing material is MPCv1 format', async function () {
-        sandbox.stub(basecoin as any, 'isMpcV2Keycard').resolves({
+        sandbox.stub(basecoin as any, 'getEddsaSigningMaterial').resolves({
           version: 'v1',
           userPrv: JSON.stringify({ uShare: {}, bitgoYShare: {} }),
         });

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import * as sjcl from '@bitgo/sjcl';
 import * as pgp from 'openpgp';
 import { NonEmptyString } from 'io-ts-types';
 import {
@@ -1076,14 +1077,17 @@ export class EddsaMPCv2Utils extends BaseEddsaUtils {
  * @param encryptedKeyShare encrypted user or backup keycard
  * @param walletPassphrase passphrase used to encrypt the keycard
  * @param bitgo optional BitGoBase instance; when provided, decrypts via
- *   bitgo.decrypt supports both v1 (SJCL) and v2 (Argon2id) envelopes.
+ *   bitgo.decrypt (supports both v1 SJCL and v2 Argon2id envelopes);
+ *   when absent, falls back to sjcl.decrypt (v1 only)
  */
 export async function isEddsaMpcV1SigningMaterial(
   encryptedKeyShare: string,
   walletPassphrase: string,
-  bitgo: BitGoBase
+  bitgo?: BitGoBase
 ): Promise<boolean> {
-  const prv = await bitgo.decrypt({ input: encryptedKeyShare, password: walletPassphrase });
+  const prv = bitgo
+    ? await bitgo.decrypt({ input: encryptedKeyShare, password: walletPassphrase })
+    : sjcl.decrypt(walletPassphrase, encryptedKeyShare);
 
   try {
     const m = JSON.parse(prv);
@@ -1108,17 +1112,18 @@ export async function isEddsaMpcV1SigningMaterial(
  * @param encryptedUserKey encrypted EdDSA MPCv2 reduced user key
  * @param encryptedBackupKey encrypted EdDSA MPCv2 reduced backup key
  * @param walletPassphrase password for user and backup keys
- * @param bitgo BitGoBase instance used for decryption (supports v1 SJCL and v2 Argon2id)
  * @returns EdDSA MPCv2 recovery key shares and common keychain
  */
 export async function getEddsaMpcV2RecoveryKeySharesFromReducedKey(
   encryptedUserKey: string,
   encryptedBackupKey: string,
-  walletPassphrase: string,
-  bitgo: BitGoBase
+  walletPassphrase?: string,
+  bitgo?: BitGoBase
 ): Promise<EddsaMPCv2RecoveryKeyShares> {
   const decodeKey = async (encryptedKey: string): Promise<MPSTypes.EddsaReducedKeyShare> => {
-    const decrypted = await bitgo.decrypt({ input: encryptedKey, password: walletPassphrase });
+    const decrypted = bitgo
+      ? await bitgo.decrypt({ input: encryptedKey, password: walletPassphrase })
+      : sjcl.decrypt(walletPassphrase, encryptedKey);
     let reduced: MPSTypes.EddsaReducedKeyShare;
     try {
       reduced = MPSTypes.getDecodedReducedKeyShare(Buffer.from(decrypted, 'base64'));
@@ -1219,7 +1224,7 @@ export type EddsaSigningMaterial = { version: 'v1'; userPrv: string } | { versio
 export async function isMpcV2Keycard(
   userKey: string,
   walletPassphrase: string,
-  bitgo: BitGoBase
+  bitgo?: BitGoBase
 ): Promise<EddsaSigningMaterial> {
   const normalized = userKey.replace(/\s/g, '');
   let isV1: boolean;
@@ -1229,6 +1234,7 @@ export async function isMpcV2Keycard(
     throw new Error(`Error decrypting user keychain: ${e instanceof Error ? e.message : String(e)}`);
   }
   if (isV1) {
+    if (!bitgo) throw new Error('bitgo instance required for MPCv1 keycard decryption');
     const userPrv = await bitgo.decrypt({ input: normalized, password: walletPassphrase });
     return { version: 'v1', userPrv };
   }
@@ -1248,7 +1254,7 @@ export async function signEddsaMpcV2RecoveryTx(params: {
   walletPassphrase: string;
   bitgoKey: string;
   derivationPath: string;
-  bitgo: BitGoBase;
+  bitgo?: BitGoBase;
 }): Promise<Buffer> {
   const { userKeyShare, backupKeyShare, commonKeyChain } = await getEddsaMpcV2RecoveryKeySharesFromReducedKey(
     params.userKey,

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
@@ -1081,26 +1081,31 @@ export class EddsaMPCv2Utils extends BaseEddsaUtils {
  *   bitgo.decrypt (supports both v1 SJCL and v2 Argon2id envelopes);
  *   when absent, falls back to sjcl.decrypt (v1 only)
  */
+function parseEddsaMpcV1Material(decrypted: string): string | null {
+  try {
+    const m = JSON.parse(decrypted);
+    if (
+      typeof m?.uShare?.seed === 'string' &&
+      typeof m?.bitgoYShare?.u === 'string' &&
+      (typeof m?.backupYShare?.u === 'string' || typeof m?.userYShare?.u === 'string')
+    ) {
+      return decrypted;
+    }
+  } catch {
+    // Not JSON → MPCv2 CBOR
+  }
+  return null;
+}
+
 export async function isEddsaMpcV1SigningMaterial(
   encryptedKeyShare: string,
   walletPassphrase: string,
   bitgo?: BitGoBase
 ): Promise<boolean> {
-  const prv = bitgo
+  const decrypted = bitgo
     ? await bitgo.decrypt({ input: encryptedKeyShare, password: walletPassphrase })
     : sjcl.decrypt(walletPassphrase, encryptedKeyShare);
-
-  try {
-    const m = JSON.parse(prv);
-    return (
-      typeof m?.uShare?.seed === 'string' &&
-      typeof m?.bitgoYShare?.u === 'string' &&
-      (typeof m?.backupYShare?.u === 'string' || typeof m?.userYShare?.u === 'string')
-    );
-  } catch {
-    // JSON parse error indicates MPCv2 CBOR format, not JSON.
-    return false;
-  }
+  return parseEddsaMpcV1Material(decrypted) !== null;
 }
 
 /**
@@ -1218,28 +1223,26 @@ export type EddsaSigningMaterial = { version: 'v1'; userPrv: string } | { versio
 
 /**
  * Detects MPCv1 vs MPCv2 keycard format and returns typed signing material.
- * For v1: decrypts the userKey and returns the plaintext.
+ * For v1: decrypts once and returns the plaintext as userPrv.
  * For v2: returns the encrypted key as-is for use with signEddsaMpcV2RecoveryTx.
- * Identical logic across all EdDSA coin recovery implementations.
+ * When bitgo is omitted, falls back to sjcl (v1 only).
  */
-export async function isMpcV2Keycard(
+export async function getEddsaSigningMaterial(
   userKey: string,
   walletPassphrase: string,
   bitgo?: BitGoBase
 ): Promise<EddsaSigningMaterial> {
   const normalized = userKey.replace(/\s/g, '');
-  let isV1: boolean;
+  let decrypted: string;
   try {
-    isV1 = await isEddsaMpcV1SigningMaterial(normalized, walletPassphrase, bitgo);
+    decrypted = bitgo
+      ? await bitgo.decrypt({ input: normalized, password: walletPassphrase })
+      : sjcl.decrypt(walletPassphrase, normalized);
   } catch (e) {
     throw new Error(`Error decrypting user keychain: ${e instanceof Error ? e.message : String(e)}`);
   }
-  if (isV1) {
-    if (!bitgo) throw new Error('bitgo instance required for MPCv1 keycard decryption');
-    const userPrv = await bitgo.decrypt({ input: normalized, password: walletPassphrase });
-    return { version: 'v1', userPrv };
-  }
-  return { version: 'v2', encryptedUserKey: normalized };
+  const userPrv = parseEddsaMpcV1Material(decrypted);
+  return userPrv !== null ? { version: 'v1', userPrv } : { version: 'v2', encryptedUserKey: normalized };
 }
 
 /**
@@ -1273,6 +1276,6 @@ export const EddsaMPCv2RecoveryFunctions = {
   isEddsaMpcV1SigningMaterial,
   getEddsaMpcV2RecoveryKeySharesFromReducedKey,
   signRecoveryEddsaMPCv2,
-  isMpcV2Keycard,
+  getEddsaSigningMaterial,
   signEddsaMpcV2RecoveryTx,
 };

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
-import * as pgp from 'openpgp';
 import * as sjcl from '@bitgo/sjcl';
+import * as pgp from 'openpgp';
 import { NonEmptyString } from 'io-ts-types';
 import {
   EddsaMPCv2KeyGenRound1Request,
@@ -1209,8 +1209,70 @@ export async function signRecoveryEddsaMPCv2(
   return signature;
 }
 
+/**
+ * Discriminated union representing EdDSA signing material detected from a keycard.
+ * v1: MPCv1 JSON keycard — userPrv is the decrypted plaintext.
+ * v2: MPCv2 CBOR keycard — encryptedUserKey is returned as-is for MPS DSG.
+ */
+export type EddsaSigningMaterial = { version: 'v1'; userPrv: string } | { version: 'v2'; encryptedUserKey: string };
+
+/**
+ * Detects MPCv1 vs MPCv2 keycard format and returns typed signing material.
+ * For v1: decrypts the userKey and returns the plaintext.
+ * For v2: returns the encrypted key as-is for use with signEddsaMpcV2RecoveryTx.
+ * Identical logic across all EdDSA coin recovery implementations.
+ */
+export async function isMpcV2Keycard(
+  userKey: string,
+  walletPassphrase: string,
+  bitgo?: BitGoBase
+): Promise<EddsaSigningMaterial> {
+  const normalized = userKey.replace(/\s/g, '');
+  let isV1: boolean;
+  try {
+    isV1 = await isEddsaMpcV1SigningMaterial(normalized, walletPassphrase, bitgo);
+  } catch (e) {
+    throw new Error(`Error decrypting user keychain: ${e instanceof Error ? e.message : String(e)}`);
+  }
+  if (isV1) {
+    if (!bitgo) throw new Error('bitgo instance required for MPCv1 keycard decryption');
+    const userPrv = await bitgo.decrypt({ input: normalized, password: walletPassphrase });
+    return { version: 'v1', userPrv };
+  }
+  return { version: 'v2', encryptedUserKey: normalized };
+}
+
+/**
+ * Full MPCv2 recovery signing flow: decrypt key shares → validate commonKeyChain → MPS DSG.
+ * Returns raw 64-byte Ed25519 signature Buffer.
+ * Caller is responsible for any coin-specific envelope
+ * (e.g. 0x00 Substrate prefix, SUI flag+pubkey wrapper, or raw for NEAR/ADA/TON).
+ */
+export async function signEddsaMpcV2RecoveryTx(params: {
+  message: Buffer;
+  userKey: string;
+  backupKey: string;
+  walletPassphrase: string;
+  bitgoKey: string;
+  derivationPath: string;
+  bitgo?: BitGoBase;
+}): Promise<Buffer> {
+  const { userKeyShare, backupKeyShare, commonKeyChain } = await getEddsaMpcV2RecoveryKeySharesFromReducedKey(
+    params.userKey,
+    params.backupKey,
+    params.walletPassphrase,
+    params.bitgo
+  );
+  if (commonKeyChain.toLowerCase() !== params.bitgoKey.toLowerCase()) {
+    throw new Error('EdDSA MPCv2 recovery: commonKeyChain from keycard does not match bitgoKey');
+  }
+  return signRecoveryEddsaMPCv2(params.message, params.derivationPath, userKeyShare, backupKeyShare, commonKeyChain);
+}
+
 export const EddsaMPCv2RecoveryFunctions = {
   isEddsaMpcV1SigningMaterial,
   getEddsaMpcV2RecoveryKeySharesFromReducedKey,
   signRecoveryEddsaMPCv2,
+  isMpcV2Keycard,
+  signEddsaMpcV2RecoveryTx,
 };

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
@@ -1,6 +1,5 @@
 import assert from 'assert';
 import * as pgp from 'openpgp';
-import * as sjcl from '@bitgo/sjcl';
 import { NonEmptyString } from 'io-ts-types';
 import {
   EddsaMPCv2KeyGenRound1Request,
@@ -1077,17 +1076,14 @@ export class EddsaMPCv2Utils extends BaseEddsaUtils {
  * @param encryptedKeyShare encrypted user or backup keycard
  * @param walletPassphrase passphrase used to encrypt the keycard
  * @param bitgo optional BitGoBase instance; when provided, decrypts via
- *   bitgo.decrypt (supports both v1 SJCL and v2 Argon2id envelopes);
- *   when absent, falls back to sjcl.decrypt (v1 only)
+ *   bitgo.decrypt supports both v1 (SJCL) and v2 (Argon2id) envelopes.
  */
 export async function isEddsaMpcV1SigningMaterial(
   encryptedKeyShare: string,
   walletPassphrase: string,
-  bitgo?: BitGoBase
+  bitgo: BitGoBase
 ): Promise<boolean> {
-  const prv = bitgo
-    ? await bitgo.decrypt({ input: encryptedKeyShare, password: walletPassphrase })
-    : sjcl.decrypt(walletPassphrase, encryptedKeyShare);
+  const prv = await bitgo.decrypt({ input: encryptedKeyShare, password: walletPassphrase });
 
   try {
     const m = JSON.parse(prv);
@@ -1112,18 +1108,17 @@ export async function isEddsaMpcV1SigningMaterial(
  * @param encryptedUserKey encrypted EdDSA MPCv2 reduced user key
  * @param encryptedBackupKey encrypted EdDSA MPCv2 reduced backup key
  * @param walletPassphrase password for user and backup keys
+ * @param bitgo BitGoBase instance used for decryption (supports v1 SJCL and v2 Argon2id)
  * @returns EdDSA MPCv2 recovery key shares and common keychain
  */
 export async function getEddsaMpcV2RecoveryKeySharesFromReducedKey(
   encryptedUserKey: string,
   encryptedBackupKey: string,
-  walletPassphrase?: string,
-  bitgo?: BitGoBase
+  walletPassphrase: string,
+  bitgo: BitGoBase
 ): Promise<EddsaMPCv2RecoveryKeyShares> {
   const decodeKey = async (encryptedKey: string): Promise<MPSTypes.EddsaReducedKeyShare> => {
-    const decrypted = bitgo
-      ? await bitgo.decrypt({ input: encryptedKey, password: walletPassphrase })
-      : sjcl.decrypt(walletPassphrase, encryptedKey);
+    const decrypted = await bitgo.decrypt({ input: encryptedKey, password: walletPassphrase });
     let reduced: MPSTypes.EddsaReducedKeyShare;
     try {
       reduced = MPSTypes.getDecodedReducedKeyShare(Buffer.from(decrypted, 'base64'));
@@ -1208,8 +1203,69 @@ export async function signRecoveryEddsaMPCv2(
   return signature;
 }
 
+/**
+ * Discriminated union representing EdDSA signing material detected from a keycard.
+ * v1: MPCv1 JSON keycard — userPrv is the decrypted plaintext.
+ * v2: MPCv2 CBOR keycard — encryptedUserKey is returned as-is for MPS DSG.
+ */
+export type EddsaSigningMaterial = { version: 'v1'; userPrv: string } | { version: 'v2'; encryptedUserKey: string };
+
+/**
+ * Detects MPCv1 vs MPCv2 keycard format and returns typed signing material.
+ * For v1: decrypts the userKey and returns the plaintext.
+ * For v2: returns the encrypted key as-is for use with signEddsaMpcV2RecoveryTx.
+ * Identical logic across all EdDSA coin recovery implementations.
+ */
+export async function isMpcV2Keycard(
+  userKey: string,
+  walletPassphrase: string,
+  bitgo: BitGoBase
+): Promise<EddsaSigningMaterial> {
+  const normalized = userKey.replace(/\s/g, '');
+  let isV1: boolean;
+  try {
+    isV1 = await isEddsaMpcV1SigningMaterial(normalized, walletPassphrase, bitgo);
+  } catch (e) {
+    throw new Error(`Error decrypting user keychain: ${e instanceof Error ? e.message : String(e)}`);
+  }
+  if (isV1) {
+    const userPrv = await bitgo.decrypt({ input: normalized, password: walletPassphrase });
+    return { version: 'v1', userPrv };
+  }
+  return { version: 'v2', encryptedUserKey: normalized };
+}
+
+/**
+ * Full MPCv2 recovery signing flow: decrypt key shares → validate commonKeyChain → MPS DSG.
+ * Returns raw 64-byte Ed25519 signature Buffer.
+ * Caller is responsible for any coin-specific envelope
+ * (e.g. 0x00 Substrate prefix, SUI flag+pubkey wrapper, or raw for NEAR/ADA/TON).
+ */
+export async function signEddsaMpcV2RecoveryTx(params: {
+  message: Buffer;
+  userKey: string;
+  backupKey: string;
+  walletPassphrase: string;
+  bitgoKey: string;
+  derivationPath: string;
+  bitgo: BitGoBase;
+}): Promise<Buffer> {
+  const { userKeyShare, backupKeyShare, commonKeyChain } = await getEddsaMpcV2RecoveryKeySharesFromReducedKey(
+    params.userKey,
+    params.backupKey,
+    params.walletPassphrase,
+    params.bitgo
+  );
+  if (commonKeyChain.toLowerCase() !== params.bitgoKey.toLowerCase()) {
+    throw new Error('EdDSA MPCv2 recovery: commonKeyChain from keycard does not match bitgoKey');
+  }
+  return signRecoveryEddsaMPCv2(params.message, params.derivationPath, userKeyShare, backupKeyShare, commonKeyChain);
+}
+
 export const EddsaMPCv2RecoveryFunctions = {
   isEddsaMpcV1SigningMaterial,
   getEddsaMpcV2RecoveryKeySharesFromReducedKey,
   signRecoveryEddsaMPCv2,
+  isMpcV2Keycard,
+  signEddsaMpcV2RecoveryTx,
 };

--- a/modules/sdk-core/src/index.ts
+++ b/modules/sdk-core/src/index.ts
@@ -31,6 +31,15 @@ import { EcdsaMPCv2Utils } from './bitgo/utils/tss/ecdsa/ecdsaMPCv2';
 export { EcdsaMPCv2Utils };
 import { EddsaMPCv2Utils } from './bitgo/utils/tss/eddsa/eddsaMPCv2';
 export { EddsaMPCv2Utils };
+export type { EddsaSigningMaterial } from './bitgo/utils/tss/eddsa/eddsaMPCv2';
+export {
+  isMpcV2Keycard,
+  signEddsaMpcV2RecoveryTx,
+  isEddsaMpcV1SigningMaterial,
+  getEddsaMpcV2RecoveryKeySharesFromReducedKey,
+  signRecoveryEddsaMPCv2,
+  EddsaMPCv2RecoveryFunctions,
+} from './bitgo/utils/tss/eddsa/eddsaMPCv2';
 export { verifyEddsaTssWalletAddress, verifyMPCWalletAddress } from './bitgo/utils/tss/addressVerification';
 export { GShare, SignShare, YShare } from './account-lib/mpc/tss/eddsa/types';
 export { TssEcdsaStep1ReturnMessage, TssEcdsaStep2ReturnMessage } from './bitgo/tss/types';

--- a/modules/sdk-core/src/index.ts
+++ b/modules/sdk-core/src/index.ts
@@ -33,7 +33,7 @@ import { EddsaMPCv2Utils } from './bitgo/utils/tss/eddsa/eddsaMPCv2';
 export { EddsaMPCv2Utils };
 export type { EddsaSigningMaterial } from './bitgo/utils/tss/eddsa/eddsaMPCv2';
 export {
-  isMpcV2Keycard,
+  getEddsaSigningMaterial,
   signEddsaMpcV2RecoveryTx,
   isEddsaMpcV1SigningMaterial,
   getEddsaMpcV2RecoveryKeySharesFromReducedKey,

--- a/modules/sdk-core/test/unit/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
+++ b/modules/sdk-core/test/unit/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
@@ -28,7 +28,7 @@ import {
   SignatureShareRecord,
   SignatureShareType,
   TxRequest,
-  isMpcV2Keycard,
+  getEddsaSigningMaterial,
   signEddsaMpcV2RecoveryTx,
 } from '../../../../../../src';
 import {
@@ -2028,7 +2028,7 @@ describe('signRecoveryEddsaMPCv2', () => {
   });
 });
 
-describe('isMpcV2Keycard', () => {
+describe('getEddsaSigningMaterial', () => {
   const PASSPHRASE = 'test-passphrase';
 
   const MPCv1_MATERIAL = {
@@ -2039,14 +2039,15 @@ describe('isMpcV2Keycard', () => {
 
   it('returns { version: v1, userPrv } for MPCv1 JSON keycard', async () => {
     const encrypted = sjcl.encrypt(PASSPHRASE, JSON.stringify(MPCv1_MATERIAL));
-    const mockBitgo = {
-      decrypt: sinon.stub().resolves(JSON.stringify(MPCv1_MATERIAL)),
-    } as unknown as BitGoBase;
+    const decryptStub = sinon.stub().resolves(JSON.stringify(MPCv1_MATERIAL));
+    const mockBitgo = { decrypt: decryptStub } as unknown as BitGoBase;
 
-    const result = await isMpcV2Keycard(encrypted, PASSPHRASE, mockBitgo);
+    const result = await getEddsaSigningMaterial(encrypted, PASSPHRASE, mockBitgo);
 
     assert.strictEqual(result.version, 'v1');
-    assert.ok('userPrv' in result);
+    assert.strictEqual((result as { version: 'v1'; userPrv: string }).userPrv, JSON.stringify(MPCv1_MATERIAL));
+    sinon.assert.calledOnce(decryptStub);
+    sinon.assert.calledWithMatch(decryptStub, { input: sinon.match.string, password: PASSPHRASE });
   });
 
   it('returns { version: v2, encryptedUserKey } for MPCv2 CBOR keycard', async () => {
@@ -2054,7 +2055,7 @@ describe('isMpcV2Keycard', () => {
     const encrypted = sjcl.encrypt(PASSPHRASE, MPCv2_CBOR_BYTES);
     const normalizedKey = encrypted.replace(/\s/g, '');
 
-    const result = await isMpcV2Keycard(encrypted, PASSPHRASE);
+    const result = await getEddsaSigningMaterial(encrypted, PASSPHRASE);
 
     assert.strictEqual(result.version, 'v2');
     assert.ok('encryptedUserKey' in result);
@@ -2063,15 +2064,17 @@ describe('isMpcV2Keycard', () => {
 
   it('throws with context message when decryption fails', async () => {
     const encrypted = sjcl.encrypt(PASSPHRASE, JSON.stringify(MPCv1_MATERIAL));
-    await assert.rejects(() => isMpcV2Keycard(encrypted, 'wrong-passphrase'), /Error decrypting user keychain/);
+    await assert.rejects(
+      () => getEddsaSigningMaterial(encrypted, 'wrong-passphrase'),
+      /Error decrypting user keychain/
+    );
   });
 
-  it('throws when bitgo instance is missing for v1 keycard decryption', async () => {
+  it('returns v1 via sjcl fallback when bitgo is omitted', async () => {
     const encrypted = sjcl.encrypt(PASSPHRASE, JSON.stringify(MPCv1_MATERIAL));
-    await assert.rejects(
-      () => isMpcV2Keycard(encrypted, PASSPHRASE),
-      /bitgo instance required for MPCv1 keycard decryption/
-    );
+    const result = await getEddsaSigningMaterial(encrypted, PASSPHRASE);
+    assert.strictEqual(result.version, 'v1');
+    assert.strictEqual((result as { version: 'v1'; userPrv: string }).userPrv, JSON.stringify(MPCv1_MATERIAL));
   });
 });
 

--- a/modules/sdk-core/test/unit/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
+++ b/modules/sdk-core/test/unit/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
@@ -28,6 +28,8 @@ import {
   SignatureShareRecord,
   SignatureShareType,
   TxRequest,
+  isMpcV2Keycard,
+  signEddsaMpcV2RecoveryTx,
 } from '../../../../../../src';
 import {
   getSignatureShareRoundOne,
@@ -2023,6 +2025,138 @@ describe('signRecoveryEddsaMPCv2', () => {
         ),
       /EdDSA MPCv2 recovery signature verification failed/
     );
+  });
+});
+
+describe('isMpcV2Keycard', () => {
+  const PASSPHRASE = 'test-passphrase';
+
+  const MPCv1_MATERIAL = {
+    uShare: { i: 1, t: 2, n: 3, y: 'aabbcc', seed: 'deadbeef01234567', chaincode: '00' },
+    bitgoYShare: { i: 3, j: 1, y: 'aabbcc', u: 'bitgo-u-value', chaincode: '00' },
+    backupYShare: { i: 2, j: 1, y: 'aabbcc', u: 'backup-u-value', chaincode: '00' },
+  };
+
+  it('returns { version: v1, userPrv } for MPCv1 JSON keycard', async () => {
+    const encrypted = sjcl.encrypt(PASSPHRASE, JSON.stringify(MPCv1_MATERIAL));
+    const mockBitgo = {
+      decrypt: sinon.stub().resolves(JSON.stringify(MPCv1_MATERIAL)),
+    } as unknown as BitGoBase;
+
+    const result = await isMpcV2Keycard(encrypted, PASSPHRASE, mockBitgo);
+
+    assert.strictEqual(result.version, 'v1');
+    assert.ok('userPrv' in result);
+  });
+
+  it('returns { version: v2, encryptedUserKey } for MPCv2 CBOR keycard', async () => {
+    const MPCv2_CBOR_BYTES = Buffer.from([0xd9, 0x01, 0x04, 0xa3, 0x61, 0x78, 0x18, 0x00]).toString('base64');
+    const encrypted = sjcl.encrypt(PASSPHRASE, MPCv2_CBOR_BYTES);
+    const normalizedKey = encrypted.replace(/\s/g, '');
+
+    const result = await isMpcV2Keycard(encrypted, PASSPHRASE);
+
+    assert.strictEqual(result.version, 'v2');
+    assert.ok('encryptedUserKey' in result);
+    assert.strictEqual((result as { version: 'v2'; encryptedUserKey: string }).encryptedUserKey, normalizedKey);
+  });
+
+  it('throws with context message when decryption fails', async () => {
+    const encrypted = sjcl.encrypt(PASSPHRASE, JSON.stringify(MPCv1_MATERIAL));
+    await assert.rejects(() => isMpcV2Keycard(encrypted, 'wrong-passphrase'), /Error decrypting user keychain/);
+  });
+
+  it('throws when bitgo instance is missing for v1 keycard decryption', async () => {
+    const encrypted = sjcl.encrypt(PASSPHRASE, JSON.stringify(MPCv1_MATERIAL));
+    await assert.rejects(
+      () => isMpcV2Keycard(encrypted, PASSPHRASE),
+      /bitgo instance required for MPCv1 keycard decryption/
+    );
+  });
+});
+
+describe('signEddsaMpcV2RecoveryTx', () => {
+  const derivationPath = 'm/0/0';
+  const walletPassphrase = 'testPass';
+
+  const makeDecryptBitgo = (userKeyBase64: string, backupKeyBase64: string): BitGoBase =>
+    ({
+      decrypt: sinon.stub().onFirstCall().resolves(userKeyBase64).onSecondCall().resolves(backupKeyBase64),
+    } as unknown as BitGoBase);
+
+  it('returns a 64-byte signature that verifies against the derived public key', async () => {
+    const [userDkg, backupDkg] = await MPSUtil.generateEdDsaDKGKeyShares();
+    const message = Buffer.from('deadbeef', 'hex');
+    const commonKeyChain = userDkg.getCommonKeychain();
+    const mockBitgo = makeDecryptBitgo(
+      userDkg.getReducedKeyShare().toString('base64'),
+      backupDkg.getReducedKeyShare().toString('base64')
+    );
+
+    const result = await signEddsaMpcV2RecoveryTx({
+      message,
+      userKey: 'encrypted-user-key',
+      backupKey: 'encrypted-backup-key',
+      walletPassphrase,
+      bitgoKey: commonKeyChain,
+      derivationPath,
+      bitgo: mockBitgo,
+    });
+
+    assert.strictEqual(result.length, 64);
+    const mpc = await getInitializedMpcInstance();
+    const derivedKeychain = mpc.deriveUnhardened(commonKeyChain, derivationPath);
+    const publicKeyBytes = Buffer.from(derivedKeychain.slice(0, 64), 'hex');
+    const ok = ed25519.verify(new Uint8Array(result), new Uint8Array(message), new Uint8Array(publicKeyBytes));
+    assert.strictEqual(ok, true);
+  });
+
+  it('throws when commonKeyChain does not match bitgoKey', async () => {
+    const [userDkg, backupDkg] = await MPSUtil.generateEdDsaDKGKeyShares();
+    const message = Buffer.from('deadbeef', 'hex');
+    const mockBitgo = makeDecryptBitgo(
+      userDkg.getReducedKeyShare().toString('base64'),
+      backupDkg.getReducedKeyShare().toString('base64')
+    );
+
+    await assert.rejects(
+      () =>
+        signEddsaMpcV2RecoveryTx({
+          message,
+          userKey: 'encrypted-user-key',
+          backupKey: 'encrypted-backup-key',
+          walletPassphrase,
+          bitgoKey: 'bbbb'.repeat(32),
+          derivationPath,
+          bitgo: mockBitgo,
+        }),
+      /commonKeyChain from keycard does not match bitgoKey/
+    );
+  });
+
+  it('passes userKey, backupKey, passphrase, and bitgo to getEddsaMpcV2RecoveryKeySharesFromReducedKey', async () => {
+    const [userDkg, backupDkg] = await MPSUtil.generateEdDsaDKGKeyShares();
+    const message = Buffer.from('deadbeef', 'hex');
+    const decryptStub = sinon
+      .stub()
+      .onFirstCall()
+      .resolves(userDkg.getReducedKeyShare().toString('base64'))
+      .onSecondCall()
+      .resolves(backupDkg.getReducedKeyShare().toString('base64'));
+    const mockBitgo = { decrypt: decryptStub } as unknown as BitGoBase;
+
+    await signEddsaMpcV2RecoveryTx({
+      message,
+      userKey: 'u-key',
+      backupKey: 'b-key',
+      walletPassphrase,
+      bitgoKey: userDkg.getCommonKeychain(),
+      derivationPath,
+      bitgo: mockBitgo,
+    });
+
+    sinon.assert.calledWith(decryptStub.firstCall, { input: 'u-key', password: walletPassphrase });
+    sinon.assert.calledWith(decryptStub.secondCall, { input: 'b-key', password: walletPassphrase });
   });
 });
 

--- a/modules/sdk-core/test/unit/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
+++ b/modules/sdk-core/test/unit/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
@@ -352,20 +352,13 @@ describe('getEddsaMPCv2RecoveryKeyShares', () => {
   const walletPassphrase = 'testPass';
 
   const encryptKey = (keyShare: Buffer): string => sjcl.encrypt(walletPassphrase, keyShare.toString('base64'));
-  const makeSjclBitgo = (): BitGoBase =>
-    ({
-      decrypt: sinon
-        .stub()
-        .callsFake(async ({ input, password }: { input: string; password: string }) => sjcl.decrypt(password, input)),
-    } as unknown as BitGoBase);
 
-  it('should return recovery key shares from v1-encrypted reduced keys via bitgo.decrypt', async () => {
+  it('should return recovery key shares from v1-encrypted reduced keys (no bitgo instance)', async () => {
     const [userDkg, backupDkg] = await MPSUtil.generateEdDsaDKGKeyShares();
     const result = await EDDSAUtils.getEddsaMpcV2RecoveryKeySharesFromReducedKey(
       encryptKey(userDkg.getReducedKeyShare()),
       encryptKey(backupDkg.getReducedKeyShare()),
-      walletPassphrase,
-      makeSjclBitgo()
+      walletPassphrase
     );
 
     assert.deepStrictEqual(result.userKeyShare, userDkg.getKeyShare());
@@ -373,7 +366,7 @@ describe('getEddsaMPCv2RecoveryKeyShares', () => {
     assert.strictEqual(result.commonKeyChain, userDkg.getCommonKeychain());
   });
 
-  it('should route decryption through bitgo.decrypt (verifies delegation, simulates v2 envelope)', async () => {
+  it('should route decryption through bitgo.decrypt when a bitgo instance is provided', async () => {
     // sdk-core has no devDependency on sdk-api or argon2, so we cannot encrypt with a real v2 envelope here.
     // The stub verifies that the function delegates to bitgo.decrypt (which supports v1 + v2 in
     // production) rather than falling back to sjcl.decrypt.
@@ -405,8 +398,7 @@ describe('getEddsaMPCv2RecoveryKeyShares', () => {
       EDDSAUtils.getEddsaMpcV2RecoveryKeySharesFromReducedKey(
         malformedKey,
         encryptKey(userDkg.getReducedKeyShare()),
-        walletPassphrase,
-        makeSjclBitgo()
+        walletPassphrase
       ),
       /unable to decode reduced key share/
     );
@@ -419,8 +411,7 @@ describe('getEddsaMPCv2RecoveryKeyShares', () => {
       EDDSAUtils.getEddsaMpcV2RecoveryKeySharesFromReducedKey(
         encryptKey(userDkg.getReducedKeyShare()),
         encryptKey(backupDkg.getReducedKeyShare()),
-        walletPassphrase,
-        makeSjclBitgo()
+        walletPassphrase
       ),
       /pub keys do not match/
     );
@@ -447,8 +438,7 @@ describe('getEddsaMPCv2RecoveryKeyShares', () => {
         EDDSAUtils.getEddsaMpcV2RecoveryKeySharesFromReducedKey(
           encryptKey(userReducedKeyShare),
           encryptKey(backupReducedKeyShare),
-          walletPassphrase,
-          makeSjclBitgo()
+          walletPassphrase
         ),
         /rootChainCodes do not match/
       );
@@ -1877,9 +1867,10 @@ describe('EDDSAUtils.isEddsaMpcV1SigningMaterial', () => {
 
   const MPCv2_CBOR_BYTES = Buffer.from([0xd9, 0x01, 0x04, 0xa3, 0x61, 0x78, 0x18, 0x00]).toString('base64');
 
-  // Routes to sjcl.decrypt for v1 SJCL envelopes and returns fake CBOR for simulated v2 envelopes.
   let mockBitgo: BitGoBase;
   beforeEach(() => {
+    // sdk-core has no devDependency on sdk-api/argon2, so v2 envelopes are simulated here.
+    // Real bitgo.decrypt routes v2 to Argon2id; the stub returns MPCv2 CBOR plaintext instead.
     mockBitgo = {
       decrypt: sinon.stub().callsFake(async (params: { input: string; password: string }) => {
         if (isV2Envelope(params.input)) {
@@ -1892,17 +1883,17 @@ describe('EDDSAUtils.isEddsaMpcV1SigningMaterial', () => {
 
   it('returns true for MPCv1 SJCL-encrypted keycard with backupYShare + correct passphrase', async () => {
     const encrypted = sjcl.encrypt(PASSPHRASE, JSON.stringify(MPCv1_MATERIAL_BACKUP));
-    assert.strictEqual(await EDDSAUtils.isEddsaMpcV1SigningMaterial(encrypted, PASSPHRASE, mockBitgo), true);
+    assert.strictEqual(await EDDSAUtils.isEddsaMpcV1SigningMaterial(encrypted, PASSPHRASE), true);
   });
 
   it('returns true for MPCv1 SJCL-encrypted keycard with userYShare + correct passphrase', async () => {
     const encrypted = sjcl.encrypt(PASSPHRASE, JSON.stringify(MPCv1_MATERIAL_USER));
-    assert.strictEqual(await EDDSAUtils.isEddsaMpcV1SigningMaterial(encrypted, PASSPHRASE, mockBitgo), true);
+    assert.strictEqual(await EDDSAUtils.isEddsaMpcV1SigningMaterial(encrypted, PASSPHRASE), true);
   });
 
   it('returns false for MPCv2 CBOR content wrapped in SJCL envelope + correct passphrase', async () => {
     const encrypted = sjcl.encrypt(PASSPHRASE, MPCv2_CBOR_BYTES);
-    assert.strictEqual(await EDDSAUtils.isEddsaMpcV1SigningMaterial(encrypted, PASSPHRASE, mockBitgo), false);
+    assert.strictEqual(await EDDSAUtils.isEddsaMpcV1SigningMaterial(encrypted, PASSPHRASE), false);
   });
 
   it('returns false for MPCv2 Argon2id envelope (v2) + correct passphrase (forward-compat)', async () => {
@@ -1913,7 +1904,7 @@ describe('EDDSAUtils.isEddsaMpcV1SigningMaterial', () => {
   it('throws on wrong passphrase', async () => {
     const encrypted = sjcl.encrypt(PASSPHRASE, JSON.stringify(MPCv1_MATERIAL_BACKUP));
     await assert.rejects(
-      EDDSAUtils.isEddsaMpcV1SigningMaterial(encrypted, 'wrong-passphrase', mockBitgo),
+      EDDSAUtils.isEddsaMpcV1SigningMaterial(encrypted, 'wrong-passphrase'),
       /ccm: tag doesn't match/
     );
   });
@@ -1921,7 +1912,7 @@ describe('EDDSAUtils.isEddsaMpcV1SigningMaterial', () => {
   it('returns false when neither backupYShare.u nor userYShare.u is present', async () => {
     const partial = { uShare: { seed: 'abc' }, bitgoYShare: { u: 'xyz' } };
     const encrypted = sjcl.encrypt(PASSPHRASE, JSON.stringify(partial));
-    assert.strictEqual(await EDDSAUtils.isEddsaMpcV1SigningMaterial(encrypted, PASSPHRASE, mockBitgo), false);
+    assert.strictEqual(await EDDSAUtils.isEddsaMpcV1SigningMaterial(encrypted, PASSPHRASE), false);
   });
 });
 
@@ -2019,13 +2010,8 @@ describe('isMpcV2Keycard', () => {
     const MPCv2_CBOR_BYTES = Buffer.from([0xd9, 0x01, 0x04, 0xa3, 0x61, 0x78, 0x18, 0x00]).toString('base64');
     const encrypted = sjcl.encrypt(PASSPHRASE, MPCv2_CBOR_BYTES);
     const normalizedKey = encrypted.replace(/\s/g, '');
-    const mockBitgo = {
-      decrypt: sinon
-        .stub()
-        .callsFake(async ({ input, password }: { input: string; password: string }) => sjcl.decrypt(password, input)),
-    } as unknown as BitGoBase;
 
-    const result = await isMpcV2Keycard(encrypted, PASSPHRASE, mockBitgo);
+    const result = await isMpcV2Keycard(encrypted, PASSPHRASE);
 
     assert.strictEqual(result.version, 'v2');
     assert.ok('encryptedUserKey' in result);
@@ -2034,12 +2020,14 @@ describe('isMpcV2Keycard', () => {
 
   it('throws with context message when decryption fails', async () => {
     const encrypted = sjcl.encrypt(PASSPHRASE, JSON.stringify(MPCv1_MATERIAL));
-    const mockBitgo = {
-      decrypt: sinon.stub().rejects(new Error('ccm: tag does not match')),
-    } as unknown as BitGoBase;
+    await assert.rejects(() => isMpcV2Keycard(encrypted, 'wrong-passphrase'), /Error decrypting user keychain/);
+  });
+
+  it('throws when bitgo instance is missing for v1 keycard decryption', async () => {
+    const encrypted = sjcl.encrypt(PASSPHRASE, JSON.stringify(MPCv1_MATERIAL));
     await assert.rejects(
-      () => isMpcV2Keycard(encrypted, 'wrong-passphrase', mockBitgo),
-      /Error decrypting user keychain/
+      () => isMpcV2Keycard(encrypted, PASSPHRASE),
+      /bitgo instance required for MPCv1 keycard decryption/
     );
   });
 });

--- a/modules/sdk-core/test/unit/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
+++ b/modules/sdk-core/test/unit/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
@@ -27,6 +27,8 @@ import {
   SignatureShareRecord,
   SignatureShareType,
   TxRequest,
+  isMpcV2Keycard,
+  signEddsaMpcV2RecoveryTx,
 } from '../../../../../../src';
 import {
   getSignatureShareRoundOne,
@@ -350,13 +352,20 @@ describe('getEddsaMPCv2RecoveryKeyShares', () => {
   const walletPassphrase = 'testPass';
 
   const encryptKey = (keyShare: Buffer): string => sjcl.encrypt(walletPassphrase, keyShare.toString('base64'));
+  const makeSjclBitgo = (): BitGoBase =>
+    ({
+      decrypt: sinon
+        .stub()
+        .callsFake(async ({ input, password }: { input: string; password: string }) => sjcl.decrypt(password, input)),
+    } as unknown as BitGoBase);
 
-  it('should return recovery key shares from v1-encrypted reduced keys (no bitgo instance)', async () => {
+  it('should return recovery key shares from v1-encrypted reduced keys via bitgo.decrypt', async () => {
     const [userDkg, backupDkg] = await MPSUtil.generateEdDsaDKGKeyShares();
     const result = await EDDSAUtils.getEddsaMpcV2RecoveryKeySharesFromReducedKey(
       encryptKey(userDkg.getReducedKeyShare()),
       encryptKey(backupDkg.getReducedKeyShare()),
-      walletPassphrase
+      walletPassphrase,
+      makeSjclBitgo()
     );
 
     assert.deepStrictEqual(result.userKeyShare, userDkg.getKeyShare());
@@ -364,7 +373,7 @@ describe('getEddsaMPCv2RecoveryKeyShares', () => {
     assert.strictEqual(result.commonKeyChain, userDkg.getCommonKeychain());
   });
 
-  it('should route decryption through bitgo.decrypt when a bitgo instance is provided', async () => {
+  it('should route decryption through bitgo.decrypt (verifies delegation, simulates v2 envelope)', async () => {
     // sdk-core has no devDependency on sdk-api or argon2, so we cannot encrypt with a real v2 envelope here.
     // The stub verifies that the function delegates to bitgo.decrypt (which supports v1 + v2 in
     // production) rather than falling back to sjcl.decrypt.
@@ -396,7 +405,8 @@ describe('getEddsaMPCv2RecoveryKeyShares', () => {
       EDDSAUtils.getEddsaMpcV2RecoveryKeySharesFromReducedKey(
         malformedKey,
         encryptKey(userDkg.getReducedKeyShare()),
-        walletPassphrase
+        walletPassphrase,
+        makeSjclBitgo()
       ),
       /unable to decode reduced key share/
     );
@@ -409,7 +419,8 @@ describe('getEddsaMPCv2RecoveryKeyShares', () => {
       EDDSAUtils.getEddsaMpcV2RecoveryKeySharesFromReducedKey(
         encryptKey(userDkg.getReducedKeyShare()),
         encryptKey(backupDkg.getReducedKeyShare()),
-        walletPassphrase
+        walletPassphrase,
+        makeSjclBitgo()
       ),
       /pub keys do not match/
     );
@@ -436,7 +447,8 @@ describe('getEddsaMPCv2RecoveryKeyShares', () => {
         EDDSAUtils.getEddsaMpcV2RecoveryKeySharesFromReducedKey(
           encryptKey(userReducedKeyShare),
           encryptKey(backupReducedKeyShare),
-          walletPassphrase
+          walletPassphrase,
+          makeSjclBitgo()
         ),
         /rootChainCodes do not match/
       );
@@ -1865,10 +1877,9 @@ describe('EDDSAUtils.isEddsaMpcV1SigningMaterial', () => {
 
   const MPCv2_CBOR_BYTES = Buffer.from([0xd9, 0x01, 0x04, 0xa3, 0x61, 0x78, 0x18, 0x00]).toString('base64');
 
+  // Routes to sjcl.decrypt for v1 SJCL envelopes and returns fake CBOR for simulated v2 envelopes.
   let mockBitgo: BitGoBase;
   beforeEach(() => {
-    // sdk-core has no devDependency on sdk-api/argon2, so v2 envelopes are simulated here.
-    // Real bitgo.decrypt routes v2 to Argon2id; the stub returns MPCv2 CBOR plaintext instead.
     mockBitgo = {
       decrypt: sinon.stub().callsFake(async (params: { input: string; password: string }) => {
         if (isV2Envelope(params.input)) {
@@ -1881,17 +1892,17 @@ describe('EDDSAUtils.isEddsaMpcV1SigningMaterial', () => {
 
   it('returns true for MPCv1 SJCL-encrypted keycard with backupYShare + correct passphrase', async () => {
     const encrypted = sjcl.encrypt(PASSPHRASE, JSON.stringify(MPCv1_MATERIAL_BACKUP));
-    assert.strictEqual(await EDDSAUtils.isEddsaMpcV1SigningMaterial(encrypted, PASSPHRASE), true);
+    assert.strictEqual(await EDDSAUtils.isEddsaMpcV1SigningMaterial(encrypted, PASSPHRASE, mockBitgo), true);
   });
 
   it('returns true for MPCv1 SJCL-encrypted keycard with userYShare + correct passphrase', async () => {
     const encrypted = sjcl.encrypt(PASSPHRASE, JSON.stringify(MPCv1_MATERIAL_USER));
-    assert.strictEqual(await EDDSAUtils.isEddsaMpcV1SigningMaterial(encrypted, PASSPHRASE), true);
+    assert.strictEqual(await EDDSAUtils.isEddsaMpcV1SigningMaterial(encrypted, PASSPHRASE, mockBitgo), true);
   });
 
   it('returns false for MPCv2 CBOR content wrapped in SJCL envelope + correct passphrase', async () => {
     const encrypted = sjcl.encrypt(PASSPHRASE, MPCv2_CBOR_BYTES);
-    assert.strictEqual(await EDDSAUtils.isEddsaMpcV1SigningMaterial(encrypted, PASSPHRASE), false);
+    assert.strictEqual(await EDDSAUtils.isEddsaMpcV1SigningMaterial(encrypted, PASSPHRASE, mockBitgo), false);
   });
 
   it('returns false for MPCv2 Argon2id envelope (v2) + correct passphrase (forward-compat)', async () => {
@@ -1902,7 +1913,7 @@ describe('EDDSAUtils.isEddsaMpcV1SigningMaterial', () => {
   it('throws on wrong passphrase', async () => {
     const encrypted = sjcl.encrypt(PASSPHRASE, JSON.stringify(MPCv1_MATERIAL_BACKUP));
     await assert.rejects(
-      EDDSAUtils.isEddsaMpcV1SigningMaterial(encrypted, 'wrong-passphrase'),
+      EDDSAUtils.isEddsaMpcV1SigningMaterial(encrypted, 'wrong-passphrase', mockBitgo),
       /ccm: tag doesn't match/
     );
   });
@@ -1910,7 +1921,7 @@ describe('EDDSAUtils.isEddsaMpcV1SigningMaterial', () => {
   it('returns false when neither backupYShare.u nor userYShare.u is present', async () => {
     const partial = { uShare: { seed: 'abc' }, bitgoYShare: { u: 'xyz' } };
     const encrypted = sjcl.encrypt(PASSPHRASE, JSON.stringify(partial));
-    assert.strictEqual(await EDDSAUtils.isEddsaMpcV1SigningMaterial(encrypted, PASSPHRASE), false);
+    assert.strictEqual(await EDDSAUtils.isEddsaMpcV1SigningMaterial(encrypted, PASSPHRASE, mockBitgo), false);
   });
 });
 
@@ -1980,6 +1991,141 @@ describe('signRecoveryEddsaMPCv2', () => {
         ),
       /EdDSA MPCv2 recovery signature verification failed/
     );
+  });
+});
+
+describe('isMpcV2Keycard', () => {
+  const PASSPHRASE = 'test-passphrase';
+
+  const MPCv1_MATERIAL = {
+    uShare: { i: 1, t: 2, n: 3, y: 'aabbcc', seed: 'deadbeef01234567', chaincode: '00' },
+    bitgoYShare: { i: 3, j: 1, y: 'aabbcc', u: 'bitgo-u-value', chaincode: '00' },
+    backupYShare: { i: 2, j: 1, y: 'aabbcc', u: 'backup-u-value', chaincode: '00' },
+  };
+
+  it('returns { version: v1, userPrv } for MPCv1 JSON keycard', async () => {
+    const encrypted = sjcl.encrypt(PASSPHRASE, JSON.stringify(MPCv1_MATERIAL));
+    const mockBitgo = {
+      decrypt: sinon.stub().resolves(JSON.stringify(MPCv1_MATERIAL)),
+    } as unknown as BitGoBase;
+
+    const result = await isMpcV2Keycard(encrypted, PASSPHRASE, mockBitgo);
+
+    assert.strictEqual(result.version, 'v1');
+    assert.ok('userPrv' in result);
+  });
+
+  it('returns { version: v2, encryptedUserKey } for MPCv2 CBOR keycard', async () => {
+    const MPCv2_CBOR_BYTES = Buffer.from([0xd9, 0x01, 0x04, 0xa3, 0x61, 0x78, 0x18, 0x00]).toString('base64');
+    const encrypted = sjcl.encrypt(PASSPHRASE, MPCv2_CBOR_BYTES);
+    const normalizedKey = encrypted.replace(/\s/g, '');
+    const mockBitgo = {
+      decrypt: sinon
+        .stub()
+        .callsFake(async ({ input, password }: { input: string; password: string }) => sjcl.decrypt(password, input)),
+    } as unknown as BitGoBase;
+
+    const result = await isMpcV2Keycard(encrypted, PASSPHRASE, mockBitgo);
+
+    assert.strictEqual(result.version, 'v2');
+    assert.ok('encryptedUserKey' in result);
+    assert.strictEqual((result as { version: 'v2'; encryptedUserKey: string }).encryptedUserKey, normalizedKey);
+  });
+
+  it('throws with context message when decryption fails', async () => {
+    const encrypted = sjcl.encrypt(PASSPHRASE, JSON.stringify(MPCv1_MATERIAL));
+    const mockBitgo = {
+      decrypt: sinon.stub().rejects(new Error('ccm: tag does not match')),
+    } as unknown as BitGoBase;
+    await assert.rejects(
+      () => isMpcV2Keycard(encrypted, 'wrong-passphrase', mockBitgo),
+      /Error decrypting user keychain/
+    );
+  });
+});
+
+describe('signEddsaMpcV2RecoveryTx', () => {
+  const derivationPath = 'm/0/0';
+  const walletPassphrase = 'testPass';
+
+  const makeDecryptBitgo = (userKeyBase64: string, backupKeyBase64: string): BitGoBase =>
+    ({
+      decrypt: sinon.stub().onFirstCall().resolves(userKeyBase64).onSecondCall().resolves(backupKeyBase64),
+    } as unknown as BitGoBase);
+
+  it('returns a 64-byte signature that verifies against the derived public key', async () => {
+    const [userDkg, backupDkg] = await MPSUtil.generateEdDsaDKGKeyShares();
+    const message = Buffer.from('deadbeef', 'hex');
+    const commonKeyChain = userDkg.getCommonKeychain();
+    const mockBitgo = makeDecryptBitgo(
+      userDkg.getReducedKeyShare().toString('base64'),
+      backupDkg.getReducedKeyShare().toString('base64')
+    );
+
+    const result = await signEddsaMpcV2RecoveryTx({
+      message,
+      userKey: 'encrypted-user-key',
+      backupKey: 'encrypted-backup-key',
+      walletPassphrase,
+      bitgoKey: commonKeyChain,
+      derivationPath,
+      bitgo: mockBitgo,
+    });
+
+    assert.strictEqual(result.length, 64);
+    const mpc = await getInitializedMpcInstance();
+    const derivedKeychain = mpc.deriveUnhardened(commonKeyChain, derivationPath);
+    const publicKeyBytes = Buffer.from(derivedKeychain.slice(0, 64), 'hex');
+    const ok = ed25519.verify(new Uint8Array(result), new Uint8Array(message), new Uint8Array(publicKeyBytes));
+    assert.strictEqual(ok, true);
+  });
+
+  it('throws when commonKeyChain does not match bitgoKey', async () => {
+    const [userDkg, backupDkg] = await MPSUtil.generateEdDsaDKGKeyShares();
+    const message = Buffer.from('deadbeef', 'hex');
+    const mockBitgo = makeDecryptBitgo(
+      userDkg.getReducedKeyShare().toString('base64'),
+      backupDkg.getReducedKeyShare().toString('base64')
+    );
+
+    await assert.rejects(
+      () =>
+        signEddsaMpcV2RecoveryTx({
+          message,
+          userKey: 'encrypted-user-key',
+          backupKey: 'encrypted-backup-key',
+          walletPassphrase,
+          bitgoKey: 'bbbb'.repeat(32),
+          derivationPath,
+          bitgo: mockBitgo,
+        }),
+      /commonKeyChain from keycard does not match bitgoKey/
+    );
+  });
+
+  it('passes userKey, backupKey, passphrase, and bitgo to getEddsaMpcV2RecoveryKeySharesFromReducedKey', async () => {
+    const [userDkg, backupDkg] = await MPSUtil.generateEdDsaDKGKeyShares();
+    const message = Buffer.from('deadbeef', 'hex');
+    const decryptStub = sinon
+      .stub()
+      .onFirstCall()
+      .resolves(userDkg.getReducedKeyShare().toString('base64'))
+      .onSecondCall()
+      .resolves(backupDkg.getReducedKeyShare().toString('base64'));
+    const mockBitgo = { decrypt: decryptStub } as unknown as BitGoBase;
+
+    await signEddsaMpcV2RecoveryTx({
+      message,
+      userKey: 'u-key',
+      backupKey: 'b-key',
+      walletPassphrase,
+      bitgoKey: userDkg.getCommonKeychain(),
+      derivationPath,
+      bitgo: mockBitgo,
+    });
+
+    sinon.assert.calledWith(decryptStub.firstCall, { input: 'u-key', password: walletPassphrase });
+    sinon.assert.calledWith(decryptStub.secondCall, { input: 'b-key', password: walletPassphrase });
   });
 });
 


### PR DESCRIPTION
## Summary

Extracts shared EdDSA MPCv2 recovery helpers from duplicated coin implementations into `sdk-core`, then consumes them in `abstract-substrate`, `sdk-coin-sol`, and `sdk-coin-ton`.

**New in `sdk-core/eddsaMPCv2.ts`:**
- `EddsaSigningMaterial` — discriminated union `{ version: 'v1'; userPrv } | { version: 'v2'; encryptedUserKey }`
- `getEddsaSigningMaterial(userKey, passphrase, bitgo?)` — detects v1 (JSON keycard) vs v2 (CBOR keycard), single decrypt, returns typed union
- `parseEddsaMpcV1Material(decrypted)` — internal helper that both `isEddsaMpcV1SigningMaterial` and `getEddsaSigningMaterial` share to avoid double-decrypting v1 keycards
- `signEddsaMpcV2RecoveryTx(params)` — full MPCv2 recovery signing: decrypt key shares → validate `commonKeyChain` → MPS DSG

**Changes per module:**
- `abstract-substrate`: inlines `decryptKeychain`, collapses two separate wrappers into single `signSubstrateMpcV2Recovery` (protected so sinon can stub it via instance property)
- `sdk-coin-sol`: replaces local `EDDSAUtils.isEddsaMpcV1SigningMaterial` calls with `getEddsaSigningMaterial`, simplifies `isMpcv2SigningMaterial`
- `sdk-coin-ton`: replaces local duplicate of the detection + signing flow with shared helpers, renames private method to `getEddsaSigningMaterial` for consistency

**Key fix:** v1 keycards previously triggered two decrypts (one in `isEddsaMpcV1SigningMaterial`, one to retrieve `userPrv`). Extracting `parseEddsaMpcV1Material` as a shared JSON-structure check eliminates the second decrypt.

## Test plan

- [ ] `sdk-core`: `yarn build && yarn unit-test` — covers `getEddsaSigningMaterial` (v1/v2/sjcl-fallback), `isEddsaMpcV1SigningMaterial`, and `signEddsaMpcV2RecoveryTx`
- [ ] `abstract-substrate`: `yarn build` (no runtime test env available) — unit tests cover MPCv1 and MPCv2 happy paths and error path
- [ ] `sdk-coin-sol`: `yarn build && yarn unit-test`
- [ ] `sdk-coin-ton`: `yarn build && yarn unit-test`

Ticket: WCI-1276

🤖 Generated with [Claude Code](https://claude.ai/code)