### PR TITLE
ci: add zizmor action-pinning policy for public repositories

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,136 @@
+# Zizmor policy for BitGo's public repositories (INF-3420).
+#
+# The org-level action-pinning required workflow cannot run against
+# public repositories: GitHub does not allow required workflows from a
+# private repository to run in public ones. This is its
+# public-repository counterpart, stored in a public repository so that
+# enforcement for public repositories can reference it.
+#
+# Every zizmor audit except unpinned-uses is disabled: this policy
+# enforces third-party action pinning and nothing else.
+#
+# The grandfathered lists came from a 2026-09-03 scan of every
+# non-archived public repository in the BitGo org for `uses:`
+# references not pinned to a full-length commit SHA (INF-3420). Both
+# lists are shrink-only: remove an entry once every public-repository
+# workflow that references it pins it to a commit SHA -- do not add
+# new entries.
+rules:
+  adhoc-packages:
+    disable: true
+  anonymous-definition:
+    disable: true
+  archived-uses:
+    disable: true
+  artipacked:
+    disable: true
+  bot-conditions:
+    disable: true
+  cache-poisoning:
+    disable: true
+  concurrency-limits:
+    disable: true
+  dangerous-triggers:
+    disable: true
+  dependabot-cooldown:
+    disable: true
+  dependabot-execution:
+    disable: true
+  excessive-permissions:
+    disable: true
+  forbidden-uses:
+    disable: true
+  github-app:
+    disable: true
+  github-env:
+    disable: true
+  hardcoded-container-credentials:
+    disable: true
+  impostor-commit:
+    disable: true
+  insecure-commands:
+    disable: true
+  insecure-url-scheme:
+    disable: true
+  known-vulnerable-actions:
+    disable: true
+  misfeature:
+    disable: true
+  obfuscation:
+    disable: true
+  overprovisioned-secrets:
+    disable: true
+  ref-confusion:
+    disable: true
+  ref-version-mismatch:
+    disable: true
+  secrets-inherit:
+    disable: true
+  secrets-outside-env:
+    disable: true
+  self-hosted-runner:
+    disable: true
+  self-repository:
+    disable: true
+  stale-action-refs:
+    disable: true
+  superfluous-actions:
+    disable: true
+  template-injection:
+    disable: true
+  typosquat-uses:
+    disable: true
+  undocumented-permissions:
+    disable: true
+  unpinned-images:
+    disable: true
+  unpinned-tools:
+    disable: true
+  unredacted-secrets:
+    disable: true
+  unsound-condition:
+    disable: true
+  unsound-contains:
+    disable: true
+  unsound-ternary:
+    disable: true
+  use-trusted-publishing:
+    disable: true
+  unpinned-uses:
+    config:
+      policies:
+        # Trusted orgs -- ref-pinning (a tag or branch) is enough.
+        # Mirrors the org-level policy: GitHub-owned (actions/*,
+        # github/*) and the docker/* and aws-actions/* orgs. These orgs
+        # are trusted enough that hash-pinning them adds SHA-churn
+        # maintenance with no security benefit.
+        "actions/*": ref-pin
+        "github/*": ref-pin
+        "docker/*": ref-pin
+        "aws-actions/*": ref-pin
+
+        # Grandfathered internal (BitGo-owned) actions and reusable
+        # workflows still referenced by a floating tag/branch by at
+        # least one public repository as of the INF-3420 scan.
+        "BitGo/gha-renovate-bot/*": ref-pin
+        "BitGo/install-github-release-binary/*": ref-pin
+        "BitGo/semantic-release-github-actions/*": ref-pin
+
+        # Grandfathered external third-party actions still referenced by
+        # a floating tag/branch by at least one public repository as of
+        # the INF-3420 scan.
+        "actions-rs/toolchain": ref-pin
+        "azure/setup-helm": ref-pin
+        "codecov/codecov-action": ref-pin
+        "dtolnay/rust-toolchain": ref-pin
+        "helm/chart-releaser-action": ref-pin
+        "ilammy/msvc-dev-cmd": ref-pin
+        "ludeeus/action-shellcheck": ref-pin
+        "peter-evans/create-pull-request": ref-pin
+        "xresloader/upload-to-github-release": ref-pin
+
+        # Everything else: every other action (including new third-party
+        # actions, subpaths of grandfathered third-party repos, and
+        # internal actions in repos not listed above) must be pinned to
+        # a full commit SHA.
+        "*": hash-pin


### PR DESCRIPTION
Add .github/zizmor.yml, the public-repo counterpart of the org-level policy in build-system, which cannot run as a required workflow in public repos. It grandfathers the third-party and internal actions still on floating refs per the INF-3420 scan; everything else must be hash-pinned.

Ticket: INF-3420
Session-Id: 217d73a9-ac3c-466a-9cd9-112324f86e76
Task-Id: bfb9a42e-a4b1-49e6-a6e5-6f8d9d3d3051