### PR TITLE
feat(statics): add ofctxlm:yghs OFC counterpart (CECHO-1893)

### DIFF
--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -4903,6 +4903,14 @@ export const ofcCoins = [
     7,
     UnderlyingAsset['txlm:TST-GC26PEYGETD7L6PUW2VCU3PSC7LCLRRPOSUILSHD2RT23IQUEAN4TQBQ']
   ),
+  // CECHO-1893 batch 0803 tokens
+  tofcStellarToken(
+    '3415e5a2-8341-4fa1-bc6a-850bbffff69b',
+    'ofctxlm:yghs',
+    'yGHS',
+    7,
+    UnderlyingAsset['txlm:yGHS-GCF46XLX3R7OXIDAFZ3HH6DEY5VT3BJJRSTKSSOKPLGNH6H7QYV3A2OA']
+  ),
   tofcArbethErc20(
     '2489c0e2-c13f-4287-bd1f-03dcd0a8562e',
     'ofctarbeth:link',

--- a/modules/statics/test/unit/ofcTokenNaming.ts
+++ b/modules/statics/test/unit/ofcTokenNaming.ts
@@ -53,6 +53,7 @@ describe('OFC Token Naming Convention Tests', function () {
         'ofctnear:stnear', // "stNEAR"
         'ofctbaseeth', // "Base Sepolia Chain"
         'ofctpolygon:activ', // "Activ"
+        'ofctxlm:yghs', // "yGHS"
       ];
 
       if (!knownExceptions.includes(token.name)) {


### PR DESCRIPTION
## Summary
Every other new token in the CECHO-1893 batch (PR #9457) got an OFC counterpart, but `txlm:yGHS` was missed — I'd assumed testnet Stellar tokens generically don't need one, but that's wrong: `ofctxlm:tst` already exists as a precedent for exactly this case (a per-token testnet Stellar OFC entry via `tofcStellarToken`).

## Change
- Added `ofctxlm:yghs` in `ofcCoins.ts`, matching the `ofctxlm:tst` pattern.
- Added `ofctxlm:yghs` to the `ofcTokenNaming` test's known-exceptions list — `yGHS` is a real external asset ticker (same category as the existing `usdc`/`usdt`/`rlusd`/`xsgd` exceptions), so it shouldn't be forced to carry a "test" marker in its display name.

## Test Plan
- [x] `tsc --noEmit` passes
- [x] `eslint` passes
- [x] `yarn unit-test` in `modules/statics` passes (33,856 tests, up from 33,855 — the new `ofcTokenNaming` case is covered)

Follow-up to: https://github.com/BitGo/BitGoJS/pull/9457
Ticket: [CECHO-1893](https://linear.app/bitgo/issue/CECHO-1893/client-requested-tokens-to-onboard-batch-0803)

🤖 Generated with [Claude Code](https://claude.com/claude-code)