### PR TITLE
chore(express): scaffold batched OpenAPI generation

### DIFF
--- a/.github/workflows/update-api-docs.yaml
+++ b/.github/workflows/update-api-docs.yaml
@@ -1,0 +1,26 @@
+---
+name: Update BitGo Express API docs
+
+# Kept manual until the first OpenAPI batch is added to openapi-index.ts.
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  generate-and-update-api-docs:
+    uses: BitGo/gha-dev-portal-updater/.github/workflows/generate-and-update.yml@645bcc9d1e669f5b53eebc0121eede056569ca1a # v5.38.0
+    with:
+      target-repo: api-docs
+      service-name: platform-express
+      types-package-path: ./modules/express
+      api-spec-file: src/typedRoutes/api/openapi-index.ts
+      api-spec-title: BitGo Express API
+      codec-config-file: ./modules/express/openapi-generator.rc.js
+      remote-working-directory: ''
+    secrets: inherit

--- a/modules/express/src/typedRoutes/api/openapi-index.ts
+++ b/modules/express/src/typedRoutes/api/openapi-index.ts
@@ -1,0 +1,14 @@
+import { apiSpec } from '@api-ts/io-ts-http';
+import { PostWalletSweep } from './v2/walletSweep';
+
+/**
+ * Cumulative OpenAPI batch entrypoint.
+ *
+ * Add approved route specs here as they are introduced. Keep previously added
+ * routes in this object so generated/openapi-express.yaml remains cumulative.
+ */
+export const ExpressOpenApiSpec = apiSpec({
+  'express.wallet.sweep': {
+    post: PostWalletSweep,
+  },
+});

--- a/modules/express/src/typedRoutes/api/v2/walletSweep.ts
+++ b/modules/express/src/typedRoutes/api/v2/walletSweep.ts
@@ -1,5 +1,5 @@
 import * as t from 'io-ts';
-import { httpRoute, httpRequest, optional } from '@api-ts/io-ts-http';
+import { httpRoute, httpRequest, optional, type HttpRoute } from '@api-ts/io-ts-http';
 import { BitgoExpressError } from '../../schemas/error';
 import { SendManyResponse } from './sendmany';
 
@@ -55,7 +55,7 @@ export const WalletSweepBody = {
  * @operationId express.wallet.sweep
  * @tag Express
  */
-export const PostWalletSweep = httpRoute({
+export const PostWalletSweep: HttpRoute<'post'> = httpRoute({
   path: '/api/v2/{coin}/wallet/{id}/sweep',
   method: 'POST',
   request: httpRequest({


### PR DESCRIPTION
- Add a cumulative OpenAPI batch entrypoint for Express routes
- Add the initial /api/v2/{coin}/wallet/{id}/sweep endpoint specification
- Configure the docs updater for the platform-express service
- Target api-docs/services/platform-express.yaml
- Keep the workflow manual until the first batch is reviewed
- Support adding additional endpoints incrementally in later PRs

Ticket: WCI-1581

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
