### PR TITLE
Solana CT: SDK Phase 1a — confidential transfer instruction builders

### DIFF
--- a/modules/sdk-coin-sol/package.json
+++ b/modules/sdk-coin-sol/package.json
@@ -62,6 +62,7 @@
     "@bitgo/sdk-lib-mpc": "^10.18.0",
     "@bitgo/statics": "^59.12.0",
     "@bitgo/wasm-solana": "^2.6.0",
+    "@solana/buffer-layout": "^4.0.1",
     "@solana/spl-stake-pool": "1.1.8",
     "@solana/spl-token": "0.4.9",
     "@solana/web3.js": "1.92.1",

--- a/modules/sdk-coin-sol/src/lib/confidentialTransferBuilder.ts
+++ b/modules/sdk-coin-sol/src/lib/confidentialTransferBuilder.ts
@@ -1,0 +1,239 @@
+import { BaseCoin as CoinConfig } from '@bitgo/statics';
+import { TransactionType } from '@bitgo/sdk-core';
+import { Transaction } from './transaction';
+import { TransactionBuilder } from './transactionBuilder';
+import { InstructionBuilderTypes } from './constants';
+import {
+  ApplyPendingBalance,
+  ConfidentialDeposit,
+  ConfidentialTransfer,
+  ConfidentialWithdraw,
+  ConfigureConfidentialTransferAccount,
+  InstructionParams,
+  VerifyEqualityProof,
+  VerifyPubkeyValidity,
+  VerifyRangeProof,
+  VerifyValidityProof,
+} from './iface';
+import assert from 'assert';
+
+/**
+ * Builder for Token-2022 confidential transfer transactions.
+ *
+ * Provides type-safe fluent setters for the following CT instructions:
+ * - ConfigureAccount (standalone, with VerifyPubkeyValidity proof)
+ * - ApplyPendingBalance (always instruction #1 in v1 spend txs, idempotent)
+ * - Deposit (public → confidential conversion)
+ * - Withdraw (confidential → public conversion, with equality + range proofs)
+ * - Transfer (confidential → confidential, with equality + validity + range proofs)
+ * - VerifyPubkeyValidity / VerifyEquality / VerifyValidity / VerifyRange proof instructions
+ *
+ * Instruction builders are v0/v1-agnostic: they produce instruction data and
+ * account metas only. The caller (Wallet Platform) assembles them into v1
+ * transactions in the correct order.
+ *
+ * @example
+ * ```ts
+ * const builder = factory.getConfidentialTransferBuilder();
+ * builder.nonce(recentBlockhash).sender(payer);
+ * builder.configureAccount({ tokenAddress, mintAddress, authorityAddress, ... });
+ * builder.verifyPubkeyValidity({ proofData });
+ * const tx = await builder.build();
+ * ```
+ */
+export class ConfidentialTransferBuilder extends TransactionBuilder {
+  private _ctInstructions: InstructionParams[] = [];
+
+  constructor(_coinConfig: Readonly<CoinConfig>) {
+    super(_coinConfig);
+    this._transaction = new Transaction(_coinConfig);
+  }
+
+  protected get transactionType(): TransactionType {
+    return TransactionType.ConfidentialTransfer;
+  }
+
+  /**
+   * Override the zk-elgamal-proof program id.
+   *
+   * Defaults to the canonical on-chain program id (`ZkE1Gama1Proof111...`)
+   * which is the same across mainnet, devnet, and testnet. Override only
+   * when targeting a custom deployment.
+   *
+   * @param programId - base58 encoded program id
+   */
+  zkProofProgramId(programId: string): this {
+    assert(programId, 'Missing programId param');
+    this._zkProofProgramId = programId;
+    return this;
+  }
+
+  /** @inheritDoc */
+  initBuilder(tx: Transaction): void {
+    super.initBuilder(tx);
+    this._ctInstructions = [];
+    for (const instruction of this._instructionsData) {
+      switch (instruction.type) {
+        case InstructionBuilderTypes.ConfigureConfidentialTransferAccount:
+        case InstructionBuilderTypes.ApplyPendingBalance:
+        case InstructionBuilderTypes.ConfidentialDeposit:
+        case InstructionBuilderTypes.ConfidentialWithdraw:
+        case InstructionBuilderTypes.ConfidentialTransfer:
+        case InstructionBuilderTypes.VerifyPubkeyValidity:
+        case InstructionBuilderTypes.VerifyEqualityProof:
+        case InstructionBuilderTypes.VerifyValidityProof:
+        case InstructionBuilderTypes.VerifyRangeProof:
+          this._ctInstructions.push(instruction);
+          break;
+        default:
+          break;
+      }
+    }
+  }
+
+  /**
+   * Add a ConfigureAccount instruction to the transaction.
+   * One-time ATA setup — registers ElGamal pubkey + AES zero ciphertext.
+   * Must be accompanied by a VerifyPubkeyValidity proof instruction.
+   */
+  configureAccount(params: ConfigureConfidentialTransferAccount['params']): this {
+    assert(params.tokenAddress, 'Missing tokenAddress param');
+    assert(params.mintAddress, 'Missing mintAddress param');
+    assert(params.authorityAddress, 'Missing authorityAddress param');
+    assert(params.decryptableZeroBalance, 'Missing decryptableZeroBalance param');
+    assert(params.maximumPendingBalanceCreditCounter, 'Missing maximumPendingBalanceCreditCounter param');
+
+    this._ctInstructions.push({
+      type: InstructionBuilderTypes.ConfigureConfidentialTransferAccount,
+      params,
+    });
+    return this;
+  }
+
+  /**
+   * Add an ApplyPendingBalance instruction to the transaction.
+   * Credits pending balance into available balance. Idempotent (no-op if 0 pending).
+   * In v1 transactions, this should always be instruction #1.
+   */
+  applyPendingBalance(params: ApplyPendingBalance['params']): this {
+    assert(params.tokenAddress, 'Missing tokenAddress param');
+    assert(params.authorityAddress, 'Missing authorityAddress param');
+    assert(params.expectedPendingBalanceCreditCounter, 'Missing expectedPendingBalanceCreditCounter param');
+    assert(params.newDecryptableAvailableBalance, 'Missing newDecryptableAvailableBalance param');
+
+    this._ctInstructions.push({
+      type: InstructionBuilderTypes.ApplyPendingBalance,
+      params,
+    });
+    return this;
+  }
+
+  /**
+   * Add a Deposit instruction to the transaction.
+   * Moves public SPL tokens into confidential pending balance. No proof required.
+   */
+  confidentialDeposit(params: ConfidentialDeposit['params']): this {
+    assert(params.tokenAddress, 'Missing tokenAddress param');
+    assert(params.mintAddress, 'Missing mintAddress param');
+    assert(params.authorityAddress, 'Missing authorityAddress param');
+    assert(params.amount, 'Missing amount param');
+
+    this._ctInstructions.push({
+      type: InstructionBuilderTypes.ConfidentialDeposit,
+      params,
+    });
+    return this;
+  }
+
+  /**
+   * Add a Withdraw instruction to the transaction.
+   * Moves confidential available balance to public balance.
+   * Requires equality + range proof verification instructions.
+   */
+  confidentialWithdraw(params: ConfidentialWithdraw['params']): this {
+    assert(params.tokenAddress, 'Missing tokenAddress param');
+    assert(params.mintAddress, 'Missing mintAddress param');
+    assert(params.authorityAddress, 'Missing authorityAddress param');
+    assert(params.amount, 'Missing amount param');
+    assert(params.newDecryptableAvailableBalance, 'Missing newDecryptableAvailableBalance param');
+
+    this._ctInstructions.push({
+      type: InstructionBuilderTypes.ConfidentialWithdraw,
+      params,
+    });
+    return this;
+  }
+
+  /**
+   * Add a confidential Transfer instruction to the transaction.
+   * Requires equality + ciphertext validity + range proof verification instructions.
+   */
+  confidentialTransfer(params: ConfidentialTransfer['params']): this {
+    assert(params.sourceTokenAddress, 'Missing sourceTokenAddress param');
+    assert(params.mintAddress, 'Missing mintAddress param');
+    assert(params.destinationTokenAddress, 'Missing destinationTokenAddress param');
+    assert(params.authorityAddress, 'Missing authorityAddress param');
+    assert(params.newSourceDecryptableAvailableBalance, 'Missing newSourceDecryptableAvailableBalance param');
+    assert(params.transferAmountAuditorCiphertextLo, 'Missing transferAmountAuditorCiphertextLo param');
+    assert(params.transferAmountAuditorCiphertextHi, 'Missing transferAmountAuditorCiphertextHi param');
+
+    this._ctInstructions.push({
+      type: InstructionBuilderTypes.ConfidentialTransfer,
+      params,
+    });
+    return this;
+  }
+
+  /**
+   * Add a VerifyPubkeyValidity proof instruction (used with ConfigureAccount).
+   */
+  verifyPubkeyValidity(params: VerifyPubkeyValidity['params']): this {
+    this._ctInstructions.push({
+      type: InstructionBuilderTypes.VerifyPubkeyValidity,
+      params,
+    });
+    return this;
+  }
+
+  /**
+   * Add a VerifyCiphertextCommitmentEquality proof instruction (used with Transfer and Withdraw).
+   */
+  verifyEqualityProof(params: VerifyEqualityProof['params']): this {
+    this._ctInstructions.push({
+      type: InstructionBuilderTypes.VerifyEqualityProof,
+      params,
+    });
+    return this;
+  }
+
+  /**
+   * Add a VerifyBatchedGroupedCiphertext3HandlesValidity proof instruction (used with Transfer).
+   */
+  verifyValidityProof(params: VerifyValidityProof['params']): this {
+    this._ctInstructions.push({
+      type: InstructionBuilderTypes.VerifyValidityProof,
+      params,
+    });
+    return this;
+  }
+
+  /**
+   * Add a VerifyBatchedRangeProofU128 proof instruction (used with Transfer).
+   */
+  verifyRangeProof(params: VerifyRangeProof['params']): this {
+    this._ctInstructions.push({
+      type: InstructionBuilderTypes.VerifyRangeProof,
+      params,
+    });
+    return this;
+  }
+
+  /** @inheritdoc */
+  protected async buildImplementation(): Promise<Transaction> {
+    assert(this._ctInstructions.length > 0, 'At least one confidential transfer instruction must be specified');
+
+    this._instructionsData = [...this._ctInstructions];
+
+    return await super.buildImplementation();
+  }
+}

--- a/modules/sdk-coin-sol/src/lib/constants.ts
+++ b/modules/sdk-coin-sol/src/lib/constants.ts
@@ -10,6 +10,41 @@ export const STAKE_ACCOUNT_RENT_EXEMPT_AMOUNT = 2282880;
 export const UNAVAILABLE_TEXT = 'UNAVAILABLE';
 
 /**
+ * Sysvar instructions account address — used by Token-2022 confidential transfer
+ * instructions to locate inline proof verification instructions in the same transaction.
+ */
+export const INSTRUCTIONS_SYSVAR_ADDRESS = 'Sysvar1nstructions1111111111111111111111111';
+
+/**
+ * Canonical on-chain program id of the zk-elgamal-proof program.
+ *
+ * This is the same across mainnet, devnet, and testnet — it is a native
+ * built-in program. Callers can override via ConfidentialTransferBuilder
+ * .zkProofProgramId() if targeting a custom deployment.
+ *
+ * Note: The deprecated zk-token-proof program id is
+ * `ZkTokenProof1111111111111111111111111111111`.
+ */
+export const ZK_ELGAMAL_PROOF_PROGRAM_ID = 'ZkE1Gama1Proof11111111111111111111111111111';
+
+/**
+ * Token-2022 confidential transfer extension discriminator (byte 0 of instruction data).
+ */
+export const CT_EXT_DISCRIMINATOR = 27;
+
+/**
+ * Valid CT sub-instruction discriminators (byte 1 after CT_EXT_DISCRIMINATOR).
+ * Used for transaction type detection (getTransactionType / deriveTransactionType).
+ */
+export const CT_SUB_DISCRIMINATORS = new Set<number>([
+  2, // ConfigureAccount
+  5, // Deposit
+  6, // Withdraw
+  7, // Transfer
+  8, // ApplyPendingBalance
+]);
+
+/**
  * Maximum over-the-wire size of a Solana transaction (in bytes)
  *
  * Source: https://github.com/anza-xyz/agave/blob/v2.1.13/sdk/packet/src/lib.rs#L27-L29
@@ -83,6 +118,16 @@ export enum ValidInstructionTypesEnum {
   Approve = 'Approve',
   CustomInstruction = 'CustomInstruction',
   PermissionlessThawIdempotent = 'PermissionlessThawIdempotent',
+  // Confidential Transfer instruction types (Token-2022 CT extension + zk-elgamal-proof)
+  ConfigureConfidentialTransferAccount = 'ConfigureConfidentialTransferAccount',
+  ApplyPendingBalance = 'ApplyPendingBalance',
+  ConfidentialDeposit = 'ConfidentialDeposit',
+  ConfidentialWithdraw = 'ConfidentialWithdraw',
+  ConfidentialTransfer = 'ConfidentialTransfer',
+  VerifyPubkeyValidity = 'VerifyPubkeyValidity',
+  VerifyEqualityProof = 'VerifyEqualityProof',
+  VerifyValidityProof = 'VerifyValidityProof',
+  VerifyRangeProof = 'VerifyRangeProof',
 }
 
 // Internal instructions types
@@ -109,6 +154,16 @@ export enum InstructionBuilderTypes {
   Approve = 'Approve',
   WithdrawStake = 'WithdrawStake',
   PermissionlessThawIdempotent = 'PermissionlessThawIdempotent',
+  // Confidential Transfer instruction types (Token-2022 CT extension + zk-elgamal-proof)
+  ConfigureConfidentialTransferAccount = 'ConfigureConfidentialTransferAccount',
+  ApplyPendingBalance = 'ApplyPendingBalance',
+  ConfidentialDeposit = 'ConfidentialDeposit',
+  ConfidentialWithdraw = 'ConfidentialWithdraw',
+  ConfidentialTransfer = 'ConfidentialTransfer',
+  VerifyPubkeyValidity = 'VerifyPubkeyValidity',
+  VerifyEqualityProof = 'VerifyEqualityProof',
+  VerifyValidityProof = 'VerifyValidityProof',
+  VerifyRangeProof = 'VerifyRangeProof',
 }
 
 export const VALID_SYSTEM_INSTRUCTION_TYPES: ValidInstructionTypes[] = [

--- a/modules/sdk-coin-sol/src/lib/explainTransactionWasm.ts
+++ b/modules/sdk-coin-sol/src/lib/explainTransactionWasm.ts
@@ -1,8 +1,14 @@
 import { ITokenEnablement } from '@bitgo/sdk-core';
 import { Transaction, parseTransaction, type ParsedTransaction, type InstructionParams } from '@bitgo/wasm-solana';
-import { UNAVAILABLE_TEXT } from './constants';
+import {
+  UNAVAILABLE_TEXT,
+  ZK_ELGAMAL_PROOF_PROGRAM_ID,
+  CT_EXT_DISCRIMINATOR,
+  CT_SUB_DISCRIMINATORS,
+} from './constants';
 import { StakingAuthorizeParams, TransactionExplanation as SolLibTransactionExplanation } from './iface';
 import { findTokenName } from './instructionParamsFactory';
+import bs58 from 'bs58';
 
 export interface ExplainTransactionWasmOptions {
   txBase64: string;
@@ -25,6 +31,7 @@ enum TransactionType {
   WalletInitialization = 'WalletInitialization',
   AssociatedTokenAccountInitialization = 'AssociatedTokenAccountInitialization',
   CustomTx = 'CustomTx',
+  ConfidentialTransfer = 'ConfidentialTransfer',
 }
 
 // =============================================================================
@@ -85,6 +92,31 @@ function detectCombinedPattern(instructions: InstructionParams[]): CombinedPatte
 
 const BOILERPLATE_TYPES = new Set(['NonceAdvance', 'Memo', 'SetComputeUnitLimit', 'SetPriorityFee']);
 
+/**
+ * Returns true if a WASM-parsed Unknown instruction is a confidential transfer instruction
+ * (Token-2022 CT extension or zk-elgamal-proof program).
+ *
+ * CT extension: byte 0 = CT_EXT_DISCRIMINATOR, byte 1 ∈ CT_SUB_DISCRIMINATORS
+ * zk-elgamal-proof: any instruction from the zk-elgamal-proof program
+ */
+function isWasmConfidentialTransferInstruction(instr: InstructionParams): boolean {
+  if (instr.type !== 'Unknown') return false;
+  const programId = instr.programId;
+  // zk-elgamal-proof program instructions are always CT proof verifications
+  if (programId === ZK_ELGAMAL_PROOF_PROGRAM_ID) {
+    return true;
+  }
+  // Token-2022 CT extension: byte 0 = CT_EXT_DISCRIMINATOR, byte 1 ∈ CT_SUB_DISCRIMINATORS
+  const TOKEN_2022_PROGRAM_ID = 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb';
+  if (programId === TOKEN_2022_PROGRAM_ID) {
+    const dataBytes = bs58.decode(instr.data);
+    if (dataBytes.length >= 2) {
+      return dataBytes[0] === CT_EXT_DISCRIMINATOR && CT_SUB_DISCRIMINATORS.has(dataBytes[1]);
+    }
+  }
+  return false;
+}
+
 function deriveTransactionType(
   instructions: InstructionParams[],
   combined: CombinedPattern | null,
@@ -110,6 +142,9 @@ function deriveTransactionType(
   if (staking) return TransactionType[staking.type as keyof typeof TransactionType];
 
   // Unknown instructions indicate a custom/unrecognized transaction
+  if (instructions.some((i) => i.type === 'Unknown' && isWasmConfidentialTransferInstruction(i))) {
+    return TransactionType.ConfidentialTransfer;
+  }
   if (instructions.some((i) => i.type === 'Unknown')) return TransactionType.CustomTx;
 
   // Send requires an explicit Transfer or TokenTransfer instruction.

--- a/modules/sdk-coin-sol/src/lib/iface.ts
+++ b/modules/sdk-coin-sol/src/lib/iface.ts
@@ -53,7 +53,16 @@ export type InstructionParams =
   | Approve
   | CustomInstruction
   | VersionedCustomInstruction
-  | PermissionlessThawIdempotent;
+  | PermissionlessThawIdempotent
+  | ConfigureConfidentialTransferAccount
+  | ApplyPendingBalance
+  | ConfidentialDeposit
+  | ConfidentialWithdraw
+  | ConfidentialTransfer
+  | VerifyPubkeyValidity
+  | VerifyEqualityProof
+  | VerifyValidityProof
+  | VerifyRangeProof;
 
 export interface Memo {
   type: InstructionBuilderTypes.Memo;
@@ -311,7 +320,16 @@ export type ValidInstructionTypes =
   | 'Burn'
   | 'Approve'
   | 'CustomInstruction'
-  | 'PermissionlessThawIdempotent';
+  | 'PermissionlessThawIdempotent'
+  | 'ConfigureConfidentialTransferAccount'
+  | 'ApplyPendingBalance'
+  | 'ConfidentialDeposit'
+  | 'ConfidentialWithdraw'
+  | 'ConfidentialTransfer'
+  | 'VerifyPubkeyValidity'
+  | 'VerifyEqualityProof'
+  | 'VerifyValidityProof'
+  | 'VerifyRangeProof';
 
 export type StakingAuthorizeParams = {
   stakingAddress: string;
@@ -367,6 +385,222 @@ export interface TransactionExplanation extends BaseTransactionExplanation {
   inputs?: { address: string; value: string; coin?: string }[];
   feePayer?: string;
   ataOwnerMap?: Record<string, string>;
+}
+
+// ─── Confidential Transfer interfaces (Token-2022 CT extension) ────────────
+
+/**
+ * Configures a token account for confidential transfers.
+ *
+ * Layout: [27][2] + decryptable_zero_balance(36) + maximum_pending_balance_credit_counter(u64) + proof_instruction_offset(i8) = 47 bytes
+ *
+ * Accounts: [token(writable), mint, instructionsSysvar|contextState, authority(signer)]
+ */
+export interface ConfigureConfidentialTransferAccount {
+  type: InstructionBuilderTypes.ConfigureConfidentialTransferAccount;
+  params: {
+    tokenAddress: string;
+    mintAddress: string;
+    authorityAddress: string;
+    /** Instructions sysvar (inline proof) or context state account (pre-verified proof). Defaults to instructions sysvar. */
+    instructionsSysvarOrContextStateAddress?: string;
+    /** AES-encrypted zero balance (36 bytes hex). */
+    decryptableZeroBalance: string;
+    /** Maximum deposits + transfers before ApplyPendingBalance is required. */
+    maximumPendingBalanceCreditCounter: string;
+    /** Relative offset to the VerifyPubkeyValidity proof instruction (i8, signed). 0 = use context state account. */
+    proofInstructionOffset: number;
+  };
+}
+
+/**
+ * Applies pending balance to available balance.
+ *
+ * Layout: [27][8] + expected_pending_balance_credit_counter(u64) + new_decryptable_available_balance(36) = 46 bytes
+ *
+ * Accounts: [token(writable), authority(signer)]
+ */
+export interface ApplyPendingBalance {
+  type: InstructionBuilderTypes.ApplyPendingBalance;
+  params: {
+    tokenAddress: string;
+    authorityAddress: string;
+    /** Expected number of pending balance credits since last ApplyPendingBalance. */
+    expectedPendingBalanceCreditCounter: string;
+    /** AES-encrypted new available balance (36 bytes hex). */
+    newDecryptableAvailableBalance: string;
+  };
+}
+
+/**
+ * Deposits public SPL tokens into confidential pending balance.
+ *
+ * Layout: [27][5] + amount(u64) + decimals(u8) = 11 bytes
+ *
+ * Accounts: [token(writable), mint, authority(signer)]
+ */
+export interface ConfidentialDeposit {
+  type: InstructionBuilderTypes.ConfidentialDeposit;
+  params: {
+    tokenAddress: string;
+    mintAddress: string;
+    authorityAddress: string;
+    /** Amount to deposit in base units. */
+    amount: string;
+    /** Number of decimals for the token. */
+    decimals: number;
+  };
+}
+
+/**
+ * Withdraws tokens from confidential available balance to public balance.
+ *
+ * Layout: [27][6] + amount(u64) + decimals(u8) + new_decryptable_available_balance(36) + equality_proof_offset(i8) + range_proof_offset(i8) = 49 bytes
+ *
+ * Accounts: [token(writable), mint, instructionsSysvar?, equalityContextState?, rangeContextState?, authority(signer)]
+ */
+export interface ConfidentialWithdraw {
+  type: InstructionBuilderTypes.ConfidentialWithdraw;
+  params: {
+    tokenAddress: string;
+    mintAddress: string;
+    authorityAddress: string;
+    /** Instructions sysvar address (if proofs are inline). Omit if using context state accounts. */
+    instructionsSysvarAddress?: string;
+    /** Equality proof context state account (if pre-verified). Omit if using inline proof. */
+    equalityProofContextStateAddress?: string;
+    /** Range proof context state account (if pre-verified). Omit if using inline proof. */
+    rangeProofContextStateAddress?: string;
+    /** Amount to withdraw in base units. */
+    amount: string;
+    /** Number of decimals for the token. */
+    decimals: number;
+    /** AES-encrypted new available balance after withdrawal (36 bytes hex). */
+    newDecryptableAvailableBalance: string;
+    /** Relative offset to VerifyCiphertextCommitmentEquality proof (i8). 0 = use context state. */
+    equalityProofInstructionOffset: number;
+    /** Relative offset to VerifyBatchedRangeProofU64 proof (i8). 0 = use context state. */
+    rangeProofInstructionOffset: number;
+  };
+}
+
+/**
+ * Transfers tokens confidentially between two accounts.
+ *
+ * Layout: [27][7] + new_source_decryptable(36) + auditor_ct_lo(64) + auditor_ct_hi(64) + eq_offset(i8) + validity_offset(i8) + range_offset(i8) = 169 bytes
+ *
+ * Accounts: [source(writable), mint, dest(writable), instructionsSysvar?, eqCtx?, validityCtx?, rangeCtx?, authority(signer)]
+ */
+export interface ConfidentialTransfer {
+  type: InstructionBuilderTypes.ConfidentialTransfer;
+  params: {
+    sourceTokenAddress: string;
+    mintAddress: string;
+    destinationTokenAddress: string;
+    authorityAddress: string;
+    /** Instructions sysvar address (if proofs are inline). Omit if using context state accounts. */
+    instructionsSysvarAddress?: string;
+    /** Equality proof context state account (if pre-verified). Omit if using inline proof. */
+    equalityProofContextStateAddress?: string;
+    /** Ciphertext validity proof context state account (if pre-verified). Omit if using inline proof. */
+    ciphertextValidityProofContextStateAddress?: string;
+    /** Range proof context state account (if pre-verified). Omit if using inline proof. */
+    rangeProofContextStateAddress?: string;
+    /** AES-encrypted new source decryptable balance (36 bytes hex). */
+    newSourceDecryptableAvailableBalance: string;
+    /** Auditor ElGamal ciphertext for transfer amount low 16 bits (64 bytes hex). */
+    transferAmountAuditorCiphertextLo: string;
+    /** Auditor ElGamal ciphertext for transfer amount high bits (64 bytes hex). */
+    transferAmountAuditorCiphertextHi: string;
+    /** Relative offset to VerifyCiphertextCommitmentEquality proof (i8). 0 = use context state. */
+    equalityProofInstructionOffset: number;
+    /** Relative offset to VerifyBatchedGroupedCiphertext3HandlesValidity proof (i8). 0 = use context state. */
+    ciphertextValidityProofInstructionOffset: number;
+    /** Relative offset to VerifyBatchedRangeProofU128 proof (i8). 0 = use context state. */
+    rangeProofInstructionOffset: number;
+  };
+}
+
+// ─── zk-elgamal-proof verification interfaces ──────────────────────────────
+
+/**
+ * Verifies the validity of an ElGamal pubkey (used with ConfigureAccount).
+ *
+ * Discriminator: [4] + proof_data
+ * Program: zk-elgamal-proof
+ * Accounts: [] (inline proof) or [contextState(writable), authority] (context state)
+ */
+export interface VerifyPubkeyValidity {
+  type: InstructionBuilderTypes.VerifyPubkeyValidity;
+  params: {
+    /** Proof data as hex string (inline proof). If omitted, uses context state account + offset. */
+    proofData?: string;
+    /** Context state account address (if pre-verified proof). */
+    contextStateAccountAddress?: string;
+    /** Context state authority address (if pre-verified proof). */
+    contextStateAuthorityAddress?: string;
+  };
+}
+
+/**
+ * Verifies ciphertext-commitment equality proof (used with Transfer and Withdraw).
+ *
+ * Discriminator: [3] + proof_data or [3] + offset(u32)
+ * Program: zk-elgamal-proof
+ */
+export interface VerifyEqualityProof {
+  type: InstructionBuilderTypes.VerifyEqualityProof;
+  params: {
+    /** Proof data as hex string (inline proof). If omitted, uses context state account + offset. */
+    proofData?: string;
+    /** Context state account address (if pre-verified proof). */
+    contextStateAccountAddress?: string;
+    /** Context state authority address (if pre-verified proof). */
+    contextStateAuthorityAddress?: string;
+    /** Offset into context state account (if using context state). */
+    offset?: number;
+  };
+}
+
+/**
+ * Verifies batched grouped ciphertext 3-handles validity proof (used with Transfer).
+ *
+ * Discriminator: [12] + proof_data or [12] + offset(u32)
+ * Program: zk-elgamal-proof
+ */
+export interface VerifyValidityProof {
+  type: InstructionBuilderTypes.VerifyValidityProof;
+  params: {
+    /** Proof data as hex string (inline proof). If omitted, uses context state account + offset. */
+    proofData?: string;
+    /** Context state account address (if pre-verified proof). */
+    contextStateAccountAddress?: string;
+    /** Context state authority address (if pre-verified proof). */
+    contextStateAuthorityAddress?: string;
+    /** Offset into context state account (if using context state). */
+    offset?: number;
+  };
+}
+
+/**
+ * Verifies batched range proof U128 (used with Transfer).
+ *
+ * Discriminator: [7] + proof_data or [7] + offset(i32)
+ * Program: zk-elgamal-proof
+ * Accounts: [] (inline proof) or [contextState(writable), authority] (context state)
+ */
+export interface VerifyRangeProof {
+  type: InstructionBuilderTypes.VerifyRangeProof;
+  params: {
+    /** Proof data as hex string (inline proof). If omitted, uses context state account + offset. */
+    proofData?: string;
+    /** Context state account address (if pre-verified proof). */
+    contextStateAccountAddress?: string;
+    /** Context state authority address (if pre-verified proof). */
+    contextStateAuthorityAddress?: string;
+    /** Offset into context state account (if using context state). */
+    offset?: number;
+  };
 }
 
 export class TokenAssociateRecipient {

--- a/modules/sdk-coin-sol/src/lib/index.ts
+++ b/modules/sdk-coin-sol/src/lib/index.ts
@@ -3,6 +3,7 @@ import * as Utils from './utils';
 
 export { AtaInitializationBuilder } from './ataInitializationBuilder';
 export { CloseAtaBuilder } from './closeAtaBuilder';
+export { ConfidentialTransferBuilder } from './confidentialTransferBuilder';
 export { CustomInstructionBuilder } from './customInstructionBuilder';
 export { KeyPair } from './keyPair';
 export { StakingActivateBuilder } from './stakingActivateBuilder';

--- a/modules/sdk-coin-sol/src/lib/instructionParamsFactory.ts
+++ b/modules/sdk-coin-sol/src/lib/instructionParamsFactory.ts
@@ -97,6 +97,8 @@ export function instructionParamsFactory(
       return parseStakingDelegateInstructions(instructions);
     case TransactionType.CustomTx:
       return parseCustomInstructions(instructions, instructionMetadata);
+    case TransactionType.ConfidentialTransfer:
+      return parseConfidentialTransferInstructions(instructions, instructionMetadata);
     default:
       throw new NotSupported('Invalid transaction, transaction type not supported: ' + type);
   }
@@ -1291,6 +1293,27 @@ function parseStakingAuthorizeRawInstructions(instructions: TransactionInstructi
 }
 
 /**
+ * Returns true if the instruction type is a confidential transfer instruction
+ * (Token-2022 CT extension or zk-elgamal-proof program).
+ */
+function isConfidentialTransferInstruction(type: InstructionBuilderTypes): boolean {
+  switch (type) {
+    case InstructionBuilderTypes.ConfigureConfidentialTransferAccount:
+    case InstructionBuilderTypes.ApplyPendingBalance:
+    case InstructionBuilderTypes.ConfidentialDeposit:
+    case InstructionBuilderTypes.ConfidentialWithdraw:
+    case InstructionBuilderTypes.ConfidentialTransfer:
+    case InstructionBuilderTypes.VerifyPubkeyValidity:
+    case InstructionBuilderTypes.VerifyEqualityProof:
+    case InstructionBuilderTypes.VerifyValidityProof:
+    case InstructionBuilderTypes.VerifyRangeProof:
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
  * Parses Solana instructions to custom instruction params
  *
  * @param {TransactionInstruction[]} instructions - containing custom solana instructions
@@ -1329,6 +1352,61 @@ function parseCustomInstructions(
       };
       instructionData.push(customInstruction);
     }
+  }
+
+  return instructionData;
+}
+
+/**
+ * Parses Solana instructions to confidential transfer instruction params.
+ *
+ * Iterates raw instructions in order, checking metadata at each position:
+ * - CT instruction metadata is preserved as-is (CT instructions cannot be
+ *   decoded by @solana/spl-token or @solana/web3.js).
+ * - CustomInstruction metadata is preserved as-is.
+ * - All other instructions fall back to CustomInstruction format with raw
+ *   programId/keys/data.
+ *
+ * This single-pass approach preserves original instruction order so that
+ * round-trip reconstruction is faithful.
+ *
+ * @param {TransactionInstruction[]} instructions - containing CT solana instructions
+ * @param {InstructionParams[]} instructionMetadata - the instruction metadata for the transaction
+ * @returns {InstructionParams[]} An array containing instruction params in original order
+ */
+function parseConfidentialTransferInstructions(
+  instructions: TransactionInstruction[],
+  instructionMetadata?: InstructionParams[]
+): InstructionParams[] {
+  const instructionData: InstructionParams[] = [];
+
+  for (let i = 0; i < instructions.length; i++) {
+    const instruction = instructions[i];
+
+    // Check if we have metadata for this instruction position
+    if (instructionMetadata && instructionMetadata[i]) {
+      const metaType = instructionMetadata[i].type;
+      // Preserve confidential transfer and custom instruction metadata as-is
+      if (isConfidentialTransferInstruction(metaType) || metaType === InstructionBuilderTypes.CustomInstruction) {
+        instructionData.push(instructionMetadata[i]);
+        continue;
+      }
+    }
+
+    // Convert the raw instruction to CustomInstruction format
+    const customInstruction: CustomInstruction = {
+      type: InstructionBuilderTypes.CustomInstruction,
+      params: {
+        programId: instruction.programId.toString(),
+        keys: instruction.keys.map((key) => ({
+          pubkey: key.pubkey.toString(),
+          isSigner: key.isSigner,
+          isWritable: key.isWritable,
+        })),
+        data: instruction.data.toString('base64'),
+      },
+    };
+    instructionData.push(customInstruction);
   }
 
   return instructionData;

--- a/modules/sdk-coin-sol/src/lib/solInstructionFactory.ts
+++ b/modules/sdk-coin-sol/src/lib/solInstructionFactory.ts
@@ -11,6 +11,7 @@ import {
   TOKEN_2022_PROGRAM_ID,
   createApproveInstruction,
 } from '@solana/spl-token';
+import { struct, u8, s8, blob } from '@solana/buffer-layout';
 import {
   AccountMeta,
   Authorized,
@@ -26,15 +27,23 @@ import {
 import assert from 'assert';
 import BigNumber from 'bignumber.js';
 import {
+  INSTRUCTIONS_SYSVAR_ADDRESS,
   InstructionBuilderTypes,
   MEMO_PROGRAM_PK,
   THAW_PERMISSIONLESS_IDEMPOTENT_DISCRIMINATOR,
   TOKEN_ACL_PROGRAM_ID,
+  ZK_ELGAMAL_PROOF_PROGRAM_ID,
+  CT_EXT_DISCRIMINATOR,
 } from './constants';
 import {
+  ApplyPendingBalance,
   AtaClose,
   AtaInit,
   AtaRecoverNested,
+  ConfidentialDeposit,
+  ConfidentialTransfer,
+  ConfidentialWithdraw,
+  ConfigureConfidentialTransferAccount,
   ExtraAccountMeta,
   InstructionParams,
   Memo,
@@ -49,6 +58,10 @@ import {
   StakingWithdraw,
   TokenTransfer,
   Transfer,
+  VerifyEqualityProof,
+  VerifyPubkeyValidity,
+  VerifyRangeProof,
+  VerifyValidityProof,
   WalletInit,
   SetComputeUnitLimit,
   SetPriorityFee,
@@ -64,7 +77,10 @@ import { depositSolInstructions, withdrawStakeInstructions } from './jitoStakePo
  * @param {InstructionParams} instructionToBuild - the data containing the instruction params
  * @returns {TransactionInstruction[]} An array containing supported Solana instructions
  */
-export function solInstructionFactory(instructionToBuild: InstructionParams): TransactionInstruction[] {
+export function solInstructionFactory(
+  instructionToBuild: InstructionParams,
+  zkProofProgramId?: string
+): TransactionInstruction[] {
   switch (instructionToBuild.type) {
     case InstructionBuilderTypes.NonceAdvance:
       return advanceNonceInstruction(instructionToBuild);
@@ -106,6 +122,24 @@ export function solInstructionFactory(instructionToBuild: InstructionParams): Tr
       return customInstruction(instructionToBuild);
     case InstructionBuilderTypes.PermissionlessThawIdempotent:
       return permissionlessThawIdempotentInstruction(instructionToBuild);
+    case InstructionBuilderTypes.ConfigureConfidentialTransferAccount:
+      return configureConfidentialTransferAccountInstruction(instructionToBuild);
+    case InstructionBuilderTypes.ApplyPendingBalance:
+      return applyPendingBalanceInstruction(instructionToBuild);
+    case InstructionBuilderTypes.ConfidentialDeposit:
+      return confidentialDepositInstruction(instructionToBuild);
+    case InstructionBuilderTypes.ConfidentialWithdraw:
+      return confidentialWithdrawInstruction(instructionToBuild);
+    case InstructionBuilderTypes.ConfidentialTransfer:
+      return confidentialTransferInstruction(instructionToBuild);
+    case InstructionBuilderTypes.VerifyPubkeyValidity:
+      return verifyPubkeyValidityInstruction(instructionToBuild, zkProofProgramId);
+    case InstructionBuilderTypes.VerifyEqualityProof:
+      return verifyEqualityProofInstruction(instructionToBuild, zkProofProgramId);
+    case InstructionBuilderTypes.VerifyValidityProof:
+      return verifyValidityProofInstruction(instructionToBuild, zkProofProgramId);
+    case InstructionBuilderTypes.VerifyRangeProof:
+      return verifyRangeProofInstruction(instructionToBuild, zkProofProgramId);
     default:
       throw new Error(`Invalid instruction type or not supported`);
   }
@@ -859,4 +893,613 @@ function addTransferHookAccounts(instruction: TransactionInstruction, extraAccou
   for (const meta of extraMetas) {
     upsertAccountMeta(instruction.keys, meta);
   }
+}
+
+// ─── Confidential Transfer instruction builders ────────────────────────────
+//
+// All layouts verified against canonical Rust source:
+// solana-program/token-2022 `interface/src/extension/confidential_transfer/instruction.rs`
+//
+// Instruction builders are v0/v1-agnostic: they produce instruction data and
+// account metas only. The caller (Wallet Platform) assembles them into v1
+// transactions in the correct order.
+
+// Token-2022 CT sub-instruction discriminators (byte 1 after CT_EXT_DISCRIMINATOR)
+const CT_CONFIGURE_ACCOUNT_DISCRIMINATOR = 2;
+const CT_DEPOSIT_DISCRIMINATOR = 5;
+const CT_WITHDRAW_DISCRIMINATOR = 6;
+const CT_TRANSFER_DISCRIMINATOR = 7;
+const CT_APPLY_PENDING_BALANCE_DISCRIMINATOR = 8;
+
+// zk-elgamal-proof instruction discriminators
+const PROOF_VERIFY_PUBKEY_VALIDITY = 4;
+const PROOF_VERIFY_EQUALITY = 3;
+const PROOF_VERIFY_VALIDITY_3HANDLES = 12;
+const PROOF_VERIFY_RANGE_U128 = 7;
+
+/**
+ * Validates that a string can be safely converted to BigInt.
+ * Accepts non-negative integer strings (e.g. "1000000", "0").
+ * Also rejects values that would overflow u64 (2^64 - 1).
+ */
+function assertValidAmountString(value: string, fieldName: string): void {
+  assert(value, `Missing ${fieldName} param`);
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`Invalid ${fieldName}: expected non-negative integer string, got "${value}"`);
+  }
+  if (BigInt(value) > 0xffffffffffffffffn) {
+    throw new Error(`Invalid ${fieldName}: value exceeds u64 max (18446744073709551615), got "${value}"`);
+  }
+}
+
+/**
+ * Validates that a number fits in a u8 (0-255).
+ */
+function assertValidU8(value: number, fieldName: string): void {
+  if (!Number.isInteger(value) || value < 0 || value > 255) {
+    throw new Error(`Invalid ${fieldName}: expected u8 (0-255), got ${value}`);
+  }
+}
+
+/**
+ * Validates that a number fits in a signed i8 (-128 to 127).
+ */
+function assertValidI8(value: number, fieldName: string): void {
+  if (!Number.isInteger(value) || value < -128 || value > 127) {
+    throw new Error(`Invalid ${fieldName}: expected i8 (-128 to 127), got ${value}`);
+  }
+}
+
+// Buffer layouts for CT instructions with multi-byte fields
+const configureAccountDataLayout = struct<{
+  instruction: number;
+  confidentialTransferInstruction: number;
+  decryptableZeroBalance: Uint8Array;
+  maximumPendingBalanceCreditCounter: Uint8Array;
+  proofInstructionOffset: number;
+}>([
+  u8('instruction'), // 27
+  u8('confidentialTransferInstruction'), // 2
+  blob(36, 'decryptableZeroBalance'),
+  blob(8, 'maximumPendingBalanceCreditCounter'),
+  s8('proofInstructionOffset'), // i8 — signed: negative = proof is before this instruction
+]); // span = 47
+
+const applyPendingBalanceDataLayout = struct<{
+  instruction: number;
+  confidentialTransferInstruction: number;
+  expectedPendingBalanceCreditCounter: Uint8Array;
+  newDecryptableAvailableBalance: Uint8Array;
+}>([
+  u8('instruction'), // 27
+  u8('confidentialTransferInstruction'), // 8
+  blob(8, 'expectedPendingBalanceCreditCounter'),
+  blob(36, 'newDecryptableAvailableBalance'),
+]); // span = 46
+
+const withdrawDataLayout = struct<{
+  instruction: number;
+  confidentialTransferInstruction: number;
+  amount: Uint8Array;
+  decimals: number;
+  newDecryptableAvailableBalance: Uint8Array;
+  equalityProofInstructionOffset: number;
+  rangeProofInstructionOffset: number;
+}>([
+  u8('instruction'), // 27
+  u8('confidentialTransferInstruction'), // 6
+  blob(8, 'amount'),
+  u8('decimals'),
+  blob(36, 'newDecryptableAvailableBalance'),
+  s8('equalityProofInstructionOffset'), // i8
+  s8('rangeProofInstructionOffset'), // i8
+]); // span = 49
+
+const transferDataLayout = struct<{
+  instruction: number;
+  confidentialTransferInstruction: number;
+  newSourceDecryptableAvailableBalance: Uint8Array;
+  transferAmountAuditorCiphertextLo: Uint8Array;
+  transferAmountAuditorCiphertextHi: Uint8Array;
+  equalityProofInstructionOffset: number;
+  ciphertextValidityProofInstructionOffset: number;
+  rangeProofInstructionOffset: number;
+}>([
+  u8('instruction'), // 27
+  u8('confidentialTransferInstruction'), // 7
+  blob(36, 'newSourceDecryptableAvailableBalance'),
+  blob(64, 'transferAmountAuditorCiphertextLo'),
+  blob(64, 'transferAmountAuditorCiphertextHi'),
+  s8('equalityProofInstructionOffset'), // i8
+  s8('ciphertextValidityProofInstructionOffset'), // i8
+  s8('rangeProofInstructionOffset'), // i8
+]); // span = 169
+
+/**
+ * Build a ConfigureAccount instruction for Token-2022 confidential transfers.
+ *
+ * Registers an ElGamal pubkey + AES zero ciphertext on a token account so it
+ * can send and receive confidential transfers. Must be accompanied by a
+ * VerifyPubkeyValidity proof instruction (inline or context state).
+ */
+function configureConfidentialTransferAccountInstruction(
+  data: ConfigureConfidentialTransferAccount
+): TransactionInstruction[] {
+  const {
+    params: {
+      tokenAddress,
+      mintAddress,
+      authorityAddress,
+      instructionsSysvarOrContextStateAddress,
+      decryptableZeroBalance,
+      maximumPendingBalanceCreditCounter,
+      proofInstructionOffset,
+    },
+  } = data;
+  assert(tokenAddress, 'Missing tokenAddress param');
+  assert(mintAddress, 'Missing mintAddress param');
+  assert(authorityAddress, 'Missing authorityAddress param');
+  assert(decryptableZeroBalance, 'Missing decryptableZeroBalance param');
+  assertValidAmountString(maximumPendingBalanceCreditCounter, 'maximumPendingBalanceCreditCounter');
+  assertValidI8(proofInstructionOffset, 'proofInstructionOffset');
+
+  const keys: AccountMeta[] = [
+    { pubkey: new PublicKey(tokenAddress), isSigner: false, isWritable: true },
+    { pubkey: new PublicKey(mintAddress), isSigner: false, isWritable: false },
+    {
+      pubkey: new PublicKey(instructionsSysvarOrContextStateAddress || INSTRUCTIONS_SYSVAR_ADDRESS),
+      isSigner: false,
+      isWritable: false,
+    },
+    { pubkey: new PublicKey(authorityAddress), isSigner: true, isWritable: false },
+  ];
+
+  const decryptableBytes = Buffer.from(decryptableZeroBalance, 'hex');
+  assert(decryptableBytes.length === 36, 'decryptableZeroBalance must be 36 bytes');
+
+  const dataBuffer = Buffer.alloc(configureAccountDataLayout.span);
+  const counterBuffer = Buffer.alloc(8);
+  counterBuffer.writeBigUInt64LE(BigInt(maximumPendingBalanceCreditCounter));
+
+  configureAccountDataLayout.encode(
+    {
+      instruction: CT_EXT_DISCRIMINATOR,
+      confidentialTransferInstruction: CT_CONFIGURE_ACCOUNT_DISCRIMINATOR,
+      decryptableZeroBalance: decryptableBytes,
+      maximumPendingBalanceCreditCounter: counterBuffer,
+      proofInstructionOffset,
+    },
+    dataBuffer
+  );
+
+  return [new TransactionInstruction({ keys, programId: TOKEN_2022_PROGRAM_ID, data: dataBuffer })];
+}
+
+/**
+ * Build an ApplyPendingBalance instruction.
+ *
+ * Credits pending balance into available balance. Idempotent — no-op if 0
+ * pending. In v1 transactions, always instruction #1.
+ */
+function applyPendingBalanceInstruction(data: ApplyPendingBalance): TransactionInstruction[] {
+  const {
+    params: { tokenAddress, authorityAddress, expectedPendingBalanceCreditCounter, newDecryptableAvailableBalance },
+  } = data;
+  assert(tokenAddress, 'Missing tokenAddress param');
+  assert(authorityAddress, 'Missing authorityAddress param');
+  assertValidAmountString(expectedPendingBalanceCreditCounter, 'expectedPendingBalanceCreditCounter');
+  assert(newDecryptableAvailableBalance, 'Missing newDecryptableAvailableBalance param');
+
+  const keys: AccountMeta[] = [
+    { pubkey: new PublicKey(tokenAddress), isSigner: false, isWritable: true },
+    { pubkey: new PublicKey(authorityAddress), isSigner: true, isWritable: false },
+  ];
+
+  const decryptableBytes = Buffer.from(newDecryptableAvailableBalance, 'hex');
+  assert(decryptableBytes.length === 36, 'newDecryptableAvailableBalance must be 36 bytes');
+
+  const dataBuffer = Buffer.alloc(applyPendingBalanceDataLayout.span);
+  const counterBuffer = Buffer.alloc(8);
+  counterBuffer.writeBigUInt64LE(BigInt(expectedPendingBalanceCreditCounter));
+
+  applyPendingBalanceDataLayout.encode(
+    {
+      instruction: CT_EXT_DISCRIMINATOR,
+      confidentialTransferInstruction: CT_APPLY_PENDING_BALANCE_DISCRIMINATOR,
+      expectedPendingBalanceCreditCounter: counterBuffer,
+      newDecryptableAvailableBalance: decryptableBytes,
+    },
+    dataBuffer
+  );
+
+  return [new TransactionInstruction({ keys, programId: TOKEN_2022_PROGRAM_ID, data: dataBuffer })];
+}
+
+/**
+ * Build a Deposit instruction (public → confidential conversion).
+ *
+ * Moves public SPL token balance into confidential pending balance.
+ * No proof required — the amount is public.
+ */
+function confidentialDepositInstruction(data: ConfidentialDeposit): TransactionInstruction[] {
+  const {
+    params: { tokenAddress, mintAddress, authorityAddress, amount, decimals },
+  } = data;
+  assert(tokenAddress, 'Missing tokenAddress param');
+  assert(mintAddress, 'Missing mintAddress param');
+  assert(authorityAddress, 'Missing authorityAddress param');
+  assertValidAmountString(amount, 'amount');
+  assertValidU8(decimals, 'decimals');
+
+  const keys: AccountMeta[] = [
+    { pubkey: new PublicKey(tokenAddress), isSigner: false, isWritable: true },
+    { pubkey: new PublicKey(mintAddress), isSigner: false, isWritable: false },
+    { pubkey: new PublicKey(authorityAddress), isSigner: true, isWritable: false },
+  ];
+
+  // Layout: [27][5] + amount(u64) + decimals(u8) = 11 bytes
+  const dataBuffer = Buffer.alloc(11);
+  dataBuffer.writeUInt8(CT_EXT_DISCRIMINATOR, 0);
+  dataBuffer.writeUInt8(CT_DEPOSIT_DISCRIMINATOR, 1);
+  dataBuffer.writeBigUInt64LE(BigInt(amount), 2);
+  dataBuffer.writeUInt8(decimals, 10);
+
+  return [new TransactionInstruction({ keys, programId: TOKEN_2022_PROGRAM_ID, data: dataBuffer })];
+}
+
+/**
+ * Build a Withdraw instruction (confidential → public conversion).
+ *
+ * Requires equality + range proof verification (inline or context state).
+ */
+function confidentialWithdrawInstruction(data: ConfidentialWithdraw): TransactionInstruction[] {
+  const {
+    params: {
+      tokenAddress,
+      mintAddress,
+      authorityAddress,
+      instructionsSysvarAddress,
+      equalityProofContextStateAddress,
+      rangeProofContextStateAddress,
+      amount,
+      decimals,
+      newDecryptableAvailableBalance,
+      equalityProofInstructionOffset,
+      rangeProofInstructionOffset,
+    },
+  } = data;
+  assert(tokenAddress, 'Missing tokenAddress param');
+  assert(mintAddress, 'Missing mintAddress param');
+  assert(authorityAddress, 'Missing authorityAddress param');
+  assertValidAmountString(amount, 'amount');
+  assertValidU8(decimals, 'decimals');
+  assertValidI8(equalityProofInstructionOffset, 'equalityProofInstructionOffset');
+  assertValidI8(rangeProofInstructionOffset, 'rangeProofInstructionOffset');
+  assert(newDecryptableAvailableBalance, 'Missing newDecryptableAvailableBalance param');
+
+  // Assert context state addresses are provided when offset == 0 (context state mode)
+  if (equalityProofInstructionOffset === 0) {
+    assert(
+      equalityProofContextStateAddress,
+      'equalityProofContextStateAddress is required when equalityProofInstructionOffset is 0 (context state mode)'
+    );
+  }
+  if (rangeProofInstructionOffset === 0) {
+    assert(
+      rangeProofContextStateAddress,
+      'rangeProofContextStateAddress is required when rangeProofInstructionOffset is 0 (context state mode)'
+    );
+  }
+
+  const keys: AccountMeta[] = [
+    { pubkey: new PublicKey(tokenAddress), isSigner: false, isWritable: true },
+    { pubkey: new PublicKey(mintAddress), isSigner: false, isWritable: false },
+  ];
+
+  // Add instructions sysvar if any proof is inline (offset != 0)
+  const hasInlineProof = equalityProofInstructionOffset !== 0 || rangeProofInstructionOffset !== 0;
+  if (hasInlineProof || instructionsSysvarAddress) {
+    keys.push({
+      pubkey: new PublicKey(instructionsSysvarAddress || INSTRUCTIONS_SYSVAR_ADDRESS),
+      isSigner: false,
+      isWritable: false,
+    });
+  }
+
+  // Add context state accounts for pre-verified proofs (offset == 0)
+  if (equalityProofInstructionOffset === 0 && equalityProofContextStateAddress) {
+    keys.push({ pubkey: new PublicKey(equalityProofContextStateAddress), isSigner: false, isWritable: false });
+  }
+  if (rangeProofInstructionOffset === 0 && rangeProofContextStateAddress) {
+    keys.push({ pubkey: new PublicKey(rangeProofContextStateAddress), isSigner: false, isWritable: false });
+  }
+
+  keys.push({ pubkey: new PublicKey(authorityAddress), isSigner: true, isWritable: false });
+
+  const decryptableBytes = Buffer.from(newDecryptableAvailableBalance, 'hex');
+  assert(decryptableBytes.length === 36, 'newDecryptableAvailableBalance must be 36 bytes');
+
+  const dataBuffer = Buffer.alloc(withdrawDataLayout.span);
+  const amountBuffer = Buffer.alloc(8);
+  amountBuffer.writeBigUInt64LE(BigInt(amount));
+
+  withdrawDataLayout.encode(
+    {
+      instruction: CT_EXT_DISCRIMINATOR,
+      confidentialTransferInstruction: CT_WITHDRAW_DISCRIMINATOR,
+      amount: amountBuffer,
+      decimals,
+      newDecryptableAvailableBalance: decryptableBytes,
+      equalityProofInstructionOffset,
+      rangeProofInstructionOffset,
+    },
+    dataBuffer
+  );
+
+  return [new TransactionInstruction({ keys, programId: TOKEN_2022_PROGRAM_ID, data: dataBuffer })];
+}
+
+/**
+ * Build a confidential Transfer instruction.
+ *
+ * Requires equality + ciphertext validity + range proof verification (inline or context state).
+ */
+function confidentialTransferInstruction(data: ConfidentialTransfer): TransactionInstruction[] {
+  const {
+    params: {
+      sourceTokenAddress,
+      mintAddress,
+      destinationTokenAddress,
+      authorityAddress,
+      instructionsSysvarAddress,
+      equalityProofContextStateAddress,
+      ciphertextValidityProofContextStateAddress,
+      rangeProofContextStateAddress,
+      newSourceDecryptableAvailableBalance,
+      transferAmountAuditorCiphertextLo,
+      transferAmountAuditorCiphertextHi,
+      equalityProofInstructionOffset,
+      ciphertextValidityProofInstructionOffset,
+      rangeProofInstructionOffset,
+    },
+  } = data;
+  assert(sourceTokenAddress, 'Missing sourceTokenAddress param');
+  assert(mintAddress, 'Missing mintAddress param');
+  assert(destinationTokenAddress, 'Missing destinationTokenAddress param');
+  assert(authorityAddress, 'Missing authorityAddress param');
+  assert(newSourceDecryptableAvailableBalance, 'Missing newSourceDecryptableAvailableBalance param');
+  assert(transferAmountAuditorCiphertextLo, 'Missing transferAmountAuditorCiphertextLo param');
+  assert(transferAmountAuditorCiphertextHi, 'Missing transferAmountAuditorCiphertextHi param');
+  assertValidI8(equalityProofInstructionOffset, 'equalityProofInstructionOffset');
+  assertValidI8(ciphertextValidityProofInstructionOffset, 'ciphertextValidityProofInstructionOffset');
+  assertValidI8(rangeProofInstructionOffset, 'rangeProofInstructionOffset');
+
+  // Assert context state addresses are provided when offset == 0 (context state mode)
+  if (equalityProofInstructionOffset === 0) {
+    assert(
+      equalityProofContextStateAddress,
+      'equalityProofContextStateAddress is required when equalityProofInstructionOffset is 0 (context state mode)'
+    );
+  }
+  if (ciphertextValidityProofInstructionOffset === 0) {
+    assert(
+      ciphertextValidityProofContextStateAddress,
+      'ciphertextValidityProofContextStateAddress is required when ciphertextValidityProofInstructionOffset is 0 (context state mode)'
+    );
+  }
+  if (rangeProofInstructionOffset === 0) {
+    assert(
+      rangeProofContextStateAddress,
+      'rangeProofContextStateAddress is required when rangeProofInstructionOffset is 0 (context state mode)'
+    );
+  }
+
+  const keys: AccountMeta[] = [
+    { pubkey: new PublicKey(sourceTokenAddress), isSigner: false, isWritable: true },
+    { pubkey: new PublicKey(mintAddress), isSigner: false, isWritable: false },
+    { pubkey: new PublicKey(destinationTokenAddress), isSigner: false, isWritable: true },
+  ];
+
+  // Add instructions sysvar if any proof is inline (offset != 0)
+  const hasInlineProof =
+    equalityProofInstructionOffset !== 0 ||
+    ciphertextValidityProofInstructionOffset !== 0 ||
+    rangeProofInstructionOffset !== 0;
+  if (hasInlineProof || instructionsSysvarAddress) {
+    keys.push({
+      pubkey: new PublicKey(instructionsSysvarAddress || INSTRUCTIONS_SYSVAR_ADDRESS),
+      isSigner: false,
+      isWritable: false,
+    });
+  }
+
+  // Add context state accounts for pre-verified proofs (offset == 0)
+  if (equalityProofInstructionOffset === 0 && equalityProofContextStateAddress) {
+    keys.push({ pubkey: new PublicKey(equalityProofContextStateAddress), isSigner: false, isWritable: false });
+  }
+  if (ciphertextValidityProofInstructionOffset === 0 && ciphertextValidityProofContextStateAddress) {
+    keys.push({
+      pubkey: new PublicKey(ciphertextValidityProofContextStateAddress),
+      isSigner: false,
+      isWritable: false,
+    });
+  }
+  if (rangeProofInstructionOffset === 0 && rangeProofContextStateAddress) {
+    keys.push({ pubkey: new PublicKey(rangeProofContextStateAddress), isSigner: false, isWritable: false });
+  }
+
+  keys.push({ pubkey: new PublicKey(authorityAddress), isSigner: true, isWritable: false });
+
+  const decryptableBytes = Buffer.from(newSourceDecryptableAvailableBalance, 'hex');
+  assert(decryptableBytes.length === 36, 'newSourceDecryptableAvailableBalance must be 36 bytes');
+  const auditorLoBytes = Buffer.from(transferAmountAuditorCiphertextLo, 'hex');
+  assert(auditorLoBytes.length === 64, 'transferAmountAuditorCiphertextLo must be 64 bytes');
+  const auditorHiBytes = Buffer.from(transferAmountAuditorCiphertextHi, 'hex');
+  assert(auditorHiBytes.length === 64, 'transferAmountAuditorCiphertextHi must be 64 bytes');
+
+  const dataBuffer = Buffer.alloc(transferDataLayout.span);
+
+  transferDataLayout.encode(
+    {
+      instruction: CT_EXT_DISCRIMINATOR,
+      confidentialTransferInstruction: CT_TRANSFER_DISCRIMINATOR,
+      newSourceDecryptableAvailableBalance: decryptableBytes,
+      transferAmountAuditorCiphertextLo: auditorLoBytes,
+      transferAmountAuditorCiphertextHi: auditorHiBytes,
+      equalityProofInstructionOffset,
+      ciphertextValidityProofInstructionOffset,
+      rangeProofInstructionOffset,
+    },
+    dataBuffer
+  );
+
+  return [new TransactionInstruction({ keys, programId: TOKEN_2022_PROGRAM_ID, data: dataBuffer })];
+}
+
+// ─── zk-elgamal-proof verification instruction builders ────────────────────
+
+/**
+ * Build a VerifyPubkeyValidity proof instruction.
+ *
+ * Used with ConfigureAccount to prove knowledge of the ElGamal secret key.
+ * Discriminator: [4]
+ */
+function verifyPubkeyValidityInstruction(
+  data: VerifyPubkeyValidity,
+  zkProofProgramId?: string
+): TransactionInstruction[] {
+  const {
+    params: { proofData, contextStateAccountAddress, contextStateAuthorityAddress },
+  } = data;
+
+  const keys: AccountMeta[] = [];
+  if (contextStateAccountAddress && contextStateAuthorityAddress) {
+    keys.push({ pubkey: new PublicKey(contextStateAccountAddress), isSigner: false, isWritable: true });
+    keys.push({ pubkey: new PublicKey(contextStateAuthorityAddress), isSigner: false, isWritable: false });
+  }
+
+  // Use buildProofDataOrOffsetBuffer to support both inline proof and context state offset
+  const dataBuffer = buildProofDataOrOffsetBuffer(PROOF_VERIFY_PUBKEY_VALIDITY, proofData, undefined, true);
+  return [
+    new TransactionInstruction({
+      keys,
+      programId: new PublicKey(zkProofProgramId || ZK_ELGAMAL_PROOF_PROGRAM_ID),
+      data: dataBuffer,
+    }),
+  ];
+}
+
+/**
+ * Build a VerifyCiphertextCommitmentEquality proof instruction.
+ *
+ * Used with Transfer and Withdraw. Discriminator: [3]
+ */
+function verifyEqualityProofInstruction(
+  data: VerifyEqualityProof,
+  zkProofProgramId?: string
+): TransactionInstruction[] {
+  const {
+    params: { proofData, contextStateAccountAddress, contextStateAuthorityAddress, offset },
+  } = data;
+
+  const keys: AccountMeta[] = [];
+  if (contextStateAccountAddress && contextStateAuthorityAddress) {
+    keys.push({ pubkey: new PublicKey(contextStateAccountAddress), isSigner: false, isWritable: true });
+    keys.push({ pubkey: new PublicKey(contextStateAuthorityAddress), isSigner: false, isWritable: false });
+  }
+
+  const dataBuffer = buildProofDataOrOffsetBuffer(PROOF_VERIFY_EQUALITY, proofData, offset, true);
+  return [
+    new TransactionInstruction({
+      keys,
+      programId: new PublicKey(zkProofProgramId || ZK_ELGAMAL_PROOF_PROGRAM_ID),
+      data: dataBuffer,
+    }),
+  ];
+}
+
+/**
+ * Build a VerifyBatchedGroupedCiphertext3HandlesValidity proof instruction.
+ *
+ * Used with Transfer. Discriminator: [12]
+ */
+function verifyValidityProofInstruction(
+  data: VerifyValidityProof,
+  zkProofProgramId?: string
+): TransactionInstruction[] {
+  const {
+    params: { proofData, contextStateAccountAddress, contextStateAuthorityAddress, offset },
+  } = data;
+
+  const keys: AccountMeta[] = [];
+  if (contextStateAccountAddress && contextStateAuthorityAddress) {
+    keys.push({ pubkey: new PublicKey(contextStateAccountAddress), isSigner: false, isWritable: true });
+    keys.push({ pubkey: new PublicKey(contextStateAuthorityAddress), isSigner: false, isWritable: false });
+  }
+
+  const dataBuffer = buildProofDataOrOffsetBuffer(PROOF_VERIFY_VALIDITY_3HANDLES, proofData, offset, true);
+  return [
+    new TransactionInstruction({
+      keys,
+      programId: new PublicKey(zkProofProgramId || ZK_ELGAMAL_PROOF_PROGRAM_ID),
+      data: dataBuffer,
+    }),
+  ];
+}
+
+/**
+ * Build a VerifyBatchedRangeProofU128 proof instruction.
+ *
+ * Used with Transfer. Discriminator: [7]
+ * Note: range proofs do not use a context state account in the same way as
+ * equality/validity proofs — the proof is either inline or read from a
+ * record account at the given offset.
+ */
+function verifyRangeProofInstruction(data: VerifyRangeProof, zkProofProgramId?: string): TransactionInstruction[] {
+  const {
+    params: { proofData, contextStateAccountAddress, contextStateAuthorityAddress, offset },
+  } = data;
+
+  const keys: AccountMeta[] = [];
+  if (contextStateAccountAddress && contextStateAuthorityAddress) {
+    keys.push({ pubkey: new PublicKey(contextStateAccountAddress), isSigner: false, isWritable: true });
+    keys.push({ pubkey: new PublicKey(contextStateAuthorityAddress), isSigner: false, isWritable: false });
+  }
+
+  const dataBuffer = buildProofDataOrOffsetBuffer(PROOF_VERIFY_RANGE_U128, proofData, offset, false);
+  return [
+    new TransactionInstruction({
+      keys,
+      programId: new PublicKey(zkProofProgramId || ZK_ELGAMAL_PROOF_PROGRAM_ID),
+      data: dataBuffer,
+    }),
+  ];
+}
+
+/**
+ * Build proof instruction data from either inline proof bytes or a context
+ * state account offset.
+ *
+ * If proofData is provided: [discriminator: u8] + [proof_data: variable]
+ * If offset is provided: [discriminator: u8] + [offset: u32 LE]
+ *
+ * @param useUInt32 - true for equality/validity (writeUInt32LE), false for range (writeInt32LE)
+ */
+function buildProofDataOrOffsetBuffer(
+  discriminator: number,
+  proofData?: string,
+  offset?: number,
+  useUInt32 = true
+): Buffer {
+  if (proofData) {
+    const proofBytes = Buffer.from(proofData, 'hex');
+    return Buffer.concat([Buffer.from([discriminator]), proofBytes]);
+  }
+  const offsetBuffer = Buffer.alloc(4);
+  if (useUInt32) {
+    offsetBuffer.writeUInt32LE(offset ?? 0, 0);
+  } else {
+    offsetBuffer.writeInt32LE(offset ?? 0, 0);
+  }
+  return Buffer.concat([Buffer.from([discriminator]), offsetBuffer]);
 }

--- a/modules/sdk-coin-sol/src/lib/transaction.ts
+++ b/modules/sdk-coin-sol/src/lib/transaction.ts
@@ -322,6 +322,9 @@ export class Transaction extends BaseTransaction {
         case TransactionType.CustomTx:
           this.setTransactionType(TransactionType.CustomTx);
           break;
+        case TransactionType.ConfidentialTransfer:
+          this.setTransactionType(TransactionType.ConfidentialTransfer);
+          break;
       }
       if (transactionType !== TransactionType.StakingAuthorizeRaw) {
         this.loadInputsAndOutputs();

--- a/modules/sdk-coin-sol/src/lib/transactionBuilder.ts
+++ b/modules/sdk-coin-sol/src/lib/transactionBuilder.ts
@@ -51,6 +51,8 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
   protected _memo?: string;
   protected _feePayer?: string;
   protected _priorityFee: number;
+  /** Optional override for the zk-elgamal-proof program id (used by CT instruction builders) */
+  protected _zkProofProgramId?: string;
 
   constructor(_coinConfig: Readonly<CoinConfig>) {
     super(_coinConfig);
@@ -176,7 +178,7 @@ export abstract class TransactionBuilder extends BaseTransactionBuilder {
       tx.recentBlockhash = this._recentBlockhash;
     }
     for (const instruction of this._instructionsData) {
-      tx.add(...solInstructionFactory(instruction));
+      tx.add(...solInstructionFactory(instruction, this._zkProofProgramId));
     }
 
     if (this._memo) {

--- a/modules/sdk-coin-sol/src/lib/transactionBuilderFactory.ts
+++ b/modules/sdk-coin-sol/src/lib/transactionBuilderFactory.ts
@@ -2,6 +2,7 @@ import { BaseTransactionBuilderFactory, InvalidTransactionError, TransactionType
 import { BaseCoin as CoinConfig } from '@bitgo/statics';
 import { AtaInitializationBuilder } from './ataInitializationBuilder';
 import { CloseAtaBuilder } from './closeAtaBuilder';
+import { ConfidentialTransferBuilder } from './confidentialTransferBuilder';
 import { RecoverNestedAtaBuilder } from './recoverNestedAtaBuilder';
 import { CustomInstructionBuilder } from './customInstructionBuilder';
 import { StakingActivateBuilder } from './stakingActivateBuilder';
@@ -62,6 +63,8 @@ export class TransactionBuilderFactory extends BaseTransactionBuilderFactory {
           return this.getCloseAtaInitializationBuilder(tx);
         case TransactionType.CustomTx:
           return this.getCustomInstructionBuilder(tx);
+        case TransactionType.ConfidentialTransfer:
+          return this.getConfidentialTransferBuilder(tx);
         default:
           throw new InvalidTransactionError('Invalid transaction');
       }
@@ -191,6 +194,17 @@ export class TransactionBuilderFactory extends BaseTransactionBuilderFactory {
    */
   getCustomInstructionBuilder(tx?: Transaction): CustomInstructionBuilder {
     return this.initializeBuilder(tx, new CustomInstructionBuilder(this._coinConfig));
+  }
+
+  /**
+   * Returns the builder to create Token-2022 confidential transfer transactions.
+   *
+   * Supports Phase 1a CT instructions: ConfigureAccount, ApplyPendingBalance,
+   * Deposit, Withdraw, Transfer, and all verify-proof instructions.
+   * Instruction builders are v0/v1-agnostic.
+   */
+  getConfidentialTransferBuilder(tx?: Transaction): ConfidentialTransferBuilder {
+    return this.initializeBuilder(tx, new ConfidentialTransferBuilder(this._coinConfig));
   }
 
   /**

--- a/modules/sdk-coin-sol/src/lib/utils.ts
+++ b/modules/sdk-coin-sol/src/lib/utils.ts
@@ -59,6 +59,9 @@ import {
   jitoStakingDeactivateInstructionsIndexes,
   jitoStakingActivateWithATAInstructionsIndexes,
   TOKEN_ACL_PROGRAM_ID,
+  ZK_ELGAMAL_PROOF_PROGRAM_ID,
+  CT_EXT_DISCRIMINATOR,
+  CT_SUB_DISCRIMINATORS,
 } from './constants';
 import { ValidInstructionTypes } from './iface';
 import { STAKE_POOL_INSTRUCTION_LAYOUTS, STAKE_POOL_PROGRAM_ID } from '@solana/spl-stake-pool';
@@ -318,6 +321,26 @@ export function matchTransactionTypeByInstructionsOrder(
 }
 
 /**
+ * Returns true if the instruction is a confidential transfer instruction
+ * (Token-2022 CT extension or zk-elgamal-proof program).
+ *
+ * CT extension: byte 0 = 27 (ConfidentialTransferExtension), byte 1 ∈ {2, 5, 6, 7, 8}
+ * zk-elgamal-proof: any instruction from the zk-elgamal-proof program
+ */
+function isConfidentialTransferRawInstruction(instruction: TransactionInstruction): boolean {
+  const programId = instruction.programId.toString();
+  // zk-elgamal-proof program instructions are always CT proof verifications
+  if (programId === ZK_ELGAMAL_PROOF_PROGRAM_ID) {
+    return true;
+  }
+  // Token-2022 CT extension: byte 0 = CT_EXT_DISCRIMINATOR, byte 1 ∈ CT_SUB_DISCRIMINATORS
+  if (programId === TOKEN_2022_PROGRAM_ID.toString() && instruction.data.length >= 2) {
+    return instruction.data[0] === CT_EXT_DISCRIMINATOR && CT_SUB_DISCRIMINATORS.has(instruction.data[1]);
+  }
+  return false;
+}
+
+/**
  * Returns the transaction Type based on the  transaction instructions.
  * Wallet initialization, Transfer and Staking transactions are supported.
  *
@@ -388,6 +411,8 @@ export function getTransactionType(transaction: SolTransaction): TransactionType
     return TransactionType.CloseAssociatedTokenAccount;
   } else if (matchTransactionTypeByInstructionsOrder(instructions, ataRecoverNestedInstructionIndexes)) {
     return TransactionType.CloseAssociatedTokenAccount;
+  } else if (instructions.some(isConfidentialTransferRawInstruction)) {
+    return TransactionType.ConfidentialTransfer;
   } else {
     return TransactionType.CustomTx;
   }

--- a/modules/sdk-coin-sol/test/unit/transactionBuilder/confidentialTransferBuilder.ts
+++ b/modules/sdk-coin-sol/test/unit/transactionBuilder/confidentialTransferBuilder.ts
@@ -1,0 +1,971 @@
+import { KeyPair, Utils, Transaction } from '../../../src';
+import should from 'should';
+import * as testData from '../../resources/sol';
+import { getBuilderFactory } from '../getBuilderFactory';
+
+describe('Solana Confidential Transfer Builder', () => {
+  const factory = getBuilderFactory('sol');
+  const account = new KeyPair(testData.associatedTokenAccounts.accounts[0]).getKeys();
+  const recentBlockHash = 'GHtXQBsoZHVnNFa9YevAzFr17DJjgHXk3ycTKD5xD3Zi';
+
+  // Test addresses (Token-2022 mint + ATAs)
+  const mintAddress = testData.associatedTokenAccountsForSol2022.mintId;
+  const tokenAddress = testData.associatedTokenAccountsForSol2022.accounts[0].ata;
+  const destinationTokenAddress = 'ENn8a2tGMS9bR5XV7smGHJvNgzkyxJmnD2eUvQxY5jSP';
+  const authorityAddress = account.pub;
+  // Valid base58 addresses for context state accounts (any valid Solana pubkey)
+  const eqCtxAddress = testData.associatedTokenAccounts.accounts[0].ata;
+  const validityCtxAddress = testData.associatedTokenAccounts.accounts[0].pub;
+  const rangeCtxAddress = testData.nonceAccount.pub;
+
+  // Hex test data
+  const zeroBytes36 = '00'.repeat(36);
+  const zeroBytes64 = '00'.repeat(64);
+  const proofDataHex = '00'.repeat(320); // typical equality proof size
+
+  const ctBuilder = () => {
+    const txBuilder = factory.getConfidentialTransferBuilder();
+    txBuilder.nonce(recentBlockHash);
+    txBuilder.sender(account.pub);
+    return txBuilder;
+  };
+
+  /** Access the raw Solana Transaction from the built tx */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const solTx = (tx: any): any => (tx as Transaction).solTransaction;
+
+  describe('ConfigureAccount', () => {
+    it('should build a configure account instruction with correct 47-byte layout', async () => {
+      const builder = ctBuilder();
+      builder.configureAccount({
+        tokenAddress,
+        mintAddress,
+        authorityAddress,
+        decryptableZeroBalance: zeroBytes36,
+        maximumPendingBalanceCreditCounter: '65536',
+        proofInstructionOffset: 1,
+      });
+
+      const tx = await builder.build();
+      const instructions = tx.toJson().instructionsData;
+      instructions.should.have.length(1);
+      instructions[0].type.should.equal('ConfigureConfidentialTransferAccount');
+
+      // Verify raw instruction data
+      const rawInstructions = solTx(tx).instructions;
+      rawInstructions.should.have.length(1);
+      const data = rawInstructions[0].data;
+      data.length.should.equal(47);
+      data[0].should.equal(27); // ConfidentialTransferExtension
+      data[1].should.equal(2); // ConfigureAccount
+      data.slice(2, 38).toString('hex').should.equal(zeroBytes36); // decryptable_zero_balance
+      data.readBigUInt64LE(38).toString().should.equal('65536'); // max pending balance credit counter
+      data[46].should.equal(1); // proof_instruction_offset
+
+      // Verify accounts
+      const keys = rawInstructions[0].keys;
+      keys.should.have.length(4);
+      keys[0].pubkey.toString().should.equal(tokenAddress);
+      keys[0].isWritable.should.be.true();
+      keys[1].pubkey.toString().should.equal(mintAddress);
+      keys[1].isWritable.should.be.false();
+      keys[2].pubkey.toString().should.equal('Sysvar1nstructions1111111111111111111111111'); // instructions sysvar
+      keys[3].pubkey.toString().should.equal(authorityAddress);
+      keys[3].isSigner.should.be.true();
+    });
+
+    it('should use context state address when provided', async () => {
+      const contextStateAddress = testData.associatedTokenAccounts.accounts[0].pub;
+      const builder = ctBuilder();
+      builder.configureAccount({
+        tokenAddress,
+        mintAddress,
+        authorityAddress,
+        instructionsSysvarOrContextStateAddress: contextStateAddress,
+        decryptableZeroBalance: zeroBytes36,
+        maximumPendingBalanceCreditCounter: '65536',
+        proofInstructionOffset: 0,
+      });
+
+      const tx = await builder.build();
+      const keys = solTx(tx).instructions[0].keys;
+      keys[2].pubkey.toString().should.equal(contextStateAddress);
+      const data = solTx(tx).instructions[0].data;
+      data[46].should.equal(0); // proof_instruction_offset = 0 (context state)
+    });
+  });
+
+  describe('ApplyPendingBalance', () => {
+    it('should build an apply pending balance instruction with correct 46-byte layout', async () => {
+      const builder = ctBuilder();
+      builder.applyPendingBalance({
+        tokenAddress,
+        authorityAddress,
+        expectedPendingBalanceCreditCounter: '3',
+        newDecryptableAvailableBalance: zeroBytes36,
+      });
+
+      const tx = await builder.build();
+      const instructions = tx.toJson().instructionsData;
+      instructions.should.have.length(1);
+      instructions[0].type.should.equal('ApplyPendingBalance');
+
+      const rawInstructions = solTx(tx).instructions;
+      rawInstructions.should.have.length(1);
+      const data = rawInstructions[0].data;
+      data.length.should.equal(46);
+      data[0].should.equal(27); // ConfidentialTransferExtension
+      data[1].should.equal(8); // ApplyPendingBalance
+      data.readBigUInt64LE(2).toString().should.equal('3'); // expected_pending_balance_credit_counter
+      data.slice(10, 46).toString('hex').should.equal(zeroBytes36); // new_decryptable_available_balance
+
+      // Verify accounts: [token(writable), authority(signer)]
+      const keys = rawInstructions[0].keys;
+      keys.should.have.length(2);
+      keys[0].pubkey.toString().should.equal(tokenAddress);
+      keys[0].isWritable.should.be.true();
+      keys[1].pubkey.toString().should.equal(authorityAddress);
+      keys[1].isSigner.should.be.true();
+    });
+  });
+
+  describe('Deposit', () => {
+    it('should build a deposit instruction with correct 11-byte layout', async () => {
+      const builder = ctBuilder();
+      builder.confidentialDeposit({
+        tokenAddress,
+        mintAddress,
+        authorityAddress,
+        amount: '1000000',
+        decimals: 6,
+      });
+
+      const tx = await builder.build();
+      const instructions = tx.toJson().instructionsData;
+      instructions.should.have.length(1);
+      instructions[0].type.should.equal('ConfidentialDeposit');
+
+      const rawInstructions = solTx(tx).instructions;
+      rawInstructions.should.have.length(1);
+      const data = rawInstructions[0].data;
+      data.length.should.equal(11);
+      data[0].should.equal(27); // ConfidentialTransferExtension
+      data[1].should.equal(5); // Deposit
+      data.readBigUInt64LE(2).toString().should.equal('1000000'); // amount
+      data[10].should.equal(6); // decimals
+
+      // Verify accounts: [token(writable), mint, authority(signer)]
+      const keys = rawInstructions[0].keys;
+      keys.should.have.length(3);
+      keys[0].pubkey.toString().should.equal(tokenAddress);
+      keys[0].isWritable.should.be.true();
+      keys[1].pubkey.toString().should.equal(mintAddress);
+      keys[2].pubkey.toString().should.equal(authorityAddress);
+      keys[2].isSigner.should.be.true();
+    });
+  });
+
+  describe('Withdraw', () => {
+    it('should build a withdraw instruction with correct 49-byte layout and inline proofs', async () => {
+      const builder = ctBuilder();
+      builder.confidentialWithdraw({
+        tokenAddress,
+        mintAddress,
+        authorityAddress,
+        amount: '500000',
+        decimals: 6,
+        newDecryptableAvailableBalance: zeroBytes36,
+        equalityProofInstructionOffset: 1,
+        rangeProofInstructionOffset: 2,
+      });
+
+      const tx = await builder.build();
+      const instructions = tx.toJson().instructionsData;
+      instructions.should.have.length(1);
+      instructions[0].type.should.equal('ConfidentialWithdraw');
+
+      const rawInstructions = solTx(tx).instructions;
+      rawInstructions.should.have.length(1);
+      const data = rawInstructions[0].data;
+      data.length.should.equal(49);
+      data[0].should.equal(27); // ConfidentialTransferExtension
+      data[1].should.equal(6); // Withdraw
+      data.readBigUInt64LE(2).toString().should.equal('500000'); // amount
+      data[10].should.equal(6); // decimals
+      data.slice(11, 47).toString('hex').should.equal(zeroBytes36); // new_decryptable
+      data[47].should.equal(1); // equality proof offset
+      data[48].should.equal(2); // range proof offset
+
+      // Verify accounts: [token(writable), mint, sysvar, authority(signer)]
+      const keys = rawInstructions[0].keys;
+      keys.should.have.length(4);
+      keys[0].pubkey.toString().should.equal(tokenAddress);
+      keys[0].isWritable.should.be.true();
+      keys[1].pubkey.toString().should.equal(mintAddress);
+      keys[2].pubkey.toString().should.equal('Sysvar1nstructions1111111111111111111111111');
+      keys[3].pubkey.toString().should.equal(authorityAddress);
+      keys[3].isSigner.should.be.true();
+    });
+
+    it('should build a withdraw instruction with context state accounts', async () => {
+      const builder = ctBuilder();
+      builder.confidentialWithdraw({
+        tokenAddress,
+        mintAddress,
+        authorityAddress,
+        equalityProofContextStateAddress: eqCtxAddress,
+        rangeProofContextStateAddress: rangeCtxAddress,
+        amount: '500000',
+        decimals: 6,
+        newDecryptableAvailableBalance: zeroBytes36,
+        equalityProofInstructionOffset: 0,
+        rangeProofInstructionOffset: 0,
+      });
+
+      const tx = await builder.build();
+      const keys = solTx(tx).instructions[0].keys;
+      // [token, mint, eqCtx, rgCtx, authority] — no sysvar since all proofs use context state
+      keys.should.have.length(5);
+      keys[2].pubkey.toString().should.equal(eqCtxAddress);
+      keys[3].pubkey.toString().should.equal(rangeCtxAddress);
+      keys[4].pubkey.toString().should.equal(authorityAddress);
+      keys[4].isSigner.should.be.true();
+    });
+  });
+
+  describe('ConfidentialTransfer', () => {
+    it('should build a transfer instruction with correct 169-byte layout and inline proofs', async () => {
+      const builder = ctBuilder();
+      builder.confidentialTransfer({
+        sourceTokenAddress: tokenAddress,
+        mintAddress,
+        destinationTokenAddress,
+        authorityAddress,
+        newSourceDecryptableAvailableBalance: zeroBytes36,
+        transferAmountAuditorCiphertextLo: zeroBytes64,
+        transferAmountAuditorCiphertextHi: zeroBytes64,
+        equalityProofInstructionOffset: 1,
+        ciphertextValidityProofInstructionOffset: 2,
+        rangeProofInstructionOffset: 3,
+      });
+
+      const tx = await builder.build();
+      const instructions = tx.toJson().instructionsData;
+      instructions.should.have.length(1);
+      instructions[0].type.should.equal('ConfidentialTransfer');
+
+      const rawInstructions = solTx(tx).instructions;
+      rawInstructions.should.have.length(1);
+      const data = rawInstructions[0].data;
+      data.length.should.equal(169);
+      data[0].should.equal(27); // ConfidentialTransferExtension
+      data[1].should.equal(7); // Transfer
+      data.slice(2, 38).toString('hex').should.equal(zeroBytes36); // new_source_decryptable
+      data.slice(38, 102).toString('hex').should.equal(zeroBytes64); // auditor_ct_lo
+      data.slice(102, 166).toString('hex').should.equal(zeroBytes64); // auditor_ct_hi
+      data[166].should.equal(1); // equality proof offset
+      data[167].should.equal(2); // validity proof offset
+      data[168].should.equal(3); // range proof offset
+
+      // Verify accounts: [source(writable), mint, dest(writable), sysvar, authority(signer)]
+      const keys = rawInstructions[0].keys;
+      keys.should.have.length(5);
+      keys[0].pubkey.toString().should.equal(tokenAddress);
+      keys[0].isWritable.should.be.true();
+      keys[1].pubkey.toString().should.equal(mintAddress);
+      keys[2].pubkey.toString().should.equal(destinationTokenAddress);
+      keys[2].isWritable.should.be.true();
+      keys[3].pubkey.toString().should.equal('Sysvar1nstructions1111111111111111111111111');
+      keys[4].pubkey.toString().should.equal(authorityAddress);
+      keys[4].isSigner.should.be.true();
+    });
+
+    it('should build a transfer instruction with context state accounts', async () => {
+      const builder = ctBuilder();
+      builder.confidentialTransfer({
+        sourceTokenAddress: tokenAddress,
+        mintAddress,
+        destinationTokenAddress,
+        authorityAddress,
+        equalityProofContextStateAddress: eqCtxAddress,
+        ciphertextValidityProofContextStateAddress: validityCtxAddress,
+        rangeProofContextStateAddress: rangeCtxAddress,
+        newSourceDecryptableAvailableBalance: zeroBytes36,
+        transferAmountAuditorCiphertextLo: zeroBytes64,
+        transferAmountAuditorCiphertextHi: zeroBytes64,
+        equalityProofInstructionOffset: 0,
+        ciphertextValidityProofInstructionOffset: 0,
+        rangeProofInstructionOffset: 0,
+      });
+
+      const tx = await builder.build();
+      const keys = solTx(tx).instructions[0].keys;
+      // [source, mint, dest, eqCtx, validityCtx, rangeCtx, authority] — no sysvar
+      keys.should.have.length(7);
+      keys[3].pubkey.toString().should.equal(eqCtxAddress);
+      keys[4].pubkey.toString().should.equal(validityCtxAddress);
+      keys[5].pubkey.toString().should.equal(rangeCtxAddress);
+      keys[6].pubkey.toString().should.equal(authorityAddress);
+      keys[6].isSigner.should.be.true();
+    });
+  });
+
+  describe('VerifyPubkeyValidity', () => {
+    it('should build a verify pubkey validity instruction with inline proof data', async () => {
+      const builder = ctBuilder();
+      builder.verifyPubkeyValidity({ proofData: proofDataHex });
+
+      const tx = await builder.build();
+      const rawInstructions = solTx(tx).instructions;
+      rawInstructions.should.have.length(1);
+      const data = rawInstructions[0].data;
+      data[0].should.equal(4); // VerifyPubkeyValidity discriminator
+      data.length.should.equal(1 + 320); // discriminator + proof data
+      data.slice(1).toString('hex').should.equal(proofDataHex);
+
+      // No accounts for inline proof
+      rawInstructions[0].keys.should.have.length(0);
+
+      // Verify program id (canonical on-chain id)
+      rawInstructions[0].programId.toString().should.equal('ZkE1Gama1Proof11111111111111111111111111111');
+    });
+
+    it('should build with context state account (fix #3)', async () => {
+      const builder = ctBuilder();
+      builder.verifyPubkeyValidity({
+        contextStateAccountAddress: eqCtxAddress,
+        contextStateAuthorityAddress: authorityAddress,
+      });
+
+      const tx = await builder.build();
+      const rawIx = solTx(tx).instructions[0];
+      const data = rawIx.data;
+      data[0].should.equal(4); // VerifyPubkeyValidity discriminator
+      // Context state accounts: [contextState(writable), authority]
+      rawIx.keys.should.have.length(2);
+      rawIx.keys[0].pubkey.toString().should.equal(eqCtxAddress);
+      rawIx.keys[0].isWritable.should.be.true();
+      rawIx.keys[1].pubkey.toString().should.equal(authorityAddress);
+    });
+  });
+
+  describe('VerifyEqualityProof', () => {
+    it('should build with inline proof data', async () => {
+      const builder = ctBuilder();
+      builder.verifyEqualityProof({ proofData: proofDataHex });
+
+      const tx = await builder.build();
+      const data = solTx(tx).instructions[0].data;
+      data[0].should.equal(3); // VerifyCiphertextCommitmentEquality discriminator
+      data.length.should.equal(1 + 320);
+      data.slice(1).toString('hex').should.equal(proofDataHex);
+    });
+
+    it('should build with context state offset', async () => {
+      const builder = ctBuilder();
+      builder.verifyEqualityProof({
+        contextStateAccountAddress: eqCtxAddress,
+        contextStateAuthorityAddress: authorityAddress,
+        offset: 0,
+      });
+
+      const tx = await builder.build();
+      const rawIx = solTx(tx).instructions[0];
+      const data = rawIx.data;
+      data[0].should.equal(3);
+      data.readUInt32LE(1).should.equal(0); // offset as u32
+
+      // Context state accounts: [contextState(writable), authority]
+      rawIx.keys.should.have.length(2);
+      rawIx.keys[0].pubkey.toString().should.equal(eqCtxAddress);
+      rawIx.keys[0].isWritable.should.be.true();
+      rawIx.keys[1].pubkey.toString().should.equal(authorityAddress);
+    });
+  });
+
+  describe('VerifyValidityProof', () => {
+    it('should build with inline proof data', async () => {
+      const builder = ctBuilder();
+      builder.verifyValidityProof({ proofData: proofDataHex });
+
+      const tx = await builder.build();
+      const data = solTx(tx).instructions[0].data;
+      data[0].should.equal(12); // VerifyBatchedGroupedCiphertext3HandlesValidity
+      data.length.should.equal(1 + 320);
+    });
+  });
+
+  describe('VerifyRangeProof', () => {
+    it('should build with inline proof data', async () => {
+      const builder = ctBuilder();
+      builder.verifyRangeProof({ proofData: '00'.repeat(1000) }); // range proof is ~1000 bytes
+
+      const tx = await builder.build();
+      const data = solTx(tx).instructions[0].data;
+      data[0].should.equal(7); // VerifyBatchedRangeProofU128
+      data.length.should.equal(1 + 1000);
+    });
+  });
+
+  describe('Multiple instructions (v1 tx simulation)', () => {
+    it('should build ApplyPendingBalance + 3 proofs + Transfer in correct order', async () => {
+      const builder = ctBuilder();
+      builder
+        .applyPendingBalance({
+          tokenAddress,
+          authorityAddress,
+          expectedPendingBalanceCreditCounter: '2',
+          newDecryptableAvailableBalance: zeroBytes36,
+        })
+        .verifyEqualityProof({ proofData: proofDataHex })
+        .verifyValidityProof({ proofData: proofDataHex })
+        .verifyRangeProof({ proofData: '00'.repeat(1000) })
+        .confidentialTransfer({
+          sourceTokenAddress: tokenAddress,
+          mintAddress,
+          destinationTokenAddress,
+          authorityAddress,
+          newSourceDecryptableAvailableBalance: zeroBytes36,
+          transferAmountAuditorCiphertextLo: zeroBytes64,
+          transferAmountAuditorCiphertextHi: zeroBytes64,
+          equalityProofInstructionOffset: 1,
+          ciphertextValidityProofInstructionOffset: 2,
+          rangeProofInstructionOffset: 3,
+        });
+
+      const tx = await builder.build();
+      const instructions = tx.toJson().instructionsData;
+      instructions.should.have.length(5);
+      instructions[0].type.should.equal('ApplyPendingBalance');
+      instructions[1].type.should.equal('VerifyEqualityProof');
+      instructions[2].type.should.equal('VerifyValidityProof');
+      instructions[3].type.should.equal('VerifyRangeProof');
+      instructions[4].type.should.equal('ConfidentialTransfer');
+
+      // Note: Cannot verify toBroadcastFormat() here because 3 proofs (320+320+1000 bytes)
+      // + transfer (169B) exceeds v0 tx size limit (1232B). These are v1 transactions (4132B).
+      // The instruction data layouts are verified individually in the tests above.
+    });
+
+    it('should build ConfigureAccount + VerifyPubkeyValidity', async () => {
+      const builder = ctBuilder();
+      builder
+        .configureAccount({
+          tokenAddress,
+          mintAddress,
+          authorityAddress,
+          decryptableZeroBalance: zeroBytes36,
+          maximumPendingBalanceCreditCounter: '65536',
+          proofInstructionOffset: 1,
+        })
+        .verifyPubkeyValidity({ proofData: proofDataHex });
+
+      const tx = await builder.build();
+      const instructions = tx.toJson().instructionsData;
+      instructions.should.have.length(2);
+      instructions[0].type.should.equal('ConfigureConfidentialTransferAccount');
+      instructions[1].type.should.equal('VerifyPubkeyValidity');
+
+      const rawTx = tx.toBroadcastFormat();
+      Utils.isValidRawTransaction(rawTx).should.equal(true);
+    });
+  });
+
+  describe('Raw transaction validity', () => {
+    it('should produce a valid raw transaction', async () => {
+      const builder = ctBuilder();
+      builder.configureAccount({
+        tokenAddress,
+        mintAddress,
+        authorityAddress,
+        decryptableZeroBalance: zeroBytes36,
+        maximumPendingBalanceCreditCounter: '65536',
+        proofInstructionOffset: 1,
+      });
+
+      const tx = await builder.build();
+      const rawTx = tx.toBroadcastFormat();
+      Utils.isValidRawTransaction(rawTx).should.equal(true);
+    });
+  });
+
+  describe('Validation', () => {
+    it('should reject empty builder', async () => {
+      const builder = ctBuilder();
+      await builder.build().should.be.rejectedWith(/confidential transfer instruction/);
+    });
+
+    it('should reject missing tokenAddress on configureAccount', () => {
+      const builder = ctBuilder();
+      should.throws(() =>
+        builder.configureAccount({
+          tokenAddress: '',
+          mintAddress,
+          authorityAddress,
+          decryptableZeroBalance: zeroBytes36,
+          maximumPendingBalanceCreditCounter: '65536',
+          proofInstructionOffset: 1,
+        })
+      );
+    });
+  });
+
+  // ─── Fix-specific tests ────────────────────────────────────────────────────
+
+  describe('Fix #1: signed i8 proof instruction offsets', () => {
+    it('should correctly encode negative offset on ConfigureAccount', async () => {
+      const builder = ctBuilder();
+      builder.configureAccount({
+        tokenAddress,
+        mintAddress,
+        authorityAddress,
+        decryptableZeroBalance: zeroBytes36,
+        maximumPendingBalanceCreditCounter: '65536',
+        proofInstructionOffset: -1, // proof is the previous instruction
+      });
+
+      const tx = await builder.build();
+      const data = solTx(tx).instructions[0].data;
+      data[46].should.equal(255); // -1 as i8 = 255 as u8 (two's complement)
+    });
+
+    it('should correctly encode negative offset on Withdraw', async () => {
+      const builder = ctBuilder();
+      builder.confidentialWithdraw({
+        tokenAddress,
+        mintAddress,
+        authorityAddress,
+        equalityProofContextStateAddress: eqCtxAddress,
+        rangeProofContextStateAddress: rangeCtxAddress,
+        amount: '100',
+        decimals: 6,
+        newDecryptableAvailableBalance: zeroBytes36,
+        equalityProofInstructionOffset: -1,
+        rangeProofInstructionOffset: -2,
+      });
+
+      const tx = await builder.build();
+      const data = solTx(tx).instructions[0].data;
+      data[47].should.equal(255); // -1 as i8
+      data[48].should.equal(254); // -2 as i8
+    });
+
+    it('should correctly encode negative offsets on Transfer', async () => {
+      const builder = ctBuilder();
+      builder.confidentialTransfer({
+        sourceTokenAddress: tokenAddress,
+        mintAddress,
+        destinationTokenAddress,
+        authorityAddress,
+        equalityProofContextStateAddress: eqCtxAddress,
+        ciphertextValidityProofContextStateAddress: validityCtxAddress,
+        rangeProofContextStateAddress: rangeCtxAddress,
+        newSourceDecryptableAvailableBalance: zeroBytes36,
+        transferAmountAuditorCiphertextLo: zeroBytes64,
+        transferAmountAuditorCiphertextHi: zeroBytes64,
+        equalityProofInstructionOffset: -3,
+        ciphertextValidityProofInstructionOffset: -2,
+        rangeProofInstructionOffset: -1,
+      });
+
+      const tx = await builder.build();
+      const data = solTx(tx).instructions[0].data;
+      data[166].should.equal(253); // -3 as i8
+      data[167].should.equal(254); // -2 as i8
+      data[168].should.equal(255); // -1 as i8
+    });
+  });
+
+  describe('Fix #2: instruction order preservation in parser', () => {
+    it('should preserve interleaved CT and custom instruction order', async () => {
+      const builder = ctBuilder();
+      builder
+        .applyPendingBalance({
+          tokenAddress,
+          authorityAddress,
+          expectedPendingBalanceCreditCounter: '1',
+          newDecryptableAvailableBalance: zeroBytes36,
+        })
+        .verifyEqualityProof({ proofData: proofDataHex })
+        .confidentialTransfer({
+          sourceTokenAddress: tokenAddress,
+          mintAddress,
+          destinationTokenAddress,
+          authorityAddress,
+          equalityProofContextStateAddress: eqCtxAddress,
+          ciphertextValidityProofContextStateAddress: validityCtxAddress,
+          rangeProofContextStateAddress: rangeCtxAddress,
+          newSourceDecryptableAvailableBalance: zeroBytes36,
+          transferAmountAuditorCiphertextLo: zeroBytes64,
+          transferAmountAuditorCiphertextHi: zeroBytes64,
+          equalityProofInstructionOffset: 0,
+          ciphertextValidityProofInstructionOffset: 0,
+          rangeProofInstructionOffset: 0,
+        });
+
+      const tx = await builder.build();
+      const instructions = tx.toJson().instructionsData;
+      // Order should be: ApplyPendingBalance, VerifyEqualityProof, ConfidentialTransfer
+      instructions.should.have.length(3);
+      instructions[0].type.should.equal('ApplyPendingBalance');
+      instructions[1].type.should.equal('VerifyEqualityProof');
+      instructions[2].type.should.equal('ConfidentialTransfer');
+    });
+  });
+
+  describe('Fix #3: VerifyPubkeyValidity context state mode', () => {
+    it('should not throw when only context state accounts are provided (no proofData)', async () => {
+      const builder = ctBuilder();
+      builder.verifyPubkeyValidity({
+        contextStateAccountAddress: eqCtxAddress,
+        contextStateAuthorityAddress: authorityAddress,
+      });
+
+      const tx = await builder.build();
+      const rawIx = solTx(tx).instructions[0];
+      // Should produce an offset-based instruction, not throw
+      rawIx.data[0].should.equal(4);
+      rawIx.keys.should.have.length(2);
+    });
+  });
+
+  describe('Fix #4: context state address required when offset == 0', () => {
+    it('should reject Withdraw with offset 0 but missing equality context state address', async () => {
+      const builder = ctBuilder();
+      builder.confidentialWithdraw({
+        tokenAddress,
+        mintAddress,
+        authorityAddress,
+        rangeProofContextStateAddress: rangeCtxAddress,
+        amount: '100',
+        decimals: 6,
+        newDecryptableAvailableBalance: zeroBytes36,
+        equalityProofInstructionOffset: 0, // context state mode but no address
+        rangeProofInstructionOffset: 0,
+      });
+      await builder.build().should.be.rejectedWith(/equalityProofContextStateAddress is required/);
+    });
+
+    it('should reject Transfer with offset 0 but missing range context state address', async () => {
+      const builder = ctBuilder();
+      builder.confidentialTransfer({
+        sourceTokenAddress: tokenAddress,
+        mintAddress,
+        destinationTokenAddress,
+        authorityAddress,
+        equalityProofContextStateAddress: eqCtxAddress,
+        ciphertextValidityProofContextStateAddress: validityCtxAddress,
+        newSourceDecryptableAvailableBalance: zeroBytes36,
+        transferAmountAuditorCiphertextLo: zeroBytes64,
+        transferAmountAuditorCiphertextHi: zeroBytes64,
+        equalityProofInstructionOffset: 0,
+        ciphertextValidityProofInstructionOffset: 0,
+        rangeProofInstructionOffset: 0, // context state mode but no address
+      });
+      await builder.build().should.be.rejectedWith(/rangeProofContextStateAddress is required/);
+    });
+  });
+
+  describe('Fix #5: numeric string validation', () => {
+    it('should reject non-numeric amount on Deposit', async () => {
+      const builder = ctBuilder();
+      builder.confidentialDeposit({
+        tokenAddress,
+        mintAddress,
+        authorityAddress,
+        amount: 'abc',
+        decimals: 6,
+      });
+      await builder.build().should.be.rejectedWith(/Invalid amount: expected non-negative integer string/);
+    });
+
+    it('should reject negative amount on Deposit', async () => {
+      const builder = ctBuilder();
+      builder.confidentialDeposit({
+        tokenAddress,
+        mintAddress,
+        authorityAddress,
+        amount: '-100',
+        decimals: 6,
+      });
+      await builder.build().should.be.rejectedWith(/Invalid amount: expected non-negative integer string/);
+    });
+
+    it('should reject non-numeric counter on ApplyPendingBalance', async () => {
+      const builder = ctBuilder();
+      builder.applyPendingBalance({
+        tokenAddress,
+        authorityAddress,
+        expectedPendingBalanceCreditCounter: 'not-a-number',
+        newDecryptableAvailableBalance: zeroBytes36,
+      });
+      await builder.build().should.be.rejectedWith(/Invalid expectedPendingBalanceCreditCounter/);
+    });
+
+    it('should reject non-numeric counter on ConfigureAccount', async () => {
+      const builder = ctBuilder();
+      builder.configureAccount({
+        tokenAddress,
+        mintAddress,
+        authorityAddress,
+        decryptableZeroBalance: zeroBytes36,
+        maximumPendingBalanceCreditCounter: 'foo',
+        proofInstructionOffset: 1,
+      });
+      await builder.build().should.be.rejectedWith(/Invalid maximumPendingBalanceCreditCounter/);
+    });
+
+    it('should accept amount of 0 on Deposit', async () => {
+      const builder = ctBuilder();
+      builder.confidentialDeposit({
+        tokenAddress,
+        mintAddress,
+        authorityAddress,
+        amount: '0',
+        decimals: 6,
+      });
+
+      const tx = await builder.build();
+      const data = solTx(tx).instructions[0].data;
+      data.readBigUInt64LE(2).toString().should.equal('0');
+    });
+  });
+
+  describe('Fix #6: canonical ZK proof program ID', () => {
+    it('should use canonical zk-elgamal-proof program id', async () => {
+      const builder = ctBuilder();
+      builder.verifyEqualityProof({ proofData: proofDataHex });
+
+      const tx = await builder.build();
+      solTx(tx).instructions[0].programId.toString().should.equal('ZkE1Gama1Proof11111111111111111111111111111');
+    });
+
+    it('should allow overriding ZK proof program id', async () => {
+      const customProgramId = testData.associatedTokenAccounts.accounts[0].pub; // any valid pubkey
+      const builder = ctBuilder();
+      builder.zkProofProgramId(customProgramId);
+      builder.verifyEqualityProof({ proofData: proofDataHex });
+
+      const tx = await builder.build();
+      solTx(tx).instructions[0].programId.toString().should.equal(customProgramId);
+    });
+  });
+
+  describe('Fix #8: from() routing for CT transactions', () => {
+    it('should route CT transaction to ConfidentialTransferBuilder on from()', async () => {
+      // Build a CT transaction
+      const builder = ctBuilder();
+      builder.configureAccount({
+        tokenAddress,
+        mintAddress,
+        authorityAddress,
+        decryptableZeroBalance: zeroBytes36,
+        maximumPendingBalanceCreditCounter: '65536',
+        proofInstructionOffset: 1,
+      });
+
+      const tx = await builder.build();
+      const rawTx = tx.toBroadcastFormat();
+
+      // Parse it back via factory.from()
+      const parsedBuilder = factory.from(rawTx);
+      // Should be a ConfidentialTransferBuilder, not CustomInstructionBuilder
+      parsedBuilder.constructor.name.should.equal('ConfidentialTransferBuilder');
+    });
+
+    it('should route non-CT custom transaction to CustomInstructionBuilder on from()', async () => {
+      // Build a non-CT custom transaction
+      const customBuilder = factory.getCustomInstructionBuilder();
+      customBuilder.nonce(recentBlockHash);
+      customBuilder.sender(account.pub);
+      customBuilder.addCustomInstruction({
+        programId: 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr',
+        keys: [],
+        data: 'hello',
+      });
+
+      const tx = await customBuilder.build();
+      const rawTx = tx.toBroadcastFormat();
+
+      // Parse it back via factory.from()
+      const parsedBuilder = factory.from(rawTx);
+      parsedBuilder.constructor.name.should.equal('CustomInstructionBuilder');
+    });
+  });
+
+  describe('Fix #9: range validation for decimals and proof offsets', () => {
+    it('should reject decimals > 255 on Deposit', async () => {
+      const builder = ctBuilder();
+      builder.confidentialDeposit({
+        tokenAddress,
+        mintAddress,
+        authorityAddress,
+        amount: '100',
+        decimals: 256,
+      });
+      await builder.build().should.be.rejectedWith(/Invalid decimals: expected u8 \(0-255\)/);
+    });
+
+    it('should reject negative decimals on Deposit', async () => {
+      const builder = ctBuilder();
+      builder.confidentialDeposit({
+        tokenAddress,
+        mintAddress,
+        authorityAddress,
+        amount: '100',
+        decimals: -1,
+      });
+      await builder.build().should.be.rejectedWith(/Invalid decimals: expected u8 \(0-255\)/);
+    });
+
+    it('should reject non-integer decimals on Deposit', async () => {
+      const builder = ctBuilder();
+      builder.confidentialDeposit({
+        tokenAddress,
+        mintAddress,
+        authorityAddress,
+        amount: '100',
+        decimals: 6.5,
+      });
+      await builder.build().should.be.rejectedWith(/Invalid decimals: expected u8 \(0-255\)/);
+    });
+
+    it('should reject proof offset > 127 on ConfigureAccount', async () => {
+      const builder = ctBuilder();
+      builder.configureAccount({
+        tokenAddress,
+        mintAddress,
+        authorityAddress,
+        decryptableZeroBalance: zeroBytes36,
+        maximumPendingBalanceCreditCounter: '65536',
+        proofInstructionOffset: 128,
+      });
+      await builder.build().should.be.rejectedWith(/Invalid proofInstructionOffset: expected i8 \(-128 to 127\)/);
+    });
+
+    it('should reject proof offset < -128 on ConfigureAccount', async () => {
+      const builder = ctBuilder();
+      builder.configureAccount({
+        tokenAddress,
+        mintAddress,
+        authorityAddress,
+        decryptableZeroBalance: zeroBytes36,
+        maximumPendingBalanceCreditCounter: '65536',
+        proofInstructionOffset: -129,
+      });
+      await builder.build().should.be.rejectedWith(/Invalid proofInstructionOffset: expected i8 \(-128 to 127\)/);
+    });
+
+    it('should reject equality proof offset > 127 on Withdraw', async () => {
+      const builder = ctBuilder();
+      builder.confidentialWithdraw({
+        tokenAddress,
+        mintAddress,
+        authorityAddress,
+        equalityProofContextStateAddress: eqCtxAddress,
+        rangeProofContextStateAddress: rangeCtxAddress,
+        amount: '100',
+        decimals: 6,
+        newDecryptableAvailableBalance: zeroBytes36,
+        equalityProofInstructionOffset: 200,
+        rangeProofInstructionOffset: 0,
+      });
+      await builder.build().should.be.rejectedWith(/Invalid equalityProofInstructionOffset: expected i8/);
+    });
+
+    it('should reject range proof offset < -128 on Withdraw', async () => {
+      const builder = ctBuilder();
+      builder.confidentialWithdraw({
+        tokenAddress,
+        mintAddress,
+        authorityAddress,
+        equalityProofContextStateAddress: eqCtxAddress,
+        rangeProofContextStateAddress: rangeCtxAddress,
+        amount: '100',
+        decimals: 6,
+        newDecryptableAvailableBalance: zeroBytes36,
+        equalityProofInstructionOffset: 0,
+        rangeProofInstructionOffset: -200,
+      });
+      await builder.build().should.be.rejectedWith(/Invalid rangeProofInstructionOffset: expected i8/);
+    });
+
+    it('should reject validity proof offset out of i8 range on Transfer', async () => {
+      const builder = ctBuilder();
+      builder.confidentialTransfer({
+        sourceTokenAddress: tokenAddress,
+        mintAddress,
+        destinationTokenAddress,
+        authorityAddress,
+        equalityProofContextStateAddress: eqCtxAddress,
+        ciphertextValidityProofContextStateAddress: validityCtxAddress,
+        rangeProofContextStateAddress: rangeCtxAddress,
+        newSourceDecryptableAvailableBalance: zeroBytes36,
+        transferAmountAuditorCiphertextLo: zeroBytes64,
+        transferAmountAuditorCiphertextHi: zeroBytes64,
+        equalityProofInstructionOffset: 0,
+        ciphertextValidityProofInstructionOffset: 255,
+        rangeProofInstructionOffset: 0,
+      });
+      await builder.build().should.be.rejectedWith(/Invalid ciphertextValidityProofInstructionOffset: expected i8/);
+    });
+
+    it('should accept boundary offset values (-128 and 127)', async () => {
+      const builder = ctBuilder();
+      builder.configureAccount({
+        tokenAddress,
+        mintAddress,
+        authorityAddress,
+        decryptableZeroBalance: zeroBytes36,
+        maximumPendingBalanceCreditCounter: '65536',
+        proofInstructionOffset: 127,
+      });
+
+      const tx = await builder.build();
+      const data = solTx(tx).instructions[0].data;
+      data[46].should.equal(127);
+    });
+  });
+
+  describe('Fix #10: u64 overflow validation', () => {
+    it('should reject amount exceeding u64 max on Deposit', async () => {
+      const builder = ctBuilder();
+      builder.confidentialDeposit({
+        tokenAddress,
+        mintAddress,
+        authorityAddress,
+        amount: '18446744073709551616', // 2^64
+        decimals: 6,
+      });
+      await builder.build().should.be.rejectedWith(/Invalid amount: value exceeds u64 max/);
+    });
+
+    it('should accept amount at u64 max on Deposit', async () => {
+      const builder = ctBuilder();
+      builder.confidentialDeposit({
+        tokenAddress,
+        mintAddress,
+        authorityAddress,
+        amount: '18446744073709551615', // 2^64 - 1
+        decimals: 6,
+      });
+
+      const tx = await builder.build();
+      const data = solTx(tx).instructions[0].data;
+      data.readBigUInt64LE(2).toString().should.equal('18446744073709551615');
+    });
+
+    it('should reject counter exceeding u64 max on ConfigureAccount', async () => {
+      const builder = ctBuilder();
+      builder.configureAccount({
+        tokenAddress,
+        mintAddress,
+        authorityAddress,
+        decryptableZeroBalance: zeroBytes36,
+        maximumPendingBalanceCreditCounter: '18446744073709551616', // 2^64
+        proofInstructionOffset: 1,
+      });
+      await builder.build().should.be.rejectedWith(/Invalid maximumPendingBalanceCreditCounter: value exceeds u64 max/);
+    });
+  });
+});

--- a/modules/sdk-core/src/account-lib/baseCoin/enum.ts
+++ b/modules/sdk-core/src/account-lib/baseCoin/enum.ts
@@ -167,6 +167,8 @@ export enum TransactionType {
   UnwrapERC7984,
   // Finalize unwrap (unshield phase-2) via finalizeUnwrap(requestId, cleartextAmount, decryptionProof)
   FinalizeUnwrapERC7984,
+  // Solana Token-2022 confidential transfer (deposits, transfers, conversions)
+  ConfidentialTransfer,
 }
 
 /**


### PR DESCRIPTION
## Description

Adds Token-2022 confidential transfer (CT) transaction construction in \`sdk-coin-sol\` for Phase 1a (deposits + transfers + conversions, without TransferFee).

This PR replaces the earlier PR #9384 which was scoped to ConfidentialMint + proof-account tx group (Phase 2 / v0 obsolete). The new PR is Phase 1a-only, with all instruction layouts verified against the canonical Rust source (\`solana-program/token-2022\`).

### New instruction builders

| Instruction | Size | Layout |
|-------------|------|--------|
| ConfigureAccount | 47B | \`[27][2] + decryptable_zero_balance(36) + counter(u64) + proof_offset(i8)\` |
| ApplyPendingBalance | 46B | \`[27][8] + expected_counter(u64) + new_decryptable(36)\` |
| Deposit | 11B | \`[27][5] + amount(u64) + decimals(u8)\` |
| Withdraw | 49B | \`[27][6] + amount(u64) + decimals(u8) + new_decryptable(36) + eq_offset(i8) + range_offset(i8)\` |
| Transfer | 169B | \`[27][7] + new_decryptable(36) + auditor_ct_lo(64) + auditor_ct_hi(64) + eq_offset(i8) + validity_offset(i8) + range_offset(i8)\` |
| VerifyPubkeyValidity | 1+proof | \`[4] + proof_data\` |
| VerifyEquality | 1+proof | \`[3] + proof_data\` or \`[3] + offset(u32)\` |
| VerifyValidity3Handles | 1+proof | \`[12] + proof_data\` or \`[12] + offset(u32)\` |
| VerifyRangeU128 | 1+proof | \`[7] + proof_data\` or \`[7] + offset(i32)\` |

### Key design decisions

- **Instruction builders are v0/v1-agnostic** — they produce instruction data + account metas only. The caller (Wallet Platform) assembles v1 transactions in the correct order.
- **ConfigureAccount 47B layout is correct** — verified against canonical \`solana-program/token-2022\` Rust source. The old \`solana-program-library\` fork had \`encryption_pubkey\` (32B) embedded in instruction data, but the current on-chain version extracts the ElGamal pubkey from the \`VerifyPubkeyValidity\` proof via the instructions sysvar.
- **Phase 1b (TransferFee)** deferred to a separate PR — 1a covers 3-proof CT Transfer only (equality + validity + range U128).
- **CreateATA** already exists in \`sdk-coin-sol\` — reused, no new code needed.
- **ConfidentialMint + proof-account tx group** dropped (Phase 2 / v0 obsolete with v1-only decision).

## Issue Number

CHALO-1090

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

18 new unit tests covering:
- All instruction data layouts (byte-level verification of discriminators, field offsets, and sizes)
- Account metas (writable/signer flags, correct addresses)
- Context state vs inline proof modes (offset == 0 → context state, offset != 0 → sysvar)
- Multi-instruction v1 tx assembly (ApplyPendingBalance + 3 proofs + Transfer)
- Validation (empty builder rejects, missing params reject)

All 680 existing sdk-coin-sol unit tests continue to pass.

\`\`\`bash
cd modules/sdk-coin-sol
yarn mocha --grep "Confidential Transfer Builder" --timeout 30000  # 18 passing
yarn mocha --timeout 60000                                          # 680 passing
\`\`\`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code compiles correctly for both Node and Browser environments
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My commits follow Conventional Commits
- [x] The ticket was included in the commit message as a reference
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes