### PR TITLE
fix(defi): tolerant dispatch codec for depositToVault + getVaultProtocol (Tier 0)

### DIFF
--- a/modules/sdk-core/src/bitgo/defi/defiVault.ts
+++ b/modules/sdk-core/src/bitgo/defi/defiVault.ts
@@ -2,7 +2,7 @@
  * @prettier
  */
 import * as t from 'io-ts';
-import { GetVaultResponse, VaultProtocol } from '@bitgo/public-types';
+import { GetVaultResponse, VaultProtocol, VaultProtocolType } from '@bitgo/public-types';
 import {
   ConcreteDepositResult,
   MorphoDepositResult,
@@ -56,18 +56,49 @@ export class DefiVault implements IDefiVault {
   }
 
   /**
+   * Minimal dispatch codec. The deposit path reads only `protocol` to choose
+   * between the concrete and morpho flows, so it must not hard-fail on the
+   * validity of unrelated response fields (e.g. `composition[]`) it never
+   * consumes. A code path must not fail on the validity of data it does not
+   * consume.
+   */
+  private static readonly VaultDispatch = t.type({ protocol: VaultProtocolType });
+
+  /**
+   * Fetch the raw vault config from defi-service. Shared by callers that
+   * decode the full response and callers that decode only what they use.
+   */
+  private async fetchVaultRaw(vaultId: string): Promise<unknown> {
+    if (!vaultId) {
+      throw new Error('vaultId is required');
+    }
+    return await this.bitgo
+      .get(this.bitgo.microservicesUrl(`/api/defi-service/v1/vaults/${vaultId}`))
+      .set('enterprise-id', this.wallet.toJSON().enterprise)
+      .result();
+  }
+
+  /**
    * Fetch vault config from defi-service. Used internally to determine
    * which deposit path to take (Concrete vs Morpho).
    */
   async getVaultConfig(params: GetVaultConfigOptions): Promise<GetVaultResponse> {
-    if (!params.vaultId) {
-      throw new Error('vaultId is required');
-    }
-    const raw = await this.bitgo
-      .get(this.bitgo.microservicesUrl(`/api/defi-service/v1/vaults/${params.vaultId}`))
-      .set('enterprise-id', this.wallet.toJSON().enterprise)
-      .result();
-    return decodeWithCodec(GetVaultResponse, raw, 'getVaultConfig');
+    return decodeWithCodec(GetVaultResponse, await this.fetchVaultRaw(params.vaultId), 'getVaultConfig');
+  }
+
+  /**
+   * Fetch only the vault protocol from defi-service. Decodes the minimal
+   * `VaultDispatch` shape rather than the full `GetVaultResponse`, so callers
+   * that need only the protocol are not hostage to the validity of unrelated
+   * response fields (e.g. `composition[]`) they never consume.
+   */
+  async getVaultProtocol(params: GetVaultConfigOptions): Promise<VaultProtocol> {
+    const { protocol } = decodeWithCodec(
+      DefiVault.VaultDispatch,
+      await this.fetchVaultRaw(params.vaultId),
+      'vaultDispatch'
+    );
+    return protocol;
   }
 
   /**
@@ -89,14 +120,14 @@ export class DefiVault implements IDefiVault {
       throw new Error('amount is required');
     }
 
-    const config = await this.getVaultConfig({ vaultId: params.vaultId });
+    const protocol = await this.getVaultProtocol({ vaultId: params.vaultId });
 
-    if (config.protocol === VaultProtocol.CONCRETE_BTCCX) {
+    if (protocol === VaultProtocol.CONCRETE_BTCCX) {
       return this.depositToConcreteVault(params);
-    } else if (config.protocol === VaultProtocol.MORPHO) {
+    } else if (protocol === VaultProtocol.MORPHO) {
       return this.depositToMorphoVault(params);
     } else {
-      throw new Error(`Unsupported vault protocol: ${config.protocol}`);
+      throw new Error(`Unsupported vault protocol: ${protocol}`);
     }
   }
 

--- a/modules/sdk-core/src/bitgo/defi/iDefiVault.ts
+++ b/modules/sdk-core/src/bitgo/defi/iDefiVault.ts
@@ -2,7 +2,7 @@
  * @prettier
  */
 
-import { GetVaultResponse } from '@bitgo/public-types';
+import { GetVaultResponse, VaultProtocol } from '@bitgo/public-types';
 
 export interface DepositToVaultOptions {
   /** DeFi-service vault identifier */
@@ -86,5 +86,6 @@ export interface IDefiVault {
   getOperation(params: GetOperationOptions): Promise<DefiOperation>;
   listOperations(params: ListOperationsOptions): Promise<DefiOperationListResult>;
   getVaultConfig(params: GetVaultConfigOptions): Promise<GetVaultResponse>;
+  getVaultProtocol(params: GetVaultConfigOptions): Promise<VaultProtocol>;
   withdrawFromVault(params: WithdrawFromVaultOptions): Promise<WithdrawResult>;
 }

--- a/modules/sdk-core/test/unit/bitgo/defi/defiVault.ts
+++ b/modules/sdk-core/test/unit/bitgo/defi/defiVault.ts
@@ -50,6 +50,17 @@ describe('DefiVault', function () {
     };
   }
 
+  // A vault response whose `composition[]` no longer matches the strict
+  // GetVaultResponse codec — mirrors the prod incident where a display-only
+  // nested field was narrowed/removed server-side. The deposit dispatch path
+  // must not hard-fail on it because it only reads `protocol`.
+  function makeConcreteVaultWithStaleComposition(id: string) {
+    return {
+      ...makeConcreteVault(id),
+      composition: [{ asset: 'btc', apy: 'not-a-number' /* stale shape */ }],
+    };
+  }
+
   beforeEach(function () {
     mockBitGo = {
       post: sinon.stub(),
@@ -132,6 +143,51 @@ describe('DefiVault', function () {
     });
   });
 
+  describe('getVaultProtocol', function () {
+    it('should fetch only the protocol for a given vaultId', async function () {
+      mockBitGo.get.returns(mockRequest(makeMorphoVault('vlt-morpho-1')));
+
+      const protocol = await defiVault.getVaultProtocol({ vaultId: 'vlt-morpho-1' });
+
+      protocol.should.equal(VaultProtocol.MORPHO);
+      mockBitGo.get.calledWith('https://bitgo.com/api/defi-service/v1/vaults/vlt-morpho-1').should.be.true();
+    });
+
+    it('should return CONCRETE_BTCCX for a concrete vault', async function () {
+      mockBitGo.get.returns(mockRequest(makeConcreteVault('vlt-concrete-1')));
+
+      const protocol = await defiVault.getVaultProtocol({ vaultId: 'vlt-concrete-1' });
+
+      protocol.should.equal(VaultProtocol.CONCRETE_BTCCX);
+    });
+
+    it('should tolerate a stale/invalid composition[] field the full GetVaultResponse codec would reject', async function () {
+      // The dispatch codec reads only `protocol`, so a display-only nested
+      // field going stale server-side must not break this call.
+      mockBitGo.get.returns(mockRequest(makeConcreteVaultWithStaleComposition('vlt-stale-1')));
+
+      const protocol = await defiVault.getVaultProtocol({ vaultId: 'vlt-stale-1' });
+
+      protocol.should.equal(VaultProtocol.CONCRETE_BTCCX);
+    });
+
+    it('should throw if vaultId is missing', async function () {
+      await assert.rejects(() => defiVault.getVaultProtocol({ vaultId: '' }), {
+        message: 'vaultId is required',
+      });
+    });
+
+    it('should propagate errors from the API (e.g. 404)', async function () {
+      const req = mockRequest(null);
+      req.result.rejects(new Error('Not Found'));
+      mockBitGo.get.returns(req);
+
+      await assert.rejects(() => defiVault.getVaultProtocol({ vaultId: 'vlt-not-found' }), {
+        message: 'Not Found',
+      });
+    });
+  });
+
   describe('depositToVault', function () {
     describe('concrete_btccx provider', function () {
       it('should call sendMany once with defi-deposit type and no recipients', async function () {
@@ -191,6 +247,22 @@ describe('DefiVault', function () {
 
         const result = await defiVault.depositToVault({ vaultId: 'vlt-btc-3', amount: '1000000' });
         (result as any).state.should.equal('awaitingSignature');
+      });
+
+      it('should tolerate a stale/invalid composition[] field that the full GetVaultResponse codec would reject', async function () {
+        // Regression guard for the cross-repo codec-drift incident: the
+        // deposit dispatch path reads only `protocol`, so a display-only
+        // nested field going stale server-side must not break deposits.
+        mockBitGo.get.returns(mockRequest(makeConcreteVaultWithStaleComposition('vlt-btc-stale')));
+
+        const sendManyStub = sinon.stub(wallet, 'sendMany').resolves({
+          pendingApproval: { id: 'pa-stale', state: 'awaitingSignature' },
+        });
+
+        const result = await defiVault.depositToVault({ vaultId: 'vlt-btc-stale', amount: '1000000' });
+
+        (result as any).pendingApprovalId.should.equal('pa-stale');
+        sendManyStub.calledOnce.should.be.true();
       });
 
       it('should throw when sendMany returns no pendingApproval', async function () {


### PR DESCRIPTION
## Summary

- Implements **Tier 0** of the API Contract Safety plan (`defi-service/docs/architecture/api-contract-safety.md`) — "decode only what you depend on."
- `depositToVault` reads exactly one field (`protocol`) to dispatch between the Concrete and Morpho deposit paths, but strictly decoded the entire `GetVaultResponse`. When a display-only nested field (`composition[]`) drifted between the `defi-service` and `@bitgo/public-types` codec copies, the strict decode threw and **deposits broke in production** (surfaced in the UI; remediation required a 4-hop release train).
- Adds a minimal dispatch codec `VaultDispatch = t.type({ protocol: VaultProtocolType })` and a new public `getVaultProtocol(params)` method that decodes only the field the dispatch path consumes. `depositToVault` now calls `getVaultProtocol` instead of decoding the full response inline.
- Extracts a shared `fetchVaultRaw` helper (preserves the `enterprise-id` header) shared by the full-decode and dispatch-decode paths.
- `getVaultConfig` is unchanged in behavior — still returns the full decoded `GetVaultResponse` for callers that genuinely want the whole object.
- Adds a regression test proving the deposit path tolerates a stale/invalid `composition[]` shape that the full `GetVaultResponse` codec would reject — the exact counterfactual the design doc calls out ("Had Tier 0 alone been in place, the incident would have been a no-op").

## Principle established

A code path must not fail on the validity of data it does not consume.

## Test plan

- [x] `npx mocha --require tsx test/unit/bitgo/defi/defiVault.ts` — **40 passing, 1 pending** (pre-existing `xit`)
- [x] Prettier — clean
- [x] ESLint — clean
- [x] Isolated `tsc` on touched files — no errors
- [x] New regression test: `should tolerate a stale/invalid composition[] field that the full GetVaultResponse codec would reject`
- [x] New `getVaultProtocol` tests: morpho/concrete protocol fetch, stale-composition tolerance, missing vaultId, API error propagation

## Out of scope

Tier 1 (single source of truth via `@bitgo/public-types`) and Tier 2 (oasdiff breaking-change CI gate) are tracked separately. Tier 0 is independently shippable with no dependencies, matching the doc's recommended **0 → 2 → 1** sequencing.

CLOSES TICKET: DEFI-682
