### PR TITLE
fix(sdk-coin-sui): guard precomputedMaterial shape in signRecoveryTx

### DIFF
--- a/modules/sdk-coin-sui/src/sui.ts
+++ b/modules/sdk-coin-sui/src/sui.ts
@@ -12,6 +12,7 @@ import {
   EddsaSigningMaterial,
   Environments,
   getEddsaSigningMaterial as sharedGetEddsaSigningMaterial,
+  isEddsaSigningMaterial,
   KeyPair,
   MPCAlgorithm,
   MPCRecoveryOptions,
@@ -695,8 +696,9 @@ export class Sui extends BaseCoin {
     const backupKey = params.backupKey.replace(/\s/g, '');
     const bitgoKey = params.bitgoKey.replace(/\s/g, '');
 
-    const signingMaterial =
-      precomputedMaterial ?? (await this.getEddsaSigningMaterial(userKey, params.walletPassphrase));
+    const signingMaterial = isEddsaSigningMaterial(precomputedMaterial)
+      ? precomputedMaterial
+      : await this.getEddsaSigningMaterial(userKey, params.walletPassphrase);
 
     if (signingMaterial.version === 'v2') {
       const signature = await this.signSuiMpcV2Recovery({


### PR DESCRIPTION
## Summary

Guards against non-`EddsaSigningMaterial` values being passed as `precomputedMaterial` in `signRecoveryTransaction`. WRW passes `openSSLBytes` (an ArrayBuffer) as the second positional arg to `recover()` for EVM coins; after PR #9496 added `precomputedMaterial` as the second arg to SUI's `recover()`, that ArrayBuffer was being consumed as signing material — producing `JSON.parse(undefined)` at runtime.

**Linear**: [WCI-1439](https://linear.app/bitgo/issue/WCI-1439)

## Changes

- Add shape validation for `precomputedMaterial` in `signRecoveryTransaction` before using it
- Falls back to `getEddsaSigningMaterial` when the value is not a valid `EddsaSigningMaterial`

## Test Plan

- `yarn unit-test` in `modules/sdk-coin-sui` — 155 passing
- `recoverConsolidations` is unaffected: its only caller passes `undefined` or the return value of `getEddsaSigningMaterial` (always a valid shape)
- Verified end-to-end SUI MPCv1 recovery in WRW with this fix applied