### PR TITLE
[SDK] buildFinalizeUnwrapCalldata + FinalizeUnwrapERC7984 explain/verify

### DIFF
--- a/modules/abstract-eth/src/lib/iface.ts
+++ b/modules/abstract-eth/src/lib/iface.ts
@@ -188,3 +188,14 @@ export interface UnwrapERC7984Data {
   /** Encryption input proof */
   inputProof: string;
 }
+
+export interface FinalizeUnwrapERC7984Data {
+  /** Confidential wrapper contract (tx.to) */
+  wrapperAddress: string;
+  /** bytes32 unwrap request id from phase-1 */
+  requestId: string;
+  /** Cleartext confidential amount released (uint64 domain, decimal string) */
+  cleartextAmount: string;
+  /** Zama decryption proof bytes */
+  decryptionProof: string;
+}

--- a/modules/abstract-eth/src/lib/transactionBuilder.ts
+++ b/modules/abstract-eth/src/lib/transactionBuilder.ts
@@ -28,6 +28,7 @@ import {
   TxData,
   WrapERC7984Data,
   UnwrapERC7984Data,
+  FinalizeUnwrapERC7984Data,
 } from './iface';
 import {
   calculateForwarderAddress,
@@ -40,6 +41,7 @@ import {
   decodeFlushERC7984ForwarderTokenData,
   decodeWrapERC7984Data,
   decodeUnwrapERC7984Data,
+  decodeFinalizeUnwrapERC7984Data,
   decodeWalletCreationData,
   flushCoinsData,
   flushTokensData,
@@ -53,7 +55,12 @@ import {
   getV1WalletInitializationData,
   getCreateForwarderParamsAndTypes,
 } from './utils';
-import { buildFlushERC7984ForwarderTokenCalldata, buildWrapCalldata, buildUnwrapCalldata } from './zamaUtils';
+import {
+  buildFlushERC7984ForwarderTokenCalldata,
+  buildWrapCalldata,
+  buildUnwrapCalldata,
+  buildFinalizeUnwrapCalldata,
+} from './zamaUtils';
 import { defaultWalletVersion, walletSimpleConstructor } from './walletUtil';
 import { ERC1155TransferBuilder } from './transferBuilders/transferBuilderERC1155';
 import { ERC721TransferBuilder } from './transferBuilders/transferBuilderERC721';
@@ -104,6 +111,11 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
   private _unwrapTo: string;
   private _unwrapEncryptedAmount: string;
   private _unwrapInputProof: string;
+
+  // FinalizeUnwrapERC7984 parameters
+  private _finalizeUnwrapRequestId: string;
+  private _finalizeUnwrapCleartextAmount: string;
+  private _finalizeUnwrapDecryptionProof: string;
 
   // Send and AddressInitialization transaction specific parameters
   protected _transfer: TransferBuilder | ERC721TransferBuilder | ERC1155TransferBuilder | TransferBuilderERC7984;
@@ -195,6 +207,8 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
         return this.buildWrapERC7984Transaction();
       case TransactionType.UnwrapERC7984:
         return this.buildUnwrapERC7984Transaction();
+      case TransactionType.FinalizeUnwrapERC7984:
+        return this.buildFinalizeUnwrapERC7984Transaction();
       default:
         throw new BuildTransactionError('Unsupported transaction type');
     }
@@ -364,6 +378,17 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
         this.unwrapTo(unwrapData.to);
         this.unwrapEncryptedAmount(unwrapData.encryptedAmount);
         this.unwrapInputProof(unwrapData.inputProof);
+        break;
+      }
+      case TransactionType.FinalizeUnwrapERC7984: {
+        this.setContract(transactionJson.to);
+        const finalizeData: FinalizeUnwrapERC7984Data = decodeFinalizeUnwrapERC7984Data(
+          transactionJson.data,
+          transactionJson.to!
+        );
+        this.finalizeUnwrapRequestId(finalizeData.requestId);
+        this.finalizeUnwrapCleartextAmount(finalizeData.cleartextAmount);
+        this.finalizeUnwrapDecryptionProof(finalizeData.decryptionProof);
         break;
       }
       default:
@@ -536,6 +561,12 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
         this.validateUnwrapEncryptedAmount();
         this.validateUnwrapInputProof();
         break;
+      case TransactionType.FinalizeUnwrapERC7984:
+        this.validateContractAddress();
+        this.validateFinalizeUnwrapRequestId();
+        this.validateFinalizeUnwrapCleartextAmount();
+        this.validateFinalizeUnwrapDecryptionProof();
+        break;
       default:
         throw new BuildTransactionError('Unsupported transaction type');
     }
@@ -652,6 +683,24 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
   private validateUnwrapInputProof(): void {
     if (!this._unwrapInputProof) {
       throw new BuildTransactionError('Invalid transaction: missing unwrapInputProof');
+    }
+  }
+
+  private validateFinalizeUnwrapRequestId(): void {
+    if (!this._finalizeUnwrapRequestId) {
+      throw new BuildTransactionError('Invalid transaction: missing finalizeUnwrapRequestId');
+    }
+  }
+
+  private validateFinalizeUnwrapCleartextAmount(): void {
+    if (!this._finalizeUnwrapCleartextAmount) {
+      throw new BuildTransactionError('Invalid transaction: missing finalizeUnwrapCleartextAmount');
+    }
+  }
+
+  private validateFinalizeUnwrapDecryptionProof(): void {
+    if (!this._finalizeUnwrapDecryptionProof) {
+      throw new BuildTransactionError('Invalid transaction: missing finalizeUnwrapDecryptionProof');
     }
   }
 
@@ -1269,6 +1318,44 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
       this._unwrapTo,
       this._unwrapEncryptedAmount,
       this._unwrapInputProof
+    );
+    return this.buildBase(data);
+  }
+
+  // endregion
+
+  // region FinalizeUnwrapERC7984 builder methods
+
+  /**
+   * Set the bytes32 unwrap request id for finalizeUnwrap.
+   */
+  finalizeUnwrapRequestId(requestId: string): void {
+    this._finalizeUnwrapRequestId = requestId;
+  }
+
+  /**
+   * Set the cleartext (decrypted) amount for finalizeUnwrap.
+   */
+  finalizeUnwrapCleartextAmount(cleartextAmount: string): void {
+    this._finalizeUnwrapCleartextAmount = cleartextAmount;
+  }
+
+  /**
+   * Set the oracle decryption proof for finalizeUnwrap.
+   */
+  finalizeUnwrapDecryptionProof(decryptionProof: string): void {
+    this._finalizeUnwrapDecryptionProof = decryptionProof;
+  }
+
+  /**
+   * Build a FinalizeUnwrapERC7984 (unshield phase-2) transaction.
+   * Does not set gasLimit — WP owns gas.
+   */
+  private buildFinalizeUnwrapERC7984Transaction(): TxData {
+    const data = buildFinalizeUnwrapCalldata(
+      this._finalizeUnwrapRequestId,
+      this._finalizeUnwrapCleartextAmount,
+      this._finalizeUnwrapDecryptionProof
     );
     return this.buildBase(data);
   }

--- a/modules/abstract-eth/src/lib/utils.ts
+++ b/modules/abstract-eth/src/lib/utils.ts
@@ -44,6 +44,7 @@ import {
   ForwarderInitializationData,
   WrapERC7984Data,
   UnwrapERC7984Data,
+  FinalizeUnwrapERC7984Data,
 } from './iface';
 import { KeyPair } from './keyPair';
 import {
@@ -97,9 +98,11 @@ import {
   decodeFlushERC7984ForwarderTokenCalldata,
   decodeWrapCalldata,
   decodeUnwrapCalldata,
+  decodeFinalizeUnwrapCalldata,
   delegateForUserDecryptionMethodId,
   wrapMethodId,
   unwrapMethodId,
+  finalizeUnwrapMethodId,
 } from './zamaUtils';
 
 /**
@@ -869,6 +872,22 @@ export function decodeUnwrapERC7984Data(data: string, to: string): UnwrapERC7984
 }
 
 /**
+ * Decode a FinalizeUnwrapERC7984 transaction's calldata into its component parts.
+ *
+ * @param data The finalizeUnwrap(bytes32,uint64,bytes) calldata hex
+ * @param to   The transaction `to` field (wrapper contract address)
+ */
+export function decodeFinalizeUnwrapERC7984Data(data: string, to: string): FinalizeUnwrapERC7984Data {
+  const decoded = decodeFinalizeUnwrapCalldata(data);
+  return {
+    wrapperAddress: to,
+    requestId: decoded.requestId,
+    cleartextAmount: decoded.cleartextAmount,
+    decryptionProof: decoded.decryptionProof,
+  };
+}
+
+/**
  * Classify the given transaction data based as a transaction type.
  * ETH transactions are defined by the first 8 bytes of the transaction data, also known as the method id
  *
@@ -955,6 +974,7 @@ const transactionTypesMap = {
   [delegateForUserDecryptionMethodId]: TransactionType.DecryptionDelegation,
   [wrapMethodId]: TransactionType.WrapERC7984,
   [unwrapMethodId]: TransactionType.UnwrapERC7984,
+  [finalizeUnwrapMethodId]: TransactionType.FinalizeUnwrapERC7984,
 };
 
 /**

--- a/modules/abstract-eth/src/lib/zamaUtils.ts
+++ b/modules/abstract-eth/src/lib/zamaUtils.ts
@@ -14,6 +14,7 @@ export const aclMulticallTypes = ['bytes[]'] as const;
 export const approveTypes = ['address', 'uint256'] as const;
 export const wrapTypes = ['address', 'uint256'] as const;
 export const unwrapTypes = ['address', 'address', 'bytes32', 'bytes'] as const;
+export const finalizeUnwrapTypes = ['bytes32', 'uint64', 'bytes'] as const;
 
 /** Max value for Solidity `uint64` / ERC-7984 confidential amount domain (`euint64`). */
 export const UINT64_MAX = 18446744073709551615n;
@@ -62,6 +63,15 @@ export const wrapMethodId = addHexPrefix(EthereumAbi.methodID('wrap', [...wrapTy
  * Burns confidential balance and requests release of underlying ERC-20 escrow.
  */
 export const unwrapMethodId = addHexPrefix(EthereumAbi.methodID('unwrap', [...unwrapTypes]).toString('hex'));
+
+/**
+ * Function selector for ERC-7984 finalizeUnwrap(bytes32,uint64,bytes)
+ * = keccak256('finalizeUnwrap(bytes32,uint64,bytes)')[0:4]
+ * Completes unshield after oracle decryption of the phase-1 unwrap request.
+ */
+export const finalizeUnwrapMethodId = addHexPrefix(
+  EthereumAbi.methodID('finalizeUnwrap', [...finalizeUnwrapTypes]).toString('hex')
+);
 
 // ---------------------------------------------------------------------------
 // Encoding functions
@@ -269,6 +279,84 @@ export function decodeUnwrapCalldata(data: string): {
     to: ethers.utils.getAddress(decoded[1]),
     encryptedAmount: ethers.utils.hexlify(decoded[2]),
     inputProof: ethers.utils.hexlify(decoded[3]),
+  };
+}
+
+/**
+ * Encodes ERC-7984 `finalizeUnwrap(requestId, cleartextAmount, decryptionProof)` calldata.
+ *
+ * Calldata is sent to the confidential wrapper to complete unshield phase-2 after
+ * the Zama oracle returns a cleartext amount and decryption proof for the unwrap
+ * request created in phase-1.
+ *
+ * Does not set gasLimit — WP owns gas.
+ *
+ * @param requestId         bytes32 unwrap request id (0x-prefixed)
+ * @param cleartextAmount   Decrypted confidential amount (uint64 domain); must be > 0
+ * @param decryptionProof   Oracle decryption proof bytes (0x-prefixed)
+ * @returns ABI-encoded calldata hex string (0x-prefixed)
+ * @throws {Error} if requestId, amount, or proof is invalid
+ */
+export function buildFinalizeUnwrapCalldata(
+  requestId: string,
+  cleartextAmount: string | number | bigint,
+  decryptionProof: string
+): string {
+  if (!ethers.utils.isHexString(requestId) || ethers.utils.hexDataLength(requestId) !== 32) {
+    throw new Error(`buildFinalizeUnwrapCalldata: requestId must be a 32-byte hex string, got '${requestId}'`);
+  }
+
+  let amountBn: bigint;
+  try {
+    amountBn = typeof cleartextAmount === 'bigint' ? cleartextAmount : BigInt(cleartextAmount);
+  } catch {
+    throw new Error(`buildFinalizeUnwrapCalldata: invalid cleartextAmount '${cleartextAmount}'`);
+  }
+  if (amountBn <= 0n) {
+    throw new Error('buildFinalizeUnwrapCalldata: cleartextAmount must be > 0');
+  }
+  if (amountBn > UINT64_MAX) {
+    throw new Error('buildFinalizeUnwrapCalldata: cleartextAmount exceeds uint64');
+  }
+
+  if (!ethers.utils.isHexString(decryptionProof) || ethers.utils.hexDataLength(decryptionProof) === 0) {
+    throw new Error(
+      `buildFinalizeUnwrapCalldata: decryptionProof must be a non-empty hex string, got '${decryptionProof}'`
+    );
+  }
+
+  const method = EthereumAbi.methodID('finalizeUnwrap', [...finalizeUnwrapTypes]);
+  const args = EthereumAbi.rawEncode(
+    [...finalizeUnwrapTypes],
+    [toBuffer(requestId), amountBn.toString(), toBuffer(decryptionProof)]
+  );
+  return addHexPrefix(Buffer.concat([method, args]).toString('hex'));
+}
+
+/**
+ * Decodes ERC-7984 `finalizeUnwrap(requestId, cleartextAmount, decryptionProof)` calldata.
+ *
+ * @param data ABI-encoded finalizeUnwrap calldata (0x-prefixed)
+ */
+export function decodeFinalizeUnwrapCalldata(data: string): {
+  requestId: string;
+  cleartextAmount: string;
+  decryptionProof: string;
+} {
+  if (!data.toLowerCase().startsWith(finalizeUnwrapMethodId.toLowerCase())) {
+    throw new Error(
+      `decodeFinalizeUnwrapCalldata: expected finalizeUnwrap selector ${finalizeUnwrapMethodId}, got ${data.slice(
+        0,
+        10
+      )}`
+    );
+  }
+  const abiCoder = new ethers.utils.AbiCoder();
+  const decoded = abiCoder.decode([...finalizeUnwrapTypes], '0x' + data.slice(10));
+  return {
+    requestId: ethers.utils.hexlify(decoded[0]),
+    cleartextAmount: decoded[1].toString(),
+    decryptionProof: ethers.utils.hexlify(decoded[2]),
   };
 }
 

--- a/modules/abstract-eth/test/unit/transactionBuilder/finalizeUnwrapERC7984.ts
+++ b/modules/abstract-eth/test/unit/transactionBuilder/finalizeUnwrapERC7984.ts
@@ -1,0 +1,148 @@
+/**
+ * TransactionBuilder tests for FinalizeUnwrapERC7984 transaction type.
+ */
+import { TransactionType } from '@bitgo/sdk-core';
+import should from 'should';
+import { ETHTransactionType, TransactionBuilder } from '../../../src';
+import {
+  buildFinalizeUnwrapCalldata,
+  decodeFinalizeUnwrapCalldata,
+  finalizeUnwrapMethodId,
+} from '../../../src/lib/zamaUtils';
+import { classifyTransaction } from '../../../src/lib/utils';
+
+const WRAPPER_ADDRESS = '0x2debbe0487ef921df4457f9e36ed05be2df1ac75'; // hteth:cusdt
+const REQUEST_ID = '0x' + '11'.repeat(32);
+const CLEARTEXT_AMOUNT = '1000000';
+const DECRYPTION_PROOF = '0x' + 'ee'.repeat(64);
+const TEST_PRV_KEY = 'FAC4D04AA0025ECF200D74BC9B5E4616E4B8338B69B61362AAAD49F76E68EF28';
+
+export function runFinalizeUnwrapERC7984Tests(
+  coinName: string,
+  getBuilder: (coin: string) => TransactionBuilder
+): void {
+  describe(`${coinName} transaction builder — FinalizeUnwrapERC7984`, () => {
+    let txBuilder: TransactionBuilder;
+
+    beforeEach(() => {
+      txBuilder = getBuilder(coinName);
+      txBuilder.fee({ fee: '1000000000', gasLimit: '200000' });
+      txBuilder.counter(1);
+    });
+
+    describe('classifyTransaction', () => {
+      it('should classify finalizeUnwrap(...) as FinalizeUnwrapERC7984', () => {
+        const calldata = buildFinalizeUnwrapCalldata(REQUEST_ID, CLEARTEXT_AMOUNT, DECRYPTION_PROOF);
+        should.equal(classifyTransaction(calldata), TransactionType.FinalizeUnwrapERC7984);
+      });
+
+      it('should NOT classify approve as FinalizeUnwrapERC7984', () => {
+        should.equal(classifyTransaction('0x095ea7b3' + '00'.repeat(64)), TransactionType.ContractCall);
+      });
+    });
+
+    describe('build from scratch', () => {
+      it('should build a FinalizeUnwrapERC7984 transaction', async () => {
+        txBuilder.type(TransactionType.FinalizeUnwrapERC7984);
+        txBuilder.contract(WRAPPER_ADDRESS);
+        txBuilder.finalizeUnwrapRequestId(REQUEST_ID);
+        txBuilder.finalizeUnwrapCleartextAmount(CLEARTEXT_AMOUNT);
+        txBuilder.finalizeUnwrapDecryptionProof(DECRYPTION_PROOF);
+
+        const tx = await txBuilder.build();
+        const json = tx.toJson();
+
+        should.equal(tx.type, TransactionType.FinalizeUnwrapERC7984);
+        json.to.toLowerCase().should.equal(WRAPPER_ADDRESS.toLowerCase());
+        json.data.should.startWith(finalizeUnwrapMethodId);
+        json.value.should.equal('0');
+
+        const decoded = decodeFinalizeUnwrapCalldata(json.data);
+        decoded.requestId.should.equal(REQUEST_ID);
+        decoded.cleartextAmount.should.equal(CLEARTEXT_AMOUNT);
+        decoded.decryptionProof.should.equal(DECRYPTION_PROOF);
+      });
+
+      it('should build with EIP-1559 fee model', async () => {
+        const builder = getBuilder(coinName);
+        builder.fee({
+          fee: '30000000000',
+          eip1559: {
+            maxFeePerGas: '30000000000',
+            maxPriorityFeePerGas: '1000000000',
+          },
+          gasLimit: '200000',
+        });
+        builder.counter(1);
+        builder.type(TransactionType.FinalizeUnwrapERC7984);
+        builder.contract(WRAPPER_ADDRESS);
+        builder.finalizeUnwrapRequestId(REQUEST_ID);
+        builder.finalizeUnwrapCleartextAmount(CLEARTEXT_AMOUNT);
+        builder.finalizeUnwrapDecryptionProof(DECRYPTION_PROOF);
+
+        const tx = await builder.build();
+        const json = tx.toJson();
+
+        should.equal(tx.type, TransactionType.FinalizeUnwrapERC7984);
+        json._type.should.equal(ETHTransactionType.EIP1559);
+        json.data.should.startWith(finalizeUnwrapMethodId);
+      });
+    });
+
+    describe('signing and round-trip', () => {
+      it('should produce a signed transaction with v, r, s and from fields', async () => {
+        txBuilder.type(TransactionType.FinalizeUnwrapERC7984);
+        txBuilder.contract(WRAPPER_ADDRESS);
+        txBuilder.finalizeUnwrapRequestId(REQUEST_ID);
+        txBuilder.finalizeUnwrapCleartextAmount(CLEARTEXT_AMOUNT);
+        txBuilder.finalizeUnwrapDecryptionProof(DECRYPTION_PROOF);
+        txBuilder.sign({ key: TEST_PRV_KEY });
+
+        const tx = await txBuilder.build();
+        const json = tx.toJson();
+
+        should.exist(json.v);
+        should.exist(json.r);
+        should.exist(json.s);
+        should.exist(json.from);
+        should.equal(tx.type, TransactionType.FinalizeUnwrapERC7984);
+      });
+
+      it('should serialize and deserialize to the same transaction', async () => {
+        txBuilder.type(TransactionType.FinalizeUnwrapERC7984);
+        txBuilder.contract(WRAPPER_ADDRESS);
+        txBuilder.finalizeUnwrapRequestId(REQUEST_ID);
+        txBuilder.finalizeUnwrapCleartextAmount(CLEARTEXT_AMOUNT);
+        txBuilder.finalizeUnwrapDecryptionProof(DECRYPTION_PROOF);
+
+        const originalTx = await txBuilder.build();
+        const rawHex = originalTx.toBroadcastFormat();
+
+        const rebuiltBuilder = getBuilder(coinName);
+        rebuiltBuilder.from(rawHex);
+        const rebuiltTx = await rebuiltBuilder.build();
+
+        rebuiltTx.toBroadcastFormat().should.equal(rawHex);
+        should.equal(rebuiltTx.type, TransactionType.FinalizeUnwrapERC7984);
+      });
+    });
+
+    describe('validation', () => {
+      it('should reject missing finalizeUnwrapRequestId', async () => {
+        txBuilder.type(TransactionType.FinalizeUnwrapERC7984);
+        txBuilder.contract(WRAPPER_ADDRESS);
+        txBuilder.finalizeUnwrapCleartextAmount(CLEARTEXT_AMOUNT);
+        txBuilder.finalizeUnwrapDecryptionProof(DECRYPTION_PROOF);
+        await txBuilder.build().should.be.rejectedWith(/missing finalizeUnwrapRequestId/);
+      });
+
+      it('should reject missing finalizeUnwrapCleartextAmount', async () => {
+        txBuilder.type(TransactionType.FinalizeUnwrapERC7984);
+        txBuilder.contract(WRAPPER_ADDRESS);
+        txBuilder.finalizeUnwrapRequestId(REQUEST_ID);
+        txBuilder.finalizeUnwrapDecryptionProof(DECRYPTION_PROOF);
+        await txBuilder.build().should.be.rejectedWith(/missing finalizeUnwrapCleartextAmount/);
+      });
+    });
+  });
+}

--- a/modules/abstract-eth/test/unit/transactionBuilder/index.ts
+++ b/modules/abstract-eth/test/unit/transactionBuilder/index.ts
@@ -6,3 +6,4 @@ export * from './decryptionDelegation';
 export * from './flushERC7984';
 export * from './wrapERC7984';
 export * from './unwrapERC7984';
+export * from './finalizeUnwrapERC7984';

--- a/modules/abstract-eth/test/unit/zamaUtils.ts
+++ b/modules/abstract-eth/test/unit/zamaUtils.ts
@@ -6,6 +6,8 @@ import {
   decodeWrapCalldata,
   buildUnwrapCalldata,
   decodeUnwrapCalldata,
+  buildFinalizeUnwrapCalldata,
+  decodeFinalizeUnwrapCalldata,
   buildDelegationCalldata,
   buildMulticallDelegationCalldata,
   buildConfidentialTransferByHandleCalldata,
@@ -16,6 +18,7 @@ import {
   wrapMethodId,
   UINT64_MAX,
   unwrapMethodId,
+  finalizeUnwrapMethodId,
   delegateForUserDecryptionMethodId,
   aclMulticallMethodId,
   callFromParentMethodId,
@@ -66,6 +69,10 @@ describe('Zama Utils', () => {
       unwrapMethodId.should.equal('0x5bf4ef06');
     });
 
+    it('should have correct selector for finalizeUnwrap(bytes32,uint64,bytes)', () => {
+      finalizeUnwrapMethodId.should.equal('0x5bb67a05');
+    });
+
     it('method IDs should all be distinct', () => {
       const ids = new Set([
         delegateForUserDecryptionMethodId,
@@ -74,8 +81,9 @@ describe('Zama Utils', () => {
         approveMethodId,
         wrapMethodId,
         unwrapMethodId,
+        finalizeUnwrapMethodId,
       ]);
-      ids.size.should.equal(6);
+      ids.size.should.equal(7);
     });
   });
 
@@ -293,6 +301,60 @@ describe('Zama Utils', () => {
 
       it('should reject an empty inputProof', () => {
         (() => buildUnwrapCalldata(FROM, TO, ENCRYPTED_AMOUNT, '0x')).should.throw(/inputProof must be a non-empty/);
+      });
+    });
+  });
+
+  describe('buildFinalizeUnwrapCalldata', () => {
+    const REQUEST_ID = '0x' + '11'.repeat(32);
+    const CLEARTEXT_AMOUNT = '1000000';
+    const DECRYPTION_PROOF = '0x' + 'ee'.repeat(64);
+
+    describe('output format', () => {
+      it('should produce a 0x-prefixed hex string starting with finalizeUnwrap selector', () => {
+        const calldata = buildFinalizeUnwrapCalldata(REQUEST_ID, CLEARTEXT_AMOUNT, DECRYPTION_PROOF);
+        calldata.should.be.a.String();
+        calldata.should.startWith(finalizeUnwrapMethodId);
+        calldata.slice(0, 10).should.equal('0x5bb67a05');
+      });
+
+      it('should round-trip through decodeFinalizeUnwrapCalldata', () => {
+        const calldata = buildFinalizeUnwrapCalldata(REQUEST_ID, CLEARTEXT_AMOUNT, DECRYPTION_PROOF);
+        const decoded = decodeFinalizeUnwrapCalldata(calldata);
+        decoded.requestId.should.equal(REQUEST_ID);
+        decoded.cleartextAmount.should.equal(CLEARTEXT_AMOUNT);
+        decoded.decryptionProof.should.equal(DECRYPTION_PROOF);
+      });
+    });
+
+    describe('validation', () => {
+      it('should reject a non-32-byte requestId', () => {
+        (() => buildFinalizeUnwrapCalldata('0xabcd', CLEARTEXT_AMOUNT, DECRYPTION_PROOF)).should.throw(
+          /requestId must be a 32-byte/
+        );
+      });
+
+      it('should reject cleartextAmount of 0', () => {
+        (() => buildFinalizeUnwrapCalldata(REQUEST_ID, '0', DECRYPTION_PROOF)).should.throw(
+          /cleartextAmount must be > 0/
+        );
+      });
+
+      it('should reject cleartextAmount exceeding uint64', () => {
+        (() => buildFinalizeUnwrapCalldata(REQUEST_ID, (UINT64_MAX + 1n).toString(), DECRYPTION_PROOF)).should.throw(
+          /cleartextAmount exceeds uint64/
+        );
+      });
+
+      it('should accept cleartextAmount equal to UINT64_MAX', () => {
+        const calldata = buildFinalizeUnwrapCalldata(REQUEST_ID, UINT64_MAX.toString(), DECRYPTION_PROOF);
+        decodeFinalizeUnwrapCalldata(calldata).cleartextAmount.should.equal(UINT64_MAX.toString());
+      });
+
+      it('should reject an empty decryptionProof', () => {
+        (() => buildFinalizeUnwrapCalldata(REQUEST_ID, CLEARTEXT_AMOUNT, '0x')).should.throw(
+          /decryptionProof must be a non-empty/
+        );
       });
     });
   });

--- a/modules/sdk-coin-eth/src/erc7984Token.ts
+++ b/modules/sdk-coin-eth/src/erc7984Token.ts
@@ -35,6 +35,9 @@ import {
   assertAmountTimesRateFitsUint64,
   decodeUnwrapCalldata,
   unwrapMethodId,
+  decodeFinalizeUnwrapCalldata,
+  finalizeUnwrapMethodId,
+  UINT64_MAX,
   decodeTransferData,
 } from '@bitgo/abstract-eth';
 import { bip32 } from '@bitgo/secp256k1';
@@ -161,6 +164,9 @@ export class Erc7984Token extends Eth {
     }
     if (params.txParams?.type === 'unwrap') {
       return this.verifyUnwrapTransaction(params);
+    }
+    if (params.txParams?.type === 'finalizeUnwrap') {
+      return this.verifyFinalizeUnwrapTransaction(params);
     }
     if (this.isConsolidationTransaction(params)) {
       return this.verifyConfidentialConsolidation(params);
@@ -367,6 +373,98 @@ export class Erc7984Token extends Eth {
 
     if (txJson.value !== undefined && txJson.value !== '0' && txJson.value !== 0) {
       throw new Error(`verifyUnwrapTransaction: expected transaction value 0 but got ${txJson.value}`);
+    }
+
+    return true;
+  }
+
+  /**
+   * Verifies FinalizeUnwrapERC7984 (unshield phase-2) transactions.
+   *
+   * TSS / direct shape:
+   *   tx.to   = wrapper contract
+   *   tx.data = finalizeUnwrap(requestId, cleartextAmount, decryptionProof)
+   *
+   * Multisig shape:
+   *   tx.to   = wallet contract
+   *   tx.data = sendMultiSig(wrapper, 0, finalizeUnwrap(...), ...)
+   */
+  private async verifyFinalizeUnwrapTransaction(params: VerifyEthTransactionOptions): Promise<boolean> {
+    const { txParams, txPrebuild } = params;
+
+    if (!txPrebuild?.txHex) {
+      throw new Error('verifyFinalizeUnwrapTransaction: missing txHex in txPrebuild');
+    }
+
+    const txBuilder = this.getTransactionBuilder();
+    txBuilder.from(txPrebuild.txHex);
+    const tx = await txBuilder.build();
+    const txJson = tx.toJson();
+
+    let wrapperAddress: string;
+    let finalizeCalldata: string;
+
+    try {
+      if (txJson.data.toLowerCase().startsWith(sendMultisigMethodId.toLowerCase())) {
+        const decoded = decodeTransferData(txJson.data);
+        wrapperAddress = decoded.to;
+        finalizeCalldata = decoded.data as string;
+        if (decoded.amount !== '0') {
+          throw new Error(`expected sendMultiSig value 0 but got ${decoded.amount}`);
+        }
+      } else if (txJson.data.toLowerCase().startsWith(finalizeUnwrapMethodId.toLowerCase())) {
+        wrapperAddress = txJson.to as string;
+        finalizeCalldata = txJson.data;
+      } else {
+        throw new Error(`unexpected method ID ${txJson.data.slice(0, 10)}`);
+      }
+    } catch (e) {
+      throw new Error(
+        `verifyFinalizeUnwrapTransaction: failed to decode finalizeUnwrap calldata — ${(e as Error).message}`
+      );
+    }
+
+    if (wrapperAddress.toLowerCase() !== this.tokenContractAddress.toLowerCase()) {
+      throw new Error(
+        `verifyFinalizeUnwrapTransaction: wrapper address mismatch — expected ${this.tokenContractAddress}, got ${wrapperAddress}`
+      );
+    }
+
+    let requestId: string;
+    let cleartextAmount: string;
+    let decryptionProof: string;
+    try {
+      ({ requestId, cleartextAmount, decryptionProof } = decodeFinalizeUnwrapCalldata(finalizeCalldata));
+    } catch (e) {
+      throw new Error(
+        `verifyFinalizeUnwrapTransaction: invalid finalizeUnwrap inner calldata — ${(e as Error).message}`
+      );
+    }
+
+    if (!requestId || requestId === '0x' || /^0x0+$/.test(requestId)) {
+      throw new Error('verifyFinalizeUnwrapTransaction: requestId is missing or empty');
+    }
+    if (!Erc7984Token.isPositiveIntegerString(cleartextAmount)) {
+      throw new Error(
+        `verifyFinalizeUnwrapTransaction: cleartextAmount must be a positive integer string, got '${cleartextAmount}'`
+      );
+    }
+    if (BigInt(cleartextAmount) > UINT64_MAX) {
+      throw new Error('verifyFinalizeUnwrapTransaction: cleartextAmount exceeds uint64');
+    }
+    if (!decryptionProof || decryptionProof === '0x') {
+      throw new Error('verifyFinalizeUnwrapTransaction: decryptionProof is missing or empty');
+    }
+
+    const expectedAmount = txParams?.recipients?.[0]?.amount ?? txPrebuild.buildParams?.recipients?.[0]?.amount;
+    if (expectedAmount !== undefined && String(expectedAmount) !== cleartextAmount) {
+      throw new Error(
+        `verifyFinalizeUnwrapTransaction: amount mismatch — calldata has '${cleartextAmount}' but params have '${expectedAmount}'`
+      );
+    }
+
+    if (txJson.value !== undefined && txJson.value !== '0' && txJson.value !== 0) {
+      throw new Error(`verifyFinalizeUnwrapTransaction: expected transaction value 0 but got ${txJson.value}`);
     }
 
     return true;

--- a/modules/sdk-coin-eth/test/unit/erc7984Token.ts
+++ b/modules/sdk-coin-eth/test/unit/erc7984Token.ts
@@ -19,6 +19,7 @@ import {
   buildFlushERC7984ForwarderTokenCalldata,
   buildWrapCalldata,
   buildUnwrapCalldata,
+  buildFinalizeUnwrapCalldata,
   sendMultiSigData,
   wrapInCallFromParent,
   decodeTokenAddressesFromDelegationCalldata,
@@ -1722,6 +1723,146 @@ describe('verifyTransaction – UnwrapERC7984', function () {
         wallet,
       })
       .should.be.rejectedWith(/unwrap to must equal wallet base address/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyTransaction – FinalizeUnwrapERC7984 (unshield phase-2)
+// ---------------------------------------------------------------------------
+
+const FINALIZE_REQUEST_ID = '0x' + '11'.repeat(32);
+const FINALIZE_CLEARTEXT_AMOUNT = '1000000';
+const FINALIZE_DECRYPTION_PROOF = '0x' + 'ee'.repeat(64);
+
+async function buildDirectFinalizeUnwrapTxHex(
+  tokenAddress: string,
+  requestId: string,
+  cleartextAmount: string,
+  decryptionProof: string
+): Promise<string> {
+  const txBuilder = getBuilder('hteth') as TransactionBuilder;
+  txBuilder.fee({ fee: '1000000000', gasLimit: '200000' });
+  txBuilder.counter(1);
+  txBuilder.type(TransactionType.FinalizeUnwrapERC7984);
+  txBuilder.contract(tokenAddress);
+  txBuilder.finalizeUnwrapRequestId(requestId);
+  txBuilder.finalizeUnwrapCleartextAmount(cleartextAmount);
+  txBuilder.finalizeUnwrapDecryptionProof(decryptionProof);
+  const tx = await txBuilder.build();
+  return tx.toBroadcastFormat();
+}
+
+async function buildMultisigFinalizeUnwrapTxHex(
+  tokenAddress: string,
+  requestId: string,
+  cleartextAmount: string,
+  decryptionProof: string
+): Promise<string> {
+  const finalizeCalldata = buildFinalizeUnwrapCalldata(requestId, cleartextAmount, decryptionProof);
+  const sendData = sendMultiSigData(
+    tokenAddress,
+    '0',
+    finalizeCalldata,
+    Math.floor(Date.now() / 1000) + 3600,
+    14,
+    DUMMY_MULTISIG_SIGNATURE
+  );
+
+  const txBuilder = getBuilder('hteth') as TransactionBuilder;
+  txBuilder.fee({ fee: '1000000000', gasLimit: '200000' });
+  txBuilder.counter(1);
+  txBuilder.type(TransactionType.ContractCall);
+  txBuilder.contract(MULTISIG_WALLET_CONTRACT);
+  txBuilder.data(sendData);
+  const tx = await txBuilder.build();
+  return tx.toBroadcastFormat();
+}
+
+describe('verifyTransaction – FinalizeUnwrapERC7984', function () {
+  let bitgo: TestBitGoAPI;
+  let coin: Erc7984Token;
+
+  before(function () {
+    bitgo = TestBitGo.decorate(BitGoAPI, { env: 'test' });
+    bitgo.initializeTestVars();
+    register(bitgo);
+    coin = bitgo.coin('hteth:ctest1') as Erc7984Token;
+  });
+
+  it('should verify a valid direct finalizeUnwrap tx (TSS shape)', async function () {
+    const txHex = await buildDirectFinalizeUnwrapTxHex(
+      CTEST1_TOKEN_ADDRESS,
+      FINALIZE_REQUEST_ID,
+      FINALIZE_CLEARTEXT_AMOUNT,
+      FINALIZE_DECRYPTION_PROOF
+    );
+
+    const result = await coin.verifyTransaction({
+      txParams: {
+        type: 'finalizeUnwrap',
+        recipients: [{ address: UNWRAP_BASE_ADDRESS, amount: FINALIZE_CLEARTEXT_AMOUNT }],
+      } as any,
+      txPrebuild: { txHex } as any,
+      wallet: {} as any,
+    });
+    result.should.equal(true);
+  });
+
+  it('should verify a valid multisig finalizeUnwrap tx (sendMultiSig → finalizeUnwrap)', async function () {
+    const txHex = await buildMultisigFinalizeUnwrapTxHex(
+      CTEST1_TOKEN_ADDRESS,
+      FINALIZE_REQUEST_ID,
+      FINALIZE_CLEARTEXT_AMOUNT,
+      FINALIZE_DECRYPTION_PROOF
+    );
+
+    const result = await coin.verifyTransaction({
+      txParams: {
+        type: 'finalizeUnwrap',
+        recipients: [{ address: UNWRAP_BASE_ADDRESS, amount: FINALIZE_CLEARTEXT_AMOUNT }],
+      } as any,
+      txPrebuild: { txHex } as any,
+      wallet: {} as any,
+    });
+    result.should.equal(true);
+  });
+
+  it('should reject finalizeUnwrap when amount mismatches recipients', async function () {
+    const txHex = await buildDirectFinalizeUnwrapTxHex(
+      CTEST1_TOKEN_ADDRESS,
+      FINALIZE_REQUEST_ID,
+      FINALIZE_CLEARTEXT_AMOUNT,
+      FINALIZE_DECRYPTION_PROOF
+    );
+
+    await coin
+      .verifyTransaction({
+        txParams: {
+          type: 'finalizeUnwrap',
+          recipients: [{ address: UNWRAP_BASE_ADDRESS, amount: '999' }],
+        } as any,
+        txPrebuild: { txHex } as any,
+        wallet: {} as any,
+      })
+      .should.be.rejectedWith(/amount mismatch/);
+  });
+
+  it('should reject finalizeUnwrap when wrapper address mismatches token', async function () {
+    const wrongWrapper = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const txHex = await buildDirectFinalizeUnwrapTxHex(
+      wrongWrapper,
+      FINALIZE_REQUEST_ID,
+      FINALIZE_CLEARTEXT_AMOUNT,
+      FINALIZE_DECRYPTION_PROOF
+    );
+
+    await coin
+      .verifyTransaction({
+        txParams: { type: 'finalizeUnwrap' } as any,
+        txPrebuild: { txHex } as any,
+        wallet: {} as any,
+      })
+      .should.be.rejectedWith(/wrapper address mismatch/);
   });
 });
 

--- a/modules/sdk-coin-eth/test/unit/transactionBuilder/flushTokens.ts
+++ b/modules/sdk-coin-eth/test/unit/transactionBuilder/flushTokens.ts
@@ -15,6 +15,7 @@ import {
   runFlushERC7984Tests,
   runWrapERC7984Tests,
   runUnwrapERC7984Tests,
+  runFinalizeUnwrapERC7984Tests,
 } from '@bitgo/abstract-eth/test/unit/transactionBuilder';
 /* eslint-enable import/no-internal-modules */
 
@@ -36,6 +37,11 @@ describe('ETH WrapERC7984 Tests (from abstract-eth)', () => {
 // Run the shared UnwrapERC7984 tests from abstract-eth
 describe('ETH UnwrapERC7984 Tests (from abstract-eth)', () => {
   runUnwrapERC7984Tests('eth', getBuilder);
+});
+
+// Run the shared FinalizeUnwrapERC7984 tests from abstract-eth
+describe('ETH FinalizeUnwrapERC7984 Tests (from abstract-eth)', () => {
+  runFinalizeUnwrapERC7984Tests('eth', getBuilder);
 });
 
 describe('Eth Transaction builder flush tokens (ETH-specific)', function () {

--- a/modules/sdk-core/src/account-lib/baseCoin/enum.ts
+++ b/modules/sdk-core/src/account-lib/baseCoin/enum.ts
@@ -165,6 +165,8 @@ export enum TransactionType {
   WrapERC7984,
   // Unwrap (unshield) an ERC-7984 confidential token via unwrap(from, to, encryptedAmount, inputProof)
   UnwrapERC7984,
+  // Finalize unwrap (unshield phase-2) via finalizeUnwrap(requestId, cleartextAmount, decryptionProof)
+  FinalizeUnwrapERC7984,
 }
 
 /**


### PR DESCRIPTION
## Description

Adds `buildFinalizeUnwrapCalldata(requestId, cleartextAmount, decryptionProof)` and `FinalizeUnwrapERC7984` transaction support for ERC-7984 unshield phase-2.

- Encodes `finalizeUnwrap(bytes32,uint64,bytes)` with selector `0x5bb67a05`
- Validates 32-byte `requestId`, `cleartextAmount > 0` and ≤ uint64, non-empty `decryptionProof`
- Adds `TransactionType.FinalizeUnwrapERC7984` with builder + `classifyTransaction` mapping
- `Erc7984Token.verifyTransaction` finalizeUnwrap branch (direct + sendMultiSig); optional amount match vs recipients
- Does not set `gasLimit` (WP owns gas)

## Issue Number

[CHALO-1157](https://linear.app/bitgo/issue/CHALO-1157/sdk-buildfinalizeunwrapcalldata-finalizeunwraperc7984-explainverify)

Parent: [CHALO-1135](https://linear.app/bitgo/issue/CHALO-1135/sdk-erc-7984-shieldunshield-calldata-builders-statics-explainverify)

## Docs
- [ ] Generated using `yarn docs`

## Tests
- Unit tests for `buildFinalizeUnwrapCalldata` / decode round-trip and validation in `abstract-eth`
- Shared `FinalizeUnwrapERC7984` transaction builder suite (wired via `sdk-coin-eth`)
- `verifyTransaction` coverage for direct and sendMultiSig finalizeUnwrap shapes


Made with [Cursor](https://cursor.com)