### PR TITLE
feat(statics): add bsc:real (RealLink) for CECHO-1941

### DIFF
--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -4783,6 +4783,7 @@ export enum UnderlyingAsset {
   'bsc:coai' = 'bsc:coai',
   'bsc:nes' = 'bsc:nes',
   'bsc:mgo' = 'bsc:mgo',
+  'bsc:real' = 'bsc:real',
   'baseeth:awe' = 'baseeth:awe',
   'baseeth:tibbir' = 'baseeth:tibbir',
   'baseeth:kta' = 'baseeth:kta',

--- a/modules/statics/src/coins/bscTokens.ts
+++ b/modules/statics/src/coins/bscTokens.ts
@@ -3496,4 +3496,13 @@ export const bscTokens = [
     UnderlyingAsset['bsc:mgo'],
     BSC_TOKEN_FEATURES_TRUST_ONLY
   ),
+  bscToken(
+    'aab70211-e646-485f-a6cc-0fb7f1c56863',
+    'bsc:real',
+    'RealLink',
+    6,
+    '0x65e7a112db1142eae919201b1232f7aa488ed83c',
+    UnderlyingAsset['bsc:real'],
+    BSC_TOKEN_FEATURES_TRUST_ONLY
+  ),
 ];

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -5397,6 +5397,7 @@ export const ofcCoins = [
   ofcBscToken('5edc712c-6d22-47c2-9f67-d46d41bcc311', 'ofcbsc:coai', 'ChainOpera AI', 18, UnderlyingAsset['bsc:coai']),
   ofcBscToken('b50fba92-d362-47d1-9a4f-c656b21c778d', 'ofcbsc:nes', 'Nesa', 18, UnderlyingAsset['bsc:nes']),
   ofcBscToken('2d43e6e0-997c-4f2b-bc9a-5f503abe3bc3', 'ofcbsc:mgo', 'Mango Network', 9, UnderlyingAsset['bsc:mgo']),
+  ofcBscToken('04f00c0d-23d9-4a45-9805-e2b12ea8fa2a', 'ofcbsc:real', 'RealLink', 6, UnderlyingAsset['bsc:real']),
   // Ondo Tokens OFC (BSC Mainnet Ungated)
   ofcBscToken(
     'cf2b0030-bd09-427f-b645-e3c0e8ebf42d',


### PR DESCRIPTION
## Summary
- The ticket's second spreadsheet lists **RealLink (REAL)** as a BEP-20 token on **BSC** — contract `0x65e7a112db1142eae919201b1232f7aa488ed83c`, 6 decimals, per its `bscscan.com` explorer link.
- We had onboarded it as `trx:real` (Tron) in [BitGoJS#9536](https://github.com/BitGo/BitGoJS/pull/9536). Verified on-chain: RealLink is a genuine multi-chain token with real deployments on both BSC and Tron, so `trx:real` is left untouched, and `bsc:real` is added alongside it to match what the ticket actually specified.
- Adds `bsc:real` + `ofcbsc:real` using `BSC_TOKEN_FEATURES_TRUST_ONLY`, matching the rest of the CECHO-1941 batch (custody scoped to BitGo Trust only, gated everywhere else).
- Verified via a built copy of `@bitgo/statics`: `bsc:real` resolves with the right contract/decimals/features, `ofcbsc:real` exists, `trx:real` is unaffected.

Stacked on #9598 (needs `BSC_TOKEN_FEATURES_TRUST_ONLY`, added there).

## Ticket
[CECHO-1941](https://linear.app/bitgo/issue/CECHO-1941/unsupported-bsc-arb-tokens-falls-under-top-1000-assets)

## Test plan
- [x] `tsc --noEmit` passes for `modules/statics`
- [x] Built statics confirms `bsc:real`/`ofcbsc:real` resolve correctly, `trx:real` unchanged
- [ ] CI passes