### PR TITLE
fix(abstract-substrate): remove double Ed25519 prefix in MPCv2 recovery

### DIFF
--- a/modules/abstract-substrate/src/abstractSubstrateCoin.ts
+++ b/modules/abstract-substrate/src/abstractSubstrateCoin.ts
@@ -517,8 +517,14 @@ export class SubstrateCoin extends BaseCoin {
 
   /**
    * Adds an MPCv1 or MPCv2 signature to a Substrate transaction builder.
-   * MPCv2 signatures are prefixed with ED25519_MULTI_SIGNATURE_PREFIX (Ed25519 discriminant
-   * in the Substrate MultiSignature enum).
+   *
+   * Both branches hand off the raw 64-byte Ed25519 signature untouched.
+   * Transaction#constructSignedPayload already prepends the 0x00 type-tag
+   * (the Substrate MultiSignature enum discriminant for Ed25519) to whatever
+   * signature buffer is passed to addSignature, so wrapping the signature
+   * here would produce a double discriminant, corrupting the on-wire sig
+   * bytes and causing the chain to reject the extrinsic with `1010: Bad
+   * signature`.
    */
   protected async addSubstrateRecoverySignature(
     txBuilder: NativeTransferBuilder,
@@ -530,7 +536,6 @@ export class SubstrateCoin extends BaseCoin {
     bitgoKey: string,
     accountId: string
   ): Promise<void> {
-    const ED25519_MULTI_SIGNATURE_PREFIX = 0x00;
     const substrateKeyPair = new SubstrateKeyPair({ pub: accountId });
 
     if (signingMaterial.version === 'v2') {
@@ -543,8 +548,7 @@ export class SubstrateCoin extends BaseCoin {
         derivationPath: currPath,
         bitgo: this.bitgo,
       });
-      const substrateSig = Buffer.concat([Buffer.from([ED25519_MULTI_SIGNATURE_PREFIX]), rawSig]);
-      txBuilder.addSignature({ pub: substrateKeyPair.getKeys().pub }, substrateSig);
+      txBuilder.addSignature({ pub: substrateKeyPair.getKeys().pub }, rawSig);
     } else {
       const userSigningMaterial = JSON.parse(signingMaterial.userPrv) as EDDSAMethodTypes.UserSigningMaterial;
       const backupPrv = await decryptKeychainPrivateKey(this.bitgo, { encryptedPrv: backupKey }, walletPassphrase);

--- a/modules/abstract-substrate/test/unit/abstractSubstrateCoin.ts
+++ b/modules/abstract-substrate/test/unit/abstractSubstrateCoin.ts
@@ -86,7 +86,12 @@ describe('SubstrateCoin MPCv2 recovery helpers:', function () {
       (coin as unknown as { bitgo: unknown }).bitgo = { decrypt: instanceDecryptStub };
     });
 
-    it('should prepend ED25519 0x00 discriminant on MPCv2 path', async function () {
+    it('should pass the raw 64-byte signature to addSignature on MPCv2 path', async function () {
+      // Regression: previously wrapped rawSig with a manual Ed25519 discriminant
+      // (0x00) before addSignature. constructSignedPayload already prepends that
+      // discriminant, so wrapping here caused a double prefix that shifted the
+      // on-wire signature by one byte, dropping the last byte of `sigma` and
+      // producing `1010: Bad signature` on-chain.
       const rawSig = Buffer.alloc(64, 0xab);
       sinon.stub(coin as unknown, 'signSubstrateMpcV2Recovery').resolves(rawSig);
 
@@ -103,8 +108,8 @@ describe('SubstrateCoin MPCv2 recovery helpers:', function () {
 
       addSignatureStub.calledOnce.should.be.true();
       const sig: Buffer = addSignatureStub.firstCall.args[1];
-      sig[0].should.equal(0x00);
-      sig.slice(1).should.deepEqual(rawSig);
+      sig.length.should.equal(64);
+      sig.should.deepEqual(rawSig);
     });
 
     it('should call getTSSSignature and pass result to addSignature on MPCv1 path', async function () {


### PR DESCRIPTION
## Summary

Fixes MPCv2 non-BitGo recovery for Substrate-based EDDSA coins (TAO, POLYX). `addSubstrateRecoverySignature` was double-prefixing the Ed25519 MultiSignature discriminant, corrupting the on-wire signature by one byte and causing the chain to reject the extrinsic with `1010: Bad signature`.

**Linear**: [WCI-1454](https://linear.app/bitgo/issue/WCI-1454)

## Root cause

`addSubstrateRecoverySignature` wrapped the raw 64-byte MPCv2 signature with `0x00` before calling `txBuilder.addSignature`:

```
const substrateSig = Buffer.concat([Buffer.from([ED25519_MULTI_SIGNATURE_PREFIX]), rawSig]);
txBuilder.addSignature({ pub }, substrateSig);
```

But `Transaction.constructSignedPayload` (called during `build()`) already prepends `0x00`:

```ts
const edSignature = \`0x00\${signature.toString('hex')}\` as HexString;
```

Result: polkadot-js's `MultiSignature` decoder consumed `0x00` as the Ed25519 discriminant, then read the next 64 bytes as the signature — which were `[0x00][R (32B)][first 31 bytes of sigma]`. The last byte of `sigma` was dropped; the chain re-verified against the true 64-byte signature and rejected.

MPCv1 was unaffected because its branch already passed the raw 64-byte sig through untouched. `sdk-coin-dot` implements the same helper correctly (see [`dot.ts` L744](https://github.com/BitGo/BitGoJS/blob/master/modules/sdk-coin-dot/src/dot.ts) — with a comment explicitly warning against double-prefixing).

## Changes

- `modules/abstract-substrate/src/abstractSubstrateCoin.ts`: MPCv2 branch of `addSubstrateRecoverySignature` now passes `rawSig` directly, mirroring MPCv1 and `sdk-coin-dot`. Removed the unused `ED25519_MULTI_SIGNATURE_PREFIX` constant. Updated the doc comment to explain the invariant.
- `modules/abstract-substrate/test/unit/abstractSubstrateCoin.ts`: updated the MPCv2 unit test which previously pinned the buggy behavior (`sig[0] === 0x00`, `sig.slice(1) === rawSig`) — it now asserts `sig.length === 64` and `sig === rawSig`.

## Scope of impact

Coins that extend `SubstrateCoin` from `@bitgo/abstract-substrate`:

| Coin | Package | Affected |
|---|---|---|
| TAO / TTAO | `sdk-coin-tao` | yes → fixed |
| POLYX / TPOLYX | `sdk-coin-polyx` | yes → fixed |
| DOT / TDOT | `sdk-coin-dot` | no — has its own `addRecoverySignature` that was already correct |

## Test Plan

- [x] Unit test updated and passes locally (`yarn nyc mocha` in `modules/abstract-substrate`).
- [x] End-to-end verified on Bittensor testnet (finney) via WRW → MPCv2 recovery → broadcast:
  - `Status: Ready → Broadcast → InBlock → Finalized`
  - Block `0x3c5605b939d2cc403211f0d32c88fe1bc4125e2632da4ffa4957eff41c8dcf06`
- [ ] Retest TAO MPCv2 recovery on staging with released package (tracked in [WCI-1435](https://linear.app/bitgo/issue/WCI-1435)).
- [ ] Retest POLYX MPCv2 recovery on staging with released package.

Made with [Cursor](https://cursor.com)