### PR TITLE
feat(statics): scope wtgxx tokens to BitGo Trust only

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -7496,7 +7496,7 @@ export const allCoinsAndTokens = [
     18,
     '0xfeb26f0943c3885b2cb85a9f933975356c81c33d',
     UnderlyingAsset['arbeth:wtgxx'],
-    AccountCoin.DEFAULT_FEATURES_EXCLUDE_SINGAPORE
+    ACCOUNT_COIN_DEFAULT_FEATURES_TRUST_ONLY
   ),
   arbethErc20(
     '54f5fdda-954e-4296-994b-a89247ad311f',
@@ -7890,7 +7890,7 @@ export const allCoinsAndTokens = [
     18,
     '0x870fd36b3bf7f5abeeea2c8d4abdf1dc4e33109d',
     UnderlyingAsset['opeth:wtgxx'],
-    AccountCoin.DEFAULT_FEATURES_EXCLUDE_SINGAPORE
+    ACCOUNT_COIN_DEFAULT_FEATURES_TRUST_ONLY
   ),
   opethErc20(
     '42729d3e-e010-43a9-91ea-378565b0aa51',

--- a/modules/statics/src/coinFeatures.ts
+++ b/modules/statics/src/coinFeatures.ts
@@ -325,6 +325,9 @@ export const SOL_TOKEN_FEATURES = [
 export const SOL_TOKEN_FEATURES_EXCLUDE_SINGAPORE = SOL_TOKEN_FEATURES.filter(
   (feature) => feature !== CoinFeature.CUSTODY_BITGO_SINGAPORE
 );
+export const SOL_TOKEN_FEATURES_TRUST_ONLY = SOL_TOKEN_FEATURES.filter(
+  (feature) => feature === CoinFeature.CUSTODY_BITGO_TRUST || !BITGO_CUSTODY_JURISDICTIONS.includes(feature)
+);
 export const SOL_OFC_TOKEN_FEATURES = [...ACCOUNT_COIN_DEFAULT_FEATURES, CoinFeature.TSS, CoinFeature.TSS_COLD];
 export const APT_OFC_TOKEN_FEATURES = [...ACCOUNT_COIN_DEFAULT_FEATURES, CoinFeature.TSS, CoinFeature.TSS_COLD];
 

--- a/modules/statics/src/coins/erc20Coins.ts
+++ b/modules/statics/src/coins/erc20Coins.ts
@@ -25,6 +25,7 @@ import {
   ZETA_EVM_FEATURES,
   ACCOUNT_COIN_DEFAULT_FEATURES_EXCLUDE_SINGAPORE_AND_MENA_FZE,
   ACCOUNT_COIN_DEFAULT_FEATURES_EXCLUDE_SINGAPORE,
+  ACCOUNT_COIN_DEFAULT_FEATURES_TRUST_ONLY,
 } from '../coinFeatures';
 
 export const erc20Coins = [
@@ -7064,7 +7065,7 @@ export const erc20Coins = [
     18,
     '0x1fecf3d9d4fee7f2c02917a66028a48c6706c179',
     UnderlyingAsset.WTGXX,
-    AccountCoin.DEFAULT_FEATURES_EXCLUDE_SINGAPORE
+    ACCOUNT_COIN_DEFAULT_FEATURES_TRUST_ONLY
   ),
   erc20(
     'acf1b526-75e0-47f8-b812-32893f85b180',
@@ -15199,7 +15200,7 @@ export const erc20Coins = [
     18,
     '0x0b2517eef907389f36fd87add36e9118d364bd67',
     UnderlyingAsset['sepeth:wtgxx'],
-    [...ACCOUNT_COIN_DEFAULT_FEATURES_EXCLUDE_SINGAPORE],
+    [...ACCOUNT_COIN_DEFAULT_FEATURES_TRUST_ONLY],
     undefined,
     undefined,
     Networks.test.sepolia

--- a/modules/statics/src/coins/solTokens.ts
+++ b/modules/statics/src/coins/solTokens.ts
@@ -4,6 +4,7 @@ import {
   SOL_TOKEN_FEATURES,
   SOL_TOKEN_FEATURES_EXCLUDE_EUROPE,
   SOL_TOKEN_FEATURES_EXCLUDE_SINGAPORE,
+  SOL_TOKEN_FEATURES_TRUST_ONLY,
   SOL_TOKEN_FEATURES_WITH_FRANKFURT,
   SOL_TOKEN_FEATURES_WITH_FRANKFURT_GERMANY,
 } from '../coinFeatures';
@@ -4292,7 +4293,7 @@ export const solTokens = [
     'Em46fxxwgY2RRoUbBMSbEjJwY62x3ESMNdhnsGpEKewm',
     'Em46fxxwgY2RRoUbBMSbEjJwY62x3ESMNdhnsGpEKewm',
     UnderlyingAsset['sol:wtgxx'],
-    SOL_TOKEN_FEATURES,
+    SOL_TOKEN_FEATURES_TRUST_ONLY,
     ProgramID.Token2022ProgramId
   ),
   solToken(

--- a/modules/statics/test/unit/coins.ts
+++ b/modules/statics/test/unit/coins.ts
@@ -734,6 +734,59 @@ const coinsWithExcludedFeatures: Record<string, { features: CoinFeature[] }> = {
       CoinFeature.CUSTODY_BITGO_INDIA,
     ],
   },
+  wtgxx: {
+    features: [
+      CoinFeature.ACCOUNT_MODEL,
+      CoinFeature.REQUIRES_BIG_NUMBER,
+      CoinFeature.VALUELESS_TRANSFER,
+      CoinFeature.TRANSACTION_DATA,
+      CoinFeature.CUSTODY,
+      CoinFeature.CUSTODY_BITGO_TRUST,
+    ],
+  },
+  'arbeth:wtgxx': {
+    features: [
+      CoinFeature.ACCOUNT_MODEL,
+      CoinFeature.REQUIRES_BIG_NUMBER,
+      CoinFeature.VALUELESS_TRANSFER,
+      CoinFeature.TRANSACTION_DATA,
+      CoinFeature.CUSTODY,
+      CoinFeature.CUSTODY_BITGO_TRUST,
+    ],
+  },
+  'opeth:wtgxx': {
+    features: [
+      CoinFeature.ACCOUNT_MODEL,
+      CoinFeature.REQUIRES_BIG_NUMBER,
+      CoinFeature.VALUELESS_TRANSFER,
+      CoinFeature.TRANSACTION_DATA,
+      CoinFeature.CUSTODY,
+      CoinFeature.CUSTODY_BITGO_TRUST,
+    ],
+  },
+  'sepeth:wtgxx': {
+    features: [
+      CoinFeature.ACCOUNT_MODEL,
+      CoinFeature.REQUIRES_BIG_NUMBER,
+      CoinFeature.VALUELESS_TRANSFER,
+      CoinFeature.TRANSACTION_DATA,
+      CoinFeature.CUSTODY,
+      CoinFeature.CUSTODY_BITGO_TRUST,
+    ],
+  },
+  'sol:wtgxx': {
+    features: [
+      CoinFeature.ACCOUNT_MODEL,
+      CoinFeature.REQUIRES_BIG_NUMBER,
+      CoinFeature.VALUELESS_TRANSFER,
+      CoinFeature.TRANSACTION_DATA,
+      CoinFeature.CUSTODY,
+      CoinFeature.CUSTODY_BITGO_TRUST,
+      CoinFeature.TSS,
+      CoinFeature.TSS_COLD,
+      CoinFeature.BULK_TRANSACTION,
+    ],
+  },
 };
 
 describe('CoinMap', function () {
@@ -1025,6 +1078,43 @@ coins.forEach((coin, coinName) => {
         coin.features.includes(CoinFeature.CUSTODY_BITGO_TRUST).should.eql(coinSupportsCustody);
       });
     }
+  });
+});
+
+describe('WTGXX Trust-only custody', () => {
+  const nonTrustCustodyFeatures = [
+    CoinFeature.CUSTODY_BITGO_MENA_FZE,
+    CoinFeature.CUSTODY_BITGO_CUSTODY_MENA_FZE,
+    CoinFeature.CUSTODY_BITGO_SINGAPORE,
+    CoinFeature.CUSTODY_BITGO_EUROPE_APS,
+    CoinFeature.CUSTODY_BITGO_FRANKFURT,
+    CoinFeature.CUSTODY_BITGO_INDIA,
+    CoinFeature.CUSTODY_BITGO_KOREA,
+    CoinFeature.CUSTODY_BITGO_GERMANY,
+    CoinFeature.CUSTODY_BITGO_SWITZERLAND,
+    CoinFeature.CUSTODY_BITGO_NEW_YORK,
+    CoinFeature.CUSTODY_BITGO_SISTER_TRUST_ONE,
+  ];
+
+  [
+    'wtgxx',
+    'arbeth:wtgxx',
+    'opeth:wtgxx',
+    'sepeth:wtgxx',
+    'sol:wtgxx',
+    'ofcwtgxx',
+    'ofcarbeth:wtgxx',
+    'ofcopeth:wtgxx',
+    'ofcsol:wtgxx',
+    'ofcsepeth:wtgxx',
+  ].forEach((name) => {
+    it(`${name} is licensed only for BitGo Trust`, function () {
+      const coin = coins.get(name);
+      coin.features.includes(CoinFeature.CUSTODY_BITGO_TRUST).should.eql(true);
+      nonTrustCustodyFeatures.forEach((feature) => {
+        coin.features.includes(feature).should.eql(false);
+      });
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Restrict `wtgxx` (eth, arbeth, opeth, sol, sepeth) and inherited OFC variants to BitGo Trust custody features only
- Add  `SOL_TOKEN_FEATURES_TRUST_ONLY` and lock the feature set in statics tests

Ticket: SCAAS-11102
