### PR TITLE
chore(security): exclude GHSA-w4pp-8pjf-rmxw pacote DoS advisory

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -71,5 +71,9 @@ id = "GHSA-jmr9-qjv8-65gv"
 reason = "extract-zip unvalidated symlink path traversal on extraction (CVE-2026-56876); transitive via cypress and @puppeteer/browsers, both dev-only tooling; extracted archives are Cypress/Chromium binary release downloads from trusted sources, never untrusted user-supplied zips; no upstream fix (last_affected: 2.0.1, which is the latest release). Re-evaluate on 2026-11-13: drop this exclusion if extract-zip ships a patched release"
 
 [[IgnoredVulns]]
+id = "GHSA-w4pp-8pjf-rmxw"
+reason = "pacote DoS via addGitSha on malicious spec.rawSpec (CVE-2026-9496); transitive via lerna (pinned pacote@21.0.1), @npmcli/arborist, and yeoman-generator (dev-time only); fix only in pacote 21.5.1+/22.0.0 which lerna does not yet support; all specs processed come from our own package.json/yarn.lock, never untrusted input"
+
+[[IgnoredVulns]]
 id = "GHSA-r292-9mhp-454m"
 reason = "tar stack-overflow DoS in tar.x()/tar.t() member-selection filtering; transitive via lerna and yeoman-generator requiring tar <7.5.21; fix only in tar 7.5.21+ which breaks lerna packDirectory (same constraint as GHSA-8qq5-rm4j-mr97); our usage is archive PACKING only, not extraction of untrusted archives"


### PR DESCRIPTION
## Why
Release CI (`Enforce Vulnerability Severity Threshold`) started blocking releases after a new HIGH-severity advisory, **GHSA-w4pp-8pjf-rmxw** (CVE-2026-9496, CVSS 7.7), was published today against `pacote` — a DoS in `addGitSha()` triggered by a malicious `spec.rawSpec`.

## Why it's safe to exclude
- `pacote` only enters our tree transitively via dev/build tooling: `lerna` (pinned to `pacote@21.0.1` exactly), `@npmcli/arborist`, `@npmcli/metavuln-calculator`, and `yeoman-generator` (`^15.2.0`, used by `yarn sdk-coin:new`).
- None of these paths feed `pacote` untrusted/attacker-controlled specs — inputs come only from our own `package.json`/`yarn.lock` and lerna's internal publish/version flow.
- The fix only lands in `pacote@21.5.1`/`22.0.0`, and no version satisfying lerna's exact `21.0.1` pin exists yet, so we can't bump without breaking the release/publish pipeline.
- Same risk profile and reasoning pattern as the existing tar/minimatch dev-tooling exclusions already in `osv-scanner.toml`.

## What
Adds one `[[IgnoredVulns]]` entry for `GHSA-w4pp-8pjf-rmxw` with the justification above.

Follow-up: re-evaluate once lerna/arborist/yeoman-generator bump to a pacote version ≥21.5.1.
