### PR TITLE
fix: bump fflate and stellar-sdk to resolve OSV HIGH/CRITICAL

### DIFF
--- a/modules/bitgo/package.json
+++ b/modules/bitgo/package.json
@@ -139,7 +139,7 @@
     "bignumber.js": "^9.1.1",
     "lodash": "^4.18.0",
     "openpgp": "5.11.3",
-    "stellar-sdk": "^10.0.1",
+    "stellar-sdk": "^13.0.0",
     "superagent": "^9.0.1"
   },
   "devDependencies": {

--- a/modules/sdk-coin-algo/package.json
+++ b/modules/sdk-coin-algo/package.json
@@ -50,7 +50,7 @@
     "joi": "^17.4.0",
     "js-sha512": "0.8.0",
     "lodash": "^4.18.0",
-    "stellar-sdk": "^10.0.1",
+    "stellar-sdk": "^13.0.0",
     "tweetnacl": "^1.0.3"
   },
   "devDependencies": {

--- a/modules/sdk-coin-hbar/package.json
+++ b/modules/sdk-coin-hbar/package.json
@@ -50,7 +50,7 @@
     "lodash": "^4.18.0",
     "long": "^5.2.3",
     "protobufjs": "^7.5.8",
-    "stellar-sdk": "^10.0.1",
+    "stellar-sdk": "^13.0.0",
     "tweetnacl": "^1.0.3"
   },
   "devDependencies": {

--- a/modules/sdk-coin-xlm/package.json
+++ b/modules/sdk-coin-xlm/package.json
@@ -44,7 +44,7 @@
     "@bitgo/statics": "^59.12.0",
     "bignumber.js": "^9.1.1",
     "lodash": "^4.18.0",
-    "stellar-sdk": "^10.0.1",
+    "stellar-sdk": "^13.0.0",
     "superagent": "^9.0.1"
   },
   "devDependencies": {

--- a/modules/sdk-coin-xlm/src/xlm.ts
+++ b/modules/sdk-coin-xlm/src/xlm.ts
@@ -432,7 +432,7 @@ export class Xlm extends BaseCoin {
    * @returns minimum balance in stroops
    */
   async getMinimumReserve(): Promise<number> {
-    const server = new stellar.Server(this.getHorizonUrl());
+    const server = new stellar.Horizon.Server(this.getHorizonUrl());
 
     const horizonLedgerInfo = await server.ledgers().order('desc').limit(1).call();
 
@@ -451,7 +451,7 @@ export class Xlm extends BaseCoin {
    * @returns transaction fee in stroops
    */
   async getBaseTransactionFee(): Promise<number> {
-    const server = new stellar.Server(this.getHorizonUrl());
+    const server = new stellar.Horizon.Server(this.getHorizonUrl());
 
     const horizonLedgerInfo = await server.ledgers().order('desc').limit(1).call();
 
@@ -599,11 +599,11 @@ export class Xlm extends BaseCoin {
    *
    * @returns instance of BitGo Federation Server
    */
-  getBitGoFederationServer(): stellar.FederationServer {
+  getBitGoFederationServer(): stellar.Federation.Server {
     // Identify the URI scheme in case we need to allow connecting to HTTP server.
     const isNonSecureEnv = !_.startsWith(common.Environments[this.bitgo.env].uri, 'https');
     const federationServerOptions = { allowHttp: isNonSecureEnv };
-    return new stellar.FederationServer(this.getFederationServerUrl(), 'bitgo.com', federationServerOptions);
+    return new stellar.Federation.Server(this.getFederationServerUrl(), 'bitgo.com', federationServerOptions);
   }
 
   /**
@@ -619,7 +619,7 @@ export class Xlm extends BaseCoin {
   }: {
     address?: string;
     accountId?: string;
-  }): Promise<stellar.FederationServer.Record> {
+  }): Promise<stellar.Federation.Api.Record> {
     try {
       const federationServer = this.getBitGoFederationServer();
       if (address) {
@@ -644,7 +644,7 @@ export class Xlm extends BaseCoin {
    *
    * @param {String} address - stellar address to look for
    */
-  async federationLookupByName(address: string): Promise<stellar.FederationServer.Record> {
+  async federationLookupByName(address: string): Promise<stellar.Federation.Api.Record> {
     if (!address) {
       throw new Error('invalid Stellar address');
     }
@@ -658,7 +658,7 @@ export class Xlm extends BaseCoin {
    *
    * @param {String} accountId - stellar account id
    */
-  async federationLookupByAccountId(accountId: string): Promise<stellar.FederationServer.Record> {
+  async federationLookupByAccountId(accountId: string): Promise<stellar.Federation.Api.Record> {
     if (!accountId) {
       throw new Error('invalid Stellar account');
     }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "**/sha.js": ">=2.4.12",
     "**/serialize-javascript": "7.0.5",
     "jspdf": ">=4.2.1",
+    "fflate": "0.8.3",
     "@ethereumjs/util": "8.0.3",
     "@types/keyv": "3.1.4",
     "@types/react": "17.0.24",
@@ -259,12 +260,6 @@
     },
     "express": {
       "path-to-regexp": "0.1.13"
-    },
-    "stellar-sdk": {
-      "bignumber.js": "4.1.0"
-    },
-    "stellar-base": {
-      "bignumber.js": "4.1.0"
     },
     "avalanche": {
       "ws": "8.18.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5744,6 +5744,25 @@
     c32check "^2.0.0"
     lodash.clonedeep "^4.5.0"
 
+"@stellar/js-xdr@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.2.tgz#db7611135cf21e989602fd72f513c3bed621bc74"
+  integrity sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==
+
+"@stellar/stellar-base@^13.1.0":
+  version "13.1.0"
+  resolved "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-13.1.0.tgz#06d9075cc72da05bc5dd6f1971e6682a0525cec9"
+  integrity sha512-90EArG+eCCEzDGj3OJNoCtwpWDwxjv+rs/RNPhvg4bulpjN/CSRj+Ys/SalRcfM4/WRC5/qAfjzmJBAuquWhkA==
+  dependencies:
+    "@stellar/js-xdr" "^3.1.2"
+    base32.js "^0.1.0"
+    bignumber.js "^9.1.2"
+    buffer "^6.0.3"
+    sha.js "^2.3.6"
+    tweetnacl "^1.0.3"
+  optionalDependencies:
+    sodium-native "^4.3.3"
+
 "@substrate/connect-extension-protocol@^2.0.0":
   version "2.2.2"
   resolved "https://registry.npmjs.org/@substrate/connect-extension-protocol/-/connect-extension-protocol-2.2.2.tgz"
@@ -6215,11 +6234,6 @@
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
 
-"@types/eventsource@^1.1.2":
-  version "1.1.15"
-  resolved "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.15.tgz"
-  integrity sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA==
-
 "@types/expect@^1.20.4":
   version "1.20.4"
   resolved "https://registry.npmjs.org/@types/expect/-/expect-1.20.4.tgz"
@@ -6421,7 +6435,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@>= 8", "@types/node@>=10.0.0", "@types/node@>=13.7.0", "@types/node@^24.10.9":
+"@types/node@*", "@types/node@>=10.0.0", "@types/node@>=13.7.0", "@types/node@^24.10.9":
   version "24.10.9"
   resolved "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz"
   integrity sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==
@@ -6699,11 +6713,6 @@
   integrity sha512-TU+fZFBTBcXj/GpDpDaBmgWk/gn96kMZ+uocaFUlV2f8a6WdMzzI44QBCmGcCiYR0Y6ZlNRiyUyKKt5nl/lbzQ==
   dependencies:
     source-map "^0.6.1"
-
-"@types/urijs@^1.19.6":
-  version "1.19.25"
-  resolved "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.25.tgz"
-  integrity sha512-XOfUup9r3Y06nFAZh3WvO0rBU4OtlfPB/vgxpjg+NRdGU6CN6djdc6OEiH+PcqHCY6eFLo9Ista73uarf4gnBg==
 
 "@types/uuid@^8.3.4":
   version "8.3.4"
@@ -7744,7 +7753,7 @@ aws4@^1.8.0:
   resolved "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz"
   integrity sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==
 
-axios@0.25.0, axios@0.27.2, axios@1.16.0, axios@1.18.0, axios@1.7.4, axios@^0.21.2, axios@^0.26.1, axios@^1.6.0:
+axios@0.27.2, axios@1.16.0, axios@1.18.0, axios@1.7.4, axios@^0.21.2, axios@^0.26.1, axios@^1.6.0, axios@^1.8.4:
   version "1.18.0"
   resolved "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz#8a7f8854af280fcaae063272df2ed9f3837d2398"
   integrity sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==
@@ -7826,6 +7835,14 @@ balanced-match@^4.0.2:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
   integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
+bare-addon-resolve@^1.3.0:
+  version "1.10.1"
+  resolved "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.1.tgz#d88174ee1c1d6ce09c3224d76f5ce7bb748d28fe"
+  integrity sha512-F/SD2du8keuYSb4xipnGz5j2E6yhNdHA8ZVxtHae6h2uOrpBIjjbhXvjzKZbr5XUOzqBzh/i8GVFycj2DlFQIA==
+  dependencies:
+    bare-module-resolve "^1.10.0"
+    bare-semver "^1.0.0"
+
 bare-events@^2.5.4, bare-events@^2.7.0:
   version "2.8.2"
   resolved "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz"
@@ -7842,6 +7859,13 @@ bare-fs@^4.0.1:
     bare-url "^2.2.2"
     fast-fifo "^1.3.2"
 
+bare-module-resolve@^1.10.0:
+  version "1.12.4"
+  resolved "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.4.tgz#ed3b79012776211f242e11402eb65b87a85c2748"
+  integrity sha512-xcfgg2u7HqgJiBmah71O9vvdFAgHCvkqC/WSC2O7Bbgosoc1eC/BWe/6IDJ4OsfKlkxuvC/TDWXC+oH5yeW8mA==
+  dependencies:
+    bare-semver "^1.0.0"
+
 bare-os@^3.0.1:
   version "3.6.2"
   resolved "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz"
@@ -7853,6 +7877,11 @@ bare-path@^3.0.0:
   integrity sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==
   dependencies:
     bare-os "^3.0.1"
+
+bare-semver@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/bare-semver/-/bare-semver-1.1.0.tgz#8c12d350673ee1413969039f05546aa2023ec210"
+  integrity sha512-1Hw5qJ7hXdVt3uPUqjeFTuxyvBUJauvz5A1I2jk8gzjZMHp04n//6nV9MDbG9CMw78JHY2lGV0w6s//LrASm2w==
 
 bare-stream@^2.6.4:
   version "2.7.0"
@@ -8013,7 +8042,7 @@ bigint-mod-arith@^3.1.0:
   resolved "https://registry.npmjs.org/bigint-mod-arith/-/bigint-mod-arith-3.3.1.tgz"
   integrity sha512-pX/cYW3dCa87Jrzv6DAr8ivbbJRzEX5yGhdt8IutnX/PCIXfpx+mabWNK/M8qqh+zQ0J3thftUBHW0ByuUlG0w==
 
-bignumber.js@4.1.0, bignumber.js@^4.0.0:
+bignumber.js@4.1.0, bignumber.js@^9.3.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz#db6f14067c140bd46624815a7916c92d9b6c24b1"
   integrity sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA==
@@ -8496,7 +8525,7 @@ buffer-xor@^1.0.2, buffer-xor@^1.0.3:
   resolved "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
   integrity sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==
 
-buffer@4.9.2, buffer@5.7.1, buffer@6.0.3, buffer@^5.0.2, buffer@^5.1.0, buffer@^5.2.1, buffer@^5.4.3, buffer@^5.5.0, buffer@^5.6.0, buffer@^5.7.1, buffer@^6.0.2, buffer@^6.0.3, buffer@~6.0.3:
+buffer@4.9.2, buffer@5.7.1, buffer@6.0.3, buffer@^5.0.2, buffer@^5.2.1, buffer@^5.4.3, buffer@^5.5.0, buffer@^5.6.0, buffer@^5.7.1, buffer@^6.0.2, buffer@^6.0.3, buffer@~6.0.3:
   version "6.0.3"
   resolved "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz"
   integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
@@ -9572,13 +9601,6 @@ crc-32@^1.2.0:
   version "1.2.2"
   resolved "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz"
   integrity sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==
-
-crc@^3.5.0:
-  version "3.8.0"
-  resolved "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz"
-  integrity sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==
-  dependencies:
-    buffer "^5.1.0"
 
 create-ecdh@^4.0.0, create-ecdh@^4.0.4:
   version "4.0.4"
@@ -10896,7 +10918,7 @@ es6-object-assign@^1.1.0:
   resolved "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz"
   integrity sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==
 
-es6-promise@4.2.8, es6-promise@^4.0.3, es6-promise@^4.2.4:
+es6-promise@4.2.8, es6-promise@^4.0.3:
   version "4.2.8"
   resolved "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz"
   integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
@@ -11457,7 +11479,7 @@ events@^3.2.0, events@^3.3.0:
   resolved "https://registry.npmjs.org/events/-/events-3.3.0.tgz"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
-eventsource@2.0.2, eventsource@^1.1.1:
+eventsource@2.0.2, eventsource@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz#76dfcc02930fb2ff339520b6d290da573a9e8508"
   integrity sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==
@@ -11800,6 +11822,13 @@ fdir@^6.4.3, fdir@^6.5.0:
   resolved "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
+feaxios@^0.0.23:
+  version "0.0.23"
+  resolved "https://registry.npmjs.org/feaxios/-/feaxios-0.0.23.tgz#76f37a2666232377ce75354e46dd85cbceeb1758"
+  integrity sha512-eghR0A21fvbkcQBgZuMfQhrXxJzC0GNUGC9fXhBge33D+mFDTwl0aJ35zoQQn575BhyjQitRc5N4f+L4cP708g==
+  dependencies:
+    is-retry-allowed "^3.0.0"
+
 fetch-blob@^3.1.2, fetch-blob@^3.1.4:
   version "3.2.0"
   resolved "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz"
@@ -11808,10 +11837,10 @@ fetch-blob@^3.1.2, fetch-blob@^3.1.4:
     node-domexception "^1.0.0"
     web-streams-polyfill "^3.0.3"
 
-fflate@^0.8.1:
-  version "0.8.2"
-  resolved "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz"
-  integrity sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==
+fflate@0.8.3, fflate@^0.8.1:
+  version "0.8.3"
+  resolved "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz#bc27d8eb30343d4d512abb03480202ce65d825fc"
+  integrity sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==
 
 figures@3.2.0, figures@^3.2.0:
   version "3.2.0"
@@ -13638,6 +13667,11 @@ is-regex@~1.1.4:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
+is-retry-allowed@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz#ea79389fd350d156823c491bee9c69f485b1445c"
+  integrity sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==
+
 is-set@^2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz"
@@ -14020,14 +14054,6 @@ js-sha512@0.8.0, js-sha512@^0.8.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
-
-js-xdr@^1.1.3:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/js-xdr/-/js-xdr-1.3.0.tgz"
-  integrity sha512-fjLTm2uBtFvWsE3l2J14VjTuuB8vJfeTtYuNS7LiLHDWIX2kt0l1pqq9334F8kODUkKPMuULjEcbGbkFFwhx5g==
-  dependencies:
-    lodash "^4.17.5"
-    long "^2.2.3"
 
 js-yaml@4.1.0, js-yaml@4.3.1, js-yaml@^3.13.1, js-yaml@^3.14.1, js-yaml@^4.1.0:
   version "4.3.1"
@@ -14773,7 +14799,7 @@ lodash.upperfirst@^4.3.1:
   resolved "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz"
   integrity sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==
 
-lodash@>=4.18.1, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5, lodash@^4.18.0:
+lodash@>=4.18.1, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.18.0:
   version "4.18.1"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
   integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
@@ -14823,11 +14849,6 @@ lolex@^5.0.1:
   integrity sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
-
-long@^2.2.3:
-  version "2.4.0"
-  resolved "https://registry.npmjs.org/long/-/long-2.4.0.tgz"
-  integrity sha512-ijUtjmO/n2A5PaosNG9ZGDsQ3vxJg7ZW8vsY8Kp0f2yIZWhSJvjmegV7t+9RPQKxKrvj8yKGehhS+po14hPLGQ==
 
 long@^4.0.0:
   version "4.0.0"
@@ -18327,6 +18348,13 @@ request-progress@^3.0.0:
     tunnel-agent "^0.6.0"
     uuid "^8.3.2"
 
+require-addon@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/require-addon/-/require-addon-1.2.0.tgz#b6a969805b82f5ed8b2ecf29453b090ca9933c89"
+  integrity sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==
+  dependencies:
+    bare-addon-resolve "^1.3.0"
+
 require-directory@2.1.1, require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
@@ -19257,12 +19285,12 @@ socks@2.8.9, socks@^2.6.2, socks@^2.8.3:
     ip-address "^10.1.1"
     smart-buffer "^4.2.0"
 
-sodium-native@^3.3.0:
-  version "3.4.1"
-  resolved "https://registry.npmjs.org/sodium-native/-/sodium-native-3.4.1.tgz"
-  integrity sha512-PaNN/roiFWzVVTL6OqjzYct38NSXewdl2wz8SRB51Br/MLIJPrbM3XexhVWkq7D3UWMysfrhKVf1v1phZq6MeQ==
+sodium-native@^4.3.3:
+  version "4.3.3"
+  resolved "https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.3.tgz#fae4866b52366f5e6cc1b7ae8c8a71673d50c7df"
+  integrity sha512-OnxSlN3uyY8D0EsLHpmm2HOFmKddQVvEMmsakCrXUzSd8kjjbzL413t4ZNF3n0UxSwNgwTyUvkmZHTfuCeiYSw==
   dependencies:
-    node-gyp-build "^4.3.0"
+    require-addon "^1.1.0"
 
 sonic-boom@^4.0.1:
   version "4.2.0"
@@ -19473,42 +19501,19 @@ statuses@2.0.1:
   resolved "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
-stellar-base@^8.2.2:
-  version "8.2.2"
-  resolved "https://registry.npmjs.org/stellar-base/-/stellar-base-8.2.2.tgz"
-  integrity sha512-YVCIuJXU1bPn+vU0ded+g0D99DcpYXH9CEXfpYEDc4Gf04h65YjOVhGojQBm1hqVHq3rKT7m1tgfNACkU84FTA==
+stellar-sdk@^13.0.0:
+  version "13.3.0"
+  resolved "https://registry.npmjs.org/stellar-sdk/-/stellar-sdk-13.3.0.tgz#848714d469e2288b9d5645ac3518d7f3eee79fd2"
+  integrity sha512-jAA3+U7oAUueldoS4kuEhcym+DigElWq9isPxt7tjMrE7kTJ2vvY29waavUb2FSfQIWwGbuwAJTYddy2BeyJsw==
   dependencies:
-    base32.js "^0.1.0"
-    bignumber.js "^4.0.0"
-    crc "^3.5.0"
-    js-xdr "^1.1.3"
-    lodash "^4.17.21"
-    sha.js "^2.3.6"
-    tweetnacl "^1.0.3"
-  optionalDependencies:
-    sodium-native "^3.3.0"
-
-stellar-sdk@^10.0.1:
-  version "10.4.1"
-  resolved "https://registry.npmjs.org/stellar-sdk/-/stellar-sdk-10.4.1.tgz"
-  integrity sha512-Wdm2UoLuN9SNrSEHO0R/I+iZuRwUkfny1xg4akhGCpO8LQZw8QzuMTJvbEoMT3sHT4/eWYiteVLp7ND21xZf5A==
-  dependencies:
-    "@types/eventsource" "^1.1.2"
-    "@types/node" ">= 8"
-    "@types/randombytes" "^2.0.0"
-    "@types/urijs" "^1.19.6"
-    axios "0.25.0"
-    bignumber.js "^4.0.0"
-    detect-node "^2.0.4"
-    es6-promise "^4.2.4"
-    eventsource "^1.1.1"
-    lodash "^4.17.21"
+    "@stellar/stellar-base" "^13.1.0"
+    axios "^1.8.4"
+    bignumber.js "^9.3.0"
+    eventsource "^2.0.2"
+    feaxios "^0.0.23"
     randombytes "^2.1.0"
-    stellar-base "^8.2.2"
-    toml "^2.3.0"
-    tslib "^1.10.0"
+    toml "^3.0.0"
     urijs "^1.19.1"
-    utility-types "^3.7.0"
 
 stop-iteration-iterator@^1.1.0:
   version "1.1.0"
@@ -20272,10 +20277,10 @@ toidentifier@1.0.1:
   resolved "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
-toml@^2.3.0:
-  version "2.3.6"
-  resolved "https://registry.npmjs.org/toml/-/toml-2.3.6.tgz"
-  integrity sha512-gVweAectJU3ebq//Ferr2JUY4WKSDe5N+z0FvjDncLGyHmIDoxgY/2Ie4qfEIDm4IS7OA6Rmdm7pdEEdMcV/xQ==
+toml@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz#342160f1af1904ec9d204d03a5d61222d762c5ee"
+  integrity sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==
 
 tonweb@^0.0.62:
   version "0.0.62"
@@ -20899,11 +20904,6 @@ utila@~0.4:
   version "0.4.0"
   resolved "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz"
   integrity sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==
-
-utility-types@^3.7.0:
-  version "3.11.0"
-  resolved "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz"
-  integrity sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==
 
 utils-merge@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Ticket: WCI-1554

## Summary

The `Publish Release` GitHub Actions job was failing at the **OSV Severity Threshold** gate — 3 advisory groups scored at or above the CVSS 7.0 HIGH/CRITICAL cutoff, blocking beta/release publishing.

This PR resolves all 3 findings via real dependency upgrades (not exclusions), because in both cases the vulnerable code path is reachable in BitGo's production usage.

## What was failing

```
Enforce Vulnerability Severity Threshold
::error:: 3 of 45 advisory group(s) at or above CVSS 7.0 (HIGH/CRITICAL). Failing the release.
  fflate@0.8.2       CVSS 7.5   GHSA-px8p-9vwx-vf98
  toml@2.3.6         CVSS 7.5   GHSA-82x6-q7mm-w9cf
  toml@2.3.6         CVSS 8.2   GHSA-v5mp-jgw5-2x6j
```

## Root cause analysis

### 1. `fflate@0.8.2` — GHSA-px8p-9vwx-vf98 (CVSS 7.5)

- **Vulnerability**: `unzipSync()` enters an infinite loop when parsing a malformed ZIP64 archive (a central directory entry declaring `compressed_size = 0xFFFFFFFF` without the required ZIP64 extra field). This is a denial-of-service vector — CWE class: uncontrolled resource consumption.
- **Where it comes from**: transitive dependency of `jspdf` (`fflate: "^0.8.1"`), which is a dependency of `modules/key-card` (used to generate PDF key cards).
- **Reachability**: key-card only uses `jspdf`/`fflate` to **compress and generate its own PDF output** — it never calls `unzipSync()` on an externally-supplied archive. The vulnerable code path (decompression of untrusted ZIP data) is not exercised by our usage. This alone would justify an `osv-scanner.toml` exclusion (same reasoning class as this repo's existing tar/extraction exclusions), but since a patched version already exists and satisfies jspdf's own version range, we chose to fix it directly instead of adding another exclusion.
- **Fix version**: `fflate@0.8.3` (published 2026-07-20, patched in the same minor line, no breaking changes).

### 2. `toml@2.3.6` — GHSA-82x6-q7mm-w9cf (CVSS 7.5) and GHSA-v5mp-jgw5-2x6j (CVSS 8.2)

- **GHSA-82x6-q7mm-w9cf**: uncontrolled recursion. `toml.parse()` crashes the Node process with `RangeError: Maximum call stack size exceeded` on a ~5-6 KB deeply nested TOML payload (bare nested arrays or inline tables). No depth guard exists in the parser.
- **GHSA-v5mp-jgw5-2x6j**: prototype pollution. `toml.parse()` can be tricked into writing attacker-controlled keys onto `Object.prototype` by routing a table path through a scalar value into `__proto__.__proto__` (a duplicate-key guard desync bug in the compiler). This corrupts every object in the process — DoS, logic/auth bypass, and potentially RCE via gadgets, depending on what reads those polluted properties.
- **Where it comes from**: transitive dependency of `stellar-sdk@10.4.1` (`toml: "^2.3.0"`), used by `modules/bitgo`, `modules/sdk-coin-xlm`, `modules/sdk-coin-algo`, and `modules/sdk-coin-hbar`.
- **Reachability**: `stellar-sdk`'s `Federation.Server` / `StellarToml` resolver fetches and parses `stellar.toml` files from **remote domains** during federation/compliance address lookups (`xlm.ts` → `federationLookupByName` / `federationLookupByAccountId`). The domain being queried is derived from the counterparty's Stellar address, i.e. attacker-influenceable input in a real transaction flow. This is a genuinely reachable attack surface in production — unlike this repo's existing tar/minimatch exclusions, which are all dev-tooling-only or usage-mode-mismatched. An exclusion would not be appropriate here.
- **Fix version**: `toml` has no `2.3.x` patched release — the fix only exists from `toml@3.0.0` onward. `stellar-sdk` itself doesn't offer a `10.x` release with a bumped `toml`; the first `stellar-sdk` version that depends on `toml@^3.0.0` is `13.0.0`. This forced a **major version bump** of `stellar-sdk` (10.4.1 → 13.3.0), not just a patch.

## What changed

| File | Change | Why |
|---|---|---|
| `package.json` | Added `"fflate": "0.8.3"` to `resolutions` | Forces the transitive `fflate` dependency (via `jspdf`) to the patched version, same pattern already used in this block for `qs`, `jspdf`, `**/sha.js`, etc. |
| `modules/bitgo/package.json` | `"stellar-sdk": "^10.0.1"` → `"^13.0.0"` | Pulls in `toml@^3.0.0` |
| `modules/sdk-coin-xlm/package.json` | `"stellar-sdk": "^10.0.1"` → `"^13.0.0"` | Same |
| `modules/sdk-coin-hbar/package.json` | `"stellar-sdk": "^10.0.1"` → `"^13.0.0"` | Same |
| `modules/sdk-coin-algo/package.json` | `"stellar-sdk": "^10.0.1"` → `"^13.0.0"` | Same |
| `modules/sdk-coin-xlm/src/xlm.ts` | 7 call-site renames (see below) | `stellar-sdk@13.x` reorganized its exports; without this, `sdk-coin-xlm` fails to compile |
| `yarn.lock` | Regenerated | Reflects `fflate@0.8.3`, `stellar-sdk@13.3.0`, `toml@3.0.0` |

### Breaking-change fix in `xlm.ts`

`stellar-sdk@13.x` moved several exports into namespaces. `sdk-coin-xlm` was the only module in the codebase referencing the old paths (confirmed via a repo-wide grep across all `stellar-sdk` consumers: `bitgo`, `sdk-coin-algo`, `sdk-coin-hbar`, `sdk-coin-xlm`, `sdk-core`):

| Old (stellar-sdk 10.x) | New (stellar-sdk 13.x) | Occurrences in `xlm.ts` |
|---|---|---|
| `stellar.Server` | `stellar.Horizon.Server` | 2 (`getMinimumReserve`, `getBaseTransactionFee`) |
| `stellar.FederationServer` | `stellar.Federation.Server` | 2 (`getBitGoFederationServer` return type and constructor call) |
| `stellar.FederationServer.Record` | `stellar.Federation.Api.Record` | 3 (`federationLookup`, `federationLookupByName`, `federationLookupByAccountId` return types) |

These are pure rename/re-export changes on our side — no behavioral logic was touched. Mapping was confirmed directly against `stellar-sdk`'s shipped `.d.ts` files (`lib/index.d.ts`, `lib/federation/index.d.ts`), not guessed.

## Why not exclude instead of bump

This repo already has a well-established pattern of excluding vulnerabilities in `osv-scanner.toml` when the vulnerable code path is provably unreachable (e.g. 19+ existing entries for tar extraction CVEs that don't apply because BitGoJS only uses `tar` for packing via lerna, never extraction of untrusted archives).

That reasoning does **not** hold for `toml`/`stellar-sdk`: the vulnerable function (`toml.parse()`) is fed content from a remote server chosen by the counterparty in a federation lookup — a real, reachable, production attack surface. A version bump was the correct fix, not an exclusion.

For `fflate`, the unreachable-path argument does apply (key-card only compresses, never calls `unzipSync()`), so an exclusion would have been defensible — but since a drop-in patched version already existed with no breaking changes, fixing it directly was simpler and strictly safer than carrying a permanent exception.

## Cooldown / supply-chain check

Before adopting these versions, checked publish dates against the general practice of not adopting very-recently-published packages:

| Package | Fix version | Published | Age as of fix |
|---|---|---|---|
| `fflate` | 0.8.3 | 2026-07-20 | ~46 days |
| `toml` | 3.0.0 | 2026-07-14 | ~52 days |
| `stellar-sdk` | 13.3.0 | 2025-10-16 | ~11 months |

All three are well clear of any reasonable cooldown window (even a conservative 30-day bar).

## Testing performed

- `yarn build` on `sdk-coin-xlm`, `sdk-coin-algo`, `sdk-coin-hbar`, `bitgo` — all compile clean with `stellar-sdk@13.3.0`.
- `yarn unit-test` on the 3 directly affected coin modules:
  - `sdk-coin-xlm`: 108 passing, 0 failing
  - `sdk-coin-algo`: 231 passing, 0 failing
  - `sdk-coin-hbar`: 233 passing, 0 failing
- Confirmed `yarn.lock` resolves to `fflate@0.8.3`, `stellar-sdk@13.3.0`, `toml@3.0.0`.
- Repo-wide grep confirmed no other file references the renamed `stellar-sdk` exports.

## Known caveat

`stellar-sdk@13.3.0` itself is deprecated in favor of `@stellar/stellar-sdk` (the package was renamed upstream; `stellar-sdk@13.3.0` is still real, maintained code, just a deprecated pointer). Migrating to the renamed package is a separate, larger effort and out of scope for this fix — this PR only does the minimum version bump needed to close the CVEs.


