### PR TITLE
chore: bump nanoid to version 3.3.18 in package.json and yarn.lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "js-yaml": "4.3.1",
     "ip-address": "10.4.0",
     "socket.io-parser": "4.2.7",
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
     "sanitize-html": "2.17.5"
   },
   "overrides": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15560,10 +15560,10 @@ nanoevents@^9.1.0:
   resolved "https://registry.npmjs.org/nanoevents/-/nanoevents-9.1.0.tgz"
   integrity sha512-Jd0fILWG44a9luj8v5kED4WI+zfkkgwKyRQKItTtlPfEsh7Lznfi1kr8/iZ+XAIss4Qq5GqRB0qtWbaz9ceO/A==
 
-nanoid@3.3.17, nanoid@^3.3.12:
-  version "3.3.17"
-  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz#f1c3aa253c52547956a52c50bff754316f61037a"
-  integrity sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==
+nanoid@3.3.18, nanoid@^3.3.12:
+  version "3.3.18"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Bump nanoid to 3.3.18 so the SDK release osv HIGH gate stops failing on GHSA-2v37-7h3g-55p8.
- Pin root `resolutions.nanoid` from 3.3.17 to 3.3.18
- Update `yarn.lock` so the tree resolves only 3.3.18
- `yarn check-deps` still passes after the pin
- OSV no longer reports GHSA-2v37-7h3g-55p8 for nanoid 3.3.18
- `@bitgo/web-demo` typecheck still passes (only consumer: postcss)
- Confirmed postcss can still process CSS with 3.3.18