### PR TITLE
SI-1524: Remove CSPR staking metadata from SDK

### DIFF
--- a/modules/statics/src/coinFeatures.ts
+++ b/modules/statics/src/coinFeatures.ts
@@ -190,7 +190,6 @@ export const CSPR_FEATURES = [
   CoinFeature.CUSTODY_BITGO_SINGAPORE,
   CoinFeature.MULTISIG_COLD,
   CoinFeature.MULTISIG,
-  CoinFeature.STAKING,
 ];
 export const ALGO_FEATURES = [
   ...ACCOUNT_COIN_DEFAULT_FEATURES,

--- a/modules/statics/test/unit/coins.ts
+++ b/modules/statics/test/unit/coins.ts
@@ -1419,6 +1419,15 @@ describe('Liquid Staking Features', () => {
   });
 });
 
+describe('CSPR staking features', () => {
+  it('should not advertise STAKING for mainnet or testnet Casper', () => {
+    ['cspr', 'tcspr'].forEach((coinName) => {
+      const coin = coins.get(coinName);
+      coin.features.includes(CoinFeature.STAKING).should.eql(false);
+    });
+  });
+});
+
 describe('ADA RealFi USDr staking', () => {
   it('should have STAKING feature for stakeable USDr tokens', () => {
     ['ada:usdr', 'tada:usdr'].forEach((coinName) => {


### PR DESCRIPTION
## Summary
- Remove CoinFeature.STAKING from shared CSPR and TCSPR statics metadata.
- Preserve CSPR registration, wallet, transfer, signing, and transaction support.
- Add focused metadata regression coverage.

Parent ticket: SI-1521
Subticket: SI-1524

## Verification
Targeted statics coin test: 36852 passing.
Commit is GPG-signed and verified.