### PR TITLE
CSHLD-1430: BitGoJS SDK — Add shielded wallet creation support

### DIFF
--- a/modules/bitgo/test/v2/unit/wallets.ts
+++ b/modules/bitgo/test/v2/unit/wallets.ts
@@ -992,6 +992,73 @@ describe('V2 Wallets:', function () {
     });
   });
 
+  describe('Generate shielded wallet:', function () {
+    const tzec = bitgo.coin('tzec');
+
+    it('should create a new shielded custodial wallet', async function () {
+      const keys = ['1', '2', '3'];
+
+      const walletParams: GenerateWalletOptions = {
+        label: 'shielded wallet',
+        isShielded: true,
+        enterprise: 'enterprise',
+        type: 'custodial',
+      };
+
+      const walletNock = nock('https://bitgo.fakeurl')
+        .post('/api/v2/tzec/wallet/add', (body) => {
+          body.multisigType.should.equal(multisigTypes.tss);
+          body.coinSpecific.should.deepEqual({ isShielded: true });
+          return true;
+        })
+        .times(1)
+        .reply(200, { ...walletParams, multisigType: multisigTypes.tss, keys });
+
+      const shieldedWallets = new Wallets(bitgo, tzec);
+
+      const res = await shieldedWallets.generateWallet(walletParams);
+      if (!isWalletWithKeychains(res)) {
+        throw new Error('wallet missing required keychains');
+      }
+      res.wallet.label().should.equal(walletParams.label);
+      should.equal(res.wallet.type(), walletParams.type);
+      res.wallet.toJSON().enterprise.should.equal(walletParams.enterprise);
+      res.wallet.multisigType().should.equal(multisigTypes.tss);
+      res.userKeychain.type.should.equal('tss');
+      res.backupKeychain.type.should.equal('tss');
+      res.bitgoKeychain.type.should.equal('tss');
+
+      walletNock.isDone().should.be.true();
+    });
+
+    it('should reject a non-custodial shielded wallet', async function () {
+      const walletParams: GenerateWalletOptions = {
+        label: 'shielded wallet',
+        isShielded: true,
+        enterprise: 'enterprise',
+        type: 'hot',
+      };
+
+      const shieldedWallets = new Wallets(bitgo, tzec);
+
+      await shieldedWallets
+        .generateWallet(walletParams)
+        .should.be.rejectedWith('shielded wallets can only be created as custodial wallets');
+    });
+
+    it('should reject a shielded wallet without an enterprise', async function () {
+      const walletParams: GenerateWalletOptions = {
+        label: 'shielded wallet',
+        isShielded: true,
+        type: 'custodial',
+      };
+
+      const shieldedWallets = new Wallets(bitgo, tzec);
+
+      await shieldedWallets.generateWallet(walletParams).should.be.rejectedWith('enterprise is required');
+    });
+  });
+
   describe('Generate TSS MPCv2 wallet:', async function () {
     const sandbox = sinon.createSandbox();
 

--- a/modules/sdk-core/src/bitgo/wallet/iWallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallets.ts
@@ -39,6 +39,7 @@ export interface GetWalletOptions {
 
 export interface GenerateBaseMpcWalletOptions {
   multisigType: 'tss';
+  isShielded?: boolean;
   label: string;
   enterprise: string;
   walletVersion?: number;
@@ -250,6 +251,8 @@ export interface GenerateWalletOptions {
   coldDerivationSeed?: string;
   rootPrivateKey?: string;
   multisigType?: 'onchain' | 'tss' | 'blsdkg';
+  // Used for zec shielded custodial wallets
+  isShielded?: boolean;
   isDistributedCustody?: boolean;
   bitgoKeyId?: string;
   commonKeychain?: string;

--- a/modules/sdk-core/src/bitgo/wallet/wallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallets.ts
@@ -481,6 +481,22 @@ export class Wallets implements IWallets {
       return walletData;
     }
 
+    // Transparent zcash wallets are multisig and isTSS is not set inherently.
+    // Shielded zcash wallets are MPC
+    if (params.isShielded) {
+      assert(enterprise, 'enterprise is required for shielded wallet');
+      if (type !== 'custodial') {
+        throw new Error('shielded wallets can only be created as custodial wallets');
+      }
+      return this.generateCustodialMpcWallet({
+        multisigType: 'tss',
+        isShielded: true,
+        label,
+        enterprise,
+        walletVersion: params.walletVersion,
+      });
+    }
+
     // Handle distributed custody
     if (isDistributedCustody) {
       if (!enterprise) {
@@ -2090,6 +2106,7 @@ export class Wallets implements IWallets {
   private async generateCustodialMpcWallet({
     label,
     multisigType,
+    isShielded,
     enterprise,
     walletVersion,
   }: GenerateBaseMpcWalletOptions): Promise<WalletWithKeychains> {
@@ -2112,6 +2129,7 @@ export class Wallets implements IWallets {
       enterprise,
       walletVersion,
       type: 'custodial',
+      ...(isShielded && { coinSpecific: { isShielded: true } }),
     };
 
     // Create Wallet


### PR DESCRIPTION
## Summary

Adds isShielded flag support for custodial wallet creation, enabling shielded Zcash (zec/tzec) wallet generation through wallet-platform. Includes validation to restrict shielded wallets to custodial type and require enterprise parameter.

**Linear**: [CSHLD-1430](https://linear.app/bitgo/issue/CSHLD-1430/task-29-bitgojs-sdk-add-shielded-wallet-creation-support)

## Changes

- Add `isShielded` optional property to `GenerateBaseMpcWalletOptions` and `GenerateWalletOptions` interfaces
- Implement shielded wallet generation logic in `generateWallet` method with validation checks
- Pass `isShielded` flag through to wallet-platform API via `coinSpecific` parameter
- Add comprehensive test coverage for shielded wallet creation (success case and error cases)

## Test Plan

Unit tests added covering:
- Creating a custodial shielded wallet with proper parameters
- Rejecting non-custodial shielded wallet creation attempt
- Rejecting shielded wallet without enterprise parameter

CLOSES TICKET: CSHLD-1430