### PR TITLE
fix: revert blanket tar 7.5.21 bump, exclude GHSA-r292-9mhp-454m instead

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -69,3 +69,7 @@ reason = "fast-uri host confusion via literal backslash authority (CVE-2026-1622
 [[IgnoredVulns]]
 id = "GHSA-jmr9-qjv8-65gv"
 reason = "extract-zip unvalidated symlink path traversal on extraction (CVE-2026-56876); transitive via cypress and @puppeteer/browsers, both dev-only tooling; extracted archives are Cypress/Chromium binary release downloads from trusted sources, never untrusted user-supplied zips; no upstream fix (last_affected: 2.0.1, which is the latest release). Re-evaluate on 2026-11-13: drop this exclusion if extract-zip ships a patched release"
+
+[[IgnoredVulns]]
+id = "GHSA-r292-9mhp-454m"
+reason = "tar stack-overflow DoS in tar.x()/tar.t() member-selection filtering; transitive via lerna and yeoman-generator requiring tar <7.5.21; fix only in tar 7.5.21+ which breaks lerna packDirectory (same constraint as GHSA-8qq5-rm4j-mr97); our usage is archive PACKING only, not extraction of untrusted archives"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "yeoman-generator": "^5.6.1"
   },
   "resolutions": {
-    "tar": "7.5.21",
     "**/cliui/strip-ansi": "6.0.1",
     "**/cliui/string-width": "4.2.3",
     "**/yargs/cliui/string-width": "4.2.3",
@@ -114,6 +113,7 @@
     "**/avalanche/**/ws": "8.18.3",
     "**/ethers/**/ws": "7.5.10",
     "**/swarm-js/**/ws": "5.2.4",
+    "**/swarm-js/**/tar": "6.2.1",
     "serialize-javascript": "7.0.5",
     "@grpc/grpc-js": "^1.14.4",
     "bigint-buffer": "npm:@trufflesuite/bigint-buffer@1.1.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11965,7 +11965,7 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-minipass@^2.1.0:
+fs-minipass@^2.0.0, fs-minipass@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz"
   integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
@@ -15321,7 +15321,7 @@ minipass@^7.0.2, minipass@^7.0.3, minipass@^7.0.4, minipass@^7.1.2:
   resolved "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz"
   integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
 
-minizlib@^2.1.2:
+minizlib@^2.1.1, minizlib@^2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz"
   integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
@@ -15348,7 +15348,7 @@ mkdirp@^0.5.5:
   dependencies:
     minimist "^1.2.6"
 
-mkdirp@^1.0.4:
+mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -19881,10 +19881,22 @@ tar-stream@^3.1.5:
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
 
-tar@6.2.1, tar@7.5.21, tar@^6.1.11, tar@^6.1.2, tar@^7.4.3:
-  version "7.5.21"
-  resolved "https://registry.npmjs.org/tar/-/tar-7.5.21.tgz#b3405af2eb493523ce4379f531e9ebda0601bc59"
-  integrity sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==
+tar@6.2.1, tar@^6.1.11, tar@^6.1.2:
+  version "6.2.1"
+  resolved "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz"
+  integrity sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^5.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
+
+tar@^7.4.3:
+  version "7.5.1"
+  resolved "https://registry.npmjs.org/tar/-/tar-7.5.1.tgz"
+  integrity sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==
   dependencies:
     "@isaacs/fs-minipass" "^4.0.0"
     chownr "^3.0.0"


### PR DESCRIPTION
## Summary
- The "Publish @bitgo-beta" workflow was failing at `packDirectory` with `TypeError: Cannot read properties of undefined (reading 'create')`, caused by 98b76a5a35's blanket root `resolutions.tar: "7.5.21"`, which also overrode lerna's own exact `tar@6.2.1` pin.
- lerna's bundled `dist/index.js` interops with tar via CJS `require("tar")` expecting the 6.x export shape (`module.exports = { create, extract, ... }`); tar 7.x's different export shape leaves `import_tar.default.create` undefined at runtime.
- This repo has repeated, established precedent for exactly this constraint in `osv-scanner.toml` ("lerna requires tar v6 ... forcing v7.x breaks lerna's packDirectory API ... our usage is archive PACKING only"), which 98b76a5a35 didn't follow for the new GHSA-r292-9mhp-454m advisory.
- Reverts `tar` back to `6.2.1` (restoring the `**/swarm-js/**/tar` resolution too) and adds a new `[[IgnoredVulns]]` entry for GHSA-r292-9mhp-454m with the same reasoning as the other tar exclusions.

Fixes CECHO-2021.

## Test plan
- [x] `yarn install` succeeds; `node_modules/tar` resolves back to `6.2.1`
- [x] Reproduced lerna's exact `packDirectory` call (`tar.create({ cwd, prefix: 'package/', portable: true, mtime, gzip: true }, files)`) directly against the installed tar — succeeds and produces a valid `.tgz`
- [x] `osv-scanner.toml` is valid TOML with the new `GHSA-r292-9mhp-454m` entry
- [ ] CI: confirm the "Publish @bitgo-beta" workflow completes past `packDirectory`