### PR TITLE
feat(statics): derive EVM token features from ERC20 support for AMS o…

### DIFF
--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -35,7 +35,7 @@ import { BaseCoin, CoinFeature, DynamicCoin } from './base';
 import { AmsNetworkConfigMap, AmsTokenConfig, TrimmedAmsTokenConfig } from './tokenConfig';
 import { CoinMap } from './map';
 import { BaseNetwork, getNetwork, getNetworksMap, NetworkType } from './networks';
-import { getNetworkFeatures } from './networkFeatureMapForTokens';
+import { getNetworkFeatures, registerErc20FamilyChecker } from './networkFeatureMapForTokens';
 import { ofcErc20Coins, tOfcErc20Coins } from './coins/ofcErc20Coins';
 import { ofcHoodethTokens } from './coins/ofcHoodethTokens';
 import { ofcCoins } from './coins/ofcCoins';
@@ -75,6 +75,11 @@ allCoinsAndTokens.forEach((coin) => {
     erc721ChainToNameMap[coin.family] = coin.name;
   }
 });
+
+// Let getNetworkFeatures() (in networkFeatureMapForTokens.ts) fall back to EVM_TOKEN_FEATURES for any
+// family whose base coin supports ERC20, so AMS token onboarding doesn't require hand-maintaining that
+// map for every new EVM family (see erc20ChainToNameMap above, built from the same statics data).
+registerErc20FamilyChecker((family) => family in erc20ChainToNameMap);
 
 export function createToken(token: AmsTokenConfig): Readonly<BaseCoin> | undefined {
   if (!token.isToken) {

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -35,7 +35,7 @@ import { BaseCoin, CoinFeature, DynamicCoin } from './base';
 import { AmsNetworkConfigMap, AmsTokenConfig, TrimmedAmsTokenConfig } from './tokenConfig';
 import { CoinMap } from './map';
 import { BaseNetwork, getNetwork, getNetworksMap, NetworkType } from './networks';
-import { getNetworkFeatures, registerErc20FamilyChecker } from './networkFeatureMapForTokens';
+import { getNetworkFeatures, registerErc20Families } from './networkFeatureMapForTokens';
 import { ofcErc20Coins, tOfcErc20Coins } from './coins/ofcErc20Coins';
 import { ofcHoodethTokens } from './coins/ofcHoodethTokens';
 import { ofcCoins } from './coins/ofcCoins';
@@ -76,10 +76,10 @@ allCoinsAndTokens.forEach((coin) => {
   }
 });
 
-// Let getNetworkFeatures() (in networkFeatureMapForTokens.ts) fall back to EVM_TOKEN_FEATURES for any
-// family whose base coin supports ERC20, so AMS token onboarding doesn't require hand-maintaining that
-// map for every new EVM family (see erc20ChainToNameMap above, built from the same statics data).
-registerErc20FamilyChecker((family) => family in erc20ChainToNameMap);
+// Backfill networkFeatureMapForTokens with EVM_TOKEN_FEATURES for any family whose base coin
+// supports ERC20 (see erc20ChainToNameMap above, built from the same statics data), so AMS token
+// onboarding doesn't require hand-maintaining that map for every new EVM family.
+registerErc20Families(Object.keys(erc20ChainToNameMap));
 
 export function createToken(token: AmsTokenConfig): Readonly<BaseCoin> | undefined {
   if (!token.isToken) {

--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -54,6 +54,8 @@ export const coins = CoinMap.fromCoins([
 // Build a map of ERC20-supporting chain family names to their mainnet coin names
 // Maps family -> coin name (e.g., 'ip' -> 'ip')
 const erc20ChainToNameMap: Record<string, string> = {};
+// Tracks whether each ERC20-supporting family's base coin also supports EIP1559 (e.g. xdc does not).
+const erc20FamilySupportsEip1559 = new Map<string, boolean>();
 
 allCoinsAndTokens.forEach((coin) => {
   if (
@@ -62,6 +64,7 @@ allCoinsAndTokens.forEach((coin) => {
     !coin.isToken
   ) {
     erc20ChainToNameMap[coin.family] = coin.name;
+    erc20FamilySupportsEip1559.set(coin.family, coin.features.includes(CoinFeature.EIP1559));
   }
 });
 
@@ -79,7 +82,7 @@ allCoinsAndTokens.forEach((coin) => {
 // Backfill networkFeatureMapForTokens with EVM_TOKEN_FEATURES for any family whose base coin
 // supports ERC20 (see erc20ChainToNameMap above, built from the same statics data), so AMS token
 // onboarding doesn't require hand-maintaining that map for every new EVM family.
-registerErc20Families(Object.keys(erc20ChainToNameMap));
+registerErc20Families(erc20FamilySupportsEip1559);
 
 export function createToken(token: AmsTokenConfig): Readonly<BaseCoin> | undefined {
   if (!token.isToken) {

--- a/modules/statics/src/index.ts
+++ b/modules/statics/src/index.ts
@@ -53,8 +53,10 @@ export { CoinMap } from './map';
 export {
   networkFeatureMapForTokens,
   registerNetworkFeatures,
+  registerErc20FamilyChecker,
   getNetworkFeatures,
   getTokenFeatures,
+  EVM_TOKEN_FEATURES,
 } from './networkFeatureMapForTokens';
 export {
   generateErc20Coin,

--- a/modules/statics/src/index.ts
+++ b/modules/statics/src/index.ts
@@ -57,6 +57,7 @@ export {
   getNetworkFeatures,
   getTokenFeatures,
   EVM_TOKEN_FEATURES,
+  EVM_TOKEN_FEATURES_NON_EIP1559,
 } from './networkFeatureMapForTokens';
 export {
   generateErc20Coin,

--- a/modules/statics/src/index.ts
+++ b/modules/statics/src/index.ts
@@ -53,7 +53,7 @@ export { CoinMap } from './map';
 export {
   networkFeatureMapForTokens,
   registerNetworkFeatures,
-  registerErc20FamilyChecker,
+  registerErc20Families,
   getNetworkFeatures,
   getTokenFeatures,
   EVM_TOKEN_FEATURES,

--- a/modules/statics/src/networkFeatureMapForTokens.ts
+++ b/modules/statics/src/networkFeatureMapForTokens.ts
@@ -32,17 +32,25 @@ export const EVM_TOKEN_FEATURES: CoinFeature[] = [
   CoinFeature.SUPPORTS_ERC20,
 ];
 
+/** Same as EVM_TOKEN_FEATURES, minus EIP1559, for EVM-compatible families that don't support it (e.g. xdc). */
+export const EVM_TOKEN_FEATURES_NON_EIP1559: CoinFeature[] = EVM_TOKEN_FEATURES.filter(
+  (feature) => feature !== CoinFeature.EIP1559
+);
+
 /**
- * Populate networkFeatureMapForTokens with EVM_TOKEN_FEATURES for every family whose base coin
- * carries CoinFeature.SUPPORTS_ERC20 and isn't already explicitly listed below. Called once from
+ * Populate networkFeatureMapForTokens for every family whose base coin carries
+ * CoinFeature.SUPPORTS_ERC20 and isn't already explicitly listed below, using EVM_TOKEN_FEATURES
+ * (or its non-EIP1559 variant, mirroring the base coin's own EIP1559 support). Called once from
  * coins.ts (which has access to the full coin map) so this module doesn't need to import it
  * directly (that would create a circular import: coins.ts -> networkFeatureMapForTokens.ts ->
  * allCoinsAndTokens.ts -> coins/botTokens.ts -> networkFeatureMapForTokens.ts).
  */
-export function registerErc20Families(families: Iterable<string>): void {
-  for (const family of families) {
+export function registerErc20Families(families: Iterable<[family: string, supportsEip1559: boolean]>): void {
+  for (const [family, supportsEip1559] of families) {
     if (!(family in networkFeatureMapForTokens)) {
-      networkFeatureMapForTokens[family as CoinFamily] = EVM_TOKEN_FEATURES;
+      networkFeatureMapForTokens[family as CoinFamily] = supportsEip1559
+        ? EVM_TOKEN_FEATURES
+        : EVM_TOKEN_FEATURES_NON_EIP1559;
     }
   }
 }

--- a/modules/statics/src/networkFeatureMapForTokens.ts
+++ b/modules/statics/src/networkFeatureMapForTokens.ts
@@ -21,13 +21,40 @@ export function registerNetworkFeatures(family: string, features: CoinFeature[])
   dynamicNetworkFeaturesMap.set(family, features);
 }
 
+/** Default token feature set shared by "plain" EVM-compatible chain families (no bespoke features). */
+export const EVM_TOKEN_FEATURES: CoinFeature[] = [
+  ...EVM_FEATURES,
+  CoinFeature.SHARED_EVM_SIGNING,
+  CoinFeature.SHARED_EVM_SDK,
+  CoinFeature.EVM_COMPATIBLE_IMS,
+  CoinFeature.EVM_COMPATIBLE_UI,
+  CoinFeature.EVM_COMPATIBLE_WP,
+  CoinFeature.SUPPORTS_ERC20,
+];
+
+// Set by coins.ts (which has access to the full coin map) so getNetworkFeatures() can fall back to
+// EVM_TOKEN_FEATURES for any family whose base coin supports ERC20, without this module needing to
+// import the coin map itself (that would create a circular import: coins.ts -> networkFeatureMapForTokens.ts
+// -> allCoinsAndTokens.ts -> coins/botTokens.ts -> networkFeatureMapForTokens.ts).
+let isErc20SupportedFamily: ((family: string) => boolean) | undefined;
+
+/** Register a predicate used to detect whether a family's base coin carries CoinFeature.SUPPORTS_ERC20. */
+export function registerErc20FamilyChecker(checker: (family: string) => boolean): void {
+  isErc20SupportedFamily = checker;
+}
+
 /**
  * Look up token features for a family.
- * Checks static map first, then falls back to dynamic map.
- * Returns undefined if the family is not registered in either map.
+ * Checks the static map first, then the dynamic map, then falls back to EVM_TOKEN_FEATURES for any
+ * family whose base coin supports ERC20 (see registerErc20FamilyChecker). Returns undefined if the
+ * family isn't recognized by any of the three.
  */
 export function getNetworkFeatures(family: string): CoinFeature[] | undefined {
-  return networkFeatureMapForTokens[family as CoinFamily] ?? dynamicNetworkFeaturesMap.get(family);
+  return (
+    networkFeatureMapForTokens[family as CoinFamily] ??
+    dynamicNetworkFeaturesMap.get(family) ??
+    (isErc20SupportedFamily?.(family) ? EVM_TOKEN_FEATURES : undefined)
+  );
 }
 
 /**
@@ -56,36 +83,12 @@ export const networkFeatureMapForTokens: Partial<Record<CoinFamily, CoinFeature[
   celo: AccountCoin.DEFAULT_FEATURES,
   eth: AccountCoin.DEFAULT_FEATURES,
   eos: AccountCoin.DEFAULT_FEATURES,
-  gasevm: [
-    ...EVM_FEATURES,
-    CoinFeature.SHARED_EVM_SIGNING,
-    CoinFeature.SHARED_EVM_SDK,
-    CoinFeature.EVM_COMPATIBLE_IMS,
-    CoinFeature.EVM_COMPATIBLE_UI,
-    CoinFeature.EVM_COMPATIBLE_WP,
-    CoinFeature.SUPPORTS_ERC20,
-  ],
+  gasevm: EVM_TOKEN_FEATURES,
   hbar: AccountCoin.DEFAULT_FEATURES,
   opeth: [...AccountCoin.DEFAULT_FEATURES, CoinFeature.EIP1559],
-  katanaeth: [
-    ...EVM_FEATURES,
-    CoinFeature.SHARED_EVM_SIGNING,
-    CoinFeature.SHARED_EVM_SDK,
-    CoinFeature.EVM_COMPATIBLE_IMS,
-    CoinFeature.EVM_COMPATIBLE_UI,
-    CoinFeature.EVM_COMPATIBLE_WP,
-    CoinFeature.SUPPORTS_ERC20,
-  ],
+  katanaeth: EVM_TOKEN_FEATURES,
   polygon: POLYGON_TOKEN_FEATURES,
-  scrolleth: [
-    ...EVM_FEATURES,
-    CoinFeature.SHARED_EVM_SIGNING,
-    CoinFeature.SHARED_EVM_SDK,
-    CoinFeature.EVM_COMPATIBLE_IMS,
-    CoinFeature.EVM_COMPATIBLE_UI,
-    CoinFeature.EVM_COMPATIBLE_WP,
-    CoinFeature.SUPPORTS_ERC20,
-  ],
+  scrolleth: EVM_TOKEN_FEATURES,
   sol: SOL_TOKEN_FEATURES,
   stx: STX_TOKEN_FEATURES,
   sui: SUI_TOKEN_FEATURES,

--- a/modules/statics/src/networkFeatureMapForTokens.ts
+++ b/modules/statics/src/networkFeatureMapForTokens.ts
@@ -32,29 +32,28 @@ export const EVM_TOKEN_FEATURES: CoinFeature[] = [
   CoinFeature.SUPPORTS_ERC20,
 ];
 
-// Set by coins.ts (which has access to the full coin map) so getNetworkFeatures() can fall back to
-// EVM_TOKEN_FEATURES for any family whose base coin supports ERC20, without this module needing to
-// import the coin map itself (that would create a circular import: coins.ts -> networkFeatureMapForTokens.ts
-// -> allCoinsAndTokens.ts -> coins/botTokens.ts -> networkFeatureMapForTokens.ts).
-let isErc20SupportedFamily: ((family: string) => boolean) | undefined;
-
-/** Register a predicate used to detect whether a family's base coin carries CoinFeature.SUPPORTS_ERC20. */
-export function registerErc20FamilyChecker(checker: (family: string) => boolean): void {
-  isErc20SupportedFamily = checker;
+/**
+ * Populate networkFeatureMapForTokens with EVM_TOKEN_FEATURES for every family whose base coin
+ * carries CoinFeature.SUPPORTS_ERC20 and isn't already explicitly listed below. Called once from
+ * coins.ts (which has access to the full coin map) so this module doesn't need to import it
+ * directly (that would create a circular import: coins.ts -> networkFeatureMapForTokens.ts ->
+ * allCoinsAndTokens.ts -> coins/botTokens.ts -> networkFeatureMapForTokens.ts).
+ */
+export function registerErc20Families(families: Iterable<string>): void {
+  for (const family of families) {
+    if (!(family in networkFeatureMapForTokens)) {
+      networkFeatureMapForTokens[family as CoinFamily] = EVM_TOKEN_FEATURES;
+    }
+  }
 }
 
 /**
  * Look up token features for a family.
- * Checks the static map first, then the dynamic map, then falls back to EVM_TOKEN_FEATURES for any
- * family whose base coin supports ERC20 (see registerErc20FamilyChecker). Returns undefined if the
- * family isn't recognized by any of the three.
+ * Checks the static map first (including entries backfilled by registerErc20Families), then the
+ * dynamic map. Returns undefined if the family isn't recognized by either.
  */
 export function getNetworkFeatures(family: string): CoinFeature[] | undefined {
-  return (
-    networkFeatureMapForTokens[family as CoinFamily] ??
-    dynamicNetworkFeaturesMap.get(family) ??
-    (isErc20SupportedFamily?.(family) ? EVM_TOKEN_FEATURES : undefined)
-  );
+  return networkFeatureMapForTokens[family as CoinFamily] ?? dynamicNetworkFeaturesMap.get(family);
 }
 
 /**

--- a/modules/statics/src/tokenConfig.ts
+++ b/modules/statics/src/tokenConfig.ts
@@ -209,7 +209,43 @@ export type TokenConfig =
   | Tip20TokenConfig
   | Erc7984TokenConfig;
 
-export interface TokenNetwork {
+/** Default bucket shape for a "plain" EVM-compatible family (ERC20 tokens only, no NFTs/confidential tokens). */
+export type EvmTokenBucket = { tokens: EthLikeTokenConfig[] };
+
+/** Families with a non-generic bucket shape (NFTs, confidential tokens, MPT tokens, or a non-EVM token config type). */
+type TokenNetworkExplicitFamily =
+  | CoinFamily.ETH
+  | CoinFamily.XLM
+  | CoinFamily.ALGO
+  | CoinFamily.OFC
+  | CoinFamily.CELO
+  | CoinFamily.EOS
+  | CoinFamily.AVAXC
+  | CoinFamily.SOL
+  | CoinFamily.HBAR
+  | CoinFamily.ADA
+  | CoinFamily.TRX
+  | CoinFamily.XRP
+  | CoinFamily.SUI
+  | CoinFamily.TAO
+  | CoinFamily.POLYX
+  | CoinFamily.APT
+  | CoinFamily.STX
+  | CoinFamily.NEAR
+  | CoinFamily.VET
+  | CoinFamily.TON
+  | CoinFamily.TEMPO
+  | CoinFamily.CANTON;
+
+/**
+ * Explicitly-shaped families above, intersected with a `Partial<Record<..., EvmTokenBucket>>` covering
+ * every other family so that any EVM family not listed here (current or future, e.g.
+ * gasevm/katanaeth/scrolleth/zksyncera/mantle/...) still type-checks — `getFormattedTokensByNetwork`
+ * already populates a bucket for every family whose base coin carries `CoinFeature.SUPPORTS_ERC20`/
+ * `SUPPORTS_ERC721` via `getEthLikeTokens`, so the type should not require hand-enumerating every such
+ * family either.
+ */
+export type TokenNetwork = {
   eth: {
     tokens: Erc20TokenConfig[];
     nfts: EthLikeTokenConfig[];
@@ -221,33 +257,14 @@ export interface TokenNetwork {
   celo: { tokens: CeloTokenConfig[] };
   eos: { tokens: EosTokenConfig[] };
   avaxc: { tokens: AvaxcTokenConfig[] };
-  polygon: { tokens: EthLikeTokenConfig[] };
-  soneium: { tokens: EthLikeTokenConfig[] };
-  bsc: { tokens: EthLikeTokenConfig[] };
-  arbeth: { tokens: EthLikeTokenConfig[] };
-  opeth: { tokens: EthLikeTokenConfig[] };
-  baseeth: { tokens: EthLikeTokenConfig[] };
-  og: { tokens: EthLikeTokenConfig[] };
-  flow: { tokens: EthLikeTokenConfig[] };
-  lineaeth: { tokens: EthLikeTokenConfig[] };
-  seievm: { tokens: EthLikeTokenConfig[] };
-  coredao: { tokens: EthLikeTokenConfig[] };
-  world: { tokens: EthLikeTokenConfig[] };
-  flr: { tokens: EthLikeTokenConfig[] };
   sol: { tokens: SolTokenConfig[] };
   hbar: { tokens: HbarTokenConfig[] };
   ada: { tokens: AdaTokenConfig[] };
   trx: { tokens: TrxTokenConfig[] };
   xrp: { tokens: XrpTokenConfig[]; mptTokens: XrpMptTokenConfig[] };
-  zketh: { tokens: EthLikeTokenConfig[] };
   sui: { tokens: SuiTokenConfig[] };
   tao: { tokens: TaoTokenConfig[] };
   polyx: { tokens: PolyxTokenConfig[] };
-  bera: { tokens: EthLikeTokenConfig[] };
-  mon: { tokens: EthLikeTokenConfig[] };
-  xdc: { tokens: EthLikeTokenConfig[] };
-  hypeevm: { tokens: EthLikeTokenConfig[] };
-  ip: { tokens: EthLikeTokenConfig[] };
   apt: {
     tokens: AptTokenConfig[];
     nftCollections: AptNFTCollectionConfig[];
@@ -262,7 +279,7 @@ export interface TokenNetwork {
   ton: { tokens: JettonTokenConfig[] };
   tempo: { tokens: Tip20TokenConfig[] };
   canton: { tokens: CantonTokenConfig[] };
-}
+} & Partial<Record<Exclude<CoinFamily, TokenNetworkExplicitFamily>, EvmTokenBucket>>;
 
 export interface Tokens {
   bitcoin: TokenNetwork;

--- a/modules/statics/src/tokenConfig.ts
+++ b/modules/statics/src/tokenConfig.ts
@@ -209,43 +209,7 @@ export type TokenConfig =
   | Tip20TokenConfig
   | Erc7984TokenConfig;
 
-/** Default bucket shape for a "plain" EVM-compatible family (ERC20 tokens only, no NFTs/confidential tokens). */
-export type EvmTokenBucket = { tokens: EthLikeTokenConfig[] };
-
-/** Families with a non-generic bucket shape (NFTs, confidential tokens, MPT tokens, or a non-EVM token config type). */
-type TokenNetworkExplicitFamily =
-  | CoinFamily.ETH
-  | CoinFamily.XLM
-  | CoinFamily.ALGO
-  | CoinFamily.OFC
-  | CoinFamily.CELO
-  | CoinFamily.EOS
-  | CoinFamily.AVAXC
-  | CoinFamily.SOL
-  | CoinFamily.HBAR
-  | CoinFamily.ADA
-  | CoinFamily.TRX
-  | CoinFamily.XRP
-  | CoinFamily.SUI
-  | CoinFamily.TAO
-  | CoinFamily.POLYX
-  | CoinFamily.APT
-  | CoinFamily.STX
-  | CoinFamily.NEAR
-  | CoinFamily.VET
-  | CoinFamily.TON
-  | CoinFamily.TEMPO
-  | CoinFamily.CANTON;
-
-/**
- * Explicitly-shaped families above, intersected with a `Partial<Record<..., EvmTokenBucket>>` covering
- * every other family so that any EVM family not listed here (current or future, e.g.
- * gasevm/katanaeth/scrolleth/zksyncera/mantle/...) still type-checks — `getFormattedTokensByNetwork`
- * already populates a bucket for every family whose base coin carries `CoinFeature.SUPPORTS_ERC20`/
- * `SUPPORTS_ERC721` via `getEthLikeTokens`, so the type should not require hand-enumerating every such
- * family either.
- */
-export type TokenNetwork = {
+export interface TokenNetwork {
   eth: {
     tokens: Erc20TokenConfig[];
     nfts: EthLikeTokenConfig[];
@@ -257,14 +221,33 @@ export type TokenNetwork = {
   celo: { tokens: CeloTokenConfig[] };
   eos: { tokens: EosTokenConfig[] };
   avaxc: { tokens: AvaxcTokenConfig[] };
+  polygon: { tokens: EthLikeTokenConfig[] };
+  soneium: { tokens: EthLikeTokenConfig[] };
+  bsc: { tokens: EthLikeTokenConfig[] };
+  arbeth: { tokens: EthLikeTokenConfig[] };
+  opeth: { tokens: EthLikeTokenConfig[] };
+  baseeth: { tokens: EthLikeTokenConfig[] };
+  og: { tokens: EthLikeTokenConfig[] };
+  flow: { tokens: EthLikeTokenConfig[] };
+  lineaeth: { tokens: EthLikeTokenConfig[] };
+  seievm: { tokens: EthLikeTokenConfig[] };
+  coredao: { tokens: EthLikeTokenConfig[] };
+  world: { tokens: EthLikeTokenConfig[] };
+  flr: { tokens: EthLikeTokenConfig[] };
   sol: { tokens: SolTokenConfig[] };
   hbar: { tokens: HbarTokenConfig[] };
   ada: { tokens: AdaTokenConfig[] };
   trx: { tokens: TrxTokenConfig[] };
   xrp: { tokens: XrpTokenConfig[]; mptTokens: XrpMptTokenConfig[] };
+  zketh: { tokens: EthLikeTokenConfig[] };
   sui: { tokens: SuiTokenConfig[] };
   tao: { tokens: TaoTokenConfig[] };
   polyx: { tokens: PolyxTokenConfig[] };
+  bera: { tokens: EthLikeTokenConfig[] };
+  mon: { tokens: EthLikeTokenConfig[] };
+  xdc: { tokens: EthLikeTokenConfig[] };
+  hypeevm: { tokens: EthLikeTokenConfig[] };
+  ip: { tokens: EthLikeTokenConfig[] };
   apt: {
     tokens: AptTokenConfig[];
     nftCollections: AptNFTCollectionConfig[];
@@ -279,7 +262,7 @@ export type TokenNetwork = {
   ton: { tokens: JettonTokenConfig[] };
   tempo: { tokens: Tip20TokenConfig[] };
   canton: { tokens: CantonTokenConfig[] };
-} & Partial<Record<Exclude<CoinFamily, TokenNetworkExplicitFamily>, EvmTokenBucket>>;
+}
 
 export interface Tokens {
   bitcoin: TokenNetwork;

--- a/modules/statics/test/unit/coins.ts
+++ b/modules/statics/test/unit/coins.ts
@@ -14,8 +14,10 @@ import {
   EosCoin,
   Erc20Coin,
   EthereumNetwork,
+  EVM_TOKEN_FEATURES,
   getFormattedTokenConfigForCoin,
   getFormattedTokens,
+  getNetworkFeatures,
   HederaToken,
   KeyCurve,
   Networks,
@@ -1665,6 +1667,30 @@ describe('create token map using config details', () => {
       should(coinName).not.be.undefined();
       // Note: This may return 'tzketh' due to legacy mapping - verify expected behavior
     });
+  });
+});
+
+describe('getNetworkFeatures EVM fallback (drift guard)', () => {
+  it('should return EVM_TOKEN_FEATURES for every mainnet family that supports ERC20 but has no explicit entry in networkFeatureMapForTokens', () => {
+    const erc20Families = new Set(
+      allCoinsAndTokens
+        .filter(
+          (coin) =>
+            !coin.isToken &&
+            coin.network.type === NetworkType.MAINNET &&
+            coin.features.includes(CoinFeature.SUPPORTS_ERC20)
+        )
+        .map((coin) => coin.family)
+    );
+
+    erc20Families.forEach((family) => {
+      const features = getNetworkFeatures(family);
+      features?.should.not.be.undefined();
+    });
+
+    // baseeth is the concrete gap this fallback closes: it has no hand-written entry in
+    // networkFeatureMapForTokens, but its base coin supports ERC20.
+    getNetworkFeatures('baseeth')?.should.deepEqual(EVM_TOKEN_FEATURES);
   });
 });
 

--- a/modules/statics/test/unit/coins.ts
+++ b/modules/statics/test/unit/coins.ts
@@ -15,6 +15,7 @@ import {
   Erc20Coin,
   EthereumNetwork,
   EVM_TOKEN_FEATURES,
+  EVM_TOKEN_FEATURES_NON_EIP1559,
   getFormattedTokenConfigForCoin,
   getFormattedTokens,
   getNetworkFeatures,
@@ -26,6 +27,7 @@ import {
   SolCoin,
   SuiCoin,
   tokens,
+  TrimmedAmsTokenConfig,
   UnderlyingAsset,
   UtxoCoin,
   XrpCoin,
@@ -1691,6 +1693,56 @@ describe('getNetworkFeatures EVM fallback (drift guard)', () => {
     // baseeth is the concrete gap this fallback closes: it has no hand-written entry in
     // networkFeatureMapForTokens, but its base coin supports ERC20.
     getNetworkFeatures('baseeth')?.should.deepEqual(EVM_TOKEN_FEATURES);
+  });
+});
+
+describe('AMS token feature composition for EVM fallback families (drift guard)', () => {
+  function trimmedConfigFor(family: string, networkName: string): TrimmedAmsTokenConfig {
+    return {
+      id: 'f1a6f7d2-5c1e-4b9a-8f0d-1e2a3b4c5d6f',
+      fullName: `${family} Faketoken`,
+      name: `t${family}:faketoken`,
+      prefix: '',
+      suffix: `T${family.toUpperCase()}:FAKETOKEN`,
+      baseUnit: 'wei',
+      kind: 'crypto',
+      family,
+      isToken: true,
+      decimalPlaces: 18,
+      asset: `t${family}:faketoken`,
+      primaryKeyCurve: 'secp256k1',
+      contractAddress: '0x1234567890abcdef1234567890abcdef12345678',
+      network: { name: networkName },
+      additionalFeatures: [CoinFeature.STAKING],
+      excludedFeatures: [CoinFeature.SHARED_EVM_SDK],
+    };
+  }
+
+  it('should compose EVM_TOKEN_FEATURES + additionalFeatures - excludedFeatures for baseeth (EIP1559-supporting fallback family)', () => {
+    const token = createTokenUsingTrimmedConfigDetails(trimmedConfigFor('baseeth', 'BaseChainTestnet'));
+    token?.should.not.be.undefined();
+
+    const expectedFeatures = new Set(EVM_TOKEN_FEATURES);
+    expectedFeatures.add(CoinFeature.STAKING);
+    expectedFeatures.delete(CoinFeature.SHARED_EVM_SDK);
+
+    token?.features.should.have.length(expectedFeatures.size);
+    expectedFeatures.forEach((feature) => token?.features.should.containEql(feature));
+    token?.features.should.not.containEql(CoinFeature.SHARED_EVM_SDK);
+  });
+
+  it('should compose EVM_TOKEN_FEATURES_NON_EIP1559 + additionalFeatures - excludedFeatures for prividiumeth (non-EIP1559 fallback family)', () => {
+    const token = createTokenUsingTrimmedConfigDetails(trimmedConfigFor('prividiumeth', 'Prividium Ethereum Testnet'));
+    token?.should.not.be.undefined();
+
+    const expectedFeatures = new Set(EVM_TOKEN_FEATURES_NON_EIP1559);
+    expectedFeatures.add(CoinFeature.STAKING);
+    expectedFeatures.delete(CoinFeature.SHARED_EVM_SDK);
+
+    token?.features.should.have.length(expectedFeatures.size);
+    expectedFeatures.forEach((feature) => token?.features.should.containEql(feature));
+    token?.features.should.not.containEql(CoinFeature.EIP1559);
+    token?.features.should.not.containEql(CoinFeature.SHARED_EVM_SDK);
   });
 });
 

--- a/modules/statics/test/unit/resources/amsTokenConfig.ts
+++ b/modules/statics/test/unit/resources/amsTokenConfig.ts
@@ -1232,4 +1232,28 @@ export const reducedTokenConfigForAllChains = {
       excludedFeatures: [],
     },
   ],
+  // 'baseeth' has no explicit entry in networkFeatureMapForTokens; this exercises the
+  // SUPPORTS_ERC20-derived EVM_TOKEN_FEATURES fallback in getNetworkFeatures().
+  'tbaseeth:faketoken': [
+    {
+      id: 'b3a6f7d2-5c1e-4b9a-8f0d-1e2a3b4c5d6e',
+      fullName: 'Base Testnet Faketoken',
+      name: 'tbaseeth:faketoken',
+      prefix: '',
+      suffix: 'TBASEETH:FAKETOKEN',
+      baseUnit: 'wei',
+      kind: 'crypto',
+      family: 'baseeth',
+      isToken: true,
+      decimalPlaces: 18,
+      asset: 'tbaseeth:faketoken',
+      primaryKeyCurve: 'secp256k1',
+      contractAddress: '0x1234567890abcdef1234567890abcdef12345678',
+      network: {
+        name: 'BaseChainTestnet',
+      },
+      additionalFeatures: [],
+      excludedFeatures: [],
+    },
+  ],
 };

--- a/modules/statics/test/unit/tokenConfigTests.ts
+++ b/modules/statics/test/unit/tokenConfigTests.ts
@@ -22,6 +22,8 @@ import {
   BaseContractAddressConfig,
 } from '../../src/tokenConfig';
 import { EthLikeERC20Token } from '../../src/account';
+import { allCoinsAndTokens } from '../../src/allCoinsAndTokens';
+import { NetworkType } from '../../src/networks';
 
 describe('EthLike Token Config Functions', function () {
   describe('getEthLikeTokenConfig', function () {
@@ -760,5 +762,31 @@ describe('EthLike Token Config Functions', function () {
         verifyTokens(formattedTokens.testnet.xlm.tokens);
       }).should.not.throw();
     });
+  });
+});
+
+describe('getFormattedTokensByNetwork EVM family coverage (drift guard)', () => {
+  it('should emit a bucket for every mainnet family that supports ERC20, even without a hand-written entry', () => {
+    const erc20Families = new Set(
+      allCoinsAndTokens
+        .filter(
+          (coin) =>
+            !coin.isToken &&
+            coin.network.type === NetworkType.MAINNET &&
+            coin.features.includes(CoinFeature.SUPPORTS_ERC20)
+        )
+        .map((coin) => coin.family)
+    );
+
+    const formattedTokens = getFormattedTokens();
+
+    erc20Families.forEach((family) => {
+      should(formattedTokens.bitcoin[family]).not.be.undefined();
+      should(formattedTokens.bitcoin[family]?.tokens).be.an.Array();
+    });
+
+    // baseeth is the concrete gap this closes: it has no hand-written entry in
+    // getFormattedTokensByNetwork's returned object, but its base coin supports ERC20.
+    should(formattedTokens.bitcoin.baseeth).not.be.undefined();
   });
 });

--- a/modules/statics/test/unit/tokenConfigTests.ts
+++ b/modules/statics/test/unit/tokenConfigTests.ts
@@ -779,10 +779,16 @@ describe('getFormattedTokensByNetwork EVM family coverage (drift guard)', () => 
     );
 
     const formattedTokens = getFormattedTokens();
+    // TokenNetwork only declares explicit keys for known families; cast to a dynamic
+    // lookup here since this test intentionally probes it with an arbitrary family string.
+    const bitcoinTokensByFamily = formattedTokens.bitcoin as unknown as Record<
+      string,
+      { tokens: unknown[] } | undefined
+    >;
 
     erc20Families.forEach((family) => {
-      should(formattedTokens.bitcoin[family]).not.be.undefined();
-      should(formattedTokens.bitcoin[family]?.tokens).be.an.Array();
+      should(bitcoinTokensByFamily[family]).not.be.undefined();
+      should(bitcoinTokensByFamily[family]?.tokens).be.an.Array();
     });
 
     // baseeth is the concrete gap this closes: it has no hand-written entry in


### PR DESCRIPTION
…nboarding

networkFeatureMapForTokens.ts required every EVM chain family to be hand-added before AMS could onboard ERC20 tokens for it, silently skipping any unlisted family (e.g. baseeth). getNetworkFeatures() now falls back to a shared EVM_TOKEN_FEATURES set for any family whose base coin has CoinFeature.SUPPORTS_ERC20, registered from coins.ts via a callback to avoid a circular import with allCoinsAndTokens.ts.

TICKET: CSHLD-1601

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
