### PR TITLE
chore: ignore GHSA-jmr9-qjv8-65gv in osv-scanner

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -65,3 +65,7 @@ reason = "tar infinite loop via negative entry size; transitive via lerna/yeoman
 [[IgnoredVulns]]
 id = "GHSA-v2hh-gcrm-f6hx"
 reason = "fast-uri host confusion via literal backslash authority (CVE-2026-16221); fixed in 3.1.4 but that release is held for SafeChain. Pinning 3.1.3 clears GHSA-4c8g-83qw-93j6 / CVE-2026-13676. Re-evaluate on 2026-07-26: bump to 3.1.4 and remove this temporary exclusion (security team guidance, WCI-1125)"
+
+[[IgnoredVulns]]
+id = "GHSA-jmr9-qjv8-65gv"
+reason = "extract-zip unvalidated symlink path traversal on extraction (CVE-2026-56876); transitive via cypress and @puppeteer/browsers, both dev-only tooling; extracted archives are Cypress/Chromium binary release downloads from trusted sources, never untrusted user-supplied zips; no upstream fix (last_affected: 2.0.1, which is the latest release). Re-evaluate on 2026-11-13: drop this exclusion if extract-zip ships a patched release"


### PR DESCRIPTION
extract-zip 2.0.1 does not validate symlink targets during extraction (CVE-2026-56876, HIGH). It reaches us transitively through cypress and @puppeteer/browsers, both devDependencies, and both only ever extract vendor-published Cypress/Chromium binaries — never untrusted archives.

No upstream fix exists: the advisory reports last_affected 2.0.1 with no fixed event, and 2.0.1 is the latest published release. Excluded with a 2026-11-13 re-evaluation date.


Ticket: CSHLD-1470

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
