### PR TITLE
feat: persist hardened parent path on safe child mint

### DIFF
--- a/modules/bitgo/test/v2/unit/keychains.ts
+++ b/modules/bitgo/test/v2/unit/keychains.ts
@@ -42,6 +42,28 @@ describe('V2 Keychains', function () {
       await keychains.add({ pub: 'pub', derivedFromParentWithSeed: 'derivedFromParentWithSeed' });
       scope.done();
     });
+
+    it('should add a safe child keychain with derivedFromParentWithHardenedPath', async function () {
+      const scope = nock(bgUrl)
+        .post('/api/v2/tltc/key', function (body) {
+          body.pub.should.equal('pub');
+          body.parent.should.equal('parent-key-id');
+          body.safeId.should.equal('safe-id');
+          body.derivedFromParentWithHardenedPath.should.equal("m/7'");
+          should.equal(body.path, undefined);
+          should.equal(body.derivedFromParentWithSeed, undefined);
+          return true;
+        })
+        .reply(200, { id: 'child-key-id', derivedFromParentWithHardenedPath: "m/7'", path: '/0/0' });
+      const result = await keychains.add({
+        pub: 'pub',
+        parent: 'parent-key-id',
+        safeId: 'safe-id',
+        derivedFromParentWithHardenedPath: "m/7'",
+      });
+      result.derivedFromParentWithHardenedPath.should.equal("m/7'");
+      scope.done();
+    });
   });
 
   /**

--- a/modules/sdk-core/src/bitgo/keychain/iKeychains.ts
+++ b/modules/sdk-core/src/bitgo/keychain/iKeychains.ts
@@ -49,6 +49,8 @@ export interface Keychain {
   reducedEncryptedPrv?: string;
   derivationPath?: string;
   derivedFromParentWithSeed?: string;
+  /** Hardened path from the safe parent (`m/<n>'`). @experimental */
+  derivedFromParentWithHardenedPath?: string;
   /** Safe root key id this child key was derived from (WCN-1172). */
   parent?: string;
   commonPub?: string;
@@ -145,7 +147,9 @@ export interface AddKeychainOptions {
   source?: string;
   originalPasscodeEncryptionCode?: string;
   enterprise?: string;
-  derivedFromParentWithSeed?: any;
+  derivedFromParentWithSeed?: string;
+  /** Hardened path from the safe parent (`m/<n>'`). @experimental */
+  derivedFromParentWithHardenedPath?: string;
   /** Safe user-root key id this child was derived from. @experimental */
   parent?: string;
   disableKRSEmail?: boolean;

--- a/modules/sdk-core/src/bitgo/keychain/keychains.ts
+++ b/modules/sdk-core/src/bitgo/keychain/keychains.ts
@@ -262,6 +262,7 @@ export class Keychains implements IKeychains {
         'originalPasscodeEncryptionCode',
         'enterprise',
         'derivedFromParentWithSeed',
+        'derivedFromParentWithHardenedPath',
         'parent',
         'safeId',
       ]
@@ -291,6 +292,7 @@ export class Keychains implements IKeychains {
         originalPasscodeEncryptionCode: params.originalPasscodeEncryptionCode,
         enterprise: params.enterprise,
         derivedFromParentWithSeed: params.derivedFromParentWithSeed,
+        derivedFromParentWithHardenedPath: params.derivedFromParentWithHardenedPath,
         parent: params.parent,
         disableKRSEmail: params.disableKRSEmail,
         krsSpecific: params.krsSpecific,

--- a/modules/sdk-core/src/bitgo/safe/safe.ts
+++ b/modules/sdk-core/src/bitgo/safe/safe.ts
@@ -23,7 +23,7 @@ import {
   ISafe,
   WalletShareData,
 } from './iSafe';
-import { deriveAndSelfCheckSafeChildHardened } from './safeDerivation';
+import { deriveAndSelfCheckSafeChildHardened, DerivedFromParentWithHardenedPath } from './safeDerivation';
 
 const SafeRootKeySlot = t.keyof({
   secp256k1Multisig: null,
@@ -145,6 +145,11 @@ export class Safe implements ISafe {
     }
 
     const derived = deriveAndSelfCheckSafeChildHardened(rootPrv, index);
+    const derivedFromParentWithHardenedPath = decodeWithCodec(
+      DerivedFromParentWithHardenedPath,
+      derived.derivationPath,
+      'derivedFromParentWithHardenedPath'
+    );
 
     const child = await keychains.add({
       pub: derived.pub,
@@ -152,6 +157,7 @@ export class Safe implements ISafe {
       keyType: 'independent',
       parent: userRootId,
       safeId: this.id(),
+      derivedFromParentWithHardenedPath,
     });
     const childId = child.id;
     if (childId.length === 0) {

--- a/modules/sdk-core/src/bitgo/safe/safeDerivation.ts
+++ b/modules/sdk-core/src/bitgo/safe/safeDerivation.ts
@@ -9,12 +9,12 @@
  * Do not use `derivedFromParentWithSeed` / `deriveKeyWithSeed` (`m/999999/a/b`) —
  * that is the custody hashed path and cannot reproduce a safe child.
  */
+import * as t from 'io-ts';
 import { bip32, BIP32Interface } from '@bitgo/utxo-lib';
+import { decodeWithCodec } from '../utils/codecs';
 
 const MAX_BIP32_INDEX = 0x7fffffff;
-
-/** Sign-time scan cap (wallet cap plus abandoned mint increments). */
-export const MAX_SAFE_CHILD_INDEX_SCAN = 4096;
+export const DERIVED_FROM_PARENT_WITH_HARDENED_PATH = /^m\/(\d+)'$/;
 
 export function parseSafeDerivationIndex(index: string | number): number {
   let idx: number;
@@ -33,6 +33,39 @@ export function parseSafeDerivationIndex(index: string | number): number {
 
 export function getSafeHardenedDerivationPath(index: string | number): string {
   return `m/${parseSafeDerivationIndex(index)}'`;
+}
+
+export interface DerivedFromParentWithHardenedPathBrand {
+  readonly DerivedFromParentWithHardenedPath: unique symbol;
+}
+
+export type DerivedFromParentWithHardenedPath = t.Branded<string, DerivedFromParentWithHardenedPathBrand>;
+
+export const DerivedFromParentWithHardenedPath = t.brand(
+  t.string,
+  (s): s is DerivedFromParentWithHardenedPath => parseDerivedFromParentWithHardenedPathIndex(s) !== undefined,
+  'DerivedFromParentWithHardenedPath'
+);
+
+function parseDerivedFromParentWithHardenedPathIndex(path: string): number | undefined {
+  const match = DERIVED_FROM_PARENT_WITH_HARDENED_PATH.exec(path);
+  if (!match) {
+    return undefined;
+  }
+  try {
+    return parseSafeDerivationIndex(match[1]);
+  } catch {
+    return undefined;
+  }
+}
+
+export function parseDerivedFromParentWithHardenedPath(path: string): number {
+  const validated = decodeWithCodec(DerivedFromParentWithHardenedPath, path, 'derivedFromParentWithHardenedPath');
+  const index = parseDerivedFromParentWithHardenedPathIndex(validated);
+  if (index === undefined) {
+    throw new Error(`Invalid derivedFromParentWithHardenedPath '${path}': expected m/<n>'`);
+  }
+  return index;
 }
 
 export interface SafeHardenedChildKey {
@@ -66,21 +99,4 @@ export function deriveAndSelfCheckSafeChildHardened(rootXprv: string, index: str
     throw new Error(`Safe child self-check failed at ${first.derivationPath}: derivation was not deterministic`);
   }
   return first;
-}
-
-/** Walk `m/0'` … `m/<max>'` until the registered child pub matches. */
-export function deriveSafeChildHardenedMatchingPub(
-  rootXprv: string,
-  expectedPub: string,
-  maxIndex: number = MAX_SAFE_CHILD_INDEX_SCAN
-): SafeHardenedChildKey {
-  const root = bip32.fromBase58(rootXprv);
-  const limit = parseSafeDerivationIndex(maxIndex);
-  for (let i = 0; i <= limit; i++) {
-    const derived = childFromNode(root.deriveHardened(i), getSafeHardenedDerivationPath(i));
-    if (derived.pub === expectedPub) {
-      return derived;
-    }
-  }
-  throw new Error(`No hardened safe child at m/0'..m/${limit}' matched the registered public key`);
 }

--- a/modules/sdk-core/src/bitgo/wallet/safeKeychain.ts
+++ b/modules/sdk-core/src/bitgo/wallet/safeKeychain.ts
@@ -3,7 +3,7 @@
  */
 import { BitGoBase } from '../bitgoBase';
 import { decryptKeychainPrivateKey, IKeychains, Keychain, KeychainWithEncryptedPrv } from '../keychain';
-import { deriveSafeChildHardenedMatchingPub } from '../safe/safeDerivation';
+import { deriveSafeChildHardenedFromXprv, parseDerivedFromParentWithHardenedPath } from '../safe/safeDerivation';
 import { IncorrectPasswordError } from '../errors';
 
 export class InvalidRootKeychainSourceError extends Error {
@@ -86,8 +86,8 @@ export interface ResolveSafeOwnerSigningPrvParams {
 /**
  * Resolve signing material for a safe owner (child key has no encryptedPrv).
  *
- * Onchain secp256k1: decrypt root → walk sequential `m/<n>'` children until the
- * registered pub matches (the mint index is not stored on the child key).
+ * Onchain secp256k1: decrypt root, hardened-derive at `derivedFromParentWithHardenedPath`
+ * (`m/<n>'`), and verify the registered pub.
  * TSS and ed25519 onchain: throw — do not return root material or BIP32-derive the wrong curve.
  *
  * Do not use for wallet sharing — that must not receive root key material.
@@ -119,12 +119,16 @@ export async function resolveSafeOwnerSigningPrv(params: ResolveSafeOwnerSigning
   if (!childKeychain.pub) {
     throw new Error(`Safe wallet ${walletId}: child keychain is missing pub for pre-sign verification`);
   }
-
-  try {
-    const derived = deriveSafeChildHardenedMatchingPub(rootPrv, childKeychain.pub);
-    return derived.prv;
-  } catch (e) {
-    const detail = e instanceof Error ? e.message : String(e);
-    throw new SafeDerivedPublicKeyMismatchError(walletId, childKeychain.pub, detail);
+  if (childKeychain.derivedFromParentWithHardenedPath === undefined) {
+    throw new Error(`Safe wallet ${walletId}: child keychain is missing derivedFromParentWithHardenedPath`);
   }
+
+  const derived = deriveSafeChildHardenedFromXprv(
+    rootPrv,
+    parseDerivedFromParentWithHardenedPath(childKeychain.derivedFromParentWithHardenedPath)
+  );
+  if (derived.pub !== childKeychain.pub) {
+    throw new SafeDerivedPublicKeyMismatchError(walletId, childKeychain.pub, derived.pub);
+  }
+  return derived.prv;
 }

--- a/modules/sdk-core/test/unit/bitgo/safe/safe.ts
+++ b/modules/sdk-core/test/unit/bitgo/safe/safe.ts
@@ -128,6 +128,7 @@ describe('Safe', function () {
 
   describe('createWallet (WCN-1203)', function () {
     const childAt0 = deriveSafeChildHardenedFromXprv(ROOT_XPRV, 0);
+    const childAt7 = deriveSafeChildHardenedFromXprv(ROOT_XPRV, 7);
     let keychainsAdd: sinon.SinonStub;
     let keychainsGet: sinon.SinonStub;
     let derivationQuery: sinon.SinonStub;
@@ -191,9 +192,11 @@ describe('Safe', function () {
         keyType: 'independent',
         parent: 'user-root-id',
         safeId: 'test-safe-id',
+        derivedFromParentWithHardenedPath: "m/0'",
       });
       addArgs.should.not.have.property('encryptedPrv');
       addArgs.should.not.have.property('derivedFromParentWithSeed');
+      addArgs.should.not.have.property('path');
 
       mockBitGo.post.calledWith('/enterprise/test-enterprise-id/safes/test-safe-id/wallets').should.be.true();
       mintSend.firstCall.args[0].should.eql({
@@ -209,6 +212,21 @@ describe('Safe', function () {
         throw new Error('expected minted wallet to include safeId');
       }
       mintedSafeId.should.equal('test-safe-id');
+    });
+
+    it('registers the child with derivedFromParentWithHardenedPath at a non-zero mint index', async function () {
+      derivationQuery.returns({
+        result: sinon.stub().resolves({ slot: 'secp256k1Multisig', index: 7 }),
+      });
+      keychainsAdd.resolves({ id: 'child-key-id', pub: childAt7.pub, type: 'independent' });
+
+      await safe.createWallet({ coin: 'tbtc', label: 'desk 8', passphrase: 'pw' });
+
+      const addArgs = keychainsAdd.firstCall.args[0];
+      addArgs.pub.should.equal(childAt7.pub);
+      addArgs.derivedFromParentWithHardenedPath.should.equal("m/7'");
+      addArgs.should.not.have.property('path');
+      addArgs.should.not.have.property('derivedFromParentWithSeed');
     });
 
     it('rejects TSS minting', async function () {

--- a/modules/sdk-core/test/unit/bitgo/wallet/safeGetUserPrv.ts
+++ b/modules/sdk-core/test/unit/bitgo/wallet/safeGetUserPrv.ts
@@ -3,10 +3,12 @@
  */
 import 'should';
 import * as sinon from 'sinon';
+import { bip32 } from '@bitgo/utxo-lib';
 import {
   deriveSafeChildHardenedFromXprv,
   fetchRootKeychainForSafeChild,
   getSafeHardenedDerivationPath,
+  parseDerivedFromParentWithHardenedPath,
   IncorrectPasswordError,
   InvalidRootKeychainSourceError,
   MissingEncryptedKeychainError,
@@ -23,9 +25,11 @@ require('should-sinon');
 describe('WCN-1200 safe child getUserPrv root-fetch detour', function () {
   const prv =
     'xprv9s21ZrQH143K3hekyNj7TciR4XNYe1kMj68W2ipjJGNHETWP7o42AjDnSPgKhdZ4x8NBAvaL72RrXjuXNdmkMqLERZza73oYugGtbLFXG8g';
-  // Soft deriveKeyWithSeedBip32(prv, '123') — must NOT be used for safe owners.
-  const softDerivedPrv =
-    'xprv9yoG67Td11uwjXwbV8zEmrySVXERu5FZAsLD9suBeEJbgJqANs8Yng5dEJoii7hag5JermK6PbfxgDmSzW7ewWeLmeJEkmPfmZUSLdETtHx';
+  const softDerivedNode = BaseCoin.deriveKeyWithSeedBip32(bip32.fromBase58(prv), '123');
+  if (!softDerivedNode.key.privateKey) {
+    throw new Error('expected deriveKeyWithSeedBip32 to return a private key');
+  }
+  const softDerivedPrv = softDerivedNode.key.toBase58();
   const hardened = deriveSafeChildHardenedFromXprv(prv, '123');
   const passphrase = 'test-passphrase';
   const rootKeyId = 'root-key-id';
@@ -115,6 +119,15 @@ describe('WCN-1200 safe child getUserPrv root-fetch detour', function () {
     it('hardened-derives a child that differs from soft deriveKeyWithSeed', function () {
       hardened.derivationPath.should.eql("m/123'");
       hardened.prv.should.not.eql(softDerivedPrv);
+    });
+
+    it('parses derivedFromParentWithHardenedPath as m/<n> primed', function () {
+      parseDerivedFromParentWithHardenedPath("m/0'").should.eql(0);
+      parseDerivedFromParentWithHardenedPath("m/123'").should.eql(123);
+      (() => parseDerivedFromParentWithHardenedPath('m/0')).should.throw(/derivedFromParentWithHardenedPath/);
+      (() => parseDerivedFromParentWithHardenedPath('m/999999/a/b')).should.throw(/derivedFromParentWithHardenedPath/);
+      (() => parseDerivedFromParentWithHardenedPath("not-a-path'")).should.throw(/derivedFromParentWithHardenedPath/);
+      (() => parseDerivedFromParentWithHardenedPath("m/0''")).should.throw(/derivedFromParentWithHardenedPath/);
     });
   });
 
@@ -243,6 +256,7 @@ describe('WCN-1200 safe child getUserPrv root-fetch detour', function () {
           pub: hardened.pub,
           type: 'independent',
           parent: rootKeyId,
+          derivedFromParentWithHardenedPath: "m/123'",
         },
         walletPassphrase: passphrase,
       });
@@ -251,6 +265,77 @@ describe('WCN-1200 safe child getUserPrv root-fetch detour', function () {
       result.should.not.eql(softDerivedPrv);
       keychainsGetStub.calledOnceWithExactly({ id: rootKeyId }).should.be.true();
       mockBaseCoin.deriveKeyWithSeed.notCalled.should.be.true();
+    });
+
+    it('requires derivedFromParentWithHardenedPath on the child keychain', async function () {
+      const wallet = makeWallet({ safe: 'safe-id-1' });
+      keychainsGetStub.resolves({
+        id: rootKeyId,
+        source: 'user',
+        encryptedPrv: `enc:${prv}`,
+        type: 'independent',
+        pub: 'root-pub',
+      });
+
+      await wallet
+        .getUserPrv({
+          keychain: {
+            id: 'child-key',
+            pub: hardened.pub,
+            type: 'independent',
+            parent: rootKeyId,
+          },
+          walletPassphrase: passphrase,
+        })
+        .should.be.rejectedWith(/missing derivedFromParentWithHardenedPath/);
+    });
+
+    it('fails closed when derivedFromParentWithHardenedPath does not match the registered pub', async function () {
+      const wallet = makeWallet({ safe: 'safe-id-1' });
+      keychainsGetStub.resolves({
+        id: rootKeyId,
+        source: 'user',
+        encryptedPrv: `enc:${prv}`,
+        type: 'independent',
+        pub: 'root-pub',
+      });
+
+      await wallet
+        .getUserPrv({
+          keychain: {
+            id: 'child-key',
+            pub: hardened.pub,
+            type: 'independent',
+            parent: rootKeyId,
+            derivedFromParentWithHardenedPath: "m/0'",
+          },
+          walletPassphrase: passphrase,
+        })
+        .should.be.rejectedWith(SafeDerivedPublicKeyMismatchError);
+    });
+
+    it('rejects a malformed derivedFromParentWithHardenedPath', async function () {
+      const wallet = makeWallet({ safe: 'safe-id-1' });
+      keychainsGetStub.resolves({
+        id: rootKeyId,
+        source: 'user',
+        encryptedPrv: `enc:${prv}`,
+        type: 'independent',
+        pub: 'root-pub',
+      });
+
+      await wallet
+        .getUserPrv({
+          keychain: {
+            id: 'child-key',
+            pub: hardened.pub,
+            type: 'independent',
+            parent: rootKeyId,
+            derivedFromParentWithHardenedPath: "not-a-path'",
+          },
+          walletPassphrase: passphrase,
+        })
+        .should.be.rejectedWith(/derivedFromParentWithHardenedPath/);
     });
 
     it('fails closed for TSS safe owner instead of returning the root prv', async function () {
@@ -310,7 +395,7 @@ describe('WCN-1200 safe child getUserPrv root-fetch detour', function () {
             pub: 'xpub-wrong-registered-key',
             type: 'independent',
             parent: rootKeyId,
-            derivedFromParentWithSeed: '123',
+            derivedFromParentWithHardenedPath: "m/123'",
           },
           walletPassphrase: passphrase,
         })


### PR DESCRIPTION
SDK sends `derivedFromParentWithHardenedPath` (`m/<n>'`) on multisig safe mint so spend can re-derive the user child.
- Registers the public-only child with that field; does not send `path` or `derivedFromParentWithSeed`
- Types/forwards the field on `keychains.add`
- Signs from the stored path and checks the registered pub; missing or bad path fails closed
- Removes sequential pub scan (`deriveSafeChildHardenedMatchingPub`)
- Leaves MPC minting rejected/unchanged

Tests
- Mint at index `0` and `7` sends `m/0'` / `m/7'` and omits `path` / seed
- `keychains.add` posts the field and reads it back
- Sign requires the field; mismatch and malformed path fail closed
- Soft `deriveKeyWithSeedBip32` fixture is computed, not hardcoded

Ticket: WCN-2399