### PR TITLE
feat(sdk-core): support preparedTransaction in TSS message signing

### DIFF
--- a/modules/bitgo/test/v2/unit/wallet.ts
+++ b/modules/bitgo/test/v2/unit/wallet.ts
@@ -4420,6 +4420,27 @@ describe('V2 Wallet:', function () {
           txRequest.should.deepEqual(txRequestForMessageSigning);
         });
 
+        it('should include preparedTransaction in the msgrequests body when provided', async function () {
+          const preparedTransaction = 'base64-prepared-transaction-bytes';
+          let capturedBody: any;
+          nock(bgUrl)
+            .post(`/api/v2/wallet/${tssEthWallet.id()}/msgrequests`, (body) => {
+              capturedBody = body;
+              return true;
+            })
+            .reply(200, txRequestForMessageSigning);
+
+          await tssEthWallet.buildSignMessageRequest({
+            message: {
+              messageRaw,
+              messageStandardType: MessageStandardType.EIP191,
+              preparedTransaction,
+            },
+          });
+
+          capturedBody.intent.preparedTransaction.should.equal(preparedTransaction);
+        });
+
         it(`[${coinName}] should sign message`, async function () {
           const signMessageTssSpy = sinon.spy(tssEthWallet, 'signMessageTss' as any);
           nock(bgUrl)
@@ -4473,6 +4494,25 @@ describe('V2 Wallet:', function () {
           actualArg.message?.messageEncoded?.should.equal(
             Buffer.from(`\u0019Ethereum Signed Message:\n${messageRaw.length}${messageRaw}`).toString('hex')
           );
+        });
+
+        it(`[${coinName}] should include preparedTransaction when signing a fresh message request`, async function () {
+          const preparedTransaction = 'base64-prepared-transaction-bytes';
+          let capturedBody: any;
+          nock(bgUrl)
+            .post(`/api/v2/wallet/${tssEthWallet.id()}/msgrequests`, (body) => {
+              capturedBody = body;
+              return true;
+            })
+            .reply(200, txRequestForMessageSigning);
+
+          await tssEthWallet.signMessage({
+            reqId,
+            message: { messageRaw, messageStandardType: MessageStandardType.EIP191, preparedTransaction },
+            prv: 'secretKey',
+          });
+
+          capturedBody.intent.preparedTransaction.should.equal(preparedTransaction);
         });
 
         it('should fail to sign message with empty prv', async function () {

--- a/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
+++ b/modules/sdk-core/src/bitgo/baseCoin/iBaseCoin.ts
@@ -457,6 +457,8 @@ export interface Message extends BaseSignable {
   messageEncoded?: string;
   messageStandardType?: MessageStandardType;
   signerAddress?: string;
+  /** Base64-encoded prepared transaction bytes required by Canton message signing. */
+  preparedTransaction?: string;
 }
 
 export interface MessageTypeProperty {

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTSSUtils.ts
@@ -473,6 +473,7 @@ export default class BaseTssUtils<KeyShare> extends MpcUtils implements ITssUtil
       messageStandardType: params.messageStandardType ?? MessageStandardType.UNKNOWN,
       messageEncoded: params.messageEncoded ?? '',
       signerAddress: params.signerAddress,
+      preparedTransaction: params.preparedTransaction,
     };
 
     return this.buildSignMessageRequestBase(intent, apiVersion, params.reqId);

--- a/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/baseTypes.ts
@@ -304,6 +304,8 @@ export interface IntentOptionsForMessage extends IntentOptionsBase {
   messageEncoded?: string;
   messageStandardType?: MessageStandardType;
   signerAddress?: string;
+  /** Base64-encoded prepared transaction bytes required by Canton message signing. */
+  preparedTransaction?: string;
 }
 
 export interface IntentOptionsForTypedData extends IntentOptionsBase {
@@ -417,6 +419,8 @@ export interface PopulatedIntentForMessageSigning extends PopulatedIntentBase {
   custodianMessageId?: string;
   messageStandardType?: MessageStandardType;
   signerAddress?: string;
+  /** Base64-encoded prepared transaction bytes required by Canton message signing. */
+  preparedTransaction?: string;
 }
 
 export interface PopulatedIntentForTypedDataSigning extends PopulatedIntentBase {

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -2527,6 +2527,7 @@ export class Wallet implements IWallet {
         messageRaw,
         messageStandardType,
         signerAddress: params.message.signerAddress,
+        preparedTransaction: params.message.preparedTransaction,
       };
 
       if (!this.tssUtils) {
@@ -5143,6 +5144,7 @@ export class Wallet implements IWallet {
           messageRaw,
           messageStandardType: params.message.messageStandardType,
           signerAddress: params.message.signerAddress,
+          preparedTransaction: params.message.preparedTransaction,
         };
         txRequest = await this.tssUtils!.buildSignMessageRequest(intentOption);
         params.message.txRequestId = txRequest.txRequestId;


### PR DESCRIPTION
## Summary

`wallet.signMessage()` had no way to pass `preparedTransaction` — a field Canton's backend requires (as `coinSpecific.preparedTransactionBase64`) for both CANTON_SIGN_TRANSACTION and CANTON_SIGN_TOPOLOGY message standard types. Every field on the message-signing intent path is explicitly enumerated end-to-end (no generic passthrough bag), so any fresh Canton message-signing request created via the SDK was missing a mandatory field, regardless of whether the earlier commit-step server defect was fixed.

Without this, a client could only create a valid Canton message request via the raw `POST /wallet/:id/msgrequests` API directly, then use `wallet.signMessage({ message: { txRequestId } })` only to *sign* it — `wallet.signMessage()` could never create one end-to-end on its own for Canton.

## Changes
  
Threaded `preparedTransaction?: string` through the existing message-intent type chain, following the same pattern already established for Canton's `cantonCommandParams` on the transaction-intent side:

  - `Message` (`bitgo/baseCoin/iBaseCoin.ts`) — public field on `wallet.signMessage({ message: { preparedTransaction } })`.
  - `IntentOptionsForMessage` (`bitgo/utils/tss/baseTypes.ts`)
  - `PopulatedIntentForMessageSigning` (`bitgo/utils/tss/baseTypes.ts`) — the shape POSTed to `/wallet/:id/msgrequests`.
  - `baseTSSUtils.buildSignMessageRequest` — passes it into the built intent.
  - `wallet.buildSignMessageRequest` — passes `params.message.preparedTransaction`.
  - `wallet.signMessageTss`'s inline intent construction (the fresh-request path taken when no `txRequestId` is given) — same, since it duplicates the intent shape instead of delegating to `buildSignMessageRequest`.

`buildSignMessageRequestBase` already spreads `{...intent}` into the POST body with no field whitelist, so no additional wiring was needed there.

Purely additive and optional — every other coin (SOL, ADA, Midnight, ETH typed-data) never sets this field, so it's `undefined` and omitted from their requests exactly as before.

## Result
  
  ```ts
  await wallet.signMessage({
    message: {
      messageRaw,
      messageStandardType: MessageStandardType.CANTON_SIGN_TOPOLOGY,
      preparedTransaction: '<base64 protobuf bytes>',
    },
    walletPassphrase,
  });```
  
now creates the message txRequest (with the field Canton's backend requires) and signs it in one call, instead of requiring a raw API call to build the request first.

Test plan

- [x] New unit tests in modules/bitgo/test/v2/unit/wallet.ts (Message Signing suite):
- should include preparedTransaction in the msgrequests body when provided (via buildSignMessageRequest())
- should include preparedTransaction when signing a fresh message request(via signMessage(), no txRequestId) Both assert the intercepted POST body's intent.preparedTransaction.
- [x] npx tsc --noEmit on sdk-core — clean (no new errors)
- [ ] Manual: full Canton wallet.signMessage() flow against bitgo-test with preparedTransaction set, paired with the server-side commit-step

Ticket: CSHLD-1557