### PR TITLE
chore(deps): bump @bitgo/wasm-utxo

### DIFF
--- a/modules/abstract-utxo/package.json
+++ b/modules/abstract-utxo/package.json
@@ -66,7 +66,7 @@
     "@bitgo/utxo-core": "^1.41.2",
     "@bitgo/utxo-descriptors": "^1.5.2",
     "@bitgo/utxo-ord": "^1.34.2",
-    "@bitgo/wasm-utxo": "^5.0.0",
+    "@bitgo/wasm-utxo": "^5.1.0",
     "@types/lodash": "^4.14.121",
     "@types/superagent": "4.1.15",
     "bignumber.js": "^9.0.2",

--- a/modules/utxo-bin/package.json
+++ b/modules/utxo-bin/package.json
@@ -31,7 +31,7 @@
     "@bitgo/unspents": "^0.51.10",
     "@bitgo/utxo-core": "^1.41.2",
     "@bitgo/utxo-lib": "^11.24.4",
-    "@bitgo/wasm-utxo": "^5.0.0",
+    "@bitgo/wasm-utxo": "^5.1.0",
     "@noble/curves": "1.8.1",
     "archy": "^1.0.0",
     "bech32": "^2.0.0",

--- a/modules/utxo-core/package.json
+++ b/modules/utxo-core/package.json
@@ -81,7 +81,7 @@
     "@bitgo/secp256k1": "^1.11.1",
     "@bitgo/unspents": "^0.51.10",
     "@bitgo/utxo-lib": "^11.24.4",
-    "@bitgo/wasm-utxo": "^5.0.0",
+    "@bitgo/wasm-utxo": "^5.1.0",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
     "fast-sha256": "^1.3.0"
   },

--- a/modules/utxo-descriptors/package.json
+++ b/modules/utxo-descriptors/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@bitgo/utxo-core": "^1.41.2",
-    "@bitgo/wasm-utxo": "^5.0.0"
+    "@bitgo/wasm-utxo": "^5.1.0"
   },
   "devDependencies": {
     "@stacks/bitcoin-staking": "7.6.0"

--- a/modules/utxo-ord/package.json
+++ b/modules/utxo-ord/package.json
@@ -45,7 +45,7 @@
     "directory": "modules/utxo-ord"
   },
   "dependencies": {
-    "@bitgo/wasm-utxo": "^5.0.0"
+    "@bitgo/wasm-utxo": "^5.1.0"
   },
   "devDependencies": {
     "@bitgo/utxo-lib": "^11.24.4"

--- a/modules/utxo-staking/package.json
+++ b/modules/utxo-staking/package.json
@@ -64,7 +64,7 @@
     "@bitgo/utxo-core": "^1.41.2",
     "@bitgo/utxo-descriptors": "^1.5.2",
     "@bitgo/utxo-lib": "^11.24.4",
-    "@bitgo/wasm-utxo": "^5.0.0",
+    "@bitgo/wasm-utxo": "^5.1.0",
     "bip174": "npm:@bitgo-forks/bip174@3.1.0-master.4",
     "bip322-js": "^2.0.0",
     "bitcoinjs-lib": "^6.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1052,10 +1052,10 @@
   resolved "https://registry.npmjs.org/@bitgo/wasm-ton/-/wasm-ton-1.1.1.tgz"
   integrity sha512-Y4x2V2ZcYWlmx42v7dlrKDtT2DuUt8smk8E98mh7RhpiifJhLk2v5RmXDwBl0A3v9TzUOU6qMOnSS/iZ8Pq52w==
 
-"@bitgo/wasm-utxo@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-5.0.0.tgz"
-  integrity sha512-9QGC5bt0Dno2ugOmWDF1GxM2kCRZxDhlqAwbCHVL2Yni7qKoZg35AD9+F+qDSp/qShT7pZpTpguofotf+oWbBQ==
+"@bitgo/wasm-utxo@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.npmjs.org/@bitgo/wasm-utxo/-/wasm-utxo-5.1.0.tgz"
+  integrity sha512-0qCAFmiDW6ZthbMG6sPkyL2c+RHU8T2zSRGMzeDEjNz48O9h2wBcATNmFQ5q+QutpKjbdIa/gvYF0UeyQHMs7Q==
 
 "@brandonblack/musig@^0.0.1-alpha.0":
   version "0.0.1-alpha.1"


### PR DESCRIPTION
Update the UTXO workspaces to @bitgo/wasm-utxo 5.1.0, which includes
native classified PSBT input metadata for PoX-5 recovery support.
