### PR TITLE
WCN-2596: Align Node.js versions across release and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,10 +205,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Setup node 22
+      - name: Setup node from .nvmrc
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version-file: .nvmrc
 
       - name: restore lerna dependencies
         id: lerna-cache
@@ -217,7 +217,7 @@ jobs:
           path: |
             node_modules
             modules/*/node_modules
-          key: ${{ runner.os }}-node22-${{ hashFiles('yarn.lock') }}-${{ hashFiles('tsconfig.packages.json') }}-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-node${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}-${{ hashFiles('tsconfig.packages.json') }}-${{ hashFiles('**/package.json') }}
 
       - name: Install Packages
         if: steps.lerna-cache.outputs.cache-hit != 'true' || contains( github.event.pull_request.labels.*.name, 'SKIP_CACHE')
@@ -262,10 +262,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Setup node 22
+      - name: Setup node from .nvmrc
         uses: actions/setup-node@v6
         with:
-          node-version: 22 # this just needs to pass our lock file requirement for compilation
+          node-version-file: .nvmrc
 
       - name: Build Info
         run: |
@@ -458,10 +458,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Setup node 22
+      - name: Setup node from .nvmrc
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version-file: .nvmrc
 
       - name: restore lerna dependencies
         id: lerna-cache
@@ -470,7 +470,7 @@ jobs:
           path: |
             node_modules
             modules/*/node_modules
-          key: ${{ runner.os }}-node22-${{ hashFiles('yarn.lock') }}-${{ hashFiles('tsconfig.packages.json')}}-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-node${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}-${{ hashFiles('tsconfig.packages.json')}}-${{ hashFiles('**/package.json') }}
 
       - name: Install Packages
         if: steps.lerna-cache.outputs.cache-hit != 'true' || contains( github.event.pull_request.labels.*.name, 'SKIP_CACHE')

--- a/.github/workflows/npmjs-release.yml
+++ b/.github/workflows/npmjs-release.yml
@@ -308,12 +308,13 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
 
       # WCN-2091: fail the release BEFORE bitgo publishes if the shrinkwrap it
-      # would ship pins any transitive that violates our declared engines (Node
-      # >=20). Runs after pass 1 because the shrinkwrap generator resolves
-      # newly-published siblings from the registry. Pack + install here, not
-      # --package-lock-only, so `engine-strict=true` actually validates every
-      # frozen entry's engines. If this fails, siblings are already on npm but
-      # bitgo isn't — fix the shrinkwrap issue and re-run in recovery-mode.
+      # would ship pins any transitive that is incompatible with the Node.js
+      # version pinned in .nvmrc. Runs after pass 1 because the shrinkwrap
+      # generator resolves newly-published siblings from the registry. Pack +
+      # install here, not --package-lock-only, so `engine-strict=true` actually
+      # validates every frozen entry's engines. If this fails, siblings are
+      # already on npm but bitgo isn't — fix the shrinkwrap issue and re-run in
+      # recovery-mode.
       - name: Pre-publish shrinkwrap check — pack bitgo tarball
         if: inputs.dry-run == false
         env:
@@ -325,13 +326,13 @@ jobs:
           echo "PREPUB_TARBALL=$tarball" >> "$GITHUB_ENV"
           echo "Packed: $tarball"
 
-      - name: Pre-publish shrinkwrap check — setup Node 20
+      - name: Pre-publish shrinkwrap check — setup Node.js from .nvmrc
         if: inputs.dry-run == false
         uses: actions/setup-node@v6
         with:
-          node-version: '20.x'
+          node-version-file: '.nvmrc'
 
-      - name: Pre-publish shrinkwrap check — install tarball on Node 20 with engine-strict
+      - name: Pre-publish shrinkwrap check — install tarball on repository Node.js with engine-strict
         if: inputs.dry-run == false
         run: |
           workdir="$(mktemp -d)"
@@ -340,17 +341,11 @@ jobs:
           npm init -y >/dev/null
           echo "Verifying $PREPUB_TARBALL installs on $(node --version) with engine-strict=true"
           if ! npm install "$PREPUB_TARBALL" --no-audit --no-fund --ignore-scripts 2>install.log; then
-            echo "::error::Pre-publish shrinkwrap check FAILED — bitgo tarball cannot be installed on Node 20 with engine-strict. Fix before publishing."
+            echo "::error::Pre-publish shrinkwrap check FAILED — bitgo tarball cannot be installed on the repository Node.js version with engine-strict. Fix before publishing."
             cat install.log
             exit 1
           fi
           echo "✅ bitgo tarball installs cleanly on $(node --version) with engine-strict."
-
-      - name: Pre-publish shrinkwrap check — restore release Node version
-        if: inputs.dry-run == false
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: ".nvmrc"
 
       - name: Publish bitgo (pass 2)
         if: inputs.dry-run == false


### PR DESCRIPTION
## Summary

- Make the pre-publish `bitgo` tarball installation gate use `node-version-file: '.nvmrc'`, currently Node.js `24.13.0`.
- Keep the blocking unit-test compatibility matrix explicit at `22.x` and `24.x`.
- Make the single-version `code-quality`, `browser-test`, and `dockerfile-check` jobs use `node-version-file: .nvmrc` as well.
- Include `.nvmrc` in the affected dependency-cache keys so an intentional Node.js upgrade cannot reuse the previous runtime's cache.
- Remove the release workflow's redundant restore step because the gate no longer switches away from the repository runtime.

## Why

The [BitGoJS release job](https://github.com/BitGo/BitGoJS/actions/runs/33922977269/job/101185240053) failed with `EBADENGINE`: `bitgo@52.11.0` requires Node.js 22 or newer, but the pre-publish gate explicitly switched to Node.js 20.

The npm shrinkwrap is the published lockfile that pins dependency versions. This change validates it on the same explicitly reviewed Node.js version used by the repository and release workflow. Rolling selectors such as `lts/*` and `lts/-1` are intentionally avoided because they can advance CI without a source change or code review.

> [!WARNING]
> The release gate now validates the `.nvmrc` runtime, currently Node.js 24.13.0, rather than the minimum supported Node.js 22 line. The explicit unit-test matrix continues to cover `22.x` compatibility.

## Validation

- Parsed `.github/workflows/npmjs-release.yml` and `.github/workflows/ci.yml` with the repository's JavaScript YAML parser: `YAML parse: OK`.
- Verified the release gate and every non-matrix `actions/setup-node@v6` step in `ci.yml` use `node-version-file: .nvmrc`.
- Verified the blocking unit-test matrix remains `[22.x, 24.x]`.
- Verified the obsolete release-runtime restore step is absent.
- Ran `git diff --check` successfully.
- Ran `yarn commitlint --from=origin/master -V`: `0 problems, 0 warnings`.

## Risk

Low. Node.js upgrades remain explicit changes to `.nvmrc`, and the cache keys change with that file. The release guard still runs before the `bitgo` publication step with `engine-strict=true`, which makes npm reject incompatible engine ranges.

## Ticket

[WCN-2596: Align BitGoJS Node.js versions across release and CI](https://linear.app/bitgo/issue/WCN-2596/align-bitgojs-nodejs-versions-across-release-and-ci)