### PR TITLE
fix: bump fflate to 0.8.3 and toml to 4.3.0 (osv-scanner CVSS 7.0+ gate)

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "yeoman-generator": "^5.6.1"
   },
   "resolutions": {
+    "fflate": "0.8.3",
+    "toml": "4.3.0",
     "**/cliui/strip-ansi": "6.0.1",
     "**/cliui/string-width": "4.2.3",
     "**/yargs/cliui/string-width": "4.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11808,10 +11808,10 @@ fetch-blob@^3.1.2, fetch-blob@^3.1.4:
     node-domexception "^1.0.0"
     web-streams-polyfill "^3.0.3"
 
-fflate@^0.8.1:
-  version "0.8.2"
-  resolved "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz"
-  integrity sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==
+fflate@0.8.3, fflate@^0.8.1:
+  version "0.8.3"
+  resolved "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz#bc27d8eb30343d4d512abb03480202ce65d825fc"
+  integrity sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==
 
 figures@3.2.0, figures@^3.2.0:
   version "3.2.0"
@@ -20272,10 +20272,10 @@ toidentifier@1.0.1:
   resolved "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
-toml@^2.3.0:
-  version "2.3.6"
-  resolved "https://registry.npmjs.org/toml/-/toml-2.3.6.tgz"
-  integrity sha512-gVweAectJU3ebq//Ferr2JUY4WKSDe5N+z0FvjDncLGyHmIDoxgY/2Ie4qfEIDm4IS7OA6Rmdm7pdEEdMcV/xQ==
+toml@4.3.0, toml@^2.3.0:
+  version "4.3.0"
+  resolved "https://registry.npmjs.org/toml/-/toml-4.3.0.tgz#10e2ff83296ec17d8935bf02364e4969cfeaae67"
+  integrity sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==
 
 tonweb@^0.0.62:
   version "0.0.62"


### PR DESCRIPTION
## Summary
The release's osv-scanner "Enforce Vulnerability Severity Threshold" gate was failing on 3 advisory groups at CVSS >= 7.0:

- `fflate@0.8.2` (transitive via `@bitgo/key-card` > `jspdf`) — **GHSA-px8p-9vwx-vf98** (CVSS 7.5): `unzipSync` can infinite-loop on a malformed ZIP64 archive.
- `toml@2.3.6` (transitive via `bitgo` > `stellar-sdk`) — **GHSA-82x6-q7mm-w9cf** (CVSS 7.5): uncontrolled recursion DoS in `toml.parse()`.
- `toml@2.3.6` — **GHSA-v5mp-jgw5-2x6j** (CVSS 8.2): prototype pollution via `__proto__` key-path desync in `toml.parse()`.

Fixed by pinning both via root `resolutions`:
- `fflate` -> `0.8.3` (patch release with the fix)
- `toml` -> `4.3.0` (latest 4.x, includes both fixes)

## Verification
- Full monorepo `yarn install` + build succeeded with both pins in place.
- `jspdf` only calls `fflate.zlibSync` (compression) — never `unzipSync` — so the bump carries no behavioral risk there.
- `stellar-sdk`'s `toml.parse()` call shape (`require("toml").default.parse(text)`) is unchanged in 4.3.0 (still CJS, `main: index.js`); confirmed with a standalone parse test.
- We also checked whether our code ever reaches stellar-sdk's toml-based domain resolution path (`StellarTomlResolver`/`FederationServer.createForDomain`) — we don't; our XLM federation lookups use a fixed BitGo URL — but bumping to the patched version was safer/cleaner than an exclusion here since it verified cleanly, unlike tar's exclusion-only case elsewhere in `osv-scanner.toml`.

## Test plan
- [x] `yarn install` succeeds, full monorepo build succeeds
- [x] `fflate` resolves to `0.8.3`, `toml` resolves to `4.3.0` (`yarn why`)
- [x] CI passes
- [ ] osv-scanner "Enforce Vulnerability Severity Threshold" step passes on next run