### PR TITLE
fix(sdk-coin-iota): constrain @iota/iota-sdk to node-20 range

### DIFF
--- a/modules/sdk-coin-iota/package.json
+++ b/modules/sdk-coin-iota/package.json
@@ -44,7 +44,7 @@
     "@bitgo/sdk-core": "^38.6.0",
     "@bitgo/statics": "^59.4.0",
     "@iota/bcs": "^1.2.0",
-    "@iota/iota-sdk": "^1.6.0",
+    "@iota/iota-sdk": ">=1.6.0 <1.11.0",
     "bignumber.js": "^9.1.2",
     "lodash": "^4.18.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3145,20 +3145,27 @@
   resolved "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz"
   integrity sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==
 
-"@iota/bcs@1.2.0", "@iota/bcs@^1.2.0":
+"@iota/bcs@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/@iota/bcs/-/bcs-1.4.0.tgz#a6b26ffc9b86d99bec0fe860778b1ce02731bd32"
+  integrity sha512-Bpg8uPB3UTweJyFS3G+aycGcTCxaJQi2a9bEy2QXWMBM8a/tLN1KCg4IzKWkAJ4FyMNrZZrdXiBqAzmNK6xdVQ==
+  dependencies:
+    bs58 "^6.0.0"
+
+"@iota/bcs@^1.2.0":
   version "1.2.0"
   resolved "https://registry.npmjs.org/@iota/bcs/-/bcs-1.2.0.tgz"
   integrity sha512-QdRSR0KpJ87tdjVNmM/j0+0DvE0aTxHIa02337iluaOsMqtJ8OdgUCfSyLduC/3qS+8tJE+UB1KOw55tF+sN2w==
   dependencies:
     bs58 "^6.0.0"
 
-"@iota/iota-sdk@^1.6.0":
-  version "1.6.1"
-  resolved "https://registry.npmjs.org/@iota/iota-sdk/-/iota-sdk-1.6.1.tgz"
-  integrity sha512-V7rx7m9erCn9lr4hNZVMtwmka2NsoTZ9EFSE4ZqEDO44cWdheM61+i/y5HJhvvmYAb/kkDfSmfdmzLaGTbVVYg==
+"@iota/iota-sdk@>=1.6.0 <1.11.0":
+  version "1.10.1"
+  resolved "https://registry.npmjs.org/@iota/iota-sdk/-/iota-sdk-1.10.1.tgz#49ad63c2c0dbb967f741328ca567b6a4360739a0"
+  integrity sha512-q0GxOCFzPqIcaw1lFuFljmMDj1ajIK6UZFzOYnnPqfs/nufOZrJQ9Bg/hLj23xbMno/tdND+aIjDWY6GG8MAXw==
   dependencies:
     "@graphql-typed-document-node/core" "^3.2.0"
-    "@iota/bcs" "1.2.0"
+    "@iota/bcs" "1.4.0"
     "@noble/curves" "^1.4.2"
     "@noble/hashes" "^1.4.0"
     "@scure/bip32" "^1.4.0"
@@ -3169,7 +3176,7 @@
     gql.tada "^1.8.2"
     graphql "^16.9.0"
     tweetnacl "^1.0.3"
-    valibot "^0.36.0"
+    valibot "^1.2.0"
 
 "@isaacs/balanced-match@^4.0.1":
   version "4.0.1"
@@ -20794,7 +20801,7 @@ v8-compile-cache@^2.0.3:
   resolved "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.4.0.tgz"
   integrity sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==
 
-valibot@1.2.0, valibot@^0.36.0:
+valibot@1.2.0, valibot@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz#8fc720d9e4082ba16e30a914064a39619b2f1d6f"
   integrity sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==


### PR DESCRIPTION
## Problem

`@iota/iota-sdk` raised `engines.node` from `>=20` to `>=24` in **1.11.0** — a *minor* release. Since this package declares `"@iota/iota-sdk": "^1.6.0"`, any fresh resolve now picks 1.15.x and fails engine checks on Node 20:

```
npm error code EBADENGINE
npm error engine Not compatible with your version of node/npm: @iota/iota-sdk@1.15.0
npm error notsup Required: {"node":">=24"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

The boundary is clean:

| version | `engines.node` | published |
|---|---|---|
| 1.10.0 | `>=20` | 2025-12-18 |
| 1.10.1 | `>=20` | 2026-01-08 |
| **1.11.0** | **`>=24`** | **2026-02-26** |
| 1.15.1 | `>=24` | — |

## Why this matters for BitGoJS itself

`modules/sdk-coin-iota/package.json` declares `"engines": { "node": ">=20" }`, and `.github/workflows/ci.yml` runs `node-version: [20.x, 22.x, 24.x]`. So this package claims Node 20 support that its own dependency range can silently forbid.

The Node 20 CI leg passes today **only** because `yarn.lock` happens to pin `@iota/iota-sdk` at `1.6.1`. Any lockfile refresh that re-resolves `^1.6.0` breaks it. This is latent, not hypothetical.

## Why downstream consumers can't work around it

`sdk-coin-iota` is a hard dependency of the `@bitgo/bitgo` aggregate — not `optional`, not `peer` — so every consumer inherits the constraint, including repos that never touch IOTA.

They also cannot pin it themselves. Once `@bitgo/bitgo` is bumped, npm stops hoisting `sdk-coin-iota` and vendors it under `node_modules/@bitgo/bitgo/node_modules/`, and npm `overrides` do not bind to that nested edge. Verified across npm 10.8.2 / 10.9.4 / 11.6.4 with flat, nested, deep-path and range override forms, plus a root-level hoisting pin — all still resolved 1.15.0. A control override of an ordinary transitive dependency in the same tree worked, so this is not a syntax or npm-version issue.

## The change

Cap the range below the Node-24 break. `1.10.1` is the newest release that still supports Node 20:

```diff
-  "@iota/iota-sdk": "^1.6.0",
+  "@iota/iota-sdk": ">=1.6.0 <1.11.0",
```

## What moves in the lockfile

Regenerated with `yarn install` (yarn 1.22.22). The resolved version goes to the new ceiling, and two transitive deps move **inside iota-sdk's own subtree**:

| package | before | after |
|---|---|---|
| `@iota/iota-sdk` | 1.6.1 | **1.10.1** |
| `@iota/bcs` (under iota-sdk) | 1.2.0 | 1.4.0 |
| `valibot` (under iota-sdk) | `^0.36.0` | `^1.2.0` → 1.2.0 |

`valibot@1.2.0` was already present in the tree, so that entry dedupes rather than adding a new version.

## Risk

All `@iota/iota-sdk` imports in this module are stable subpaths:

```
@iota/iota-sdk/transactions      @iota/iota-sdk/utils
@iota/iota-sdk/cryptography      @iota/iota-sdk/keypairs/ed25519
```

**Reviewer note — please confirm via CI:** I was not able to get a clean local build of this module to run its unit tests. The build fails on my checkout inside `sdk-core` (`@bitgo/secp256k1` missing `bip32utils`, `@bitgo/sdk-lib-mpc` missing `MPSComms`), and I confirmed it fails **identically on pristine `master` with this change stashed** — a stale-`dist` artifact of my local clone, unrelated to this diff. So the 1.6.1 → 1.10.1 move is not locally test-verified and should be validated by CI's Node 20/22/24 matrix.

If the four-minor jump is not wanted right now, the alternative is to keep the range fix and pin the resolution at `1.6.1`, which constrains downstream consumers with zero dependency movement here. Happy to switch to that if preferred.

## Context

Blocks `@bitgo-beta` SDK bumps in prime-microservices ([#7596](https://github.com/BitGo/prime-microservices/pull/7596) has the background). Note that prime-microservices [#7546](https://github.com/BitGo/prime-microservices/pull/7546) currently has `@iota/iota-sdk@1.15.0` baked into its lockfile as a nested copy; it will break `npm ci` for Node 20 developers if it lands before this is fixed.

TICKET: GOA-1525

🤖 Generated with [Claude Code](https://claude.com/claude-code)
