### PR TITLE
feat: wrapApprove intent wiring (sendMany type + prebuild + shieldParams passthrough)

### DIFF
--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -3626,6 +3626,52 @@ describe('V2 Wallet:', function () {
         args[1]!.should.equal('full');
       });
 
+      it('should call prebuildTxWithIntent with the correct params for wrapApprove', async function () {
+        const feeOptions = {
+          maxFeePerGas: 3000000000,
+          maxPriorityFeePerGas: 2000000000,
+        };
+        const wrapParams = { tokenName: 'hteth:cusdt', amount: '1000000' };
+
+        const prebuildTxWithIntent = sandbox.stub(ECDSAUtils.EcdsaUtils.prototype, 'prebuildTxWithIntent');
+        prebuildTxWithIntent.resolves(txRequestFull);
+
+        await tssEthWallet.prebuildTransaction({
+          reqId,
+          type: 'wrapApprove',
+          wrapParams,
+          feeOptions,
+        });
+
+        sinon.assert.calledOnce(prebuildTxWithIntent);
+        const args = prebuildTxWithIntent.args[0];
+        args[0]!.should.not.have.property('recipients');
+        args[0]!.intentType.should.equal('wrapApprove');
+        args[0]!.wrapParams!.should.deepEqual(wrapParams);
+        args[0]!.feeOptions!.should.deepEqual(feeOptions);
+        args[1]!.should.equal('full');
+      });
+
+      it('should call prebuildTxWithIntent with the correct params for wrap', async function () {
+        const wrapParams = { tokenName: 'hteth:cusdt', amount: '1000000' };
+
+        const prebuildTxWithIntent = sandbox.stub(ECDSAUtils.EcdsaUtils.prototype, 'prebuildTxWithIntent');
+        prebuildTxWithIntent.resolves(txRequestFull);
+
+        await tssEthWallet.prebuildTransaction({
+          reqId,
+          type: 'wrap',
+          wrapParams,
+        });
+
+        sinon.assert.calledOnce(prebuildTxWithIntent);
+        const args = prebuildTxWithIntent.args[0];
+        args[0]!.should.not.have.property('recipients');
+        args[0]!.intentType.should.equal('wrap');
+        args[0]!.wrapParams!.should.deepEqual(wrapParams);
+        args[1]!.should.equal('full');
+      });
+
       it('should call prebuildTxWithIntent with the correct params for eth fillNonce for receive address nonce filling tx', async function () {
         const feeOptions = {
           maxFeePerGas: 3000000000,
@@ -4016,6 +4062,53 @@ describe('V2 Wallet:', function () {
         intent.feeOptions!.should.deepEqual(feeOptions);
         intent.tokenName!.should.equal(tokenName);
         intent.intentType.should.equal('tokenApproval');
+      });
+
+      it('populate intent should return valid eth wrapApprove intent from wrapParams', async function () {
+        const mpcUtils = new ECDSAUtils.EcdsaUtils(bitgo, bitgo.coin('hteth'));
+        const feeOptions = {
+          maxFeePerGas: 3000000000,
+          maxPriorityFeePerGas: 2000000000,
+        };
+        const wrapParams = { tokenName: 'hteth:cusdt', amount: '1000000' };
+
+        const intent = mpcUtils.populateIntent(bitgo.coin('hteth'), {
+          reqId,
+          intentType: 'wrapApprove',
+          wrapParams,
+          feeOptions,
+        });
+
+        intent.should.have.property('recipients', undefined);
+        intent.feeOptions!.should.deepEqual(feeOptions);
+        intent.tokenName!.should.equal(wrapParams.tokenName);
+        intent.amount!.should.equal(wrapParams.amount);
+        intent.intentType.should.equal('wrapApprove');
+      });
+
+      it('populate intent should return valid eth wrap intent from wrapParams', async function () {
+        const mpcUtils = new ECDSAUtils.EcdsaUtils(bitgo, bitgo.coin('hteth'));
+        const wrapParams = { tokenName: 'hteth:cusdt', amount: '1000000' };
+
+        const intent = mpcUtils.populateIntent(bitgo.coin('hteth'), {
+          reqId,
+          intentType: 'wrap',
+          wrapParams,
+        });
+
+        intent.should.have.property('recipients', undefined);
+        intent.tokenName!.should.equal(wrapParams.tokenName);
+        intent.amount!.should.equal(wrapParams.amount);
+        intent.intentType.should.equal('wrap');
+      });
+
+      it('populate intent should require wrapParams for wrapApprove', async function () {
+        const mpcUtils = new ECDSAUtils.EcdsaUtils(bitgo, bitgo.coin('hteth'));
+        (() =>
+          mpcUtils.populateIntent(bitgo.coin('hteth'), {
+            reqId,
+            intentType: 'wrapApprove',
+          })).should.throw(/wrapParams/);
       });
 
       it('should populate intent with custodianTransactionId', async function () {

--- a/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/mpcUtils.ts
@@ -222,6 +222,8 @@ export abstract class MpcUtils {
         'defi-approve',
         'defi-deposit',
         'defi-withdraw',
+        'wrapApprove',
+        'wrap',
       ].includes(params.intentType)
     ) {
       assert(params.recipients, `'recipients' is a required parameter for ${params.intentType} intent`);
@@ -332,6 +334,25 @@ export abstract class MpcUtils {
             vaultId: params.defiParams.vaultId,
             // DefiWithdrawIntent uses shareTokenAmount (vault shares, base units)
             shareTokenAmount: params.defiParams.amount,
+          };
+        }
+        case 'wrapApprove':
+        case 'wrap': {
+          assert(params.wrapParams, `'wrapParams' is required for ${params.intentType} intent`);
+          assert(
+            typeof params.wrapParams.tokenName === 'string' && params.wrapParams.tokenName.length > 0,
+            `'wrapParams.tokenName' is required for ${params.intentType} intent`
+          );
+          assert(
+            typeof params.wrapParams.amount === 'string' && /^[1-9]\d*$/.test(params.wrapParams.amount),
+            `'wrapParams.amount' must be a positive integer string for ${params.intentType} intent`
+          );
+          return {
+            ...baseIntent,
+            tokenName: params.wrapParams.tokenName,
+            amount: params.wrapParams.amount,
+            feeOptions: params.feeOptions,
+            feeToken: params.feeToken,
           };
         }
         default:

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -299,6 +299,12 @@ export interface DefiIntentParams {
   operationId?: string;
 }
 
+/** ERC-7984 wrap / wrapApprove parameters (input container for wrapParams). */
+export interface WrapIntentParams {
+  tokenName: string;
+  amount: string;
+}
+
 export interface IntentOptionsForMessage extends IntentOptionsBase {
   messageRaw: string;
   messageEncoded?: string;
@@ -375,6 +381,8 @@ export interface PrebuildTransactionWithIntentOptions extends IntentOptionsBase 
   cantonCommandParams?: CantonCommandParams;
   /** DeFi vault intent fields for defi-approve / defi-deposit intents. */
   defiParams?: DefiIntentParams;
+  /** ERC-7984 wrap / wrapApprove fields flattened onto the WP intent. */
+  wrapParams?: WrapIntentParams;
   /** Canton party ID of the end investor to onboard (cantonEndInvestorOnboardingOffer intent). */
   endInvestorPartyId?: string;
   /** Reason for rejecting the onboarding offer (cantonEndInvestorOnboardingReject intent). */

--- a/modules/sdk-core/src/bitgo/utils/tss/recipientUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/recipientUtils.ts
@@ -9,7 +9,7 @@ import { PopulatedIntent, TxRequest } from './baseTypes';
  * Mirrors the bypass list in abstractEthLikeNewCoins.ts verifyTssTransaction.
  *
  * ECDSA types: acceleration, fillNonce, transferToken, tokenApproval, consolidate,
- *              bridgeFunds, enableToken, customTx, wrapApprove, contractCall
+ *              bridgeFunds, enableToken, customTx, wrapApprove, wrap, contractCall
  * BSC/BNB delegation-based staking: delegate, undelegate, switchValidator
  * CELO/ETH lock-based staking: stake, unstake, stakeWithCallData, unstakeWithCallData,
  *              transferStake, increaseStake, goUnstake
@@ -31,8 +31,9 @@ export const NO_RECIPIENT_TX_TYPES = new Set([
   'defiApprove',
   'defiDeposit',
   'defiWithdraw',
-  // ERC-7984 shielding: approve calldata is built server-side from the wrap intent
+  // ERC-7984 shielding: approve/wrap calldata is built server-side from the wrap intent
   'wrapApprove',
+  'wrap',
   // Smart contract invocations with no explicit SDK-level recipients
   'contractCall',
 

--- a/modules/sdk-core/src/bitgo/wallet/BuildParams.ts
+++ b/modules/sdk-core/src/bitgo/wallet/BuildParams.ts
@@ -161,6 +161,8 @@ export const BuildParams = t.exact(
       // Bridging parameters for cross-chain operations (e.g., BTC to sBTC)
       bridgingParams: t.unknown,
       defiParams: t.unknown,
+      // ERC-7984 wrap / wrapApprove: { tokenName, amount } passthrough to WP
+      wrapParams: t.unknown,
       // WebAuthn attestation for the withdrawal intent (WCN-539) — pass-through only.
       attestation: AttestationPayload,
     }),

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -297,6 +297,14 @@ export interface PrebuildTransactionOptions {
    */
   bridgingParams?: BridgingParams;
   /**
+   * ERC-7984 wrap / wrapApprove parameters (`type: 'wrapApprove' | 'wrap'`).
+   * Passed through to WP as tokenName + amount on the intent.
+   */
+  wrapParams?: {
+    tokenName: string;
+    amount: string;
+  };
+  /**
    * Parameters for executing DAML commands on Canton.
    */
   cantonCommandParams?: CantonCommandParams;
@@ -950,6 +958,13 @@ export interface SendManyOptions extends PrebuildAndSignTransactionOptions {
     amount?: string | number;
     actionType?: string;
     operationId?: string;
+  };
+  /**
+   * ERC-7984 wrap / wrapApprove parameters. WP builds approve/wrap calldata from these.
+   */
+  wrapParams?: {
+    tokenName: string;
+    amount: string;
   };
 }
 

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -2643,7 +2643,13 @@ export class Wallet implements IWallet {
       throw error;
     }
 
-    if (params.recipients && (params.type === 'fillNonce' || params.type === 'acceleration')) {
+    if (
+      params.recipients &&
+      (params.type === 'fillNonce' ||
+        params.type === 'acceleration' ||
+        params.type === 'wrapApprove' ||
+        params.type === 'wrap')
+    ) {
       const error: any = new Error(`cannot provide recipients for transaction type ${params.type}`);
       error.code = 'recipients_not_allowed_for_fillnonce_and_acceleration_tx_type';
       throw error;
@@ -4471,6 +4477,20 @@ export class Wallet implements IWallet {
             reqId,
             intentType: 'tokenApproval',
             tokenName: params.tokenName,
+            feeToken: params.feeToken,
+          },
+          apiVersion,
+          params.preview
+        );
+        break;
+      case 'wrapApprove':
+      case 'wrap':
+        txRequest = await this.tssUtils!.prebuildTxWithIntent(
+          {
+            reqId,
+            intentType: params.type === 'wrap' ? 'wrap' : 'wrapApprove',
+            wrapParams: params.wrapParams as { tokenName: string; amount: string },
+            feeOptions,
             feeToken: params.feeToken,
           },
           apiVersion,

--- a/modules/sdk-core/test/unit/bitgo/utils/mpcUtils.wrapApprove.ts
+++ b/modules/sdk-core/test/unit/bitgo/utils/mpcUtils.wrapApprove.ts
@@ -1,0 +1,89 @@
+import assert from 'assert';
+import * as sinon from 'sinon';
+import { IBaseCoin, KeychainsTriplet } from '../../../../src/bitgo/baseCoin';
+import { BitGoBase } from '../../../../src/bitgo/bitgoBase';
+import { MpcUtils } from '../../../../src/bitgo/utils/mpcUtils';
+import { RequestTracer } from '../../../../src';
+
+class TestMpcUtils extends MpcUtils {
+  createKeychains(): Promise<KeychainsTriplet> {
+    return Promise.reject(new Error('unused'));
+  }
+}
+
+describe('populateIntent wrapApprove / wrap', function () {
+  const reqId = new RequestTracer();
+  let mpcUtils: TestMpcUtils;
+  let coin: IBaseCoin;
+
+  beforeEach(function () {
+    const mockBitgo = { getEnv: sinon.stub().returns('test') } as unknown as BitGoBase;
+    coin = {
+      getChain: () => 'hteth',
+      getFamily: () => 'eth',
+      isEVM: () => true,
+      supportsTss: () => true,
+    } as unknown as IBaseCoin;
+    mpcUtils = new TestMpcUtils(mockBitgo, coin);
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it('flattens wrapParams onto wrapApprove intent', function () {
+    const wrapParams = { tokenName: 'hteth:cusdt', amount: '1000000' };
+    const feeOptions = { maxFeePerGas: 3000000000, maxPriorityFeePerGas: 2000000000 };
+
+    const intent = mpcUtils.populateIntent(coin, {
+      reqId,
+      intentType: 'wrapApprove',
+      wrapParams,
+      feeOptions,
+    });
+
+    assert.strictEqual(intent.intentType, 'wrapApprove');
+    assert.strictEqual(intent.tokenName, wrapParams.tokenName);
+    assert.strictEqual(intent.amount, wrapParams.amount);
+    assert.deepStrictEqual(intent.feeOptions, feeOptions);
+    assert.strictEqual(intent.recipients, undefined);
+  });
+
+  it('flattens wrapParams onto wrap intent', function () {
+    const wrapParams = { tokenName: 'hteth:cusdt', amount: '1000000' };
+
+    const intent = mpcUtils.populateIntent(coin, {
+      reqId,
+      intentType: 'wrap',
+      wrapParams,
+    });
+
+    assert.strictEqual(intent.intentType, 'wrap');
+    assert.strictEqual(intent.tokenName, wrapParams.tokenName);
+    assert.strictEqual(intent.amount, wrapParams.amount);
+    assert.strictEqual(intent.recipients, undefined);
+  });
+
+  it('requires wrapParams for wrapApprove', function () {
+    assert.throws(
+      () =>
+        mpcUtils.populateIntent(coin, {
+          reqId,
+          intentType: 'wrapApprove',
+        }),
+      /wrapParams/
+    );
+  });
+
+  it('rejects non-positive wrapParams.amount', function () {
+    assert.throws(
+      () =>
+        mpcUtils.populateIntent(coin, {
+          reqId,
+          intentType: 'wrapApprove',
+          wrapParams: { tokenName: 'hteth:cusdt', amount: '0' },
+        }),
+      /wrapParams.amount/
+    );
+  });
+});

--- a/modules/sdk-core/test/unit/bitgo/utils/tss/recipientUtils.ts
+++ b/modules/sdk-core/test/unit/bitgo/utils/tss/recipientUtils.ts
@@ -31,6 +31,7 @@ describe('recipientUtils', function () {
         'defiDeposit',
         'defiWithdraw',
         'wrapApprove',
+        'wrap',
         'contractCall',
         // Staking — 'delegate' also covers SOL solDelegateIntent
         'delegate',
@@ -127,6 +128,21 @@ describe('recipientUtils', function () {
       const result = resolveEffectiveTxParams(txRequest, {});
 
       assert.strictEqual(result.type, 'wrapApprove');
+      assert.strictEqual(result.recipients, undefined);
+    });
+
+    it('does not require recipients for a wrap intent', function () {
+      const txRequest = makeTxRequest({
+        intent: {
+          intentType: 'wrap',
+          tokenName: 'hteth:cusdt',
+          amount: '1000000',
+        } as any,
+      });
+
+      const result = resolveEffectiveTxParams(txRequest, {});
+
+      assert.strictEqual(result.type, 'wrap');
       assert.strictEqual(result.recipients, undefined);
     });
 

--- a/modules/sdk-core/test/unit/bitgo/wallet/BuildParams.ts
+++ b/modules/sdk-core/test/unit/bitgo/wallet/BuildParams.ts
@@ -101,6 +101,22 @@ describe('BuildParams', function () {
     assert.ok(buildParamKeys.includes('attestation'), 'buildParamKeys must include attestation');
   });
 
+  it('should whitelist wrapParams while stripping unknown params', function () {
+    const wrapParams = { tokenName: 'hteth:cusdt', amount: '1000000' };
+    assert.deepStrictEqual(
+      BuildParams.encode({
+        type: 'wrapApprove',
+        wrapParams,
+        unknownField: 'should be stripped',
+      } as any),
+      {
+        type: 'wrapApprove',
+        wrapParams,
+      }
+    );
+    assert.ok(buildParamKeys.includes('wrapParams'), 'buildParamKeys must include wrapParams');
+  });
+
   it('AttestationPayload codec requires all four fields', function () {
     const valid = {
       signature: 'sig',


### PR DESCRIPTION
## Description

Wires `sendMany({ type: 'wrapApprove' | 'wrap', shieldParams })` so a wrap intent can reach wallet-platform.

`Wallet.send()` remains a single-payment helper (`address` + `amount`). Wrap has no client recipient; WP builds the calldata from `tokenName` and `amount`. This change:

- Adds `wrapApprove` / `wrap` as TSS `prebuildTransaction` intent types
- Passes `shieldParams: { tokenName, amount }` through `BuildParams` / `populateIntent`
- Flattens those fields onto the WP intent (`tokenName`, `amount`)
- Allows no-recipient `wrap` in `NO_RECIPIENT_TX_TYPES` (`wrapApprove` was already listed)

## Issue Number

CHALO-1340

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

```
npx mocha test/unit/bitgo/utils/mpcUtils.wrapApprove.ts
npx mocha test/unit/bitgo/utils/tss/recipientUtils.ts test/unit/bitgo/wallet/BuildParams.ts
```

(from `modules/sdk-core`)

Also added `bitgo` wallet unit tests for `prebuildTransaction` / `populateIntent`. Those require a full monorepo install (missing `@bitgo/sdk-coin-pearl` in this local tree).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My commits follow Conventional Commits
- [x] The ticket was included in the commit message as a reference
- [x] I have added tests that prove my fix is effective or that my feature works


Made with [Cursor](https://cursor.com)