### PR TITLE
perf(sdk-core): pin high-entropy encryption to v1

### DIFF
--- a/modules/key-card/src/generateQrData.ts
+++ b/modules/key-card/src/generateQrData.ts
@@ -1,5 +1,5 @@
 import { BaseCoin } from '@bitgo/statics';
-import { Keychain, KeychainsTriplet } from '@bitgo/sdk-core';
+import { HIGH_ENTROPY_ENCRYPTION_VERSION, Keychain, KeychainsTriplet } from '@bitgo/sdk-core';
 import { encrypt } from '@bitgo/sdk-api';
 import * as assert from 'assert';
 import {
@@ -136,10 +136,12 @@ function generateUserMasterPublicKeyQRData(publicKey: string): MasterPublicKeyQr
 async function generatePasscodeQrData(
   passphrase: string,
   passcodeEncryptionCode: string,
-  encryptionVersion?: 1 | 2,
   entityNoun: KeycardEntity = 'wallet'
 ): Promise<QrDataEntry> {
-  const encryptedPasscode = await encrypt(passcodeEncryptionCode, passphrase, { encryptionVersion });
+  // Box D uses the fixed version for its generated encryption key.
+  const encryptedPasscode = await encrypt(passcodeEncryptionCode, passphrase, {
+    encryptionVersion: HIGH_ENTROPY_ENCRYPTION_VERSION,
+  });
   const titleNoun = entityNoun === 'safe' ? 'Safe' : 'Wallet';
   return {
     title: `D: Encrypted ${titleNoun} Password`,
@@ -199,11 +201,7 @@ export async function generateQrData(params: GenerateQrDataParams): Promise<QrDa
   const qrData = buildWalletQrData(params);
 
   if (params.passphrase && params.passcodeEncryptionCode) {
-    qrData.passcode = await generatePasscodeQrData(
-      params.passphrase,
-      params.passcodeEncryptionCode,
-      params.encryptionVersion
-    );
+    qrData.passcode = await generatePasscodeQrData(params.passphrase, params.passcodeEncryptionCode);
   }
 
   return qrData;
@@ -213,11 +211,7 @@ export async function generateLightningQrData(params: GenerateLightningQrDataPar
   const qrData = buildLightningQrData(params);
 
   if (params.passphrase && params.passcodeEncryptionCode) {
-    qrData.passcode = await generatePasscodeQrData(
-      params.passphrase,
-      params.passcodeEncryptionCode,
-      params.encryptionVersion
-    );
+    qrData.passcode = await generatePasscodeQrData(params.passphrase, params.passcodeEncryptionCode);
   }
 
   return qrData;
@@ -282,12 +276,7 @@ export async function generateSafeQrData(params: GenerateSafeQrDataParams): Prom
   };
 
   if (params.passphrase && params.passcodeEncryptionCode) {
-    qrData.passcode = await generatePasscodeQrData(
-      params.passphrase,
-      params.passcodeEncryptionCode,
-      params.encryptionVersion,
-      'safe'
-    );
+    qrData.passcode = await generatePasscodeQrData(params.passphrase, params.passcodeEncryptionCode, 'safe');
   }
 
   return qrData;

--- a/modules/key-card/src/types.ts
+++ b/modules/key-card/src/types.ts
@@ -25,6 +25,7 @@ export interface GenerateQrDataCoinParams {
   // If both the passphrase and passcodeEncryptionCode are passed, then this code encrypts the passphrase with the
   // passcodeEncryptionCode and puts the result into Box D. Allows recoveries of the wallet password.
   passphrase?: string;
+  /** @deprecated Ignored because Box D uses a high-entropy key. */
   encryptionVersion?: EncryptionVersion;
 }
 

--- a/modules/key-card/src/upgradeWalletEncryption.ts
+++ b/modules/key-card/src/upgradeWalletEncryption.ts
@@ -81,7 +81,6 @@ export function createKeycardPdfGenerator(options: KeycardPdfGeneratorOptions = 
       bitgoKeychain,
       passphrase,
       passcodeEncryptionCode,
-      encryptionVersion: 2,
     });
     const questions = generateFaq(staticsCoin.fullName);
     return drawKeycard({ qrData, questions, walletLabel, keyCardImage });

--- a/modules/key-card/test/unit/generateQrData.ts
+++ b/modules/key-card/test/unit/generateQrData.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as should from 'should';
 import { decrypt } from '@bitgo/sdk-api';
 import { generateLightningQrData, generateQrData } from '../../src/generateQrData';
-import { ApiKeyShare, Keychain, KeyType } from '@bitgo/sdk-core';
+import { ApiKeyShare, HIGH_ENTROPY_ENCRYPTION_VERSION, Keychain, KeyType } from '@bitgo/sdk-core';
 import { coins } from '@bitgo/statics';
 
 function createKeychain({
@@ -241,7 +241,7 @@ describe('generateQrData', function () {
     decryptedData.should.equal(passphrase);
   });
 
-  it('produces a v2 Box D when encryptionVersion is not set', async function () {
+  it('pins Box D to the high-entropy version when encryptionVersion is not set', async function () {
     const passphrase = 'testingIsFun';
     const passcodeEncryptionCode = '123456';
     const qrData = await generateQrData({
@@ -255,10 +255,10 @@ describe('generateQrData', function () {
 
     assert.ok(qrData.passcode);
     const envelope = JSON.parse(qrData.passcode.data);
-    assert.strictEqual(envelope.v, 2, 'should default to v2 envelope');
+    assert.strictEqual(envelope.v, HIGH_ENTROPY_ENCRYPTION_VERSION, 'should use the high-entropy envelope version');
   });
 
-  it('produces a v2 Box D when encryptionVersion: 2', async function () {
+  it('pins Box D to the high-entropy version when encryptionVersion: 2', async function () {
     const passphrase = 'testingIsFun';
     const passcodeEncryptionCode = '123456';
     const qrData = await generateQrData({
@@ -273,12 +273,12 @@ describe('generateQrData', function () {
 
     assert.ok(qrData.passcode);
     const envelope = JSON.parse(qrData.passcode.data);
-    assert.strictEqual(envelope.v, 2, 'should produce v2 envelope');
+    assert.strictEqual(envelope.v, HIGH_ENTROPY_ENCRYPTION_VERSION, 'should ignore the caller-selected version');
     const decryptedData = await decrypt(passcodeEncryptionCode, qrData.passcode.data);
     decryptedData.should.equal(passphrase);
   });
 
-  it('produces a v1 Box D when encryptionVersion: 1 is explicit', async function () {
+  it('pins Box D to the high-entropy version when encryptionVersion: 1', async function () {
     const passphrase = 'testingIsFun';
     const passcodeEncryptionCode = '123456';
     const qrData = await generateQrData({
@@ -293,7 +293,7 @@ describe('generateQrData', function () {
 
     assert.ok(qrData.passcode);
     const envelope = JSON.parse(qrData.passcode.data);
-    assert.notStrictEqual(envelope.v, 2, 'should produce v1 envelope');
+    assert.strictEqual(envelope.v, HIGH_ENTROPY_ENCRYPTION_VERSION, 'should use the high-entropy envelope version');
   });
 
   it('omits Box D when passphrase or passcodeEncryptionCode is missing', async function () {
@@ -324,7 +324,7 @@ describe('generateLightningQrData', function () {
     decryptedData.should.equal(passphrase);
   });
 
-  it('produces a v2 Box D when encryptionVersion: 2', async function () {
+  it('pins Lightning Box D to the high-entropy version when encryptionVersion: 2', async function () {
     const passphrase = 'testingIsFun';
     const passcodeEncryptionCode = '123456';
     const qrData = await generateLightningQrData({
@@ -337,7 +337,7 @@ describe('generateLightningQrData', function () {
 
     assert.ok(qrData.passcode);
     const envelope = JSON.parse(qrData.passcode.data);
-    assert.strictEqual(envelope.v, 2);
+    assert.strictEqual(envelope.v, HIGH_ENTROPY_ENCRYPTION_VERSION, 'should ignore the caller-selected version');
     const decryptedData = await decrypt(passcodeEncryptionCode, qrData.passcode.data);
     decryptedData.should.equal(passphrase);
   });

--- a/modules/sdk-core/src/api/types.ts
+++ b/modules/sdk-core/src/api/types.ts
@@ -20,6 +20,13 @@ export interface DecryptKeysOptions {
 export type EncryptionVersion = 1 | 2;
 
 /**
+ * Encryption version for values protected by high-entropy keys, including ECDH shared secrets and
+ * passcode encryption codes. It is independent of the caller-selected version for password-based
+ * encryption.
+ */
+export const HIGH_ENTROPY_ENCRYPTION_VERSION: EncryptionVersion = 1;
+
+/**
  * Return type for encryption session operations.
  * Runs the expensive KDF once; all subsequent calls derive keys via HKDF.
  */

--- a/modules/sdk-core/src/bitgo/internal/keycard.ts
+++ b/modules/sdk-core/src/bitgo/internal/keycard.ts
@@ -6,7 +6,7 @@
  */
 import { isUndefined } from 'lodash';
 import { Keychain } from '../keychain';
-import { EncryptFnAsync, EncryptionVersion } from '../../api';
+import { EncryptFnAsync, EncryptionVersion, HIGH_ENTROPY_ENCRYPTION_VERSION } from '../../api';
 
 /**
  * Return the list of questions that will appear on the second page of the keycard
@@ -194,10 +194,11 @@ async function getKeyData(options: GetKeyDataOptions): Promise<any> {
 
   let encryptedWalletPasscode: string | undefined;
   if (passphrase && passcodeEncryptionCode) {
+    // Box D uses its fixed version; the backup key follows encryptionVersion.
     encryptedWalletPasscode = await encrypt({
       input: passphrase,
       password: passcodeEncryptionCode,
-      encryptionVersion,
+      encryptionVersion: HIGH_ENTROPY_ENCRYPTION_VERSION,
     });
   }
 
@@ -373,7 +374,8 @@ function renderKeycardPdf(options: DrawKeycardLayoutOptions, keyData: any): any 
 
 /**
  * Draw a keycard into a new pdf document object.
- * Defaults to v2 (Argon2id) encryption for Box D; pass `encryptionVersion: 1` for legacy v1.
+ *
+ * `encryptionVersion` applies to the backup key. Box D uses its fixed version.
  * @param options
  */
 export async function drawKeycard(options: DrawKeycardOptions): Promise<any> {

--- a/modules/sdk-core/src/bitgo/wallet/iWallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/iWallet.ts
@@ -832,6 +832,7 @@ export interface ShareWalletOptions {
    */
   skipKeychain?: boolean;
   disableEmail?: boolean;
+  /** @deprecated Ignored because the shared key is high entropy. */
   encryptionVersion?: EncryptionVersion;
   /**
    * Pre-decrypted wallet keychain. When supplied, shareWallet skips its internal
@@ -856,6 +857,7 @@ export interface BulkWalletShareOptions {
     path: string;
     permissions: string[];
   }>;
+  /** @deprecated Ignored because the shared key is high entropy. */
   encryptionVersion?: EncryptionVersion;
 }
 

--- a/modules/sdk-core/src/bitgo/wallet/wallet.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallet.ts
@@ -8,7 +8,7 @@ import BigNumber from 'bignumber.js';
 import * as t from 'io-ts';
 import { BigIntFromString } from 'io-ts-types';
 import * as _ from 'lodash';
-import { EncryptionVersion, IRequestTracer } from '../../api';
+import { EncryptionVersion, HIGH_ENTROPY_ENCRYPTION_VERSION, IRequestTracer } from '../../api';
 import * as common from '../../common';
 import { AddressBook, IAddressBook } from '../address-book';
 import {
@@ -2043,7 +2043,7 @@ export class Wallet implements IWallet {
    * @param pub - The wallet's public key
    * @param userPubkey - The recipient user's public key
    * @param path - The key path
-   * @param encryptionVersion - Optional encryption version (defaults to v2)
+   * @param encryptionVersion - Deprecated and ignored because the shared key is high entropy.
    * @returns The encrypted keychain for the recipient with all required fields
    */
   async encryptPrvForUser(
@@ -2051,11 +2051,18 @@ export class Wallet implements IWallet {
     pub: string,
     userPubkey: string,
     path: string,
+    /** @deprecated Ignored because the shared key is high entropy. */
     encryptionVersion?: EncryptionVersion
   ): Promise<BulkWalletShareKeychain> {
+    void encryptionVersion;
     const eckey = makeRandomKey();
     const secret = getSharedSecret(eckey, Buffer.from(userPubkey, 'hex')).toString('hex');
-    const newEncryptedPrv = await this.bitgo.encrypt({ password: secret, input: decryptedPrv, encryptionVersion });
+    // Use the fixed version for encryption to the recipient.
+    const newEncryptedPrv = await this.bitgo.encrypt({
+      password: secret,
+      input: decryptedPrv,
+      encryptionVersion: HIGH_ENTROPY_ENCRYPTION_VERSION,
+    });
 
     const keychain: BulkWalletShareKeychain = {
       pub,
@@ -2093,12 +2100,15 @@ export class Wallet implements IWallet {
    * @param walletPassphrase - The passphrase to decrypt the keychain
    * @param pubkey - The recipient's public key
    * @param path - The key path
+   * @param encryptionVersion - Deprecated and ignored because the shared key is high entropy.
+   * @param decryptedKeychain - Pre-decrypted keychain for bulk sharing
    * @returns The encrypted keychain for the recipient
    */
   async prepareSharedKeychain(
     walletPassphrase: string | undefined,
     pubkey: string,
     path: string,
+    /** @deprecated Ignored because the shared key is high entropy. */
     encryptionVersion?: EncryptionVersion,
     decryptedKeychain?: DecryptedKeychainData
   ): Promise<SharedKeyChain> {
@@ -3453,7 +3463,7 @@ export class Wallet implements IWallet {
 
   /**
    * Creates and downloads PDF keycard for wallet (requires response from wallets.generateWallet).
-   * Defaults to v2 encryption for Box D; pass `encryptionVersion: 1` for legacy v1.
+   * `encryptionVersion` applies to the backup key. Box D uses its fixed version.
    *
    * Note: this is example code and is not the version used on bitgo.com
    *

--- a/modules/sdk-core/src/bitgo/wallet/wallets.ts
+++ b/modules/sdk-core/src/bitgo/wallet/wallets.ts
@@ -7,7 +7,7 @@ import { bip32 } from '@bitgo/utxo-lib';
 import * as _ from 'lodash';
 import { CoinFeature } from '@bitgo/statics';
 
-import { EncryptionVersion, IEncryptionSession, sanitizeLegacyPath } from '../../api';
+import { EncryptionVersion, HIGH_ENTROPY_ENCRYPTION_VERSION, IEncryptionSession, sanitizeLegacyPath } from '../../api';
 import * as common from '../../common';
 import { IBaseCoin, KeychainsTriplet, SupplementGenerateWalletOptions } from '../baseCoin';
 import { BitGoBase } from '../bitgoBase';
@@ -171,6 +171,19 @@ export class Wallets implements IWallets {
     return {
       wallet: new Wallet(this.bitgo, this.baseCoin, newWallet),
     };
+  }
+
+  /**
+   * Encrypt the wallet passphrase for recovery and Box D.
+   *
+   * Box D uses a fixed version independent of the caller's keychain encryption version.
+   */
+  private async encryptPassphraseForRecovery(passphrase: string, passcodeEncryptionCode: string): Promise<string> {
+    return await this.bitgo.encrypt({
+      input: passphrase,
+      password: passcodeEncryptionCode,
+      encryptionVersion: HIGH_ENTROPY_ENCRYPTION_VERSION,
+    });
   }
 
   private async generateLightningWallet(params: GenerateLightningWalletOptions): Promise<LightningWalletWithKeychains> {
@@ -341,11 +354,10 @@ export class Wallets implements IWallets {
       );
 
       const walletData = await this.generateLightningWallet(options);
-      walletData.encryptedWalletPassphrase = await this.bitgo.encrypt({
-        input: options.passphrase,
-        password: options.passcodeEncryptionCode,
-        encryptionVersion: options.encryptionVersion,
-      });
+      walletData.encryptedWalletPassphrase = await this.encryptPassphraseForRecovery(
+        options.passphrase,
+        options.passcodeEncryptionCode
+      );
       return walletData;
     }
 
@@ -362,11 +374,10 @@ export class Wallets implements IWallets {
 
       const walletData = await this.generateGoAccountWallet(options);
       if (options.passphrase !== undefined && options.passcodeEncryptionCode !== undefined) {
-        walletData.encryptedWalletPassphrase = await this.bitgo.encrypt({
-          input: options.passphrase,
-          password: options.passcodeEncryptionCode,
-          encryptionVersion: options.encryptionVersion,
-        });
+        walletData.encryptedWalletPassphrase = await this.encryptPassphraseForRecovery(
+          options.passphrase,
+          options.passcodeEncryptionCode
+        );
       }
       return walletData;
     }
@@ -472,11 +483,10 @@ export class Wallets implements IWallets {
         encryptionVersion: params.encryptionVersion,
       });
       if (params.passcodeEncryptionCode) {
-        walletData.encryptedWalletPassphrase = await this.bitgo.encrypt({
-          input: passphrase,
-          password: params.passcodeEncryptionCode,
-          encryptionVersion: params.encryptionVersion,
-        });
+        walletData.encryptedWalletPassphrase = await this.encryptPassphraseForRecovery(
+          passphrase,
+          params.passcodeEncryptionCode
+        );
       }
       return walletData;
     }
@@ -745,11 +755,10 @@ export class Wallets implements IWallets {
       }
 
       if (canEncrypt && params.passcodeEncryptionCode) {
-        result.encryptedWalletPassphrase = await this.bitgo.encrypt({
-          input: passphrase,
-          password: params.passcodeEncryptionCode,
-          encryptionVersion: params.encryptionVersion,
-        });
+        result.encryptedWalletPassphrase = await this.encryptPassphraseForRecovery(
+          passphrase,
+          params.passcodeEncryptionCode
+        );
       }
 
       return result;

--- a/modules/sdk-core/test/unit/bitgo/wallet/walletsEncryptionVersion.ts
+++ b/modules/sdk-core/test/unit/bitgo/wallet/walletsEncryptionVersion.ts
@@ -3,6 +3,8 @@ import * as sinon from 'sinon';
 import 'should';
 import { Wallets } from '../../../../src/bitgo/wallet/wallets';
 import { Wallet } from '../../../../src/bitgo/wallet/wallet';
+import { makeRandomKey } from '../../../../src/bitgo/bitcoin';
+import { HIGH_ENTROPY_ENCRYPTION_VERSION } from '../../../../src/api';
 
 describe('Wallets - encryptionVersion threading', function () {
   let wallets: Wallets;
@@ -213,8 +215,10 @@ describe('Wallets - encryptionVersion threading', function () {
 
   describe('Wallet.shareWallet / createBulkWalletShare', function () {
     let wallet: Wallet;
+    let recipientPubKey: string;
 
     beforeEach(function () {
+      recipientPubKey = makeRandomKey().publicKey.toString('hex');
       const mockWalletData = {
         id: 'wallet-id',
         keys: ['key-1', 'key-2', 'key-3'],
@@ -229,9 +233,26 @@ describe('Wallets - encryptionVersion threading', function () {
       wallet = new Wallet(mockBitGo, mockBaseCoin, mockWalletData);
     });
 
-    it('shareWallet passes encryptionVersion to prepareSharedKeychain', async function () {
-      const prepareStub = sinon.stub(wallet, 'prepareSharedKeychain').resolves({});
-      mockBitGo.getSharingKey = sinon.stub().resolves({ userId: 'user-id', pubkey: 'recvPub', path: 'm/0' });
+    it('encryptPrvForUser encrypts to the ECDH secret at the high-entropy version', async function () {
+      await wallet.encryptPrvForUser('prv', 'pub', recipientPubKey, 'm/0', 2);
+
+      assert.ok(mockBitGo.encrypt.calledOnce, 'encrypt should have been called');
+      assert.strictEqual(mockBitGo.encrypt.firstCall.args[0].encryptionVersion, HIGH_ENTROPY_ENCRYPTION_VERSION);
+    });
+
+    it('preserves the encryptionVersion position before a pre-decrypted keychain', async function () {
+      await wallet.prepareSharedKeychain(undefined, recipientPubKey, 'm/0', 2, {
+        prv: 'prv',
+        pub: 'pub',
+      });
+
+      assert.strictEqual(mockBitGo.encrypt.firstCall.args[0].input, 'prv');
+      assert.strictEqual(mockBitGo.encrypt.firstCall.args[0].encryptionVersion, HIGH_ENTROPY_ENCRYPTION_VERSION);
+    });
+
+    it('shareWallet ignores a caller-supplied encryptionVersion for the shared keychain', async function () {
+      sinon.stub(wallet, 'getDecryptedKeychainForSharing').resolves({ prv: 'prv', pub: 'pub' });
+      mockBitGo.getSharingKey = sinon.stub().resolves({ userId: 'user-id', pubkey: recipientPubKey, path: 'm/0' });
       mockBitGo.post.returns({ send: sinon.stub().returns({ result: sinon.stub().resolves({}) }) });
 
       await wallet.shareWallet({
@@ -241,60 +262,55 @@ describe('Wallets - encryptionVersion threading', function () {
         encryptionVersion: 2,
       });
 
-      assert.ok(prepareStub.calledOnce, 'prepareSharedKeychain should be called');
-      assert.strictEqual(prepareStub.firstCall.args[3], 2, 'encryptionVersion should be forwarded');
+      assert.ok(mockBitGo.encrypt.calledOnce, 'encrypt should have been called');
+      assert.strictEqual(
+        mockBitGo.encrypt.firstCall.args[0].encryptionVersion,
+        HIGH_ENTROPY_ENCRYPTION_VERSION,
+        'the ECDH-keyed share must not be encrypted at the caller-requested version'
+      );
     });
 
-    it('shareWallet passes encryptionVersion: undefined when not set', async function () {
-      const prepareStub = sinon.stub(wallet, 'prepareSharedKeychain').resolves({});
-      mockBitGo.getSharingKey = sinon.stub().resolves({ userId: 'user-id', pubkey: 'recvPub', path: 'm/0' });
-      mockBitGo.post.returns({ send: sinon.stub().returns({ result: sinon.stub().resolves({}) }) });
-
-      await wallet.shareWallet({
-        email: 'test@test.com',
-        permissions: 'spend',
-        walletPassphrase: 'passphrase',
-      });
-
-      assert.ok(prepareStub.calledOnce);
-      assert.strictEqual(prepareStub.firstCall.args[3], undefined);
-    });
-
-    it('createBulkWalletShare passes encryptionVersion to encryptPrvForUser', async function () {
-      const encryptPrvStub = sinon
-        .stub(wallet, 'encryptPrvForUser')
-        .resolves({ encryptedPrv: 'enc', pub: 'pub', fromPubKey: 'fpk', toPubKey: 'tpk', path: 'm/0' });
-      sinon
-        .stub(wallet as any, 'getDecryptedKeychainForSharing')
-        .resolves({ prv: 'prv', pub: 'pub', encryptedPrv: 'encPrv' });
-      sinon.stub(wallet as any, 'createBulkKeyShares').resolves({ shares: [] });
+    it('createBulkWalletShare ignores a caller-supplied encryptionVersion for every share', async function () {
+      sinon.stub(wallet, 'getDecryptedKeychainForSharing').resolves({ prv: 'prv', pub: 'pub' });
+      sinon.stub(wallet, 'createBulkKeyShares').resolves({ shares: [] });
 
       await wallet.createBulkWalletShare({
         walletPassphrase: 'passphrase',
-        keyShareOptions: [{ userId: 'user-1', pubKey: 'pubKey', path: 'm/0', permissions: ['spend'] }],
+        keyShareOptions: [
+          { userId: 'user-1', pubKey: recipientPubKey, path: 'm/0', permissions: ['spend'] },
+          { userId: 'user-2', pubKey: recipientPubKey, path: 'm/1', permissions: ['spend'] },
+        ],
         encryptionVersion: 2,
       });
 
-      assert.ok(encryptPrvStub.calledOnce);
-      assert.strictEqual(encryptPrvStub.firstCall.args[4], 2, 'encryptionVersion should be forwarded');
+      assert.strictEqual(mockBitGo.encrypt.callCount, 2, 'each recipient gets its own encryption');
+      for (const call of mockBitGo.encrypt.getCalls()) {
+        assert.strictEqual(call.args[0].encryptionVersion, HIGH_ENTROPY_ENCRYPTION_VERSION);
+      }
     });
+  });
 
-    it('createBulkWalletShare passes encryptionVersion: undefined when not set', async function () {
-      const encryptPrvStub = sinon
-        .stub(wallet, 'encryptPrvForUser')
-        .resolves({ encryptedPrv: 'enc', pub: 'pub', fromPubKey: 'fpk', toPubKey: 'tpk', path: 'm/0' });
-      sinon
-        .stub(wallet as any, 'getDecryptedKeychainForSharing')
-        .resolves({ prv: 'prv', pub: 'pub', encryptedPrv: 'encPrv' });
-      sinon.stub(wallet as any, 'createBulkKeyShares').resolves({ shares: [] });
+  describe('Wallets.generateWallet', function () {
+    it('keeps human-passphrase encryption at the requested version and pins recovery encryption', async function () {
+      mockKeychains.createBackup = sinon.stub().resolves({ id: 'backup-key-id', pub: 'backup-pub' });
+      mockKeychains.createBitGo = sinon.stub().resolves({ id: 'bitgo-key-id', pub: 'bitgo-pub' });
+      mockBitGo.post.returns({ send: sinon.stub().returns({ result: sinon.stub().resolves({ id: 'wallet-id' }) }) });
+      mockBaseCoin.getDefaultMultisigType = sinon.stub().returns('onchain');
+      mockBaseCoin.isEVM = sinon.stub().returns(false);
+      mockBaseCoin.isValidMofNSetup = sinon.stub().returns(true);
+      mockBaseCoin.supplementGenerateWallet = sinon.stub().callsFake(async (params: unknown) => params);
+      mockBaseCoin.signMessage = sinon.stub().resolves(Buffer.from('aabbcc', 'hex'));
 
-      await wallet.createBulkWalletShare({
-        walletPassphrase: 'passphrase',
-        keyShareOptions: [{ userId: 'user-1', pubKey: 'pubKey', path: 'm/0', permissions: ['spend'] }],
+      await wallets.generateWallet({
+        label: 'Test Wallet',
+        passphrase: 'wallet-passphrase',
+        passcodeEncryptionCode: 'recovery-code',
+        encryptionVersion: 2,
       });
 
-      assert.ok(encryptPrvStub.calledOnce);
-      assert.strictEqual(encryptPrvStub.firstCall.args[4], undefined);
+      assert.strictEqual(mockBitGo.encrypt.callCount, 2);
+      assert.strictEqual(mockBitGo.encrypt.firstCall.args[0].encryptionVersion, 2);
+      assert.strictEqual(mockBitGo.encrypt.secondCall.args[0].encryptionVersion, HIGH_ENTROPY_ENCRYPTION_VERSION);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Pins ECDH wallet-share secrets and generated passcode encryption codes to v1/SJCL.
- Preserves caller-selected encryption for human passphrases and keeps affected API options source-compatible.
- Updates wallet-share and Box D version assertions.

TICKET: WCN-2616

## Test plan
- [x] `modules/sdk-core`: `yarn unit-test --grep "encryptionVersion threading"` (9 passing)
- [x] `modules/key-card`: `yarn unit-test` (37 passing)
- [x] `modules/sdk-core`: `yarn lint`
- [x] `modules/key-card`: `eslint --quiet src test`
- [x] `yarn check-commits`
- [ ] `yarn lint-changed` cannot enumerate packages from a worktree nested under the repository; Lerna resolves `../../modules/*` outside this worktree.