### PR TITLE
feat(statics): onboard real1 token on sepolia

### DIFF
--- a/modules/statics/src/base.ts
+++ b/modules/statics/src/base.ts
@@ -2008,6 +2008,7 @@ export enum UnderlyingAsset {
   'sepeth:usdc' = 'sepeth:usdc',
   'sepeth:pyusd' = 'sepeth:pyusd',
   'sepeth:wtgxx' = 'sepeth:wtgxx',
+  'sepeth:real1' = 'sepeth:real1',
   // Robinhood Chain testnet ERC-20 tokens
   'thoodeth:amzn' = 'thoodeth:amzn',
   'thoodeth:tsla' = 'thoodeth:tsla',

--- a/modules/statics/src/coins/erc20Coins.ts
+++ b/modules/statics/src/coins/erc20Coins.ts
@@ -15204,4 +15204,16 @@ export const erc20Coins = [
     undefined,
     Networks.test.sepolia
   ),
+  terc20(
+    '97658fdb-33fc-4995-bd11-7b6d3b1bf20d',
+    'sepeth:real1',
+    'REAL1',
+    6,
+    '0x8463e1f760d0572d04bc76a6031361d76124562f',
+    UnderlyingAsset['sepeth:real1'],
+    ACCOUNT_COIN_DEFAULT_FEATURES,
+    undefined,
+    undefined,
+    Networks.test.sepolia
+  ),
 ];

--- a/modules/statics/src/coins/ofcErc20Coins.ts
+++ b/modules/statics/src/coins/ofcErc20Coins.ts
@@ -5163,6 +5163,20 @@ export const tOfcErc20Coins = [
     undefined,
     'sepeth'
   ),
+  tofcerc20(
+    '70bef63c-60ff-4a1b-8045-6ca14a04aa96',
+    'ofcsepeth:real1',
+    'REAL1',
+    6,
+    UnderlyingAsset['sepeth:real1'],
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    'sepeth'
+  ),
 
   ofcerc20(
     'cc2a92cf-d799-463b-b08c-e9a4d5e87934',

--- a/modules/statics/test/unit/tokenNamingConvention.ts
+++ b/modules/statics/test/unit/tokenNamingConvention.ts
@@ -82,6 +82,7 @@ describe('Token Naming Convention Tests', function () {
       'sepeth:usdc',
       'sepeth:pyusd',
       'sepeth:wtgxx',
+      'sepeth:real1',
       'fixed',
       'schz',
       'bgerch',


### PR DESCRIPTION
## WHAT
Onboard the `REAL1` testnet ERC-20 token and its corresponding OFC token on Sepolia (`sepeth:real1` and `ofcsepeth:real1`).

## WHY
Client-requested testnet token onboarding under ticket CSHLD-1671.

### Changes
- Added `sepeth:real1` to `UnderlyingAsset` enum in `modules/statics/src/base.ts`.
- Registered `sepeth:real1` (name `REAL1`, 6 decimals, contract `0x8463e1f760d0572d04bc76a6031361d76124562f`) in `modules/statics/src/coins/erc20Coins.ts` on Sepolia.
- Registered `ofcsepeth:real1` OFC variant in `modules/statics/src/coins/ofcErc20Coins.ts` with base coin `sepeth`.
- Added `sepeth:real1` to `testnetPrefixExceptions` in `modules/statics/test/unit/tokenNamingConvention.ts`.

Ticket: CSHLD-1671