### PR TITLE
refactor(utxo-staking): classify PoX-5 recovery branches

### DIFF
--- a/modules/utxo-staking/src/pox5/recovery.ts
+++ b/modules/utxo-staking/src/pox5/recovery.ts
@@ -58,6 +58,17 @@ export function assertPox5EarlyExitSpend(psbt: Psbt, input: pox5.Pox5InputMatch)
   getMatchedTransactionInput(psbt, input);
 }
 
+export type Pox5SpendBranch = 'locktime' | 'early-exit';
+
+/** Classify a PoX-5 spend from native principal-preimage metadata. */
+export function classifyPox5Spend(psbt: Psbt, input: pox5.Pox5InputMatch): Pox5SpendBranch {
+  getMatchedTransactionInput(psbt, input);
+  const hasPrincipalPreimage = psbt
+    .getInputKeyValues(input.inputIndex)
+    .some((record) => record.type === 'known' && record.key === 'PSBT_IN_SHA256');
+  return hasPrincipalPreimage ? 'early-exit' : 'locktime';
+}
+
 /** Add validated principal-preimage metadata for an early-exit spend. */
 export function preparePox5EarlyExit(
   psbt: Psbt,

--- a/modules/utxo-staking/test/unit/pox5/recovery.ts
+++ b/modules/utxo-staking/test/unit/pox5/recovery.ts
@@ -8,6 +8,7 @@ import { getKey, getKeyTriple } from '@bitgo/wasm-utxo/testutils';
 import {
   assertPox5EarlyExitSpend,
   assertPox5LocktimeSpend,
+  classifyPox5Spend,
   POX5_MAX_UNLOCK_HEIGHT,
   preparePox5EarlyExit,
 } from '../../../src/pox5';
@@ -58,6 +59,15 @@ describe('PoX-5 spend policy', function () {
     assert.doesNotThrow(() => assertPox5EarlyExitSpend(locktimeSpend.psbt, locktimeSpend.match));
     assert.doesNotThrow(() => assertPox5EarlyExitSpend(earlyExitSpend.psbt, earlyExitSpend.match));
     assert.doesNotThrow(() => assertPox5EarlyExitSpend(timestampLocktime.psbt, timestampLocktime.match));
+  });
+
+  it('classifies the spend from native principal-preimage metadata', function () {
+    const locktimeSpend = createPox5RecoveryPsbt(UNLOCK_HEIGHT);
+    assert.equal(classifyPox5Spend(locktimeSpend.psbt, locktimeSpend.match), 'locktime');
+
+    const earlyExitSpend = createPox5RecoveryPsbt(0);
+    preparePox5EarlyExit(earlyExitSpend.psbt, 0, earlyExitSpend.match, earlyExitSpend.principalPreimage);
+    assert.equal(classifyPox5Spend(earlyExitSpend.psbt, earlyExitSpend.match), 'early-exit');
   });
 
   it('enforces the block-height and unlock-height boundaries', function () {


### PR DESCRIPTION
Add the native PoX-5 spend-branch classifier required by the thin Wallet
Platform adapter. The classifier revalidates the descriptor-bound input and
distinguishes the locktime branch from the principal-preimage early-exit
branch using native PSBT_IN_SHA256 metadata.

Add unit coverage for both native metadata states. Wallet Platform remains
responsible for request and wallet policy, legacy conversion boundaries, and
error translation; it does not parse PoX-5 descriptors or raw PSBT key-value
data.