### PR TITLE
fix(sdk-api): keep browser v1 decrypt to SJCL

### DIFF
--- a/modules/sdk-api/src/encrypt.ts
+++ b/modules/sdk-api/src/encrypt.ts
@@ -1,7 +1,7 @@
 import * as sjcl from '@bitgo/sjcl';
 import { randomBytes } from 'crypto';
 
-import { decryptV1 } from './decryptV1';
+import { decryptV1, parseV1Envelope } from './decryptV1';
 import { decryptV2, encryptV2 } from './encryptV2';
 
 /**
@@ -77,6 +77,15 @@ function isIterCapViolation(err: unknown): boolean {
 }
 
 /**
+ * True in window and worker runtimes. Used to route browser v1 decrypt
+ * straight to SJCL instead of through the Node-oriented `native` path, whose
+ * `crypto-browserify` AES-CCM has been reported not to work in a real browser.
+ */
+function isBrowserRuntime(): boolean {
+  return typeof window !== 'undefined' || typeof self !== 'undefined';
+}
+
+/**
  * v1 decrypt with an SJCL safety net.
  *
  * Design intent during rollout: zero false negatives. Any native failure
@@ -98,6 +107,15 @@ export async function decryptV1WithFallback(
   ciphertext: string,
   native: (pw: string, ct: string) => Promise<string> = decryptV1
 ): Promise<string> {
+  if (isBrowserRuntime()) {
+    try {
+      parseV1Envelope(ciphertext);
+    } catch (parseErr) {
+      if (isIterCapViolation(parseErr)) throw parseErr;
+      // Any other parse rejection (e.g. absent `v`) is a shape SJCL still accepts.
+    }
+    return sjcl.decrypt(password, ciphertext);
+  }
   try {
     return await native(password, ciphertext);
   } catch (nativeErr) {


### PR DESCRIPTION
crypto-browserify's AES-CCM is reported broken in real browsers, so skip the native attempt there and go directly to sjcl.decrypt after the existing iteration-cap check. Also drops the unused, unreviewed WebCrypto CCM candidate (decryptV1WebCrypto.ts) that had no caller.

TICKET: WCN-2576

<!--
# Please be aware of the following when making your pull request:

## Description

Please include a summary of your proposed changes and which issue is being addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

Internal Users - Please include the related internal tracking number (e.g. BG-000000).
External Users - Please link to any relevant github issues as necessary.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code compiles correctly for both Node and Browser environments
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and I have properly described any BREAKING CHANGES
- [ ] The ticket or github issue was included in the commit message as a reference
- [ ] I have made corresponding changes to the documentation and on any new/updated functions and/or methods - [jsdoc](https://jsdoc.app/)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
-->
