### PR TITLE
sdk-coin-canton: add generic CantonCommand builder

### DIFF
--- a/modules/sdk-coin-canton/src/canton.ts
+++ b/modules/sdk-coin-canton/src/canton.ts
@@ -114,6 +114,7 @@ export class Canton extends BaseCoin {
       case TransactionType.TransferAcknowledge:
       case TransactionType.OneStepPreApproval:
       case TransactionType.TransferOfferWithdrawn:
+      case TransactionType.CantonCommand:
         // There is no input for these type of transactions, so always return true.
         return true;
       case TransactionType.Send:

--- a/modules/sdk-coin-canton/src/lib/cantonCommandBuilder.ts
+++ b/modules/sdk-coin-canton/src/lib/cantonCommandBuilder.ts
@@ -1,0 +1,166 @@
+import { InvalidTransactionError, PublicKey, TransactionType } from '@bitgo/sdk-core';
+import { BaseCoin as CoinConfig } from '@bitgo/statics';
+import {
+  CantonCommandRequest,
+  CantonCommandResolveContractSpec,
+  CantonCommandUnion,
+  CantonPrepareCommandResponse,
+} from './iface';
+import { TransactionBuilder } from './transactionBuilder';
+import { Transaction } from './transaction/transaction';
+import utils from './utils';
+
+/**
+ * Generic builder for any allowlisted Canton DAML command (CreateCommand or ExerciseCommand).
+ * Unlike the purpose-built builders (e.g. TransferRejectionBuilder), this builder does not
+ * know the shape of the command it carries — it only validates the envelope fields
+ * (commandId, actAs, command) and passes the command through unchanged. The template/choice
+ * allowlist and any active-contract resolution are enforced server-side.
+ */
+export class CantonCommandBuilder extends TransactionBuilder {
+  private _commandId: string;
+  private _actAs: string[] = [];
+  private _readAs: string[] = [];
+  private _command: CantonCommandUnion;
+  private _resolveContracts: CantonCommandResolveContractSpec[] = [];
+
+  constructor(_coinConfig: Readonly<CoinConfig>) {
+    super(_coinConfig);
+  }
+
+  initBuilder(tx: Transaction): void {
+    super.initBuilder(tx);
+    this.setTransactionType();
+  }
+
+  get transactionType(): TransactionType {
+    return TransactionType.CantonCommand;
+  }
+
+  setTransactionType(): void {
+    this.transaction.transactionType = TransactionType.CantonCommand;
+  }
+
+  setTransaction(transaction: CantonPrepareCommandResponse): void {
+    this.transaction.prepareCommand = transaction;
+  }
+
+  /** @inheritDoc */
+  addSignature(publicKey: PublicKey, signature: Buffer): void {
+    if (!this.transaction) {
+      throw new InvalidTransactionError('transaction is empty!');
+    }
+    this._signatures.push({ publicKey, signature });
+    const pubKeyBase64 = utils.getBase64FromHex(publicKey.pub);
+    this.transaction.signerFingerprint = utils.getAddressFromPublicKey(pubKeyBase64);
+    this.transaction.signatures = signature.toString('base64');
+  }
+
+  /**
+   * Sets the unique id for the command
+   * Also sets the _id of the transaction
+   *
+   * @param id - A uuid
+   * @returns The current builder instance for chaining.
+   * @throws Error if id is empty.
+   */
+  commandId(id: string): this {
+    if (!id || !id.trim()) {
+      throw new Error('commandId must be a non-empty string');
+    }
+    this._commandId = id.trim();
+    // also set the transaction _id
+    this.transaction.id = id.trim();
+    return this;
+  }
+
+  /**
+   * Sets the parties that must sign the command
+   *
+   * @param parties - the acting party ids
+   * @returns The current builder instance for chaining.
+   * @throws Error if parties is empty.
+   */
+  actAs(parties: string[]): this {
+    if (!parties || parties.length === 0) {
+      throw new Error('actAs must contain at least one party');
+    }
+    this._actAs = parties;
+    return this;
+  }
+
+  /**
+   * Sets the parties used for read-only ACS visibility
+   *
+   * @param parties - the read-only party ids
+   * @returns The current builder instance for chaining.
+   */
+  readAs(parties: string[]): this {
+    this._readAs = parties;
+    return this;
+  }
+
+  /**
+   * Sets the DAML command (CreateCommand or ExerciseCommand) to execute
+   *
+   * @param command - the command envelope
+   * @returns The current builder instance for chaining.
+   * @throws Error if command is missing.
+   */
+  command(command: CantonCommandUnion): this {
+    if (!command) {
+      throw new Error('command must be provided');
+    }
+    this._command = command;
+    return this;
+  }
+
+  /**
+   * Sets the ACS resolution specs used to look up and inject contractIds into the command
+   * at build time (e.g. when the caller doesn't know the contractId up front)
+   *
+   * @param specs - the resolve-contract specs
+   * @returns The current builder instance for chaining.
+   */
+  resolveContracts(specs: CantonCommandResolveContractSpec[]): this {
+    this._resolveContracts = specs;
+    return this;
+  }
+
+  /**
+   * Builds and returns the CantonCommandRequest object from the builder's internal state.
+   *
+   * This method performs validation before constructing the object. If required fields are
+   * missing or invalid, it throws an error.
+   *
+   * @returns {CantonCommandRequest} - A fully constructed and validated request object for the command.
+   * @throws {Error} If any required field is missing or fails validation.
+   */
+  toRequestObject(): CantonCommandRequest {
+    this.validate();
+
+    const request: CantonCommandRequest = {
+      commandId: this._commandId,
+      command: this._command,
+      verboseHashing: false,
+      actAs: this._actAs,
+      readAs: this._readAs,
+    };
+    if (this._resolveContracts.length > 0) {
+      request.resolveContracts = this._resolveContracts;
+    }
+    return request;
+  }
+
+  /**
+   * Validates the internal state of the builder before building the request object.
+   *
+   * @private
+   * @throws {Error} If any required field is missing or invalid.
+   */
+  private validate(): void {
+    if (!this._commandId) throw new Error('commandId is missing');
+    if (!this._actAs || this._actAs.length === 0) throw new Error('actAs is missing');
+    if (!this._command) throw new Error('command is missing');
+  }
+}

--- a/modules/sdk-coin-canton/src/lib/iface.ts
+++ b/modules/sdk-coin-canton/src/lib/iface.ts
@@ -161,3 +161,41 @@ export interface CantonTransferRequest {
   memoId?: string;
   tokenName?: string;
 }
+
+export interface CantonCreateCommand {
+  CreateCommand: {
+    templateId: string;
+    createArguments: Record<string, unknown>;
+  };
+}
+
+export interface CantonExerciseCommand {
+  ExerciseCommand: {
+    templateId: string;
+    choice: string;
+    choiceArgument?: Record<string, unknown>;
+    // omitted when the contractId will be resolved via resolveContracts at build time
+    contractId?: string;
+  };
+}
+
+export type CantonCommandUnion = CantonCreateCommand | CantonExerciseCommand;
+
+/**
+ * Declares a contract to resolve from the active contract set at build time, and the
+ * dot-notation path within the command where its resolved contractId should be injected
+ * (e.g. "ExerciseCommand.contractId").
+ */
+export interface CantonCommandResolveContractSpec {
+  templateId: string;
+  actAs: string[];
+  readAs?: string[];
+  // if true, resolves all active contracts for the templateId instead of just the first match
+  resolveAll?: boolean;
+  injectAs: string;
+}
+
+export interface CantonCommandRequest extends CantonPrepareCommandRequest {
+  command: CantonCommandUnion;
+  resolveContracts?: CantonCommandResolveContractSpec[];
+}

--- a/modules/sdk-coin-canton/src/lib/index.ts
+++ b/modules/sdk-coin-canton/src/lib/index.ts
@@ -1,6 +1,7 @@
 import * as Utils from './utils';
 import * as Interface from './iface';
 
+export { CantonCommandBuilder } from './cantonCommandBuilder';
 export { KeyPair } from './keyPair';
 export { OneStepPreApprovalBuilder } from './oneStepPreApprovalBuilder';
 export { Transaction } from './transaction/transaction';

--- a/modules/sdk-coin-canton/src/lib/transaction/transaction.ts
+++ b/modules/sdk-coin-canton/src/lib/transaction/transaction.ts
@@ -147,6 +147,13 @@ export class Transaction extends BaseTransaction {
     if (!this._prepareCommand || !this._prepareCommand.preparedTransaction) {
       throw new InvalidTransactionError('Empty transaction data');
     }
+    if (this._type === TransactionType.CantonCommand) {
+      // Generic allowlisted DAML command (CreateCommand/ExerciseCommand) — unlike the
+      // purpose-built transaction types, there's no fixed sender/receiver/amount shape to
+      // parse from the prepared transaction bytes here.
+      result.amount = '0';
+      return result;
+    }
     // TODO: extract other required data (utxo used, request time, execute before etc)
     let parsedInfo: PreparedTxnParsedInfo;
     try {

--- a/modules/sdk-coin-canton/src/lib/transactionBuilderFactory.ts
+++ b/modules/sdk-coin-canton/src/lib/transactionBuilderFactory.ts
@@ -5,6 +5,7 @@ import {
   TransactionType,
 } from '@bitgo/sdk-core';
 import { BaseCoin as CoinConfig } from '@bitgo/statics';
+import { CantonCommandBuilder } from './cantonCommandBuilder';
 import { OneStepPreApprovalBuilder } from './oneStepPreApprovalBuilder';
 import { TransferAcceptanceBuilder } from './transferAcceptanceBuilder';
 import { TransferAcknowledgeBuilder } from './transferAcknowledgeBuilder';
@@ -48,6 +49,9 @@ export class TransactionBuilderFactory extends BaseTransactionBuilderFactory {
         case TransactionType.TransferReject: {
           return this.getTransferRejectBuilder(tx);
         }
+        case TransactionType.CantonCommand: {
+          return this.getCantonCommandBuilder(tx);
+        }
         default: {
           throw new InvalidTransactionError('unsupported transaction');
         }
@@ -73,6 +77,10 @@ export class TransactionBuilderFactory extends BaseTransactionBuilderFactory {
 
   getTransferRejectBuilder(tx?: Transaction): TransferRejectionBuilder {
     return TransactionBuilderFactory.initializeBuilder(tx, new TransferRejectionBuilder(this._coinConfig));
+  }
+
+  getCantonCommandBuilder(tx?: Transaction): CantonCommandBuilder {
+    return TransactionBuilderFactory.initializeBuilder(tx, new CantonCommandBuilder(this._coinConfig));
   }
 
   /** @inheritdoc */

--- a/modules/sdk-coin-canton/test/unit/builder/cantonCommand/cantonCommandBuilder.ts
+++ b/modules/sdk-coin-canton/test/unit/builder/cantonCommand/cantonCommandBuilder.ts
@@ -1,0 +1,137 @@
+import assert from 'assert';
+import should from 'should';
+
+import { coins } from '@bitgo/statics';
+
+import { CantonCommandBuilder, Transaction } from '../../../../src';
+import { CantonCommandRequest } from '../../../../src/lib/iface';
+
+const CantonCommandPrepareResponse = {
+  preparedTransaction: 'dGVzdC1wcmVwYXJlZC10cmFuc2FjdGlvbg==',
+  preparedTransactionHash: 'dGVzdC1oYXNo',
+  hashingSchemeVersion: 'HASHING_SCHEME_VERSION_V2',
+};
+
+const partyId = '12201::1220175583b704cbb493393c1dbe17b9909ee4cf55ef345e8147cd6900c5768f861d';
+const commandId = '3935a06d-3b03-41be-99a5-95b2ecaabf7d';
+
+describe('Canton Command Builder', () => {
+  it('should get the exercise command request object', function () {
+    const txBuilder = new CantonCommandBuilder(coins.get('tcanton'));
+    const tx = new Transaction(coins.get('tcanton'));
+    txBuilder.initBuilder(tx);
+    txBuilder.setTransaction(CantonCommandPrepareResponse);
+    txBuilder
+      .commandId(commandId)
+      .actAs([partyId])
+      .command({
+        ExerciseCommand: {
+          templateId: 'Splice.AmuletRules:TransferPreapproval',
+          choice: 'TransferPreapproval_Cancel',
+          choiceArgument: { p: partyId },
+        },
+      })
+      .resolveContracts([
+        {
+          templateId: 'Splice.AmuletRules:TransferPreapproval',
+          actAs: [partyId],
+          injectAs: 'ExerciseCommand.contractId',
+        },
+      ]);
+    const requestObj: CantonCommandRequest = txBuilder.toRequestObject();
+    should.exist(requestObj);
+    assert.equal(requestObj.commandId, commandId);
+    assert.equal(requestObj.actAs.length, 1);
+    assert.equal(requestObj.actAs[0], partyId);
+    assert.deepEqual(requestObj.command, {
+      ExerciseCommand: {
+        templateId: 'Splice.AmuletRules:TransferPreapproval',
+        choice: 'TransferPreapproval_Cancel',
+        choiceArgument: { p: partyId },
+      },
+    });
+    assert.equal(requestObj.resolveContracts?.length, 1);
+    assert.equal(requestObj.resolveContracts?.[0].injectAs, 'ExerciseCommand.contractId');
+  });
+
+  it('should get the create command request object without resolveContracts', function () {
+    const txBuilder = new CantonCommandBuilder(coins.get('tcanton'));
+    const tx = new Transaction(coins.get('tcanton'));
+    txBuilder.initBuilder(tx);
+    txBuilder.setTransaction(CantonCommandPrepareResponse);
+    txBuilder
+      .commandId(commandId)
+      .actAs([partyId])
+      .command({
+        CreateCommand: {
+          templateId: 'Splice.Wallet.TransferPreapproval:TransferPreapprovalProposal',
+          createArguments: { provider: partyId, receiver: partyId },
+        },
+      });
+    const requestObj: CantonCommandRequest = txBuilder.toRequestObject();
+    should.exist(requestObj);
+    assert.equal(requestObj.resolveContracts, undefined);
+  });
+
+  it('should not throw building toJson for a generic command', function () {
+    const txBuilder = new CantonCommandBuilder(coins.get('tcanton'));
+    const tx = new Transaction(coins.get('tcanton'));
+    txBuilder.initBuilder(tx);
+    txBuilder.setTransaction(CantonCommandPrepareResponse);
+    txBuilder
+      .commandId(commandId)
+      .actAs([partyId])
+      .command({
+        ExerciseCommand: {
+          templateId: 'Splice.AmuletRules:TransferPreapproval',
+          choice: 'TransferPreapproval_Cancel',
+          choiceArgument: { p: partyId },
+        },
+      });
+    const txData = txBuilder.transaction.toJson();
+    should.exist(txData);
+    assert.equal(txData.amount, '0');
+  });
+
+  it('should throw if commandId is missing', function () {
+    const txBuilder = new CantonCommandBuilder(coins.get('tcanton'));
+    const tx = new Transaction(coins.get('tcanton'));
+    txBuilder.initBuilder(tx);
+    txBuilder.setTransaction(CantonCommandPrepareResponse);
+    txBuilder.actAs([partyId]).command({
+      ExerciseCommand: {
+        templateId: 'Splice.AmuletRules:TransferPreapproval',
+        choice: 'TransferPreapproval_Cancel',
+      },
+    });
+    assert.throws(() => txBuilder.toRequestObject(), /commandId is missing/);
+  });
+
+  it('should throw if actAs is missing', function () {
+    const txBuilder = new CantonCommandBuilder(coins.get('tcanton'));
+    const tx = new Transaction(coins.get('tcanton'));
+    txBuilder.initBuilder(tx);
+    txBuilder.setTransaction(CantonCommandPrepareResponse);
+    txBuilder.commandId(commandId).command({
+      ExerciseCommand: {
+        templateId: 'Splice.AmuletRules:TransferPreapproval',
+        choice: 'TransferPreapproval_Cancel',
+      },
+    });
+    assert.throws(() => txBuilder.toRequestObject(), /actAs is missing/);
+  });
+
+  it('should throw if command is missing', function () {
+    const txBuilder = new CantonCommandBuilder(coins.get('tcanton'));
+    const tx = new Transaction(coins.get('tcanton'));
+    txBuilder.initBuilder(tx);
+    txBuilder.setTransaction(CantonCommandPrepareResponse);
+    txBuilder.commandId(commandId).actAs([partyId]);
+    assert.throws(() => txBuilder.toRequestObject(), /command is missing/);
+  });
+
+  it('should throw if actAs is set to an empty array', function () {
+    const txBuilder = new CantonCommandBuilder(coins.get('tcanton'));
+    assert.throws(() => txBuilder.actAs([]), /actAs must contain at least one party/);
+  });
+});

--- a/modules/sdk-core/src/account-lib/baseCoin/enum.ts
+++ b/modules/sdk-core/src/account-lib/baseCoin/enum.ts
@@ -97,6 +97,8 @@ export enum TransactionType {
   TransferReject,
   // canton transfer offer withdrawn, 2-step
   TransferOfferWithdrawn,
+  // canton generic allowlisted DAML command (CreateCommand/ExerciseCommand)
+  CantonCommand,
 
   // trx
   FREEZE,


### PR DESCRIPTION
## Summary
- Adds `TransactionType.CantonCommand` and a generic `CantonCommandBuilder` in `sdk-coin-canton` that passes an arbitrary allowlisted DAML command (`CreateCommand`/`ExerciseCommand`), `actAs`/`readAs` parties, and optional `resolveContracts` specs through unchanged.
- This is the SDK-side piece for routing `TransferPreapproval_Cancel` (reverting a Canton wallet from 1-step back to 2-step approval) through the existing generic `cantonCommand` intent already defined in `@bitgo/public-types`, instead of building a bespoke dedicated transaction type end-to-end.
- No preapproval-specific logic here — the builder is fully generic and reusable for any future allowlisted command.
- `verifyTransaction()` and `toJson()` handle the new type the same way the existing no-input types (`OneStepPreApproval`, `TransferReject`, etc.) are handled — no fixed sender/receiver/amount shape to parse for a generic command.

Ref: [CHALO-1494](https://linear.app/bitgo/issue/CHALO-1494), part of [CHALO-1492](https://linear.app/bitgo/issue/CHALO-1492/sandbox-reverting-canton-wallets-to-2-step-approval)

## Test plan
- [x] `yarn tsc --build --incremental .` — clean build
- [x] `BITGOJS_TEST_PASSWORD=test npx mocha` in `modules/sdk-coin-canton` — 65 passing (7 new tests for `CantonCommandBuilder`)
- [x] `eslint`/`prettier` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)