### PR TITLE
fix(statics): replace dead Algorand testnet explorer URL with Pera

### DIFF
--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -224,7 +224,7 @@ class Algorand extends Mainnet implements AccountNetwork {
 class AlgorandTestnet extends Testnet implements AccountNetwork {
   name = 'AlgorandTestnet';
   family = CoinFamily.ALGO;
-  explorerUrl = 'https://explorer.bitquery.io/algorand_testnet/tx/';
+  explorerUrl = 'https://testnet.explorer.perawallet.app/tx/';
 }
 
 class Ada extends Mainnet implements AdaNetwork {

--- a/modules/statics/test/unit/resources/amsTokenConfig.ts
+++ b/modules/statics/test/unit/resources/amsTokenConfig.ts
@@ -153,7 +153,7 @@ export const amsTokenConfig = {
         type: 'testnet',
         name: 'AlgorandTestnet',
         family: 'algo',
-        explorerUrl: 'https://explorer.bitquery.io/algorand_testnet/tx/',
+        explorerUrl: 'https://testnet.explorer.perawallet.app/tx/',
       },
       primaryKeyCurve: 'ed25519',
     },


### PR DESCRIPTION
## Summary

The Algorand **testnet** explorer URL in BitGoJS statics was dead — `explorer.bitquery.io` returns HTTP 403 (Bitquery deprecated its public explorer pages for a GraphQL API product). This broke talgo transaction links in the BitGo UI/API. Replaced with the Pera Explorer (AlgoExplorer's official successor).

## Changes

- `modules/statics/src/networks.ts` — `AlgorandTestnet.explorerUrl`: `https://explorer.bitquery.io/algorand_testnet/tx/` → `https://testnet.explorer.perawallet.app/tx/`
- `modules/statics/test/unit/resources/amsTokenConfig.ts` — updated the matching `talgo:JPT-162085446` fixture, since the `create a valid token map from AmsTokenConfig` unit test asserts `JSON.stringify` equality between the AMS-config network and the static coin-map network.

## Scope

**Testnet only.** Mainnet (`https://allo.info/tx/`) still returns HTTP 200 and is left unchanged.

## Verification

- Probed both URLs: `explorer.bitquery.io` → **HTTP 403** (root domain too, even with a browser UA); `allo.info` → HTTP 200.
- `https://testnet.explorer.perawallet.app/tx/<txid>/` resolves in a browser to the correct transaction page (verified against a real testnet tx, Kalki asset 16026733, round 66303443).
- Pera returns 403 to curl (Cloudflare bot wall) but renders correctly in a real browser — sufficient for user-facing links.
- lint-staged (prettier + eslint) and commitlint passed locally.

## Linear

https://linear.app/bitgo/issue/CSHLD-1491/fixstatics-replace-dead-algorand-testnet-explorer-url-with-pera

🤖 Generated with [Claude Code](https://claude.com/claude-code)