### PR TITLE
statics: add mainnet erc721:hbarevmtoken generic placeholder

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -2889,6 +2889,15 @@ export const allCoinsAndTokens = [
   ),
 
   erc721Token(
+    'bbf99e39-c911-4ccd-a23d-c71f5189e41f',
+    'erc721:hbarevmtoken',
+    'Generic Hedera EVM NFT',
+    '0xerc721:hbarevmtoken',
+    Networks.main.hederaEVM,
+    GENERIC_TOKEN_FEATURES
+  ),
+
+  erc721Token(
     '48a79873-fd50-46ed-9c78-e8fc1b6ef08a',
     'thbarevm:tmnft',
     'Testnet HBAREVM ERC721 Token',


### PR DESCRIPTION
## Summary
- Adds the missing mainnet generic ERC721 catch-all coin `erc721:hbarevmtoken` for the `hbarevm` family in `modules/statics/src/allCoinsAndTokens.ts`.
- Mirrors the existing testnet `terc721:hbarevmtoken` entry and the eth/polygon generic-token convention (`erc721:token`, `erc721:polygontoken`) — a non-binding placeholder token with a literal (non-real) contract address, used purely as a catch-all label.

## Context (DE-2591)
`erc721:hbarevmtoken` was reported missing from `coinmetadatas`/the warehouse. Investigation showed it's not a data-pipeline gap: `bitgo-microservices`'s `cron-coins-metadata.ts` only mirrors what exists in `@bitgo-beta/statics`, and this mainnet placeholder coin was never defined there — only the testnet placeholder and the specific NFT `hbarevm:mclmongp` exist.

`wallet-platform` dynamically derives a generic fallback token name for any mainnet EVM family with `EVM_COMPATIBLE_WP` + `SUPPORTS_ERC721` features (`GENERIC_TOKEN_NAME` in `config/types/ETH.ts` → `` `erc721:${family}token` ``) and stamps any *unrecognized* ERC721 transfer on that chain with it (`decorateUnsupportedNftEntries` in `ethLikeMethods.ts`). `hbarevm` has both flags, so this generic label is actively used at runtime, but had no backing statics entry to resolve against — meaning any not-yet-onboarded hbarevm NFT transfer (as happened before `mclmongp` was added) falls back to a token name that can't resolve anywhere downstream.

## Notes for reviewers
- `asset_id`: newly generated UUID (`bbf99e39-c911-4ccd-a23d-c71f5189e41f`), not tied to any real on-chain entity — please confirm this is an acceptable convention/value.
- `contractAddress`: literal string `0xerc721:hbarevmtoken`, following the eth (`0xerc721:token`) / polygon (`0xerc721:polygontoken`) generic-placeholder convention, rather than a real or Hedera-precompile-style address — this is intentionally non-binding since it's a many-to-one catch-all, not a specific token.
- Related: CECHO-2034 (ERC-721 NFTs resolving to generic fallback instead of registered name).
- Did not run the full monorepo test suite locally (repo size); relying on CI plus manual verification that the new id/name/address don't collide with any existing entries.

## Test plan
- [ ] CI passes (statics unit tests, lint, build)
- [ ] Confirm no duplicate id/name/contractAddress in `allCoinsAndTokens.ts`
- [ ] Once merged and `@bitgo-beta/statics` is bumped in `bitgo-microservices`, confirm `cron-coins-metadata.ts` picks up `erc721:hbarevmtoken` and it flows through to `raw__coinmetadatas` / `stg_wallet_platform_bitgo2__coinmetadatas` / `dim_wallet_platform__asset_mapping` (DE-2591 verification criteria)

Ref: DE-2591