### PR TITLE
ci(release): verify shrinkwrap installs on node 20 before publish

### DIFF
--- a/.github/workflows/npmjs-release.yml
+++ b/.github/workflows/npmjs-release.yml
@@ -307,6 +307,51 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: true
 
+      # WCN-2091: fail the release BEFORE bitgo publishes if the shrinkwrap it
+      # would ship pins any transitive that violates our declared engines (Node
+      # >=20). Runs after pass 1 because the shrinkwrap generator resolves
+      # newly-published siblings from the registry. Pack + install here, not
+      # --package-lock-only, so `engine-strict=true` actually validates every
+      # frozen entry's engines. If this fails, siblings are already on npm but
+      # bitgo isn't — fix the shrinkwrap issue and re-run in recovery-mode.
+      - name: Pre-publish shrinkwrap check — pack bitgo tarball
+        if: inputs.dry-run == false
+        env:
+          BITGO_GENERATE_SHRINKWRAP: true
+        run: |
+          mkdir -p "$RUNNER_TEMP/tarballs"
+          (cd modules/bitgo && npm pack --pack-destination "$RUNNER_TEMP/tarballs/")
+          tarball="$(ls "$RUNNER_TEMP/tarballs"/*.tgz | head -1)"
+          echo "PREPUB_TARBALL=$tarball" >> "$GITHUB_ENV"
+          echo "Packed: $tarball"
+
+      - name: Pre-publish shrinkwrap check — setup Node 20
+        if: inputs.dry-run == false
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20.x'
+
+      - name: Pre-publish shrinkwrap check — install tarball on Node 20 with engine-strict
+        if: inputs.dry-run == false
+        run: |
+          workdir="$(mktemp -d)"
+          cd "$workdir"
+          echo "engine-strict=true" > .npmrc
+          npm init -y >/dev/null
+          echo "Verifying $PREPUB_TARBALL installs on $(node --version) with engine-strict=true"
+          if ! npm install "$PREPUB_TARBALL" --no-audit --no-fund --ignore-scripts 2>install.log; then
+            echo "::error::Pre-publish shrinkwrap check FAILED — bitgo tarball cannot be installed on Node 20 with engine-strict. Fix before publishing."
+            cat install.log
+            exit 1
+          fi
+          echo "✅ bitgo tarball installs cleanly on $(node --version) with engine-strict."
+
+      - name: Pre-publish shrinkwrap check — restore release Node version
+        if: inputs.dry-run == false
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+
       - name: Publish bitgo (pass 2)
         if: inputs.dry-run == false
         run: |


### PR DESCRIPTION
Adds a pre-publish gate between the siblings publish (pass 1) and the bitgo publish (pass 2): npm pack triggers the shrinkwrap generator via prepack, then we install the resulting tarball on Node 20 with engine-strict=true. Any transitive pinned by the shrinkwrap that violates engines (like sanitize-html@2.17.6 in WCN-2091) fails the release before the bad bitgo tarball reaches npm.

Runs after pass 1 because the generator resolves newly-published siblings from the registry. If it fails, siblings are on npm but bitgo isn't -- fix and re-run in recovery-mode.

Skipped in dry-run since siblings aren't published there.

TICKET: WCN-2098

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
