### PR TITLE
fix: batch bulkAcceptShare 

### DIFF
--- a/modules/sdk-core/src/bitgo/wallet/wallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallets.ts
@@ -1308,67 +1308,76 @@ export class Wallets implements IWallets {
     });
     const newWalletPassphrase = params.newWalletPassphrase || params.userLoginPassword;
     const webauthnInfo = params.webauthnInfo;
-    const keysForWalletShares = (
-      await Promise.all(
-        walletShares.map(async (walletShare) => {
-          // Handle userMultiKeyRotationRequired case - these shares don't have keychains
-          if (walletShare.userMultiKeyRotationRequired) {
-            if (!params.userLoginPassword) {
-              throw new Error('userLoginPassword param must be provided to generate user keychain');
-            }
-            const walletKeychain = this.baseCoin.keychains().create();
-            const encryptedPrv = await this.bitgo.encrypt({
-              password: newWalletPassphrase,
-              input: walletKeychain.prv,
-              encryptionVersion: params.encryptionVersion,
-            });
-            return [
-              {
-                walletShareId: walletShare.id,
-                encryptedPrv: encryptedPrv,
-                pub: walletKeychain.pub,
-              },
-            ];
-          }
 
-          // Standard case: shares with keychains
-          if (!walletShare.keychain) {
-            return [];
-          }
-          const secret = getSharedSecret(
-            bip32.fromBase58(sharingKeychain.prv).derivePath(sanitizeLegacyPath(walletShare.keychain.path)),
-            Buffer.from(walletShare.keychain.fromPubKey, 'hex')
-          ).toString('hex');
+    // Each decrypt/encrypt call runs Argon2id inside a WebAssembly instance that reserves ~2 GiB of
+    // virtual address space. Running all shares concurrently via Promise.all exhausts the browser's
+    // WASM memory at scale (e.g. 96 wallets). Process in small batches so only a bounded number of
+    // WASM instances are alive at once.
+    const BATCH_SIZE = 16;
 
-          const decryptedSharedWalletPrv = await this.bitgo.decrypt({
-            password: secret,
-            input: walletShare.keychain.encryptedPrv,
-          });
-          const newEncryptedPrv = await this.bitgo.encrypt({
-            password: newWalletPassphrase,
+    const processShare = async (walletShare: WalletShare): Promise<AcceptShareOptionsRequest[]> => {
+      // Handle userMultiKeyRotationRequired case - these shares don't have keychains
+      if (walletShare.userMultiKeyRotationRequired) {
+        if (!params.userLoginPassword) {
+          throw new Error('userLoginPassword param must be provided to generate user keychain');
+        }
+        const walletKeychain = this.baseCoin.keychains().create();
+        const encryptedPrv = await this.bitgo.encrypt({
+          password: newWalletPassphrase,
+          input: walletKeychain.prv,
+          encryptionVersion: params.encryptionVersion,
+        });
+        return [
+          {
+            walletShareId: walletShare.id,
+            encryptedPrv: encryptedPrv,
+            pub: walletKeychain.pub,
+          },
+        ];
+      }
+
+      // Standard case: shares with keychains
+      if (!walletShare.keychain) {
+        return [];
+      }
+      const secret = getSharedSecret(
+        bip32.fromBase58(sharingKeychain.prv).derivePath(sanitizeLegacyPath(walletShare.keychain.path)),
+        Buffer.from(walletShare.keychain.fromPubKey, 'hex')
+      ).toString('hex');
+
+      const decryptedSharedWalletPrv = await this.bitgo.decrypt({
+        password: secret,
+        input: walletShare.keychain.encryptedPrv,
+      });
+      const newEncryptedPrv = await this.bitgo.encrypt({
+        password: newWalletPassphrase,
+        input: decryptedSharedWalletPrv,
+        encryptionVersion: params.encryptionVersion,
+      });
+      const entry: AcceptShareOptionsRequest = {
+        walletShareId: walletShare.id,
+        encryptedPrv: newEncryptedPrv,
+      };
+      if (webauthnInfo) {
+        entry.webauthnInfo = {
+          otpDeviceId: webauthnInfo.otpDeviceId,
+          prfSalt: webauthnInfo.prfSalt,
+          encryptedPrv: await this.bitgo.encrypt({
+            password: webauthnInfo.passphrase,
             input: decryptedSharedWalletPrv,
             encryptionVersion: params.encryptionVersion,
-          });
-          const entry: AcceptShareOptionsRequest = {
-            walletShareId: walletShare.id,
-            encryptedPrv: newEncryptedPrv,
-          };
-          if (webauthnInfo) {
-            entry.webauthnInfo = {
-              otpDeviceId: webauthnInfo.otpDeviceId,
-              prfSalt: webauthnInfo.prfSalt,
-              encryptedPrv: await this.bitgo.encrypt({
-                password: webauthnInfo.passphrase,
-                input: decryptedSharedWalletPrv,
-                encryptionVersion: params.encryptionVersion,
-                adata: walletShare.enterprise,
-              }),
-            };
-          }
-          return [entry];
-        })
-      )
-    ).flat();
+            adata: walletShare.enterprise,
+          }),
+        };
+      }
+      return [entry];
+    };
+
+    const keysForWalletShares: AcceptShareOptionsRequest[] = [];
+    for (const batch of _.chunk(walletShares, BATCH_SIZE)) {
+      const batchResults = await Promise.all(batch.map((walletShare) => processShare(walletShare)));
+      keysForWalletShares.push(...batchResults.flat());
+    }
 
     return this.bulkAcceptShareRequest(keysForWalletShares);
   }

--- a/modules/sdk-core/test/unit/bitgo/wallet/walletsEncryptionVersion.ts
+++ b/modules/sdk-core/test/unit/bitgo/wallet/walletsEncryptionVersion.ts
@@ -135,6 +135,59 @@ describe('Wallets - encryptionVersion threading', function () {
       const call = mockBitGo.encrypt.firstCall;
       assert.strictEqual(call.args[0].encryptionVersion, undefined);
     });
+
+    it('processes shares in batches of 16 to avoid WASM memory exhaustion', async function () {
+      // 20 shares → 2 batches (16 + 4), verifying the batch boundary is crossed
+      const manyShares = Array.from({ length: 20 }, (_, i) => ({
+        id: `share-${i}`,
+        userMultiKeyRotationRequired: true,
+        keychain: null,
+        permissions: ['spend'],
+      }));
+      mockBitGo.get.returns({
+        result: sinon.stub().resolves({ incoming: manyShares, outgoing: [] }),
+      });
+
+      await wallets.bulkAcceptShare({
+        walletShareIds: manyShares.map((s) => s.id),
+        userLoginPassword: 'login-password',
+      });
+
+      // All 20 shares should have been encrypted (one encrypt call per share)
+      assert.strictEqual(mockBitGo.encrypt.callCount, 20);
+    });
+
+    it('never runs more than 16 shares concurrently', async function () {
+      let inFlight = 0;
+      let maxInFlight = 0;
+
+      mockBitGo.encrypt.callsFake(() => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        return Promise.resolve('encrypted').then((r) => {
+          inFlight--;
+          return r;
+        });
+      });
+
+      const manyShares = Array.from({ length: 20 }, (_, i) => ({
+        id: `share-${i}`,
+        userMultiKeyRotationRequired: true,
+        keychain: null,
+        permissions: ['spend'],
+      }));
+      mockBitGo.get.returns({
+        result: sinon.stub().resolves({ incoming: manyShares, outgoing: [] }),
+      });
+
+      await wallets.bulkAcceptShare({
+        walletShareIds: manyShares.map((s) => s.id),
+        userLoginPassword: 'login-password',
+      });
+
+      assert.ok(maxInFlight <= 16, `expected max concurrency <= 16, got ${maxInFlight}`);
+      assert.strictEqual(mockBitGo.encrypt.callCount, 20);
+    });
   });
 
   describe('Wallet.shareWallet / createBulkWalletShare', function () {


### PR DESCRIPTION
# fix(sdk-core): batch bulkAcceptShare to prevent WASM OOM in browser

## Problem

Users with a large number of shared wallets (e.g. 96) get the following error when clicking "Accept Keys" in Kintsugi:

```
RangeError: WebAssembly.instantiate(): Out of memory: Cannot allocate Wasm memory for new instance
```

**Root cause:** `bulkAcceptShare` decrypts each wallet's shared keychain using Argon2id — a WASM-based KDF. Each `decrypt` call creates a fresh `WebAssembly.Instance` that commits ~64 MB of real memory and reserves ~2 GB of virtual address space. With `Promise.all` launching all shares simultaneously, a user with 96 wallets triggers ~192 concurrent WASM instances (decrypt + re-encrypt per share) — exhausting the browser tab's virtual address space (~256 GB on V8) and crashing.

This was introduced in WCN-174 (`feat: make encrypt/decrypt async`) when the original sequential `flatMap` loop was converted to `Promise.all` to handle the newly async encrypt/decrypt calls, without accounting for the per-call WASM memory cost.

**Before (broken):**
```ts
// All 96 shares run simultaneously — up to 192 WASM instances at once
const keysForWalletShares = (
  await Promise.all(
    walletShares.map(async (walletShare) => {
      const decryptedPrv = await this.bitgo.decrypt(...)  // new WASM instance per call
      const newEncryptedPrv = await this.bitgo.encrypt(...)  // another WASM instance
      ...
    })
  )
).flat();
```

## Fix

Process shares in batches of 16. At most 32 WASM instances are alive at once (~2 GB real, ~64 GB virtual), well within browser limits.

**Batch size rationale:** Benchmarking shows a Chrome tab on a modern machine hits OOM at ~124 concurrent WASM instances (~248 GB virtual). A typical 8–16 GB machine under normal browser load has a lower effective ceiling. `BATCH_SIZE = 16` → 32 concurrent instances → ~2 GB RAM committed — safe across devices while being 4× faster than a conservative batch of 4.

**After:**
```ts
const BATCH_SIZE = 16;
const keysForWalletShares: AcceptShareOptionsRequest[] = [];
for (const batch of _.chunk(walletShares, BATCH_SIZE)) {
  const batchResults = await Promise.all(batch.map((walletShare) => processShare(walletShare)));
  keysForWalletShares.push(...batchResults.flat());
}
```

Per-share logic is **identical** — no behaviour change for any individual share, no API changes.

## Performance impact

For 96 wallets: 6 batches × ~3s per batch ≈ **~18s** vs. a crash. Acceptable for a one-time accept-keys action. Previously when the flow was synchronous (before WCN-174), latency was similar — the async conversion didn't reduce total time for a single user, it just introduced the concurrency bug.

## Testing

- Existing `encryptionVersion` threading tests continue to pass
- Added test asserting all 20 shares are processed when count exceeds `BATCH_SIZE`
- Added concurrency test asserting max in-flight encrypt calls never exceeds 16

## Related

- Bug introduced: WCN-174
- Reported via: Bullish (GI) Limited — user with 96 wallets unable to accept keyshares
