### PR TITLE
chore(deps): exclude GHSA-w4pp-8pjf-rmxw pacote DoS advisory [cherry-pick to rel/latest]

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -71,5 +71,9 @@ id = "GHSA-jmr9-qjv8-65gv"
 reason = "extract-zip unvalidated symlink path traversal on extraction (CVE-2026-56876); transitive via cypress and @puppeteer/browsers, both dev-only tooling; extracted archives are Cypress/Chromium binary release downloads from trusted sources, never untrusted user-supplied zips; no upstream fix (last_affected: 2.0.1, which is the latest release). Re-evaluate on 2026-11-13: drop this exclusion if extract-zip ships a patched release"
 
 [[IgnoredVulns]]
+id = "GHSA-w4pp-8pjf-rmxw"
+reason = "pacote DoS via addGitSha on malicious spec.rawSpec (CVE-2026-9496); transitive via lerna (pinned pacote@21.0.1), @npmcli/arborist, and yeoman-generator (dev-time only); fix only in pacote 21.5.1+/22.0.0 which lerna does not yet support; all specs processed come from our own package.json/yarn.lock, never untrusted input"
+
+[[IgnoredVulns]]
 id = "GHSA-r292-9mhp-454m"
 reason = "tar stack-overflow DoS in tar.x()/tar.t() member-selection filtering; transitive via lerna and yeoman-generator requiring tar <7.5.21; fix only in tar 7.5.21+ which breaks lerna packDirectory (same constraint as GHSA-8qq5-rm4j-mr97); our usage is archive PACKING only, not extraction of untrusted archives"


### PR DESCRIPTION
Cherry-pick of #9584 (already merged to `master`) into `rel/latest` — needed to unblock the current SDK release, which was failing the `Enforce Vulnerability Severity Threshold` gate on a newly published pacote DoS advisory.

## Why
A new HIGH-severity advisory, **GHSA-w4pp-8pjf-rmxw** (CVE-2026-9496, CVSS 7.7), was published against `pacote` and started blocking release CI.

## Why it's safe to exclude
- `pacote` only enters our tree transitively via dev/build tooling: `lerna` (pinned to `pacote@21.0.1`), `@npmcli/arborist`, `@npmcli/metavuln-calculator`, and `yeoman-generator`.
- None of these paths feed `pacote` untrusted/attacker-controlled specs — inputs come only from our own `package.json`/`yarn.lock`.
- Fix only lands in `pacote@21.5.1`/`22.0.0`, incompatible with lerna's current pin.
- Same pattern as existing tar/minimatch dev-tooling exclusions in `osv-scanner.toml`.

Original PR: #9584 (approved pattern, already reviewed).

TICKET: WEB-000