### PR TITLE
feat(statics): replace Story explorer URLs with Data Network

### DIFF
--- a/modules/sdk-core/src/bitgo/environments.ts
+++ b/modules/sdk-core/src/bitgo/environments.ts
@@ -275,7 +275,7 @@ const mainnetBase: EnvironmentTemplate = {
       baseUrl: 'https://api.etherscan.io/v2',
     },
     ip: {
-      baseUrl: 'https://www.storyscan.io',
+      baseUrl: 'https://datanetscan.io',
     },
     somi: {
       baseUrl: 'https://mainnet.somnia.w3us.site',
@@ -522,7 +522,7 @@ const testnetBase: EnvironmentTemplate = {
       baseUrl: 'https://api.etherscan.io/v2',
     },
     ip: {
-      baseUrl: 'https://aeneid.storyscan.io',
+      baseUrl: 'https://aeneid.datanetscan.io',
     },
     tbaseeth: {
       baseUrl: 'https://api.etherscan.io/v2',

--- a/modules/statics/src/networks.ts
+++ b/modules/statics/src/networks.ts
@@ -1686,8 +1686,8 @@ class CoredaoTestnet extends Testnet implements EthereumNetwork {
 class IP extends Mainnet implements EthereumNetwork {
   name = 'Data Network';
   family = CoinFamily.IP;
-  explorerUrl = 'https://www.storyscan.io/tx/';
-  accountExplorerUrl = 'https://www.storyscan.io/address/';
+  explorerUrl = 'https://datanetscan.io/tx/';
+  accountExplorerUrl = 'https://datanetscan.io/address/';
   chainId = 1514;
   nativeCoinOperationHashPrefix = '1514';
 }
@@ -1695,8 +1695,8 @@ class IP extends Mainnet implements EthereumNetwork {
 class IPTestnet extends Testnet implements EthereumNetwork {
   name = 'Data Network Testnet';
   family = CoinFamily.IP;
-  explorerUrl = 'https://aeneid.storyscan.io/tx/';
-  accountExplorerUrl = 'https://aeneid.storyscan.io/address/';
+  explorerUrl = 'https://aeneid.datanetscan.io/tx/';
+  accountExplorerUrl = 'https://aeneid.datanetscan.io/address/';
   chainId = 1315;
   nativeCoinOperationHashPrefix = '1315';
 }


### PR DESCRIPTION
## Summary
- Replace IP mainnet/testnet explorer and account explorer hosts from `storyscan.io` → `datanetscan.io` in statics networks
- Update sdk-core environment explorer `baseUrl`s to match
- Part of [CECHO-2075](https://linear.app/bitgo/issue/CECHO-2075/replace-rpc-urls-from-storyip-to-data-network) Phase 1 (display/link hosts only; no public RPC change in this PR)

## Test plan
- [ ] Confirm statics `explorerUrl` / `accountExplorerUrl` for `ip` / tip networks point at datanetscan
- [ ] Confirm sdk-core env baseUrls updated for ip/tip
- [ ] Spot-check a sample explorer tx/address URL resolves on datanetscan.io / aeneid.datanetscan.io

Ticket: CECHO-2075

Made with [Cursor](https://cursor.com)