### PR TITLE
feat(statics): add ofctmon:sofid testnet OFC coin

### DIFF
--- a/modules/statics/src/coins/ofcErc20Coins.ts
+++ b/modules/statics/src/coins/ofcErc20Coins.ts
@@ -6426,6 +6426,20 @@ export const tOfcErc20Coins = [
     true,
     'mon'
   ),
+  tofcerc20(
+    '9ec5268d-74dd-4db2-8e53-f7fae33b73ee',
+    'ofctmon:sofid',
+    'Test SoFiUSD',
+    6,
+    underlyingAssetForSymbol('tmon:sofid'),
+    undefined,
+    [...OfcCoin.DEFAULT_FEATURES, CoinFeature.STABLECOIN],
+    '',
+    undefined,
+    undefined,
+    true,
+    'tmon'
+  ),
 
   // GasEVM (Neo X) tokens
   ofcerc20(


### PR DESCRIPTION
## Summary
- Adds `ofctmon:sofid` — the MON testnet OFC variant for SoFiUSD, missing alongside the existing `ofcmon:sofid` (mainnet) and `ofctpolygon:sofid` (Polygon testnet).
- Blocks usd-tokenization-service from configuring `tmon:sofid` (referenced there but not yet resolvable).

## Test plan
- [x] `yarn build` in `modules/statics`
- [x] `coins.get('ofctmon:sofid')` resolves
- [x] `yarn unit-test` in `modules/statics` passes (33905 passing)

Ticket: SCAAS-10818