### PR TITLE
fix(root): bump browserslist to 4.28.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "react-router-dom": "6.30.4",
     "webpack": "5.107.2",
     "@babel/core": "^7.29.7",
-    "browserslist": "4.28.4",
+    "browserslist": "4.28.7",
     "enhanced-resolve": "5.24.1",
     "es-module-lexer": "2.1.0",
     "webpack/webpack-sources": "3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8392,15 +8392,15 @@ browserify@^14.4.0:
     vm-browserify "~0.0.1"
     xtend "^4.0.0"
 
-browserslist@4.28.4, browserslist@^4.21.4, browserslist@^4.24.0, browserslist@^4.24.4, browserslist@^4.25.3, browserslist@^4.28.1:
-  version "4.28.4"
-  resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz#dd8b8167a32845ff5f8cd6ce13f5abba16cd04c9"
-  integrity sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==
+browserslist@4.28.7, browserslist@^4.21.4, browserslist@^4.24.0, browserslist@^4.24.4, browserslist@^4.25.3, browserslist@^4.28.1:
+  version "4.28.7"
+  resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz#409046517fccd2e51cdc20f077454b7141184028"
+  integrity sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==
   dependencies:
-    baseline-browser-mapping "^2.10.38"
-    caniuse-lite "^1.0.30001799"
-    electron-to-chromium "^1.5.376"
-    node-releases "^2.0.48"
+    baseline-browser-mapping "^2.10.44"
+    caniuse-lite "^1.0.30001806"
+    electron-to-chromium "^1.5.393"
+    node-releases "^2.0.51"
     update-browserslist-db "^1.2.3"
 
 bs58@4.0.1, bs58@^4.0.0, bs58@^4.0.1:


### PR DESCRIPTION
## Summary

- bump the root Yarn resolution from `browserslist@4.28.4` to `4.28.7`
- update the matching `yarn.lock` entry
- clear `GHSA-73wf-gq98-2v4g` and `GHSA-c83g-rgw3-j3cx`, whose first patched version is `4.28.7`

## Sequencing

PR #9625 merged `rel/latest` into `master` as commit `aa714372915044a61c1d93ca9754d9502b686473`.

This feature branch is rebased directly onto that `master` commit. GitHub reports one feature commit and only the intended `package.json` and `yarn.lock` changes. The rebase changed only this feature branch; it did not rewrite `rel/latest` or any release tag.

Tracking: [WAL-2005](https://linear.app/bitgo/issue/WAL-2005/bitgojs-stable-release-2026-09-01)

## Verification

- `yarn install --frozen-lockfile --ignore-scripts` with Node `26.8.1` — passed after rebase
- `yarn check-deps` — passed after rebase
- `yarn why browserslist` — resolved `browserslist@4.28.7` after rebase
- OSV API query for `browserslist@4.28.7` — no advisories returned
- `git diff --check` — passed
- GitHub commit verification for `31d51e05f2442ead1605d2d0e9b892b9e4505b11` — valid signature

No `osv-scanner.toml` exclusion is added. This pull request does not authorize or dispatch a release workflow.
