### PR TITLE
fix(sdk-coin-ada,sdk-coin-iota): validate precomputed EdDSA signing material

### DIFF
--- a/modules/sdk-coin-ada/src/ada.ts
+++ b/modules/sdk-coin-ada/src/ada.ts
@@ -34,6 +34,7 @@ import {
   extractCommonKeychain,
   TssVerifyAddressOptions,
   getEddsaSigningMaterial as sharedGetEddsaSigningMaterial,
+  isEddsaSigningMaterial,
   signEddsaMpcV2RecoveryTx,
   EddsaSigningMaterial,
   decryptKeychainPrivateKey,
@@ -459,8 +460,9 @@ export class Ada extends BaseCoin {
       const userKey = params.userKey.replace(/\s/g, '');
       const backupKey = params.backupKey.replace(/\s/g, '');
       const adaKeyPair = new AdaKeyPair({ pub: accountId });
-      const signingMaterial =
-        precomputedMaterial ?? (await this.getEddsaSigningMaterial(userKey, params.walletPassphrase));
+      const signingMaterial = isEddsaSigningMaterial(precomputedMaterial)
+        ? precomputedMaterial
+        : await this.getEddsaSigningMaterial(userKey, params.walletPassphrase);
 
       if (signingMaterial.version === 'v2') {
         const signature = await this.signAdaMpcV2Recovery({

--- a/modules/sdk-coin-ada/test/unit/ada.ts
+++ b/modules/sdk-coin-ada/test/unit/ada.ts
@@ -900,6 +900,32 @@ describe('ADA', function () {
       sandBox.assert.calledOnce(getEddsaMaterialSpy);
     });
 
+    it('should ignore a malformed precomputedMaterial and detect signing material itself (regression: WRW openSSLBytes collision)', async function () {
+      // WRW's generic Electron 'recover' IPC handler passes openSSLBytes (an ArrayBuffer)
+      // as a second positional argument to every coin's recover(), regardless of whether
+      // that coin uses it. Previously this was blindly trusted as precomputedMaterial,
+      // producing `JSON.parse(undefined)` -> SyntaxError: "undefined" is not valid JSON.
+      const getEddsaMaterialSpy = sandBox.spy(
+        basecoin as unknown as { getEddsaSigningMaterial: unknown },
+        'getEddsaSigningMaterial'
+      );
+
+      const res = await basecoin.recover(
+        {
+          userKey: mpcV2UserKey,
+          backupKey: mpcV2BackupKey,
+          bitgoKey: mpcV2CommonKeyChain,
+          walletPassphrase,
+          recoveryDestination: destAddr,
+        },
+        new ArrayBuffer(8) as any
+      );
+
+      res.should.not.be.empty();
+      res.should.hasOwnProperty('serializedTx');
+      sandBox.assert.calledOnce(getEddsaMaterialSpy);
+    });
+
     it('should route to MPCv1 path when keycard is MPCv1 (regression)', async function () {
       callBack
         .withArgs('address_info', { _addresses: [wrwUser.walletAddress0] })

--- a/modules/sdk-coin-iota/src/iota.ts
+++ b/modules/sdk-coin-iota/src/iota.ts
@@ -7,6 +7,7 @@ import {
   EddsaSigningMaterial,
   Environments,
   getEddsaSigningMaterial as sharedGetEddsaSigningMaterial,
+  isEddsaSigningMaterial,
   KeyPair,
   MPCAlgorithm,
   MPCConsolidationRecoveryOptions,
@@ -857,8 +858,9 @@ export class Iota extends BaseCoin {
     const backupKey = params.backupKey.replace(/\s/g, '');
     const bitgoKey = params.bitgoKey.replace(/\s/g, '');
 
-    const signingMaterial =
-      precomputedMaterial ?? (await this.getEddsaSigningMaterial(userKey, params.walletPassphrase));
+    const signingMaterial = isEddsaSigningMaterial(precomputedMaterial)
+      ? precomputedMaterial
+      : await this.getEddsaSigningMaterial(userKey, params.walletPassphrase);
 
     let signatureBuffer: Buffer;
 

--- a/modules/sdk-coin-iota/test/unit/iota.ts
+++ b/modules/sdk-coin-iota/test/unit/iota.ts
@@ -774,6 +774,42 @@ describe('IOTA:', function () {
       sandBox.assert.notCalled(getTSSSignatureSpy);
     });
 
+    it('should ignore a malformed precomputedMaterial and detect signing material itself (regression: WRW openSSLBytes collision)', async function () {
+      // WRW's generic Electron 'recover' IPC handler passes openSSLBytes (an ArrayBuffer)
+      // as a second positional argument to every coin's recover(), regardless of whether
+      // that coin uses it. Previously this was blindly trusted as precomputedMaterial,
+      // producing `JSON.parse(undefined)` -> SyntaxError: "undefined" is not valid JSON.
+      sandBox.stub(Iota.prototype, 'fetchOwnedObjects' as keyof Iota).resolves([
+        {
+          objectId: '0xc05c765e26e6ae84c78fa245f38a23fb20406a5cf3f61b57bd323a0df9d98003',
+          version: '195',
+          digest: validDigest,
+          balance: '1900000000',
+        },
+      ]);
+      sandBox.stub(Iota.prototype, 'fetchGasPrice' as keyof Iota).resolves(1000);
+      sandBox.stub(Iota.prototype, 'estimateGas' as keyof Iota).resolves(1997880);
+      const getEddsaMaterialSpy = sandBox.spy(
+        basecoin as unknown as { getEddsaSigningMaterial: unknown },
+        'getEddsaSigningMaterial'
+      );
+
+      const res = await basecoin.recover(
+        {
+          userKey: mpcV2UserKey,
+          backupKey: mpcV2BackupKey,
+          bitgoKey: mpcV2CommonKeyChain,
+          recoveryDestination,
+          walletPassphrase,
+        },
+        new ArrayBuffer(8) as any
+      );
+
+      res.should.not.be.empty();
+      res.should.hasOwnProperty('transactions');
+      sandBox.assert.calledOnce(getEddsaMaterialSpy);
+    });
+
     it('should throw missing userKey error on MPCv2 path', async function () {
       sandBox.stub(Iota.prototype, 'fetchOwnedObjects' as keyof Iota).resolves([
         {

--- a/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
@@ -1342,6 +1342,31 @@ export async function getEddsaSigningMaterial(
 }
 
 /**
+ * Type guard validating that a value has the shape of EddsaSigningMaterial.
+ *
+ * Coin `recover()` implementations accept an optional precomputed signing-material
+ * parameter (set by recoverConsolidations() to avoid re-decrypting the keycard per
+ * scanned index). Some callers pass an unrelated second positional argument to
+ * recover() for other purposes (e.g. openSSLBytes for EVM-like coins); validating
+ * the shape here prevents that from being misinterpreted as signing material.
+ */
+export function isEddsaSigningMaterial(value: unknown): value is EddsaSigningMaterial {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  if (!('version' in value)) {
+    return false;
+  }
+  if (value.version === 'v1') {
+    return 'userPrv' in value && typeof value.userPrv === 'string';
+  }
+  if (value.version === 'v2') {
+    return 'encryptedUserKey' in value && typeof value.encryptedUserKey === 'string';
+  }
+  return false;
+}
+
+/**
  * Full MPCv2 recovery signing flow: decrypt key shares → validate commonKeyChain → MPS DSG.
  * Returns raw 64-byte Ed25519 signature Buffer.
  * Caller is responsible for any coin-specific envelope
@@ -1373,5 +1398,6 @@ export const EddsaMPCv2RecoveryFunctions = {
   getEddsaMpcV2RecoveryKeySharesFromReducedKey,
   signRecoveryEddsaMPCv2,
   getEddsaSigningMaterial,
+  isEddsaSigningMaterial,
   signEddsaMpcV2RecoveryTx,
 };

--- a/modules/sdk-core/src/index.ts
+++ b/modules/sdk-core/src/index.ts
@@ -34,6 +34,7 @@ export { EddsaMPCv2Utils };
 export type { EddsaSigningMaterial } from './bitgo/utils/tss/eddsa/eddsaMPCv2';
 export {
   getEddsaSigningMaterial,
+  isEddsaSigningMaterial,
   signEddsaMpcV2RecoveryTx,
   isEddsaMpcV1SigningMaterial,
   getEddsaMpcV2RecoveryKeySharesFromReducedKey,

--- a/modules/sdk-core/test/unit/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
+++ b/modules/sdk-core/test/unit/bitgo/utils/tss/eddsa/eddsaMPCv2.ts
@@ -29,6 +29,7 @@ import {
   SignatureShareType,
   TxRequest,
   getEddsaSigningMaterial,
+  isEddsaSigningMaterial,
   signEddsaMpcV2RecoveryTx,
 } from '../../../../../../src';
 import {
@@ -2075,6 +2076,53 @@ describe('getEddsaSigningMaterial', () => {
     const result = await getEddsaSigningMaterial(encrypted, PASSPHRASE);
     assert.strictEqual(result.version, 'v1');
     assert.strictEqual((result as { version: 'v1'; userPrv: string }).userPrv, JSON.stringify(MPCv1_MATERIAL));
+  });
+});
+
+describe('isEddsaSigningMaterial', () => {
+  it('returns true for a valid v1 shape', () => {
+    assert.strictEqual(isEddsaSigningMaterial({ version: 'v1', userPrv: '{}' }), true);
+  });
+
+  it('returns true for a valid v2 shape', () => {
+    assert.strictEqual(isEddsaSigningMaterial({ version: 'v2', encryptedUserKey: 'abc123' }), true);
+  });
+
+  it('returns false for a v1 shape with a non-string userPrv', () => {
+    assert.strictEqual(isEddsaSigningMaterial({ version: 'v1', userPrv: 123 }), false);
+  });
+
+  it('returns false for a v2 shape with a non-string encryptedUserKey', () => {
+    assert.strictEqual(isEddsaSigningMaterial({ version: 'v2', encryptedUserKey: 123 }), false);
+  });
+
+  it('returns false for an unrecognized version value', () => {
+    assert.strictEqual(isEddsaSigningMaterial({ version: 'v3', userPrv: '{}' }), false);
+  });
+
+  it('returns false for an object missing a version field', () => {
+    assert.strictEqual(isEddsaSigningMaterial({ userPrv: '{}' }), false);
+  });
+
+  it('returns false for null', () => {
+    assert.strictEqual(isEddsaSigningMaterial(null), false);
+  });
+
+  it('returns false for undefined', () => {
+    assert.strictEqual(isEddsaSigningMaterial(undefined), false);
+  });
+
+  it('returns false for primitive values', () => {
+    assert.strictEqual(isEddsaSigningMaterial('a string'), false);
+    assert.strictEqual(isEddsaSigningMaterial(42), false);
+    assert.strictEqual(isEddsaSigningMaterial(true), false);
+  });
+
+  it('returns false for an ArrayBuffer (regression: WRW openSSLBytes collision)', () => {
+    // WRW's generic Electron 'recover' IPC handler passes openSSLBytes as a second
+    // positional argument to every coin's recover(), colliding with precomputedMaterial
+    // on coins that accept it. This must be rejected rather than misread as signing material.
+    assert.strictEqual(isEddsaSigningMaterial(new ArrayBuffer(8)), false);
   });
 });
 


### PR DESCRIPTION
## Summary

Found while manually testing ADA/NEAR/TON/IOTA non-BitGo recovery end-to-end through the Wallet Recovery Wizard against staging (see WCI-1460).

Wallet Recovery Wizard's generic Electron `recover` IPC handler always passes a second positional argument (`openSSLBytes`, an `ArrayBuffer` meant only for EVM-like coins) to every coin's `recover()` call:

```js
return await baseCoin.recover({ ...parameters, openSSLBytes }, openSSLBytes);
```

`Ada.recover()` and `Iota.recover()` both accept an optional second parameter of their own — `precomputedMaterial`, used by `recoverConsolidations()` to avoid re-decrypting the keycard once per scanned index. WRW's stray `openSSLBytes` argument gets silently misinterpreted as that signing material:

```
const signingMaterial = precomputedMaterial ?? (await this.getEddsaSigningMaterial(...));
// signingMaterial = the ArrayBuffer, since it's truthy
JSON.parse(signingMaterial.userPrv)  // ArrayBuffer has no .userPrv -> JSON.parse(undefined)
// -> SyntaxError: "undefined" is not valid JSON
```

`sdk-coin-dot` already guards against exactly this with a local `isEddsaSigningMaterial()` type guard (added when DOT's `recoverConsolidations` was written) — which is why DOT was unaffected. This PR extracts that guard into `sdk-core` (next to `EddsaSigningMaterial`/`getEddsaSigningMaterial`/`signEddsaMpcV2RecoveryTx`) and applies it in ADA and IOTA's `signRecoveryTransaction()`.

`sdk-coin-sui` has the same latent issue but is intentionally left untouched in this PR (out of scope — no SUI changes requested).

## Changes

- `sdk-core`: add and export `isEddsaSigningMaterial()` type guard
- `sdk-coin-ada`: validate `precomputedMaterial` shape before trusting it in `signRecoveryTransaction()`
- `sdk-coin-iota`: same

## Test plan

- [x] Manually verified ADA and IOTA non-BitGo recovery end-to-end via Wallet Recovery Wizard against staging (broadcast + confirmed on-chain) — reproduced the bug pre-fix, confirmed resolved post-fix
- [x] `yarn unit-test` for `sdk-coin-ada` (183 passing) and `sdk-coin-iota` (255 passing)
- [x] `tsc --build` and `eslint` clean for all touched packages

TICKET: WCI-1460

🤖 Generated with [Claude Code](https://claude.com/claude-code)