### PR TITLE
fix(root): pin sanitize-html to 2.17.5 for node 20 shrinkwrap compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,8 @@
     "js-yaml": "4.3.1",
     "ip-address": "10.4.0",
     "socket.io-parser": "4.2.7",
-    "nanoid": "3.3.17"
+    "nanoid": "3.3.17",
+    "sanitize-html": "2.17.5"
   },
   "overrides": {
     "qs": "6.15.2",
@@ -220,6 +221,7 @@
     "js-yaml": "4.3.1",
     "ip-address": "10.4.0",
     "socket.io-parser": "4.2.7",
+    "sanitize-html": "2.17.5",
     "cliui": {
       "strip-ansi": "6.0.1",
       "string-width": "4.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18509,7 +18509,7 @@ safe-stable-stringify@^2.3.1:
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sanitize-html@^2.17.4:
+sanitize-html@2.17.5, sanitize-html@^2.17.4:
   version "2.17.5"
   resolved "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.5.tgz#bef1d103773760e1c52a01b1f58178bee9c10556"
   integrity sha512-ZmU1joGRrvoyctKIiuwUxqR6moLoU2Wk+2bMccN6f7UwhAmwYDvWziqPxRDDN2Qip62NqnIrVrT9akbL6Wretg==


### PR DESCRIPTION
Pin `sanitize-html` to `2.17.5` in root `resolutions`/`overrides`. `2.17.6` requires `node >=22.12.0` and was breaking `npm install bitgo` on Node 20 with `engine-strict=true` (WCN-2091). Unblocks the release
  train.