### PR TITLE
feat(sdk-lib-mpc): add VrfDkg wrapper for DKLS VRF keygen

### DIFF
--- a/modules/sdk-lib-mpc/src/tss/dkls-vrf/dkg.ts
+++ b/modules/sdk-lib-mpc/src/tss/dkls-vrf/dkg.ts
@@ -1,0 +1,290 @@
+import type {
+  Message as VrfWasmMessage,
+  VrfKeygenSession,
+  VrfKeyshare as DklsVrfKeyshare,
+} from '@silencelaboratories/dkls-wasm-ll-vrf-node';
+import type { VrfKeygenSession as VrfWebKeygenSession } from '@silencelaboratories/dkls-wasm-ll-vrf-web';
+import { decode } from 'cbor-x';
+import { Buffer } from 'buffer';
+import { DeserializedMessages } from '../ecdsa-dkls/types';
+import { VrfDkgSessionData, VrfDkgState } from './types';
+
+// Platform-specific modules that do not exist everywhere: the node/web/bundler wasm
+// variants are mutually exclusive and selected at runtime (node process vs browser vs
+// bundler). Static imports would load the wrong platform's wasm binding, so both the
+// type aliases below and the lazy `await import()` calls are deliberate.
+type NodeVrfWasmer = typeof import('@silencelaboratories/dkls-wasm-ll-vrf-node');
+type WebVrfWasmer = typeof import('@silencelaboratories/dkls-wasm-ll-vrf-web');
+type BundlerVrfWasmer = typeof import('@silencelaboratories/dkls-wasm-ll-vrf-bundler');
+
+type VrfWasm = NodeVrfWasmer | WebVrfWasmer | BundlerVrfWasmer;
+
+/**
+ * Round driver for the DKLS VRF DKG, which produces a Ristretto VRF keyshare.
+ *
+ * Two rounds, all broadcast: round 1 exchanges commitments (VrfKeygenMsg1), round 2
+ * exchanges openings (VrfKeygenMsg2, emitted per recipient) and the DKG finalizes
+ * locally. There is no chain-code commitment step, unlike the signing DKG.
+ *
+ * Callers pass every message they hold; this class routes them internally. Round 1
+ * must exclude the party's own commitment (the wasm rejects a sender set containing
+ * it) and round 2 consumes the openings addressed to this party, own included.
+ *
+ * Party indices follow the MPCv2 convention: 0 = user, 1 = backup, 2 = bitgo.
+ */
+export class VrfDkg {
+  protected vrfSession: VrfKeygenSession | VrfWebKeygenSession | undefined;
+  protected vrfSessionBytes: Uint8Array;
+  protected vrfKeyShare: DklsVrfKeyshare | undefined;
+  protected keyShareBuff: Buffer | undefined;
+  protected publicKey: Buffer | undefined;
+  protected keyId: Buffer | undefined;
+  protected rootChainCode: Buffer | undefined;
+  protected n: number;
+  protected t: number;
+  protected partyIdx: number;
+  protected seed: Buffer | undefined;
+  protected vrfState: VrfDkgState = VrfDkgState.Uninitialized;
+  protected vrfWasm: VrfWasm | null;
+
+  constructor(n: number, t: number, partyIdx: number, seed?: Buffer, vrfWasm?: BundlerVrfWasmer) {
+    this.n = n;
+    this.t = t;
+    this.partyIdx = partyIdx;
+    this.seed = seed;
+    this.vrfWasm = vrfWasm ?? null;
+  }
+
+  private async loadVrfWasm(): Promise<void> {
+    if (!this.vrfWasm) {
+      this.vrfWasm = await import('@silencelaboratories/dkls-wasm-ll-vrf-node');
+    }
+  }
+
+  private getVrfWasm() {
+    if (!this.vrfWasm) {
+      throw Error('VRF wasm not loaded');
+    }
+    return this.vrfWasm;
+  }
+
+  private _restoreSession() {
+    if (!this.vrfSession) {
+      this.vrfSession = this.getVrfWasm().VrfKeygenSession.fromBytes(this.vrfSessionBytes);
+    }
+  }
+
+  /**
+   * Re-derive the round state from the wasm session bytes instead of trusting a
+   * caller-supplied enum. The wasm embeds a round tag for exactly this reason; this
+   * is what lets a stateless server resume mid-protocol.
+   */
+  private _deserializeState() {
+    if (!this.vrfSession) {
+      throw Error('Session not initialized');
+    }
+    const round = decode(this.vrfSession.toBytes()).round;
+    if (round === 'Init') {
+      this.vrfState = VrfDkgState.Uninitialized;
+    } else if (round === 'WaitMsg1') {
+      this.vrfState = VrfDkgState.Round1;
+    } else if (round === 'WaitMsg2') {
+      this.vrfState = VrfDkgState.Round2;
+    } else if (typeof round === 'object' && round !== null && 'Share' in round) {
+      this.vrfState = VrfDkgState.Complete;
+    } else {
+      this.vrfState = VrfDkgState.InvalidState;
+      throw Error(`Invalid State: ${JSON.stringify(round)}`);
+    }
+  }
+
+  /**
+   * Create this party's VRF DKG commitment (VrfKeygenMsg1, broadcast).
+   */
+  async initDkg(): Promise<DeserializedMessages> {
+    if (!this.vrfWasm) {
+      await this.loadVrfWasm();
+    }
+    if (this.t > this.n || this.partyIdx >= this.n) {
+      throw Error('Invalid parameters for VRF DKG');
+    }
+    if (this.vrfState != VrfDkgState.Uninitialized) {
+      throw Error('VRF DKG session already initialized');
+    }
+    if (
+      typeof window !== 'undefined' &&
+      /* checks for electron processes */
+      !window.process &&
+      !window.process?.['type']
+    ) {
+      /* This is only needed for browsers/web because it uses fetch to resolve the wasm asset for the web */
+      const initVrf = await import('@silencelaboratories/dkls-wasm-ll-vrf-web');
+      await initVrf.default();
+    }
+    if (this.seed && this.seed.length !== 32) {
+      throw Error(`Seed should be 32 bytes, got ${this.seed.length}.`);
+    }
+    const { VrfKeygenSession } = this.getVrfWasm();
+    this.vrfSession = this.seed
+      ? new VrfKeygenSession(this.n, this.t, this.partyIdx, new Uint8Array(this.seed))
+      : new VrfKeygenSession(this.n, this.t, this.partyIdx);
+    try {
+      const message = this.vrfSession.createFirstMessage();
+      // Copy the payload out before freeing the wasm message object.
+      const payload = new Uint8Array(message.payload);
+      message.free();
+      this.vrfSessionBytes = this.vrfSession.toBytes();
+      this._deserializeState();
+      return { broadcastMessages: [{ payload, from: this.partyIdx }], p2pMessages: [] };
+    } catch (e) {
+      throw Error(`Error while creating the first VRF message from party ${this.partyIdx}: ${e}`);
+    }
+  }
+
+  /**
+   * Process the messages this party holds for the current round and return this
+   * party's messages for the next round. Callers pass everything they hold; the
+   * round routing happens here:
+   *
+   * - Round 1 (WaitMsg1): consumes the other parties' commitments (own excluded —
+   *   the wasm rejects a sender set containing the party's own Msg1) and emits this
+   *   party's openings (VrfKeygenMsg2), one broadcast message per recipient.
+   * - Round 2 (WaitMsg2): consumes the openings addressed to this party (own
+   *   self-addressed opening included) and finalizes the DKG, returning no messages.
+   */
+  async handleIncomingMessages(messagesForIthRound: DeserializedMessages): Promise<DeserializedMessages> {
+    this._restoreSession();
+    if (!this.vrfSession) {
+      throw Error('Session not initialized');
+    }
+    const { Message: VrfMessage } = this.getVrfWasm();
+    let nextRoundMessages: VrfWasmMessage[] = [];
+    const nextRoundDeserializedMessages: DeserializedMessages = { broadcastMessages: [], p2pMessages: [] };
+    try {
+      switch (this.vrfState) {
+        case VrfDkgState.Round1: {
+          const othersCommitments = messagesForIthRound.broadcastMessages.filter((m) => m.from !== this.partyIdx);
+          nextRoundMessages = this.vrfSession.handleMessages(
+            othersCommitments.map((m) => new VrfMessage(m.payload, m.from))
+          );
+          this._deserializeState();
+          break;
+        }
+        case VrfDkgState.Round2: {
+          const openingsForMe = messagesForIthRound.p2pMessages.filter((m) => m.to === this.partyIdx);
+          nextRoundMessages = this.vrfSession.handleMessages(
+            openingsForMe.map((m) => new VrfMessage(m.payload, m.from, m.to))
+          );
+          // vrfKeyshare() consumes (and deallocates) the session in all cases.
+          const vrfKeyShare = this.vrfSession.vrfKeyshare();
+          this.vrfKeyShare = vrfKeyShare;
+          this.keyShareBuff = Buffer.from(vrfKeyShare.toBytes());
+          this.publicKey = Buffer.from(vrfKeyShare.publicKey);
+          this.keyId = Buffer.from(vrfKeyShare.keyId);
+          this.rootChainCode = Buffer.from(vrfKeyShare.rootChainCode);
+          vrfKeyShare.free();
+          this.vrfState = VrfDkgState.Complete;
+          return nextRoundDeserializedMessages;
+        }
+        default:
+          throw Error(`Invalid VRF DKG state: ${this.vrfState}`);
+      }
+
+      nextRoundDeserializedMessages.broadcastMessages = nextRoundMessages
+        .filter((m) => m.to_id === undefined)
+        .map((m) => ({ payload: new Uint8Array(m.payload), from: m.from_id }));
+      nextRoundDeserializedMessages.p2pMessages = nextRoundMessages
+        .filter((m) => m.to_id !== undefined)
+        .map((m) => ({ payload: new Uint8Array(m.payload), from: m.from_id, to: m.to_id! }));
+      return nextRoundDeserializedMessages;
+    } catch (e) {
+      throw Error(`Error while creating VRF messages from party ${this.partyIdx}, state ${this.vrfState}: ${e}`);
+    } finally {
+      nextRoundMessages.forEach((m) => m.free());
+      if (this.vrfState !== VrfDkgState.Complete) {
+        this.vrfSessionBytes = this.vrfSession.toBytes();
+        this.vrfSession = undefined;
+      }
+    }
+  }
+
+  /**
+   * Get the VRF keyshare bytes (CBOR VrfKeyshare) once the DKG is complete.
+   * This buffer is private key material.
+   */
+  getKeyShare(): Buffer {
+    if (!this.keyShareBuff) {
+      throw Error('Can not get key share, VRF DKG is not complete yet.');
+    }
+    return this.keyShareBuff;
+  }
+
+  /** 32-byte compressed Ristretto VRF public key, available once the DKG is complete. */
+  getPublicKey(): Buffer {
+    if (!this.publicKey) {
+      throw Error('Can not get public key, VRF DKG is not complete yet.');
+    }
+    return this.publicKey;
+  }
+
+  /** 32-byte VRF key identifier, available once the DKG is complete. */
+  getKeyId(): Buffer {
+    if (!this.keyId) {
+      throw Error('Can not get key id, VRF DKG is not complete yet.');
+    }
+    return this.keyId;
+  }
+
+  /** 32-byte VRF root chain code, available once the DKG is complete. */
+  getRootChainCode(): Buffer {
+    if (!this.rootChainCode) {
+      throw Error('Can not get root chain code, VRF DKG is not complete yet.');
+    }
+    return this.rootChainCode;
+  }
+
+  /**
+   * Get the current session data that can be used to restore the session later.
+   *
+   * The returned session bytes are secret key material — they carry this party's
+   * secret polynomial share. They must never be logged or persisted in the clear;
+   * the caller encrypts them exactly like the key share itself.
+   */
+  getSessionData(): VrfDkgSessionData {
+    const sessionData: VrfDkgSessionData = {
+      vrfSessionBytes: this.vrfSessionBytes,
+      vrfState: this.vrfState,
+    };
+    if (this.keyShareBuff) {
+      sessionData.keyShareBuff = this.keyShareBuff;
+    }
+    return sessionData;
+  }
+
+  /**
+   * Restore a VRF DKG session from previous session data.
+   * Note: This should not be used for Round 1 as that's the initialization phase.
+   * The round state is re-derived from the wasm session bytes, not trusted from the
+   * caller-supplied enum, so a tampered `vrfState` cannot steer the protocol.
+   */
+  static async restoreSession(
+    n: number,
+    t: number,
+    partyIdx: number,
+    sessionData: VrfDkgSessionData,
+    seed?: Buffer,
+    vrfWasm?: BundlerVrfWasmer
+  ): Promise<VrfDkg> {
+    const vrfDkg = new VrfDkg(n, t, partyIdx, seed, vrfWasm);
+    if (!vrfDkg.vrfWasm) {
+      await vrfDkg.loadVrfWasm();
+    }
+    vrfDkg.vrfSessionBytes = sessionData.vrfSessionBytes;
+    vrfDkg._restoreSession();
+    vrfDkg._deserializeState();
+    if (sessionData.keyShareBuff) {
+      vrfDkg.keyShareBuff = sessionData.keyShareBuff;
+    }
+    return vrfDkg;
+  }
+}

--- a/modules/sdk-lib-mpc/src/tss/dkls-vrf/index.ts
+++ b/modules/sdk-lib-mpc/src/tss/dkls-vrf/index.ts
@@ -1,0 +1,3 @@
+export * as DklsVrf from './dkg';
+export * as DklsVrfTypes from './types';
+export * as DklsVrfUtils from './util';

--- a/modules/sdk-lib-mpc/src/tss/dkls-vrf/types.ts
+++ b/modules/sdk-lib-mpc/src/tss/dkls-vrf/types.ts
@@ -1,0 +1,28 @@
+/**
+ * States of the VRF DKG state machine: a two-round, commit-then-open distributed
+ * key generation. Kept separate from `ecdsa-dkls`'s `DkgState` because the round
+ * counts differ (2 vs 4).
+ *
+ * The wasm session bytes embed a round tag (`Init` / `WaitMsg1` / `WaitMsg2` /
+ * `{Share: …}`); `VrfDkg` re-derives this state from the bytes rather than
+ * trusting a caller-supplied value.
+ */
+export enum VrfDkgState {
+  Uninitialized = 0,
+  /** Commitment created and broadcast; waiting for the other parties' VrfKeygenMsg1. */
+  Round1,
+  /** Openings created and broadcast; waiting for the other parties' VrfKeygenMsg2. */
+  Round2,
+  Complete,
+  InvalidState,
+}
+
+export interface VrfDkgSessionData {
+  /**
+   * Serialized wasm session. Secret key material — it carries the party's
+   * secret polynomial share. Never log it or persist it in the clear.
+   */
+  vrfSessionBytes: Uint8Array;
+  vrfState: VrfDkgState;
+  keyShareBuff?: Buffer;
+}

--- a/modules/sdk-lib-mpc/src/tss/dkls-vrf/util.ts
+++ b/modules/sdk-lib-mpc/src/tss/dkls-vrf/util.ts
@@ -1,0 +1,55 @@
+import { Buffer } from 'buffer';
+import { VrfDkg } from './dkg';
+
+/**
+ * Runs a local 2-of-3 VRF DKG across user (0), backup (1) and bitgo (2) parties and
+ * returns the three completed VrfDkg sessions, mirroring `generateDKGKeyShares` from
+ * `ecdsa-dkls/util.ts` so VRF tests read like the existing DKLS ones.
+ */
+export async function generateVrfDKGKeyShares(
+  seedUser?: Buffer,
+  seedBackup?: Buffer,
+  seedBitgo?: Buffer
+): Promise<[VrfDkg, VrfDkg, VrfDkg]> {
+  const user = new VrfDkg(3, 2, 0, seedUser);
+  const backup = new VrfDkg(3, 2, 1, seedBackup);
+  const bitgo = new VrfDkg(3, 2, 2, seedBitgo);
+  // #region round 1
+  const userRound1Messages = await user.initDkg();
+  const backupRound1Messages = await backup.initDkg();
+  const bitgoRound1Messages = await bitgo.initDkg();
+  const bitgoRound2Messages = await bitgo.handleIncomingMessages({
+    p2pMessages: [],
+    broadcastMessages: [...userRound1Messages.broadcastMessages, ...backupRound1Messages.broadcastMessages],
+  });
+  // #endregion
+
+  // #region round 2
+  const userRound2Messages = await user.handleIncomingMessages({
+    p2pMessages: [],
+    broadcastMessages: [...bitgoRound1Messages.broadcastMessages, ...backupRound1Messages.broadcastMessages],
+  });
+  const backupRound2Messages = await backup.handleIncomingMessages({
+    p2pMessages: [],
+    broadcastMessages: [...userRound1Messages.broadcastMessages, ...bitgoRound1Messages.broadcastMessages],
+  });
+  await bitgo.handleIncomingMessages({
+    p2pMessages: [bitgoRound2Messages, userRound2Messages, backupRound2Messages]
+      .flatMap((m) => m.p2pMessages)
+      .filter((m) => m.to === 2),
+    broadcastMessages: [],
+  });
+  await user.handleIncomingMessages({
+    p2pMessages: [bitgoRound2Messages, userRound2Messages, backupRound2Messages]
+      .flatMap((m) => m.p2pMessages)
+      .filter((m) => m.to === 0),
+    broadcastMessages: [],
+  });
+  await backup.handleIncomingMessages({
+    p2pMessages: [bitgoRound2Messages, userRound2Messages, backupRound2Messages]
+      .flatMap((m) => m.p2pMessages)
+      .filter((m) => m.to === 1),
+    broadcastMessages: [],
+  });
+  return [user, backup, bitgo];
+}

--- a/modules/sdk-lib-mpc/src/tss/index.ts
+++ b/modules/sdk-lib-mpc/src/tss/index.ts
@@ -1,4 +1,5 @@
 export * from './ecdsa';
 export * from './ecdsa-dkls';
+export * from './dkls-vrf';
 export * from './eddsa-mps';
 export * from './redpallas-mps';

--- a/modules/sdk-lib-mpc/test/unit/tss/dkls-vrf/dkg.ts
+++ b/modules/sdk-lib-mpc/test/unit/tss/dkls-vrf/dkg.ts
@@ -1,0 +1,260 @@
+import assert from 'assert';
+import { decode } from 'cbor-x';
+import * as openpgp from 'openpgp';
+import { DklsComms, DklsTypes, DklsVrf, DklsVrfUtils } from '../../../../src/tss';
+import { serializeMessages } from '../../../../src/tss/ecdsa-dkls/types';
+
+// Fixed seeds so the VRF DKG output is deterministic; the pinned public key below is
+// the fixture (same approach as dklsDkg.ts pinning 0207a404…).
+const seedUser = Buffer.from('a304733c16cc821fe171d5c7dbd7276fd90deae808b7553d17a1e55e4a76b270', 'hex');
+const seedBackup = Buffer.from('9d91c2e6353202cf61f8f275158b3468e9a00f7872fc2fd310b72cd026e2e2f9', 'hex');
+const seedBitgo = Buffer.from('33c749b635cdba7f9fbf51ad0387431cde47e20d8dc13acd1f51a9a0ad06ebfe', 'hex');
+
+const PINNED_PUBLIC_KEY = '5c814ae89c8ba8100aa2a8eb62387df59a5301aec12abfbd9ea6d4be113c4e2a';
+const PINNED_KEY_ID = '592c56f4aed1cf9e8989399ffc5b56a8618c9c44a9affe8f55357264957ba4af';
+const PINNED_ROOT_CHAIN_CODE = 'c13ededafc532c47780dd121986963e26beba7546ada9c297512dedc839afd68';
+// The CBOR VrfKeyshare encoding length varies slightly between parties and runs.
+const VRF_KEYSHARE_SIZE_MIN_BYTES = 600;
+const VRF_KEYSHARE_SIZE_MAX_BYTES = 700;
+
+function assertVrfKeyShareSize(keyShare: Buffer): void {
+  assert.ok(
+    keyShare.length >= VRF_KEYSHARE_SIZE_MIN_BYTES && keyShare.length <= VRF_KEYSHARE_SIZE_MAX_BYTES,
+    `VRF keyshare size ${keyShare.length} outside measured range ${VRF_KEYSHARE_SIZE_MIN_BYTES}-${VRF_KEYSHARE_SIZE_MAX_BYTES}`
+  );
+}
+
+describe('VRF DKG 2x3', function () {
+  it('should create VRF key shares with all parties agreeing on the public key, key id and root chain code', async function () {
+    const [user, backup, bitgo] = await DklsVrfUtils.generateVrfDKGKeyShares();
+    const userKeyShare = decode(user.getKeyShare());
+    const backupKeyShare = decode(backup.getKeyShare());
+    const bitgoKeyShare = decode(bitgo.getKeyShare());
+    assert.deepEqual(user.getPublicKey(), backup.getPublicKey());
+    assert.deepEqual(user.getPublicKey(), bitgo.getPublicKey());
+    assert.deepEqual(user.getKeyId(), backup.getKeyId());
+    assert.deepEqual(user.getKeyId(), bitgo.getKeyId());
+    assert.deepEqual(user.getRootChainCode(), backup.getRootChainCode());
+    assert.deepEqual(user.getRootChainCode(), bitgo.getRootChainCode());
+    // The CBOR keyshare carries the same material as the getters.
+    assert.equal(Buffer.from(userKeyShare.public_key).toString('hex'), user.getPublicKey().toString('hex'));
+    assert.equal(Buffer.from(userKeyShare.key_id).toString('hex'), user.getKeyId().toString('hex'));
+    assert.equal(Buffer.from(userKeyShare.root_chain_code).toString('hex'), user.getRootChainCode().toString('hex'));
+    // Shares are party-specific.
+    assert.equal(userKeyShare.party_id, 0);
+    assert.equal(backupKeyShare.party_id, 1);
+    assert.equal(bitgoKeyShare.party_id, 2);
+    assert.notDeepStrictEqual(userKeyShare.d_i, backupKeyShare.d_i);
+    assertVrfKeyShareSize(user.getKeyShare());
+  });
+
+  it('should produce a deterministic public key with fixed seeds', async function () {
+    const [user, backup, bitgo] = await DklsVrfUtils.generateVrfDKGKeyShares(seedUser, seedBackup, seedBitgo);
+    // Seed is used so the public key is the same every time.
+    assert.equal(user.getPublicKey().toString('hex'), PINNED_PUBLIC_KEY);
+    assert.equal(user.getKeyId().toString('hex'), PINNED_KEY_ID);
+    assert.equal(user.getRootChainCode().toString('hex'), PINNED_ROOT_CHAIN_CODE);
+    assert.equal(backup.getPublicKey().toString('hex'), PINNED_PUBLIC_KEY);
+    assert.equal(bitgo.getPublicKey().toString('hex'), PINNED_PUBLIC_KEY);
+  });
+
+  it('should carry VRF messages through the existing comms layer unchanged', async function () {
+    openpgp.config.rejectCurves = new Set();
+    const [userGpg, backupGpg, bitgoGpg] = await Promise.all([
+      openpgp.generateKey({ userIDs: [{ name: 'user', email: 'u@test.com' }], curve: 'secp256k1' }),
+      openpgp.generateKey({ userIDs: [{ name: 'backup', email: 'b@test.com' }], curve: 'secp256k1' }),
+      openpgp.generateKey({ userIDs: [{ name: 'bitgo', email: 'bg@test.com' }], curve: 'secp256k1' }),
+    ]);
+    const prvKeys = [
+      { partyId: 0, gpgKey: userGpg.privateKey },
+      { partyId: 1, gpgKey: backupGpg.privateKey },
+      { partyId: 2, gpgKey: bitgoGpg.privateKey },
+    ];
+    const pubKeys = [
+      { partyId: 0, gpgKey: userGpg.publicKey },
+      { partyId: 1, gpgKey: backupGpg.publicKey },
+      { partyId: 2, gpgKey: bitgoGpg.publicKey },
+    ];
+    const parties = [new DklsVrf.VrfDkg(3, 2, 0), new DklsVrf.VrfDkg(3, 2, 1), new DklsVrf.VrfDkg(3, 2, 2)];
+
+    // Round 1: every party signs (broadcast) its commitment through the comms layer.
+    const round1 = await Promise.all(parties.map((p) => p.initDkg()));
+    const round1Serialized = await Promise.all(
+      round1.map((m) =>
+        DklsComms.encryptAndAuthOutgoingMessages(serializeMessages(m), [], [prvKeys[m.broadcastMessages[0].from]])
+      )
+    );
+    const round1Outputs = [];
+    for (const [i, party] of parties.entries()) {
+      const others = round1Serialized.filter((_, j) => j !== i);
+      const decrypted = await DklsComms.decryptAndVerifyIncomingMessages(
+        { p2pMessages: [], broadcastMessages: others.flatMap((s) => s.broadcastMessages) },
+        pubKeys,
+        [prvKeys[i]]
+      );
+      round1Outputs.push(await party.handleIncomingMessages(DklsTypes.deserializeMessages(decrypted)));
+    }
+
+    // Round 2: every opening is p2p-addressed; encrypt each to its recipient.
+    const round2Ciphertexts: Record<number, DklsTypes.AuthEncMessages[]> = { 0: [], 1: [], 2: [] };
+    for (const [i, msgs] of round1Outputs.entries()) {
+      for (const p2p of msgs.p2pMessages) {
+        round2Ciphertexts[p2p.to].push(
+          await DklsComms.encryptAndAuthOutgoingMessages(
+            { p2pMessages: [DklsTypes.serializeP2PMessage(p2p)], broadcastMessages: [] },
+            [pubKeys[p2p.to]],
+            [prvKeys[i]]
+          )
+        );
+      }
+    }
+    for (const [i, party] of parties.entries()) {
+      const decrypted = await DklsComms.decryptAndVerifyIncomingMessages(
+        { p2pMessages: round2Ciphertexts[i].flatMap((m) => m.p2pMessages), broadcastMessages: [] },
+        pubKeys,
+        [prvKeys[i]]
+      );
+      await party.handleIncomingMessages(DklsTypes.deserializeMessages(decrypted));
+    }
+    // All three parties completed the VRF DKG over the comms layer and agree.
+    assert.deepEqual(parties[0].getPublicKey(), parties[1].getPublicKey());
+    assert.deepEqual(parties[0].getPublicKey(), parties[2].getPublicKey());
+    assertVrfKeyShareSize(parties[0].getKeyShare());
+  });
+
+  it('should round-trip round-1 messages through serializeMessages/deserializeMessages', async function () {
+    const parties = [new DklsVrf.VrfDkg(3, 2, 0), new DklsVrf.VrfDkg(3, 2, 1), new DklsVrf.VrfDkg(3, 2, 2)];
+    const round1 = await Promise.all(parties.map((p) => p.initDkg()));
+    const serialized = serializeMessages(round1[0]);
+    const deserialized = DklsTypes.deserializeMessages(serialized);
+    assert.equal(deserialized.broadcastMessages.length, round1[0].broadcastMessages.length);
+    assert.equal(deserialized.broadcastMessages[0].from, round1[0].broadcastMessages[0].from);
+    assert.deepEqual(deserialized.broadcastMessages[0].payload, round1[0].broadcastMessages[0].payload);
+    assert.equal(deserialized.p2pMessages.length, 0);
+    // The re-hydrated messages still drive a real session to completion.
+    const userRound2 = await parties[0].handleIncomingMessages({
+      p2pMessages: [],
+      broadcastMessages: [...round1[1].broadcastMessages, ...round1[2].broadcastMessages],
+    });
+    const backupRound2 = await parties[1].handleIncomingMessages({
+      p2pMessages: [],
+      broadcastMessages: [...round1[0].broadcastMessages, ...round1[2].broadcastMessages],
+    });
+    const bitgoRound2 = await parties[2].handleIncomingMessages({
+      p2pMessages: [],
+      broadcastMessages: [...round1[0].broadcastMessages, ...round1[1].broadcastMessages],
+    });
+    // Each party consumes every opening addressed to it, its own self-addressed
+    // opening included.
+    const round2Outputs = [userRound2, backupRound2, bitgoRound2];
+    for (const [i, party] of parties.entries()) {
+      await party.handleIncomingMessages({
+        p2pMessages: round2Outputs.flatMap((m) => m.p2pMessages).filter((m) => m.to === i),
+        broadcastMessages: [],
+      });
+    }
+    assertVrfKeyShareSize(parties[0].getKeyShare());
+  });
+
+  it('should restore a session serialized after initialization', async function () {
+    const restored = await runWithRestore('afterInit');
+    assert.equal(restored.getPublicKey().toString('hex'), PINNED_PUBLIC_KEY);
+  });
+
+  it('should restore a session serialized after round 1', async function () {
+    const restored = await runWithRestore('afterRound1');
+    assert.equal(restored.getPublicKey().toString('hex'), PINNED_PUBLIC_KEY);
+  });
+
+  it('should reject a wrong message count in round 1', async function () {
+    const user = new DklsVrf.VrfDkg(3, 2, 0);
+    const backup = new DklsVrf.VrfDkg(3, 2, 1);
+    const bitgo = new DklsVrf.VrfDkg(3, 2, 2);
+    await user.initDkg();
+    const backupMessages = await backup.initDkg();
+    await bitgo.initDkg();
+    // Round 1 needs both other parties' commitments; passing only one must fail.
+    await assert.rejects(
+      user.handleIncomingMessages({ p2pMessages: [], broadcastMessages: [...backupMessages.broadcastMessages] }),
+      /Invalid message count|invalid message count/
+    );
+  });
+
+  it('should reject duplicate senders in round 1', async function () {
+    const user = new DklsVrf.VrfDkg(3, 2, 0);
+    const backup = new DklsVrf.VrfDkg(3, 2, 1);
+    const bitgo = new DklsVrf.VrfDkg(3, 2, 2);
+    await user.initDkg();
+    const backupMessages = await backup.initDkg();
+    await bitgo.initDkg();
+    // Two commitments claiming to be from backup must fail the sender set check.
+    await assert.rejects(
+      user.handleIncomingMessages({
+        p2pMessages: [],
+        broadcastMessages: [...backupMessages.broadcastMessages, ...backupMessages.broadcastMessages],
+      }),
+      /Invalid message sender set|invalid message sender set|invalid participant set/
+    );
+  });
+
+  it('should reject getKeyShare before the DKG completes', async function () {
+    const user = new DklsVrf.VrfDkg(3, 2, 0);
+    assert.throws(() => user.getKeyShare(), /Can not get key share/);
+    await user.initDkg();
+    assert.throws(() => user.getKeyShare(), /Can not get key share/);
+  });
+
+  it('should reject invalid constructor parameters and double initialization', async function () {
+    assert.rejects(new DklsVrf.VrfDkg(2, 3, 0).initDkg(), /Invalid parameters for VRF DKG/);
+    assert.rejects(new DklsVrf.VrfDkg(3, 2, 5).initDkg(), /Invalid parameters for VRF DKG/);
+    assert.rejects(new DklsVrf.VrfDkg(3, 2, 0, Buffer.alloc(16)).initDkg(), /Seed should be 32 bytes, got 16/);
+    const user = new DklsVrf.VrfDkg(3, 2, 0);
+    await user.initDkg();
+    await assert.rejects(() => user.initDkg(), /VRF DKG session already initialized/);
+  });
+
+  /**
+   * Runs a full seeded ceremony where party 0's session is serialized and restored at
+   * the requested point, returning party 0's completed session.
+   */
+  async function runWithRestore(restoreAfter: 'afterInit' | 'afterRound1'): Promise<DklsVrf.VrfDkg> {
+    const user = new DklsVrf.VrfDkg(3, 2, 0, seedUser);
+    const backup = new DklsVrf.VrfDkg(3, 2, 1, seedBackup);
+    const bitgo = new DklsVrf.VrfDkg(3, 2, 2, seedBitgo);
+    const round1 = await Promise.all([user, backup, bitgo].map((p) => p.initDkg()));
+    const [userRound1, backupRound1, bitgoRound1] = round1;
+
+    let userSession: DklsVrf.VrfDkg = user;
+    if (restoreAfter === 'afterInit') {
+      userSession = await DklsVrf.VrfDkg.restoreSession(3, 2, 0, user.getSessionData(), seedUser);
+    }
+    const userRound2 = await userSession.handleIncomingMessages({
+      p2pMessages: [],
+      broadcastMessages: [...backupRound1.broadcastMessages, ...bitgoRound1.broadcastMessages],
+    });
+    if (restoreAfter === 'afterRound1') {
+      userSession = await DklsVrf.VrfDkg.restoreSession(3, 2, 0, userSession.getSessionData(), seedUser);
+    }
+    const backupRound2 = await backup.handleIncomingMessages({
+      p2pMessages: [],
+      broadcastMessages: [...userRound1.broadcastMessages, ...bitgoRound1.broadcastMessages],
+    });
+    const bitgoRound2 = await bitgo.handleIncomingMessages({
+      p2pMessages: [],
+      broadcastMessages: [...userRound1.broadcastMessages, ...backupRound1.broadcastMessages],
+    });
+    await userSession.handleIncomingMessages({
+      p2pMessages: [userRound2, backupRound2, bitgoRound2].flatMap((m) => m.p2pMessages).filter((m) => m.to === 0),
+      broadcastMessages: [],
+    });
+    await backup.handleIncomingMessages({
+      p2pMessages: [userRound2, backupRound2, bitgoRound2].flatMap((m) => m.p2pMessages).filter((m) => m.to === 1),
+      broadcastMessages: [],
+    });
+    await bitgo.handleIncomingMessages({
+      p2pMessages: [userRound2, backupRound2, bitgoRound2].flatMap((m) => m.p2pMessages).filter((m) => m.to === 2),
+      broadcastMessages: [],
+    });
+    return userSession;
+  }
+});


### PR DESCRIPTION
Ticket: WCN-2446


 Adds a standalone round-driver for the DKLS VRF DKG — VrfDkg — to sdk-lib-mpc, letting one party (user/backup/BitGo) run its side of a 2-of-3 VRF key generation. This is the crypto primitive for safe MPC root
 keys that carry a VRF share for hardened derivation; it wraps the VrfKeygenSession wasm (deps added in #9635) behind the same session-persistence and message-handling patterns as the existing signing Dkg, and
 reuses the existing comms layer unchanged. No platform, wire-format, or createKeychains changes — the driver is fully exercisable with a local 3-party in-process run.

 ## Changes

 - `src/tss/dkls-vrf/dkg.ts` — VrfDkg class: initDkg() (broadcast commitment), handleIncomingMessages() (round routing incl. the measured n−1 / n message asymmetry; round-2 openings are emitted per-recipient),
   getKeyShare() / getPublicKey() / getKeyId() / getRootChainCode(), and getSessionData() / restoreSession() with round state re-derived from the wasm session bytes (_deserializeState) rather than trusted from
   the caller.
 - `src/tss/dkls-vrf/types.ts` — VrfDkgState + VrfDkgSessionData (own enum, kept separate from DkgState since round counts differ).
 - `src/tss/dkls-vrf/util.ts` — generateVrfDKGKeyShares() local 3-party helper, mirroring generateDKGKeyShares.
 - `src/tss/dkls-vrf/index.ts` + `src/tss/index.ts` — exported as DklsVrf, matching the DklsDkg/DklsComms naming convention.
 - `test/unit/tss/dkls-vrf/dkg.ts` — 10 tests: 3-party agreement on publicKey/keyId/rootChainCode, deterministic pinned seed fixture, full round-trip through the comms layer (openpgp sign/verify),
   serialize/deserialize round-trip, session restore after each round, and rejection cases (wrong message count, duplicate senders, early getKeyShare).


