### PR TITLE
refactor: allow TSS signing of wrapApprove without client recipients

### DIFF
--- a/modules/sdk-coin-eth/test/unit/eth.ts
+++ b/modules/sdk-coin-eth/test/unit/eth.ts
@@ -903,6 +903,38 @@ describe('ETH:', function () {
       isTransactionVerified.should.equal(true);
     });
 
+    it('should verify TSS transaction with wrapApprove type and no recipients', async function () {
+      const coin = bitgo.coin('hteth') as Hteth;
+      const wallet = new Wallet(bitgo, coin, {
+        coinSpecific: {
+          baseAddress: '0x174cfd823af8ce27ed0afee3fcf3c3ba259116be',
+        },
+      });
+
+      // WP derives the underlying token contract, wrapper spender, and approve
+      // calldata from tokenName and amount, so the client intent has no recipients.
+      const txParams = {
+        type: 'wrapApprove',
+        tokenName: 'hteth:cusdt',
+        amount: '1000000',
+      };
+      const txPrebuild = {
+        txHex: '0x',
+        coin: 'hteth',
+        walletId: 'fakeWalletId',
+      };
+
+      const isTransactionVerified = await coin.verifyTransaction({
+        txParams: txParams as any,
+        txPrebuild: txPrebuild as any,
+        wallet,
+        verification: {},
+        walletType: 'tss',
+      });
+
+      isTransactionVerified.should.equal(true);
+    });
+
     it('should verify TSS transaction with defiDeposit type', async function () {
       const coin = bitgo.coin('hteth') as Hteth;
       const baseAddress = '0x174cfd823af8ce27ed0afee3fcf3c3ba259116be';

--- a/modules/sdk-core/src/bitgo/utils/tss/recipientUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/recipientUtils.ts
@@ -9,7 +9,7 @@ import { PopulatedIntent, TxRequest } from './baseTypes';
  * Mirrors the bypass list in abstractEthLikeNewCoins.ts verifyTssTransaction.
  *
  * ECDSA types: acceleration, fillNonce, transferToken, tokenApproval, consolidate,
- *              bridgeFunds, enableToken, customTx, contractCall
+ *              bridgeFunds, enableToken, customTx, wrapApprove, contractCall
  * BSC/BNB delegation-based staking: delegate, undelegate, switchValidator
  * CELO/ETH lock-based staking: stake, unstake, stakeWithCallData, unstakeWithCallData,
  *              transferStake, increaseStake, goUnstake
@@ -31,6 +31,8 @@ export const NO_RECIPIENT_TX_TYPES = new Set([
   'defiApprove',
   'defiDeposit',
   'defiWithdraw',
+  // ERC-7984 shielding: approve calldata is built server-side from the wrap intent
+  'wrapApprove',
   // Smart contract invocations with no explicit SDK-level recipients
   'contractCall',
 

--- a/modules/sdk-core/test/unit/bitgo/utils/tss/recipientUtils.ts
+++ b/modules/sdk-core/test/unit/bitgo/utils/tss/recipientUtils.ts
@@ -30,6 +30,7 @@ describe('recipientUtils', function () {
         'defiApprove',
         'defiDeposit',
         'defiWithdraw',
+        'wrapApprove',
         'contractCall',
         // Staking — 'delegate' also covers SOL solDelegateIntent
         'delegate',
@@ -112,6 +113,21 @@ describe('recipientUtils', function () {
         const txRequest = makeTxRequest();
         assert.doesNotThrow(() => resolveEffectiveTxParams(txRequest, { type: txType }));
       }
+    });
+
+    it('does not require recipients for a wrapApprove intent', function () {
+      const txRequest = makeTxRequest({
+        intent: {
+          intentType: 'wrapApprove',
+          tokenName: 'hteth:cusdt',
+          amount: '1000000',
+        } as any,
+      });
+
+      const result = resolveEffectiveTxParams(txRequest, {});
+
+      assert.strictEqual(result.type, 'wrapApprove');
+      assert.strictEqual(result.recipients, undefined);
     });
 
     it('does not throw for Avalanche cross-chain imports resolved from intent.intentType', function () {


### PR DESCRIPTION
## Description

TSS signing of ERC-7984 `wrapApprove` failed because the client intent has no `recipients`. Wallet Platform builds the underlying ERC-20 `approve(wrapper, amount)` calldata server-side (same shape as `defiApprove` / `tokenApproval`).

This adds `wrapApprove` to `NO_RECIPIENT_TX_TYPES` so ECDSA MPCv2 can sign, and ETH TSS `verifyTransaction` accepts the type without recipients. Payment / unknown intents still require recipients.

## Issue Number

[CHALO-1357](https://linear.app/bitgo/issue/CHALO-1357/allow-tss-signing-of-wrapapprove-intents-with-no-client-recipients)

Related: CHALO-1162 (WP wrapApprove create path)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- `npx mocha test/unit/bitgo/utils/tss/recipientUtils.ts` in `modules/sdk-core` — 29 passing
- `BITGOJS_TEST_PASSWORD=… npx mocha test/unit/eth.ts --grep "wrapApprove type"` in `modules/sdk-coin-eth` — 1 passing
- Staging sign of wrapApprove txRequest `01a03397-7df7-7a58-b0b5-46a7e05257f7` on hteth wallet `6a8c28e22352eff3da6470b5b6f5ed41` succeeded after this allowlist change (Hoodi `0xa9ad0a51654b7cbf9c697f5fb2cc5d3da6acf19c4b6408eb78414fa69165f121`)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [x] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Made with [Cursor](https://cursor.com)