### PR TITLE
fix(sdk-core): allow encryptionVersion 1 for lightning wallets

### DIFF
--- a/modules/sdk-core/src/bitgo/wallet/iWallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallets.ts
@@ -287,8 +287,9 @@ export const GenerateLightningWalletOptionsCodec = t.intersection(
     }),
     t.partial({
       lightningProvider: t.union([t.literal('amboss'), t.literal('voltage')]),
-      // Codec intentionally accepts only 2: v1 is the implicit default and never sent on the wire.
-      encryptionVersion: t.literal(2),
+      // 1 is accepted during the v2-decrypt rollout window: some UI/SDK consumers can't
+      // decrypt v2 envelopes yet, so callers may still need to force v1 explicitly.
+      encryptionVersion: t.union([t.literal(1), t.literal(2)]),
     }),
   ],
   'GenerateLightningWalletOptions'

--- a/modules/sdk-core/test/unit/bitgo/wallet/walletOptionsCodecs.ts
+++ b/modules/sdk-core/test/unit/bitgo/wallet/walletOptionsCodecs.ts
@@ -35,6 +35,10 @@ describe('wallet options codecs with encryptionVersion', () => {
     assert.ok(isRight(GenerateLightningWalletOptionsCodec.decode(lightningBase)));
   });
 
+  it('GenerateLightningWalletOptionsCodec accepts encryptionVersion: 1 during the v2-decrypt rollout window', () => {
+    assert.ok(isRight(GenerateLightningWalletOptionsCodec.decode({ ...lightningBase, encryptionVersion: 1 })));
+  });
+
   it('GenerateGoAccountWalletOptionsCodec accepts encryptionVersion: 2', () => {
     assert.ok(isRight(GenerateGoAccountWalletOptionsCodec.decode({ ...goAccountBase, encryptionVersion: 2 })));
   });


### PR DESCRIPTION
Lightning wallet creation rejected explicit encryptionVersion: 1 even though it's still needed while some UI/SDK consumers can't decrypt v2 envelopes yet.

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
