### PR TITLE
fix(examples): use 'test' env consistently in Go Account scripts

### DIFF
--- a/examples/ts/go-account/create-go-account-address.ts
+++ b/examples/ts/go-account/create-go-account-address.ts
@@ -20,7 +20,7 @@ require('dotenv').config({ path: '../../../.env' });
 // Initialize BitGo SDK
 const bitgo = new BitGoAPI({
   accessToken: process.env.TESTNET_ACCESS_TOKEN,
-  env: 'test', // Change this to env: 'production' when you are ready for production
+  env: 'test', // Change this to env: 'prod' when you are ready for production
 });
 
 // Go Accounts use the 'ofc' (Off-Chain) coin

--- a/examples/ts/go-account/create-go-account-advanced.ts
+++ b/examples/ts/go-account/create-go-account-advanced.ts
@@ -26,7 +26,7 @@ require('dotenv').config({ path: '../../../.env' });
 // Initialize BitGo SDK
 const bitgo = new BitGoAPI({
   accessToken: process.env.TESTNET_ACCESS_TOKEN,
-  env: 'test', // Change this to env: 'production' when you are ready for production
+  env: 'test', // Change this to env: 'prod' when you are ready for production
 });
 
 // Go Accounts use the 'ofc' (Off-Chain) coin

--- a/examples/ts/go-account/create-go-account.ts
+++ b/examples/ts/go-account/create-go-account.ts
@@ -21,7 +21,7 @@ require('dotenv').config({ path: '../../../.env' });
 // Initialize BitGo SDK
 const bitgo = new BitGoAPI({
   accessToken: process.env.TESTNET_ACCESS_TOKEN,
-  env: 'test', // Change this to env: 'production' when you are ready for production
+  env: 'test', // Change this to env: 'prod' when you are ready for production
 });
 
 // Go Accounts use the 'ofc' (Off-Chain) coin

--- a/examples/ts/go-account/go-account-approve.ts
+++ b/examples/ts/go-account/go-account-approve.ts
@@ -34,7 +34,7 @@ require('dotenv').config({ path: '../../../.env' });
 // Initialize BitGo SDK with the APPROVING admin's access token
 const bitgo = new BitGoAPI({
   accessToken: process.env.TESTNET_ACCESS_TOKEN,
-  env: 'test', // Change to 'production' for mainnet
+  env: 'test', // Change to 'prod' for mainnet
 });
 
 const baseCoin = 'ofc';

--- a/examples/ts/go-account/go-account-get-balance.ts
+++ b/examples/ts/go-account/go-account-get-balance.ts
@@ -25,7 +25,7 @@ require('dotenv').config({ path: '../../../.env' });
 // Initialize BitGo SDK
 const bitgo = new BitGoAPI({
   accessToken: process.env.TESTNET_ACCESS_TOKEN,
-  env: 'staging', // Change to 'production' for mainnet
+  env: 'test', // Change to 'prod' for mainnet
 });
 
 // ---------------------------------------------------------------------------

--- a/examples/ts/go-account/go-account-get-order.ts
+++ b/examples/ts/go-account/go-account-get-order.ts
@@ -20,7 +20,7 @@ require('dotenv').config({ path: '../../../.env' });
 // Initialize BitGo SDK
 const bitgo = new BitGoAPI({
   accessToken: process.env.TESTNET_ACCESS_TOKEN,
-  env: 'test', // Change to 'production' for mainnet
+  env: 'test', // Change to 'prod' for mainnet
 });
 
 // ---------------------------------------------------------------------------

--- a/examples/ts/go-account/go-account-get-pending-approval.ts
+++ b/examples/ts/go-account/go-account-get-pending-approval.ts
@@ -17,7 +17,7 @@ require('dotenv').config({ path: '../../../.env' });
 
 const bitgo = new BitGoAPI({
   accessToken: process.env.TESTNET_ACCESS_TOKEN,
-  env: 'test', // Change to 'production' for mainnet
+  env: 'test', // Change to 'prod' for mainnet
 });
 
 const baseCoin = 'ofc';

--- a/examples/ts/go-account/go-account-list-orders.ts
+++ b/examples/ts/go-account/go-account-list-orders.ts
@@ -22,7 +22,7 @@ require('dotenv').config({ path: '../../../.env' });
 // Initialize BitGo SDK
 const bitgo = new BitGoAPI({
   accessToken: process.env.TESTNET_ACCESS_TOKEN,
-  env: 'test', // Change to 'production' for mainnet
+  env: 'test', // Change to 'prod' for mainnet
 });
 
 // ---------------------------------------------------------------------------

--- a/examples/ts/go-account/go-account-list-products.ts
+++ b/examples/ts/go-account/go-account-list-products.ts
@@ -19,7 +19,7 @@ require('dotenv').config({ path: '../../../.env' });
 // Initialize BitGo SDK
 const bitgo = new BitGoAPI({
   accessToken: process.env.TESTNET_ACCESS_TOKEN,
-  env: 'staging', // Change to 'production' for mainnet
+  env: 'test', // Change to 'prod' for mainnet
 });
 
 // ---------------------------------------------------------------------------

--- a/examples/ts/go-account/go-account-place-order.ts
+++ b/examples/ts/go-account/go-account-place-order.ts
@@ -38,7 +38,7 @@ require('dotenv').config({ path: '../../../.env' });
 // Initialize BitGo SDK
 const bitgo = new BitGoAPI({
   accessToken: process.env.TESTNET_ACCESS_TOKEN,
-  env: 'test', // Change to 'production' for mainnet
+  env: 'test', // Change to 'prod' for mainnet
 });
 
 // ---------------------------------------------------------------------------

--- a/examples/ts/go-account/go-account-whitelist-update.ts
+++ b/examples/ts/go-account/go-account-whitelist-update.ts
@@ -31,7 +31,7 @@ require('dotenv').config({ path: '../../../.env' });
 // Initialize BitGo SDK
 const bitgo = new BitGoAPI({
   accessToken: process.env.TESTNET_ACCESS_TOKEN,
-  env: 'test', // Change to 'production' for mainnet
+  env: 'test', // Change to 'prod' for mainnet
 });
 
 const baseCoin = 'ofc';

--- a/examples/ts/go-account/go-account-withdrawal.ts
+++ b/examples/ts/go-account/go-account-withdrawal.ts
@@ -31,7 +31,7 @@ require('dotenv').config({ path: '../../../.env' });
 // Initialize BitGo SDK
 const bitgo = new BitGoAPI({
   accessToken: process.env.TESTNET_ACCESS_TOKEN,
-  env: 'test', // Change to 'production' for mainnet
+  env: 'test', // Change to 'prod' for mainnet
 });
 
 // Go Accounts use the 'ofc' (Off-Chain) coin family.

--- a/examples/ts/go-account/sign-transaction.ts
+++ b/examples/ts/go-account/sign-transaction.ts
@@ -32,7 +32,7 @@ require('dotenv').config({ path: '../../../.env' });
 // Initialize BitGo SDK
 const bitgo = new BitGoAPI({
   accessToken: process.env.TESTNET_ACCESS_TOKEN,
-  env: 'test', // Change to 'production' for mainnet
+  env: 'test', // Change to 'prod' for mainnet
 });
 
 // Go Accounts use the 'ofc' (Off-Chain) coin


### PR DESCRIPTION
## Summary
- `go-account-get-balance.ts` and `go-account-list-products.ts` used `env: 'staging'`, inconsistent with the rest of the Go Account example scripts which use `env: 'test'`. These scripts are client-facing and only `test`/`prod` are meaningful envs to them.
- Updated the mainnet comment across all Go Account scripts to reference `'prod'` (the canonical `EnvironmentName`) instead of the `'production'` alias.

## Test plan
- [ ] Verify all `examples/ts/go-account/*.ts` scripts use `env: 'test'` by default
- [ ] Confirm comments consistently say `'prod'` for mainnet

Linear: CAAS-2581

🤖 Generated with [Claude Code](https://claude.com/claude-code)