### PR TITLE
WCN-2644: Address GHSA-7w5x-hrqm-74c2 in BitGoJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,8 @@
     "socket.io-parser": "4.2.7",
     "nanoid": "3.3.18",
     "sanitize-html": "2.17.5",
-    "node-releases": "2.0.52"
+    "node-releases": "2.0.52",
+    "smol-toml": "1.7.1"
   },
   "overrides": {
     "qs": "6.15.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19181,10 +19181,10 @@ smart-buffer@^4.1.0, smart-buffer@^4.2.0:
   resolved "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
 
-smol-toml@1.6.1:
-  version "1.6.1"
-  resolved "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz#4fceb5f7c4b86c2544024ef686e12ff0983465be"
-  integrity sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==
+smol-toml@1.6.1, smol-toml@1.7.1:
+  version "1.7.1"
+  resolved "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.1.tgz#ba3e28d2e4348874a824fd8e1d73fec618cb763b"
+  integrity sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==
 
 smoldot@2.0.26:
   version "2.0.26"


### PR DESCRIPTION
## Description

Update `smol-toml` to 1.7.1 in BitGoJS and refresh the lockfile entry to remediate GHSA-7w5x-hrqm-74c2.

## Issue Number

WCN-2644 — https://linear.app/bitgo/issue/WCN-2644/address-ghsa-7w5x-hrqm-74c2-in-bitgojs

## Type of change

- [x] Bug fix (non-breaking change)

## How Has This Been Tested?

Commit hooks passed: lint-staged, commit message preparation, and commitlint. No runtime tests were run; this change only updates dependency metadata.

## Checklist

- [x] Conventional commit and ticket reference included
- [x] package.json and yarn.lock updated together