### PR TITLE
WCN-2442: Drop Node.js versions past EOL from engines field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x]
 
     steps:
       - uses: socketdev/action@937f824ec476dfd164d4a4d9995751427b0be143 # v1.3.0
@@ -140,10 +140,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Setup node 20
+      - name: Setup node 22
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
 
       - name: restore lerna dependencies
         id: lerna-cache
@@ -152,7 +152,7 @@ jobs:
           path: |
             node_modules
             modules/*/node_modules
-          key: ${{ runner.os }}-node20-${{ hashFiles('yarn.lock') }}-${{ hashFiles('tsconfig.packages.json') }}-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-node22-${{ hashFiles('yarn.lock') }}-${{ hashFiles('tsconfig.packages.json') }}-${{ hashFiles('**/package.json') }}
 
       - name: Install Packages
         if: steps.lerna-cache.outputs.cache-hit != 'true' || contains( github.event.pull_request.labels.*.name, 'SKIP_CACHE')
@@ -197,10 +197,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Setup node 20
+      - name: Setup node 22
         uses: actions/setup-node@v6
         with:
-          node-version: 20 # this just needs to pass our lock file requirement for compilation
+          node-version: 22 # this just needs to pass our lock file requirement for compilation
 
       - name: Build Info
         run: |

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,7 +1,7 @@
 # Requirements
 
 - yarn version 1 (classic)
-- node version >=20 and <25
+- node version >=22 and <25
 
 # Installing
 
@@ -180,7 +180,7 @@ Engines should be set to the following:
 ```json
 {
   "engines": {
-    "node": ">=20 <25",
+    "node": ">=22 <25",
     "npm": ">=3.10.10"
   }
 }

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ BitGoJS currently provides support for the following Node versions per package.j
 
 ```
 "engines": {
-  "node": ">=20 <25",
+  "node": ">=22 <25",
   "npm": ">=3.10.10"
 }
 ```
@@ -60,7 +60,6 @@ We specifically limit our support to these versions of Node, not because this pa
 
 As each Node LTS version reaches its end-of-life we will exclude that version from the node engines property of our package's package.json file. Removing a Node version is considered a breaking change and will entail the publishing of a new major version of this package. We will not accept any requests to support an end-of-life version of Node, and any pull requests or issues regarding support for an end-of-life version of Node will be closed. We will accept code that allows this package to run on newer, non-LTS, versions of Node. Furthermore, we will attempt to ensure our own changes work on the latest version of Node. To help in that commitment, our continuous integration setup runs the full test suite on the latest release of the following versions of node:
 
-- `20`
 - `22`
 - `24`
 

--- a/modules/abstract-cosmos/package.json
+++ b/modules/abstract-cosmos/package.json
@@ -16,7 +16,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/abstract-eth/package.json
+++ b/modules/abstract-eth/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/abstract-lightning/package.json
+++ b/modules/abstract-lightning/package.json
@@ -17,7 +17,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/abstract-substrate/package.json
+++ b/modules/abstract-substrate/package.json
@@ -16,7 +16,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/abstract-utxo/package.json
+++ b/modules/abstract-utxo/package.json
@@ -38,7 +38,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/account-lib/package.json
+++ b/modules/account-lib/package.json
@@ -24,7 +24,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "ISC",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "dependencies": {
     "@bitgo/sdk-coin-ada": "^5.1.1",

--- a/modules/babylonlabs-io-btc-staking-ts/package.json
+++ b/modules/babylonlabs-io-btc-staking-ts/package.json
@@ -34,7 +34,7 @@
     "btc-staking"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "author": "Babylon Labs Ltd.",
   "license": "SEE LICENSE IN LICENSE",

--- a/modules/bitgo/package.json
+++ b/modules/bitgo/package.json
@@ -17,7 +17,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20",
+    "node": ">=22",
     "npm": ">=3.10.10"
   },
   "scripts": {

--- a/modules/sdk-coin-ada/package.json
+++ b/modules/sdk-coin-ada/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-algo/package.json
+++ b/modules/sdk-coin-algo/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-apechain/package.json
+++ b/modules/sdk-coin-apechain/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-apt/package.json
+++ b/modules/sdk-coin-apt/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-arbeth/package.json
+++ b/modules/sdk-coin-arbeth/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-asi/package.json
+++ b/modules/sdk-coin-asi/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-atom/package.json
+++ b/modules/sdk-coin-atom/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-avaxc/package.json
+++ b/modules/sdk-coin-avaxc/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-avaxp/package.json
+++ b/modules/sdk-coin-avaxp/package.json
@@ -26,7 +26,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "lint-staged": {
     "*.{js,ts}": [

--- a/modules/sdk-coin-baby/package.json
+++ b/modules/sdk-coin-baby/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-bch/package.json
+++ b/modules/sdk-coin-bch/package.json
@@ -32,7 +32,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-bcha/package.json
+++ b/modules/sdk-coin-bcha/package.json
@@ -32,7 +32,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-bera/package.json
+++ b/modules/sdk-coin-bera/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-bld/package.json
+++ b/modules/sdk-coin-bld/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-bsc/package.json
+++ b/modules/sdk-coin-bsc/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-bsv/package.json
+++ b/modules/sdk-coin-bsv/package.json
@@ -32,7 +32,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-btc/package.json
+++ b/modules/sdk-coin-btc/package.json
@@ -32,7 +32,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-btg/package.json
+++ b/modules/sdk-coin-btg/package.json
@@ -32,7 +32,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-canton/package.json
+++ b/modules/sdk-coin-canton/package.json
@@ -36,7 +36,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-celo/package.json
+++ b/modules/sdk-coin-celo/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-coredao/package.json
+++ b/modules/sdk-coin-coredao/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-coreum/package.json
+++ b/modules/sdk-coin-coreum/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-cosmos/package.json
+++ b/modules/sdk-coin-cosmos/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-cronos/package.json
+++ b/modules/sdk-coin-cronos/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-cspr/package.json
+++ b/modules/sdk-coin-cspr/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-dash/package.json
+++ b/modules/sdk-coin-dash/package.json
@@ -32,7 +32,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-doge/package.json
+++ b/modules/sdk-coin-doge/package.json
@@ -32,7 +32,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-dot/package.json
+++ b/modules/sdk-coin-dot/package.json
@@ -34,7 +34,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-eos/package.json
+++ b/modules/sdk-coin-eos/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-etc/package.json
+++ b/modules/sdk-coin-etc/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-eth/package.json
+++ b/modules/sdk-coin-eth/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-ethlike/package.json
+++ b/modules/sdk-coin-ethlike/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-ethw/package.json
+++ b/modules/sdk-coin-ethw/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-flr/package.json
+++ b/modules/sdk-coin-flr/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-flrp/package.json
+++ b/modules/sdk-coin-flrp/package.json
@@ -26,7 +26,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "lint-staged": {
     "*.{js,ts}": [

--- a/modules/sdk-coin-hash/package.json
+++ b/modules/sdk-coin-hash/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-hbar/package.json
+++ b/modules/sdk-coin-hbar/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-icp/package.json
+++ b/modules/sdk-coin-icp/package.json
@@ -19,7 +19,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-initia/package.json
+++ b/modules/sdk-coin-initia/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-injective/package.json
+++ b/modules/sdk-coin-injective/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-iota/package.json
+++ b/modules/sdk-coin-iota/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-irys/package.json
+++ b/modules/sdk-coin-irys/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-islm/package.json
+++ b/modules/sdk-coin-islm/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-kaspa/package.json
+++ b/modules/sdk-coin-kaspa/package.json
@@ -23,7 +23,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "lint-staged": {
     "*.{js,ts}": [

--- a/modules/sdk-coin-lnbtc/package.json
+++ b/modules/sdk-coin-lnbtc/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-ltc/package.json
+++ b/modules/sdk-coin-ltc/package.json
@@ -32,7 +32,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-mantra/package.json
+++ b/modules/sdk-coin-mantra/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-mon/package.json
+++ b/modules/sdk-coin-mon/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-near/package.json
+++ b/modules/sdk-coin-near/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-oas/package.json
+++ b/modules/sdk-coin-oas/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-opeth/package.json
+++ b/modules/sdk-coin-opeth/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-osmo/package.json
+++ b/modules/sdk-coin-osmo/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-pearl/package.json
+++ b/modules/sdk-coin-pearl/package.json
@@ -32,7 +32,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-polygon/package.json
+++ b/modules/sdk-coin-polygon/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-polyx/package.json
+++ b/modules/sdk-coin-polyx/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-rbtc/package.json
+++ b/modules/sdk-coin-rbtc/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-rune/package.json
+++ b/modules/sdk-coin-rune/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-sei/package.json
+++ b/modules/sdk-coin-sei/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-sgb/package.json
+++ b/modules/sdk-coin-sgb/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-sol/package.json
+++ b/modules/sdk-coin-sol/package.json
@@ -34,7 +34,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-soneium/package.json
+++ b/modules/sdk-coin-soneium/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-starknet/package.json
+++ b/modules/sdk-coin-starknet/package.json
@@ -19,7 +19,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-stt/package.json
+++ b/modules/sdk-coin-stt/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-stx/package.json
+++ b/modules/sdk-coin-stx/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-sui/package.json
+++ b/modules/sdk-coin-sui/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-tao/package.json
+++ b/modules/sdk-coin-tao/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-tempo/package.json
+++ b/modules/sdk-coin-tempo/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-tia/package.json
+++ b/modules/sdk-coin-tia/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-ton/package.json
+++ b/modules/sdk-coin-ton/package.json
@@ -34,7 +34,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-trx/package.json
+++ b/modules/sdk-coin-trx/package.json
@@ -21,7 +21,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-vet/package.json
+++ b/modules/sdk-coin-vet/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-wemix/package.json
+++ b/modules/sdk-coin-wemix/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-world/package.json
+++ b/modules/sdk-coin-world/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-xdc/package.json
+++ b/modules/sdk-coin-xdc/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-xlm/package.json
+++ b/modules/sdk-coin-xlm/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-xrp/package.json
+++ b/modules/sdk-coin-xrp/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-xtz/package.json
+++ b/modules/sdk-coin-xtz/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-zec/package.json
+++ b/modules/sdk-coin-zec/package.json
@@ -32,7 +32,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-zeta/package.json
+++ b/modules/sdk-coin-zeta/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-coin-zketh/package.json
+++ b/modules/sdk-coin-zketh/package.json
@@ -18,7 +18,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/sdk-rpc-wrapper/package.json
+++ b/modules/sdk-rpc-wrapper/package.json
@@ -23,7 +23,7 @@
   "author": "Bitgo DEFI Team <defi-team@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/secp256k1/package.json
+++ b/modules/secp256k1/package.json
@@ -4,7 +4,7 @@
   "description": "Low-level cryptographic methods used in BitGo packages for the secp256k1 curve",
   "main": "./dist/src/index.js",
   "engines": {
-    "node": ">=20",
+    "node": ">=22",
     "npm": ">=3.10.10"
   },
   "keywords": [

--- a/modules/utxo-descriptors/package.json
+++ b/modules/utxo-descriptors/package.json
@@ -37,7 +37,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/modules/utxo-lib/package.json
+++ b/modules/utxo-lib/package.json
@@ -4,7 +4,7 @@
   "description": "Client-side Bitcoin JavaScript library",
   "main": "./dist/src/index.js",
   "engines": {
-    "node": ">=20",
+    "node": ">=22",
     "npm": ">=3.10.10"
   },
   "keywords": [

--- a/modules/utxo-staking/package.json
+++ b/modules/utxo-staking/package.json
@@ -37,7 +37,7 @@
   "author": "BitGo SDK Team <sdkteam@bitgo.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Node 20 reached end-of-life on 2026-04-30. Bumps `engines.node` lower bound from `>=20` to `>=22` across all 93 modules that declare it.
- Drops `20.x` from the CI `unit-test` matrix and bumps the two hardcoded `node-version: 20` setup steps to `22`.
- Updates the README's Node version support policy section to match.

## Test plan
- [x] Verified all modified `package.json` files remain valid JSON
- [x] Confirmed no remaining `node-version: 20` / `20.x` references in `.github/workflows/*.yml`
- [ ] CI passes on this PR (matrix now `[22.x, 24.x]`)

Ticket: WCN-2442