### PR TITLE
statics: add mainnet erc721:hbarevmtoken generic placeholder

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -2889,6 +2889,15 @@ export const allCoinsAndTokens = [
   ),
 
   erc721Token(
+    'bbf99e39-c911-4ccd-a23d-c71f5189e41f',
+    'erc721:hbarevmtoken',
+    'Generic Hedera EVM NFT',
+    '0xerc721:hbarevmtoken',
+    Networks.main.hederaEVM,
+    GENERIC_TOKEN_FEATURES
+  ),
+
+  erc721Token(
     '48a79873-fd50-46ed-9c78-e8fc1b6ef08a',
     'thbarevm:tmnft',
     'Testnet HBAREVM ERC721 Token',


### PR DESCRIPTION
## Summary
- Adds the missing mainnet generic ERC721 catch-all coin `erc721:hbarevmtoken` for the `hbarevm` family in `modules/statics/src/allCoinsAndTokens.ts`.
- Mirrors the existing testnet `terc721:hbarevmtoken` entry and the eth/polygon generic-token convention (`erc721:token`, `erc721:polygontoken`) — a non-binding placeholder token with a literal (non-real) contract address, used purely as a catch-all label.

## Context
`erc721:hbarevmtoken` is the generic fallback label `wallet-platform` stamps on any unrecognized ERC721 transfer on `hbarevm` mainnet (`GENERIC_TOKEN_NAME` in `bitgo-microservices/config/types/ETH.ts` → `` `erc721:${family}token` ``, used by `decorateUnsupportedNftEntries`). `hbarevm` has both `EVM_COMPATIBLE_WP` + `SUPPORTS_ERC721`, so this label is actively produced at runtime, but the mainnet placeholder coin was never defined in statics — only the testnet placeholder and the specific NFT `hbarevm:mclmongp` exist. Result: any not-yet-onboarded hbarevm NFT transfer (as happened before `mclmongp` was individually onboarded) resolves to a generic fallback name instead of a real token, and that fallback name itself has no statics/coinmetadata entry to resolve against (see CECHO-2034, and the related data gap DE-2591).

## Notes for reviewers
- `asset_id`: newly generated UUID (`bbf99e39-c911-4ccd-a23d-c71f5189e41f`), not tied to any real on-chain entity — please confirm this is an acceptable convention/value.
- `contractAddress`: literal string `0xerc721:hbarevmtoken`, following the eth (`0xerc721:token`) / polygon (`0xerc721:polygontoken`) generic-placeholder convention, rather than a real or Hedera-precompile-style address — intentionally non-binding since it's a many-to-one catch-all, not a specific token.
- Did not run the full monorepo test suite locally (repo size); relying on CI plus manual verification that the new id/name/address don't collide with any existing entries.
- Supersedes #9573 (same change, retitled to reference CECHO-2034).

## Test plan
- [ ] CI passes (statics unit tests, lint, build)
- [ ] Confirm no duplicate id/name/contractAddress in `allCoinsAndTokens.ts`
- [ ] Once merged and `@bitgo-beta/statics` is bumped in `bitgo-microservices`, confirm supported/unsupported hbarevm ERC721 NFTs resolve correctly instead of falling back to an unresolvable generic label

Ticket: CECHO-2034