### PR TITLE
fix(account-lib): register sepeth ETH transaction builder

### DIFF
--- a/modules/account-lib/src/index.ts
+++ b/modules/account-lib/src/index.ts
@@ -232,6 +232,7 @@ const coinBuilderMap = {
   teth: Eth.TransactionBuilder,
   gteth: Eth.TransactionBuilder,
   hteth: Eth.TransactionBuilder,
+  sepeth: Eth.TransactionBuilder,
   rbtc: Rbtc.TransactionBuilder,
   trbtc: Rbtc.TransactionBuilder,
   celo: Celo.TransactionBuilder,

--- a/modules/account-lib/test/unit/index.ts
+++ b/modules/account-lib/test/unit/index.ts
@@ -5,4 +5,11 @@ describe('Coin factory', () => {
   it('should fail to instantiate an unsupported coin', () => {
     assert.throws(() => getBuilder('fakeUnsupported'));
   });
+
+  it('should return the ETH builder for sepeth', () => {
+    const sepethBuilder = getBuilder('sepeth');
+    const htethBuilder = getBuilder('hteth');
+    assert.ok(sepethBuilder);
+    assert.strictEqual(sepethBuilder.constructor, htethBuilder.constructor);
+  });
 });


### PR DESCRIPTION
## Summary
- Registers `sepeth` (Sepolia) on the ETH `TransactionBuilder` in account-lib, same as `gteth`/`hteth`.
- Fixes staging send/sign: `getBuilder('sepeth')` was throwing `Coin sepeth not supported` (e.g. `POST /api/v2/wallet/.../txrequests/.../transactions/0/send`).

`sepeth` is `CoinFamily.ETH`, so it is not auto-registered via `SHARED_EVM_SDK`.

Ticket: [CECHO-1912](https://linear.app/bitgo/issue/CECHO-1912/sepeth-staging-send-fails-coin-sepeth-not-supported)

## Test plan
- [x] Unit test: `getBuilder('sepeth')` uses the same builder as `hteth`
- [ ] After merge, bump `@bitgo-beta/account-lib` into WP staging/test and re-try Sepolia send
- [ ] Confirm `getBuilder('sepeth')` no longer throws on staging WP


Made with [Cursor](https://cursor.com)