### PR TITLE
feat(statics): onboard CHALO-1400 tokens

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -5243,6 +5243,24 @@ export const allCoinsAndTokens = [
     Networks.main.basechain,
     EVM_TOKEN_FEATURES_TRUST_ONLY
   ),
+  erc20Token(
+    'e5da6a40-7c39-445a-b274-dd20f5e5a1d4',
+    'baseeth:tel',
+    'Telcoin',
+    2,
+    '0x09be1692ca16e06f536f0038ff11d1da8524adb1',
+    UnderlyingAsset['baseeth:tel'],
+    Networks.main.basechain
+  ),
+  erc20Token(
+    'f4d03f54-5da6-4282-a6f2-47973fe9f27e',
+    'baseeth:svvv',
+    'Staked Venice Token',
+    18,
+    '0x321b7ff75154472b18edb199033ff4d116f340ff',
+    UnderlyingAsset['baseeth:svvv'],
+    Networks.main.basechain
+  ),
 
   // ARC mainnet tokens
   erc20Token(

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -2308,6 +2308,8 @@ export enum UnderlyingAsset {
   'hoodeth:jbl' = 'hoodeth:jbl',
   'hoodeth:shy' = 'hoodeth:shy',
   'hoodeth:bnd' = 'hoodeth:bnd',
+  'hoodeth:pons' = 'hoodeth:pons',
+  'hoodeth:stonkbroker' = 'hoodeth:stonkbroker',
   'hemieth:hemi' = 'hemieth:hemi',
   'hemieth:hemibtc' = 'hemieth:hemibtc',
   'usdt0:stable' = 'usdt0:stable',
@@ -3345,6 +3347,7 @@ export enum UnderlyingAsset {
   'polygon:seag' = 'polygon:seag',
   'polygon:infra' = 'polygon:infra',
   'polygon:sofid' = 'polygon:sofid',
+  'polygon:tel' = 'polygon:tel',
   // Polygon NFTs
   // generic NFTs
   'erc721:polygontoken' = 'erc721:polygontoken',
@@ -4791,6 +4794,8 @@ export enum UnderlyingAsset {
   'baseeth:fai' = 'baseeth:fai',
   'baseeth:roll' = 'baseeth:roll',
   'baseeth:zen' = 'baseeth:zen',
+  'baseeth:tel' = 'baseeth:tel',
+  'baseeth:svvv' = 'baseeth:svvv',
   'arbeth:rain' = 'arbeth:rain',
   'arbeth:mlk' = 'arbeth:mlk',
   'polygon:apepe' = 'polygon:apepe',

--- a/modules/statics/src/coins/hoodethTokens.ts
+++ b/modules/statics/src/coins/hoodethTokens.ts
@@ -2955,6 +2955,26 @@ export const hoodethTokens = [
     EVM_ERC20_TOKEN_FEATURES_EXCLUDE_SINGAPORE
   ),
   erc20Token(
+    '4f42f640-c589-4852-91d3-0a712a3b032d',
+    'hoodeth:pons',
+    'Pons',
+    18,
+    '0x39dbed3a2bd333467115de45665cc57f813c4571',
+    UnderlyingAsset['hoodeth:pons'],
+    Networks.main.hoodeth,
+    EVM_ERC20_TOKEN_FEATURES_EXCLUDE_SINGAPORE
+  ),
+  erc20Token(
+    'c4cb14c7-8ee6-4ecb-a9ba-85f1dc99b4a4',
+    'hoodeth:stonkbroker',
+    'StonkBroker',
+    18,
+    '0xe934e36a439c94017b64a3fece66af12099abf50',
+    UnderlyingAsset['hoodeth:stonkbroker'],
+    Networks.main.hoodeth,
+    EVM_ERC20_TOKEN_FEATURES_EXCLUDE_SINGAPORE
+  ),
+  erc20Token(
     '3493d608-fd3e-45dc-926d-783d54a8fe4d',
     'thoodeth:amzn',
     'Amazon',

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -4704,6 +4704,13 @@ export const ofcCoins = [
     18,
     UnderlyingAsset['polygon:apepe']
   ),
+  ofcPolygonErc20(
+    '01f75a16-b736-4869-8f6b-d2ac73b46cbe',
+    'ofcpolygon:tel',
+    'Telcoin',
+    2,
+    UnderlyingAsset['polygon:tel']
+  ),
 
   tofcPolygonErc20(
     '62f4329d-11cd-4875-b91b-9ceae66c9439',

--- a/modules/statics/src/coins/ofcErc20Coins.ts
+++ b/modules/statics/src/coins/ofcErc20Coins.ts
@@ -7606,6 +7606,34 @@ export const tOfcErc20Coins = [
     'baseeth'
   ),
   ofcerc20(
+    'fa5fa323-5dc0-4e0e-9c3f-46f1622aa9ba',
+    'ofcbaseeth:tel',
+    'Telcoin',
+    2,
+    UnderlyingAsset['baseeth:tel'],
+    undefined,
+    undefined,
+    '',
+    undefined,
+    undefined,
+    true,
+    'baseeth'
+  ),
+  ofcerc20(
+    'cffaede1-4e68-47bb-87a4-59a1a5cbefda',
+    'ofcbaseeth:svvv',
+    'Staked Venice Token',
+    18,
+    UnderlyingAsset['baseeth:svvv'],
+    undefined,
+    undefined,
+    '',
+    undefined,
+    undefined,
+    true,
+    'baseeth'
+  ),
+  ofcerc20(
     'e5ffd11d-59b4-4c95-a4c7-bebaf57222f0',
     'ofczketh:zk',
     'zkSync',

--- a/modules/statics/src/coins/ofcHoodethTokens.ts
+++ b/modules/statics/src/coins/ofcHoodethTokens.ts
@@ -4162,4 +4162,32 @@ export const ofcHoodethTokens = [
     true,
     'hoodeth'
   ),
+  ofcerc20(
+    '02e35215-1c14-482f-a59f-fffaaa3b7937',
+    'ofchoodeth:pons',
+    'Pons',
+    18,
+    UnderlyingAsset['hoodeth:pons'],
+    undefined,
+    undefined,
+    '',
+    undefined,
+    undefined,
+    true,
+    'hoodeth'
+  ),
+  ofcerc20(
+    'ab0d939c-e023-42c1-bd55-008d0a614b7c',
+    'ofchoodeth:stonkbroker',
+    'StonkBroker',
+    18,
+    UnderlyingAsset['hoodeth:stonkbroker'],
+    undefined,
+    undefined,
+    '',
+    undefined,
+    undefined,
+    true,
+    'hoodeth'
+  ),
 ];

--- a/modules/statics/src/coins/polygonTokens.ts
+++ b/modules/statics/src/coins/polygonTokens.ts
@@ -1682,6 +1682,15 @@ export const polygonTokens = [
     UnderlyingAsset['polygon:sofid'],
     POLYGON_TOKEN_FEATURES
   ),
+  polygonErc20(
+    'a024c5c7-1333-45bd-b31d-3cc17e830947',
+    'polygon:tel',
+    'Telcoin',
+    2,
+    '0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32',
+    UnderlyingAsset['polygon:tel'],
+    POLYGON_TOKEN_FEATURES
+  ),
   tpolygonErc20(
     '13dd4ab7-2d94-493c-9a61-323f6300f7e5',
     'tpolygon:tusdl',


### PR DESCRIPTION
## Summary
- Onboard ungated tokens from CHALO-1400: `baseeth:tel`, `polygon:tel`, `hoodeth:pons`, `hoodeth:stonkbroker`, `baseeth:svvv`
- Skip `baseeth:diem` (already onboarded in CECHO-1941)

## Ticket
[CHALO-1400](https://linear.app/bitgo/issue/CHALO-1400/client-requested-tokens-to-onboard-batch-2-0831)

