### PR TITLE
feat(sdk-lib-mpc): add RedPallas MPS DSG rounds and PGP helpers

### DIFF
--- a/modules/sdk-lib-mpc/src/tss/redpallas-mps/commsLayer.ts
+++ b/modules/sdk-lib-mpc/src/tss/redpallas-mps/commsLayer.ts
@@ -1,0 +1,70 @@
+import * as pgp from 'openpgp';
+import { MPSSignedMessage } from './types';
+
+/**
+ * PGP detached-signs raw WASM bytes with the given private key.
+ * Returns an MPSSignedMessage with the base64-encoded payload and armored signature.
+ *
+ * Mirrors `detachSignMpsMessage` in `../eddsa-mps/commsLayer.ts`. Kept as an independent
+ * copy (rather than a shared import) so RedPallas MPS never depends on the EdDSA MPS
+ * module, and vice versa.
+ */
+export async function detachSignMpsMessage(
+  rawBytes: Buffer | Uint8Array,
+  signingKey: pgp.PrivateKey
+): Promise<MPSSignedMessage> {
+  const signature = await pgp.sign({
+    message: await pgp.createMessage({ binary: rawBytes }),
+    signingKeys: signingKey,
+    detached: true,
+  });
+  return {
+    message: Buffer.from(rawBytes).toString('base64'),
+    signature: signature as string,
+  };
+}
+
+/**
+ * Verifies a PGP detached signature on an MPSSignedMessage and returns the decoded raw bytes.
+ * Throws if the signature is invalid or not present.
+ */
+export async function verifyMpsMessage(msg: MPSSignedMessage, verificationKey: pgp.Key): Promise<Buffer> {
+  const rawBytes = Buffer.from(msg.message, 'base64');
+  const result = await pgp.verify({
+    message: await pgp.createMessage({ binary: rawBytes }),
+    signature: await pgp.readSignature({ armoredSignature: msg.signature }),
+    verificationKeys: verificationKey,
+    expectSigned: true,
+  });
+  await result.signatures[0].verified;
+  return rawBytes;
+}
+
+/**
+ * Extracts the X25519 public key bytes from a GPG key's encryption subkey.
+ * Works for both public-only and private keys — use this for third-party keys (e.g. BitGo's).
+ *
+ * @param key - A GPG key with an X25519 encryption subkey.
+ * @returns 32-byte X25519 public key.
+ */
+export async function extractEd25519PublicKey(key: pgp.Key): Promise<Buffer> {
+  const { keyPacket } = await key.getEncryptionKey();
+  return Buffer.from((keyPacket.publicParams as { Q: Uint8Array }).Q).subarray(1);
+}
+
+/**
+ * Extracts the X25519 public and private key bytes from a GPG ed25519 private key's
+ * encryption subkey. Encapsulates the keyPacket internals and the little-endian scalar
+ * reversal in one place so sdk-core only deals with plain Buffers.
+ *
+ * @param privateKey - An ed25519 GPG private key with an X25519 encryption subkey.
+ * @returns  [pk, sk] — 32-byte X25519 public key and private scalar.
+ */
+export async function extractEd25519KeyPair(privateKey: pgp.PrivateKey): Promise<[Buffer, Buffer]> {
+  const encKey = await privateKey.getEncryptionKey();
+  const pk = Buffer.from((encKey.keyPacket.publicParams as { Q: Uint8Array }).Q).subarray(1);
+  const sk = Buffer.from(
+    (encKey.keyPacket as unknown as { privateParams: { d: Uint8Array } }).privateParams.d
+  ).reverse();
+  return [pk, sk];
+}

--- a/modules/sdk-lib-mpc/src/tss/redpallas-mps/dsg.ts
+++ b/modules/sdk-lib-mpc/src/tss/redpallas-mps/dsg.ts
@@ -1,0 +1,347 @@
+import assert from 'assert';
+import type { MsgState, RedPallasSignature } from '@bitgo/wasm-mps';
+import { DeserializedMessage, DeserializedMessages, RedPallasDsgState, RedPallasSignatureResult } from './types';
+
+type NodeWasmer = typeof import('@bitgo/wasm-mps');
+type WebWasmer = typeof import('@bitgo/wasm-mps/web');
+type WasmMps = NodeWasmer | WebWasmer;
+
+/**
+ * RedPallas (Zcash Ironwood) Distributed Sign Generation (DSG) implementation using
+ * @bitgo/wasm-mps.
+ *
+ * Mirrors the structure of the EdDSA MPS `DSG` class (see `../eddsa-mps/dsg.ts`), but wraps
+ * the `redpallas_dsg_*` WASM bindings. Unlike the EdDSA version:
+ *
+ * - `redpallas_dsg_round0_process` does not take a derivation path: RedPallas key derivation
+ *   (ask/nk/rivk/ivks) happens upstream, as part of DKG (`redpallas_dkg_round2_process` +
+ *   the platform-side-only `redpallas_derivation_process`); DSG only ever operates on an
+ *   already-derived (or root) opaque `Keyshare`.
+ * - Round3 does not return a raw signature; it returns a `RedPallasSignature` bundle of
+ *   `signature` (64 raw bytes), `rk` (the randomized verification key the signature
+ *   verifies against — NOT the DKG public key) and `alpha` (the 32-byte randomizer scalar
+ *   used to re-randomize the DKG public key into `rk`). See `RedPallasSignatureResult`.
+ *
+ * State is explicit: each WASM round function returns `{ msg, state }` bytes; the state
+ * bytes are stored between rounds and passed to the next round function (this is what a
+ * server would persist to a database between API rounds).
+ *
+ * The protocol is hard-coded 2-of-3: each signing party communicates with exactly one
+ * counterpart. `handleIncomingMessages` accepts both messages (own + counterpart), and
+ * filters own out internally.
+ *
+ * @example
+ * ```typescript
+ * const dsg = new RedPallasDSG(0);  // partyIdx 0
+ * await dsg.initDsg(keyShare, message, 2);  // counterpart is party 2
+ * const msg1 = dsg.getFirstMessage();
+ * const msg2 = dsg.handleIncomingMessages([msg1, peerMsg1]);  // emits SignMsg2
+ * const msg3 = dsg.handleIncomingMessages([msg2[0], peerMsg2]);  // emits SignMsg3
+ * dsg.handleIncomingMessages([msg3[0], peerMsg3]);  // completes DSG
+ * const { signature, rk, alpha } = dsg.getSignature();  // 64-byte RedPallas signature + rk/alpha
+ * ```
+ */
+export class RedPallasDSG {
+  protected partyIdx: number;
+  protected otherPartyIdx: number | null = null;
+
+  /** Opaque bincode-serialised Keyshare from a prior DKG (already derived, if applicable) */
+  private keyShare: Buffer | null = null;
+  /** Raw message bytes to sign */
+  private message: Buffer | null = null;
+
+  /** Serialised round state bytes returned by the previous round function */
+  private dsgStateBytes: Buffer | null = null;
+  /** Final signature bundle, available after WaitMsg3 -> Complete */
+  private signatureResult: RedPallasSignatureResult | null = null;
+  /** Lazily loaded WASM module */
+  private wasmMps: WasmMps | null = null;
+
+  protected dsgState: RedPallasDsgState = RedPallasDsgState.Uninitialized;
+
+  constructor(partyIdx: number) {
+    this.partyIdx = partyIdx;
+  }
+
+  getState(): RedPallasDsgState {
+    return this.dsgState;
+  }
+
+  getPartyIdx(): number {
+    return this.partyIdx;
+  }
+
+  getOtherPartyIdx(): number | null {
+    return this.otherPartyIdx;
+  }
+
+  private async loadWasmMps(): Promise<void> {
+    if (!this.wasmMps) {
+      if (
+        typeof window !== 'undefined' &&
+        /* checks for electron processes */
+        !window.process &&
+        !window.process?.['type']
+      ) {
+        // Browser: web build has explicit init() — guaranteed ready after await
+        // eslint-disable-next-line import/no-internal-modules -- @bitgo/wasm-mps exposes environment-specific subpath exports.
+        const webWasm = await import('@bitgo/wasm-mps/web');
+        await webWasm.default();
+        this.wasmMps = webWasm;
+      } else {
+        // Node.js: dynamic import() rewritten to require() by tsc → CJS build → readFileSync
+        this.wasmMps = await import('@bitgo/wasm-mps');
+      }
+    }
+  }
+
+  private getWasmMps(): WasmMps {
+    if (!this.wasmMps) {
+      throw Error('WASM module not loaded');
+    }
+    return this.wasmMps;
+  }
+
+  /**
+   * Initialises the DSG session. The keyshare must come from a prior DKG run (and, if a
+   * derived key is being used, from the subsequent platform-side derivation process), and
+   * `otherPartyIdx` must be the single counterpart who will co-sign with this party.
+   *
+   * @param keyShare - Opaque bincode-serialised Keyshare bytes from `RedPallasDKG.getKeyShare()`.
+   * @param message - Raw message bytes to sign.
+   * @param otherPartyIdx - Party index of the single counterpart in this signing session.
+   *   Must differ from this party's own `partyIdx` and be in `[0, 2]`.
+   */
+  async initDsg(keyShare: Buffer, message: Buffer, otherPartyIdx: number): Promise<void> {
+    await this.loadWasmMps();
+    if (!keyShare || keyShare.length === 0) {
+      throw Error('Missing or invalid keyShare');
+    }
+    if (!message || message.length === 0) {
+      throw Error('Missing or invalid message');
+    }
+    if (this.partyIdx < 0 || this.partyIdx > 2) {
+      throw Error(`Invalid partyIdx ${this.partyIdx}: must be in [0, 2]`);
+    }
+    if (otherPartyIdx < 0 || otherPartyIdx > 2 || otherPartyIdx === this.partyIdx) {
+      throw Error(`Invalid otherPartyIdx ${otherPartyIdx}: must be in [0, 2] and != partyIdx`);
+    }
+
+    this.keyShare = keyShare;
+    this.message = message;
+    this.otherPartyIdx = otherPartyIdx;
+    this.dsgState = RedPallasDsgState.Init;
+  }
+
+  /**
+   * Runs round 0 of the DSG protocol. Returns this party's broadcast message
+   * (a `SignMsg1` containing the commitment to `R_i`). Stores the round state
+   * bytes internally for the next round.
+   */
+  getFirstMessage(): DeserializedMessage {
+    if (this.dsgState !== RedPallasDsgState.Init) {
+      throw Error('DSG session not initialized');
+    }
+    assert(this.keyShare, 'keyShare must be set after initDsg');
+    assert(this.message, 'message must be set after initDsg');
+
+    const wasm = this.getWasmMps();
+    let result: MsgState;
+    try {
+      result = wasm.redpallas_dsg_round0_process(this.keyShare, this.message);
+    } catch (err) {
+      throw new Error(`Error while creating the first message from party ${this.partyIdx}: ${err}`);
+    }
+
+    this.dsgStateBytes = Buffer.from(result.state);
+    this.dsgState = RedPallasDsgState.WaitMsg1;
+    return { payload: new Uint8Array(result.msg), from: this.partyIdx };
+  }
+
+  /**
+   * Handles incoming messages for the current round and advances the protocol.
+   *
+   * - In `WaitMsg1`: runs round 1, returns this party's `SignMsg2` broadcast.
+   * - In `WaitMsg2`: runs round 2 (which internally fuses two Silence Labs transitions),
+   *   returns this party's `SignMsg3` broadcast (partial signature).
+   * - In `WaitMsg3`: runs round 3, completes DSG, returns `[]`.
+   *
+   * The caller passes both messages (own + counterpart) for symmetry with
+   * `RedPallasDKG.handleIncomingMessages`. Own message is filtered out internally; only the
+   * counterpart's payload is forwarded to the WASM round function.
+   *
+   * @param messagesForIthRound - Both messages for this round (own + counterpart).
+   */
+  handleIncomingMessages(messagesForIthRound: DeserializedMessages): DeserializedMessages {
+    if (this.dsgState === RedPallasDsgState.Complete) {
+      throw Error('DSG session already completed');
+    }
+    if (this.dsgState === RedPallasDsgState.Uninitialized) {
+      throw Error('DSG session not initialized');
+    }
+    if (this.dsgState === RedPallasDsgState.Init) {
+      throw Error(
+        'DSG session must call getFirstMessage() before handling incoming messages. Call getFirstMessage() first.'
+      );
+    }
+    if (messagesForIthRound.length !== 2) {
+      throw Error('Invalid number of messages for the round. Expected 2 messages (own + counterpart) for 2-of-3 DSG');
+    }
+
+    const peerMessages = messagesForIthRound.filter((m) => m.from !== this.partyIdx);
+    if (peerMessages.length !== 1) {
+      throw Error(`Expected exactly 1 counterpart message; got ${peerMessages.length}`);
+    }
+    const peerMsg = peerMessages[0];
+    if (peerMsg.from !== this.otherPartyIdx) {
+      throw Error(`Unexpected counterpart party index: got ${peerMsg.from}, expected ${this.otherPartyIdx}`);
+    }
+    const peerPayload = Buffer.from(peerMsg.payload);
+    const wasm = this.getWasmMps();
+
+    if (this.dsgState === RedPallasDsgState.WaitMsg1) {
+      assert(this.dsgStateBytes, 'dsgStateBytes must be set in WaitMsg1');
+      let result: MsgState;
+      try {
+        result = wasm.redpallas_dsg_round1_process(peerPayload, this.dsgStateBytes);
+      } catch (err) {
+        throw new Error(`Error while creating messages from party ${this.partyIdx}, round ${this.dsgState}: ${err}`);
+      }
+      this.dsgStateBytes = Buffer.from(result.state);
+      this.dsgState = RedPallasDsgState.WaitMsg2;
+      return [{ payload: new Uint8Array(result.msg), from: this.partyIdx }];
+    }
+
+    if (this.dsgState === RedPallasDsgState.WaitMsg2) {
+      assert(this.dsgStateBytes, 'dsgStateBytes must be set in WaitMsg2');
+      let result: MsgState;
+      try {
+        result = wasm.redpallas_dsg_round2_process(peerPayload, this.dsgStateBytes);
+      } catch (err) {
+        throw new Error(`Error while creating messages from party ${this.partyIdx}, round ${this.dsgState}: ${err}`);
+      }
+      this.dsgStateBytes = Buffer.from(result.state);
+      this.dsgState = RedPallasDsgState.WaitMsg3;
+      return [{ payload: new Uint8Array(result.msg), from: this.partyIdx }];
+    }
+
+    if (this.dsgState === RedPallasDsgState.WaitMsg3) {
+      assert(this.dsgStateBytes, 'dsgStateBytes must be set in WaitMsg3');
+      let result: RedPallasSignature;
+      try {
+        result = wasm.redpallas_dsg_round3_process(peerPayload, this.dsgStateBytes);
+      } catch (err) {
+        throw new Error(`Error while creating messages from party ${this.partyIdx}, round ${this.dsgState}: ${err}`);
+      }
+      this.signatureResult = {
+        signature: Buffer.from(result.signature),
+        rk: Buffer.from(result.rk),
+        alpha: Buffer.from(result.alpha),
+      };
+      this.dsgStateBytes = null;
+      this.dsgState = RedPallasDsgState.Complete;
+      return [];
+    }
+
+    throw Error('Unexpected DSG state');
+  }
+
+  /**
+   * Returns the final signature bundle produced by round 3: the 64-byte raw RedPallas
+   * signature, the randomized verification key `rk` it must be verified against (via
+   * `redpallas_verify(rk, signature, message)` — NOT the DKG public key), and the
+   * `alpha` randomizer scalar used to derive `rk` from the DKG public key.
+   */
+  getSignature(): RedPallasSignatureResult {
+    if (!this.signatureResult) {
+      throw Error('DSG session has not produced a signature yet');
+    }
+    return this.signatureResult;
+  }
+
+  /**
+   * Exports the current session state as a JSON string for persistence.
+   * Includes the opaque round state bytes plus everything needed to re-enter the
+   * protocol after a restart (keyshare, message, counterpart).
+   */
+  getSession(): string {
+    if (this.dsgState === RedPallasDsgState.Complete) {
+      throw Error('DSG session is complete. Exporting the session is not allowed.');
+    }
+    if (this.dsgState === RedPallasDsgState.Uninitialized) {
+      throw Error('DSG session not initialized');
+    }
+    if (this.dsgState === RedPallasDsgState.Init) {
+      throw Error('DSG session must produce its first message before exporting.');
+    }
+    return JSON.stringify({
+      dsgStateBytes: this.dsgStateBytes?.toString('base64') ?? null,
+      dsgRound: this.dsgState,
+      keyShare: this.keyShare?.toString('base64') ?? null,
+      message: this.message?.toString('base64') ?? null,
+      partyIdx: this.partyIdx,
+      otherPartyIdx: this.otherPartyIdx,
+    });
+  }
+
+  /**
+   * Restores a previously exported session. Allows the protocol to continue from
+   * where it left off, as if the round state was loaded from a database.
+   */
+  async restoreSession(session: string): Promise<void> {
+    await this.loadWasmMps();
+    const data = JSON.parse(session);
+    if (!Object.values(RedPallasDsgState).includes(data.dsgRound)) {
+      throw Error(`Invalid dsgRound in session: ${data.dsgRound}`);
+    }
+    if (data.dsgRound === RedPallasDsgState.Uninitialized || data.dsgRound === RedPallasDsgState.Init) {
+      throw Error(`Cannot restore DSG session in state ${data.dsgRound}`);
+    }
+    if (data.dsgRound === RedPallasDsgState.Complete) {
+      throw Error('DSG session is complete. Restoring the session is not allowed.');
+    }
+    if (typeof data.partyIdx !== 'number' || data.partyIdx < 0 || data.partyIdx > 2) {
+      throw Error(`Invalid partyIdx in session: ${data.partyIdx}`);
+    }
+    if (
+      typeof data.otherPartyIdx !== 'number' ||
+      data.otherPartyIdx < 0 ||
+      data.otherPartyIdx > 2 ||
+      data.otherPartyIdx === data.partyIdx
+    ) {
+      throw Error(`Invalid otherPartyIdx in session: ${data.otherPartyIdx}`);
+    }
+    if (this.partyIdx !== data.partyIdx) {
+      throw Error(`Session partyIdx ${data.partyIdx} does not match instance ${this.partyIdx}`);
+    }
+    if (typeof data.dsgStateBytes !== 'string' || data.dsgStateBytes.length === 0) {
+      throw Error(`Round ${data.dsgRound} requires dsgStateBytes`);
+    }
+    if (typeof data.keyShare !== 'string' || data.keyShare.length === 0) {
+      throw Error('Restored session missing keyShare');
+    }
+    if (typeof data.message !== 'string' || data.message.length === 0) {
+      throw Error('Restored session missing message');
+    }
+
+    const dsgStateBytes = Buffer.from(data.dsgStateBytes, 'base64');
+    const keyShare = Buffer.from(data.keyShare, 'base64');
+    const message = Buffer.from(data.message, 'base64');
+    if (dsgStateBytes.length === 0) {
+      throw Error(`Round ${data.dsgRound} requires dsgStateBytes`);
+    }
+    if (keyShare.length === 0) {
+      throw Error('Restored session missing keyShare');
+    }
+    if (message.length === 0) {
+      throw Error('Restored session missing message');
+    }
+
+    this.dsgStateBytes = dsgStateBytes;
+    this.dsgState = data.dsgRound;
+    this.keyShare = keyShare;
+    this.message = message;
+    this.partyIdx = data.partyIdx;
+    this.otherPartyIdx = data.otherPartyIdx;
+  }
+}

--- a/modules/sdk-lib-mpc/src/tss/redpallas-mps/index.ts
+++ b/modules/sdk-lib-mpc/src/tss/redpallas-mps/index.ts
@@ -1,3 +1,6 @@
 export * as RedPallasMPSDkg from './dkg';
+export * as RedPallasMPSDsg from './dsg';
 export * as RedPallasMPSUtil from './util';
 export * as RedPallasMPSTypes from './types';
+export * as RedPallasMPSComms from './commsLayer';
+export type { RedPallasSignatureResult } from './types';

--- a/modules/sdk-lib-mpc/src/tss/redpallas-mps/types.ts
+++ b/modules/sdk-lib-mpc/src/tss/redpallas-mps/types.ts
@@ -30,6 +30,54 @@ export enum RedPallasDkgState {
   Complete = 'Complete',
 }
 
+/**
+ * Represents the state of a RedPallas DSG (Distributed Sign Generation) session.
+ *
+ * Mirrors the EdDSA MPS `DsgState`, except `redpallas_dsg_round0_process` does not take a
+ * derivation path: RedPallas key derivation (ask/nk/rivk/ivks) happens separately, upstream,
+ * as part of DKG (see `RedPallasDkgState`); the DSG round functions only ever operate on an
+ * already-derived (or root) `Keyshare`.
+ */
+export enum RedPallasDsgState {
+  /** DSG session has not been initialized */
+  Uninitialized = 'Uninitialized',
+  /** initDsg() has been called; ready for getFirstMessage() */
+  Init = 'Init',
+  /** R0 broadcast emitted; waiting for counterpart's R0 broadcast (SignMsg1) */
+  WaitMsg1 = 'WaitMsg1',
+  /** R1 broadcast emitted; waiting for counterpart's R1 broadcast (SignMsg2) */
+  WaitMsg2 = 'WaitMsg2',
+  /** R2 broadcast emitted; waiting for counterpart's R2 broadcast (SignMsg3, the partial sig) */
+  WaitMsg3 = 'WaitMsg3',
+  /** Final RedPallas signature (signature/rk/alpha) is available via getSignature() */
+  Complete = 'Complete',
+}
+
+/**
+ * The final output of a RedPallas DSG session.
+ *
+ * - `signature` is the 64-byte raw Schnorr (RedPallas) signature.
+ * - `rk` is the randomized verification key that the signature must be verified against
+ *   (i.e. `redpallas_verify(rk, signature, message)`), not the original DKG public key.
+ * - `alpha` is the 32-byte randomizer scalar used to re-randomize the DKG public key into
+ *   `rk` (`rk = pk + [alpha]G`). Callers that need to independently re-derive/verify `rk`
+ *   from the DKG public key can use `alpha` to do so.
+ */
+export interface RedPallasSignatureResult {
+  signature: Buffer;
+  rk: Buffer;
+  alpha: Buffer;
+}
+
+/** A PGP detached-signed message by a party.
+ * `message` is the raw payload encoded as base64.
+ * `signature` is an armored PGP detached signature over those bytes.
+ */
+export interface MPSSignedMessage {
+  message: string;
+  signature: string;
+}
+
 export interface Message<T> {
   payload: T;
   from: number;

--- a/modules/sdk-lib-mpc/src/tss/redpallas-mps/util.ts
+++ b/modules/sdk-lib-mpc/src/tss/redpallas-mps/util.ts
@@ -2,6 +2,8 @@ import crypto from 'crypto';
 import assert from 'assert';
 import { x25519 } from '@noble/curves/ed25519';
 import { RedPallasDKG } from './dkg';
+import { RedPallasDSG } from './dsg';
+import { DeserializedMessages, RedPallasSignatureResult } from './types';
 
 function generateX25519Keypair(seed?: Buffer): { privKey: Buffer; pubKey: Buffer } {
   const privKey = seed ? seed.subarray(0, 32) : crypto.randomBytes(32);
@@ -70,4 +72,78 @@ export async function generateRedPallasDKGKeyShares(
   bitgo.handleIncomingMessages(r2Messages, derivationSeed);
 
   return [user, backup, bitgo];
+}
+
+/**
+ * Initializes two RedPallas DSG parties and drives them through the protocol until the
+ * specified round. Mirrors `executeTillRound` in `../eddsa-mps/util.ts`, minus the
+ * derivation path (RedPallas DSG operates on an already-(root-or-derived) keyshare; there
+ * is no per-signing-session derivation path).
+ *
+ * @param round - Round to execute until (1–3). Returns intermediate message arrays for 1–2,
+ *   or the final `RedPallasSignatureResult` (signature/rk/alpha) for 3.
+ * @param party1Dsg - First DSG party (`new RedPallasDSG(partyIdx)`), not yet initialized.
+ * @param party2Dsg - Second DSG party (`new RedPallasDSG(partyIdx)`), not yet initialized.
+ * @param keyShare1 - Key share for the first party.
+ * @param keyShare2 - Key share for the second party.
+ * @param message - Raw message bytes to sign.
+ */
+export async function executeTillRound(
+  round: number,
+  party1Dsg: RedPallasDSG,
+  party2Dsg: RedPallasDSG,
+  keyShare1: Buffer,
+  keyShare2: Buffer,
+  message: Buffer
+): Promise<DeserializedMessages[] | RedPallasSignatureResult> {
+  if (round < 1 || round > 3) {
+    throw Error('Invalid round number');
+  }
+  await party1Dsg.initDsg(keyShare1, message, party2Dsg.getPartyIdx());
+  await party2Dsg.initDsg(keyShare2, message, party1Dsg.getPartyIdx());
+  const party1Round0Message = party1Dsg.getFirstMessage();
+  const party2Round0Message = party2Dsg.getFirstMessage();
+
+  const [party2Round1Messages] = party2Dsg.handleIncomingMessages([party1Round0Message, party2Round0Message]);
+  const [party1Round1Messages] = party1Dsg.handleIncomingMessages([party1Round0Message, party2Round0Message]);
+  if (round === 1) return [[party1Round1Messages], [party2Round1Messages]];
+
+  const [party1Round2Messages] = party1Dsg.handleIncomingMessages([party1Round1Messages, party2Round1Messages]);
+  const [party2Round2Messages] = party2Dsg.handleIncomingMessages([party1Round1Messages, party2Round1Messages]);
+  if (round === 2) return [[party1Round2Messages], [party2Round2Messages]];
+
+  party1Dsg.handleIncomingMessages([party1Round2Messages, party2Round2Messages]);
+  party2Dsg.handleIncomingMessages([party1Round2Messages, party2Round2Messages]);
+
+  const sig1 = party1Dsg.getSignature();
+  const sig2 = party2Dsg.getSignature();
+  assert(sig1.signature.toString('hex') === sig2.signature.toString('hex'));
+  assert(sig1.rk.toString('hex') === sig2.rk.toString('hex'));
+  assert(sig1.alpha.toString('hex') === sig2.alpha.toString('hex'));
+  return sig1;
+}
+
+/**
+ * Verifies a `RedPallasSignatureResult` against the raw message.
+ *
+ * IMPORTANT: unlike EdDSA, RedPallas signatures must be verified against `rk` — the
+ * randomized verification key produced alongside the signature by DSG round3 — and NOT
+ * against the DKG (or derived) public key directly. `rk = pk + [alpha]G`; `alpha` is
+ * included in `RedPallasSignatureResult` for callers that need to independently confirm
+ * the relationship between `rk` and a known `pk`, but is not required to verify the
+ * signature itself.
+ */
+export async function verifyRedPallasSignature(
+  signatureResult: RedPallasSignatureResult,
+  message: Buffer
+): Promise<boolean> {
+  const wasm =
+    typeof window !== 'undefined' && !window.process && !window.process?.['type']
+      ? // eslint-disable-next-line import/no-internal-modules -- @bitgo/wasm-mps exposes environment-specific subpath exports.
+        await import('@bitgo/wasm-mps/web').then(async (webWasm) => {
+          await webWasm.default();
+          return webWasm;
+        })
+      : await import('@bitgo/wasm-mps');
+  return wasm.redpallas_verify(signatureResult.rk, signatureResult.signature, message);
 }

--- a/modules/sdk-lib-mpc/test/unit/tss/redpallas/dsg.ts
+++ b/modules/sdk-lib-mpc/test/unit/tss/redpallas/dsg.ts
@@ -1,0 +1,364 @@
+import assert from 'assert';
+import {
+  RedPallasMPSDkg,
+  RedPallasMPSDsg,
+  RedPallasMPSTypes,
+  RedPallasMPSUtil,
+} from '../../../../src/tss/redpallas-mps';
+import { generateRedPallasDKGKeyShares, executeTillRound, verifyRedPallasSignature } from './util';
+
+const MESSAGE = Buffer.from('The Times 03/Jan/2009 Chancellor on brink of second bailout for banks');
+const DERIVATION_SEED = Buffer.from('c526955e37be0a0c8b77a831eb615948772b38df9f04d8c5a2e0e1f1d0c9b8a7', 'hex');
+
+describe('RedPallas MPS DSG', function () {
+  // DKG is expensive; generate keyshares once and reuse across tests.
+  let userDkg: RedPallasMPSDkg.RedPallasDKG;
+  let backupDkg: RedPallasMPSDkg.RedPallasDKG;
+  let bitgoDkg: RedPallasMPSDkg.RedPallasDKG;
+
+  let userKeyShare: Buffer;
+  let backupKeyShare: Buffer;
+  let bitgoKeyShare: Buffer;
+
+  before(async function () {
+    [userDkg, backupDkg, bitgoDkg] = await generateRedPallasDKGKeyShares(DERIVATION_SEED);
+    userKeyShare = userDkg.getKeyShare();
+    backupKeyShare = backupDkg.getKeyShare();
+    bitgoKeyShare = bitgoDkg.getKeyShare();
+  });
+
+  describe('DSG Initialization', function () {
+    it('should accept valid inputs and produce a first message', async function () {
+      const dsg = new RedPallasMPSDsg.RedPallasDSG(0);
+      await dsg.initDsg(userKeyShare, MESSAGE, 2);
+
+      const msg = dsg.getFirstMessage();
+      assert.strictEqual(msg.from, 0, 'First message should be from party 0');
+      assert(msg.payload.length > 0, 'First message should have non-empty payload');
+    });
+
+    it('should throw when getFirstMessage is called before initDsg', function () {
+      const dsg = new RedPallasMPSDsg.RedPallasDSG(0);
+      assert.throws(() => dsg.getFirstMessage(), /DSG session not initialized/);
+    });
+
+    it('should throw when handleIncomingMessages is called before initDsg', function () {
+      const dsg = new RedPallasMPSDsg.RedPallasDSG(0);
+      assert.throws(() => dsg.handleIncomingMessages([]), /DSG session not initialized/);
+    });
+
+    it('should throw when getSignature is called before completion', async function () {
+      const dsg = new RedPallasMPSDsg.RedPallasDSG(0);
+      await dsg.initDsg(userKeyShare, MESSAGE, 2);
+      assert.throws(() => dsg.getSignature(), /has not produced a signature yet/);
+    });
+
+    it('should throw on empty keyShare', async function () {
+      const dsg = new RedPallasMPSDsg.RedPallasDSG(0);
+      await assert.rejects(dsg.initDsg(Buffer.alloc(0), MESSAGE, 2), /Missing or invalid keyShare/);
+    });
+
+    it('should throw on empty message', async function () {
+      const dsg = new RedPallasMPSDsg.RedPallasDSG(0);
+      await assert.rejects(dsg.initDsg(userKeyShare, Buffer.alloc(0), 2), /Missing or invalid message/);
+    });
+
+    it('should throw when otherPartyIdx equals own partyIdx', async function () {
+      const dsg = new RedPallasMPSDsg.RedPallasDSG(0);
+      await assert.rejects(dsg.initDsg(userKeyShare, MESSAGE, 0), /Invalid otherPartyIdx/);
+    });
+
+    it('should throw when otherPartyIdx is out of range', async function () {
+      const dsg = new RedPallasMPSDsg.RedPallasDSG(0);
+      await assert.rejects(dsg.initDsg(userKeyShare, MESSAGE, 5), /Invalid otherPartyIdx/);
+    });
+
+    it('should throw when partyIdx is out of range', async function () {
+      const dsg = new RedPallasMPSDsg.RedPallasDSG(7);
+      await assert.rejects(dsg.initDsg(userKeyShare, MESSAGE, 0), /Invalid partyIdx/);
+    });
+
+    it('should throw when handleIncomingMessages is called before getFirstMessage', async function () {
+      const dsg = new RedPallasMPSDsg.RedPallasDSG(0);
+      await dsg.initDsg(userKeyShare, MESSAGE, 2);
+      assert.throws(() => dsg.handleIncomingMessages([]), /must call getFirstMessage/);
+    });
+  });
+
+  describe('DSG Protocol Execution (2-of-3)', function () {
+    it('should complete full DSG between user (0) and bitgo (2) and produce identical signatures', async function () {
+      const dsgA = new RedPallasMPSDsg.RedPallasDSG(0);
+      const dsgB = new RedPallasMPSDsg.RedPallasDSG(2);
+      await executeTillRound(3, dsgA, dsgB, userKeyShare, bitgoKeyShare, MESSAGE);
+
+      assert.strictEqual(dsgA.getState(), 'Complete');
+      assert.strictEqual(dsgB.getState(), 'Complete');
+
+      const sigA = dsgA.getSignature();
+      const sigB = dsgB.getSignature();
+
+      assert.strictEqual(sigA.signature.length, 64, 'Signature must be 64 bytes');
+      assert.strictEqual(sigA.rk.length, 32, 'rk must be 32 bytes');
+      assert.strictEqual(sigA.alpha.length, 32, 'alpha must be 32 bytes');
+      assert.strictEqual(
+        sigA.signature.toString('hex'),
+        sigB.signature.toString('hex'),
+        'Both parties must produce identical signatures'
+      );
+      assert.strictEqual(sigA.rk.toString('hex'), sigB.rk.toString('hex'), 'Both parties must agree on rk');
+      assert.strictEqual(sigA.alpha.toString('hex'), sigB.alpha.toString('hex'), 'Both parties must agree on alpha');
+    });
+
+    it('should produce a signature that verifies under rk (not the DKG public key directly)', async function () {
+      const sig = (await executeTillRound(
+        3,
+        new RedPallasMPSDsg.RedPallasDSG(0),
+        new RedPallasMPSDsg.RedPallasDSG(2),
+        userKeyShare,
+        bitgoKeyShare,
+        MESSAGE
+      )) as RedPallasMPSTypes.RedPallasSignatureResult;
+
+      const isValid = await verifyRedPallasSignature(sig, MESSAGE);
+      assert(isValid, 'Signature should verify under rk');
+    });
+
+    it('should sign the same message identically across all 2-of-3 party combinations', async function () {
+      const userBackupSig = (await executeTillRound(
+        3,
+        new RedPallasMPSDsg.RedPallasDSG(0),
+        new RedPallasMPSDsg.RedPallasDSG(1),
+        userKeyShare,
+        backupKeyShare,
+        MESSAGE
+      )) as RedPallasMPSTypes.RedPallasSignatureResult;
+      const backupBitgoSig = (await executeTillRound(
+        3,
+        new RedPallasMPSDsg.RedPallasDSG(1),
+        new RedPallasMPSDsg.RedPallasDSG(2),
+        backupKeyShare,
+        bitgoKeyShare,
+        MESSAGE
+      )) as RedPallasMPSTypes.RedPallasSignatureResult;
+      const userBitgoSig = (await executeTillRound(
+        3,
+        new RedPallasMPSDsg.RedPallasDSG(0),
+        new RedPallasMPSDsg.RedPallasDSG(2),
+        userKeyShare,
+        bitgoKeyShare,
+        MESSAGE
+      )) as RedPallasMPSTypes.RedPallasSignatureResult;
+
+      // Per-session nonce (and rerandomizer alpha) randomisation means signatures across
+      // DIFFERENT signing sessions WILL differ. The invariant we test is that every 2-of-3
+      // subset produces a signature that verifies under its own (session-specific) rk.
+      assert(await verifyRedPallasSignature(userBackupSig, MESSAGE), 'user+backup signature should verify');
+      assert(await verifyRedPallasSignature(backupBitgoSig, MESSAGE), 'backup+bitgo signature should verify');
+      assert(await verifyRedPallasSignature(userBitgoSig, MESSAGE), 'user+bitgo signature should verify');
+    });
+
+    it('should sign arbitrary message lengths', async function () {
+      const shortMsg = Buffer.from([0x01]);
+      const longMsg = Buffer.alloc(4096, 0xab);
+
+      const shortSig = (await executeTillRound(
+        3,
+        new RedPallasMPSDsg.RedPallasDSG(0),
+        new RedPallasMPSDsg.RedPallasDSG(2),
+        userKeyShare,
+        bitgoKeyShare,
+        shortMsg
+      )) as RedPallasMPSTypes.RedPallasSignatureResult;
+      const longSig = (await executeTillRound(
+        3,
+        new RedPallasMPSDsg.RedPallasDSG(0),
+        new RedPallasMPSDsg.RedPallasDSG(2),
+        userKeyShare,
+        bitgoKeyShare,
+        longMsg
+      )) as RedPallasMPSTypes.RedPallasSignatureResult;
+
+      assert(await verifyRedPallasSignature(shortSig, shortMsg), '1-byte message signature should verify');
+      assert(await verifyRedPallasSignature(longSig, longMsg), '4096-byte message signature should verify');
+    });
+
+    it('should throw when handleIncomingMessages is called after completion', async function () {
+      const dsgA = new RedPallasMPSDsg.RedPallasDSG(0);
+      await executeTillRound(3, dsgA, new RedPallasMPSDsg.RedPallasDSG(2), userKeyShare, bitgoKeyShare, MESSAGE);
+      assert.throws(() => dsgA.handleIncomingMessages([]), /already completed/);
+    });
+
+    it('should fail when parties sign different messages', async function () {
+      const dsg1 = new RedPallasMPSDsg.RedPallasDSG(0);
+      const dsg2 = new RedPallasMPSDsg.RedPallasDSG(2);
+      await dsg1.initDsg(userKeyShare, Buffer.from('MESSAGE'), 2);
+      await dsg2.initDsg(bitgoKeyShare, Buffer.from('DIFFERENT_MESSAGE'), 0);
+
+      const r0_1 = dsg1.getFirstMessage();
+      const r0_2 = dsg2.getFirstMessage();
+
+      const [r1_1] = dsg1.handleIncomingMessages([r0_1, r0_2]);
+      const [r1_2] = dsg2.handleIncomingMessages([r0_1, r0_2]);
+
+      assert.throws(() => dsg1.handleIncomingMessages([r1_1, r1_2]), /Error while creating messages from party 0/);
+    });
+  });
+
+  describe('Error Handling', function () {
+    it('should throw when handleIncomingMessages receives the wrong number of messages', async function () {
+      const dsg = new RedPallasMPSDsg.RedPallasDSG(0);
+      await dsg.initDsg(userKeyShare, MESSAGE, 2);
+      const own = dsg.getFirstMessage();
+
+      assert.throws(() => dsg.handleIncomingMessages([own]), /Expected 2 messages/);
+      assert.throws(() => dsg.handleIncomingMessages([own, own, own]), /Expected 2 messages/);
+    });
+
+    it('should throw when counterpart message comes from an unexpected party', async function () {
+      const dsg = new RedPallasMPSDsg.RedPallasDSG(0);
+      await dsg.initDsg(userKeyShare, MESSAGE, 2);
+
+      const own = dsg.getFirstMessage();
+      // Forge a "counterpart" message from party 1 instead of expected party 2
+      const wrongPeer = { from: 1, payload: own.payload };
+
+      assert.throws(() => dsg.handleIncomingMessages([own, wrongPeer]), /Unexpected counterpart party index/);
+    });
+
+    it('should throw when both messages claim to come from this party', async function () {
+      const dsg = new RedPallasMPSDsg.RedPallasDSG(0);
+      await dsg.initDsg(userKeyShare, MESSAGE, 2);
+      const own = dsg.getFirstMessage();
+
+      assert.throws(() => dsg.handleIncomingMessages([own, own]), /Expected exactly 1 counterpart message/);
+    });
+  });
+
+  describe('Message Serialization', function () {
+    it('should serialize and deserialize DSG messages round-trip', async function () {
+      const dsgA = new RedPallasMPSDsg.RedPallasDSG(0);
+      const dsgB = new RedPallasMPSDsg.RedPallasDSG(2);
+      await dsgA.initDsg(userKeyShare, MESSAGE, 2);
+      await dsgB.initDsg(bitgoKeyShare, MESSAGE, 0);
+
+      const a0 = dsgA.getFirstMessage();
+      const b0 = dsgB.getFirstMessage();
+
+      const serialized = RedPallasMPSTypes.serializeMessages([a0, b0]);
+      assert(
+        serialized.every((m) => typeof m.payload === 'string'),
+        'Serialized payloads should be strings'
+      );
+
+      const deserialized = RedPallasMPSTypes.deserializeMessages(serialized);
+      assert.strictEqual(deserialized.length, 2);
+      deserialized.forEach((msg, i) => {
+        const original = i === 0 ? a0 : b0;
+        assert.strictEqual(msg.from, original.from);
+        assert.deepStrictEqual(Buffer.from(msg.payload), Buffer.from(original.payload));
+      });
+    });
+  });
+
+  describe('Session Management', function () {
+    it('should export and restore DSG session and continue protocol to a valid signature', async function () {
+      const dsgA = new RedPallasMPSDsg.RedPallasDSG(0);
+      const dsgB = new RedPallasMPSDsg.RedPallasDSG(2);
+      await dsgA.initDsg(userKeyShare, MESSAGE, 2);
+      await dsgB.initDsg(bitgoKeyShare, MESSAGE, 0);
+
+      const a0 = dsgA.getFirstMessage();
+      const b0 = dsgB.getFirstMessage();
+
+      const sessionA = dsgA.getSession();
+      assert(typeof sessionA === 'string' && sessionA.length > 0);
+
+      // Restore A in a fresh instance and finish the protocol from there.
+      const restoredA = new RedPallasMPSDsg.RedPallasDSG(0);
+      await restoredA.restoreSession(sessionA);
+      assert.strictEqual(restoredA.getState(), dsgA.getState(), 'Restored state should match original');
+
+      const [a1] = restoredA.handleIncomingMessages([a0, b0]);
+      const [b1] = dsgB.handleIncomingMessages([a0, b0]);
+
+      const [a2] = restoredA.handleIncomingMessages([a1, b1]);
+      const [b2] = dsgB.handleIncomingMessages([a1, b1]);
+
+      restoredA.handleIncomingMessages([a2, b2]);
+      dsgB.handleIncomingMessages([a2, b2]);
+
+      const sigA = restoredA.getSignature();
+      const sigB = dsgB.getSignature();
+
+      assert.strictEqual(
+        sigA.signature.toString('hex'),
+        sigB.signature.toString('hex'),
+        'Restored signer must agree with counterpart'
+      );
+      assert(await verifyRedPallasSignature(sigA, MESSAGE), 'Restored-session signature should verify under rk');
+    });
+
+    it('should throw when exporting session after completion', async function () {
+      const dsgA = new RedPallasMPSDsg.RedPallasDSG(0);
+      const dsgB = new RedPallasMPSDsg.RedPallasDSG(2);
+      await executeTillRound(3, dsgA, dsgB, userKeyShare, bitgoKeyShare, MESSAGE);
+      assert.throws(() => dsgA.getSession(), /DSG session is complete\. Exporting the session is not allowed\./);
+      assert.throws(() => dsgB.getSession(), /DSG session is complete\. Exporting the session is not allowed\./);
+    });
+
+    it('should throw when exporting session before the first message', async function () {
+      const dsg = new RedPallasMPSDsg.RedPallasDSG(0);
+      await dsg.initDsg(userKeyShare, MESSAGE, 2);
+      assert.throws(() => dsg.getSession(), /must produce its first message before exporting/);
+    });
+
+    it('should throw when exporting session before initialization', function () {
+      const dsg = new RedPallasMPSDsg.RedPallasDSG(0);
+      assert.throws(() => dsg.getSession(), /DSG session not initialized/);
+    });
+
+    it('should throw when restoring a session with invalid fields', async function () {
+      const dsg = new RedPallasMPSDsg.RedPallasDSG(0);
+      await dsg.initDsg(userKeyShare, MESSAGE, 2);
+      dsg.getFirstMessage();
+
+      const session = JSON.parse(dsg.getSession());
+
+      await assert.rejects(
+        new RedPallasMPSDsg.RedPallasDSG(0).restoreSession(JSON.stringify({ ...session, dsgRound: 'Invalid' })),
+        /Invalid dsgRound in session/
+      );
+      await assert.rejects(
+        new RedPallasMPSDsg.RedPallasDSG(0).restoreSession(JSON.stringify({ ...session, partyIdx: 4 })),
+        /Invalid partyIdx in session/
+      );
+      await assert.rejects(
+        new RedPallasMPSDsg.RedPallasDSG(0).restoreSession(JSON.stringify({ ...session, otherPartyIdx: 0 })),
+        /Invalid otherPartyIdx in session/
+      );
+      await assert.rejects(
+        new RedPallasMPSDsg.RedPallasDSG(0).restoreSession(JSON.stringify({ ...session, dsgStateBytes: null })),
+        /requires dsgStateBytes/
+      );
+      await assert.rejects(
+        new RedPallasMPSDsg.RedPallasDSG(1).restoreSession(JSON.stringify(session)),
+        /Session partyIdx 0 does not match instance 1/
+      );
+    });
+  });
+
+  describe('Reduced key share format', function () {
+    it('should produce a reduced key share with only keyShare and pub fields (no rootChainCode)', function () {
+      const reduced = RedPallasMPSTypes.getDecodedReducedKeyShare(userDkg.getReducedKeyShare());
+      assert.deepStrictEqual(Object.keys(reduced).sort(), ['keyShare', 'pub']);
+      assert(!('rootChainCode' in reduced));
+    });
+  });
+
+  describe('RedPallasMPSUtil re-exports', function () {
+    it('should expose executeTillRound and verifyRedPallasSignature from the production util module', function () {
+      assert.strictEqual(RedPallasMPSUtil.executeTillRound, executeTillRound);
+      assert.strictEqual(RedPallasMPSUtil.verifyRedPallasSignature, verifyRedPallasSignature);
+    });
+  });
+});

--- a/modules/sdk-lib-mpc/test/unit/tss/redpallas/util.ts
+++ b/modules/sdk-lib-mpc/test/unit/tss/redpallas/util.ts
@@ -1,3 +1,7 @@
-// Re-export the production helper so tests can resolve via './util'
+// Re-export the production helpers so tests can resolve via './util'
 // without a separate, drifting copy.
-export { generateRedPallasDKGKeyShares } from '../../../../src/tss/redpallas-mps/util';
+export {
+  generateRedPallasDKGKeyShares,
+  executeTillRound,
+  verifyRedPallasSignature,
+} from '../../../../src/tss/redpallas-mps/util';


### PR DESCRIPTION
TICKET: WCI-1524

This pull request introduces a full implementation of RedPallas Distributed Sign Generation (DSG) support in the `sdk-lib-mpc` package, mirroring the EdDSA MPS structure but tailored for Zcash Ironwood's RedPallas protocol. It adds the core DSG protocol logic, supporting types, message signing/verification helpers, and utility orchestration for multi-party signing. The changes are organized to keep RedPallas and EdDSA implementations decoupled, and provide a clean interface for RedPallas DSG operations.

**Key changes in this pull request:**

### 1. RedPallas DSG Protocol Implementation

- Added a new `RedPallasDSG` class in `dsg.ts` that implements the full 2-of-3 RedPallas DSG protocol, including session initialization, round handling, state management, signature extraction, session export/restore, and WASM module loading. The protocol ensures explicit state transitions and robust error handling throughout the signing process.

### 2. Types and Interfaces for DSG

- Introduced the `RedPallasDsgState` enum to track DSG session states, and the `RedPallasSignatureResult` interface to encapsulate the output signature, randomized verification key (`rk`), and randomizer scalar (`alpha`). Also added the `MPSSignedMessage` interface for PGP-signed message handling.

### 3. Communication Layer for RedPallas MPS

- Implemented message signing and verification helpers in `commsLayer.ts`, including functions to create and verify PGP detached signatures and extract X25519 public/private keys from GPG keys. These utilities ensure secure message exchange between DSG parties.

### 4. Utility Functions for Testing and Verification

- Added orchestration helpers in `util.ts` to drive two DSG parties through the protocol (`executeTillRound`) and verify RedPallas signatures (`verifyRedPallasSignature`). These functions facilitate integration testing and protocol validation.

### 5. Module Exports and Integration

- Updated `index.ts` to export the new DSG, comms, and types modules, making the full RedPallas DSG implementation accessible to consumers of the package. [[1]](diffhunk://#diff-cda823b37588d901e9fdfc20f4b22d04602b0328d641b3db2afce0cfeb3466aeR2-R6) [[2]](diffhunk://#diff-6588f074a46d932e9b55e3c2a3301053f99155a78292c05497a6edba207f6f07R5-R6)

These changes collectively provide a robust, modular, and testable RedPallas DSG implementation, enabling secure multi-party signing for Zcash Ironwood within the BitGo SDK.

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
