### PR TITLE
fix(sdk-api): skip doomed native v1 decrypt attempt in browser

### DIFF
--- a/modules/sdk-api/src/encrypt.ts
+++ b/modules/sdk-api/src/encrypt.ts
@@ -1,8 +1,35 @@
 import * as sjcl from '@bitgo/sjcl';
 import { randomBytes } from 'crypto';
 
-import { decryptV1 } from './decryptV1';
+import { decryptV1, V1_MAX_ITER } from './decryptV1';
 import { decryptV2, encryptV2 } from './encryptV2';
+
+/**
+ * True when running in a bundled browser build. `browserify-aes` -- the AES
+ * polyfill webpack substitutes for `node:crypto` in browser bundles -- has no
+ * AES-CCM mode at all, so native v1 decrypt fails on literally every call
+ * there. There's no point paying for the doomed native attempt (a full
+ * PBKDF2 run) before falling back; go straight to SJCL.
+ */
+const isBrowserRuntime = typeof window !== 'undefined';
+
+/**
+ * SJCL has no upper bound on `iter`, so a hostile v1 envelope could burn CPU
+ * running an inflated PBKDF2. Native decrypt's codec normally catches this
+ * before any KDF work runs; the browser path skips native entirely, so it
+ * needs this narrow check to preserve the same DoS protection.
+ */
+function assertIterWithinCap(ciphertext: string): void {
+  let iter: unknown;
+  try {
+    iter = JSON.parse(ciphertext)?.iter;
+  } catch {
+    return; // malformed JSON -- let sjcl.decrypt raise its own error
+  }
+  if (typeof iter === 'number' && iter > V1_MAX_ITER) {
+    throw new Error(`v1 decrypt: iter ${iter} exceeds cap of ${V1_MAX_ITER}`);
+  }
+}
 
 /**
  * convert a 4 element Uint8Array to a 4 byte Number
@@ -92,12 +119,19 @@ function isIterCapViolation(err: unknown): boolean {
  *
  * `native` defaults to the module's `decryptV1` but is exposed as a parameter
  * so tests can inject a throwing version to exercise the fallback path.
+ * `isBrowser` defaults to a real runtime check but is exposed so tests can
+ * exercise the browser-only branch under Node.
  */
 export async function decryptV1WithFallback(
   password: string,
   ciphertext: string,
-  native: (pw: string, ct: string) => Promise<string> = decryptV1
+  native: (pw: string, ct: string) => Promise<string> = decryptV1,
+  isBrowser: boolean = isBrowserRuntime
 ): Promise<string> {
+  if (isBrowser) {
+    assertIterWithinCap(ciphertext);
+    return sjcl.decrypt(password, ciphertext);
+  }
   try {
     return await native(password, ciphertext);
   } catch (nativeErr) {

--- a/modules/sdk-api/test/unit/decryptV1.ts
+++ b/modules/sdk-api/test/unit/decryptV1.ts
@@ -185,4 +185,41 @@ describe('decryptV1 (native, SJCL-free)', () => {
       assert.ok(warnings[0].includes('SJCL fallback succeeded'));
     });
   });
+
+  describe('browser runtime (isBrowser = true)', () => {
+    it('skips native and decrypts via SJCL without warning', async () => {
+      const ct = await encrypt(password, plaintext, { encryptionVersion: 1 });
+      const neverCalled = async (): Promise<string> => {
+        throw new Error('native should not be attempted in the browser');
+      };
+      // eslint-disable-next-line no-console
+      const originalWarn = console.warn;
+      const warnings: string[] = [];
+      // eslint-disable-next-line no-console
+      console.warn = (...args: unknown[]) => {
+        warnings.push(args.join(' '));
+      };
+      try {
+        const result = await decryptV1WithFallback(password, ct, neverCalled, true);
+        assert.strictEqual(result, plaintext);
+        assert.deepStrictEqual(warnings, []);
+      } finally {
+        // eslint-disable-next-line no-console
+        console.warn = originalWarn;
+      }
+    });
+
+    it('still enforces the iter cap before running PBKDF2', async () => {
+      const envelope = JSON.parse(await encrypt(password, plaintext, { encryptionVersion: 1 }));
+      envelope.iter = V1_MAX_ITER + 1;
+      const start = Date.now();
+      await assert.rejects(() => decryptV1WithFallback(password, JSON.stringify(envelope), decryptV1, true), /iter/);
+      assert.ok(Date.now() - start < 100, 'must reject before any KDF work');
+    });
+
+    it('rejects wrong password via SJCL auth failure', async () => {
+      const ct = await encrypt(password, plaintext, { encryptionVersion: 1 });
+      await assert.rejects(() => decryptV1WithFallback('wrongPassword', ct, decryptV1, true));
+    });
+  });
 });


### PR DESCRIPTION
browserify-aes (webpack's node:crypto polyfill) has no AES-CCM mode, so native v1 decrypt fails on every call in a real browser bundle, paying for a wasted PBKDF2 run and logging a warning each time before falling back to SJCL. Detect browser runtime and go straight to SJCL, while still enforcing the iter cap to preserve DoS protection.

TICKET: WCN-43

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
