### PR TITLE
feat: createBackup composes a derivable ed25519 root pub

### DIFF
--- a/modules/sdk-core/src/bitgo/keychain/keychains.ts
+++ b/modules/sdk-core/src/bitgo/keychain/keychains.ts
@@ -5,6 +5,11 @@ import * as common from '../../common';
 import { IBaseCoin, KeychainsTriplet, KeyPair } from '../baseCoin';
 import { BitGoBase } from '../bitgoBase';
 import { SafeMpcCeremonyUnsupportedError } from '../errors';
+import {
+  encodeDerivableEd25519Pub,
+  generateEd25519ChainCodeBase32,
+  isValidEd25519StrKeyPublicKey,
+} from '../safe/derivableEd25519Pub';
 import { decodeOrElse, ECDSAUtils, EDDSAUtils, generateRandomPassword, RequestTracer } from '../utils';
 import {
   AddKeychainOptions,
@@ -344,6 +349,19 @@ export class Keychains implements IKeychains {
           }),
         });
       }
+    }
+
+    // Wallet Safes v1 slot ④ (`ed25519Multisig`): make the backup root soft-derivable by folding a
+    // fresh chain code into `pub`. Nothing else on the wire changes — the chain code has no field of
+    // its own, and callers recover it with `decodeDerivableEd25519Pub` on the returned pub.
+    //
+    // The slot is identified from the generated pub itself: `safeId` marks it as a safe root, and a
+    // StrKey ed25519 pub narrows it to slot ④. That is exact — slot ① roots are secp256k1 (an xpub,
+    // which already carries its own chain code) and slots ②③ are MPC, which run through `createMpc`
+    // and never reach here.
+    const withKey = params as CreateBackupOptions & { pub?: string };
+    if (params.safeId !== undefined && withKey.pub !== undefined && isValidEd25519StrKeyPublicKey(withKey.pub)) {
+      withKey.pub = encodeDerivableEd25519Pub(withKey.pub, generateEd25519ChainCodeBase32());
     }
 
     const serverResponse = await this.add(params);

--- a/modules/sdk-core/src/bitgo/safe/derivableEd25519Pub.ts
+++ b/modules/sdk-core/src/bitgo/safe/derivableEd25519Pub.ts
@@ -11,15 +11,20 @@
  * new field — the same shape BitGo already uses for the MPC slots, whose `commonKeychain` is
  * `pub || chaincode`.
  *
- *   pub = <StrKey ed25519 public key> || <chainCode, 64 lowercase hex>
- *          exactly 56 chars, 'G…'         exactly 64 chars
- *   total length exactly 120
+ *   pub = <StrKey ed25519 public key> || <chainCode, 52 base32 chars>
+ *          exactly 56 chars, 'G…'         exactly 52 chars
+ *   total length exactly 108
+ *
+ * Both halves use the SAME encoding — RFC 4648 base32 over the alphabet StrKey itself uses — so the
+ * composite is one uniform string rather than a base32 pub with a hex tail bolted on.
  *
  * StrKey ed25519 public keys are always exactly 56 characters, so the split is a fixed offset. That
  * offset is a CROSS-REPO contract shared with wallet-platform, `modules/key-card` and WRW; four
  * independent implementations drifting produces unrecoverable wallets. Every call site — here and in
  * the other repos — MUST go through these helpers rather than slicing inline.
  */
+
+import { randomBytes } from 'crypto';
 
 /**
  * The fixed character offset at which a composite slot-④ pub splits into (StrKey pub, chain code).
@@ -32,19 +37,24 @@
  */
 export const DERIVABLE_ED25519_PUB_SPLIT_OFFSET = 56;
 
-/** Length of the hex-encoded chain code half (32 bytes). */
-export const DERIVABLE_ED25519_CHAIN_CODE_LENGTH = 64;
+/** Raw length of a chain code before encoding. */
+export const DERIVABLE_ED25519_CHAIN_CODE_BYTES = 32;
+
+/** Length of the base32-encoded chain code half: ceil(32 bytes * 8 / 5) = 52 characters. */
+export const DERIVABLE_ED25519_CHAIN_CODE_LENGTH = 52;
 
 /** Total length of a well-formed composite pub. */
 export const DERIVABLE_ED25519_PUB_LENGTH = DERIVABLE_ED25519_PUB_SPLIT_OFFSET + DERIVABLE_ED25519_CHAIN_CODE_LENGTH;
 
 /**
- * Chain codes are serialized as LOWERCASE hex only. Uppercase and mixed-case are rejected rather
- * than normalized: accepting both casings would make the composite pub non-canonical, so the same
- * key could be stored under two distinct strings and equality against a previously-persisted pub
- * would spuriously fail.
+ * Chain codes are serialized as unpadded RFC 4648 base32, the same encoding and alphabet StrKey
+ * uses, so the composite pub is base32 end to end.
+ *
+ * The alphabet is uppercase-only and lowercase is rejected rather than normalized: accepting both
+ * casings would make the composite non-canonical, so the same key could be stored under two
+ * distinct strings and equality against a previously-persisted pub would spuriously fail.
  */
-const CHAIN_CODE_REGEX = /^[0-9a-f]{64}$/;
+const CHAIN_CODE_REGEX = /^[A-Z2-7]{52}$/;
 
 /** StrKey version byte for an ed25519 public key (`G…`). */
 const STRKEY_VERSION_BYTE_ED25519_PUBLIC_KEY = 6 << 3;
@@ -56,12 +66,12 @@ const BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
 const STRKEY_ED25519_PUBLIC_KEY_REGEX = /^G[A-Z2-7]{55}$/;
 
 /**
- * Decode an unpadded RFC 4648 base32 string. The caller guarantees the input matched
- * {@link STRKEY_ED25519_PUBLIC_KEY_REGEX}, so 56 chars × 5 bits = 280 bits = exactly 35 bytes with
- * no leftover bits — the encoding is unambiguously canonical.
+ * Decode an unpadded RFC 4648 base32 string. Callers guarantee the input already matched one of the
+ * alphabet regexes below. Any bits left over past the last whole byte are dropped, so a decode alone
+ * does NOT prove the input was canonical — see {@link isValidEd25519ChainCode}, which re-encodes.
  */
 function base32Decode(input: string): Buffer {
-  const out = Buffer.alloc((input.length * 5) / 8);
+  const out = Buffer.alloc(Math.floor((input.length * 5) / 8));
   let bits = 0;
   let value = 0;
   let index = 0;
@@ -72,6 +82,25 @@ function base32Decode(input: string): Buffer {
       bits -= 8;
       out[index++] = (value >>> bits) & 0xff;
     }
+  }
+  return out;
+}
+
+/** Encode to unpadded RFC 4648 base32. Trailing bits of the final character are zero-filled. */
+function base32Encode(data: Buffer): string {
+  let bits = 0;
+  let value = 0;
+  let out = '';
+  for (const byte of data) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      bits -= 5;
+      out += BASE32_ALPHABET[(value >>> bits) & 0x1f];
+    }
+  }
+  if (bits > 0) {
+    out += BASE32_ALPHABET[(value << (5 - bits)) & 0x1f];
   }
   return out;
 }
@@ -108,9 +137,31 @@ export function isValidEd25519StrKeyPublicKey(pub: string): boolean {
   );
 }
 
-/** Returns true iff `chainCode` is exactly 64 lowercase hex characters. */
+/**
+ * Returns true iff `chainCode` is the canonical base32 encoding of exactly 32 bytes.
+ *
+ * The length check alone is not sufficient. 52 base32 characters carry 260 bits but a chain code is
+ * only 256, so the final character has 4 unused low bits — 16 distinct strings decode to the same 32
+ * bytes. Only the one whose trailing bits are zero is accepted, which the re-encode enforces. Were
+ * non-canonical spellings allowed, one key could be persisted under several different composite pubs
+ * and equality against a stored pub would spuriously fail.
+ */
 export function isValidEd25519ChainCode(chainCode: string): boolean {
-  return CHAIN_CODE_REGEX.test(chainCode);
+  if (!CHAIN_CODE_REGEX.test(chainCode)) {
+    return false;
+  }
+  return base32Encode(base32Decode(chainCode)) === chainCode;
+}
+
+/**
+ * Mint a fresh chain code for a derivable slot-④ root, base32-encoded.
+ *
+ * The chain code is independent randomness (TDD Part II-3 D1) — it is NOT derived from the seed, so
+ * it can be generated wherever the composite pub is assembled. Encoding 32 bytes always yields the
+ * canonical form, so the result satisfies {@link isValidEd25519ChainCode} by construction.
+ */
+export function generateEd25519ChainCodeBase32(): string {
+  return base32Encode(randomBytes(DERIVABLE_ED25519_CHAIN_CODE_BYTES));
 }
 
 /**
@@ -124,7 +175,7 @@ export function encodeDerivableEd25519Pub(pub: string, chainCode: string): strin
     throw new Error('Invalid derivable ed25519 pub: pub half is not a valid ed25519 public key');
   }
   if (!isValidEd25519ChainCode(chainCode)) {
-    throw new Error('Invalid derivable ed25519 pub: chainCode must be 64 lowercase hex characters');
+    throw new Error('Invalid derivable ed25519 pub: chainCode must be 52 canonical base32 characters');
   }
   return `${pub}${chainCode}`;
 }
@@ -148,7 +199,7 @@ export function decodeDerivableEd25519Pub(composite: string): { pub: string; cha
     throw new Error('Invalid derivable ed25519 pub: pub half is not a valid ed25519 public key');
   }
   if (!isValidEd25519ChainCode(chainCode)) {
-    throw new Error('Invalid derivable ed25519 pub: chainCode must be 64 lowercase hex characters');
+    throw new Error('Invalid derivable ed25519 pub: chainCode must be 52 canonical base32 characters');
   }
   return { pub, chainCode };
 }

--- a/modules/sdk-core/src/bitgo/safe/safes.ts
+++ b/modules/sdk-core/src/bitgo/safe/safes.ts
@@ -19,6 +19,7 @@ import { IBaseCoin } from '../baseCoin';
 import { BitGoBase } from '../bitgoBase';
 import { ApiResponseError } from '../errors';
 import { decodeWithCodec } from '../utils/codecs';
+import { DERIVABLE_ED25519_PUB_LENGTH } from './derivableEd25519Pub';
 import { postWithCodec } from '../utils/postWithCodec';
 import { FinalizeSafeOptions, InitializeSafeOptions } from './iSafe';
 import { CreateSafeOptions, GetSafeOptions, ISafes, ListSafesOptions, SafeCreationHandle, SafeKeys } from './iSafes';
@@ -258,6 +259,18 @@ export class Safes implements ISafes {
       backupKeychainPromise,
       bitgoKeychainPromise,
     ]);
+
+    // Tripwire. createBackup infers slot ④ from the shape of the pub it generates, so it composes
+    // silently or not at all. Here the slot is known explicitly, which makes this the one place the
+    // outcome can be checked without circularity: a root coin that stopped yielding StrKey pubs
+    // would otherwise mint non-derivable roots, and the symptom is unrecoverable wallets much later.
+    if (slot === 'ed25519Multisig' && backupKeychain.pub?.length !== DERIVABLE_ED25519_PUB_LENGTH) {
+      throw new Error(
+        `Safe ed25519Multisig backup root is not derivable: expected a ${DERIVABLE_ED25519_PUB_LENGTH}-character ` +
+          `composite pub, got ${backupKeychain.pub?.length ?? 0}.`
+      );
+    }
+
     return [userKeychain.id, backupKeychain.id, bitgoKeychain.id];
   }
 

--- a/modules/sdk-core/test/unit/bitgo/keychain/keychains.ts
+++ b/modules/sdk-core/test/unit/bitgo/keychain/keychains.ts
@@ -1,0 +1,131 @@
+import * as sinon from 'sinon';
+import 'should';
+import { Keychains, decodeDerivableEd25519Pub } from '../../../../src';
+
+/**
+ * Slot-④ root keys are generated as XLM keychains, so `create()` yields a 56-char StrKey pub.
+ * Taken from the cross-repo fixture pinned in WCN-2485.
+ */
+const STRKEY_PUB = 'GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYH';
+
+/** Marks the key as a safe root; combined with the pub's shape this identifies slot ④. */
+const SAFE_ID = 'safe-1';
+
+/** An xpub, as the secp256k1Multisig (slot ①) root coin generates. Already has a chain code. */
+const XPUB =
+  'xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8';
+
+describe('Keychains.createBackup', function () {
+  let keychains: Keychains;
+  let send: sinon.SinonStub;
+  let mockBitGo: any;
+
+  /** The body actually handed to `.send()` — i.e. what goes on the wire. */
+  function sentBody(): Record<string, unknown> {
+    return send.firstCall.args[0];
+  }
+
+  function buildKeychains(pub = STRKEY_PUB): Keychains {
+    const mockBaseCoin = {
+      url: sinon.stub().callsFake((path: string) => path),
+      generateKeyPair: sinon.stub().returns({ pub, prv: 'SOME_SEED' }),
+    };
+    return new Keychains(mockBitGo, mockBaseCoin as any);
+  }
+
+  beforeEach(function () {
+    send = sinon.stub().returns({ result: sinon.stub().resolves({ id: 'backup-key-id' }) });
+    mockBitGo = {
+      post: sinon.stub().returns({ send }),
+      encrypt: sinon.stub().resolves('encrypted-prv'),
+      setRequestTracer: sinon.stub(),
+    };
+    keychains = buildKeychains();
+  });
+
+  describe('safe ed25519Multisig root (slot ④)', function () {
+    it('posts a 108-char composite pub built from the generated key', async function () {
+      await keychains.createBackup({ passphrase: 'pw', safeId: SAFE_ID });
+
+      const pub = sentBody().pub as string;
+      pub.length.should.equal(108);
+      decodeDerivableEd25519Pub(pub).pub.should.equal(STRKEY_PUB);
+    });
+
+    it('mints a chain code that round-trips out of the pub', async function () {
+      await keychains.createBackup({ passphrase: 'pw', safeId: SAFE_ID });
+
+      // The chain code has no field of its own; this decode is how callers (e.g. the keycard's
+      // box B) recover it.
+      const { chainCode } = decodeDerivableEd25519Pub(sentBody().pub as string);
+      chainCode.should.match(/^[A-Z2-7]{52}$/);
+    });
+
+    it('mints a different chain code for each backup key', async function () {
+      await keychains.createBackup({ passphrase: 'pw', safeId: SAFE_ID });
+      await keychains.createBackup({ passphrase: 'pw', safeId: SAFE_ID });
+
+      const first = decodeDerivableEd25519Pub(send.firstCall.args[0].pub).chainCode;
+      const second = decodeDerivableEd25519Pub(send.secondCall.args[0].pub).chainCode;
+      first.should.not.equal(second);
+    });
+
+    it('sends no chainCode field of its own', async function () {
+      await keychains.createBackup({ passphrase: 'pw', safeId: SAFE_ID });
+
+      sentBody().should.not.have.property('chainCode');
+    });
+
+    it('still encrypts and returns the un-composed prv', async function () {
+      const result = await keychains.createBackup({ passphrase: 'pw', safeId: SAFE_ID });
+
+      sentBody().encryptedPrv!.should.equal('encrypted-prv');
+      result.prv!.should.equal('SOME_SEED');
+    });
+  });
+
+  describe('leaves every other key untouched', function () {
+    it('does not compose without a safeId, even for an ed25519 coin', async function () {
+      await keychains.createBackup({ passphrase: 'pw' });
+
+      const body = sentBody();
+      body.pub!.should.equal(STRKEY_PUB);
+      (body.pub as string).length.should.equal(56);
+    });
+
+    it('does not compose a safe secp256k1Multisig root (slot ①)', async function () {
+      // An xpub already carries its own chain code; composing onto it would corrupt the pub.
+      const btcKeychains = buildKeychains(XPUB);
+
+      await btcKeychains.createBackup({ passphrase: 'pw', safeId: SAFE_ID });
+
+      sentBody().pub!.should.equal(XPUB);
+    });
+
+    it('sends a body with no chainCode and source backup', async function () {
+      await keychains.createBackup({ passphrase: 'pw' });
+
+      const body = sentBody();
+      body.should.not.have.property('chainCode');
+      body.source!.should.equal('backup');
+      body.encryptedPrv!.should.equal('encrypted-prv');
+    });
+
+    it('leaves a TSS backup key untouched', async function () {
+      // No local keypair is generated on the TSS path, so there is no pub to inspect or compose.
+      await keychains.createBackup({ prv: 'tss-prv', commonKeychain: 'common-keychain', safeId: SAFE_ID });
+
+      const body = sentBody();
+      body.commonKeychain!.should.equal('common-keychain');
+      (body.pub === undefined).should.be.true();
+    });
+
+    it('leaves a KRS-provider backup key untouched', async function () {
+      await keychains.createBackup({ provider: 'krs-provider', safeId: SAFE_ID });
+
+      const body = sentBody();
+      (body.pub === undefined).should.be.true();
+      body.provider!.should.equal('krs-provider');
+    });
+  });
+});

--- a/modules/sdk-core/test/unit/bitgo/safe/derivableEd25519Pub.ts
+++ b/modules/sdk-core/test/unit/bitgo/safe/derivableEd25519Pub.ts
@@ -8,6 +8,7 @@ import {
   isDerivableEd25519Pub,
   isValidEd25519ChainCode,
   isValidEd25519StrKeyPublicKey,
+  generateEd25519ChainCodeBase32,
 } from '../../../../src';
 
 // Cross-repo fixture: byte-identical to
@@ -69,17 +70,35 @@ describe('derivableEd25519Pub', function () {
   describe('isValidEd25519ChainCode', function () {
     const { chainCode } = fixture.valid[3];
 
-    it('accepts 64 lowercase hex characters', function () {
+    it('accepts 52 canonical base32 characters', function () {
       isValidEd25519ChainCode(chainCode).should.equal(true);
     });
 
-    it('rejects uppercase hex', function () {
-      isValidEd25519ChainCode(chainCode.toUpperCase()).should.equal(false);
+    it('rejects lowercase', function () {
+      isValidEd25519ChainCode(chainCode.toLowerCase()).should.equal(false);
     });
 
     it('rejects a chain code of the wrong length', function () {
-      isValidEd25519ChainCode(chainCode.slice(0, 63)).should.equal(false);
-      isValidEd25519ChainCode(chainCode + '0').should.equal(false);
+      isValidEd25519ChainCode(chainCode.slice(0, 51)).should.equal(false);
+      isValidEd25519ChainCode(chainCode + 'A').should.equal(false);
+    });
+
+    it('rejects a character outside the base32 alphabet', function () {
+      // 0, 1, 8 and 9 are absent from the RFC 4648 alphabet.
+      isValidEd25519ChainCode('0' + chainCode.slice(1)).should.equal(false);
+    });
+
+    it('rejects a non-canonical spelling whose padding bits are set', function () {
+      // The 52nd character holds 1 significant bit and 4 padding bits, so 16 strings decode to the
+      // same 32 bytes. Only the zero-padded one is the chain code.
+      const BASE32 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+      const bumped = chainCode.slice(0, 51) + BASE32[BASE32.indexOf(chainCode[51]) + 1];
+      bumped.should.not.equal(chainCode);
+      isValidEd25519ChainCode(bumped).should.equal(false);
+    });
+
+    it('accepts what the generator mints', function () {
+      isValidEd25519ChainCode(generateEd25519ChainCodeBase32()).should.equal(true);
     });
   });
 

--- a/modules/sdk-core/test/unit/bitgo/safe/fixtures/derivableEd25519Pub.json
+++ b/modules/sdk-core/test/unit/bitgo/safe/fixtures/derivableEd25519Pub.json
@@ -1,145 +1,197 @@
 {
-  "$comment": "Shared cross-repo fixture for the derivable slot-4 (ed25519Multisig) root pub format: composite = <56-char Stellar StrKey ed25519 public key> || <64 lowercase hex chain code>. Plain JSON with no repo-specific imports so wallet-platform, BitGoJS sdk-core, BitGoJS modules/key-card and WRW can all consume this identical file. Append new vectors rather than editing existing ones in place.",
+  "$comment": "Shared cross-repo fixture for the derivable slot-4 (ed25519Multisig) root pub format: composite = <56-char Stellar StrKey ed25519 public key> || <52-char base32 chain code>. BASE32 END TO END: both halves use RFC 4648 unpadded base32 over the alphabet StrKey itself uses, so the composite is one uniform string. A chain code is 32 bytes = 52 base32 characters, whose final character carries 1 significant bit and 4 zero padding bits, so 16 spellings decode to the same bytes and only the zero-padded one is valid — validators must re-encode, not just match the alphabet. Plain JSON with no repo-specific imports so wallet-platform, BitGoJS sdk-core, BitGoJS modules/key-card and WRW can all consume this identical file. Append new vectors rather than editing existing ones in place.",
+  "$detectedBy": "Which check rejects an invalid vector. format = the coin-agnostic codec (length, StrKey shape, canonical base32 chain code) rejects it, so encode/decode catch it. coin = the codec accepts it and only the coin-aware gate (StrKey checksum via coin.isValidPub) rejects it; an implementation without a coin instance MUST NOT be expected to catch these. An implementation whose codec verifies the StrKey checksum itself (e.g. BitGoJS sdk-core) rejects the coin vectors too — detectedBy is a floor, not a ceiling.",
   "splitOffset": 56,
-  "chainCodeLength": 64,
-  "compositeLength": 120,
+  "chainCodeLength": 52,
+  "compositeLength": 108,
   "valid": [
     {
       "name": "all-zero pub with all-zero chain code",
       "pub": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
-      "chainCode": "0000000000000000000000000000000000000000000000000000000000000000",
-      "composite": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF0000000000000000000000000000000000000000000000000000000000000000"
+      "chainCode": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "composite": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
     },
     {
-      "name": "all-ones pub with all-f chain code",
+      "name": "all-ones pub with all-ones chain code",
       "pub": "GD7777777777777777777777777777777777777777777777777773DB",
-      "chainCode": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "composite": "GD7777777777777777777777777777777777777777777777777773DBffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+      "chainCode": "777777777777777777777777777777777777777777777777777Q",
+      "composite": "GD7777777777777777777777777777777777777777777777777773DB777777777777777777777777777777777777777777777777777Q"
     },
     {
-      "name": "low-order pub with a leading-zero chain code",
+      "name": "low-order pub with a near-zero chain code",
       "pub": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC6PV",
-      "chainCode": "0000000000000000000000000000000000000000000000000000000000000001",
-      "composite": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC6PV0000000000000000000000000000000000000000000000000000000000000001"
+      "chainCode": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQ",
+      "composite": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC6PVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQ"
     },
     {
       "name": "typical pub with a mixed alphanumeric chain code",
       "pub": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYH",
-      "chainCode": "9a0f3c7d1e5b28460af3d92c6e81b7053fa4c2e98d17b60543a2fc8e19d7b046",
-      "composite": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYH9a0f3c7d1e5b28460af3d92c6e81b7053fa4c2e98d17b60543a2fc8e19d7b046"
+      "chainCode": "TIHTY7I6LMUEMCXT3EWG5ANXAU72JQXJRUL3MBKDUL6I4GOXWBDA",
+      "composite": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYHTIHTY7I6LMUEMCXT3EWG5ANXAU72JQXJRUL3MBKDUL6I4GOXWBDA"
     },
     {
-      "name": "typical pub with an all-digit chain code",
+      "name": "typical pub with a repeating chain code",
       "pub": "GDD7GGYPJUX3BNVA6OPIXUFXYOY2FVHF6YDRQKJ2JNOG27UPSAJDJCMV",
-      "chainCode": "1234567890123456789012345678901234567890123456789012345678901234",
-      "composite": "GDD7GGYPJUX3BNVA6OPIXUFXYOY2FVHF6YDRQKJ2JNOG27UPSAJDJCMV1234567890123456789012345678901234567890123456789012345678901234"
+      "chainCode": "CI2FM6EQCI2FM6EQCI2FM6EQCI2FM6EQCI2FM6EQCI2FM6EQCI2A",
+      "composite": "GDD7GGYPJUX3BNVA6OPIXUFXYOY2FVHF6YDRQKJ2JNOG27UPSAJDJCMVCI2FM6EQCI2FM6EQCI2FM6EQCI2FM6EQCI2FM6EQCI2FM6EQCI2A"
     }
   ],
   "invalidComposite": [
     {
       "name": "empty string",
       "composite": "",
-      "reason": "length"
+      "reason": "length",
+      "detectedBy": "format"
     },
     {
       "name": "bare 56-char pub with no chain code",
       "composite": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYH",
-      "reason": "length"
+      "reason": "length",
+      "detectedBy": "format"
     },
     {
       "name": "bare chain code with no pub",
-      "composite": "9a0f3c7d1e5b28460af3d92c6e81b7053fa4c2e98d17b60543a2fc8e19d7b046",
-      "reason": "length"
-    },
-    {
-      "name": "uppercase hex chain code",
-      "composite": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYH9A0F3C7D1E5B28460AF3D92C6E81B7053FA4C2E98D17B60543A2FC8E19D7B046",
-      "reason": "chainCode"
-    },
-    {
-      "name": "mixed-case hex chain code",
-      "composite": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYH9A0f3c7d1e5b28460af3d92c6e81b7053fa4c2e98d17b60543a2fc8e19d7b046",
-      "reason": "chainCode"
-    },
-    {
-      "name": "non-hex character in chain code",
-      "composite": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYHga0f3c7d1e5b28460af3d92c6e81b7053fa4c2e98d17b60543a2fc8e19d7b046",
-      "reason": "chainCode"
+      "composite": "TIHTY7I6LMUEMCXT3EWG5ANXAU72JQXJRUL3MBKDUL6I4GOXWBDA",
+      "reason": "length",
+      "detectedBy": "format"
     },
     {
       "name": "chain code one character short",
-      "composite": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYH9a0f3c7d1e5b28460af3d92c6e81b7053fa4c2e98d17b60543a2fc8e19d7b04",
-      "reason": "length"
+      "composite": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYHTIHTY7I6LMUEMCXT3EWG5ANXAU72JQXJRUL3MBKDUL6I4GOXWBD",
+      "reason": "length",
+      "detectedBy": "format"
     },
     {
       "name": "chain code one character long",
-      "composite": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYH9a0f3c7d1e5b28460af3d92c6e81b7053fa4c2e98d17b60543a2fc8e19d7b0460",
-      "reason": "length"
+      "composite": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYHTIHTY7I6LMUEMCXT3EWG5ANXAU72JQXJRUL3MBKDUL6I4GOXWBDAA",
+      "reason": "length",
+      "detectedBy": "format"
     },
     {
-      "name": "pub half is not a valid StrKey (bad checksum)",
-      "composite": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYA9a0f3c7d1e5b28460af3d92c6e81b7053fa4c2e98d17b60543a2fc8e19d7b046",
-      "reason": "pub"
+      "name": "lowercase chain code",
+      "composite": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYHtihty7i6lmuemcxt3ewg5anxau72jqxjrul3mbkdul6i4goxwbda",
+      "reason": "chainCode",
+      "detectedBy": "format"
+    },
+    {
+      "name": "mixed-case chain code",
+      "composite": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYHTihty7i6lmuemcxt3ewg5anxau72jqxjrul3mbkdul6i4goxwbda",
+      "reason": "chainCode",
+      "detectedBy": "format"
+    },
+    {
+      "name": "chain code with a character outside the base32 alphabet",
+      "composite": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYH0IHTY7I6LMUEMCXT3EWG5ANXAU72JQXJRUL3MBKDUL6I4GOXWBDA",
+      "reason": "chainCode",
+      "detectedBy": "format"
+    },
+    {
+      "name": "non-canonical chain code with padding bits set",
+      "composite": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYHTIHTY7I6LMUEMCXT3EWG5ANXAU72JQXJRUL3MBKDUL6I4GOXWBDB",
+      "reason": "chainCode",
+      "detectedBy": "format"
     },
     {
       "name": "pub half is a secret seed (S...) not a public key",
-      "composite": "SA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYH9a0f3c7d1e5b28460af3d92c6e81b7053fa4c2e98d17b60543a2fc8e19d7b046",
-      "reason": "pub"
+      "composite": "SA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYHTIHTY7I6LMUEMCXT3EWG5ANXAU72JQXJRUL3MBKDUL6I4GOXWBDA",
+      "reason": "pub",
+      "detectedBy": "format"
+    },
+    {
+      "name": "pub half contains a lowercase character",
+      "composite": "Ga5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYHTIHTY7I6LMUEMCXT3EWG5ANXAU72JQXJRUL3MBKDUL6I4GOXWBDA",
+      "reason": "pub",
+      "detectedBy": "format"
+    },
+    {
+      "name": "pub half contains 0 and 1, which are not in the base32 alphabet",
+      "composite": "G01WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYHTIHTY7I6LMUEMCXT3EWG5ANXAU72JQXJRUL3MBKDUL6I4GOXWBDA",
+      "reason": "pub",
+      "detectedBy": "format"
     },
     {
       "name": "halves swapped",
-      "composite": "9a0f3c7d1e5b28460af3d92c6e81b7053fa4c2e98d17b60543a2fc8eGA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYH19d7b046",
-      "reason": "pub"
+      "composite": "TIHTY7I6LMUEMCXT3EWG5ANXAU72JQXJRUL3MBKDUL6I4GOXWBDAGA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYH",
+      "reason": "pub",
+      "detectedBy": "format"
+    },
+    {
+      "name": "pub half has a bad StrKey checksum",
+      "composite": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYATIHTY7I6LMUEMCXT3EWG5ANXAU72JQXJRUL3MBKDUL6I4GOXWBDA",
+      "reason": "pub",
+      "detectedBy": "coin"
     }
   ],
   "invalidEncodeInputs": [
     {
       "name": "empty pub",
       "pub": "",
-      "chainCode": "9a0f3c7d1e5b28460af3d92c6e81b7053fa4c2e98d17b60543a2fc8e19d7b046",
-      "reason": "pub"
-    },
-    {
-      "name": "pub with bad StrKey checksum",
-      "pub": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYA",
-      "chainCode": "9a0f3c7d1e5b28460af3d92c6e81b7053fa4c2e98d17b60543a2fc8e19d7b046",
-      "reason": "pub"
+      "chainCode": "TIHTY7I6LMUEMCXT3EWG5ANXAU72JQXJRUL3MBKDUL6I4GOXWBDA",
+      "reason": "pub",
+      "detectedBy": "format"
     },
     {
       "name": "composite passed as the pub half",
-      "pub": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYH9a0f3c7d1e5b28460af3d92c6e81b7053fa4c2e98d17b60543a2fc8e19d7b046",
-      "chainCode": "9a0f3c7d1e5b28460af3d92c6e81b7053fa4c2e98d17b60543a2fc8e19d7b046",
-      "reason": "pub"
+      "pub": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYHTIHTY7I6LMUEMCXT3EWG5ANXAU72JQXJRUL3MBKDUL6I4GOXWBDA",
+      "chainCode": "TIHTY7I6LMUEMCXT3EWG5ANXAU72JQXJRUL3MBKDUL6I4GOXWBDA",
+      "reason": "pub",
+      "detectedBy": "format"
+    },
+    {
+      "name": "pub half is a secret seed (S...)",
+      "pub": "SA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYH",
+      "chainCode": "TIHTY7I6LMUEMCXT3EWG5ANXAU72JQXJRUL3MBKDUL6I4GOXWBDA",
+      "reason": "pub",
+      "detectedBy": "format"
     },
     {
       "name": "empty chain code",
       "pub": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYH",
       "chainCode": "",
-      "reason": "chainCode"
+      "reason": "chainCode",
+      "detectedBy": "format"
     },
     {
-      "name": "uppercase hex chain code",
+      "name": "lowercase chain code",
       "pub": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYH",
-      "chainCode": "9A0F3C7D1E5B28460AF3D92C6E81B7053FA4C2E98D17B60543A2FC8E19D7B046",
-      "reason": "chainCode"
+      "chainCode": "tihty7i6lmuemcxt3ewg5anxau72jqxjrul3mbkdul6i4goxwbda",
+      "reason": "chainCode",
+      "detectedBy": "format"
     },
     {
       "name": "chain code with 0x prefix",
       "pub": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYH",
-      "chainCode": "0x0f3c7d1e5b28460af3d92c6e81b7053fa4c2e98d17b60543a2fc8e19d7b046",
-      "reason": "chainCode"
+      "chainCode": "0xHTY7I6LMUEMCXT3EWG5ANXAU72JQXJRUL3MBKDUL6I4GOXWBDA",
+      "reason": "chainCode",
+      "detectedBy": "format"
+    },
+    {
+      "name": "non-canonical chain code with padding bits set",
+      "pub": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYH",
+      "chainCode": "TIHTY7I6LMUEMCXT3EWG5ANXAU72JQXJRUL3MBKDUL6I4GOXWBDB",
+      "reason": "chainCode",
+      "detectedBy": "format"
     },
     {
       "name": "chain code too short",
       "pub": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYH",
-      "chainCode": "9a0f3c7d1e5b28460af3d92c6e81b7053fa4c2e98d17b60543a2fc8e19d7b04",
-      "reason": "chainCode"
+      "chainCode": "TIHTY7I6LMUEMCXT3EWG5ANXAU72JQXJRUL3MBKDUL6I4GOXWBD",
+      "reason": "chainCode",
+      "detectedBy": "format"
     },
     {
       "name": "chain code too long",
       "pub": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYH",
-      "chainCode": "9a0f3c7d1e5b28460af3d92c6e81b7053fa4c2e98d17b60543a2fc8e19d7b0460",
-      "reason": "chainCode"
+      "chainCode": "TIHTY7I6LMUEMCXT3EWG5ANXAU72JQXJRUL3MBKDUL6I4GOXWBDAA",
+      "reason": "chainCode",
+      "detectedBy": "format"
+    },
+    {
+      "name": "pub with a bad StrKey checksum",
+      "pub": "GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYA",
+      "chainCode": "TIHTY7I6LMUEMCXT3EWG5ANXAU72JQXJRUL3MBKDUL6I4GOXWBDA",
+      "reason": "pub",
+      "detectedBy": "coin"
     }
   ]
 }

--- a/modules/sdk-core/test/unit/bitgo/safe/safes.ts
+++ b/modules/sdk-core/test/unit/bitgo/safe/safes.ts
@@ -3,6 +3,10 @@ import 'should';
 import { InitializeSafeResponse } from '@bitgo/public-types';
 import { Enterprise, Safe, SafeKeys, Safes } from '../../../../src';
 
+/** A derivable slot-④ backup root pub: 56-char StrKey || 52-char base32 chain code. */
+const COMPOSITE_BACKUP_PUB =
+  'GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYH' + 'TIHTY7I6LMUEMCXT3EWG5ANXAU72JQXJRUL3MBKDUL6I4GOXWBDA';
+
 describe('Safes', function () {
   let safes: Safes;
   let mockBitGo: any;
@@ -67,7 +71,12 @@ describe('Safes', function () {
       return {
         create: sinon.stub().returns({ pub: `${coin}-pub`, prv: `${coin}-prv` }),
         add: sinon.stub().resolves({ id: `${coin}-user` }),
-        createBackup: sinon.stub().resolves({ id: `${coin}-backup` }),
+        // txlm is the ed25519Multisig root coin, so its backup pub comes back composite —
+        // createMultisigRoot asserts that before returning the triplet.
+        createBackup: sinon.stub().resolves({
+          id: `${coin}-backup`,
+          ...(coin === 'txlm' || coin === 'xlm' ? { pub: COMPOSITE_BACKUP_PUB } : {}),
+        }),
         createBitGo: sinon.stub().resolves({ id: `${coin}-bitgo` }),
         createMpc: sinon.stub().resolves({
           userKeychain: { id: `${coin}-user` },
@@ -102,6 +111,29 @@ describe('Safes', function () {
           },
         },
       });
+    });
+
+    it('rejects an ed25519Multisig backup root that came back non-derivable', async function () {
+      // createBackup infers slot ④ from the generated pub's shape; if that inference ever misses,
+      // the root is silently non-derivable and the wallets minted from it are unrecoverable.
+      keychainsByCoin['txlm'] = makeKeychains('txlm');
+      // A bare 56-char StrKey: the pub createBackup would post if it failed to recognise slot ④.
+      keychainsByCoin['txlm'].createBackup.resolves({
+        id: 'txlm-backup',
+        pub: 'GA5WUJ54Z23KILLCUOUNAKTPBVZWKMQVO4O6EQ5GHLAERIMLLHNCSKYH',
+      });
+
+      await safes
+        .createSafeKeys({ label: 'my safe', passphrase: 'pw', safeId: 'safe-1' })
+        .should.be.rejectedWith(/ed25519Multisig backup root is not derivable/);
+    });
+
+    it('does not apply the derivable check to the secp256k1Multisig slot', async function () {
+      // Slot ① backup roots are xpubs, which already carry a chain code and are never composed.
+      keychainsByCoin['tbtc'] = makeKeychains('tbtc');
+      keychainsByCoin['tbtc'].createBackup.resolves({ id: 'tbtc-backup' });
+
+      await safes.createSafeKeys({ label: 'my safe', passphrase: 'pw', safeId: 'safe-1' }).should.be.fulfilled();
     });
 
     it('tags every multisig key registration with safeId and the correct source', async function () {


### PR DESCRIPTION
[WCN-2485](https://linear.app/bitgo/issue/WCN-2485) · [WCN-2488](https://linear.app/bitgo/issue/WCN-2488) · [WCN-2489](https://linear.app/bitgo/issue/WCN-2489) — TDD Part II-3 §1.3, §2.1, §2.2

Three commits, one per ticket.

## 1. `fix:` chain code is base32, not hex (WCN-2485)

The format merged in #9592 concatenated a base32 StrKey with a hex chain code. Two encodings in one string with no marker between them is arbitrary — you cannot tell from the value where one alphabet stops and the other starts. The chain code half is now base32 too, over the same RFC 4648 alphabet StrKey already uses:

```
pub = <56-char StrKey 'G…'> || <52-char base32 chainCode>     // 108 total
```

Split offset unchanged at 56. The pub half stays an untouched StrKey, so a legacy non-derivable pub is still a clean prefix and `coin.isValidPub` still accepts it. Re-encoding the whole payload as one blob would have satisfied "all base32" too, but breaks both of those.

**The one trap this introduces.** 52 base32 characters carry 260 bits for a 256-bit value, so the final character has 4 unused low bits and **16 spellings decode to the same chain code**. Hex had no slack; base32 does. Only the zero-padded spelling is valid, and `isValidEd25519ChainCode` enforces it by re-encoding — `/^[A-Z2-7]{52}$/` passes all 16, and a validator stopping there would let one key be persisted under 16 distinct pubs. The fixture pins an explicit non-canonical vector.

Two vectors worth a look: the all-ones chain code ends in `Q`, not `7`, and all-zero ends in `A`.

## 2. `feat:` createBackup composes (WCN-2488)

`createBackup` generates the keypair internally, so it mints the chain code at the point of composition and folds it into `pub`.

**No new option, no new wire field.** `CreateBackupOptions` has a zero diff; callers recover the chain code with `decodeDerivableEd25519Pub(keychain.pub)`, which is what the keycard (WCN-2490) needs for box B. An explicit parameter would be a value that can disagree with the pub it is folded into, and would let a caller pass a reused or weak chain code.

The slot is read off the generated pub: `safeId` says safe root, StrKey ed25519 pub says slot ④. Exact — slot ① roots are xpubs, which already carry a chain code, and slots ②③ are MPC, which go through `createMpc` and never reach here. Every other backup key is untouched, including the TSS and KRS-provider paths, which generate no local keypair to compose onto.

Note `add()` builds an explicit field allowlist that has never included `chainCode`, so the wire is protected independently.

## 3. `feat:` post-condition assert (WCN-2489)

`createBackup` infers the slot from the pub's shape, so it composes silently or not at all. `createMultisigRoot` takes `slot` as an explicit parameter, making it the one place the outcome can be checked without circularity — inside `createBackup` the pub's shape *is* the slot signal, so a check there would only re-assert what the branch already decided.

Without it, a root coin that stopped yielding StrKey pubs would mint non-derivable roots silently, and the symptom is unrecoverable wallets much later. The chain code cannot be retrofitted.

## Shared fixture

`test/unit/bitgo/safe/fixtures/derivableEd25519Pub.json` is **byte-identical** to the wallet-platform copy — verified, before and after prettier. I regenerated from the wallet-platform version rather than the other way round: it had diverged with a `detectedBy` field separating vectors the coin-agnostic codec catches from ones only a coin's StrKey checksum catches, which is the better structure. I extended its doc to note `detectedBy` is a floor, not a ceiling — sdk-core's codec verifies the CRC16 itself, so it rejects the `coin` vectors too.

Vector count went from 12/8 to 14/10, including a non-canonical base32 vector in each set.

## Testing

**726 passing** across sdk-core, `tsc --noEmit` and `eslint` clean. The `derivableEd25519Pub` suite went 47 → 55 tests on the richer vectors.

## Coordination — please read before merging

wallet-platform [#62429](https://github.com/BitGo/bitgo-microservices/pull/62429) is **open and not yet updated** in the version reviewers may have seen; I have the matching base32 change staged locally against that branch. Until both land, the two repos disagree on the format. The offset is a cross-repo contract shared with `modules/key-card` and WRW, so they should go together.

The TDD and all seven tickets (2484–2490) have been updated to the base32 format. WCN-2489 was retitled — nothing generates a chain code in `createMultisigRoot` anymore, so only the assert remains.