### PR TITLE
feat(statics): enable STAKING on ada:usdr and tada:usdr (SI-1464)

### DIFF
--- a/modules/statics/src/coins/adaTokens.ts
+++ b/modules/statics/src/coins/adaTokens.ts
@@ -35,7 +35,7 @@ export const adaTokens = [
     'USDr',
     'asset1phc5mnwh5p5tsqqxuf2mtvcvpsm6f6vjf8ue08',
     UnderlyingAsset['tada:usdr'],
-    [...ADA_TOKEN_FEATURES, CoinFeature.STABLECOIN]
+    [...ADA_TOKEN_FEATURES, CoinFeature.STABLECOIN, CoinFeature.STAKING]
   ),
   tadaToken(
     'a84eff6c-4f7e-48b1-a92f-f535dcccc28c',
@@ -178,7 +178,7 @@ export const adaTokens = [
     'USDr',
     'asset19k6sv4ry9cu7pd25lry27k0crt3x3hyc5zgv3g',
     UnderlyingAsset['ada:usdr'],
-    [...ADA_TOKEN_FEATURES, CoinFeature.STABLECOIN]
+    [...ADA_TOKEN_FEATURES, CoinFeature.STABLECOIN, CoinFeature.STAKING]
   ),
   adaToken(
     'e9d2b3bb-a668-404d-a6bf-bf2dfefed4d2',

--- a/modules/statics/test/unit/coins.ts
+++ b/modules/statics/test/unit/coins.ts
@@ -1413,6 +1413,23 @@ describe('Liquid Staking Features', () => {
   });
 });
 
+describe('ADA RealFi USDr staking', () => {
+  it('should have STAKING feature for stakeable USDr tokens', () => {
+    ['ada:usdr', 'tada:usdr'].forEach((coinName) => {
+      const coin = coins.get(coinName);
+      coin.features.includes(CoinFeature.STAKING).should.eql(true);
+      coin.features.includes(CoinFeature.STABLECOIN).should.eql(true);
+    });
+  });
+
+  it('should not mark sUSDr as stakeable', () => {
+    ['ada:susdr', 'tada:susdr'].forEach((coinName) => {
+      const coin = coins.get(coinName);
+      coin.features.includes(CoinFeature.STAKING).should.eql(false);
+    });
+  });
+});
+
 describe('create token map using config details', () => {
   it('should create a valid token map from AmsTokenConfig', () => {
     const tokenMap = createTokenMapUsingConfigDetails(amsTokenConfig);


### PR DESCRIPTION
## Summary
- Add `CoinFeature.STAKING` to `ada:usdr` / `tada:usdr` so the BitGo UI Asset dropdown can list RealFi USDr alongside native ADA (ETH token pattern).
- Leave `ada:susdr` / `tada:susdr` without `STAKING` (receipt token, not the stake asset).
- Add unit coverage for the stakeable vs non-stakeable feature split.

Pairs with staking-service [PR #8154](https://github.com/BitGo/staking-service/pull/8154) (SI-1464). UI needs this statics flag + SS deployed for the dropdown and stake path to work end-to-end.

## Test plan
- [ ] `yarn workspace @bitgo/statics unit-test` — ADA RealFi USDr cases pass
- [ ] Confirm `coins.get('tada:usdr').features` includes `staking`
- [ ] Confirm `coins.get('tada:susdr').features` does **not** include `staking`
- [ ] On a TADA wallet with `tada:usdr` enabled, Staking Asset dropdown shows ADA + USDr once SS is on test

Ticket: SI-1464


Made with [Cursor](https://cursor.com)