### PR TITLE
feat(statics): merge CECHO-1941 bsc:real addition to master

### DIFF
--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -4783,6 +4783,7 @@ export enum UnderlyingAsset {
   'bsc:coai' = 'bsc:coai',
   'bsc:nes' = 'bsc:nes',
   'bsc:mgo' = 'bsc:mgo',
+  'bsc:real' = 'bsc:real',
   'baseeth:awe' = 'baseeth:awe',
   'baseeth:tibbir' = 'baseeth:tibbir',
   'baseeth:kta' = 'baseeth:kta',

--- a/modules/statics/src/coins/bscTokens.ts
+++ b/modules/statics/src/coins/bscTokens.ts
@@ -3496,4 +3496,13 @@ export const bscTokens = [
     UnderlyingAsset['bsc:mgo'],
     BSC_TOKEN_FEATURES_TRUST_ONLY
   ),
+  bscToken(
+    'aab70211-e646-485f-a6cc-0fb7f1c56863',
+    'bsc:real',
+    'RealLink',
+    6,
+    '0x65e7a112db1142eae919201b1232f7aa488ed83c',
+    UnderlyingAsset['bsc:real'],
+    BSC_TOKEN_FEATURES_TRUST_ONLY
+  ),
 ];

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -5397,6 +5397,7 @@ export const ofcCoins = [
   ofcBscToken('5edc712c-6d22-47c2-9f67-d46d41bcc311', 'ofcbsc:coai', 'ChainOpera AI', 18, UnderlyingAsset['bsc:coai']),
   ofcBscToken('b50fba92-d362-47d1-9a4f-c656b21c778d', 'ofcbsc:nes', 'Nesa', 18, UnderlyingAsset['bsc:nes']),
   ofcBscToken('2d43e6e0-997c-4f2b-bc9a-5f503abe3bc3', 'ofcbsc:mgo', 'Mango Network', 9, UnderlyingAsset['bsc:mgo']),
+  ofcBscToken('04f00c0d-23d9-4a45-9805-e2b12ea8fa2a', 'ofcbsc:real', 'RealLink', 6, UnderlyingAsset['bsc:real']),
   // Ondo Tokens OFC (BSC Mainnet Ungated)
   ofcBscToken(
     'cf2b0030-bd09-427f-b645-e3c0e8ebf42d',


### PR DESCRIPTION
## Summary
- #9599 (adds `bsc:real`/`ofcbsc:real`, RealLink on BSC) was merged into this branch instead of directly into master, so it was never actually published in any `@bitgo-beta/statics` release.
- This PR merges that branch (which already contains #9598's trust-only scoping, published in beta.2024/2025, plus #9599's `bsc:real` addition, not yet published) into master so `bsc:real` actually ships.

No new changes — this is just the missing merge-to-master step.

## Ticket
[CECHO-1941](https://linear.app/bitgo/issue/CECHO-1941/unsupported-bsc-arb-tokens-falls-under-top-1000-assets)

## Test plan
- [ ] CI passes