### PR TITLE
feat(statics): rename Story display name to Data Network

### DIFF
--- a/modules/bitgo/test/v2/resources/amsTokenConfig.ts
+++ b/modules/bitgo/test/v2/resources/amsTokenConfig.ts
@@ -24,7 +24,7 @@ export const reducedAmsTokenConfig = {
   'tip:faketoken': [
     {
       id: 'a1b2c3d4-e5f6-4789-8abc-def123456789',
-      fullName: 'Story Testnet Faketoken',
+      fullName: 'Data Network Testnet Faketoken',
       name: 'tip:faketoken',
       prefix: '',
       suffix: 'TIP:FAKETOKEN',

--- a/modules/bitgo/test/v2/unit/coins/ofcErc20Tokens.ts
+++ b/modules/bitgo/test/v2/unit/coins/ofcErc20Tokens.ts
@@ -103,8 +103,8 @@ describe('OFC ERC20 Tokens Configuration:', function () {
         { token: 'ofcmon:wmon', addressCoin: 'mon', chain: 'MON' },
         // HYPE Network token
         { token: 'ofchype:hwhype', addressCoin: 'hype', chain: 'HYPE' },
-        // IP (Story Network) token
-        { token: 'ofcip:aria', addressCoin: 'ip', chain: 'Story' },
+        // IP (Data Network) token
+        { token: 'ofcip:aria', addressCoin: 'ip', chain: 'Data Network' },
       ];
 
       const errors: string[] = [];

--- a/modules/bitgo/test/v2/unit/keychains.ts
+++ b/modules/bitgo/test/v2/unit/keychains.ts
@@ -118,7 +118,7 @@ describe('V2 Keychains', function () {
         n.asset !== UnderlyingAsset.KAIA &&
         n.asset !== UnderlyingAsset.IRYS &&
         n.asset !== UnderlyingAsset.LINEAETH &&
-        n.asset !== UnderlyingAsset.IP && // Story Chain
+        n.asset !== UnderlyingAsset.IP && // Data Network
         n.asset !== UnderlyingAsset.BASEETH &&
         n.asset !== UnderlyingAsset.SOMI &&
         n.asset !== UnderlyingAsset.FLRP &&

--- a/modules/sdk-core/src/bitgo/staking/iStakingWallet.ts
+++ b/modules/sdk-core/src/bitgo/staking/iStakingWallet.ts
@@ -195,7 +195,7 @@ export interface VetStakeOptions extends StakeOptions {
 
 export interface StoryStakeOptions extends StakeOptions {
   /**
-   * Story staking period
+   * Data Network staking period
    */
   stakingPeriod?: string;
 }

--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -1943,7 +1943,7 @@ export const allCoinsAndTokens = [
   account(
     'ead0435a-ee3f-4dc5-91fd-8897f1811701',
     'ip',
-    'Story',
+    'Data Network',
     Networks.main.ip,
     18,
     UnderlyingAsset.IP,
@@ -1963,7 +1963,7 @@ export const allCoinsAndTokens = [
   account(
     '86e7b7d6-02db-4ef7-9552-e8aeeeec2d52',
     'tip',
-    'Story Testnet',
+    'Data Network Testnet',
     Networks.test.ip,
     18,
     UnderlyingAsset.IP,
@@ -5523,11 +5523,11 @@ export const allCoinsAndTokens = [
     [...AccountCoin.DEFAULT_FEATURES_EXCLUDE_SINGAPORE, CoinFeature.EIP1559]
   ),
 
-  // Story testnet tokens
+  // Data Network testnet tokens
   erc20Token(
     'f9a9c36f-8938-4206-bf0d-5016a861c58f',
     'tip:usdc',
-    'Testnet Story USDC',
+    'Testnet Data Network USDC',
     6,
     '0x8c7c52eabb0fcbcaebce2556d9a719d539ea02d8',
     UnderlyingAsset['tip:usdc'],
@@ -5537,14 +5537,14 @@ export const allCoinsAndTokens = [
   erc20Token(
     '9d0e81bc-b049-402b-83ce-3a5dd9680f17',
     'tip:tmt',
-    'Testnet Story TMT',
+    'Testnet Data Network TMT',
     6,
     '0xb283ec8dad644effc5c4c50bb7bb21442ac3c2db',
     UnderlyingAsset['tip:tmt'],
     Networks.test.ip
   ),
 
-  // Story mainnet tokens
+  // Data Network mainnet tokens
   erc20Token(
     '2460e83c-e819-42c3-83c9-3974e08a45c8',
     'ip:aria',

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -143,7 +143,7 @@ export enum CoinFamily {
   ZKETH = 'zketh',
   ZKSYNCERA = 'zksyncera', // ZkSync Era
   LINEAETH = 'lineaeth',
-  IP = 'ip', // Story Chain
+  IP = 'ip', // Data Network
   SOMI = 'somi', // Somnia Chain
   FLUENTETH = 'fluenteth',
   MORPH = 'morph',
@@ -696,7 +696,7 @@ export enum UnderlyingAsset {
   HPPETH = 'hppeth', // House Party Protocol
   ICP = 'icp',
   INKETH = 'inketh', // INK L2
-  IP = 'ip', // Story Chain
+  IP = 'ip', // Data Network
   INITIA = 'initia',
   INJECTIVE = 'injective',
   IOTA = 'iota',
@@ -3921,11 +3921,11 @@ export enum UnderlyingAsset {
   // X Layer (OKB) testnet tokens
   'tokbxlayer:tzeb' = 'tokbxlayer:tzeb',
 
-  // Story testnet tokens
+  // Data Network testnet tokens
   'tip:usdc' = 'tip:usdc',
   'tip:tmt' = 'tip:tmt',
 
-  // Story mainnet tokens
+  // Data Network mainnet tokens
   'ip:aria' = 'ip:aria',
 
   // MegaEth mainnet tokens

--- a/modules/statics/src/coins/ofcCoins.ts
+++ b/modules/statics/src/coins/ofcCoins.ts
@@ -551,8 +551,15 @@ export const ofcCoins = [
     UnderlyingAsset.FLUENTETH,
     CoinKind.CRYPTO
   ),
-  ofc('aa7e956f-2d59-4bf6-aba6-2d51bd298150', 'ofcip', 'Story', 18, UnderlyingAsset.IP, CoinKind.CRYPTO),
-  tofc('773b02f6-32ea-493a-bca5-13d93cb0afff', 'ofctip', 'Story Testnet', 18, UnderlyingAsset.IP, CoinKind.CRYPTO),
+  ofc('aa7e956f-2d59-4bf6-aba6-2d51bd298150', 'ofcip', 'Data Network', 18, UnderlyingAsset.IP, CoinKind.CRYPTO),
+  tofc(
+    '773b02f6-32ea-493a-bca5-13d93cb0afff',
+    'ofctip',
+    'Data Network Testnet',
+    18,
+    UnderlyingAsset.IP,
+    CoinKind.CRYPTO
+  ),
   ofc(
     '9fd3e1b0-2e67-46c6-ab3b-a9942533b9d6',
     'ofcbobaeth',

--- a/modules/statics/src/coins/ofcErc20Coins.ts
+++ b/modules/statics/src/coins/ofcErc20Coins.ts
@@ -6847,7 +6847,7 @@ export const tOfcErc20Coins = [
     true,
     'tjovayeth'
   ),
-  // Story Network tokens
+  // Data Network tokens
   ofcerc20(
     '452cc4f6-3c77-4193-a572-4b0d0f838c3c',
     'ofcip:aria',

--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -1682,7 +1682,7 @@ class CoredaoTestnet extends Testnet implements EthereumNetwork {
 }
 
 class IP extends Mainnet implements EthereumNetwork {
-  name = 'Story';
+  name = 'Data Network';
   family = CoinFamily.IP;
   explorerUrl = 'https://www.storyscan.io/tx/';
   accountExplorerUrl = 'https://www.storyscan.io/address/';
@@ -1691,7 +1691,7 @@ class IP extends Mainnet implements EthereumNetwork {
 }
 
 class IPTestnet extends Testnet implements EthereumNetwork {
-  name = 'StoryTestnet';
+  name = 'Data Network Testnet';
   family = CoinFamily.IP;
   explorerUrl = 'https://aeneid.storyscan.io/tx/';
   accountExplorerUrl = 'https://aeneid.storyscan.io/address/';

--- a/modules/statics/test/unit/fixtures/expectedColdFeatures.ts
+++ b/modules/statics/test/unit/fixtures/expectedColdFeatures.ts
@@ -108,7 +108,7 @@ export const expectedColdFeatures = {
     'hoodeth',
     'hppeth',
     'icp',
-    'ip', // Story chain
+    'ip', // Data Network
     'initia',
     'iota',
     'irys',
@@ -210,7 +210,7 @@ export const expectedColdFeatures = {
     'thorchain:rune',
     'tia',
     'ticp',
-    'tip', // Story chain
+    'tip', // Data Network
     'tinitia',
     'tirys',
     'tislm',


### PR DESCRIPTION
## Summary
- Rename IP coin display names from Story to Data Network while keeping ticker `ip` / `tip`.
- Update statics fullNames, OFC names, network names, and related tests/comments.

## Out of scope
Ticker IP → DATA, RPC/explorer/domain changes, and WDATA (CECHO-1625).

## Test plan
- [ ] Confirm `ip` fullName is `Data Network` and `tip` is `Data Network Testnet`
- [ ] Confirm OFC names `ofcip` / `ofctip` match
- [ ] Confirm ticker remains `ip`

TICKET: CECHO-2067
https://linear.app/bitgo/issue/CECHO-2067/rename-story-ip-to-data-network-and-update-logos

Made with [Cursor](https://cursor.com)