### PR TITLE
fix(sdk-coin-polyx): transferAllowDeath in getFee and remove double Ed25519 prefix

### DIFF
--- a/modules/sdk-coin-polyx/src/polyx.ts
+++ b/modules/sdk-coin-polyx/src/polyx.ts
@@ -108,7 +108,7 @@ export class Polyx extends SubstrateCoin {
 
   protected async getFee(destAddr: string, srcAddr: string, amount: number): Promise<number> {
     const api = await this.getInitializedNodeAPI();
-    const info = await api.tx.balances.transfer(destAddr, amount).paymentInfo(srcAddr);
+    const info = await api.tx.balances.transferAllowDeath(destAddr, amount).paymentInfo(srcAddr);
     return info.partialFee.toNumber();
   }
 
@@ -195,7 +195,6 @@ export class Polyx extends SubstrateCoin {
       assert(params.walletPassphrase, 'missing wallet passphrase');
 
       const signingMaterial = await this.getEddsaSigningMaterial(params.userKey, params.walletPassphrase);
-      const ED25519_PREFIX = 0x00;
       const substrateKeyPair = new SubstrateKeyPair({ pub: accountId });
       if (signingMaterial.version === 'v2') {
         const rawSig = await this.signSubstrateMpcV2Recovery({
@@ -207,10 +206,7 @@ export class Polyx extends SubstrateCoin {
           derivationPath: currPath,
           bitgo: this.bitgo,
         });
-        txBuilder.addSignature(
-          { pub: substrateKeyPair.getKeys().pub },
-          Buffer.concat([Buffer.from([ED25519_PREFIX]), rawSig])
-        );
+        txBuilder.addSignature({ pub: substrateKeyPair.getKeys().pub }, rawSig);
       } else {
         const userSigningMaterial = JSON.parse(signingMaterial.userPrv) as EDDSAMethodTypes.UserSigningMaterial;
         const backupPrv = await this.bitgo.decrypt({

--- a/modules/sdk-coin-polyx/test/unit/polyx.ts
+++ b/modules/sdk-coin-polyx/test/unit/polyx.ts
@@ -234,11 +234,11 @@ describe('Polyx:', function () {
         (result.serializedTx as string).should.be.a.String().and.not.be.empty();
         sandBox.assert.notCalled(getTSSSignatureSpy);
 
-        // Substrate MultiSignature Ed25519 discriminant (0x00) must prefix the 64-byte signature.
         sandBox.assert.calledOnce(addSignatureSpy);
         const signature: Buffer = addSignatureSpy.firstCall.args[1];
-        signature.length.should.equal(65);
-        signature[0].should.equal(0x00);
+        // constructSignedPayload prepends the 0x00 Ed25519 discriminant internally;
+        // recover() must pass the raw 64-byte signature unchanged.
+        signature.length.should.equal(64);
       });
 
       it('should produce a cryptographically valid Ed25519 signature', async function () {
@@ -330,6 +330,26 @@ describe('Polyx:', function () {
       it('should throw missing wallet passphrase when userKey and backupKey are present but walletPassphrase is not', async function () {
         const paramsWithoutPassphrase = { ...mpcV2RecoverParams, walletPassphrase: undefined };
         await baseCoin.recover(paramsWithoutPassphrase).should.be.rejectedWith('missing wallet passphrase');
+      });
+
+      it('should pass the raw 64-byte signature to addSignature on MPCv2 path', async function () {
+        // Regression: previously wrapped rawSig with a manual Ed25519 discriminant (0x00)
+        // before addSignature. constructSignedPayload already prepends that discriminant,
+        // so wrapping here caused a double prefix that shifted the on-wire signature by
+        // one byte, dropping the last byte of sigma and producing
+        // `1010: Bad signature` on-chain.
+        const rawSig = Buffer.alloc(64, 0xab);
+        sandBox
+          .stub(baseCoin as unknown as { signSubstrateMpcV2Recovery: unknown }, 'signSubstrateMpcV2Recovery')
+          .resolves(rawSig);
+        const addSignatureSpy = sandBox.spy(TransferBuilder.prototype, 'addSignature');
+
+        await baseCoin.recover(mpcV2RecoverParams);
+
+        sandBox.assert.calledOnce(addSignatureSpy);
+        const sig: Buffer = addSignatureSpy.firstCall.args[1];
+        sig.length.should.equal(64);
+        sig.should.deepEqual(rawSig);
       });
     });
   });


### PR DESCRIPTION
## Summary

Two bugs that together block POLYX MPCv2 recovery end-to-end, discovered during WCI-1437 staging tests.

**Linear**: [WCI-1437](https://linear.app/bitgo/issue/WCI-1437)

## Changes

### 1. `getFee`: `balances.transfer` → `balances.transferAllowDeath`

Polymesh v8 renamed `balances.transfer` to `balances.transferAllowDeath` (same call slot `0x0500`). The old name no longer exists on the runtime, causing `TypeError: api.tx.balances.transfer is not a function` at fee estimation — preventing any recovery JSON from being produced. Already documented in `polyx/src/lib/iface.ts:72`. This is a dry-run `.paymentInfo()` call only, not a transaction submission.

### 2. Remove double Ed25519 discriminant in MPCv2 signing path

`Transaction#constructSignedPayload` in abstract-substrate already prepends `0x00` (the `MultiSignature::Ed25519` variant byte) to whatever buffer is passed to `addSignature`. The MPCv2 path in `polyx.ts` was also manually prepending `0x00`, producing a double discriminant. This shifted the on-wire signature by one byte, dropped the last byte of sigma, and caused `1010: Invalid Transaction: Transaction has a bad signature` on broadcast. Mirrors the fix applied to `abstractSubstrateCoin.ts` in WCI-1454 — POLYX overrides `recover()` entirely so it was not covered by that fix.

## Test Plan

- 235 unit tests passing
- Regression test added: stubs `signSubstrateMpcV2Recovery` to return a controlled 64-byte buffer and asserts `addSignature` receives exactly that buffer (no prefix)
- End-to-end POLYX MPCv2 recovery tested in WRW against Polymesh testnet — transaction successfully broadcast