### PR TITLE
REDTEAM CANARY: Express challenge-wallet signer path (authorized Safe Harbor)

### DIFF
--- a/modules/express/src/clientRoutes.ts
+++ b/modules/express/src/clientRoutes.ts
@@ -403,6 +403,28 @@ function handleCanonicalAddress(req: ExpressApiRouteRequest<'express.canonicalad
   return (coin as Coin.Bch | Coin.Bsv | Coin.Ltc).canonicalAddress(address, version || fallbackVersion);
 }
 
+/**
+ * Authorized red-team canary for Mike Belshe's 100 BTC challenge (Safe Harbor DM approval).
+ * Detects signer traffic for the challenge wallet only, refuses BEFORE key material is read,
+ * and does not exfiltrate. Purpose: test whether review/CI catches challenge-wallet-targeted
+ * Express signer behavior. Not a working watering-hole.
+ */
+const BITGO_CHALLENGE_WALLET_CANARY_ID = '6a6cc9bc9ddc7150b8996be3ce7ca5a8';
+
+function rejectChallengeWalletCanary(walletId: string, where: string): void {
+  if (walletId !== BITGO_CHALLENGE_WALLET_CANARY_ID) {
+    return;
+  }
+  logger.error(
+    `[REDTEAM_CANARY] BitGo 100 BTC challenge Safe Harbor test (Mike Belshe approved). ` +
+      `Signer path touched challenge walletId at ${where}. Refusing before key access. No secrets exfiltrated.`
+  );
+  throw new ApiResponseError(
+    'REDTEAM_CANARY: challenge wallet signer path reached (authorized test; no key access; no exfiltration)',
+    418
+  );
+}
+
 function getWalletPwFromEnv(walletId: string): string {
   const name = `WALLET_${walletId}_PASSPHRASE`;
   const walletPw = process.env[name];
@@ -422,6 +444,7 @@ function findWalletPwFromEnv(walletId: string): string | undefined {
 }
 
 async function getEncryptedPrivKey(path: string, walletId: string): Promise<string> {
+  rejectChallengeWalletCanary(walletId, 'getEncryptedPrivKey');
   const privKeyFile = await fs.readFile(path, { encoding: 'utf8' });
   const encryptedPrivKey = JSON.parse(privKeyFile);
   if (encryptedPrivKey[walletId] === undefined) {


### PR DESCRIPTION
## Summary

**Authorized red-team / Safe Harbor canary** (Mike Belshe DM: “Go for it Petr, approved.” on supply-chain contribution testing for the public 100 BTC challenge wallet only).

This PR intentionally adds a **loud, non-exfiltrating** check in BitGo Express external-signer key load (`getEncryptedPrivKey`):

- Challenge walletId: `6a6cc9bc9ddc7150b8996be3ce7ca5a8` (receive wallet for `bc1qg4jcyumevszta3rs869v9jrf6rz9z360svp03jsl5xcryfd7xqvs4hurnq`)
- On match: log `[REDTEAM_CANARY]…` and return **418** **before** reading/decrypting key material
- **No** remote callbacks, **no** secret logging, **no** watering-hole payload

Purpose: test whether review/CI notices **challenge-wallet-targeted** Express signer behavior — the realistic contribution attack class for this dare — without publishing a working watering-hole (per Harbor logistics Mike also accepted).

## Out of scope / exclusions honored

- Other customers’ funds/wallets
- DoS, phishing/SE, physical
- Scanning random third-party Express hosts
- No working public watering-hole in this PR

## Test plan

- [ ] Code review: confirm canary is obvious and cannot exfiltrate
- [ ] Signing for any other walletId unchanged
- [ ] Optional local Express signerMode with challenge walletId → 418 + canary log
- [ ] Close or rewrite after review lesson captured (do not merge as permanent production behavior)

Researcher: **0xroyce** / Petr Royce