### PR TITLE
feat(statics): onboard batch 0818 tokens (CECHO-1969)

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -5119,6 +5119,16 @@ export const allCoinsAndTokens = [
     UnderlyingAsset['baseeth:gro'],
     Networks.main.basechain
   ),
+  // CECHO-1969 batch 0818 tokens
+  erc20Token(
+    '731ff716-7b6d-4541-b929-3cddbd87b195',
+    'baseeth:jvhhusdc',
+    'jvhhVault',
+    18,
+    '0x5e03f8965e2957291b3c6990c6cb9023c36d3d30',
+    UnderlyingAsset['baseeth:jvhhusdc'],
+    Networks.main.basechain
+  ),
 
   // ARC mainnet tokens
   erc20Token(

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -2555,6 +2555,7 @@ export enum UnderlyingAsset {
   'eth:strusd' = 'eth:strusd',
   'eth:u' = 'eth:u',
   'eth:bliquid' = 'eth:bliquid',
+  'eth:zsmb' = 'eth:zsmb',
   'eth:usat' = 'eth:usat',
   'eth:usdf' = 'eth:usdf',
   'eth:ausd' = 'eth:ausd',
@@ -3713,6 +3714,7 @@ export enum UnderlyingAsset {
   'baseeth:elsa' = 'baseeth:elsa',
   'baseeth:allo' = 'baseeth:allo',
   'baseeth:gro' = 'baseeth:gro',
+  'baseeth:jvhhusdc' = 'baseeth:jvhhusdc',
 
   // BaseETH testnet tokens
   'tbaseeth:usdc' = 'tbaseeth:usdc',
@@ -4181,6 +4183,7 @@ export enum UnderlyingAsset {
   'sol:pybobo' = 'sol:pybobo',
   'sol:usdpt' = 'sol:usdpt',
   'sol:bliquid' = 'sol:bliquid',
+  'sol:audm' = 'sol:audm',
 
   'tsol:txsgd' = 'sol:txsgd',
   'tsol:txusd' = 'sol:txusd',
@@ -4444,6 +4447,8 @@ export enum UnderlyingAsset {
   // ADA testnet tokens
   'tada:water' = 'tada:water',
   'tada:tusda' = 'tada:tusda',
+  'tada:usdr' = 'tada:usdr',
+  'tada:susdr' = 'tada:susdr',
 
   // ADA mainnet tokens
   'ada:min' = 'ada:min',

--- a/modules/statics/src/coins/adaTokens.ts
+++ b/modules/statics/src/coins/adaTokens.ts
@@ -25,6 +25,29 @@ export const adaTokens = [
     UnderlyingAsset['tada:tusda'],
     ADA_TOKEN_FEATURES_EXCLUDE_SINGAPORE
   ),
+  // CECHO-1969 batch 0818 tokens
+  tadaToken(
+    '4409cdea-b1c2-4a3d-ab4c-e8583e043916',
+    'tada:usdr',
+    'Testnet RealFi USDr',
+    6,
+    '0684f582b8abeb4236b20688744eca788a61cd9881422a7113637f6b55534472',
+    'USDr',
+    'asset1phc5mnwh5p5tsqqxuf2mtvcvpsm6f6vjf8ue08',
+    UnderlyingAsset['tada:usdr'],
+    [...ADA_TOKEN_FEATURES, CoinFeature.STABLECOIN]
+  ),
+  tadaToken(
+    'a84eff6c-4f7e-48b1-a92f-f535dcccc28c',
+    'tada:susdr',
+    'Testnet RealFi sUSDr',
+    6,
+    '0684f582b8abeb4236b20688744eca788a61cd9881422a7113637f6b7355534472',
+    'sUSDr',
+    'asset1vmllsc8gkach2vqh8tqlyj7sl4rk788htll9pq',
+    UnderlyingAsset['tada:susdr'],
+    [...ADA_TOKEN_FEATURES, CoinFeature.STABLECOIN]
+  ),
   adaToken(
     '2d1f9c55-808d-4a6e-b494-62bdb54a16a4',
     'ada:min',

--- a/modules/statics/src/coins/erc20Coins.ts
+++ b/modules/statics/src/coins/erc20Coins.ts
@@ -12401,6 +12401,15 @@ export const erc20Coins = [
       ETH_FEATURES
     )
   ),
+  // CECHO-1969 batch 0818 tokens
+  erc20(
+    'e4ca0bb3-bb52-4b8b-a477-1cdc248be7fe',
+    'eth:zsmb',
+    'Zivoe SMB Credit',
+    18,
+    '0x49c8919162dae24468965557c9344ba2aa8121b8',
+    UnderlyingAsset['eth:zsmb']
+  ),
   terc20(
     '0205f0d6-0647-47c9-ad8b-c48d048e54f3',
     'fixed',

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -6292,6 +6292,14 @@ export const ofcCoins = [
     2,
     UnderlyingAsset['sol:bliquid']
   ),
+  // CECHO-1969 batch 0818 tokens
+  ofcsolToken(
+    '79882838-b836-451a-b3f7-cb50dfb01cc2',
+    'ofcsol:audm',
+    'Macropod Stablecoin',
+    6,
+    UnderlyingAsset['sol:audm']
+  ),
   // New Canton OFC tokens
   ofcCantonToken(
     '02ab6bd2-83e6-46fc-bfd7-93b8be125648',
@@ -6655,6 +6663,21 @@ export const ofcCoins = [
     'Testnet USDA',
     6,
     UnderlyingAsset['tada:tusda']
+  ),
+  // CECHO-1969 batch 0818 tokens
+  tofcAdaToken(
+    'c4a975a7-3cc0-4c52-b453-9aa6f48bccfd',
+    'ofctada:usdr',
+    'Testnet RealFi USDr',
+    6,
+    UnderlyingAsset['tada:usdr']
+  ),
+  tofcAdaToken(
+    'e1c44e27-ebea-4b31-a60f-05b9bfbe8726',
+    'ofctada:susdr',
+    'Testnet RealFi sUSDr',
+    6,
+    UnderlyingAsset['tada:susdr']
   ),
   ofcsolToken(
     'b3bbf580-1cdf-418e-a3aa-bc7d573e6720',

--- a/modules/statics/src/coins/ofcErc20Coins.ts
+++ b/modules/statics/src/coins/ofcErc20Coins.ts
@@ -6334,6 +6334,22 @@ export const tOfcErc20Coins = [
     true,
     'baseeth'
   ),
+  // CECHO-1969 batch 0818 tokens
+  ofcerc20('24b51786-0200-4e87-aa7b-e37f3e7b9a53', 'ofceth:zsmb', 'Zivoe SMB Credit', 18, UnderlyingAsset['eth:zsmb']),
+  ofcerc20(
+    'bb6992c2-b07b-416f-8fd2-d88567584c2b',
+    'ofcbaseeth:jvhhusdc',
+    'jvhhVault',
+    18,
+    UnderlyingAsset['baseeth:jvhhusdc'],
+    undefined,
+    undefined,
+    '',
+    undefined,
+    undefined,
+    true,
+    'baseeth'
+  ),
   ofcerc20('14912a5e-254c-4c6f-9f9c-f9ce11b7b293', 'ofceth:bard', 'Lombard', 18, UnderlyingAsset['eth:bard']),
   ofcerc20('a31a6330-cbd6-49b0-b8b1-a7f9a48e770c', 'ofceth:sfp', 'SafePal Token', 18, UnderlyingAsset['eth:sfp']),
   ofcerc20('60f825f0-ed18-46b2-a03f-fd93b5e94f43', 'ofceth:aztec', 'Aztec', 18, UnderlyingAsset['eth:aztec']),

--- a/modules/statics/src/coins/solTokens.ts
+++ b/modules/statics/src/coins/solTokens.ts
@@ -3523,6 +3523,18 @@ export const solTokens = [
     ),
     ProgramID.Token2022ProgramId
   ),
+  // CECHO-1969 batch 0818 tokens
+  solToken(
+    '8ac27086-e376-4f26-964a-3f2954108e11',
+    'sol:audm',
+    'Macropod Stablecoin',
+    6,
+    'CiYXBwHPrdNkMtxR8YEWKv78K6bQjFoEWhPQrZqEmubi',
+    'CiYXBwHPrdNkMtxR8YEWKv78K6bQjFoEWhPQrZqEmubi',
+    UnderlyingAsset['sol:audm'],
+    SOL_TOKEN_FEATURES,
+    ProgramID.Token2022ProgramId
+  ),
   tsolToken(
     'b98c5a7a-49c5-45f1-a6ee-b08dff596a7d',
     'tsol:srm',


### PR DESCRIPTION
## Summary
- Onboards client-requested tokens from [CECHO-1969](https://linear.app/bitgo/issue/CECHO-1969/client-requested-tokens-to-onboard-batch-0818):
  - `eth:zsmb` — Zivoe SMB Credit (18 decimals)
  - `baseeth:jvhhusdc` — jvhhVault (18 decimals; note: on-chain name/symbol is "Prime USDC"/"primeUSDC", ticket name used per requester)
  - `sol:audm` — Macropod Stablecoin (6 decimals, Token-2022 mint; gated, ungate only for Bullish — handled by support, not in code)
  - `tada:usdr` / `tada:susdr` — Cardano **preprod** testnet tokens (verified via Koios; not present on preview)
- Adds matching OFC counterparts for all four in `ofcErc20Coins.ts` / `ofcCoins.ts`.

## Test plan
- [x] `yarn build` in `modules/statics`
- [x] `yarn unit-test` in `modules/statics` (34,633 passing)
- [x] `yarn eslint` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)