### PR TITLE
feat(statics): add ofctgasevm:usd1 and ofctgasevm:stgusd1 testnet OFC coins

### DIFF
--- a/modules/statics/src/coins/ofcErc20Coins.ts
+++ b/modules/statics/src/coins/ofcErc20Coins.ts
@@ -6456,6 +6456,34 @@ export const tOfcErc20Coins = [
     true,
     'gasevm'
   ),
+  tofcerc20(
+    'cce57090-db6e-41d2-bf7b-b907e9eb719b',
+    'ofctgasevm:usd1',
+    'Test USD1 Token',
+    18,
+    underlyingAssetForSymbol('tgasevm:usd1'),
+    undefined,
+    [...OfcCoin.DEFAULT_FEATURES, CoinFeature.STABLECOIN],
+    '',
+    undefined,
+    undefined,
+    true,
+    'tgasevm'
+  ),
+  tofcerc20(
+    '360c3293-b28b-4117-952c-6b21f8f0c657',
+    'ofctgasevm:stgusd1',
+    'Test USD1 Token',
+    18,
+    underlyingAssetForSymbol('tgasevm:stgusd1'),
+    undefined,
+    [...OfcCoin.DEFAULT_FEATURES, CoinFeature.STABLECOIN],
+    '',
+    undefined,
+    undefined,
+    true,
+    'tgasevm'
+  ),
 
   // XDC Network tokens
   ofcerc20(


### PR DESCRIPTION
## Summary
- Add missing testnet OFC coins `ofctgasevm:usd1` and `ofctgasevm:stgusd1` for GasEVM (Neo X).
- Mainnet `ofcgasevm:usd1` already exists; these complete OFC coverage for test and staging.

## Test plan
- [x] `@bitgo/statics` unit tests pass locally
- [ ] Confirm `ofctgasevm:usd1` and `ofctgasevm:stgusd1` resolve in CoinMap after SDK bump
- [ ] Confirm `ofcgasevm:usd1` still present for prod

Ticket: SCAAS-10802

Made with [Cursor](https://cursor.com)