### PR TITLE
fix(sdk-core): clean up stale signature shares before every TSS sign

### DIFF
--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -4308,6 +4308,7 @@ describe('V2 Wallet:', function () {
       });
 
       it('should sign lite transaction', async function () {
+        const deleteSignatureSharesSpy = sandbox.stub(TssUtils.prototype, 'deleteSignatureShares');
         const getUserKeyAndSignTssTxSpy = sandbox.stub(tssSolWallet, 'getUserKeyAndSignTssTransaction');
         getUserKeyAndSignTssTxSpy.resolves(exampleSignedTx);
         const submitTxSpy = sandbox.stub(tssSolWallet, 'submitTransaction');
@@ -4319,6 +4320,7 @@ describe('V2 Wallet:', function () {
           isTxRequestFull: false,
         });
 
+        sandbox.assert.calledOnce(deleteSignatureSharesSpy);
         sandbox.assert.calledOnce(getUserKeyAndSignTssTxSpy);
         sandbox.assert.calledOnce(submitTxSpy);
         signedTx.should.deepEqual(exampleSignedTx);

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -4870,6 +4870,10 @@ export class Wallet implements IWallet {
    * Signs and sends a transaction request from a TSS (hot) wallet, or a SMC (cold) wallet with an external signer.
    * Meant to be used for a transaction request where the signing process is aborted.
    *
+   * Always clears any existing signature shares before signing, for both full and lite transaction
+   * requests, so a resumed/retried sign (including one picked up by a different user than whoever
+   * last touched this transaction request) restarts cleanly instead of building on stale shares.
+   *
    * @param params
    *    txRequestId - The ID of the transaction request.
    *    walletPassphrase - The passphrase for the wallet.
@@ -4877,9 +4881,7 @@ export class Wallet implements IWallet {
    * @returns A promise that resolves to a SignedTransaction.
    */
   public async signAndSendTxRequest(params: SignAndSendTxRequestOptions): Promise<SignedTransaction> {
-    if (params.isTxRequestFull) {
-      await this.tssUtils?.deleteSignatureShares(params.txRequestId);
-    }
+    await this.tssUtils?.deleteSignatureShares(params.txRequestId);
 
     const ret = await this.getUserKeyAndSignTssTransaction({
       walletPassphrase: params.walletPassphrase,


### PR DESCRIPTION
## Description
`Wallet.signAndSendTxRequest` already unconditionally deletes stale TSS signature shares before signing when `apiVersion: 'full'`, but never did for `'lite'`. This meant a `lite` txRequest that was partially signed (commitment/R-share submitted) and then resumed — whether by the same session retrying or a different user picking it up — could build on top of cryptographically stale shares and get permanently stuck instead of completing.

This extends the same, already-proven-in-production cleanup to `lite`: `deleteSignatureShares` is now called unconditionally for both `full` and `lite` before every sign attempt.

Validated end-to-end against a live TSS Solana (tsol) hot wallet on BitGo test env: partially signed a txRequest as one user, then resumed/resigned as a second user, confirming the recovery (delete shares -> resign -> deliver) completes cleanly.

## Issue Number
WCN-2452

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Updated `modules/bitgo/test/v2/unit/wallet.ts` `signAndSendTxRequest` lite test to assert `deleteSignatureShares` is now called before signing.
- Ran the full `modules/bitgo/test/v2/unit/wallet.ts` suite locally — all green, no regressions.
- Manually validated the underlying recovery flow (delete shares + resign + deliver) end-to-end against a live TSS lite Solana txRequest on BitGo test env.

## Checklist
- [x] My commits follow Conventional Commits
- [x] The ticket was included in the commit message reference (WCN-2452, this PR)
- [x] I have added/updated tests that prove the fix is effective
- [x] New and existing unit tests pass locally with my changes