### PR TITLE
fix(root): bump nanoid to 3.3.17 via yarn resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,8 @@
     "uuid": "11.1.1",
     "js-yaml": "4.3.1",
     "ip-address": "10.4.0",
-    "socket.io-parser": "4.2.7"
+    "socket.io-parser": "4.2.7",
+    "nanoid": "3.3.17"
   },
   "overrides": {
     "qs": "6.15.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15553,10 +15553,10 @@ nanoevents@^9.1.0:
   resolved "https://registry.npmjs.org/nanoevents/-/nanoevents-9.1.0.tgz"
   integrity sha512-Jd0fILWG44a9luj8v5kED4WI+zfkkgwKyRQKItTtlPfEsh7Lznfi1kr8/iZ+XAIss4Qq5GqRB0qtWbaz9ceO/A==
 
-nanoid@^3.3.12:
-  version "3.3.16"
-  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
-  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
+nanoid@3.3.17, nanoid@^3.3.12:
+  version "3.3.17"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz#f1c3aa253c52547956a52c50bff754316f61037a"
+  integrity sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
## Summary
Fixes the `@bitgo-beta` release workflow's OSV vulnerability severity gate failure, seen in [this run](https://github.com/BitGo/BitGoJS/actions/runs/31373826670/job/93408513842):

```
1 of 38 advisory group(s) at or above CVSS 7.0 (HIGH/CRITICAL). Failing the release.
  nanoid@3.3.16  CVSS 8.2  GHSA-2v37-7h3g-55p8
```

## Root cause
`GHSA-2v37-7h3g-55p8` / `CVE-2026-67213`: nanoid's `customAlphabet` and `customRandom` loop indefinitely when called with `size: 0`, causing a DoS. Fixed in `nanoid@3.3.17` (3.x line) / `5.1.6` (5.x line). The resolved version in `yarn.lock` was `3.3.16`, one patch behind the fix.

## Change
- Added `"nanoid": "3.3.17"` to root `resolutions` in `package.json`
- Regenerated `yarn.lock` — the single `nanoid@^3.3.12` entry now resolves to `3.3.17`

## Cooldown check
`3.3.17` was published 2026-08-03, clearing BitGo's 7-day dependency cooldown as of this PR.

## Test Plan
- [x] `yarn install` completes cleanly, all workspace packages build/link
- [ ] Re-run the OSV severity gate / release workflow to confirm the nanoid finding clears

Ticket: [CECHO-1893](https://linear.app/bitgo/issue/CECHO-1893/client-requested-tokens-to-onboard-batch-0803)

🤖 Generated with [Claude Code](https://claude.com/claude-code)