### PR TITLE
test: throwaway Node 24 required-check verification (WAL-1475)

### DIFF
--- a/modules/logger/test/unit/node24Verify.ts
+++ b/modules/logger/test/unit/node24Verify.ts
@@ -1,0 +1,9 @@
+import assert from 'assert';
+
+// Throwaway test for WAL-1475: fails only on Node 24 to verify branch protection
+// actually blocks merge on a Node-24-only CI failure. Delete before merging.
+describe('WAL-1475 node24 required-check verification', function () {
+  it('should not be on node 24 (intentionally fails on node 24 only)', function () {
+    assert.notStrictEqual(process.version.split('.')[0], 'v24');
+  });
+});


### PR DESCRIPTION
## Purpose

Throwaway verification PR for [WAL-1475](https://linear.app/bitgo/issue/WAL-1475). Adds a test that fails **only** on Node 24 (`modules/logger/test/unit/node24Verify.ts`) to confirm whether a Node-24-only CI failure actually blocks merge under current branch protection.

Not intended to merge — will be closed once the checks list is observed.

## What to check

- Does `unit-test (24.x)` go red?
- Does the `all-checks` umbrella job (which is a required check) also go red as a result?
- Does GitHub actually block the merge button?

Ticket: WAL-1475