### PR TITLE
chore: add Silence Labs DKLS VRF and EdDSA WASM deps

### DIFF
--- a/modules/sdk-lib-mpc/package.json
+++ b/modules/sdk-lib-mpc/package.json
@@ -39,7 +39,11 @@
     "@bitgo/wasm-mps": "1.13.0",
     "@noble/curves": "1.8.1",
     "@silencelaboratories/dkls-wasm-ll-node": "1.2.0-pre.4",
+    "@silencelaboratories/dkls-wasm-ll-vrf-node": "1.0.0-pre.9",
+    "@silencelaboratories/dkls-wasm-ll-vrf-web": "1.0.0-pre.9",
     "@silencelaboratories/dkls-wasm-ll-web": "1.2.0-pre.4",
+    "@silencelaboratories/eddsa-wasm-node": "1.0.0-pre.9",
+    "@silencelaboratories/eddsa-wasm-web": "1.0.0-pre.9",
     "@types/superagent": "4.1.15",
     "@wasmer/wasi": "^1.2.2",
     "bigint-crypto-utils": "3.1.4",
@@ -56,15 +60,25 @@
     "@bitgo/sdk-opensslbytes": "^2.1.0",
     "@bitgo/sjcl": "^1.1.0",
     "@silencelaboratories/dkls-wasm-ll-bundler": "1.2.0-pre.4",
+    "@silencelaboratories/dkls-wasm-ll-vrf-bundler": "1.0.0-pre.9",
+    "@silencelaboratories/eddsa-wasm-bundler": "1.0.0-pre.9",
     "@types/lodash": "^4.14.151",
     "@types/node": "^24.10.9",
     "nyc": "^15.0.0"
   },
   "peerDependencies": {
-    "@silencelaboratories/dkls-wasm-ll-bundler": "1.2.0-pre.4"
+    "@silencelaboratories/dkls-wasm-ll-bundler": "1.2.0-pre.4",
+    "@silencelaboratories/dkls-wasm-ll-vrf-bundler": "1.0.0-pre.9",
+    "@silencelaboratories/eddsa-wasm-bundler": "1.0.0-pre.9"
   },
   "peerDependenciesMeta": {
     "@silencelaboratories/dkls-wasm-ll-bundler": {
+      "optional": true
+    },
+    "@silencelaboratories/dkls-wasm-ll-vrf-bundler": {
+      "optional": true
+    },
+    "@silencelaboratories/eddsa-wasm-bundler": {
       "optional": true
     }
   },

--- a/modules/sdk-lib-mpc/src/tss/ecdsa-dkls/dkg.ts
+++ b/modules/sdk-lib-mpc/src/tss/ecdsa-dkls/dkg.ts
@@ -1,4 +1,6 @@
 import type { KeygenSession, Keyshare, Message } from '@silencelaboratories/dkls-wasm-ll-node';
+import type { VrfKeygenSession as DklsVrfKeygenSession } from '@silencelaboratories/dkls-wasm-ll-vrf-node';
+import type { VrfKeygenSession as DklsVrfWebKeygenSession } from '@silencelaboratories/dkls-wasm-ll-vrf-web';
 import { decode, encode } from 'cbor-x';
 import { createHash } from 'crypto';
 import { Secp256k1Curve } from '../../curves';
@@ -10,6 +12,7 @@ type WebWasmer = typeof import('@silencelaboratories/dkls-wasm-ll-web');
 type BundlerWasmer = typeof import('@silencelaboratories/dkls-wasm-ll-bundler');
 
 type DklsWasm = NodeWasmer | WebWasmer | BundlerWasmer;
+export type { DklsVrfKeygenSession, DklsVrfWebKeygenSession };
 
 export interface DkgSessionData {
   dkgSessionBytes: Uint8Array;

--- a/modules/sdk-lib-mpc/src/tss/eddsa-mps/dkg.ts
+++ b/modules/sdk-lib-mpc/src/tss/eddsa-mps/dkg.ts
@@ -1,4 +1,6 @@
 import type { MsgState, Share } from '@bitgo/wasm-mps';
+import type { VrfKeygenSession as EddsaVrfKeygenSession } from '@silencelaboratories/eddsa-wasm-node';
+import type { VrfKeygenSession as EddsaVrfWebKeygenSession } from '@silencelaboratories/eddsa-wasm-web';
 import { encode } from 'cbor-x';
 import crypto from 'crypto';
 import { DeserializedMessage, DeserializedMessages, DkgState, EddsaReducedKeyShare, EddsaRetrofitData } from './types';
@@ -6,6 +8,7 @@ import { DeserializedMessage, DeserializedMessages, DkgState, EddsaReducedKeySha
 type NodeWasmer = typeof import('@bitgo/wasm-mps');
 type WebWasmer = typeof import('@bitgo/wasm-mps/web');
 type WasmMps = NodeWasmer | WebWasmer;
+export type { EddsaVrfKeygenSession, EddsaVrfWebKeygenSession };
 
 /**
  * EdDSA Distributed Key Generation (DKG) implementation using @bitgo/wasm-mps.

--- a/webpack/bitgojs.config.js
+++ b/webpack/bitgojs.config.js
@@ -61,6 +61,14 @@ module.exports = {
       /\@silencelaboratories\/dkls-wasm-ll-node/,
       '@silencelaboratories/dkls-wasm-ll-web'
     ),
+    new webpack.NormalModuleReplacementPlugin(
+      /\@silencelaboratories\/dkls-wasm-ll-vrf-node/,
+      '@silencelaboratories/dkls-wasm-ll-vrf-web'
+    ),
+    new webpack.NormalModuleReplacementPlugin(
+      /\@silencelaboratories\/eddsa-wasm-node/,
+      '@silencelaboratories/eddsa-wasm-web'
+    ),
 
     new webpack.ContextReplacementPlugin(/cardano-serialization-lib-browser/),
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5224,10 +5224,40 @@
   resolved "https://registry.npmjs.org/@silencelaboratories/dkls-wasm-ll-node/-/dkls-wasm-ll-node-1.2.0-pre.4.tgz"
   integrity sha512-KWHR/6SCa67mrYVPbhNjzoYEKadhQ5cL3UPI4UgtVZEk/Fc5yB0AaYUX3DuWHskxQTvj0mF2shYcZe9OubkvnQ==
 
+"@silencelaboratories/dkls-wasm-ll-vrf-bundler@1.0.0-pre.9":
+  version "1.0.0-pre.9"
+  resolved "https://registry.npmjs.org/@silencelaboratories/dkls-wasm-ll-vrf-bundler/-/dkls-wasm-ll-vrf-bundler-1.0.0-pre.9.tgz#e6f254404b5677210b7a6fad0c84b593c67a37cd"
+  integrity sha512-HW0XbTcztQOnmxNv5fd/pmd1KdMB8GEWDjsumxv9cS7ygNov4R3sMq4hpyO47wxXz0ibg13isbQJioLcNN2feA==
+
+"@silencelaboratories/dkls-wasm-ll-vrf-node@1.0.0-pre.9":
+  version "1.0.0-pre.9"
+  resolved "https://registry.npmjs.org/@silencelaboratories/dkls-wasm-ll-vrf-node/-/dkls-wasm-ll-vrf-node-1.0.0-pre.9.tgz#e7e8548255dea3fe84a7d41eb371c4c79df6f382"
+  integrity sha512-K1f8MfPWodWj4v1OftxjDuSHrES3yxMSaNwvZDilHVhsW6wml+HwhOLQEbyMZWjFg0zUoZp+lQvKJYa7FJZq/A==
+
+"@silencelaboratories/dkls-wasm-ll-vrf-web@1.0.0-pre.9":
+  version "1.0.0-pre.9"
+  resolved "https://registry.npmjs.org/@silencelaboratories/dkls-wasm-ll-vrf-web/-/dkls-wasm-ll-vrf-web-1.0.0-pre.9.tgz#d524bfd47d9a77f446416f7b4ca95c0d94a9dab8"
+  integrity sha512-aPuHtl4jV6DjekpD4CS1zclgN3ZG3xyWpDzL5Baadkkl2L+RMc3BZ3I0P4L/NGUxcaW09rKD7p4qpShEX1SPXw==
+
 "@silencelaboratories/dkls-wasm-ll-web@1.2.0-pre.4":
   version "1.2.0-pre.4"
   resolved "https://registry.npmjs.org/@silencelaboratories/dkls-wasm-ll-web/-/dkls-wasm-ll-web-1.2.0-pre.4.tgz"
   integrity sha512-RDyGVX6nyABPchnucl4IOV78LWzXBV9QucRiitRNONo3pfO4z375T00lI/wPiId13wXb8YNkB1Ej90hBNUK25A==
+
+"@silencelaboratories/eddsa-wasm-bundler@1.0.0-pre.9":
+  version "1.0.0-pre.9"
+  resolved "https://registry.npmjs.org/@silencelaboratories/eddsa-wasm-bundler/-/eddsa-wasm-bundler-1.0.0-pre.9.tgz#6de3bc8c5f8fa157f9c9da53b79cb9c3811e9eaf"
+  integrity sha512-HzKnHEk5m+wItMuxu7liEKsp4qOX6sLiz+y+BY6X3/XJETm3zyrja33cyPTzQ8+NLwwt7X29upj8aS4QF8aUZA==
+
+"@silencelaboratories/eddsa-wasm-node@1.0.0-pre.9":
+  version "1.0.0-pre.9"
+  resolved "https://registry.npmjs.org/@silencelaboratories/eddsa-wasm-node/-/eddsa-wasm-node-1.0.0-pre.9.tgz#cfe4a57249abe4663f9fec44420ea4cb897dd90e"
+  integrity sha512-fKN+GEL4Zd2BvkfSUPhDHhdi4I2EuB6liMrLsq9QPi0PVZP4DazDL4QbeTattPhnXvHqhmGF0g3Au0jvSpG7cg==
+
+"@silencelaboratories/eddsa-wasm-web@1.0.0-pre.9":
+  version "1.0.0-pre.9"
+  resolved "https://registry.npmjs.org/@silencelaboratories/eddsa-wasm-web/-/eddsa-wasm-web-1.0.0-pre.9.tgz#cb7fda8350b106da3e9e754055c88d00246ff228"
+  integrity sha512-OSkQDsPSvQt+Wlg8dI38yE5WxTxb3wdK0zhoOCg/KYKCysNBjA2sJhUNm6+ICPRaAv/dsx3PGxt3aVUaV48Eog==
 
 "@sinclair/typebox@^0.34.0":
   version "0.34.41"


### PR DESCRIPTION
Ticket: WCN-2546

Adds Silence Labs WASM so Wallet Safes MPC root creation can run VRF DKG next to the signing DKG. Deps only 

Packages added:

* @silencelaboratories/dkls-wasm-ll-vrf-{node,web,bundler}
* @silencelaboratories/eddsa-wasm-{node,web,bundler}

