### PR TITLE
feat(statics): enable ZAMA staking metadata (SI-609)

### DIFF
--- a/modules/statics/src/coins/botTokens.ts
+++ b/modules/statics/src/coins/botTokens.ts
@@ -460,6 +460,7 @@ export const botTokens = [
       'custody-bitgo-switzerland' as CoinFeature,
       'custody-bitgo-sister-trust-one' as CoinFeature,
       'custody-bitgo-korea' as CoinFeature,
+      CoinFeature.STAKING,
     ]),
     undefined,
     undefined,

--- a/modules/statics/test/unit/base.ts
+++ b/modules/statics/test/unit/base.ts
@@ -1,4 +1,4 @@
-import { CoinFamily, CoinFeature, coins } from '../../src';
+import { CoinFamily, CoinFeature, Networks, coins } from '../../src';
 
 const should = require('should');
 const { UnderlyingAsset } = require('../../src/base');
@@ -372,5 +372,43 @@ describe('Tokenized Equity CoinFeatures', function () {
     threw.should.be.true();
     errorType.should.equal('MissingRequiredCoinFeatureError');
     errorMessage.should.containEql('tokenized-equity');
+  });
+});
+describe('ZAMA staking feature', function () {
+  it('eth:zama should not expose STAKING', function () {
+    const coin = coins.get('eth:zama');
+    coin.features.includes(CoinFeature.STAKING).should.be.false();
+  });
+
+  it('hteth:zamamock should expose correct staking metadata', function () {
+    const coin = coins.get('hteth:zamamock');
+    coin.fullName.should.equal('ZAMAMock');
+    coin.decimalPlaces.should.equal(18);
+    coin.contractAddress.should.equal('0x58713eca04e01114480b30be8ca0d8838f342a55');
+    coin.network.name.should.equal(Networks.test.hoodi.name);
+    coin.features.should.containEql(CoinFeature.STAKING);
+  });
+
+  it('ERC-7984 ZAMA tokens should not expose STAKING', function () {
+    [
+      'eth:czama',
+      'eth:cxaut',
+      'eth:ctgbp',
+      'eth:cweth',
+      'eth:cusdt',
+      'eth:cusdc',
+      'hteth:ctest1',
+      'hteth:cusdt',
+    ].forEach((name) => {
+      coins.get(name).features.includes(CoinFeature.STAKING).should.be.false();
+    });
+  });
+
+  it('stZAMA LSTs should not expose STAKING', function () {
+    ['hteth:stzamakms', 'hteth:stzamadfns', 'hteth:stzamafig', 'hteth:stzamacop', 'hteth:stzamablco'].forEach(
+      (name) => {
+        coins.get(name).features.includes(CoinFeature.STAKING).should.be.false();
+      }
+    );
   });
 });


### PR DESCRIPTION
## Summary

Enable staking metadata for the ZAMA assets used as staking inputs.

## Changes

- Add `CoinFeature.STAKING` to the newly onboarded Hoodi `hteth:zamamock` entry (`ZAMAMock`, contract `0x58713eca04e01114480b30be8ca0d8838f342a55`).
- Keep the five onboarded `stZAMA` LST entries as receipt/share assets without `CoinFeature.STAKING`; their balances are already on-chain share balances.
- Keep ERC-7984 confidential ZAMA tokens excluded from staking.
- Add focused positive and negative statics tests.

The ZAMAMock test asserts the registered asset key, name, 18 decimals, Hoodi network, contract address, and staking feature. `CoinFeature.STAKING` is reserved for assets whose delegated underlying balance is fetched from staking-service. Staking-service reports delegated ZAMA, not operator-specific stZAMA shares.

## Test

- `yarn unit-test test/unit/base.ts --grep "ZAMA staking feature"` — 4 passing
- `yarn build` from `modules/statics` — passed
- Changed-file ESLint — passed

Ticket: SI-609