### PR TITLE
ci: add merge_group trigger to enable GitHub merge queue

### DIFF
--- a/.github/workflows/audit-api-spec.yaml
+++ b/.github/workflows/audit-api-spec.yaml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
       - rel/**
+  merge_group:
+    types: [checks_requested]
 
 env:
   STATIC_ANALYSIS_BOT_APP_ID: 1819979
@@ -16,7 +18,7 @@ jobs:
       - name: Checkout PR
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -68,13 +70,13 @@ jobs:
       - name: Checkout PR
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Find and checkout merge base
         run: |
-          git fetch origin ${{ github.event.pull_request.base.ref }}
-          MERGE_BASE=$(git merge-base HEAD origin/${{ github.event.pull_request.base.ref }})
+          git fetch origin ${{ github.event.pull_request.base.ref || 'master' }}
+          MERGE_BASE=$(git merge-base HEAD origin/${{ github.event.pull_request.base.ref || 'master' }})
           echo "Merge base commit: $MERGE_BASE"
           git checkout $MERGE_BASE
 
@@ -158,7 +160,7 @@ jobs:
       - name: Checkout PR head for ruleset
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Download head API spec artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - master
       - rel/**
+  merge_group:
+    types: [checks_requested]
 
   workflow_dispatch:
 
@@ -19,8 +21,8 @@ env:
 
 jobs:
   # Detect which file groups changed so downstream jobs can skip when irrelevant.
-  # Only runs on pull_request — on push/workflow_dispatch it is skipped, which causes
-  # downstream jobs (via `needs.changes.result == 'skipped'`) to run unconditionally.
+  # Only runs on pull_request — on push/workflow_dispatch/merge_group it is skipped,
+  # which causes downstream jobs (via `needs.changes.result == 'skipped'`) to run unconditionally.
   changes:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
@@ -66,7 +68,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Setup node:${{ matrix.node-version }}
@@ -85,7 +87,7 @@ jobs:
 
       - name: Fetch Base Ref
         run: |
-          git fetch origin $GITHUB_BASE_REF
+          git fetch origin ${GITHUB_BASE_REF:-master}
 
       - name: restore lerna dependencies
         id: lerna-cache
@@ -136,7 +138,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup node 20
         uses: actions/setup-node@v6
@@ -165,10 +167,10 @@ jobs:
         run: yarn run check-fmt
 
       - name: Lint Commit Messages
-        if: matrix.check == 'commit-lint'
+        if: matrix.check == 'commit-lint' && github.event_name != 'merge_group'
         run: |
-          git fetch --unshallow origin $GITHUB_BASE_REF
-          GITHUB_REPO_BRANCH=$GITHUB_BASE_REF yarn run check-commits
+          git fetch --unshallow origin ${GITHUB_BASE_REF:-master}
+          GITHUB_REPO_BRANCH=${GITHUB_BASE_REF:-master} yarn run check-commits
 
       - name: Check Package Dependencies
         if: matrix.check == 'dependencies'
@@ -193,7 +195,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup node 20
         uses: actions/setup-node@v6
@@ -287,7 +289,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Generate build info
         id: build-info
@@ -361,7 +363,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Verify argon2 vendor integrity
         run: modules/argon2/scripts/verify-vendor.sh
@@ -372,7 +374,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Verify all packages exist on npm
         uses: ./.github/actions/verify-npm-packages
@@ -389,7 +391,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup node 22
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

Wires up the `merge_group` event in `ci.yml` so GitHub's merge queue has CI checks to gate on before landing PRs on `master`.

- Add `merge_group: types: [checks_requested]` trigger
- Fall back to `github.sha` for checkout `ref` (PR sha is null in queue context)
- Fall back to `master` for `GITHUB_BASE_REF` when unset (merge_group context)
- Skip `commit-lint` in merge_group — commits already vetted when the PR's own CI ran

The existing `all-checks` umbrella job serves as the required status check — no new jobs needed.

## Remaining step (requires repo admin)

In **Settings → Branches → Edit rule for `master`**:
- Enable **Require merge queue**
- Strategy: `ALLGREEN`
- Required status check: `all-checks`
- Max entries to build: `2`
- Timeout: `60–120 min`

## Linear

WCI-1097