### PR TITLE
fix: skip ECDH decrypt for plaintext access tokens

### DIFF
--- a/modules/sdk-api/src/bitgoAPI.ts
+++ b/modules/sdk-api/src/bitgoAPI.ts
@@ -1468,7 +1468,8 @@ export class BitGoAPI implements BitGoBase {
       // verify the authenticity of the server's response before proceeding any further
       await verifyResponseAsync(this, this._token, 'post', request, response, this._authVersion);
 
-      if (this._ecdhXprv) {
+      // Skip ECDH decrypt when the server returned a v1 plaintext token.
+      if (this._ecdhXprv && response.body.encryptedToken) {
         const responseDetails = await this.handleTokenIssuance(response.body);
         response.body.token = responseDetails.token;
       }

--- a/modules/sdk-api/test/unit/bitgoAPI.ts
+++ b/modules/sdk-api/test/unit/bitgoAPI.ts
@@ -692,6 +692,33 @@ describe('Constructor', function () {
         result.token.should.equal('v2xnewplaintoken');
       });
 
+      it('should not call handleTokenIssuance when ecdhXprv is present but the server returned a plaintext token', async function () {
+        const handleTokenSpy = sinon.spy(BitGoAPI.prototype, 'handleTokenIssuance');
+        const { strategy } = makeStrategy({
+          isAuthenticated: sinon.stub().returns(true),
+        });
+        const bitgo = new BitGoAPI({ env: 'custom', customRootURI: ROOT, hmacAuthStrategy: strategy });
+        bitgo.fromJSON({
+          user: { username: 'test@example.com' },
+          token: 'a'.repeat(40),
+          ecdhXprv: 'xprv-test-key',
+        });
+
+        nock(ROOT).post('/api/auth/v1/accesstoken').reply(200, {
+          token: 'v2xplaintextfromv1',
+          label: 'test-token',
+        });
+
+        try {
+          const result = await bitgo.addAccessToken(validParams);
+
+          handleTokenSpy.called.should.be.false();
+          result.token.should.equal('v2xplaintextfromv1');
+        } finally {
+          handleTokenSpy.restore();
+        }
+      });
+
       it('should not call handleTokenIssuance when ecdhXprv is absent', async function () {
         const handleTokenSpy = sinon.spy(BitGoAPI.prototype, 'handleTokenIssuance');
         const { strategy } = makeStrategy({


### PR DESCRIPTION
Skip ECDH decryption in `addAccessToken` when the server returns a plaintext token.
- only call `handleTokenIssuance` if the response includes `encryptedToken`
- covers the v1 session path where `ecdhXprv` is set but the body has no `derivationPath`
- adds a unit test that `ecdhXprv` plus a plaintext access-token body does not call `handleTokenIssuance` and returns the token

Ticket: WCN-2423