### PR TITLE
fix(sdk-core): disable assertSignableConsistency call pending chain-ID fix (WCI-1398)

### DIFF
--- a/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/ecdsa/ecdsaMPCv2.ts
@@ -52,7 +52,6 @@ import {
 } from '../baseTypes';
 import { shouldUsePreHashedSignable } from '../preHashedSignable';
 import { shouldVerifyWithSerializedTxHex } from '../serializedTxHexVerify';
-import { isCoinWithSignableConsistency } from '../signableConsistency';
 import { BaseEcdsaUtils } from './base';
 import { EcdsaMPCv2KeyGenSendFn, KeyGenSenderForEnterprise } from './ecdsaMPCv2KeyGenSender';
 import { envRequiresBitgoPubGpgKeyConfig, isBitgoMpcPubKey } from '../../../tss/bitgoPubKeys';
@@ -959,13 +958,6 @@ export class EcdsaMPCv2Utils extends BaseEcdsaUtils {
           wallet: this.wallet,
           walletType: this.wallet.multisigType(),
         });
-        // Gap 2 fix (WCI-1398): verifyTransaction sees serializedTxHex but signing uses
-        // signableHex — both are server-supplied independently. For coins that implement
-        // the consistency check, derive signableHex from serializedTxHex and confirm they
-        // match before signing.
-        if (shouldVerifyWithSerializedTxHex(this.baseCoin) && isCoinWithSignableConsistency(this.baseCoin)) {
-          this.baseCoin.assertSignableConsistency(unsignedTx.serializedTxHex, unsignedTx.signableHex);
-        }
       } else {
         await this.baseCoin.verifyTransaction({
           txPrebuild: { txHex: unsignedTx.signableHex },


### PR DESCRIPTION
## Summary

- Removes the `assertSignableConsistency` call in `ecdsaMPCv2.ts` that was causing false-positive tamper errors for BSC, BSC:BUSD, and TXDC `sendMany` withdrawals (introduced in #9526, shipped in beta.2169)
- The interface and method remain in place — a follow-up PR will re-enable the call with the correct `Common` object (using `getCustomChainCommon(this.getChainId())`) so the chain ID is derived from the coin rather than defaulting to mainnet

## Root cause

Unsigned EVM transactions have `v=0` — no chain ID in the serialized bytes. `fromSerializedData` without an explicit `Common` defaults to mainnet (chain ID 1), while the server computes `signableHex` with the correct chain ID (e.g. 97 for BSC testnet). This caused a derivation mismatch and a false-positive tamper error on every signing flow.

## Test plan

- [ ] CI passes
- [ ] No unit tests affected (BSC/XDC `assertSignableConsistency` tests call the method directly on the coin, not through this call site)

Fixes: WCI-1398