### PR TITLE
feat(statics): onboard tbaseeth:wabaseusdc stata token on base-sepolia

### DIFF
--- a/modules/statics/src/allCoinsAndTokens.ts
+++ b/modules/statics/src/allCoinsAndTokens.ts
@@ -4405,6 +4405,16 @@ export const allCoinsAndTokens = [
     [...AccountCoin.DEFAULT_FEATURES, CoinFeature.EIP1559, CoinFeature.RECEIPT_TOKEN]
   ),
   erc20Token(
+    'e354c3b7-397c-436c-b756-1b266c3d79dc',
+    'tbaseeth:waBasSepLidUSDC',
+    'Wrapped Aave Base Sepolia USDC',
+    6,
+    '0xf430cb6e2b85f99222fbfa6dfea18ff60fa6b32a',
+    UnderlyingAsset['tbaseeth:waBasSepLidUSDC'],
+    Networks.test.basechain,
+    [...AccountCoin.DEFAULT_FEATURES, CoinFeature.EIP1559, CoinFeature.RECEIPT_TOKEN]
+  ),
+  erc20Token(
     '79fcac64-cad2-4c17-b8fc-2930b7022384',
     'tbaseeth:tpdd',
     'MarketplacePDD ALPACA',

--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -3829,6 +3829,7 @@ export enum UnderlyingAsset {
   'tbaseeth:tnmr' = 'tbaseeth:tnmr',
   'tbaseeth:tabeq' = 'tbaseeth:tabeq',
   'tbaseeth:ctbtccx_99e833' = 'tbaseeth:ctbtccx_99e833',
+  'tbaseeth:waBasSepLidUSDC' = 'tbaseeth:waBasSepLidUSDC',
 
   // Og mainnet tokens
   'og:wog' = 'og:wog',


### PR DESCRIPTION
## Summary

Onboards the Base Sepolia Aave V3 **StataTokenV2 (ERC-4626) USDC wrapper** as the BitGo testnet coin `tbaseeth:wabaseusdc` — the staging/E2E test reserve for the ERC-4626 flow ([TDD - Aave V3 §15.2](https://linear.app/bitgo/document/tdd-aave-v3-502dd62553ef)).

- `UnderlyingAsset` enum entry in `modules/statics/src/base.ts`
- `erc20Token` entry in `modules/statics/src/allCoinsAndTokens.ts` — 6 decimals, contract `0xf430cb6e2b85f99222fbfa6dfea18ff60fa6b32a`, `CoinFeature.RECEIPT_TOKEN` (mirrors the `tbaseeth:ctbtccx_99e833` vault-share-token precedent, DEFI-494)

## On-chain verification (checklist item 1 — Basescan was Cloudflare-gated)

Verified via `eth_call` against `https://sepolia.base.org`:

| call | result |
| -- | -- |
| `name()` | `Wrapped Aave Base Sepolia USDC` |
| `symbol()` | `waBaseSepUSDC` |
| `asset()` | `0xba50Cd2A20f6DA35D788639E581bca8d0B5d4D5f` (Base Sepolia USDC underlying ✓) |
| `decimals()` | 6 ✓ |

Address cross-checked against [aave-dao/aave-address-book `AaveV3BaseSepolia.ts`](https://github.com/aave-dao/aave-address-book/blob/main/src/ts/AaveV3BaseSepolia.ts) (`ASSETS.USDC.STATA_TOKEN`).

## Sequencing (per [PR Sequence doc](https://linear.app/bitgo/document/pr-sequence-onboarding-base-sepolia-statatoken-usdc-4e6da52f6b2f))

This PR is step 1 of 4. **Merge + trigger the `@bitgo-beta/statics` publish (publish.yml) and confirm the beta version before the downstream PRs consume it:**
- asset-metadata-service: `instrumentMetadata.json` + `marketCoinConfig.ts` (keyed off the UUID minted here: `e354c3b7-397c-436c-b756-1b266c3d79dc`)
- bitgo-microservices: bumps `@bitgo-beta/statics` to the published beta + adds the token to `testBaseethTokens`
- defi-service: `vaultRegistry` staging entry (`TBASEETH_USDC_AAVE_TEST`)

## Tests

- `modules/statics` build ✅ and full unit suite ✅ (36013 passing)
- Coin resolves via `coins.get('tbaseeth:wabaseusdc')` ✅

TICKET: DEFI-802