### PR TITLE
fix(sdk-coin-sol): support Token-2022 close ATA

### DIFF
--- a/modules/sdk-coin-sol/src/lib/closeAtaBuilder.ts
+++ b/modules/sdk-coin-sol/src/lib/closeAtaBuilder.ts
@@ -14,7 +14,12 @@ const MIX_API_ERROR_MESSAGE =
 
 export class CloseAtaBuilder extends TransactionBuilder {
   // Unified storage for all close entries (single or bulk)
-  protected _closeAtaEntries: { accountAddress: string; destinationAddress: string; authorityAddress: string }[] = [];
+  protected _closeAtaEntries: {
+    accountAddress: string;
+    destinationAddress: string;
+    authorityAddress: string;
+    programId?: string;
+  }[] = [];
 
   // Which API has been used on this builder instance. Locks in on first call so we can
   // reject attempts to mix the legacy single-ATA setters with the bulk addCloseAtaInstruction().
@@ -71,6 +76,16 @@ export class CloseAtaBuilder extends TransactionBuilder {
     return this;
   }
 
+  /** Sets the SPL token program used by the close instruction. */
+  programId(programId: string): this {
+    this._assertSingleAtaApiUsable();
+    validateAddress(programId, 'programId');
+    this._apiMode = 'single';
+    this._ensureSingleEntry();
+    this._closeAtaEntries[0].programId = programId;
+    return this;
+  }
+
   /**
    * Throws if the bulk-ATA API has already been used on this builder.
    */
@@ -93,11 +108,17 @@ export class CloseAtaBuilder extends TransactionBuilder {
    * Add an ATA to close in this transaction (for bulk closure).
    * Cannot be mixed with the single-ATA API (accountAddress/destinationAddress/authorityAddress).
    *
-   * @param {string} accountAddress - the ATA address to close
-   * @param {string} destinationAddress - where rent SOL goes (root wallet address)
-   * @param {string} authorityAddress - ATA owner who must sign
+   * @param accountAddress - the ATA address to close
+   * @param destinationAddress - where rent SOL goes (root wallet address)
+   * @param authorityAddress - ATA owner who must sign
+   * @param programId - SPL token program owning the ATA; omitted for legacy SPL
    */
-  addCloseAtaInstruction(accountAddress: string, destinationAddress: string, authorityAddress: string): this {
+  addCloseAtaInstruction(
+    accountAddress: string,
+    destinationAddress: string,
+    authorityAddress: string,
+    programId?: string
+  ): this {
     if (this._apiMode === 'single') {
       throw new BuildTransactionError(MIX_API_ERROR_MESSAGE);
     }
@@ -105,6 +126,9 @@ export class CloseAtaBuilder extends TransactionBuilder {
     validateAddress(accountAddress, 'accountAddress');
     validateAddress(destinationAddress, 'destinationAddress');
     validateAddress(authorityAddress, 'authorityAddress');
+    if (programId) {
+      validateAddress(programId, 'programId');
+    }
 
     if (accountAddress === destinationAddress) {
       throw new BuildTransactionError('Account address to close cannot be the same as the destination address');
@@ -115,7 +139,7 @@ export class CloseAtaBuilder extends TransactionBuilder {
     }
 
     this._apiMode = 'bulk';
-    this._closeAtaEntries.push({ accountAddress, destinationAddress, authorityAddress });
+    this._closeAtaEntries.push({ accountAddress, destinationAddress, authorityAddress, programId });
     return this;
   }
 
@@ -129,6 +153,7 @@ export class CloseAtaBuilder extends TransactionBuilder {
           accountAddress: ataCloseInstruction.params.accountAddress,
           destinationAddress: ataCloseInstruction.params.destinationAddress,
           authorityAddress: ataCloseInstruction.params.authorityAddress,
+          programId: ataCloseInstruction.params.programId,
         });
       }
     }
@@ -158,6 +183,7 @@ export class CloseAtaBuilder extends TransactionBuilder {
           accountAddress: entry.accountAddress,
           destinationAddress: entry.destinationAddress,
           authorityAddress: entry.authorityAddress,
+          ...(entry.programId ? { programId: entry.programId } : {}),
         },
       })
     );

--- a/modules/sdk-coin-sol/src/lib/iface.ts
+++ b/modules/sdk-coin-sol/src/lib/iface.ts
@@ -280,7 +280,13 @@ export interface AtaInit {
 
 export interface AtaClose {
   type: InstructionBuilderTypes.CloseAssociatedTokenAccount;
-  params: { accountAddress: string; destinationAddress: string; authorityAddress: string };
+  params: {
+    accountAddress: string;
+    destinationAddress: string;
+    authorityAddress: string;
+    /** SPL token program owning the ATA; omitted for legacy Token Program. */
+    programId?: string;
+  };
 }
 
 export interface AtaRecoverNested {

--- a/modules/sdk-coin-sol/src/lib/instructionParamsFactory.ts
+++ b/modules/sdk-coin-sol/src/lib/instructionParamsFactory.ts
@@ -312,6 +312,9 @@ function parseSendInstructions(
             accountAddress,
             destinationAddress,
             authorityAddress,
+            ...(instruction.programId.equals(TOKEN_2022_PROGRAM_ID)
+              ? { programId: instruction.programId.toString() }
+              : {}),
           },
         };
         instructionData.push(ataClose);
@@ -1176,6 +1179,9 @@ function parseAtaCloseInstructions(instructions: TransactionInstruction[]): Arra
             accountAddress: instruction.keys[ataCloseInstructionKeysIndexes.AccountAddress].pubkey.toString(),
             destinationAddress: instruction.keys[ataCloseInstructionKeysIndexes.DestinationAddress].pubkey.toString(),
             authorityAddress: instruction.keys[ataCloseInstructionKeysIndexes.AuthorityAddress].pubkey.toString(),
+            ...(instruction.programId.equals(TOKEN_2022_PROGRAM_ID)
+              ? { programId: instruction.programId.toString() }
+              : {}),
           },
         };
         instructionData.push(ataClose);

--- a/modules/sdk-coin-sol/src/lib/solInstructionFactory.ts
+++ b/modules/sdk-coin-sol/src/lib/solInstructionFactory.ts
@@ -9,6 +9,7 @@ import {
   createTransferCheckedInstruction,
   createTransferCheckedWithFeeInstruction,
   TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   createApproveInstruction,
 } from '@solana/spl-token';
 import {
@@ -574,16 +575,19 @@ function createATAInstruction(data: AtaInit): TransactionInstruction[] {
  */
 function closeATAInstruction(data: AtaClose): TransactionInstruction[] {
   const {
-    params: { accountAddress, destinationAddress, authorityAddress },
+    params: { accountAddress, destinationAddress, authorityAddress, programId },
   } = data;
   assert(accountAddress, 'Missing accountAddress param');
   assert(destinationAddress, 'Missing destinationAddress param');
   assert(authorityAddress, 'Missing authorityAddress param');
 
+  const tokenProgramId = programId ? new PublicKey(programId) : TOKEN_PROGRAM_ID;
   const closeAssociatedTokenAccountInstruction = createCloseAccountInstruction(
     new PublicKey(accountAddress),
     new PublicKey(destinationAddress),
-    new PublicKey(authorityAddress)
+    new PublicKey(authorityAddress),
+    [],
+    tokenProgramId
   );
   return [closeAssociatedTokenAccountInstruction];
 }

--- a/modules/sdk-coin-sol/test/unit/solInstructionFactory.ts
+++ b/modules/sdk-coin-sol/test/unit/solInstructionFactory.ts
@@ -39,6 +39,20 @@ describe('Instruction Builder Tests: ', function () {
       ]);
     });
 
+    it('Close ATA uses Token-2022 program when specified', () => {
+      const result = solInstructionFactory({
+        type: InstructionBuilderTypes.CloseAssociatedTokenAccount,
+        params: {
+          accountAddress: testData.authAccount.pub,
+          destinationAddress: testData.authAccount2.pub,
+          authorityAddress: testData.authAccount.pub,
+          programId: TOKEN_2022_PROGRAM_ID.toString(),
+        },
+      });
+
+      result[0].programId.equals(TOKEN_2022_PROGRAM_ID).should.be.true();
+    });
+
     it('Transfer', () => {
       const fromAddress = testData.authAccount.pub;
       const toAddress = testData.nonceAccount.pub;

--- a/modules/sdk-coin-sol/test/unit/transactionBuilder/closeAtaBuilder.ts
+++ b/modules/sdk-coin-sol/test/unit/transactionBuilder/closeAtaBuilder.ts
@@ -220,6 +220,23 @@ describe('Sol Close ATA Builder', () => {
           instruction.params.destinationAddress.should.equal(destinationAddress);
         }
       });
+
+      it('builds mixed legacy SPL and Token-2022 close instructions', async () => {
+        const txBuilder = closeAtaBuilder();
+        txBuilder.addCloseAtaInstruction(ataAddress1, destinationAddress, account.pub);
+        txBuilder.addCloseAtaInstruction(
+          ataAddress2,
+          destinationAddress,
+          account.pub,
+          'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'
+        );
+
+        const tx = await txBuilder.build();
+        const instructions = tx.toJson().instructionsData;
+        instructions.length.should.equal(2);
+        should.not.exist(instructions[0].params.programId);
+        instructions[1].params.programId.should.equal('TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb');
+      });
     });
 
     describe('Fail', () => {


### PR DESCRIPTION
Ticket: CHALO-1417

This pull request enhances the Solana SDK's handling of closing associated token accounts (ATAs) by adding support for specifying a custom SPL token program (such as Token-2022) in both single and bulk close operations. It updates the builder, instruction factories, and related interfaces to allow for this flexibility and adds corresponding tests to ensure correct behavior.

**Support for specifying SPL token program in ATA close operations:**

* The `CloseAtaBuilder` class and related interfaces now accept an optional `programId` parameter, allowing users to specify which SPL token program (legacy or Token-2022) should be used when closing ATAs. This applies to both single and bulk close scenarios. [[1]](diffhunk://#diff-7e9e957696ee9a215bbc248e4a0ccf6cde06a087418acb2bc914259b829b6aa3L17-R22) [[2]](diffhunk://#diff-7e9e957696ee9a215bbc248e4a0ccf6cde06a087418acb2bc914259b829b6aa3R79-R88) [[3]](diffhunk://#diff-7e9e957696ee9a215bbc248e4a0ccf6cde06a087418acb2bc914259b829b6aa3L96-R131) [[4]](diffhunk://#diff-7e9e957696ee9a215bbc248e4a0ccf6cde06a087418acb2bc914259b829b6aa3L118-R142) [[5]](diffhunk://#diff-1538f35651592cf3c235984fa0d758333a401d59cabd9326401489d867c3bc0aL283-R289)

* The `closeATAInstruction` function now uses the provided `programId` (if any) to determine which SPL token program to use for the close instruction, defaulting to the legacy program if not specified.

**Instruction parsing and serialization improvements:**

* Instruction factories and parsers (`instructionParamsFactory.ts`) are updated to extract and serialize the `programId` when present, ensuring correct round-trip handling of instructions involving Token-2022 or other SPL token programs. [[1]](diffhunk://#diff-5a80e0d73852303b131e525a833a8378e3c986ca93a012e7be5530776f65fab6R315-R317) [[2]](diffhunk://#diff-5a80e0d73852303b131e525a833a8378e3c986ca93a012e7be5530776f65fab6R1182-R1184) [[3]](diffhunk://#diff-7e9e957696ee9a215bbc248e4a0ccf6cde06a087418acb2bc914259b829b6aa3R156) [[4]](diffhunk://#diff-7e9e957696ee9a215bbc248e4a0ccf6cde06a087418acb2bc914259b829b6aa3R186)

**Expanded test coverage:**

* New and updated tests verify that close ATA instructions use the correct SPL token program when specified, including scenarios mixing legacy and Token-2022 program IDs in bulk operations. [[1]](diffhunk://#diff-6c8d4ae36f2f22b3230059f7b45982fb57ec02f077c9d689735caeed848abd86R42-R55) [[2]](diffhunk://#diff-28898f2b2bf23c70887545d45edd30a99d5c0c1dfd9dc14c7f50d48674309d6eR223-R239)

These changes make the SDK more robust and future-proof by supporting multiple SPL token programs for ATA management.

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
