### PR TITLE
fix(sdk-core): route EdDSA message-sign commitment exchange to /messages/0

### DIFF
--- a/modules/bitgo/test/v2/unit/internal/tssUtils/common.ts
+++ b/modules/bitgo/test/v2/unit/internal/tssUtils/common.ts
@@ -88,13 +88,11 @@ export async function nockExchangeCommitments(params: {
   txRequestId: string;
   response: ExchangeCommitmentResponse;
   apiMode?: 'lite' | 'full';
+  requestType?: RequestType;
   notPersist?: boolean;
 }): Promise<nock.Scope> {
-  const { apiMode = 'lite' } = params;
-  let addendum = '';
-  if (apiMode === 'full') {
-    addendum = '/transactions/0';
-  }
+  const { apiMode = 'lite', requestType = RequestType.tx } = params;
+  const addendum = getRoute('eddsa', requestType, apiMode);
   return nock('https://bitgo.fakeurl')
     .persist(true)
     .post(`/api/v2/wallet/${params.walletId}/txrequests/${params.txRequestId}${addendum}/commit`)

--- a/modules/bitgo/test/v2/unit/internal/tssUtils/eddsa.ts
+++ b/modules/bitgo/test/v2/unit/internal/tssUtils/eddsa.ts
@@ -955,6 +955,7 @@ describe('TSS Utils:', async function () {
         txRequestId: txRequest.txRequestId,
         response: exchangeCommitResponse,
         apiMode: 'full',
+        requestType: RequestType.message,
       });
     });
 

--- a/modules/sdk-core/src/bitgo/tss/common.ts
+++ b/modules/sdk-core/src/bitgo/tss/common.ts
@@ -224,6 +224,7 @@ export async function sendTxRequest(
  * @param {EncryptedSignerShareRecord} encryptedSignerShare - the client encrypted signer share
  * @param {string} [apiMode] - the txRequest api mode (full or lite) - defaults to lite
  * @param {IRequestTracer} reqId - the request tracer request Id
+ * @param requestType - The type of request being submitted (either tx or message for signing) - defaults to tx
  * @returns {Promise<ExchangeCommitmentResponse>} - the server commitment share
  */
 export async function exchangeEddsaCommitments(
@@ -233,11 +234,12 @@ export async function exchangeEddsaCommitments(
   commitmentShare: CommitmentShareRecord,
   encryptedSignerShare: EncryptedSignerShareRecord,
   apiMode: 'full' | 'lite' = 'lite',
-  reqId?: IRequestTracer
+  reqId?: IRequestTracer,
+  requestType: RequestType = RequestType.tx
 ): Promise<ExchangeCommitmentResponse> {
   let addendum = '';
   if (apiMode === 'full') {
-    addendum = '/transactions/0';
+    addendum = requestType === RequestType.message ? '/messages/0' : '/transactions/0';
   }
   const urlPath = '/wallet/' + walletId + '/txrequests/' + txRequestId + addendum + '/commit';
   const reqTracer = reqId || new RequestTracer();

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsa.ts
@@ -806,7 +806,8 @@ export class EddsaUtils extends baseTSSUtils<KeyShare> {
       commitmentShare,
       encryptedSignerShare,
       apiVersion,
-      params.reqId
+      params.reqId,
+      requestType
     );
 
     await offerUserToBitgoRShare(

--- a/modules/sdk-core/test/unit/bitgo/tss/common.ts
+++ b/modules/sdk-core/test/unit/bitgo/tss/common.ts
@@ -1,0 +1,94 @@
+import 'should';
+import sinon from 'sinon';
+import { exchangeEddsaCommitments } from '../../../../src/bitgo/tss/common';
+import {
+  BitGoBase,
+  CommitmentShareRecord,
+  CommitmentType,
+  EncryptedSignerShareRecord,
+  RequestType,
+} from '../../../../src';
+
+function makeMockBitGo(result: unknown): { bitgo: BitGoBase; post: sinon.SinonStub } {
+  const send = sinon.stub().returnsThis();
+  const resultStub = sinon.stub().resolves(result);
+  const post = sinon.stub().returns({ send, result: resultStub });
+  const bitgo = {
+    post,
+    url: sinon.stub().callsFake((path: string) => path),
+    setRequestTracer: sinon.stub(),
+  } as unknown as BitGoBase;
+  return { bitgo, post };
+}
+
+describe('exchangeEddsaCommitments', function () {
+  const walletId = 'walletId';
+  const txRequestId = 'txRequestId';
+  const commitmentShare: CommitmentShareRecord = {
+    from: 'user',
+    to: 'bitgo',
+    type: CommitmentType.COMMITMENT,
+    share: 'commitmentShareValue',
+  };
+  const encryptedSignerShare: EncryptedSignerShareRecord = {
+    from: 'user',
+    to: 'bitgo',
+    type: 'encryptedSignerShare',
+    share: 'encryptedSignerShareValue',
+  };
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it('posts to /transactions/0/commit for a tx request with apiMode full', async function () {
+    const { bitgo, post } = makeMockBitGo({ commitmentShare });
+    await exchangeEddsaCommitments(
+      bitgo,
+      walletId,
+      txRequestId,
+      commitmentShare,
+      encryptedSignerShare,
+      'full',
+      undefined,
+      RequestType.tx
+    );
+    post.calledOnceWith(`/wallet/${walletId}/txrequests/${txRequestId}/transactions/0/commit`).should.be.true();
+  });
+
+  it('posts to /messages/0/commit for a message request with apiMode full', async function () {
+    const { bitgo, post } = makeMockBitGo({ commitmentShare });
+    await exchangeEddsaCommitments(
+      bitgo,
+      walletId,
+      txRequestId,
+      commitmentShare,
+      encryptedSignerShare,
+      'full',
+      undefined,
+      RequestType.message
+    );
+    post.calledOnceWith(`/wallet/${walletId}/txrequests/${txRequestId}/messages/0/commit`).should.be.true();
+  });
+
+  it('defaults to RequestType.tx when requestType is not provided, preserving prior behavior', async function () {
+    const { bitgo, post } = makeMockBitGo({ commitmentShare });
+    await exchangeEddsaCommitments(bitgo, walletId, txRequestId, commitmentShare, encryptedSignerShare, 'full');
+    post.calledOnceWith(`/wallet/${walletId}/txrequests/${txRequestId}/transactions/0/commit`).should.be.true();
+  });
+
+  it('posts to plain /commit regardless of requestType when apiMode is lite', async function () {
+    const { bitgo, post } = makeMockBitGo({ commitmentShare });
+    await exchangeEddsaCommitments(
+      bitgo,
+      walletId,
+      txRequestId,
+      commitmentShare,
+      encryptedSignerShare,
+      'lite',
+      undefined,
+      RequestType.message
+    );
+    post.calledOnceWith(`/wallet/${walletId}/txrequests/${txRequestId}/commit`).should.be.true();
+  });
+});


### PR DESCRIPTION
## Summary

`exchangeEddsaCommitments` (bitgo/tss/common.ts) builds its commit-step URL based only on `apiMode`, never on `RequestType`. For `apiMode: 'full'` it always appends `/transactions/0`, even when signing a message-type
txRequest. Every sibling function in the same file (`sendSignatureShare`, `sendSignatureShareV2`, `sendTxRequest`) already branches `/transactions/0` vs `/messages/0` on `requestType` — this one predates message signing and was never updated when EdDSA message signing was added.

Message-signing txRequests always use `apiVersion: 'full'`, so any EdDSA coin doing TSS message signing (Canton, SOL, ADA) hits this: the SDK correctly builds a message-signing payload but POSTs it to `/transactions/0/commit`, which the server tries to parse as transaction data and fails.

Reported via a Canton TSS message-signing client testing on bitgo-test, who hit `500 InvalidTransactionError: Unable to parse raw transaction data` on `POST .../txrequests/:id/transactions/0/commit` when calling `wallet.signMessage()`.

## Changes
  
- `exchangeEddsaCommitments`: add `requestType: RequestType = RequestType.tx` param, branch `/transactions/0` vs `/messages/0` when `apiMode === 'full'` (defaults preserve existing tx-signing behavior).
- `EddsaUtils.signRequestBase` (eddsa.ts): pass its already-in-scope `requestType` through to `exchangeEddsaCommitments`.
- Test fixture `nockExchangeCommitments` (modules/bitgo) had the identical missing branch, so the existing message-signing unit test was asserting against the wrong URL and passing for the wrong reason. Rewired it to use the existing `getRoute()` helper and added `requestType` to the one test that needed it.
- New unit test (`sdk-core/test/unit/bitgo/tss/common.ts`) covering tx/full, message/full (the bug), default-requestType, and lite-mode cases for `exchangeEddsaCommitments`.

Ticket: CSHLD-1557