### PR TITLE
chore: bump @bitgo/public-types to 6.64.1

### DIFF
--- a/modules/abstract-lightning/package.json
+++ b/modules/abstract-lightning/package.json
@@ -39,7 +39,7 @@
     ]
   },
   "dependencies": {
-    "@bitgo/public-types": "6.63.0",
+    "@bitgo/public-types": "6.64.1",
     "@bitgo/sdk-core": "^38.11.0",
     "@bitgo/statics": "^59.10.0",
     "@bitgo/utxo-lib": "^11.24.3",

--- a/modules/bitgo/package.json
+++ b/modules/bitgo/package.json
@@ -143,7 +143,7 @@
     "superagent": "^9.0.1"
   },
   "devDependencies": {
-    "@bitgo/public-types": "6.63.0",
+    "@bitgo/public-types": "6.64.1",
     "@bitgo/sdk-opensslbytes": "^2.1.0",
     "@bitgo/sdk-test": "^9.1.71",
     "@openpgp/web-stream-tools": "0.0.14",

--- a/modules/express/package.json
+++ b/modules/express/package.json
@@ -60,7 +60,7 @@
     "superagent": "^9.0.1"
   },
   "devDependencies": {
-    "@bitgo/public-types": "6.63.0",
+    "@bitgo/public-types": "6.64.1",
     "@bitgo/sdk-lib-mpc": "^10.18.0",
     "@bitgo/sdk-test": "^9.1.71",
     "@types/argparse": "^1.0.36",

--- a/modules/passkey-crypto/package.json
+++ b/modules/passkey-crypto/package.json
@@ -35,7 +35,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@bitgo/public-types": "6.63.0",
+    "@bitgo/public-types": "6.64.1",
     "@bitgo/sdk-core": "^38.11.0"
   },
   "devDependencies": {

--- a/modules/sdk-coin-flrp/package.json
+++ b/modules/sdk-coin-flrp/package.json
@@ -48,7 +48,7 @@
     "nock": "^13.3.1"
   },
   "dependencies": {
-    "@bitgo/public-types": "6.63.0",
+    "@bitgo/public-types": "6.64.1",
     "@bitgo/sdk-core": "^38.11.0",
     "@bitgo/secp256k1": "^1.11.0",
     "@bitgo/statics": "^59.10.0",

--- a/modules/sdk-coin-sol/package.json
+++ b/modules/sdk-coin-sol/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@bitgo/logger": "^1.4.0",
-    "@bitgo/public-types": "6.63.0",
+    "@bitgo/public-types": "6.64.1",
     "@bitgo/sdk-core": "^38.11.0",
     "@bitgo/sdk-lib-mpc": "^10.18.0",
     "@bitgo/statics": "^59.10.0",

--- a/modules/sdk-core/package.json
+++ b/modules/sdk-core/package.json
@@ -40,7 +40,7 @@
     ]
   },
   "dependencies": {
-    "@bitgo/public-types": "6.63.0",
+    "@bitgo/public-types": "6.64.1",
     "@bitgo/sdk-lib-mpc": "^10.18.0",
     "@bitgo/secp256k1": "^1.11.0",
     "@bitgo/sjcl": "^1.1.0",

--- a/modules/sdk-core/src/bitgo/utils/tss/redpallas/SMC/utils.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/redpallas/SMC/utils.ts
@@ -106,7 +106,6 @@ export class RedpallasMPCv2SMCUtils {
       sessionId,
       userMsg2: ovc1.ovcMsg2,
       backupMsg2: ovc2.ovcMsg2,
-      derivationSeed: payload.derivationSeed,
     });
 
     assert.equal(sessionId, result.sessionId, 'Round 1 and round 2 session IDs do not match');
@@ -126,7 +125,6 @@ export class RedpallasMPCv2SMCUtils {
       walletType: payload.walletType,
       coin: payload.coin,
       ovc: payload.ovc,
-      derivationSeed: payload.derivationSeed,
       platform: {
         // sessionId/bitgoMsg1 carried over from payload.platform; safe because the assert
         // above guarantees payload.platform.sessionId equals result.sessionId.

--- a/modules/sdk-core/src/bitgo/utils/tss/redpallas/redpallasMPCv2.ts
+++ b/modules/sdk-core/src/bitgo/utils/tss/redpallas/redpallasMPCv2.ts
@@ -26,11 +26,8 @@ import {
  * addresses is out of scope for this SDK.
  *
  * RedPallas MPS DKG completes in the same 2-round shape as EdDSA MPS DKG (round0 local, round1 +
- * round2 online), but round2 additionally requires a `derivationSeed`: a 32-byte value consumed by
- * a subsequent, platform-side-only key derivation step (Zcash Orchard ask/nk/rivk/ivks) that is
- * intentionally not implemented here. The resulting `commonPublicKeychain` is the raw 32-byte
- * RedPallas group public key (64 hex chars) - there is no BIP32-style chain code, unlike EdDSA/ECDSA
- * commonKeychains.
+ * round2 online). The resulting `commonPublicKeychain` is the raw 32-byte RedPallas group public
+ * key (64 hex chars) - there is no BIP32-style chain code, unlike EdDSA/ECDSA commonKeychains.
  */
 export class RedpallasMPCv2Utils extends BaseTssUtils<unknown> {
   constructor(bitgo: BitGoBase, baseCoin: IBaseCoin, wallet?: IWallet) {

--- a/modules/sdk-core/test/unit/bitgo/utils/tss/redpallas/redpallasMPCv2.ts
+++ b/modules/sdk-core/test/unit/bitgo/utils/tss/redpallas/redpallasMPCv2.ts
@@ -44,7 +44,6 @@ describe('RedpallasMPCv2Utils', function () {
         sessionId: 's1',
         userMsg2: { message: 'u2', signature: 'usig' },
         backupMsg2: { message: 'b2', signature: 'bsig' },
-        derivationSeed: 'a'.repeat(64),
       };
 
       const result = await utils.sendKeyGenerationRound2BySender(senderFn as never, payload as never);

--- a/modules/sdk-core/test/unit/bitgo/utils/tss/redpallas/smcUtil.ts
+++ b/modules/sdk-core/test/unit/bitgo/utils/tss/redpallas/smcUtil.ts
@@ -73,7 +73,6 @@ describe('RedPallas MPCv2 SMC Utils:', function () {
         sessionId,
         bitgoMsg1: fakeSignedMessage('bitgo-1'),
       },
-      derivationSeed: 'a'.repeat(64),
     } as unknown as RedpallasOVC2ToBitgoRound2Payload);
 
   beforeEach(function () {
@@ -190,7 +189,6 @@ describe('RedPallas MPCv2 SMC Utils:', function () {
       assert.strictEqual(senderPayload.sessionId, 'session-xyz');
       assert.deepStrictEqual(senderPayload.userMsg2, payload.ovc[OVCIndexEnum.ONE].ovcMsg2);
       assert.deepStrictEqual(senderPayload.backupMsg2, payload.ovc[OVCIndexEnum.TWO].ovcMsg2);
-      assert.strictEqual(senderPayload.derivationSeed, payload.derivationSeed);
 
       assert.ok(keychainsStub.add.calledOnce);
       assert.deepStrictEqual(keychainsStub.add.firstCall.args[0], {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1021,10 +1021,10 @@
     "@scure/base" "1.1.5"
     micro-eth-signer "0.7.2"
 
-"@bitgo/public-types@6.63.0":
-  version "6.63.0"
-  resolved "https://registry.npmjs.org/@bitgo/public-types/-/public-types-6.63.0.tgz#8f19956f043f4e4e20f6dc52b04ae03a8d227489"
-  integrity sha512-SaZOl4kCxr7HzJQtupIvqofMrdAQhX42KyRmxfG51j6Hh7mPnO2Ny7dTiKUwU1zh5u8MmTXpyIFwscyVW00BpA==
+"@bitgo/public-types@6.64.1":
+  version "6.64.1"
+  resolved "https://registry.npmjs.org/@bitgo/public-types/-/public-types-6.64.1.tgz#85c529e968a2393784373a611eca188a3b5e2832"
+  integrity sha512-+3Y+9gJDDy8YorytnfqcR5IXjb35BloZilaEjwAnJYOqWO+wD+fLHvhc5eIAYnFJKNFE2gie4JBfdQ2055HVOw==
   dependencies:
     fp-ts "^2.0.0"
     io-ts "npm:@bitgo-forks/io-ts@2.1.4"
@@ -12795,7 +12795,18 @@ html-minifier-terser@^6.0.2:
     tapable "^1.1.3"
     util.promisify "1.0.0"
 
-"html-webpack-plugin-5@npm:html-webpack-plugin@^5", html-webpack-plugin@^5.5.0:
+"html-webpack-plugin-5@npm:html-webpack-plugin@^5":
+  version "5.6.4"
+  resolved "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.4.tgz"
+  integrity sha512-V/PZeWsqhfpE27nKeX9EO2sbR+D17A+tLf6qU+ht66jdUsN0QLKJN27Z+1+gHrVMKgndBahes0PU6rRihDgHTw==
+  dependencies:
+    "@types/html-minifier-terser" "^6.0.0"
+    html-minifier-terser "^6.0.2"
+    lodash "^4.17.21"
+    pretty-error "^4.0.0"
+    tapable "^2.0.0"
+
+html-webpack-plugin@^5.5.0:
   version "5.6.4"
   resolved "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.4.tgz"
   integrity sha512-V/PZeWsqhfpE27nKeX9EO2sbR+D17A+tLf6qU+ht66jdUsN0QLKJN27Z+1+gHrVMKgndBahes0PU6rRihDgHTw==
@@ -21360,7 +21371,16 @@ workerpool@^6.5.1:
   resolved "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@7.0.0, wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@7.0.0, wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
TICKET: WCI-1513

This pull request primarily updates the `@bitgo/public-types` dependency across several modules to version `6.64.1` and removes the unused `derivationSeed` parameter from the RedPallas MPCv2 SMC utility logic and related tests. The changes help keep dependencies up to date and simplify the RedPallas MPCv2 implementation by removing unnecessary parameters.

**Dependency updates:**
* Bumped `@bitgo/public-types` from `6.63.0` to `6.64.1` in the dependencies or devDependencies of the following packages: `abstract-lightning`, `bitgo`, `express`, `passkey-crypto`, `sdk-coin-flrp`, `sdk-coin-sol`, and `sdk-core`. [[1]](diffhunk://#diff-1faab301f9375be8c0e9acb260209ffd2b6476e88fa5cb70e9925f45c1718341L42-R42) [[2]](diffhunk://#diff-8d92a0a1b22bc80f4f0c0b25695f0cc892ae3284604007791b03b862a817f6aeL146-R146) [[3]](diffhunk://#diff-9e69556f5d29f0e16fe114065d425359eb77e9df39cf8468fd2c574c90d389f8L63-R63) [[4]](diffhunk://#diff-9401d9cdbc8b88ac4595d817f9dc4428697ddf5e1c7f02d09bba05f93088dc30L38-R38) [[5]](diffhunk://#diff-cd326358c68ed3f735143bb868e0227e29be683a958f8d1d44ba625e3c36ee95L51-R51) [[6]](diffhunk://#diff-1e4a0d3cb6a73d80dd40f97e359b196710d74f2f914c6d1344ec90d9e32e7a97L60-R60) [[7]](diffhunk://#diff-33948460d04a9947ab00b457830e2a05ba03718ca07181f86360824b15cbbddcL43-R43)

**RedPallas MPCv2 SMC utility simplification:**
* Removed the `derivationSeed` parameter from function calls, payloads, and assertions in `RedpallasMPCv2SMCUtils` and related test files, as it is no longer required for the key generation flow. [[1]](diffhunk://#diff-e6dfb83cb07570650b42555b7de4d861d8e81585b6a3d5c8ed696138f52d5dcdL109) [[2]](diffhunk://#diff-e6dfb83cb07570650b42555b7de4d861d8e81585b6a3d5c8ed696138f52d5dcdL129) [[3]](diffhunk://#diff-a32c1dca7cc628f5d0a7ddff78679247e45cb3c0249356c92a101cd515226b88L47) [[4]](diffhunk://#diff-d07f30d64efd67727b267dfd6e144316ddbf954fa0d2838f95b08ab94354e3e3L76) [[5]](diffhunk://#diff-d07f30d64efd67727b267dfd6e144316ddbf954fa0d2838f95b08ab94354e3e3L193)
* Updated documentation in `redpallasMPCv2.ts` to remove references to `derivationSeed` in the class-level comments.

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
