### PR TITLE
feat(statics): enable ERC20 token batching for bera, oas, soneium, tapechain

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -1777,6 +1777,7 @@ export const allCoinsAndTokens = [
       CoinFeature.EVM_COMPATIBLE_UI,
       CoinFeature.EVM_NON_BITGO_RECOVERY,
       CoinFeature.EVM_UNSIGNED_SWEEP_RECOVERY,
+      CoinFeature.ERC20_BULK_TRANSACTION,
     ]
   ),
   account(

--- a/modules/statics/src/coinFeatures.ts
+++ b/modules/statics/src/coinFeatures.ts
@@ -599,6 +599,7 @@ export const BERA_FEATURES = [
   CoinFeature.CUSTODY_BITGO_FRANKFURT,
   CoinFeature.CUSTODY_BITGO_GERMANY,
   CoinFeature.CUSTODY_BULK_TRANSACTION,
+  CoinFeature.ERC20_BULK_TRANSACTION,
 ];
 export const OAS_FEATURES = [
   ...ETH_FEATURES,
@@ -609,6 +610,7 @@ export const OAS_FEATURES = [
   CoinFeature.BULK_TRANSACTION,
   CoinFeature.STUCK_TRANSACTION_MANAGEMENT_TSS,
   CoinFeature.EIP1559,
+  CoinFeature.ERC20_BULK_TRANSACTION,
 ];
 export const COREDAO_FEATURES = [
   ...ETH_FEATURES,
@@ -703,6 +705,7 @@ export const SONEIUM_FEATURES = [
   CoinFeature.MULTISIG_COLD,
   CoinFeature.MULTISIG_SUPPORT_GATED,
   CoinFeature.USES_NON_PACKED_ENCODING_FOR_TXDATA,
+  CoinFeature.ERC20_BULK_TRANSACTION,
 ];
 
 export const POLYX_FEATURES = [

--- a/modules/statics/test/unit/coins.ts
+++ b/modules/statics/test/unit/coins.ts
@@ -1300,6 +1300,13 @@ describe('ERC20 Bulk Transaction Feature', () => {
       'bsc',
       'tbsc',
       'tavaxc',
+      'bera',
+      'tbera',
+      'oas',
+      'toas',
+      'soneium',
+      'tsoneium',
+      'tapechain',
     ];
     erc20BulkTransactionCoins.forEach((coinName) => {
       const coin = coins.get(coinName);


### PR DESCRIPTION
## Description

Enables ERC-20 **token batching** for chains that already have a deployed Batcher contract configured in statics but were missing the `CoinFeature.ERC20_BULK_TRANSACTION` flag. Native/coin batching (`sendMany`) is already live on all EVM chains; only token batching was gated.

Part of the CECHO-2024 audit of disabled EVM chains for token batching.

Unlike `hoodeth` ([PR #9548](https://github.com/BitGo/BitGoJS/pull/9548)), which needed both a feature flag **and** a new `batcherContractAddress`, the chains here already had `batcherContractAddress` set on both mainnet and testnet network classes — only the feature flag was missing:

- `bera` / `tbera` — `Berachain` / `BerachainTestnet` already have `batcherContractAddress` set
- `oas` / `toas` — `Oas` / `OasTestnet` already have `batcherContractAddress` set
- `soneium` / `tsoneium` — `Soneium` / `SoneiumTestnet` already have `batcherContractAddress` set
- `tapechain` — `ApeChainTestnet` already has `batcherContractAddress` set (mainnet `apechain` intentionally excluded — no batcher deployed there yet)

Changes:
- Add `CoinFeature.ERC20_BULK_TRANSACTION` to `BERA_FEATURES`, `OAS_FEATURES`, `SONEIUM_FEATURES` (`modules/statics/src/coinFeatures.ts`)
- Add `CoinFeature.ERC20_BULK_TRANSACTION` to `tapechain`'s inline feature array only (`modules/statics/src/allCoinsAndTokens.ts`)
- Extend the existing `ERC20 Bulk Transaction Feature` test with the new coin identifiers (`modules/statics/test/unit/coins.ts`)

`calculateTokenBatchSpendAmounts` is already generic in `abstractEthLikeCommon` / inherited by `EVMCoin`, so no wallet-platform code changes are needed. Downstream: bump `@bitgo-beta/statics` in bitgo-microservices and deploy.

## Issue Number

CECHO-2024

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- `tsc --noEmit` on `modules/statics` passes.
- Full `modules/statics` unit test suite passes (35,961 tests), including the extended `ERC20 Bulk Transaction Feature` test.

## Not included (follow-up work)

- `apechain` mainnet, `baseeth`, `seievm`, `zketh`, `zksyncera`, `tempo`, `vet` — no Batcher contract deployed yet; needs deployment/compatibility confirmation first.
- `hyperliquid`, `iota` — non-EVM `AccountNetwork` coins, out of scope.
- `zetaevm` — represented as an ERC-20 token on Ethereum mainnet, not a native EVM chain; nothing to enable.