### PR TITLE
feat(statics): onboard batch 0803 tokens (CECHO-1893)

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -5091,6 +5091,25 @@ export const allCoinsAndTokens = [
     UnderlyingAsset['baseeth:elsa'],
     Networks.main.basechain
   ),
+  // CECHO-1893 batch 0803 tokens
+  erc20Token(
+    '12d3d4ee-12ab-45b4-bb6e-46b6f223c04d',
+    'baseeth:allo',
+    'Allora',
+    18,
+    '0x032d86656db142138ac97d2c5c4e3766e8c0482d',
+    UnderlyingAsset['baseeth:allo'],
+    Networks.main.basechain
+  ),
+  erc20Token(
+    'a5666ecd-2ec3-4282-b4d5-283ccd467658',
+    'baseeth:gro',
+    'GromaCoin',
+    18,
+    '0x3dcce9e05fc9c30a6a4e9fc1c0ec1ff15c16e0b5',
+    UnderlyingAsset['baseeth:gro'],
+    Networks.main.basechain
+  ),
 
   // ARC mainnet tokens
   erc20Token(
@@ -6404,6 +6423,18 @@ export const allCoinsAndTokens = [
     AccountCoin.DEFAULT_FEATURES,
     '',
     'TXLM:BTGT'
+  ),
+  // CECHO-1893 batch 0803 tokens
+  tstellarToken(
+    '02f4297e-e0dc-4a14-af6c-15e0063d1ec6',
+    'txlm:yGHS-GCF46XLX3R7OXIDAFZ3HH6DEY5VT3BJJRSTKSSOKPLGNH6H7QYV3A2OA',
+    'yGHS',
+    7,
+    UnderlyingAsset['txlm:yGHS-GCF46XLX3R7OXIDAFZ3HH6DEY5VT3BJJRSTKSSOKPLGNH6H7QYV3A2OA'],
+    '',
+    AccountCoin.DEFAULT_FEATURES,
+    '',
+    'TXLM:yGHS'
   ),
   ttronToken(
     '4ece7f15-a5c9-4302-8c82-787d7eb7e3c9',

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -2551,6 +2551,9 @@ export enum UnderlyingAsset {
   'eth:lngvx' = 'eth:lngvx',
   'eth:eqtyx' = 'eth:eqtyx',
   'eth:deuro' = 'eth:deuro',
+  'eth:strusd' = 'eth:strusd',
+  'eth:u' = 'eth:u',
+  'eth:bliquid' = 'eth:bliquid',
   'eth:usat' = 'eth:usat',
   'eth:usdf' = 'eth:usdf',
   'eth:ausd' = 'eth:ausd',
@@ -2959,6 +2962,7 @@ export enum UnderlyingAsset {
   'txlm:BST-GCWHAO4SVB4KX3Q62QZGZUHUH2GSH3OIV7IS7Y3MPQOFGQFGBP6IYCOU' = 'txlm:BST-GCWHAO4SVB4KX3Q62QZGZUHUH2GSH3OIV7IS7Y3MPQOFGQFGBP6IYCOU',
   'txlm:TST-GC26PEYGETD7L6PUW2VCU3PSC7LCLRRPOSUILSHD2RT23IQUEAN4TQBQ' = 'txlm:TST-GC26PEYGETD7L6PUW2VCU3PSC7LCLRRPOSUILSHD2RT23IQUEAN4TQBQ',
   'txlm:BTGT-GCCUFJV5P32QGVZVW73SF7P53ZH2OXJ5C3DYSXDECSRCP3FU2GJ2PXGE' = 'txlm:BTGT-GCCUFJV5P32QGVZVW73SF7P53ZH2OXJ5C3DYSXDECSRCP3FU2GJ2PXGE',
+  'txlm:yGHS-GCF46XLX3R7OXIDAFZ3HH6DEY5VT3BJJRSTKSSOKPLGNH6H7QYV3A2OA' = 'txlm:yGHS-GCF46XLX3R7OXIDAFZ3HH6DEY5VT3BJJRSTKSSOKPLGNH6H7QYV3A2OA',
 
   // Algorand testnet tokens
   'talgo:USON-16026728' = 'talgo:USON-16026728',
@@ -3398,6 +3402,7 @@ export enum UnderlyingAsset {
   'bsc:ftm' = 'bsc:ftm',
   'bsc:comp' = 'bsc:comp',
   'bsc:uni' = 'bsc:uni',
+  'bsc:u' = 'bsc:u',
   'bsc:yfi' = 'bsc:yfi',
   'bsc:link' = 'bsc:link',
   'bsc:cusdo' = 'bsc:cusdo',
@@ -3700,6 +3705,8 @@ export enum UnderlyingAsset {
   'baseeth:flock' = 'baseeth:flock',
   'baseeth:gps' = 'baseeth:gps',
   'baseeth:elsa' = 'baseeth:elsa',
+  'baseeth:allo' = 'baseeth:allo',
+  'baseeth:gro' = 'baseeth:gro',
 
   // BaseETH testnet tokens
   'tbaseeth:usdc' = 'tbaseeth:usdc',
@@ -4167,6 +4174,7 @@ export enum UnderlyingAsset {
   'sol:birb' = 'sol:birb',
   'sol:pybobo' = 'sol:pybobo',
   'sol:usdpt' = 'sol:usdpt',
+  'sol:bliquid' = 'sol:bliquid',
 
   'tsol:txsgd' = 'sol:txsgd',
   'tsol:txusd' = 'sol:txusd',
@@ -4550,6 +4558,7 @@ export enum UnderlyingAsset {
   // Canton mainnet tokens
   'canton:usdcx' = 'canton:usdcx',
   'canton:usd1' = 'canton:usd1',
+  'canton:usdm1' = 'canton:usdm1',
   'canton:cbtc' = 'canton:cbtc',
   'canton:usdxlr' = 'canton:usdxlr',
   'canton:cltc' = 'canton:cltc',

--- a/modules/statics/src/coins/bscTokens.ts
+++ b/modules/statics/src/coins/bscTokens.ts
@@ -1447,6 +1447,16 @@ export const bscTokens = [
     UnderlyingAsset['bsc:rekt'],
     BSC_TOKEN_FEATURES
   ),
+  // CECHO-1893 batch 0803 tokens
+  bscToken(
+    '3d20d5c4-ba91-4ee5-83af-62b92029432e',
+    'bsc:u',
+    'United Stables',
+    18,
+    '0xce24439f2d9c6a2289f741120fe202248b666666',
+    UnderlyingAsset['bsc:u'],
+    BSC_TOKEN_FEATURES
+  ),
   tbscToken(
     'b31aa2b5-8d8c-4ac1-b5e5-0f9d59377eab',
     'tbsc:busd',

--- a/modules/statics/src/coins/cantonTokens.ts
+++ b/modules/statics/src/coins/cantonTokens.ts
@@ -233,6 +233,17 @@ export const cantonTokens = [
     UnderlyingAsset['canton:912810rc4'],
     [...CANTON_TOKEN_FEATURES]
   ),
+  // CECHO-1893 batch 0803 tokens
+  cantonToken(
+    '4f056316-2286-4d7b-8064-43f4401ecadd',
+    'canton:usdm1',
+    'USDM1',
+    10,
+    'https://api.utilities.digitalasset.com/api/token-standard/v0/registrars/',
+    'M1-validator-1::12207b40944692e083593819697e1cd87a94026afca2564253d16ff8696b233a6637',
+    UnderlyingAsset['canton:usdm1'],
+    CANTON_TOKEN_FEATURES
+  ),
   // testnet tokens
   tcantonToken(
     '46356790-0ac4-4c3b-8b70-39094106d772',

--- a/modules/statics/src/coins/erc20Coins.ts
+++ b/modules/statics/src/coins/erc20Coins.ts
@@ -12367,6 +12367,40 @@ export const erc20Coins = [
     '0x7cf9a80db3b29ee8efe3710aadb7b95270572d47',
     UnderlyingAsset['eth:nil']
   ),
+  // CECHO-1893 batch 0803 tokens
+  erc20(
+    '52f48b8e-33c3-480c-973a-12e492adfde8',
+    'eth:strusd',
+    'Tori Staked trUSD',
+    18,
+    '0x280839980a7ed0d7717f64125fe241012e5f5815',
+    UnderlyingAsset['eth:strusd']
+  ),
+  erc20(
+    '809067fa-017d-47eb-8abb-fa29085e037f',
+    'eth:u',
+    'United Stables',
+    18,
+    '0xce24439f2d9c6a2289f741120fe202248b666666',
+    UnderlyingAsset['eth:u']
+  ),
+  erc20(
+    '9056302f-1748-4675-b563-dfddcb2c9bb2',
+    'eth:bliquid',
+    'BNY Dreyfus On-Chain Liquidity Fund',
+    2,
+    '0x80fdea151e79d6904859b12b0b3fb40d4209e462',
+    UnderlyingAsset['eth:bliquid'],
+    AccountCoin.getFeaturesByTypeExcluding(
+      [
+        CoinFeature.CUSTODY_BITGO_SINGAPORE,
+        CoinFeature.CUSTODY_BITGO_GERMANY,
+        CoinFeature.CUSTODY_BITGO_EUROPE_APS,
+        CoinFeature.CUSTODY_BITGO_FRANKFURT,
+      ],
+      ETH_FEATURES
+    )
+  ),
   terc20(
     '0205f0d6-0647-47c9-ad8b-c48d048e54f3',
     'fixed',

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -3022,6 +3022,8 @@ export const ofcCoins = [
   ofcBscToken('822d85d7-f42d-40de-a14c-220a375eda3f', 'ofcbsc:sfp', 'SafePal Token', 18, UnderlyingAsset['bsc:sfp']),
   ofcBscToken('f5a0b8c3-7d4e-4f9b-9a2c-6e8d9f3b5c7a', 'ofcbsc:btr', 'Bitlayer', 18, UnderlyingAsset['bsc:btr']),
   ofcBscToken('10226e82-2fac-49f4-8ee0-e0f7affeaeec', 'ofcbsc:mask', 'Mask Network', 18, UnderlyingAsset['bsc:mask']),
+  // CECHO-1893 batch 0803 tokens
+  ofcBscToken('13c89c60-5ffd-42c8-acbc-b7b5fa22a5bd', 'ofcbsc:u', 'United Stables', 18, UnderlyingAsset['bsc:u']),
   ofcBscToken(
     'a1380903-6d91-4555-b8ef-74b1bcd993d0',
     'ofcbsc:usdt',
@@ -6252,6 +6254,14 @@ export const ofcCoins = [
   ),
   ofcsolToken('4c928099-4b07-457a-944e-58ed464418de', 'ofcsol:slx', 'Solstice', 6, UnderlyingAsset['sol:slx']),
   ofcsolToken('8ff32b48-1bab-4769-b239-d34afbb74a89', 'ofcsol:ab1', 'Animoca', 0, UnderlyingAsset['sol:ab1']),
+  // CECHO-1893 batch 0803 tokens
+  ofcsolToken(
+    '0f1801dc-befd-46af-b57c-80437406c6d2',
+    'ofcsol:bliquid',
+    'BNY Dreyfus On-Chain Liquidity Fund',
+    2,
+    UnderlyingAsset['sol:bliquid']
+  ),
   // New Canton OFC tokens
   ofcCantonToken(
     '02ab6bd2-83e6-46fc-bfd7-93b8be125648',
@@ -6312,6 +6322,14 @@ export const ofcCoins = [
     UnderlyingAsset['canton:sofid'],
     undefined,
     [CoinFeature.STABLECOIN]
+  ),
+  // CECHO-1893 batch 0803 tokens
+  ofcCantonToken(
+    '010e9b79-ec36-406f-b933-e973d81cf3cf',
+    'ofccanton:usdm1',
+    'USDM1',
+    10,
+    UnderlyingAsset['canton:usdm1']
   ),
   tofcCantonToken(
     'd7297535-c1d4-429d-b3c5-d36351b110e5',

--- a/modules/statics/src/coins/ofcErc20Coins.ts
+++ b/modules/statics/src/coins/ofcErc20Coins.ts
@@ -6276,6 +6276,50 @@ export const tOfcErc20Coins = [
   ofcerc20('253e2858-a27b-4d39-b1fc-b8f719584d1f', 'ofceth:nvylds', 'NUVA YLDS', 12, UnderlyingAsset['eth:nvylds']),
   ofcerc20('e68260cc-3f0c-4429-9681-5a2cd46a6c87', 'ofceth:nvheloc', 'NUVA HELOC', 12, UnderlyingAsset['eth:nvheloc']),
   ofcerc20('02a7867a-754e-4132-8802-1b4aa979a441', 'ofceth:nil', 'Nillion', 6, UnderlyingAsset['eth:nil']),
+  // CECHO-1893 batch 0803 tokens
+  ofcerc20(
+    '07c67706-5e28-4117-b181-38d4b8424b73',
+    'ofceth:strusd',
+    'Tori Staked trUSD',
+    18,
+    UnderlyingAsset['eth:strusd']
+  ),
+  ofcerc20('d4e7002b-4299-442a-bda4-0e35a80c079a', 'ofceth:u', 'United Stables', 18, UnderlyingAsset['eth:u']),
+  ofcerc20(
+    'c9fb114e-e8cd-46b3-ae72-9f0e4cb842c1',
+    'ofceth:bliquid',
+    'BNY Dreyfus On-Chain Liquidity Fund',
+    2,
+    UnderlyingAsset['eth:bliquid']
+  ),
+  ofcerc20(
+    '14aa687a-ee62-431e-bfe5-a78764cca714',
+    'ofcbaseeth:allo',
+    'Allora',
+    18,
+    UnderlyingAsset['baseeth:allo'],
+    undefined,
+    undefined,
+    '',
+    undefined,
+    undefined,
+    true,
+    'baseeth'
+  ),
+  ofcerc20(
+    'e5612640-d0fa-493e-a799-e7d02ab69069',
+    'ofcbaseeth:gro',
+    'GromaCoin',
+    18,
+    UnderlyingAsset['baseeth:gro'],
+    undefined,
+    undefined,
+    '',
+    undefined,
+    undefined,
+    true,
+    'baseeth'
+  ),
   ofcerc20('14912a5e-254c-4c6f-9f9c-f9ce11b7b293', 'ofceth:bard', 'Lombard', 18, UnderlyingAsset['eth:bard']),
   ofcerc20('a31a6330-cbd6-49b0-b8b1-a7f9a48e770c', 'ofceth:sfp', 'SafePal Token', 18, UnderlyingAsset['eth:sfp']),
   ofcerc20('60f825f0-ed18-46b2-a03f-fd93b5e94f43', 'ofceth:aztec', 'Aztec', 18, UnderlyingAsset['eth:aztec']),

--- a/modules/statics/src/coins/solTokens.ts
+++ b/modules/statics/src/coins/solTokens.ts
@@ -3503,6 +3503,26 @@ export const solTokens = [
     SOL_TOKEN_FEATURES,
     ProgramID.Token2022ProgramId
   ),
+  // CECHO-1893 batch 0803 tokens
+  solToken(
+    'e0b4ee3f-8958-4cf3-a24f-9b9400e978d4',
+    'sol:bliquid',
+    'BNY Dreyfus On-Chain Liquidity Fund',
+    2,
+    '33J6F2wAHrFXAQJpgz3mLfzbvSNkVVfXTbZVMGxXF8Ab',
+    '33J6F2wAHrFXAQJpgz3mLfzbvSNkVVfXTbZVMGxXF8Ab',
+    UnderlyingAsset['sol:bliquid'],
+    SolCoin.getFeaturesByTypeExcluding(
+      [
+        CoinFeature.CUSTODY_BITGO_SINGAPORE,
+        CoinFeature.CUSTODY_BITGO_GERMANY,
+        CoinFeature.CUSTODY_BITGO_EUROPE_APS,
+        CoinFeature.CUSTODY_BITGO_FRANKFURT,
+      ],
+      SOL_TOKEN_FEATURES
+    ),
+    ProgramID.Token2022ProgramId
+  ),
   tsolToken(
     'b98c5a7a-49c5-45f1-a6ee-b08dff596a7d',
     'tsol:srm',


### PR DESCRIPTION
## Summary
Onboard 9 new tokens from client requested batch (CECHO-1893), following the existing per-chain token file conventions (see #9371 for reference pattern).

## Tokens Added
### Ungated
- **ETH** (`erc20Coins.ts`): strUSD (0x280839980a7ed0d7717f64125fe241012e5f5815, 18 decimals), U (0xce24439f2d9c6a2289f741120fe202248b666666, 18 decimals)
- **BSC** (`bscTokens.ts`): U (0xce24439f2d9c6a2289f741120fe202248b666666, 18 decimals)
- **BASE** (`allCoinsAndTokens.ts`, inline with existing baseeth entries): ALLO (0x032d86656db142138ac97d2c5c4e3766e8c0482d, 18 decimals), GRO (0x3dcce9e05fc9c30a6a4e9fc1c0ec1ff15c16e0b5, 18 decimals)
- **CANTON** (`cantonTokens.ts`): USDM1 (M1 validator contract, 10 decimals)
- **Stellar testnet** (`allCoinsAndTokens.ts`, inline with existing txlm entries): yGHS (7 decimals)

### Gated (Money Market Funds)
- **ETH** (`erc20Coins.ts`): BLIQUID (0x80fdea151e79d6904859b12b0b3fb40d4209e462, 2 decimals)
- **SOL** (`solTokens.ts`): BLIQUID (33J6F2wAHrFXAQJpgz3mLfzbvSNkVVfXTbZVMGxXF8Ab, 2 decimals, Token-2022 program)

Gated tokens exclude Singapore, Germany, Europe APS, and Frankfurt custody features, matching the existing BUIDL (BlackRock USD Institutional Digital Liquidity Fund) gating pattern.

## Changes
- `base.ts`: UnderlyingAsset enum entries
- `erc20Coins.ts` / `bscTokens.ts` / `solTokens.ts` / `cantonTokens.ts`: per-chain mainnet token entries
- `allCoinsAndTokens.ts`: inline BASE and Stellar-testnet entries (matching existing inline conventions for those chains)
- `ofcErc20Coins.ts` / `ofcCoins.ts`: OFC counterparts for all new tokens

## Decimal Verification
Every token's decimals were verified on-chain (not assumed) via RPC calls (`eth_call` decimals() for EVM chains, `getAccountInfo` for SOL) and cross-checked against existing conventions for CANTON/Stellar:

| Token | Decimals | Source |
|---|---|---|
| eth:strusd | 18 | on-chain `decimals()` |
| eth:u | 18 | on-chain `decimals()` |
| eth:bliquid | 2 | on-chain `decimals()` |
| bsc:u | 18 | on-chain `decimals()` |
| baseeth:allo | 18 | on-chain `decimals()` |
| baseeth:gro | 18 | on-chain `decimals()` |
| sol:bliquid | 2 | on-chain mint account (Token-2022 program) |
| canton:usdm1 | 10 | matches fixed Canton network precision (all 120 existing Canton tokens use 10) |
| txlm:yGHS | 7 | matches fixed Stellar protocol precision (all existing Stellar tokens use 7) |

Both BLIQUID tokens (BNY Dreyfus On-Chain Liquidity Fund, ~$1 NAV) use 2 decimals on-chain, not 18/6 as initially assumed — corrected after verification. `sol:bliquid` also required the Token-2022 program ID instead of the default classic SPL Token program.

## Test Plan
- [x] TypeScript compilation passes
- [x] ESLint and Prettier pass
- [x] Commit lint validation passes
- [x] `yarn unit-test` in `modules/statics` passes (33,852 tests)

## Notes
- Pricing fixes for other existing tokens (sol:ansem, hoodeth:cashcat, canton:ceth, eth:deuro, eth:usdm1) are out of scope for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)