### PR TITLE
WCN-2441: Run CI against Node Current, Active LTS, and Maintenance LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: [changes]
     if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.source == 'true')
+    permissions:
+      contents: read
+      pull-requests: write
 
     strategy:
       fail-fast: false
       matrix:
         node-version: [22.x, 24.x]
+        experimental: [false]
+        include:
+          # Node's Current release line — not yet an LTS. Failures here are
+          # surfaced via PR comment but do not block merge (see all-checks).
+          - node-version: 26.x
+            experimental: true
 
     steps:
       - uses: socketdev/action@937f824ec476dfd164d4a4d9995751427b0be143 # v1.3.0
@@ -112,9 +121,65 @@ jobs:
         run: yarn run postinstall
 
       - name: Unit Test
+        id: unit-test
+        continue-on-error: ${{ matrix.experimental }}
         run: yarn run unit-test-changed
         env:
           BITGOJS_TEST_PASSWORD: ${{ secrets.BITGOJS_TEST_PASSWORD }}
+
+      - name: Comment on Node Current failure
+        if: matrix.experimental && steps.unit-test.outcome == 'failure' && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- node-current-ci-failure -->';
+            const body = `${marker}\n⚠️ Unit tests are failing on Node ${{ matrix.node-version }} (Current release line, non-blocking). ` +
+              `This is not an LTS version yet, so it does not block merge, but it signals an incompatibility to fix before Node ${{ matrix.node-version }} becomes LTS.\n\n` +
+              `[View run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+            const existing = comments.find((c) => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body,
+              });
+            }
+
+      - name: Resolve Node Current failure comment
+        if: matrix.experimental && steps.unit-test.outcome == 'success' && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- node-current-ci-failure -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+            const existing = comments.find((c) => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: `${marker}\n✅ Unit tests now pass on Node ${{ matrix.node-version }} (Current release line).`,
+              });
+            }
 
       # - name: Upload Code Coverage
       #   run: |

--- a/README.md
+++ b/README.md
@@ -60,8 +60,11 @@ We specifically limit our support to these versions of Node, not because this pa
 
 As each Node LTS version reaches its end-of-life we will exclude that version from the node engines property of our package's package.json file. Removing a Node version is considered a breaking change and will entail the publishing of a new major version of this package. We will not accept any requests to support an end-of-life version of Node, and any pull requests or issues regarding support for an end-of-life version of Node will be closed. We will accept code that allows this package to run on newer, non-LTS, versions of Node. Furthermore, we will attempt to ensure our own changes work on the latest version of Node. To help in that commitment, our continuous integration setup runs the full test suite on the latest release of the following versions of node:
 
-- `22`
-- `24`
+- `22` (Maintenance LTS) — required to pass
+- `24` (Active LTS) — required to pass
+- `26` (Current) — run non-blocking; a failure posts a warning comment on the PR instead of blocking merge
+
+When a new Node major becomes Active LTS, update the `node-version` matrix in `.github/workflows/ci.yml` (moving the outgoing Current version into the required set and adding the new Current release), and bump the `engines.node` range across all `modules/*/package.json` files accordingly.
 
 JavaScript package managers should allow you to install this package with any version of Node, with, at most, a warning if your version of Node does not fall within the range specified by our node engines property. If you encounter issues installing this package on a supported version of Node, please report the issue to us.
 


### PR DESCRIPTION
## Summary
- Adds Node's Current release line (`26.x`) to the `unit-test` CI matrix alongside the required Active LTS (`24.x`) and Maintenance LTS (`22.x`) versions.
- The `26.x` leg runs with `continue-on-error` so failures don't block merge — it's not an LTS version yet.
- A failure on the Current leg posts (or updates) a PR comment so it isn't silently missed; the comment is cleared once it passes again.
- Documents the bump process in README.md: when a Node major is promoted to Active LTS, move it into the required matrix set, add the new Current release, and bump `engines.node` across modules.

Stacked on #9614 (WCN-2442, drops EOL Node 20) — this PR only adds the Current leg + comment automation on top.

Follow-up ticket for automating the Current/Active/Maintenance detection itself (rather than hardcoding version numbers): [WAL-2001](https://linear.app/bitgo/issue/WAL-2001/automate-detection-of-nodejs-currentactive-ltsmaintenance-lts-versions) (`good-for-intern`).

## Test plan
- [x] Validated `ci.yml` YAML syntax
- [ ] CI passes: `22.x`/`24.x` required, `26.x` non-blocking
- [ ] Manually verify PR comment posts on a forced 26.x failure, then clears on a following green run

Ticket: WCN-2441