### PR TITLE
fix(root): run private package changed tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -290,7 +290,7 @@
     "postinstall": "test -n \"$NOYARNPOSTINSTALL\" || lerna run build --stream",
     "lint": "lerna run lint --stream",
     "lint-changed": "lerna run lint --since origin/${GITHUB_REPO_BRANCH:-master}..HEAD --stream",
-    "unit-test-changed": "lerna run unit-test --since $(git merge-base HEAD~ origin/${GITHUB_REPO_BRANCH:-master}) --stream",
+    "unit-test-changed": "lerna run unit-test --since $(git merge-base HEAD~ origin/${GITHUB_REPO_BRANCH:-master}) --private --stream",
     "browser-tests": "lerna run --scope bitgo compile-test && lerna run --scope bitgo browser-test && lerna run --scope @bitgo/web-demo test",
     "gen-coverage-changed": "lerna run gen-coverage --since origin/${GITHUB_REPO_BRANCH:-master}..HEAD --stream --parallel",
     "coverage-changed": "lerna run upload-coverage --since origin/${GITHUB_REPO_BRANCH:-master}..HEAD --stream --parallel --",


### PR DESCRIPTION
## Description

- Pass Lerna's `--private` filter to `unit-test-changed`.
- Recreate the closed Ralph PR with a Conventional Commit that satisfies the repository's 100-character commit-body limit.

## Issue Number

WAL-1960

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `yarn commitlint --from=HEAD~ --to=HEAD -V`
- `yarn postinstall`
- `yarn lerna run --scope bitgo unit-test --private --stream` reaches the `bitgo` suite; completing that suite locally requires `BITGOJS_TEST_PASSWORD`, which CI injects.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My commits follow Conventional Commits and include the ticket reference
- [ ] New and existing unit tests pass locally with my changes (blocked on `BITGOJS_TEST_PASSWORD`)