### PR TITLE
feat(sdk-lib-mpc): add EdDSA retrofit DKG helper

### DIFF
--- a/modules/sdk-lib-mpc/test/unit/tss/eddsa/dkg.ts
+++ b/modules/sdk-lib-mpc/test/unit/tss/eddsa/dkg.ts
@@ -412,6 +412,10 @@ describe('EdDSA MPS DKG', function () {
 
       assert.strictEqual(userPk, backupPk, 'user and backup must agree on public key after retrofit DKG');
       assert.strictEqual(backupPk, bitgoPk, 'backup and bitgo must agree on public key after retrofit DKG');
+      assert.strictEqual(userPk, retrofitUser.expectedPk, 'retrofit DKG must preserve the original public key');
+      assert.strictEqual(user.getCommonKeychain(), backup.getCommonKeychain());
+      assert.strictEqual(user.getCommonKeychain(), bitgo.getCommonKeychain());
+      assert.strictEqual(user.getCommonKeychain(), retrofitUser.expectedPk + retrofitUser.chainCode);
       assert.strictEqual(userPk.length, 64, 'public key must be 32 bytes (64 hex chars)');
     });
 


### PR DESCRIPTION
## What

- Add a data-first `generateEdDsaRetrofitKeyShares` helper for complete three-party EdDSA retrofit DKG ceremonies.
- Update retrofit DKG tests to use the new helper and verify public-key and common-keychain compatibility.

## Why

- The retrofit flow needs an explicit three-party test helper so the MPCv1 public key and chain code remain compatible after MPCv2 migration.

## Test plan

- [] Run the scoped EdDSA MPS DKG test suite after installing repository dependencies.
- [x] Run `git diff --check`.

Ticket: WCI-1262