### PR TITLE
fix(abstract-eth,sdk-core): enforce signableHex/serializedTxHex consistency for BSC and XDC (WCI-1398)

### DIFF
--- a/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
+++ b/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
@@ -62,7 +62,7 @@ import {
 } from '@bitgo/statics';
 import type * as EthLikeCommon from '@ethereumjs/common';
 import type * as EthLikeTxLib from '@ethereumjs/tx';
-import { FeeMarketEIP1559Transaction, Transaction as LegacyTransaction } from '@ethereumjs/tx';
+import { FeeMarketEIP1559Transaction, Transaction as LegacyTransaction, TransactionFactory } from '@ethereumjs/tx';
 import { RLP } from '@ethereumjs/rlp';
 import { SignTypedDataVersion, TypedDataUtils, TypedMessage } from '@metamask/eth-sig-util';
 import { BigNumber } from 'bignumber.js';
@@ -3177,15 +3177,11 @@ export abstract class AbstractEthLikeNewCoins extends AbstractEthLikeCoin implem
    *
   /** @inheritdoc CoinWithSignableConsistency */
   assertSignableConsistency(serializedTxHex: string, signableHex: string): void {
-    const txBytes = Buffer.from(stripHexPrefix(serializedTxHex), 'hex');
-    let derivedSignableHex: string;
-    try {
-      const eip1559Tx = FeeMarketEIP1559Transaction.fromSerializedTx(txBytes);
-      derivedSignableHex = eip1559Tx.getMessageToSign(false).toString('hex');
-    } catch {
-      const legacyTx = LegacyTransaction.fromSerializedTx(txBytes);
-      derivedSignableHex = Buffer.from(RLP.encode(bufArrToArr(legacyTx.getMessageToSign(false)))).toString('hex');
-    }
+    const ethTx = TransactionFactory.fromSerializedData(toBuffer(addHexPrefix(serializedTxHex)));
+    const derivedSignableHex =
+      ethTx instanceof FeeMarketEIP1559Transaction
+        ? ethTx.getMessageToSign(false).toString('hex')
+        : Buffer.from(RLP.encode(bufArrToArr((ethTx as LegacyTransaction).getMessageToSign(false)))).toString('hex');
     if (derivedSignableHex !== signableHex) {
       throw new InvalidTransactionError('signableHex is inconsistent with serializedTxHex: possible server tampering');
     }

--- a/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
+++ b/modules/abstract-eth/src/abstractEthLikeNewCoins.ts
@@ -16,6 +16,7 @@ import {
   HalfSignedTransaction,
   InvalidAddressError,
   InvalidAddressVerificationObjectPropertyError,
+  InvalidTransactionError,
   IWallet,
   KeyPair,
   MPCSweepRecoveryOptions,
@@ -47,6 +48,7 @@ import {
   DeriveAddressOptions,
   DeriveAddressResult,
   NO_RECIPIENT_TX_TYPES,
+  CoinWithSignableConsistency,
 } from '@bitgo/sdk-core';
 import { getDerivationPath } from '@bitgo/sdk-lib-mpc';
 import { bip32 } from '@bitgo/secp256k1';
@@ -509,7 +511,7 @@ export const optionalDeps = {
   },
 };
 
-export abstract class AbstractEthLikeNewCoins extends AbstractEthLikeCoin {
+export abstract class AbstractEthLikeNewCoins extends AbstractEthLikeCoin implements CoinWithSignableConsistency {
   static hopTransactionSalt = 'bitgoHopAddressRequestSalt';
   protected readonly sendMethodName: 'sendMultiSig' | 'sendMultiSigToken';
 
@@ -3173,6 +3175,23 @@ export abstract class AbstractEthLikeNewCoins extends AbstractEthLikeCoin {
   /**
    * Verify if a tss transaction is valid
    *
+  /** @inheritdoc CoinWithSignableConsistency */
+  assertSignableConsistency(serializedTxHex: string, signableHex: string): void {
+    const txBytes = Buffer.from(stripHexPrefix(serializedTxHex), 'hex');
+    let derivedSignableHex: string;
+    try {
+      const eip1559Tx = FeeMarketEIP1559Transaction.fromSerializedTx(txBytes);
+      derivedSignableHex = eip1559Tx.getMessageToSign(false).toString('hex');
+    } catch {
+      const legacyTx = LegacyTransaction.fromSerializedTx(txBytes);
+      derivedSignableHex = Buffer.from(RLP.encode(bufArrToArr(legacyTx.getMessageToSign(false)))).toString('hex');
+    }
+    if (derivedSignableHex !== signableHex) {
+      throw new InvalidTransactionError('signableHex is inconsistent with serializedTxHex: possible server tampering');
+    }
+  }
+
+  /**
    * @param {VerifyEthTransactionOptions} params
    * @param {TransactionParams} params.txParams - params object passed to send
    * @param {TransactionPrebuild} params.txPrebuild - prebuild object returned by server
@@ -3211,6 +3230,7 @@ export abstract class AbstractEthLikeNewCoins extends AbstractEthLikeCoin {
     if (!wallet || !txPrebuild) {
       throw new Error('missing params');
     }
+
     if (txParams.hop && txParams.recipients && txParams.recipients.length > 1) {
       throw new Error('tx cannot be both a batch and hop transaction');
     }

--- a/modules/sdk-coin-bsc/package.json
+++ b/modules/sdk-coin-bsc/package.json
@@ -48,7 +48,10 @@
   },
   "devDependencies": {
     "@bitgo/sdk-api": "^2.4.1",
-    "@bitgo/sdk-test": "^9.1.70"
+    "@bitgo/sdk-test": "^9.1.70",
+    "@ethereumjs/rlp": "^4.0.0",
+    "@ethereumjs/tx": "^3.3.0",
+    "ethereumjs-util": "7.1.5"
   },
   "gitHead": "18e460ddf02de2dbf13c2aa243478188fb539f0c",
   "files": [

--- a/modules/sdk-coin-bsc/test/unit/bsc.ts
+++ b/modules/sdk-coin-bsc/test/unit/bsc.ts
@@ -3,6 +3,9 @@ import 'should';
 import { TestBitGo, TestBitGoAPI } from '@bitgo/sdk-test';
 import { BitGoAPI } from '@bitgo/sdk-api';
 import { TransactionType, Wallet } from '@bitgo/sdk-core';
+import { Transaction as LegacyTransaction } from '@ethereumjs/tx';
+import { RLP } from '@ethereumjs/rlp';
+import { bufArrToArr } from 'ethereumjs-util';
 
 import { Bsc, Tbsc } from '../../src/index';
 import { TransactionBuilder } from '../../src/lib';
@@ -221,6 +224,45 @@ describe('Native BNB', function () {
           wallet,
         })
         .should.be.rejectedWith('destination address does not match with the recipient address');
+    });
+
+    describe('assertSignableConsistency (Gap 2 / WCI-1398)', function () {
+      function stripHex(hex: string): string {
+        return hex.startsWith('0x') ? hex.slice(2) : hex;
+      }
+
+      async function buildSerializedTxHex(address: string): Promise<string> {
+        const txBuilder = getBuilder('tbsc') as TransactionBuilder;
+        txBuilder.type(TransactionType.SingleSigSend);
+        txBuilder.fee({ fee: '10', gasLimit: '21000' });
+        txBuilder.counter(1);
+        txBuilder.contract(address);
+        txBuilder.value(transferAmount);
+        const tx = await txBuilder.build();
+        return stripHex(tx.toBroadcastFormat());
+      }
+
+      function deriveSignableHex(serializedTxHex: string): string {
+        const legacyTx = LegacyTransaction.fromSerializedTx(Buffer.from(serializedTxHex, 'hex'));
+        return Buffer.from(RLP.encode(bufArrToArr(legacyTx.getMessageToSign(false)))).toString('hex');
+      }
+
+      it('should pass when signableHex is consistent with serializedTxHex', async function () {
+        const coin = bitgo.coin('tbsc') as Tbsc;
+        const serializedTxHex = await buildSerializedTxHex(recipientAddress);
+        const signableHex = deriveSignableHex(serializedTxHex);
+        coin.assertSignableConsistency(serializedTxHex, signableHex);
+      });
+
+      it('should throw when signableHex does not match serializedTxHex (Gap 2 attack)', async function () {
+        const coin = bitgo.coin('tbsc') as Tbsc;
+        const benignSerializedTxHex = await buildSerializedTxHex(recipientAddress);
+        const maliciousSerializedTxHex = await buildSerializedTxHex(wrongAddress);
+        const tamperedSignableHex = deriveSignableHex(maliciousSerializedTxHex);
+        (() => coin.assertSignableConsistency(benignSerializedTxHex, tamperedSignableHex)).should.throw(
+          'signableHex is inconsistent with serializedTxHex: possible server tampering'
+        );
+      });
     });
   });
 });

--- a/modules/sdk-coin-xdc/package.json
+++ b/modules/sdk-coin-xdc/package.json
@@ -48,7 +48,9 @@
   },
   "devDependencies": {
     "@bitgo/sdk-api": "^2.4.1",
-    "@bitgo/sdk-test": "^9.1.70"
+    "@bitgo/sdk-test": "^9.1.70",
+    "@ethereumjs/rlp": "^4.0.0",
+    "ethereumjs-util": "7.1.5"
   },
   "gitHead": "18e460ddf02de2dbf13c2aa243478188fb539f0c",
   "files": [

--- a/modules/sdk-coin-xdc/test/unit/xdc.ts
+++ b/modules/sdk-coin-xdc/test/unit/xdc.ts
@@ -9,7 +9,9 @@ import { mockDataUnsignedSweep, mockDataNonBitGoRecovery } from '../resources';
 import nock from 'nock';
 import { common, TransactionType, Wallet } from '@bitgo/sdk-core';
 import { Transaction } from '@ethereumjs/tx';
+import { RLP } from '@ethereumjs/rlp';
 import { stripHexPrefix } from '@ethereumjs/util';
+import { bufArrToArr } from 'ethereumjs-util';
 
 import { TransactionBuilder } from '../../src/lib';
 import { getBuilder } from './getBuilder';
@@ -166,6 +168,45 @@ describe('xdc', function () {
           wallet,
         })
         .should.be.rejectedWith('destination address does not match with the recipient address');
+    });
+
+    describe('assertSignableConsistency (Gap 2 / WCI-1398)', function () {
+      function stripHex(hex: string): string {
+        return hex.startsWith('0x') ? hex.slice(2) : hex;
+      }
+
+      async function buildSerializedTxHex(address: string): Promise<string> {
+        const txBuilder = getBuilder('txdc') as TransactionBuilder;
+        txBuilder.type(TransactionType.SingleSigSend);
+        txBuilder.fee({ fee: '10', gasLimit: '21000' });
+        txBuilder.counter(1);
+        txBuilder.contract(address);
+        txBuilder.value(transferAmount);
+        const tx = await txBuilder.build();
+        return stripHex(tx.toBroadcastFormat());
+      }
+
+      function deriveSignableHex(serializedTxHex: string): string {
+        const legacyTx = Transaction.fromSerializedTx(Buffer.from(serializedTxHex, 'hex'));
+        return Buffer.from(RLP.encode(bufArrToArr(legacyTx.getMessageToSign(false)))).toString('hex');
+      }
+
+      it('should pass when signableHex is consistent with serializedTxHex', async function () {
+        const coin = bitgo.coin('txdc') as Txdc;
+        const serializedTxHex = await buildSerializedTxHex(recipientAddress);
+        const signableHex = deriveSignableHex(serializedTxHex);
+        coin.assertSignableConsistency(serializedTxHex, signableHex);
+      });
+
+      it('should throw when signableHex does not match serializedTxHex (Gap 2 attack)', async function () {
+        const coin = bitgo.coin('txdc') as Txdc;
+        const benignSerializedTxHex = await buildSerializedTxHex(recipientAddress);
+        const maliciousSerializedTxHex = await buildSerializedTxHex(wrongAddress);
+        const tamperedSignableHex = deriveSignableHex(maliciousSerializedTxHex);
+        (() => coin.assertSignableConsistency(benignSerializedTxHex, tamperedSignableHex)).should.throw(
+          'signableHex is inconsistent with serializedTxHex: possible server tampering'
+        );
+      });
     });
   });
 });

--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
@@ -52,6 +52,7 @@ import {
 } from '../baseTypes';
 import { shouldUsePreHashedSignable } from '../preHashedSignable';
 import { shouldVerifyWithSerializedTxHex } from '../serializedTxHexVerify';
+import { isCoinWithSignableConsistency } from '../signableConsistency';
 import { BaseEcdsaUtils } from './base';
 import { EcdsaMPCv2KeyGenSendFn, KeyGenSenderForEnterprise } from './ecdsaMPCv2KeyGenSender';
 import { envRequiresBitgoPubGpgKeyConfig, isBitgoMpcPubKey } from '../../../tss/bitgoPubKeys';
@@ -958,6 +959,13 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
           wallet: this.wallet,
           walletType: this.wallet.multisigType(),
         });
+        // Gap 2 fix (WCI-1398): verifyTransaction sees serializedTxHex but signing uses
+        // signableHex — both are server-supplied independently. For coins that implement
+        // the consistency check, derive signableHex from serializedTxHex and confirm they
+        // match before signing.
+        if (shouldVerifyWithSerializedTxHex(this.baseCoin) && isCoinWithSignableConsistency(this.baseCoin)) {
+          this.baseCoin.assertSignableConsistency(unsignedTx.serializedTxHex, unsignedTx.signableHex);
+        }
       } else {
         await this.baseCoin.verifyTransaction({
           txPrebuild: { txHex: unsignedTx.signableHex },

--- a/modules/sdk-core/src/bitgo/utils/tss/index.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/index.ts
@@ -17,3 +17,4 @@ export * from './baseTypes';
 export * from './addressVerification';
 export * from './preHashedSignable';
 export * from './recipientUtils';
+export * from './signableConsistency';

--- a/modules/sdk-core/src/bitgo/utils/tss/signableConsistency.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/signableConsistency.ts
@@ -1,0 +1,18 @@
+export interface CoinWithSignableConsistency {
+  /**
+   * Verify that the server-supplied signableHex is consistent with serializedTxHex.
+   * For TSS_VERIFY_USE_SERIALIZED_TX_HEX coins (BSC, XDC), the MPC signing flow
+   * verifies serializedTxHex but signs signableHex — both are server-supplied
+   * independently.  This method derives the expected signableHex from the
+   * serializedTxHex locally and throws InvalidTransactionError if they diverge.
+   */
+  assertSignableConsistency(serializedTxHex: string, signableHex: string): void;
+}
+
+export function isCoinWithSignableConsistency(coin: unknown): coin is CoinWithSignableConsistency {
+  return (
+    coin !== null &&
+    typeof coin === 'object' &&
+    typeof (coin as CoinWithSignableConsistency).assertSignableConsistency === 'function'
+  );
+}


### PR DESCRIPTION
## Summary

For BSC and XDC, the ECDSA MPCv2 signing flow verifies `serializedTxHex` but signs `signableHex` — both are independent server-supplied fields. This PR adds a consistency check that locally derives the expected `signableHex` from `serializedTxHex` and throws before signing if they diverge.

## Changes

- Adds `CoinWithSignableConsistency` interface and type guard to `sdk-core`
- `AbstractEthLikeNewCoins` implements `assertSignableConsistency` using `TransactionFactory.fromSerializedData`, handling both EIP-1559 and legacy EIP-155 transactions
- `ecdsaMPCv2.ts` calls the check after `verifyTransaction` succeeds in the `TSS_VERIFY_USE_SERIALIZED_TX_HEX` branch

## Test plan

- [x] Unit tests: consistent pair passes, tampered `signableHex` throws — BSC + XDC
- [x] Full unit test suites passing (BSC, XDC, abstract-eth)
- [x] End-to-end: native sends on staging for BSC and XDC
- [x] QA automation playwright tests `@wp_api_tbsc` and `@wp_api_txdc` passed